### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,4 +1,6 @@
 name: Pre Commit Check
+permissions:
+  contents: read
 
 "on":
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/traceroot-ai/traceroot/security/code-scanning/2](https://github.com/traceroot-ai/traceroot/security/code-scanning/2)

To resolve this issue, add a `permissions` key to the workflow to minimally restrict GITHUB_TOKEN permissions. The best and most standard mitigation is to add `permissions: contents: read` at the root level of the workflow configuration, which applies to all jobs unless overridden. This ensures the GITHUB_TOKEN used by actions only has read access to the repository contents and does not have permission to write, create releases, or modify any other protected resources. Place this block immediately after the `name` (on line 2), as it is conventionally positioned before `on:` and `jobs:` blocks. No other code changes or new imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
