### PR TITLE
Fix missing EE import fallbacks for open source compatibility

### DIFF
--- a/rest/routers/auth/router.py
+++ b/rest/routers/auth/router.py
@@ -12,7 +12,10 @@ try:
 except ImportError:
     from rest.utils.auth import verify_cognito_token
 
-from rest.client.ee.mongodb_client import TraceRootMongoDBClient
+try:
+    from rest.client.ee.mongodb_client import TraceRootMongoDBClient
+except ImportError:
+    from rest.client.mongodb_client import TraceRootMongoDBClient
 from rest.config.subscription import UserSubscription
 
 


### PR DESCRIPTION
Fixes ModuleNotFoundError when running the open source version by adding try/except fallback for EE import in auth router.

The auth router was missing the import fallback pattern used elsewhere in the codebase, causing the server to fail on
startup when rest.client.ee modules are unavailable in open source mode.