### PR TITLE
Support docker compose [1/n]

### DIFF
--- a/docker/public/compose/README.md
+++ b/docker/public/compose/README.md
@@ -12,27 +12,32 @@ This directory contains Docker Compose configuration for running TraceRoot local
 ## Quick Start
 
 1. **Clone the repository** (if you haven't already):
+
    ```bash
    git clone https://github.com/traceroot-ai/traceroot.git
    cd traceroot
    ```
 
-2. **Navigate to the compose directory**:
+1. **Navigate to the compose directory**:
+
    ```bash
    cd docker/public/compose
    ```
 
-3. **Start all services**:
+1. **Start all services**:
+
    ```bash
    docker-compose up -d
    ```
 
-4. **Wait for services to be ready** (this may take 5-10 minutes on first run):
+1. **Wait for services to be ready** (this may take 5-10 minutes on first run):
+
    ```bash
    docker-compose logs -f traceroot
    ```
 
-5. **Access the applications**:
+1. **Access the applications**:
+
    - **TraceRoot UI**: http://localhost:3000
    - **TraceRoot API**: http://localhost:8000
    - **Jaeger UI**: http://localhost:16686
@@ -40,8 +45,9 @@ This directory contains Docker Compose configuration for running TraceRoot local
 ## Services
 
 ### Jaeger (Tracing Backend)
+
 - **Image**: `cr.jaegertracing.io/jaegertracing/jaeger:2.8.0`
-- **Ports**: 
+- **Ports**:
   - `16686` - Jaeger UI
   - `14268` - Jaeger collector HTTP
   - `14250` - Jaeger collector gRPC
@@ -49,6 +55,7 @@ This directory contains Docker Compose configuration for running TraceRoot local
   - `4318` - OTLP HTTP receiver
 
 ### TraceRoot
+
 - **Build**: Uses local Dockerfile with `LOCAL_BUILD=true`
 - **Ports**:
   - `3000` - Frontend (Next.js)
@@ -57,11 +64,13 @@ This directory contains Docker Compose configuration for running TraceRoot local
 ## Common Commands
 
 ### Start services
+
 ```bash
 docker-compose up -d
 ```
 
 ### View logs
+
 ```bash
 # All services
 docker-compose logs -f
@@ -72,22 +81,26 @@ docker-compose logs -f jaeger
 ```
 
 ### Stop services
+
 ```bash
 docker-compose down
 ```
 
 ### Restart services
+
 ```bash
 docker-compose restart
 ```
 
 ### Rebuild and restart (after code changes)
+
 ```bash
 docker-compose down
 docker-compose up -d --build
 ```
 
 ### Check service status
+
 ```bash
 docker-compose ps
 ```
@@ -100,6 +113,7 @@ Both services include health checks:
 - **TraceRoot**: Checks if both frontend (3000) and backend (8000) are responding
 
 You can check the health status with:
+
 ```bash
 docker-compose ps
 ```
@@ -107,21 +121,26 @@ docker-compose ps
 ## Troubleshooting
 
 ### Services won't start
+
 1. **Check if ports are already in use**:
+
    ```bash
    lsof -i :3000,8000,16686
    ```
 
-2. **Check Docker logs**:
+1. **Check Docker logs**:
+
    ```bash
    docker-compose logs traceroot
    ```
 
-3. **Ensure Docker has enough resources**:
+1. **Ensure Docker has enough resources**:
+
    - At least 4GB RAM allocated to Docker
    - At least 2GB disk space available
 
 ### Build fails
+
 1. **Clean up and rebuild**:
    ```bash
    docker-compose down -v
@@ -130,7 +149,9 @@ docker-compose ps
    ```
 
 ### Services are slow to start
+
 - **First build** can take 5-10 minutes as it needs to:
+
   - Install Python dependencies
   - Install Node.js dependencies
   - Build the Next.js frontend
@@ -138,18 +159,21 @@ docker-compose ps
 - **Subsequent starts** should be much faster (under 1 minute)
 
 ### Can't access services
+
 1. **Check if services are healthy**:
+
    ```bash
    docker-compose ps
    ```
 
-2. **Wait for health checks to pass** (especially for TraceRoot, which takes longer to start)
+1. **Wait for health checks to pass** (especially for TraceRoot, which takes longer to start)
 
-3. **Check firewall settings** - ensure ports 3000, 8000, and 16686 are not blocked
+1. **Check firewall settings** - ensure ports 3000, 8000, and 16686 are not blocked
 
 ## Development
 
 ### Making code changes
+
 After making changes to the codebase:
 
 ```bash
@@ -158,20 +182,21 @@ docker-compose up -d --build
 ```
 
 ### Using local development mode
+
 The compose setup uses `LOCAL_BUILD=true`, which means it will use your local code instead of cloning from GitHub.
 
 ## Differences from One-Line Installer
 
-| Feature | One-Line Installer | Docker Compose |
-|---------|-------------------|----------------|
-| **Setup** | Single command | Requires Docker Compose |
+| Feature        | One-Line Installer          | Docker Compose                 |
+| -------------- | --------------------------- | ------------------------------ |
+| **Setup**      | Single command              | Requires Docker Compose        |
 | **Management** | Manual container management | Declarative service management |
-| **Logs** | `docker logs <container>` | `docker-compose logs` |
-| **Updates** | Re-run installer script | `docker-compose up --build` |
-| **Cleanup** | Manual container removal | `docker-compose down` |
+| **Logs**       | `docker logs <container>`   | `docker-compose logs`          |
+| **Updates**    | Re-run installer script     | `docker-compose up --build`    |
+| **Cleanup**    | Manual container removal    | `docker-compose down`          |
 
 ## Getting Help
 
 - **TraceRoot Documentation**: https://docs.traceroot.ai
 - **Discord Community**: https://discord.gg/tPyffEZvvJ
-- **GitHub Issues**: https://github.com/traceroot-ai/traceroot/issues 
+- **GitHub Issues**: https://github.com/traceroot-ai/traceroot/issues

--- a/docker/public/compose/README.md
+++ b/docker/public/compose/README.md
@@ -1,0 +1,177 @@
+# TraceRoot Docker Compose Setup
+
+This directory contains Docker Compose configuration for running TraceRoot locally with all its dependencies.
+
+## Prerequisites
+
+- **Docker** and **Docker Compose** installed on your system
+  - [Install Docker](https://docs.docker.com/get-docker/)
+  - [Install Docker Compose](https://docs.docker.com/compose/install/)
+- **Git** (for cloning the repository if needed)
+
+## Quick Start
+
+1. **Clone the repository** (if you haven't already):
+   ```bash
+   git clone https://github.com/traceroot-ai/traceroot.git
+   cd traceroot
+   ```
+
+2. **Navigate to the compose directory**:
+   ```bash
+   cd docker/public/compose
+   ```
+
+3. **Start all services**:
+   ```bash
+   docker-compose up -d
+   ```
+
+4. **Wait for services to be ready** (this may take 5-10 minutes on first run):
+   ```bash
+   docker-compose logs -f traceroot
+   ```
+
+5. **Access the applications**:
+   - **TraceRoot UI**: http://localhost:3000
+   - **TraceRoot API**: http://localhost:8000
+   - **Jaeger UI**: http://localhost:16686
+
+## Services
+
+### Jaeger (Tracing Backend)
+- **Image**: `cr.jaegertracing.io/jaegertracing/jaeger:2.8.0`
+- **Ports**: 
+  - `16686` - Jaeger UI
+  - `14268` - Jaeger collector HTTP
+  - `14250` - Jaeger collector gRPC
+  - `4317` - OTLP gRPC receiver
+  - `4318` - OTLP HTTP receiver
+
+### TraceRoot
+- **Build**: Uses local Dockerfile with `LOCAL_BUILD=true`
+- **Ports**:
+  - `3000` - Frontend (Next.js)
+  - `8000` - Backend API (FastAPI)
+
+## Common Commands
+
+### Start services
+```bash
+docker-compose up -d
+```
+
+### View logs
+```bash
+# All services
+docker-compose logs -f
+
+# Specific service
+docker-compose logs -f traceroot
+docker-compose logs -f jaeger
+```
+
+### Stop services
+```bash
+docker-compose down
+```
+
+### Restart services
+```bash
+docker-compose restart
+```
+
+### Rebuild and restart (after code changes)
+```bash
+docker-compose down
+docker-compose up -d --build
+```
+
+### Check service status
+```bash
+docker-compose ps
+```
+
+## Health Checks
+
+Both services include health checks:
+
+- **Jaeger**: Checks if the UI is accessible on port 16686
+- **TraceRoot**: Checks if both frontend (3000) and backend (8000) are responding
+
+You can check the health status with:
+```bash
+docker-compose ps
+```
+
+## Troubleshooting
+
+### Services won't start
+1. **Check if ports are already in use**:
+   ```bash
+   lsof -i :3000,8000,16686
+   ```
+
+2. **Check Docker logs**:
+   ```bash
+   docker-compose logs traceroot
+   ```
+
+3. **Ensure Docker has enough resources**:
+   - At least 4GB RAM allocated to Docker
+   - At least 2GB disk space available
+
+### Build fails
+1. **Clean up and rebuild**:
+   ```bash
+   docker-compose down -v
+   docker system prune -f
+   docker-compose up -d --build
+   ```
+
+### Services are slow to start
+- **First build** can take 5-10 minutes as it needs to:
+  - Install Python dependencies
+  - Install Node.js dependencies
+  - Build the Next.js frontend
+
+- **Subsequent starts** should be much faster (under 1 minute)
+
+### Can't access services
+1. **Check if services are healthy**:
+   ```bash
+   docker-compose ps
+   ```
+
+2. **Wait for health checks to pass** (especially for TraceRoot, which takes longer to start)
+
+3. **Check firewall settings** - ensure ports 3000, 8000, and 16686 are not blocked
+
+## Development
+
+### Making code changes
+After making changes to the codebase:
+
+```bash
+docker-compose down
+docker-compose up -d --build
+```
+
+### Using local development mode
+The compose setup uses `LOCAL_BUILD=true`, which means it will use your local code instead of cloning from GitHub.
+
+## Differences from One-Line Installer
+
+| Feature | One-Line Installer | Docker Compose |
+|---------|-------------------|----------------|
+| **Setup** | Single command | Requires Docker Compose |
+| **Management** | Manual container management | Declarative service management |
+| **Logs** | `docker logs <container>` | `docker-compose logs` |
+| **Updates** | Re-run installer script | `docker-compose up --build` |
+| **Cleanup** | Manual container removal | `docker-compose down` |
+
+## Getting Help
+
+- **TraceRoot Documentation**: https://docs.traceroot.ai
+- **Discord Community**: https://discord.gg/tPyffEZvvJ
+- **GitHub Issues**: https://github.com/traceroot-ai/traceroot/issues 

--- a/docker/public/compose/docker-compose.yml
+++ b/docker/public/compose/docker-compose.yml
@@ -45,4 +45,4 @@ services:
 
 networks:
   default:
-    name: traceroot-network 
+    name: traceroot-network

--- a/docker/public/compose/docker-compose.yml
+++ b/docker/public/compose/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.8'
+
+services:
+  jaeger:
+    image: cr.jaegertracing.io/jaegertracing/jaeger:2.8.0
+    container_name: jaeger
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686"  # Jaeger UI
+      - "14268:14268"  # Jaeger collector HTTP
+      - "14250:14250"  # Jaeger collector gRPC
+      - "4317:4317"    # OTLP gRPC receiver
+      - "4318:4318"    # OTLP HTTP receiver
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:16686/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  traceroot:
+    build:
+      context: ../../..
+      dockerfile: ./docker/public/Dockerfile
+      args:
+        - LOCAL_BUILD=true
+    container_name: traceroot
+    ports:
+      - "3000:3000"    # Frontend
+      - "8000:8000"    # Backend API
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      jaeger:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000", "&&", "curl", "-f", "http://localhost:8000/docs"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+
+networks:
+  default:
+    name: traceroot-network 


### PR DESCRIPTION
How to use it

```
# Clone and navigate
git clone https://github.com/traceroot-ai/traceroot.git
cd traceroot/docker/public/compose

# Start everything
docker-compose up -d

# View logs
docker-compose logs -f

# Access at same URLs as before
# http://localhost:3000 (UI)
# http://localhost:8000 (API) 
# http://localhost:16686 (Jaeger)
```