### PR TITLE
logic update for the generate button

### DIFF
--- a/ui/src/components/integrate/Item.tsx
+++ b/ui/src/components/integrate/Item.tsx
@@ -466,7 +466,7 @@ export default function Item({ integration, onUpdateIntegration }: ItemProps) {
             {integration.id === "traceroot" ? (
               <Button
                 onClick={handleGenerateToken}
-                disabled={isLoading}
+                disabled={isLoading || displayToken !== ""}
                 variant="default"
                 size="sm"
                 className="flex-1"


### PR DESCRIPTION
# PR: Disable Generate Button When Token Exists

## Fixes
- Updated the `Generate` button to remain disabled if:
  - The token is already generated (`displayToken` is not an empty string).
  - OR the token generation process is still loading (`isLoading` is true).
- Prevents users from generating multiple tokens unnecessarily.

### Code Changes
```tsx
<Button
  onClick={handleGenerateToken}
  disabled={isLoading || displayToken !== ""}
  variant="default"
  size="sm"
  className="flex-1"
>
  {isLoading ? "Generating..." : "Generate"}
</Button>

```

---

## screenshot
- 
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/89db0040-11bd-4d78-ad51-6911e90f52f5" />

---
## Fixes: #167 