### PR TITLE
Fixes/the trace section can be hidden

### DIFF
--- a/ui/src/components/right-panel/agent/ChatMessage.tsx
+++ b/ui/src/components/right-panel/agent/ChatMessage.tsx
@@ -253,6 +253,7 @@ const renderMarkdown = (
             }}
           >
             {match}
+
             {hoveredRef?.messageId === messageId &&
               hoveredRef?.refNum === refNumber &&
               reference && (
@@ -289,10 +290,10 @@ const renderMarkdown = (
                     {/* Tooltip arrow */}
                     <div
                       className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0
-        border-l-4 border-r-4 border-t-4
-        border-l-transparent border-r-transparent
-        border-t-gray-300 dark:border-t-zinc-600"
-                    ></div>
+                    border-l-4 border-r-4 border-t-4
+                    border-l-transparent border-r-transparent
+                    border-t-gray-300 dark:border-t-zinc-600"
+                    />
                   </div>
                 </div>
               )}
@@ -485,7 +486,7 @@ export default function ChatMessage({
 
   const handleReferenceHover = (messageId: string, refNum: number | null) => {
     if (refNum === null) {
-      setHoveredRef(null);
+      setTimeout(() => setHoveredRef(null), 150); // small delay
     } else {
       setHoveredRef({ messageId, refNum });
     }

--- a/ui/src/components/right-panel/agent/ChatMessage.tsx
+++ b/ui/src/components/right-panel/agent/ChatMessage.tsx
@@ -141,7 +141,7 @@ const renderMarkdown = (
         return (
           <pre
             key={currentIndex++}
-            className="bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md p-3 my-2 overflow-x-auto relative group"
+            className="bg-gray-100 dark:bg-zinc-800 border border-gray-300 dark:border-zinc-600 rounded-md p-3 my-2 overflow-x-auto relative group"
           >
             <button
               onClick={handleCopy}
@@ -256,8 +256,8 @@ const renderMarkdown = (
             {hoveredRef?.messageId === messageId &&
               hoveredRef?.refNum === refNumber &&
               reference && (
-                <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-[9999] pointer-events-none">
-                  <div className="bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg p-3 min-w-[200px] max-w-[400px] text-xs">
+                <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-[9999]">
+                  <div className="bg-white dark:bg-zinc-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg p-3 min-w-[200px] max-w-[400px] text-xs">
                     <div className="text-gray-900 dark:text-gray-100">
                       {reference.span_id && (
                         <div className="mb-1">
@@ -280,14 +280,19 @@ const renderMarkdown = (
                       {reference.log_message && (
                         <div className="mb-1">
                           <span className="font-semibold">Log:</span>
-                          <div className="mt-1 p-2 bg-gray-100 dark:bg-gray-700 rounded text-xs font-mono">
+                          <div className="mt-1 p-2 bg-gray-100 dark:bg-zinc-700 rounded text-xs font-mono whitespace-pre-wrap max-h-40 overflow-auto">
                             {reference.log_message}
                           </div>
                         </div>
                       )}
                     </div>
                     {/* Tooltip arrow */}
-                    <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-gray-300 dark:border-t-gray-600"></div>
+                    <div
+                      className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0
+        border-l-4 border-r-4 border-t-4
+        border-l-transparent border-r-transparent
+        border-t-gray-300 dark:border-t-zinc-600"
+                    ></div>
                   </div>
                 </div>
               )}
@@ -402,7 +407,7 @@ const renderMarkdown = (
       component: (match: string, ...args: string[]) => (
         <code
           key={currentIndex++}
-          className="bg-gray-100 dark:bg-gray-600 px-1 py-0.5 rounded text-xs font-mono"
+          className="bg-gray-100 dark:bg-zinc-600 px-1 py-0.5 rounded text-xs font-mono"
         >
           {args[0]}
         </code>

--- a/ui/src/components/right-panel/agent/ChatMessage.tsx
+++ b/ui/src/components/right-panel/agent/ChatMessage.tsx
@@ -1,15 +1,15 @@
-import React, { useState } from "react";
-import { RiRobot2Line } from "react-icons/ri";
-import { GoCopy } from "react-icons/go";
-import { FaGithub } from "react-icons/fa";
-import { useUser } from "../../../hooks/useUser";
-import { Reference } from "../../../models/chat";
-import { Spinner } from "../../ui/shadcn-io/spinner";
+import React, { useState } from 'react';
+import { RiRobot2Line } from 'react-icons/ri';
+import { GoCopy } from 'react-icons/go';
+import { FaGithub } from 'react-icons/fa';
+import { useUser } from '../../../hooks/useUser';
+import { Reference } from '../../../models/chat';
+import { Spinner } from '../../ui/shadcn-io/spinner';
 
 interface Message {
   id: string;
   content: string;
-  role: "user" | "assistant" | "github";
+  role: 'user' | 'assistant' | 'github';
   timestamp: Date | string; // Allow both Date and string for formatted timestamps
   references?: Reference[];
 }
@@ -23,41 +23,41 @@ interface ChatMessageProps {
 
 // Helper function to format timestamp like in LogDetail
 const formatTimestamp = (timestamp: Date | string) => {
-  const date = typeof timestamp === "string" ? new Date(timestamp) : timestamp;
+  const date = typeof timestamp === 'string' ? new Date(timestamp) : timestamp;
   const months = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
   ];
 
   const y = date.getFullYear();
   const m = months[date.getMonth()];
   const d = date.getDate();
-  const h = String(date.getHours()).padStart(2, "0");
-  const min = String(date.getMinutes()).padStart(2, "0");
-  const s = String(date.getSeconds()).padStart(2, "0");
+  const h = String(date.getHours()).padStart(2, '0');
+  const min = String(date.getMinutes()).padStart(2, '0');
+  const s = String(date.getSeconds()).padStart(2, '0');
 
   // Add ordinal suffix to day
   const getOrdinalSuffix = (day: number) => {
-    if (day >= 11 && day <= 13) return "th";
+    if (day >= 11 && day <= 13) return 'th';
     switch (day % 10) {
       case 1:
-        return "st";
+        return 'st';
       case 2:
-        return "nd";
+        return 'nd';
       case 3:
-        return "rd";
+        return 'rd';
       default:
-        return "th";
+        return 'th';
     }
   };
 
@@ -67,18 +67,18 @@ const formatTimestamp = (timestamp: Date | string) => {
 // Helper function to get log level colors
 const getLogLevelColor = (level: string) => {
   switch (level) {
-    case "CRITICAL":
-      return "font-medium text-[#7f1d1d]";
-    case "ERROR":
-      return "font-medium text-[#dc2626]";
-    case "WARNING":
-      return "font-medium text-[#fb923c]";
-    case "INFO":
-      return "font-medium text-[#64748b]";
-    case "DEBUG":
-      return "font-medium text-[#a855f7]";
+    case 'CRITICAL':
+      return 'font-medium text-[#7f1d1d]';
+    case 'ERROR':
+      return 'font-medium text-[#dc2626]';
+    case 'WARNING':
+      return 'font-medium text-[#fb923c]';
+    case 'INFO':
+      return 'font-medium text-[#64748b]';
+    case 'DEBUG':
+      return 'font-medium text-[#a855f7]';
     default:
-      return "font-medium text-[#64748b]";
+      return 'font-medium text-[#64748b]';
   }
 };
 
@@ -88,11 +88,11 @@ const renderMarkdown = (
   messageId: string,
   references?: Reference[],
   hoveredRef?: { messageId: string; refNum: number } | null,
-  onReferenceHover?: (messageId: string, refNum: number | null) => void,
+  onReferenceHover?: (messageId: string, refNum: number | null) => void
 ): React.ReactNode => {
   let currentIndex = 0;
 
-  console.log("🔍 renderMarkdown called with text:", text);
+  console.log('🔍 renderMarkdown called with text:', text);
 
   // Patterns for markdown elements (order matters - code blocks should be processed first)
   const patterns = [
@@ -108,7 +108,7 @@ const renderMarkdown = (
 
         return (
           <span key={currentIndex++}>
-            PR created:{" "}
+            PR created:{' '}
             <a
               href={fullUrl}
               target="_blank"
@@ -134,7 +134,7 @@ const renderMarkdown = (
           try {
             await navigator.clipboard.writeText(trimmedContent);
           } catch (err) {
-            console.error("Failed to copy text: ", err);
+            console.error('Failed to copy text: ', err);
           }
         };
 
@@ -228,27 +228,27 @@ const renderMarkdown = (
 
         // Debug logging
         console.log(
-          "Reference pattern matched:",
+          'Reference pattern matched:',
           match,
-          "refNumber:",
+          'refNumber:',
           refNumber,
-          "reference found:",
+          'reference found:',
           !!reference,
-          "hoveredRef:",
-          hoveredRef,
+          'hoveredRef:',
+          hoveredRef
         );
-        console.log("Available references:", references);
+        console.log('Available references:', references);
 
         return (
           <span
             key={currentIndex++}
             className="relative inline-block cursor-help text-blue-600 dark:text-blue-400 font-medium underline hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
             onMouseEnter={() => {
-              console.log("Mouse enter on reference:", refNumber);
+              console.log('Mouse enter on reference:', refNumber);
               onReferenceHover?.(messageId, refNumber);
             }}
             onMouseLeave={() => {
-              console.log("Mouse leave on reference:", refNumber);
+              console.log('Mouse leave on reference:', refNumber);
               onReferenceHover?.(messageId, null);
             }}
           >
@@ -261,19 +261,19 @@ const renderMarkdown = (
                     <div className="text-gray-900 dark:text-gray-100">
                       {reference.span_id && (
                         <div className="mb-1">
-                          <span className="font-semibold">Span ID:</span>{" "}
+                          <span className="font-semibold">Span ID:</span>{' '}
                           {reference.span_id}
                         </div>
                       )}
                       {reference.span_function_name && (
                         <div className="mb-1">
-                          <span className="font-semibold">Function:</span>{" "}
+                          <span className="font-semibold">Function:</span>{' '}
                           {reference.span_function_name}
                         </div>
                       )}
                       {reference.line_number && (
                         <div className="mb-1">
-                          <span className="font-semibold">Line:</span>{" "}
+                          <span className="font-semibold">Line:</span>{' '}
                           {reference.line_number}
                         </div>
                       )}
@@ -330,7 +330,7 @@ const renderMarkdown = (
             messageId,
             references,
             hoveredRef,
-            onReferenceHover,
+            onReferenceHover
           )}
         </h3>
       ),
@@ -347,7 +347,7 @@ const renderMarkdown = (
             messageId,
             references,
             hoveredRef,
-            onReferenceHover,
+            onReferenceHover
           )}
         </h2>
       ),
@@ -364,7 +364,7 @@ const renderMarkdown = (
             messageId,
             references,
             hoveredRef,
-            onReferenceHover,
+            onReferenceHover
           )}
         </h1>
       ),
@@ -378,7 +378,7 @@ const renderMarkdown = (
             messageId,
             references,
             hoveredRef,
-            onReferenceHover,
+            onReferenceHover
           )}
         </strong>
       ),
@@ -392,7 +392,7 @@ const renderMarkdown = (
             messageId,
             references,
             hoveredRef,
-            onReferenceHover,
+            onReferenceHover
           )}
         </em>
       ),
@@ -423,12 +423,12 @@ const renderMarkdown = (
       const match = pattern.regex.exec(remainingText);
       if (match) {
         console.log(
-          "Pattern match found:",
+          'Pattern match found:',
           match[0],
-          "at index:",
+          'at index:',
           match.index,
-          "regex source:",
-          pattern.regex.source,
+          'regex source:',
+          pattern.regex.source
         );
       }
       if (match && match.index < earliestIndex) {
@@ -446,12 +446,12 @@ const renderMarkdown = (
 
       // Add the formatted element
       elements.push(
-        matchingPattern.component(earliestMatch[0], ...earliestMatch.slice(1)),
+        matchingPattern.component(earliestMatch[0], ...earliestMatch.slice(1))
       );
 
       // Update remaining text
       remainingText = remainingText.substring(
-        earliestIndex + earliestMatch[0].length,
+        earliestIndex + earliestMatch[0].length
       );
 
       // Reset regex lastIndex for next iteration
@@ -507,15 +507,15 @@ export default function ChatMessage({
         <div
           key={message.id}
           className={`flex ${
-            message.role === "user" ? "justify-end" : "justify-start"
+            message.role === 'user' ? 'justify-end' : 'justify-start'
           } mb-4 items-start gap-2`}
         >
           {/* Avatar for assistant and github */}
-          {(message.role === "assistant" || message.role === "github") && (
+          {(message.role === 'assistant' || message.role === 'github') && (
             <div
               className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 bg-zinc-600 dark:bg-zinc-200 border border-zinc-600 dark:border-zinc-200`}
             >
-              {message.role === "github" ? (
+              {message.role === 'github' ? (
                 <FaGithub className="w-5 h-5 text-white dark:text-zinc-600" />
               ) : (
                 <RiRobot2Line className="w-5 h-5 text-white dark:text-zinc-600" />
@@ -526,11 +526,11 @@ export default function ChatMessage({
           {/* Message content */}
           <div
             className={`max-w-[70%] max-w-[600px] rounded-lg px-4 py-2 break-words ${
-              message.role === "user"
-                ? "bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 border border-zinc-300 dark:border-zinc-700"
-                : message.role === "github"
-                  ? "bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 border border-zinc-300 dark:border-zinc-700"
-                  : "bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 border border-zinc-300 dark:border-zinc-700"
+              message.role === 'user'
+                ? 'bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 border border-zinc-300 dark:border-zinc-700'
+                : message.role === 'github'
+                  ? 'bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 border border-zinc-300 dark:border-zinc-700'
+                  : 'bg-white dark:bg-zinc-900 text-zinc-800 dark:text-zinc-200 border border-zinc-300 dark:border-zinc-700'
             }`}
           >
             <div className="whitespace-pre-wrap break-words text-sm">
@@ -539,7 +539,7 @@ export default function ChatMessage({
                 message.id,
                 message.references,
                 hoveredRef,
-                handleReferenceHover,
+                handleReferenceHover
               )}
             </div>
             <p className="text-xs mt-1 opacity-70">
@@ -548,7 +548,7 @@ export default function ChatMessage({
           </div>
 
           {/* Avatar for user */}
-          {message.role === "user" && (
+          {message.role === 'user' && (
             <div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0">
               {userAvatarUrl ? (
                 <img
@@ -559,7 +559,7 @@ export default function ChatMessage({
               ) : (
                 <div className="w-full h-full bg-sidebar-accent/50 flex items-center justify-center bg-zinc-200 dark:bg-zinc-800">
                   <span className="text-sidebar-accent-foreground font-semibold text-sm">
-                    {avatarLetter || "U"}
+                    {avatarLetter || 'U'}
                   </span>
                 </div>
               )}


### PR DESCRIPTION
# Tooltip & Log Message Fix in ChatMessage

## Overview
While rendering **log message tooltips** in `ChatMessage`, we noticed that very large log messages were **overflowing** and breaking the layout.  

During the fix, we also discovered that the tooltip disappeared immediately when hovering from the reference number `[1]` into the tooltip (due to `onMouseLeave` firing too early). Both issues have now been fixed.

---

## Fixes Applied

### 1. Proper Overflow Handling for Log Messages
Large log messages are now **scrollable inside the tooltip** instead of expanding infinitely.

```tsx
{reference.log_message && (
  <div className="mb-1">
    <span className="font-semibold">Log:</span>
    <div className="mt-1 p-2 bg-gray-100 dark:bg-zinc-700 rounded text-xs font-mono whitespace-pre-wrap max-h-40 overflow-auto">
      {reference.log_message}
    </div>
  </div>
)}
```

**Key changes:**
- `max-h-40` → restricts tooltip height to avoid breaking layout.
- `overflow-auto` → enables scrolling for large log messages.
- `whitespace-pre-wrap` + `font-mono` → preserves formatting and readability.

---

### 2. Fixed Tooltip Hover Behavior
The tooltip was disappearing immediately when moving from the reference number into the tooltip.  

This happened because the tooltip was positioned absolutely **outside the reference span’s bounding box**, causing `onMouseLeave` to trigger too soon.

**Solution:**  
We now wrap both the **reference number** and the **tooltip** inside a single `relative` container, so the tooltip remains part of the hover target.

```tsx
<span
  className="relative inline-block cursor-help text-blue-600 dark:text-blue-400 font-medium underline hover:text-blue-800 dark:hover:text-blue-300 transition-colors"
  onMouseEnter={() => onReferenceHover?.(messageId, refNumber)}
  onMouseLeave={() => onReferenceHover?.(messageId, null)}
>
  {match}

  {hoveredRef?.messageId === messageId &&
    hoveredRef?.refNum === refNumber &&
    reference && (
      <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-[9999]">
        <div className="bg-white dark:bg-zinc-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg p-3 min-w-[200px] max-w-[400px] text-xs">
          {/* Reference details */}
        </div>
      </div>
    )}
</span>
```

---

## Why This Matters
- **Large logs** no longer overflow or break the UI.
- **Tooltips** stay open while hovering into them (no flicker).
- **Readability** is improved with scrollable, pre-wrapped, monospaced log content.

---

## Fixes: #118 

## screenshots
- 
<img width="860" height="488" alt="image" src="https://github.com/user-attachments/assets/bd9baba7-bacf-43d2-85b4-85c95945f527" />



