### PR TITLE
fix: allow click settings when payment false and fix keep autumn calling bug

### DIFF
--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -24,6 +24,22 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  // Check if payment/subscription features should be disabled for local development
+  const isPaymentDisabled = process.env.NEXT_PUBLIC_DISABLE_PAYMENT === "true";
+
+  // Core app content that's wrapped differently based on payment settings
+  const AppContent = () => (
+    <AuthGuard>
+      <SubscriptionGuard>
+        {/* Make sidebar collapsed by default */}
+        <SidebarProvider defaultOpen={false}>
+          <AppSidebar />
+          <SidebarInset>{children}</SidebarInset>
+        </SidebarProvider>
+      </SubscriptionGuard>
+    </AuthGuard>
+  );
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.className} h-screen overflow-hidden`}>
@@ -33,47 +49,46 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          <AutumnProvider includeCredentials={true}>
-            <AuthGuard>
-              <SubscriptionGuard>
-                {/* Make it false by default */}
-                <SidebarProvider defaultOpen={false}>
-                  <AppSidebar />
-                  <SidebarInset>{children}</SidebarInset>
-                </SidebarProvider>
-              </SubscriptionGuard>
-            </AuthGuard>
-            <Toaster
-              position="top-right"
-              toastOptions={{
-                duration: 4000,
-                style: {
-                  background: "#363636",
-                  color: "#fff",
+          {/* Conditionally wrap with AutumnProvider only when payment is enabled */}
+          {isPaymentDisabled ? (
+            // Local development mode - no subscription/payment features
+            <AppContent />
+          ) : (
+            // Production mode - full subscription/payment features enabled
+            <AutumnProvider includeCredentials={true}>
+              <AppContent />
+            </AutumnProvider>
+          )}
+          <Toaster
+            position="top-right"
+            toastOptions={{
+              duration: 4000,
+              style: {
+                background: "#363636",
+                color: "#fff",
+              },
+              success: {
+                duration: 3000,
+                iconTheme: {
+                  primary: "#4ade80",
+                  secondary: "#fff",
                 },
-                success: {
-                  duration: 3000,
-                  iconTheme: {
-                    primary: "#4ade80",
-                    secondary: "#fff",
-                  },
+              },
+              error: {
+                duration: 5000,
+                iconTheme: {
+                  primary: "#ef4444",
+                  secondary: "#fff",
                 },
-                error: {
-                  duration: 5000,
-                  iconTheme: {
-                    primary: "#ef4444",
-                    secondary: "#fff",
-                  },
+              },
+              loading: {
+                iconTheme: {
+                  primary: "#3b82f6",
+                  secondary: "#fff",
                 },
-                loading: {
-                  iconTheme: {
-                    primary: "#3b82f6",
-                    secondary: "#fff",
-                  },
-                },
-              }}
-            />
-          </AutumnProvider>
+              },
+            }}
+          />
         </ThemeProvider>
       </body>
     </html>

--- a/ui/src/components/side-bar/Sidebar.tsx
+++ b/ui/src/components/side-bar/Sidebar.tsx
@@ -300,42 +300,21 @@ function DocumentationComponent() {
 function SettingsComponent() {
   const { state } = useSidebar();
   const pathname = usePathname();
-  const { hasActiveSubscription } = useSubscription();
-
-  // Disable settings when payment is disabled or no active subscription
-  const DISABLE_PAYMENT = process.env.NEXT_PUBLIC_DISABLE_PAYMENT === "true";
-  const isDisabled = DISABLE_PAYMENT || !hasActiveSubscription;
 
   return (
     <SidebarMenuButton
-      asChild={!isDisabled}
+      asChild
       isActive={pathname === "/settings"}
-      tooltip={
-        isDisabled
-          ? DISABLE_PAYMENT
-            ? "Settings disabled in local mode"
-            : "Select a plan to access settings"
-          : "Settings"
-      }
-      className={`flex items-center rounded-md p-2 mb-1 ${state === "collapsed" ? "!justify-center" : "!justify-start gap-1"} ${isDisabled ? "opacity-50 cursor-not-allowed" : ""}`}
-      disabled={isDisabled}
+      tooltip="Settings"
+      className={`flex items-center rounded-md p-2 mb-1 ${state === "collapsed" ? "!justify-center" : "!justify-start gap-1"}`}
     >
-      {isDisabled ? (
-        <div
-          className={`flex items-center w-full ${state === "collapsed" ? "justify-center" : "justify-start gap-1"}`}
-        >
-          <Settings className="!w-5.5 !h-5.5 flex-shrink-0" />
-          {state === "expanded" && <span>Settings</span>}
-        </div>
-      ) : (
-        <Link
-          href="/settings"
-          className={`flex items-center w-full ${state === "collapsed" ? "justify-center" : "justify-start gap-1"}`}
-        >
-          <Settings className="!w-5.5 !h-5.5 flex-shrink-0" />
-          {state === "expanded" && <span>Settings</span>}
-        </Link>
-      )}
+      <Link
+        href="/settings"
+        className={`flex items-center w-full ${state === "collapsed" ? "justify-center" : "justify-start gap-1"}`}
+      >
+        <Settings className="!w-5.5 !h-5.5 flex-shrink-0" />
+        {state === "expanded" && <span>Settings</span>}
+      </Link>
     </SidebarMenuButton>
   );
 }


### PR DESCRIPTION
fix: allow click settings when payment false and fix keep autumn calling bug

## Summary

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
