### PR TITLE
feat: add settings page with different tabs

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,8 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-hover-card": "^1.1.15",
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",

--- a/ui/src/app/settings/page.tsx
+++ b/ui/src/app/settings/page.tsx
@@ -1,14 +1,11 @@
 "use client";
 
 import React from "react";
-import { LocalSettingsContainer } from "@/components/settings/LocalSettingsContainer";
 import { SettingsContainer } from "@/components/settings/SettingsContainer";
 
-const DISABLE_PAYMENT = process.env.NEXT_PUBLIC_DISABLE_PAYMENT === "true";
-
 /**
- * Wrapper: choose Local mock (no Autumn) vs Prod (Autumn).
+ * Settings page - now uses unified SettingsContainer that handles both local and production modes.
  */
 export default function SettingsPage() {
-  return DISABLE_PAYMENT ? <LocalSettingsContainer /> : <SettingsContainer />;
+  return <SettingsContainer />;
 }

--- a/ui/src/components/explore/SearchBar.tsx
+++ b/ui/src/components/explore/SearchBar.tsx
@@ -5,6 +5,9 @@ import { IoMdClose } from "react-icons/io";
 import { TbCategory } from "react-icons/tb";
 import { LuSquareEqual } from "react-icons/lu";
 import { ChevronDownIcon } from "lucide-react";
+import { FaAws } from "react-icons/fa";
+import { BsTencentQq } from "react-icons/bs";
+import { SiJaeger } from "react-icons/si";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -20,6 +23,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useCloudProvider } from "@/hooks/useCloudProvider";
 
 export interface SearchCriterion {
   id: string;
@@ -58,6 +62,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
   onMetadataSearchTermsChange,
   disabled = false,
 }) => {
+  const { selectedProvider } = useCloudProvider();
   const [criteria, setCriteria] = useState<SearchCriterion[]>([]);
   const [isExpanded, setIsExpanded] = useState(false);
   const [currentCriterion, setCurrentCriterion] = useState<
@@ -176,8 +181,26 @@ const SearchBar: React.FC<SearchBarProps> = ({
     return OPERATIONS.find((op) => op.value === value)?.label || value;
   };
 
+  const getProviderIcon = () => {
+    switch (selectedProvider) {
+      case "aws":
+        return <FaAws size={20} className="text-foreground" />;
+      case "tencent":
+        return <BsTencentQq size={20} className="text-foreground" />;
+      case "jaeger":
+        return <SiJaeger size={20} className="text-foreground" />;
+      default:
+        return <FaAws size={20} className="text-foreground" />;
+    }
+  };
+
   return (
     <div className="relative flex items-start gap-2 justify-start">
+      {/* Provider Icon */}
+      <div className="h-[2.5rem] w-[2.5rem] border border-input rounded-md bg-background flex items-center justify-center shrink-0">
+        {getProviderIcon()}
+      </div>
+
       <div
         className={`flex flex-col gap-2 px-2 py-1 border rounded-md transition-all duration-200 min-h-[2rem] max-h-[10rem] ${criteria.length === 0 ? "justify-center" : ""} w-auto max-w-md ${disabled ? "opacity-50 pointer-events-none" : ""}`}
         onClick={() => !disabled && setIsExpanded(true)}

--- a/ui/src/components/settings/AccountActionsCard.tsx
+++ b/ui/src/components/settings/AccountActionsCard.tsx
@@ -31,9 +31,7 @@ export function AccountActionsCard({
         <div className="flex items-center space-x-2.5">
           <FaCreditCard className="text-foreground" size={24} />
           <div className="flex-1 min-w-0">
-            <CardTitle className="text-sm font-semibold">
-              Account Actions
-            </CardTitle>
+            <CardTitle className="text-sm font-semibold">MANAGE</CardTitle>
             <CardDescription className="text-xs">
               Manage your subscription and billing
             </CardDescription>
@@ -77,9 +75,7 @@ export function LocalAccountActionsCard() {
         <div className="flex items-center space-x-2.5">
           <FaCreditCard className="text-foreground" size={24} />
           <div className="flex-1 min-w-0">
-            <CardTitle className="text-base font-semibold">
-              Account Actions
-            </CardTitle>
+            <CardTitle className="text-base font-semibold">MANAGE</CardTitle>
             <CardDescription className="text-sm">
               Manage subscription and billing
             </CardDescription>

--- a/ui/src/components/settings/CloudProviderTabContent.tsx
+++ b/ui/src/components/settings/CloudProviderTabContent.tsx
@@ -1,0 +1,258 @@
+import React, { useState, useEffect } from "react";
+import { Cloud } from "lucide-react";
+import { FaAws } from "react-icons/fa";
+import { BsTencentQq } from "react-icons/bs";
+import { SiJaeger } from "react-icons/si";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type CloudProvider = "aws" | "tencent" | "jaeger";
+
+export function CloudProviderTabContent() {
+  const [selectedProvider, setSelectedProvider] =
+    useState<CloudProvider>("aws");
+  const [awsRegion, setAwsRegion] = useState("us-west-2");
+  const [tencentRegion, setTencentRegion] = useState("ap-hongkong");
+  const [tencentSecretId, setTencentSecretId] = useState("");
+  const [tencentSecretKey, setTencentSecretKey] = useState("");
+  const [tencentTraceToken, setTencentTraceToken] = useState("");
+  const [jaegerEndpoint, setJaegerEndpoint] = useState("");
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Load saved data from localStorage on component mount
+  useEffect(() => {
+    const savedData = localStorage.getItem("cloudProviderSettings");
+    if (savedData) {
+      try {
+        const parsedData = JSON.parse(savedData);
+        console.log("Loading saved settings:", parsedData); // Debug log
+        setSelectedProvider(parsedData.selectedProvider || "aws");
+        setAwsRegion(parsedData.awsRegion || "us-west-2");
+        setTencentRegion(parsedData.tencentRegion || "ap-hongkong");
+        setTencentSecretId(parsedData.tencentSecretId || "");
+        setTencentSecretKey(parsedData.tencentSecretKey || "");
+        setTencentTraceToken(parsedData.tencentTraceToken || "");
+        setJaegerEndpoint(parsedData.jaegerEndpoint || "");
+      } catch (error) {
+        console.error("Error parsing saved cloud provider settings:", error);
+      }
+    }
+    setIsLoaded(true);
+  }, []);
+
+  // Save data to localStorage whenever any setting changes (but only after initial load)
+  useEffect(() => {
+    if (!isLoaded) return; // Don't save during initial load
+
+    const settingsData = {
+      selectedProvider,
+      awsRegion,
+      tencentRegion,
+      tencentSecretId,
+      tencentSecretKey,
+      tencentTraceToken,
+      jaegerEndpoint,
+    };
+    console.log("Saving settings:", settingsData); // Debug log
+    localStorage.setItem("cloudProviderSettings", JSON.stringify(settingsData));
+  }, [
+    isLoaded,
+    selectedProvider,
+    awsRegion,
+    tencentRegion,
+    tencentSecretId,
+    tencentSecretKey,
+    tencentTraceToken,
+    jaegerEndpoint,
+  ]);
+
+  const providers = [
+    {
+      value: "aws" as const,
+      label: "Amazon Web Services",
+      icon: FaAws,
+    },
+    {
+      value: "tencent" as const,
+      label: "Tencent Cloud",
+      icon: BsTencentQq,
+    },
+    {
+      value: "jaeger" as const,
+      label: "Jaeger",
+      icon: SiJaeger,
+    },
+  ];
+
+  const tencentRegions = [
+    { value: "ap-hongkong", label: "Hong Kong (ap-hongkong)" },
+    { value: "ap-beijing", label: "Beijing (ap-beijing)" },
+    { value: "ap-shanghai", label: "Shanghai (ap-shanghai)" },
+    { value: "ap-guangzhou", label: "Guangzhou (ap-guangzhou)" },
+    { value: "ap-singapore", label: "Singapore (ap-singapore)" },
+  ];
+
+  return (
+    <div className="flex-1 p-6">
+      <div className="mb-6">
+        <h2 className="text-2xl font-semibold mb-2 flex items-center space-x-2">
+          <span>Cloud Provider</span>
+        </h2>
+        <p className="text-muted-foreground">
+          Configure your cloud service provider settings for tracing and
+          monitoring.
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <Card>
+          <CardContent className="space-y-6">
+            <div className="space-y-2">
+              <Label
+                htmlFor="provider-select"
+                className="text-lg font-medium flex items-center space-x-0.5"
+              >
+                <Cloud size={20} />
+                <span>Selected Provider</span>
+              </Label>
+              <Select
+                value={selectedProvider}
+                onValueChange={(value: CloudProvider) =>
+                  setSelectedProvider(value)
+                }
+              >
+                <SelectTrigger id="provider-select">
+                  <SelectValue placeholder="Select a cloud provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  {providers.map((provider) => {
+                    const Icon = provider.icon;
+                    return (
+                      <SelectItem key={provider.value} value={provider.value}>
+                        <div className="flex items-center space-x-2">
+                          <Icon size={18} />
+                          <span>{provider.label}</span>
+                        </div>
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {selectedProvider === "aws" && (
+              <div className="space-y-4 border-t pt-4">
+                <h3 className="text-lg font-medium flex items-center space-x-2">
+                  <FaAws size={20} />
+                  <span>Amazon Web Services Configuration</span>
+                </h3>
+                <div className="space-y-2">
+                  <Label htmlFor="aws-region">Region</Label>
+                  <Select value={awsRegion} onValueChange={setAwsRegion}>
+                    <SelectTrigger id="aws-region">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="us-west-2">
+                        US West 2 (Oregon)
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            )}
+
+            {selectedProvider === "tencent" && (
+              <div className="space-y-4 border-t pt-4">
+                <h3 className="text-lg font-medium flex items-center space-x-2">
+                  <BsTencentQq size={20} />
+                  <span>Tencent Cloud Configuration</span>
+                </h3>
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="tencent-region">Region</Label>
+                    <Select
+                      value={tencentRegion}
+                      onValueChange={setTencentRegion}
+                    >
+                      <SelectTrigger id="tencent-region">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {tencentRegions.map((region) => (
+                          <SelectItem key={region.value} value={region.value}>
+                            {region.label}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="tencent-secret-id">Secret ID</Label>
+                    <Input
+                      id="tencent-secret-id"
+                      type="text"
+                      placeholder="Enter your Secret ID"
+                      value={tencentSecretId}
+                      onChange={(e) => setTencentSecretId(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="tencent-secret-key">Secret Key</Label>
+                    <Input
+                      id="tencent-secret-key"
+                      type="password"
+                      placeholder="Enter your Secret Key"
+                      value={tencentSecretKey}
+                      onChange={(e) => setTencentSecretKey(e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="tencent-trace-token">Trace Token</Label>
+                    <Input
+                      id="tencent-trace-token"
+                      type="text"
+                      placeholder="Enter your Trace Token"
+                      value={tencentTraceToken}
+                      onChange={(e) => setTencentTraceToken(e.target.value)}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {selectedProvider === "jaeger" && (
+              <div className="space-y-4 border-t pt-4">
+                <h3 className="text-lg font-medium flex items-center space-x-2">
+                  <SiJaeger size={20} />
+                  <span>Jaeger Configuration</span>
+                </h3>
+                <div className="space-y-2">
+                  <Label htmlFor="jaeger-endpoint">Jaeger Endpoint</Label>
+                  <Input
+                    id="jaeger-endpoint"
+                    type="url"
+                    placeholder="https://your-jaeger-endpoint.com"
+                    value={jaegerEndpoint}
+                    onChange={(e) => setJaegerEndpoint(e.target.value)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Enter the full URL to your Jaeger collector endpoint
+                  </p>
+                </div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/settings/CloudProviderTabContent.tsx
+++ b/ui/src/components/settings/CloudProviderTabContent.tsx
@@ -33,14 +33,11 @@ export function CloudProviderTabContent() {
     if (savedData) {
       try {
         const parsedData = JSON.parse(savedData);
-        console.log("Loading saved settings:", parsedData); // Debug log
         setSelectedProvider(parsedData.selectedProvider || "aws");
         setAwsRegion(parsedData.awsRegion || "us-west-2");
         setTencentRegion(parsedData.tencentRegion || "ap-hongkong");
-        setTencentSecretId(parsedData.tencentSecretId || "");
-        setTencentSecretKey(parsedData.tencentSecretKey || "");
-        setTencentTraceToken(parsedData.tencentTraceToken || "");
         setJaegerEndpoint(parsedData.jaegerEndpoint || "");
+        // Don't load sensitive Tencent credentials from localStorage
       } catch (error) {
         console.error("Error parsing saved cloud provider settings:", error);
       }
@@ -49,6 +46,7 @@ export function CloudProviderTabContent() {
   }, []);
 
   // Save data to localStorage whenever any setting changes (but only after initial load)
+  // Exclude sensitive Tencent credentials from localStorage
   useEffect(() => {
     if (!isLoaded) return; // Don't save during initial load
 
@@ -56,22 +54,17 @@ export function CloudProviderTabContent() {
       selectedProvider,
       awsRegion,
       tencentRegion,
-      tencentSecretId,
-      tencentSecretKey,
-      tencentTraceToken,
       jaegerEndpoint,
+      // Don't save sensitive Tencent credentials to localStorage
     };
-    console.log("Saving settings:", settingsData); // Debug log
     localStorage.setItem("cloudProviderSettings", JSON.stringify(settingsData));
   }, [
     isLoaded,
     selectedProvider,
     awsRegion,
     tencentRegion,
-    tencentSecretId,
-    tencentSecretKey,
-    tencentTraceToken,
     jaegerEndpoint,
+    // Removed sensitive credentials from dependency array
   ]);
 
   const providers = [

--- a/ui/src/components/settings/SettingsSidebar.tsx
+++ b/ui/src/components/settings/SettingsSidebar.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { FaChartLine, FaCrown } from "react-icons/fa";
+import { Cloud } from "lucide-react";
+
+interface SettingsSidebarProps {
+  activeTab: "usage" | "plan" | "provider";
+  onTabChange: (tab: "usage" | "plan" | "provider") => void;
+}
+
+export function SettingsSidebar({
+  activeTab,
+  onTabChange,
+}: SettingsSidebarProps) {
+  const tabs = [
+    {
+      id: "provider" as const,
+      label: "Provider",
+      icon: Cloud,
+      description: "Cloud Service Provider",
+    },
+    {
+      id: "usage" as const,
+      label: "Usage",
+      icon: FaChartLine,
+      description: "LLM Tokens and Trace Logs",
+    },
+    {
+      id: "plan" as const,
+      label: "Plan",
+      icon: FaCrown,
+      description: "Plan and Billing",
+    },
+  ];
+
+  return (
+    <div className="w-64 bg-background border-r border-border">
+      <div className="p-4">
+        <nav className="space-y-2">
+          {tabs.map((tab) => {
+            const Icon = tab.icon;
+            const isActive = activeTab === tab.id;
+
+            return (
+              <button
+                key={tab.id}
+                onClick={() => onTabChange(tab.id)}
+                className={`
+                  w-full flex items-start space-x-3 p-3 rounded-md text-left transition-colors
+                  ${
+                    isActive
+                      ? "bg-primary/10 text-primary border border-primary/20"
+                      : "hover:bg-muted text-muted-foreground hover:text-foreground"
+                  }
+                `}
+              >
+                <Icon size={18} className="mt-0.5 flex-shrink-0" />
+                <div className="flex-1 min-w-0">
+                  <div
+                    className={`text-sm font-medium ${isActive ? "text-primary" : ""}`}
+                  >
+                    {tab.label}
+                  </div>
+                  <div
+                    className={`text-xs mt-0.5 ${isActive ? "text-primary/70" : "text-muted-foreground"}`}
+                  >
+                    {tab.description}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </nav>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/settings/TokenUsageCard.tsx
+++ b/ui/src/components/settings/TokenUsageCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FaRobot } from "react-icons/fa";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 
 interface TokenUsageInfo {
   limit: number;
@@ -63,26 +64,14 @@ export function TokenUsageCard({
                 <span className="text-xs text-muted-foreground uppercase tracking-wide">
                   This Month
                 </span>
-                <span
-                  className={`text-xs font-medium ${getUsageColor(tokenInfo.percentage)}`}
-                >
+                <span className="text-xs text-muted-foreground uppercase tracking-wide">
                   {tokenInfo.percentage.toFixed(1)}% used
                 </span>
               </div>
-              <div className="w-full bg-muted rounded-full h-2">
-                <div
-                  className={`h-2 rounded-full transition-all duration-300 ${
-                    tokenInfo.percentage >= 90
-                      ? "bg-destructive"
-                      : tokenInfo.percentage >= 75
-                        ? "bg-yellow-500 dark:bg-yellow-600"
-                        : "bg-green-500 dark:bg-green-600"
-                  }`}
-                  style={{
-                    width: `${Math.min(100, tokenInfo.percentage)}%`,
-                  }}
-                ></div>
-              </div>
+              <Progress
+                value={Math.min(100, tokenInfo.percentage)}
+                className="w-full h-2"
+              />
             </div>
           )}
           <div className="text-center">
@@ -138,26 +127,14 @@ export function LocalTokenUsageCard({
               <span className="text-xs text-muted-foreground uppercase tracking-wide">
                 This Month
               </span>
-              <span
-                className={`text-xs font-medium ${getUsageColor(tokenUsage.percentage)}`}
-              >
+              <span className="text-xs text-muted-foreground uppercase tracking-wide">
                 {tokenUsage.percentage.toFixed(1)}% used
               </span>
             </div>
-            <div className="w-full bg-gray-200 rounded-full h-2">
-              <div
-                className={`h-2 rounded-full transition-all duration-300 ${
-                  tokenUsage.percentage >= 90
-                    ? "bg-red-500"
-                    : tokenUsage.percentage >= 75
-                      ? "bg-yellow-500"
-                      : "bg-green-500"
-                }`}
-                style={{
-                  width: `${Math.min(100, tokenUsage.percentage)}%`,
-                }}
-              />
-            </div>
+            <Progress
+              value={Math.min(100, tokenUsage.percentage)}
+              className="w-full h-2"
+            />
           </div>
           <div className="text-center">
             <div className="text-sm font-medium">

--- a/ui/src/components/settings/TracesLogsCard.tsx
+++ b/ui/src/components/settings/TracesLogsCard.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { FaChartLine } from "react-icons/fa";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 
 interface TracesLogsInfo {
   limit: number;
@@ -66,26 +67,14 @@ export function TracesLogsCard({
               <span className="text-xs text-muted-foreground uppercase tracking-wide">
                 This Month
               </span>
-              <span
-                className={`text-xs font-medium ${getUsageColor(tracesLogsInfo.percentage)}`}
-              >
+              <span className="text-xs text-muted-foreground uppercase tracking-wide">
                 {tracesLogsInfo.percentage.toFixed(1)}% used
               </span>
             </div>
-            <div className="w-full bg-muted rounded-full h-2">
-              <div
-                className={`h-2 rounded-full transition-all duration-300 ${
-                  tracesLogsInfo.percentage >= 90
-                    ? "bg-destructive"
-                    : tracesLogsInfo.percentage >= 75
-                      ? "bg-yellow-500 dark:bg-yellow-600"
-                      : "bg-green-500 dark:bg-green-600"
-                }`}
-                style={{
-                  width: `${Math.min(100, tracesLogsInfo.percentage)}%`,
-                }}
-              ></div>
-            </div>
+            <Progress
+              value={Math.min(100, tracesLogsInfo.percentage)}
+              className="w-full h-2"
+            />
           </div>
         )}
         <div className="text-center">
@@ -155,26 +144,14 @@ export function LocalTracesLogsCard({
               <span className="text-xs text-muted-foreground uppercase tracking-wide">
                 This Month
               </span>
-              <span
-                className={`text-xs font-medium ${getUsageColor(tracesUsage.percentage)}`}
-              >
+              <span className="text-xs text-muted-foreground uppercase tracking-wide">
                 {tracesUsage.percentage.toFixed(1)}% used
               </span>
             </div>
-            <div className="w-full bg-gray-200 rounded-full h-2">
-              <div
-                className={`h-2 rounded-full transition-all duration-300 ${
-                  tracesUsage.percentage >= 90
-                    ? "bg-red-500"
-                    : tracesUsage.percentage >= 75
-                      ? "bg-yellow-500"
-                      : "bg-green-500"
-                }`}
-                style={{
-                  width: `${Math.min(100, tracesUsage.percentage)}%`,
-                }}
-              />
-            </div>
+            <Progress
+              value={Math.min(100, tracesUsage.percentage)}
+              className="w-full h-2"
+            />
           </div>
           <div className="text-center">
             <div className="text-sm font-medium">

--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className,

--- a/ui/src/components/ui/label.tsx
+++ b/ui/src/components/ui/label.tsx
@@ -1,21 +1,24 @@
 "use client";
 
 import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+
 import { cn } from "@/lib/utils";
 
-const Label = React.forwardRef<
-  HTMLLabelElement,
-  React.LabelHTMLAttributes<HTMLLabelElement>
->(({ className, ...props }, ref) => (
-  <label
-    ref={ref}
-    className={cn(
-      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
-      className,
-    )}
-    {...props}
-  />
-));
-Label.displayName = "Label";
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
 
 export { Label };

--- a/ui/src/components/ui/progress.tsx
+++ b/ui/src/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+
+import { cn } from "@/lib/utils";
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        "bg-primary/20 relative h-2 w-full overflow-hidden rounded-full",
+        className,
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="bg-primary h-full w-full flex-1 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/ui/src/hooks/useCloudProvider.ts
+++ b/ui/src/hooks/useCloudProvider.ts
@@ -35,6 +35,10 @@ export function useCloudProvider() {
         setSettings({
           ...defaultSettings,
           ...parsedData,
+          // Always reset sensitive credentials to empty (don't load from localStorage)
+          tencentSecretId: "",
+          tencentSecretKey: "",
+          tencentTraceToken: "",
         });
       } catch (error) {
         console.error("Error parsing saved cloud provider settings:", error);

--- a/ui/src/hooks/useCloudProvider.ts
+++ b/ui/src/hooks/useCloudProvider.ts
@@ -1,0 +1,51 @@
+import { useState, useEffect } from "react";
+
+export type CloudProvider = "aws" | "tencent" | "jaeger";
+
+export interface CloudProviderSettings {
+  selectedProvider: CloudProvider;
+  awsRegion: string;
+  tencentRegion: string;
+  tencentSecretId: string;
+  tencentSecretKey: string;
+  tencentTraceToken: string;
+  jaegerEndpoint: string;
+}
+
+const defaultSettings: CloudProviderSettings = {
+  selectedProvider: "aws",
+  awsRegion: "us-west-2",
+  tencentRegion: "ap-hongkong",
+  tencentSecretId: "",
+  tencentSecretKey: "",
+  tencentTraceToken: "",
+  jaegerEndpoint: "",
+};
+
+export function useCloudProvider() {
+  const [settings, setSettings] =
+    useState<CloudProviderSettings>(defaultSettings);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const savedData = localStorage.getItem("cloudProviderSettings");
+    if (savedData) {
+      try {
+        const parsedData = JSON.parse(savedData);
+        setSettings({
+          ...defaultSettings,
+          ...parsedData,
+        });
+      } catch (error) {
+        console.error("Error parsing saved cloud provider settings:", error);
+      }
+    }
+    setIsLoaded(true);
+  }, []);
+
+  return {
+    selectedProvider: settings.selectedProvider,
+    settings,
+    isLoaded,
+  };
+}


### PR DESCRIPTION
## Summary

Add settings page with different tabs and change some style

## Type of Change

- [x] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [x] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)
<img width="3450" height="1700" alt="image" src="https://github.com/user-attachments/assets/880f3009-2771-46d7-9be4-fd7537eb42b1" />

<img width="3456" height="1694" alt="image" src="https://github.com/user-attachments/assets/2ecf66e9-9217-4d2d-beca-c65b777f5ab7" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
