### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ name: Test
   push:
     branches: [main]
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/traceroot-ai/traceroot/security/code-scanning/1](https://github.com/traceroot-ai/traceroot/security/code-scanning/1)

To fix this problem, you should add an explicit `permissions` block to your workflow to restrict GITHUB_TOKEN permissions to only what's needed. Since your workflow merely checks out code, sets up Python, installs, and runs tests, it does not need any privileged write access to repository contents or other GitHub resources. The safest minimal permissions setting is `contents: read`. This should be placed at the root of the workflow file (above `jobs:`) so that it applies to all jobs unless overridden.

**How to fix:**  
Add the following block to `.github/workflows/test.yml` just before the `jobs:` key:
```yaml
permissions:
  contents: read
```
No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
