### PR TITLE
bug: Modify pyproject.toml

### DIFF
--- a/examples/distributed_services/multi_code_agent/code_agent.py
+++ b/examples/distributed_services/multi_code_agent/code_agent.py
@@ -1,8 +1,7 @@
+import traceroot
 from dotenv import load_dotenv
 from langchain.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
-
-import traceroot
 
 load_dotenv()
 

--- a/examples/distributed_services/multi_code_agent/main.py
+++ b/examples/distributed_services/multi_code_agent/main.py
@@ -1,14 +1,13 @@
 import os
 from typing import Any, TypedDict
 
+import traceroot
 from code_agent import create_code_agent
 from dotenv import load_dotenv
 from execution_agent import create_execution_agent
 from langgraph.graph import END, StateGraph
 from plan_agent import create_plan_agent
 from summarize_agent import create_summarize_agent
-
-import traceroot
 
 load_dotenv()
 

--- a/examples/distributed_services/multi_code_agent/plan_agent.py
+++ b/examples/distributed_services/multi_code_agent/plan_agent.py
@@ -1,11 +1,10 @@
 from typing import Any, Optional
 
+import traceroot
 from dotenv import load_dotenv
 from langchain.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, Field
-
-import traceroot
 
 load_dotenv()
 

--- a/examples/distributed_services/multi_code_agent/rest/code_agent.py
+++ b/examples/distributed_services/multi_code_agent/rest/code_agent.py
@@ -1,8 +1,7 @@
+import traceroot
 from dotenv import load_dotenv
 from langchain.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
-
-import traceroot
 
 load_dotenv()
 

--- a/examples/distributed_services/multi_code_agent/rest/main.py
+++ b/examples/distributed_services/multi_code_agent/rest/main.py
@@ -1,10 +1,10 @@
 import os
 from typing import Any, TypedDict
 
+import traceroot
 from dotenv import load_dotenv
 from langgraph.graph import END, StateGraph
 
-import traceroot
 from rest.code_agent import create_code_agent
 from rest.execution_agent import create_execution_agent
 from rest.plan_agent import create_plan_agent

--- a/examples/distributed_services/multi_code_agent/rest/plan_agent.py
+++ b/examples/distributed_services/multi_code_agent/rest/plan_agent.py
@@ -1,11 +1,10 @@
 from typing import Any, Optional
 
+import traceroot
 from dotenv import load_dotenv
 from langchain.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, Field
-
-import traceroot
 
 load_dotenv()
 

--- a/examples/distributed_services/multi_code_agent/rest/summarize_agent.py
+++ b/examples/distributed_services/multi_code_agent/rest/summarize_agent.py
@@ -1,10 +1,9 @@
 from typing import Any, Dict
 
+import traceroot
 from dotenv import load_dotenv
 from langchain.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
-
-import traceroot
 
 load_dotenv()
 

--- a/examples/distributed_services/multi_code_agent/simple_server.py
+++ b/examples/distributed_services/multi_code_agent/simple_server.py
@@ -1,14 +1,14 @@
 import os
 from typing import Dict
 
+import traceroot
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-
-import traceroot
-from rest.main import MultiAgentSystem
 from traceroot.integrations.fastapi import connect_fastapi
 from traceroot.logger import get_logger
+
+from rest.main import MultiAgentSystem
 
 logger = get_logger()
 

--- a/examples/distributed_services/multi_code_agent/summarize_agent.py
+++ b/examples/distributed_services/multi_code_agent/summarize_agent.py
@@ -1,10 +1,9 @@
 from typing import Any, Dict
 
+import traceroot
 from dotenv import load_dotenv
 from langchain.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
-
-import traceroot
 
 load_dotenv()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 90
+known_third_party = ["traceroot"]
 
 [tool.flake8]
 max-line-length = 90


### PR DESCRIPTION
Add
```
known_third_party = ["traceroot"]
```
which ensures that when isort organizes imports, it will put import `traceroot` in the third-party imports block, not with project’s own modules.