### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/ui/src/components/ui/shadcn-io/ai/web-preview.tsx
+++ b/ui/src/components/ui/shadcn-io/ai/web-preview.tsx
@@ -183,12 +183,30 @@ export const WebPreviewBody = ({
 }: WebPreviewBodyProps) => {
   const { url } = useWebPreview();
 
+  // Sanitize url before rendering iframe
+  function sanitizeUrl(inputUrl: string | undefined): string | undefined {
+    if (typeof inputUrl !== "string") return undefined;
+    // Allow only http(s) URLs
+    if (
+      inputUrl.startsWith("http://") ||
+      inputUrl.startsWith("https://")
+    ) {
+      return inputUrl;
+    }
+    // Optionally, allow relative URLs starting with /
+    if (inputUrl.startsWith("/")) {
+      return inputUrl;
+    }
+    // Block all other protocols
+    return undefined;
+  }
+
   return (
     <div className="flex-1">
       <iframe
         className={cn("size-full", className)}
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-presentation"
-        src={(src ?? url) || undefined}
+        src={sanitizeUrl(src ?? url)}
         title="Preview"
         {...props}
       />


### PR DESCRIPTION
Potential fix for [https://github.com/traceroot-ai/traceroot/security/code-scanning/3](https://github.com/traceroot-ai/traceroot/security/code-scanning/3)

To fix the issue, we should sanitize any attacker-controlled value before using it as the `src` of an `<iframe>`. This means ensuring that only URLs with safe protocols (like `http:`, `https:`) are allowed; we should block `javascript:`, `data:`, `vbscript:`, etc. The single best way to do this is to add a simple URL sanitizer function in the component file, used before passing the value for `src`. Only allow URLs starting with `http://` or `https://`, or, depending on requirements, URLs that are relative paths. 

Required changes:
- Add a `sanitizeUrl` helper to the file.
- Use `sanitizeUrl(src ?? url)` instead of `(src ?? url)` for the iframe `src` attribute. 

Methods/definitions to add:
- `sanitizeUrl(url: string): string | undefined` helper
- Update the relevant line (191) to call the sanitizer.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
