### PR TITLE
changes for TRACE_ROOT_LOCAL_MODE to REST_LOCAL_MODE

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,7 +7,7 @@ NEXT_PUBLIC_REST_API_ENDPOINT=http://localhost:8000
 NEXT_PUBLIC_LOCAL_MODE=true # Set to true to start locally
 
 # Credentials to run the server
-TRACE_ROOT_LOCAL_MODE=true # Set to true to start locally
+REST_LOCAL_MODE=true # Set to true to start locally
 DB_NAME=traceroot
 DB_CHAT_COLLECTION=agent_chat
 DB_CHAT_METADATA_COLLECTION=chat_metadata

--- a/docker/public/Dockerfile
+++ b/docker/public/Dockerfile
@@ -107,7 +107,7 @@ ENV NEXT_PUBLIC_REST_API_ENDPOINT="http://localhost:8000"
 ENV JAEGER_URL="http://host.docker.internal:16686"
 
 # Set local mode to true
-ENV TRACE_ROOT_LOCAL_MODE=true
+ENV REST_LOCAL_MODE=true
 ENV NEXT_PUBLIC_LOCAL_MODE=true
 
 # Expose ports

--- a/rest/app.py
+++ b/rest/app.py
@@ -37,7 +37,7 @@ class App:
             RateLimitExceeded,
             _rate_limit_exceeded_handler,
         )
-        self.local_mode = os.getenv("TRACE_ROOT_LOCAL_MODE", "false").lower() == "true"
+        self.local_mode = os.getenv("REST_LOCAL_MODE", "false").lower() == "true"
 
         # Add CORS middleware
         self.add_middleware()

--- a/rest/routers/explore.py
+++ b/rest/routers/explore.py
@@ -98,8 +98,8 @@ class ExploreRouter:
         self.agent = Agent()
         self.logger = logging.getLogger(__name__)
 
-        # Choose client based on TRACE_ROOT_LOCAL_MODE environment variable
-        self.local_mode = os.getenv("TRACE_ROOT_LOCAL_MODE", "false").lower() == "true"
+        # Choose client based on REST_LOCAL_MODE environment variable
+        self.local_mode = os.getenv("REST_LOCAL_MODE", "false").lower() == "true"
         if self.local_mode:
             self.db_client = TraceRootSQLiteClient()
         else:

--- a/rest/routers/integrate.py
+++ b/rest/routers/integrate.py
@@ -43,7 +43,7 @@ class IntegrateRouter:
         self.router = APIRouter()
 
         # Choose client based on REMOTE_MODE environment variable
-        self.local_mode = os.getenv("TRACE_ROOT_LOCAL_MODE", "false").lower() == "true"
+        self.local_mode = os.getenv("REST_LOCAL_MODE", "false").lower() == "true"
         if self.local_mode:
             self.db_client = TraceRootSQLiteClient()
         else:


### PR DESCRIPTION
# Rename `TRACE_ROOT_LOCAL_MODE` to `REST_LOCAL_MODE`

## Summary
This PR updates the environment variable `TRACE_ROOT_LOCAL_MODE` to `REST_LOCAL_MODE` across the codebase for better clarity and consistency.

## Changes
- Replaced all instances of `TRACE_ROOT_LOCAL_MODE` with `REST_LOCAL_MODE`.
- Updated `.env.example` and related documentation.
- Adjusted tests and configs to use the new variable name.

## Migration Notes
If you are using a `.env` file or exporting environment variables manually:
```diff
- TRACE_ROOT_LOCAL_MODE=true
+ REST_LOCAL_MODE=true
```


##FIXES : #75 