### PR TITLE
changes for updating the docs of python sdk

### DIFF
--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -1,46 +1,67 @@
 # Python SDK for TraceRoot
 
 ## Introduction
-This SDK is a lightweight wrapper around OpenTelemetry, optimized for ease of use.
 
+The [TraceRoot Python SDK](https://pypi.org/project/traceroot) is a lightweight wrapper around OpenTelemetry, optimized for ease of use.
 
 ## Installation
+
 ```bash
 pip install traceroot
 ```
 
 ## Environment Setup
 
-Create an [TraceRoot token](https://test.traceroot.ai/integrate) from the dashboard, and add it to your backend `.env` file.
+Create a [TraceRoot token](https://test.traceroot.ai/integrate) from the dashboard.
+
+### Recommended: Use environment variables directly
+
+Set the required variables in your shell or deployment environment:
+
+```bash
+export TRACEROOT_TOKEN="traceroot-430246"
+export TRACEROOT_SERVICE_NAME="traceroot"
+export TRACEROOT_GITHUB_OWNER="github_owner"
+export TRACEROOT_GITHUB_REPO_NAME="github_repo_name"
+export TRACEROOT_GITHUB_COMMIT_HASH="main"
+export TRACEROOT_ENABLE_SPAN_CLOUD_EXPORT=true
+export TRACEROOT_ENABLE_LOG_CLOUD_EXPORT=true
+export TRACEROOT_ENABLE_SPAN_CONSOLE_EXPORT=false
+export TRACEROOT_ENABLE_LOG_CONSOLE_EXPORT=true
+export TRACEROOT_LOCAL_MODE=true
+```
+
+### Optional: Using a `.env` file
+
+If you prefer to keep variables in a `.env` file for local development, you must **load it manually** in Python (the SDK does not auto-load `.env`):
 
 ```bash .env
-# The token for the TraceRoot API
 TRACEROOT_TOKEN=traceroot-430246
-
-# The name of the service you are tracking
 TRACEROOT_SERVICE_NAME=traceroot
-
-# The owner of the GitHub repository
 TRACEROOT_GITHUB_OWNER=github_owner
-
-# The name of the GitHub repository
 TRACEROOT_GITHUB_REPO_NAME=github_repo_name
-
-# The commit hash of the GitHub repository
 TRACEROOT_GITHUB_COMMIT_HASH=main
-
-# Enable cloud export of spans (default: `true`)
 TRACEROOT_ENABLE_SPAN_CLOUD_EXPORT=true
-
-# Enable cloud export of logs (default: `true`)
 TRACEROOT_ENABLE_LOG_CLOUD_EXPORT=true
-
-# Enable console export of spans (default: `false`)
 TRACEROOT_ENABLE_SPAN_CONSOLE_EXPORT=false
-
-# Enable console export of logs (default: `true`)
 TRACEROOT_ENABLE_LOG_CONSOLE_EXPORT=true
 ```
+
+Then load it in your code:
+
+```python
+from dotenv import load_dotenv
+import os
+import traceroot
+
+load_dotenv()  # load variables from .env into os.environ
+traceroot.init()
+
+```
+
+> ⚠️ Note: Just creating a `.env` file is not enough—you need to explicitly call `load_dotenv()` and `traceroot.init()` or set variables in your shell.
+
+---
 
 ## Examples
 
@@ -70,6 +91,7 @@ if __name__ == "__main__":
 ```
 
 ## Development Installation
+
 If you want to contribute or use the latest features, install from source:
 
 ```bash

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -12,7 +12,7 @@ pip install traceroot
 
 ## Environment Setup
 
-Create a [TraceRoot token](https://test.traceroot.ai/integrate) from the dashboard.
+Create a [TraceRoot token](https://test.traceroot.ai/integrate) from the dashboard, and add it to your backend `.env` file.
 
 ```bash .env
 # The token for the TraceRoot API
@@ -24,7 +24,7 @@ TRACEROOT_SERVICE_NAME=traceroot
 # The owner of the GitHub repository
 TRACEROOT_GITHUB_OWNER=github_owner
 
-# # The name of the GitHub repository
+# The name of the GitHub repository
 TRACEROOT_GITHUB_REPO_NAME=github_repo_name
 
 # The commit hash of the GitHub repository

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -14,54 +14,44 @@ pip install traceroot
 
 Create a [TraceRoot token](https://test.traceroot.ai/integrate) from the dashboard.
 
-### Recommended: Use environment variables directly
-
-Set the required variables in your shell or deployment environment:
-
-```bash
-export TRACEROOT_TOKEN="traceroot-430246"
-export TRACEROOT_SERVICE_NAME="traceroot"
-export TRACEROOT_GITHUB_OWNER="github_owner"
-export TRACEROOT_GITHUB_REPO_NAME="github_repo_name"
-export TRACEROOT_GITHUB_COMMIT_HASH="main"
-export TRACEROOT_ENABLE_SPAN_CLOUD_EXPORT=true
-export TRACEROOT_ENABLE_LOG_CLOUD_EXPORT=true
-export TRACEROOT_ENABLE_SPAN_CONSOLE_EXPORT=false
-export TRACEROOT_ENABLE_LOG_CONSOLE_EXPORT=true
-export TRACEROOT_LOCAL_MODE=true
-```
-
-### Optional: Using a `.env` file
-
-If you prefer to keep variables in a `.env` file for local development, you must **load it manually** in Python (the SDK does not auto-load `.env`):
-
 ```bash .env
+# The token for the TraceRoot API
 TRACEROOT_TOKEN=traceroot-430246
+
+# The name of the service you are tracking
 TRACEROOT_SERVICE_NAME=traceroot
+
+# The owner of the GitHub repository
 TRACEROOT_GITHUB_OWNER=github_owner
+
+# # The name of the GitHub repository
 TRACEROOT_GITHUB_REPO_NAME=github_repo_name
+
+# The commit hash of the GitHub repository
 TRACEROOT_GITHUB_COMMIT_HASH=main
+
+# Enable cloud export of spans (default: `true`)
 TRACEROOT_ENABLE_SPAN_CLOUD_EXPORT=true
+
+# Enable cloud export of logs (default: `true`)
 TRACEROOT_ENABLE_LOG_CLOUD_EXPORT=true
+
+# Enable console export of spans (default: `false`)
 TRACEROOT_ENABLE_SPAN_CONSOLE_EXPORT=false
+
+# Enable console export of logs (default: `true`)
 TRACEROOT_ENABLE_LOG_CONSOLE_EXPORT=true
 ```
 
-Then load it in your code:
+Then run
 
 ```python
 from dotenv import load_dotenv
-import os
 import traceroot
 
 load_dotenv()  # load variables from .env into os.environ
 traceroot.init()
-
 ```
-
-> ⚠️ Note: Just creating a `.env` file is not enough—you need to explicitly call `load_dotenv()` and `traceroot.init()` or set variables in your shell.
-
----
 
 ## Examples
 

--- a/docs/sdk/python.mdx
+++ b/docs/sdk/python.mdx
@@ -1,46 +1,67 @@
 # Python SDK for TraceRoot
 
 ## Introduction
+
 The [TraceRoot Python SDK](https://pypi.org/project/traceroot) is a lightweight wrapper around OpenTelemetry, optimized for ease of use.
 
-
 ## Installation
+
 ```bash
 pip install traceroot
 ```
 
 ## Environment Setup
 
-Create an [TraceRoot token](https://test.traceroot.ai/integrate) from the dashboard, and add it to your backend `.env` file.
+Create a [TraceRoot token](https://test.traceroot.ai/integrate) from the dashboard.
+
+### Recommended: Use environment variables directly
+
+Set the required variables in your shell or deployment environment:
+
+```bash
+export TRACEROOT_TOKEN="traceroot-430246"
+export TRACEROOT_SERVICE_NAME="traceroot"
+export TRACEROOT_GITHUB_OWNER="github_owner"
+export TRACEROOT_GITHUB_REPO_NAME="github_repo_name"
+export TRACEROOT_GITHUB_COMMIT_HASH="main"
+export TRACEROOT_ENABLE_SPAN_CLOUD_EXPORT=true
+export TRACEROOT_ENABLE_LOG_CLOUD_EXPORT=true
+export TRACEROOT_ENABLE_SPAN_CONSOLE_EXPORT=false
+export TRACEROOT_ENABLE_LOG_CONSOLE_EXPORT=true
+export TRACEROOT_LOCAL_MODE=true
+```
+
+### Optional: Using a `.env` file
+
+If you prefer to keep variables in a `.env` file for local development, you must **load it manually** in Python (the SDK does not auto-load `.env`):
 
 ```bash .env
-# The token for the TraceRoot API
 TRACEROOT_TOKEN=traceroot-430246
-
-# The name of the service you are tracking
 TRACEROOT_SERVICE_NAME=traceroot
-
-# The owner of the GitHub repository
 TRACEROOT_GITHUB_OWNER=github_owner
-
-# The name of the GitHub repository
 TRACEROOT_GITHUB_REPO_NAME=github_repo_name
-
-# The commit hash of the GitHub repository
 TRACEROOT_GITHUB_COMMIT_HASH=main
-
-# Enable cloud export of spans (default: `true`)
 TRACEROOT_ENABLE_SPAN_CLOUD_EXPORT=true
-
-# Enable cloud export of logs (default: `true`)
 TRACEROOT_ENABLE_LOG_CLOUD_EXPORT=true
-
-# Enable console export of spans (default: `false`)
 TRACEROOT_ENABLE_SPAN_CONSOLE_EXPORT=false
-
-# Enable console export of logs (default: `true`)
 TRACEROOT_ENABLE_LOG_CONSOLE_EXPORT=true
 ```
+
+Then load it in your code:
+
+```python
+from dotenv import load_dotenv
+import os
+import traceroot
+
+load_dotenv()  # load variables from .env into os.environ
+traceroot.init()
+
+```
+
+> ⚠️ Note: Just creating a `.env` file is not enough—you need to explicitly call `load_dotenv()` and `traceroot.init()` or set variables in your shell.
+
+---
 
 ## Examples
 
@@ -70,6 +91,7 @@ if __name__ == "__main__":
 ```
 
 ## Development Installation
+
 If you want to contribute or use the latest features, install from source:
 
 ```bash


### PR DESCRIPTION
# 📖 Documentation Update: Clarify Environment Setup in Python SDK

## Summary
This PR updates the **Python SDK documentation** to resolve confusion around environment setup.  
Previously, the docs implied that simply creating a `.env` file would work out-of-the-box. However, Python does **not** auto-load `.env` files, which led to misleading expectations.  

## Changes
- Updated **Environment Setup** section:
  - **Recommended**: use environment variables directly (`export ...`).
  - **Optional**: `.env` file support, but requires manual loading with `python-dotenv`.
- Added example code showing how to use:
  ```python
  from dotenv import load_dotenv
  load_dotenv()  # manually load .env
  traceroot.init()
  ```
- Added warnings and clarification notes to prevent incorrect assumptions.
- Kept existing examples intact, only adjusted configuration instructions.

## Motivation
- Aligns with maintainer feedback ([discussion in PR #65](https://github.com/traceroot-ai/traceroot-sdk/pull/65)) that `.env` files should not be assumed to load automatically.
- Matches the broader recommendation across Traceroot and Langfuse: **use environment variables as the default**, with `.env` optional for local development.

## Testing
- Verified `.env` works correctly when loaded with `python-dotenv`.
- Confirmed SDK functions with environment variables exported directly in shell.

## Next Steps
- For now, this PR ensures the docs are accurate and user-friendly.


## Fixes: #157  