### PR TITLE
feat: support selecting multiple traces

### DIFF
--- a/ui/src/app/explore/page.tsx
+++ b/ui/src/app/explore/page.tsx
@@ -12,7 +12,7 @@ export default function Explore() {
   useEffect(() => {
     initializeProviders();
   }, []);
-  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
+  const [selectedTraceIds, setSelectedTraceIds] = useState<string[]>([]);
   const [selectedSpanIds, setSelectedSpanIds] = useState<string[]>([]);
   const [timeRange, setTimeRange] = useState<{ start: Date; end: Date } | null>(
     null,
@@ -42,7 +42,7 @@ export default function Explore() {
   // Validate selected spans when trace changes
   useEffect(() => {
     if (
-      selectedTraceId &&
+      selectedTraceIds.length > 0 &&
       currentTraceSpans.length > 0 &&
       selectedSpanIds.length > 0
     ) {
@@ -55,11 +55,11 @@ export default function Explore() {
       if (validSelectedSpans.length !== selectedSpanIds.length) {
         setSelectedSpanIds(validSelectedSpans);
       }
-    } else if (!selectedTraceId) {
+    } else if (selectedTraceIds.length === 0) {
       // Clear spans when no trace is selected
       setSelectedSpanIds([]);
     }
-  }, [selectedTraceId, currentTraceSpans]);
+  }, [selectedTraceIds, currentTraceSpans]);
 
   const handleSpanSelect = (spanIds: string[]) => {
     setSelectedSpanIds(spanIds);
@@ -69,8 +69,8 @@ export default function Explore() {
     setSelectedSpanIds([]);
   };
 
-  const handleTraceSelect = useCallback((traceId: string | null) => {
-    setSelectedTraceId(traceId);
+  const handleTraceSelect = useCallback((traceIds: string[]) => {
+    setSelectedTraceIds(traceIds);
     // Note: We don't clear spans here - the useEffect above will validate them
   }, []);
 
@@ -111,13 +111,13 @@ export default function Explore() {
           onTracesUpdate={handleTracesUpdate}
           onLogSearchValueChange={handleLogSearchValueChange}
           onMetadataSearchTermsChange={handleMetadataSearchTermsChange}
-          selectedTraceId={selectedTraceId}
+          selectedTraceIds={selectedTraceIds}
           selectedSpanIds={selectedSpanIds}
         />
       }
       rightPanel={
         <RightPanelSwitch
-          traceId={selectedTraceId || undefined}
+          traceIds={selectedTraceIds}
           spanIds={selectedSpanIds}
           traceQueryStartTime={timeRange?.start}
           traceQueryEndTime={timeRange?.end}

--- a/ui/src/components/right-panel/RightPanelSwitch.tsx
+++ b/ui/src/components/right-panel/RightPanelSwitch.tsx
@@ -9,21 +9,21 @@ import { Span, Trace as TraceModel } from "@/models/trace";
 import { useAuth } from "@clerk/nextjs";
 
 interface RightPanelSwitchProps {
-  traceId?: string;
+  traceIds?: string[];
   spanIds?: string[];
   traceQueryStartTime?: Date;
   traceQueryEndTime?: Date;
   allTraces?: TraceModel[];
   logSearchValue?: string;
   metadataSearchTerms?: { category: string; value: string }[];
-  onTraceSelect?: (traceId: string) => void;
+  onTraceSelect?: (traceIds: string[]) => void;
   onSpanClear?: () => void;
   onTraceSpansUpdate?: (spans: Span[]) => void;
   onSpanSelect?: (spanIds: string[]) => void;
 }
 
 export default function RightPanelSwitch({
-  traceId,
+  traceIds = [],
   spanIds = [],
   traceQueryStartTime,
   traceQueryEndTime,
@@ -62,21 +62,37 @@ export default function RightPanelSwitch({
     }
   }, [allTraces]);
 
-  // Update spans when traceId changes, using already fetched trace data
+  // Update spans when traceIds changes, using already fetched trace data
+  // For single trace selection, we load the spans from that trace.
+  // For multiple traces, we merge all spans from selected traces.
   useEffect(() => {
-    if (traceId && allTraces.length > 0) {
-      const trace: TraceModel | undefined = allTraces.find(
-        (t: TraceModel) => t.id === traceId,
-      );
-      const newSpans = trace ? trace.spans : undefined;
-      setSpans(newSpans);
-      // Notify parent of spans update for validation
-      onTraceSpansUpdate?.(newSpans || []);
+    if (traceIds.length > 0 && allTraces.length > 0) {
+      if (traceIds.length === 1) {
+        // Single trace: load spans from that trace
+        const trace: TraceModel | undefined = allTraces.find(
+          (t: TraceModel) => t.id === traceIds[0],
+        );
+        const newSpans = trace ? trace.spans : undefined;
+        setSpans(newSpans);
+        // Notify parent of spans update for validation
+        onTraceSpansUpdate?.(newSpans || []);
+      } else {
+        // Multiple traces: merge all spans from selected traces
+        const allSpans: Span[] = [];
+        traceIds.forEach((traceId) => {
+          const trace = allTraces.find((t) => t.id === traceId);
+          if (trace && trace.spans) {
+            allSpans.push(...trace.spans);
+          }
+        });
+        setSpans(allSpans.length > 0 ? allSpans : undefined);
+        onTraceSpansUpdate?.(allSpans);
+      }
     } else {
       setSpans(undefined);
       onTraceSpansUpdate?.([]);
     }
-  }, [traceId, allTraces, onTraceSpansUpdate]);
+  }, [traceIds, allTraces, onTraceSpansUpdate]);
 
   // Handler for span selection from chat references
   const handleSpanSelectFromChat = (spanId: string) => {
@@ -141,11 +157,12 @@ export default function RightPanelSwitch({
         {/* Log view - conditionally rendered */}
         {viewType === "log" && (
           <LogPanelSwitch
-            traceId={traceId}
+            traceIds={traceIds}
             spanIds={spanIds}
             traceQueryStartTime={traceQueryStartTime}
             traceQueryEndTime={traceQueryEndTime}
             segments={spans}
+            allTraces={allTraces}
             traceDurations={traceDurations}
             traceStartTimes={traceStartTimes}
             traceEndTimes={traceEndTimes}
@@ -187,7 +204,8 @@ export default function RightPanelSwitch({
           }
         >
           <Agent
-            traceId={traceId}
+            traceId={traceIds.length === 1 ? traceIds[0] : undefined}
+            traceIds={traceIds}
             spanIds={spanIds}
             queryStartTime={traceQueryStartTime}
             queryEndTime={traceQueryEndTime}
@@ -199,7 +217,7 @@ export default function RightPanelSwitch({
         {/* Trace view - conditionally rendered */}
         {viewType === "trace" && (
           <TracePanelSwitch
-            traceId={traceId}
+            traceId={traceIds.length === 1 ? traceIds[0] : undefined}
             spanIds={spanIds}
             traceQueryStartTime={traceQueryStartTime}
             traceQueryEndTime={traceQueryEndTime}

--- a/ui/src/components/right-panel/agent/Agent.tsx
+++ b/ui/src/components/right-panel/agent/Agent.tsx
@@ -38,6 +38,7 @@ interface Message {
 
 interface AgentProps {
   traceId?: string;
+  traceIds?: string[];
   spanIds?: string[];
   userAvatarUrl?: string;
   queryStartTime?: Date;
@@ -48,6 +49,7 @@ interface AgentProps {
 
 export default function Agent({
   traceId,
+  traceIds = [],
   spanIds = [],
   userAvatarUrl,
   queryStartTime,
@@ -671,6 +673,7 @@ export default function Agent({
         selectedProvider={selectedProvider}
         setSelectedProvider={setSelectedProvider}
         traceId={traceId}
+        traceIds={traceIds}
         spanIds={spanIds}
       />
     </div>

--- a/ui/src/components/right-panel/agent/MessageInput.tsx
+++ b/ui/src/components/right-panel/agent/MessageInput.tsx
@@ -50,6 +50,7 @@ interface MessageInputProps {
   selectedProvider?: Provider;
   setSelectedProvider?: (provider: Provider) => void;
   traceId?: string;
+  traceIds?: string[];
   spanIds?: string[];
 }
 
@@ -65,11 +66,17 @@ export default function MessageInput({
   selectedProvider = DEFAULT_PROVIDER,
   setSelectedProvider,
   traceId,
+  traceIds = [],
   spanIds = [],
 }: MessageInputProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const status: PromptInputStatus = isLoading ? "streaming" : "ready";
-  const hasTraceOrSpans = !!(traceId || (spanIds && spanIds.length > 0));
+  const hasMultipleTraces = traceIds.length > 1;
+  const hasTraceOrSpans = !!(
+    traceId ||
+    traceIds.length > 0 ||
+    (spanIds && spanIds.length > 0)
+  );
 
   useEffect(() => {
     if (!isLoading && inputRef.current) {
@@ -135,21 +142,27 @@ export default function MessageInput({
     <div className="border border-zinc-300 rounded-lg dark:border-zinc-700 bg-white dark:bg-zinc-800 mx-4 mb-2">
       <div className="p-3">
         <div className="mb-1 text-xs text-gray-500 dark:text-gray-400 pb-2 flex gap-2 items-center">
-          {traceId && (
+          {hasMultipleTraces ? (
+            <Badge variant="outline" className="font-mono">
+              {traceIds.length} traces selected
+            </Badge>
+          ) : traceId ? (
             <Badge variant="outline" className="font-mono">
               Trace: {traceId}
             </Badge>
-          )}
+          ) : null}
           {spanIds && spanIds.length > 0 && (
             <Badge variant="outline" className="font-mono">
               Spans: {spanIds.length}
             </Badge>
           )}
-          {!traceId && (!spanIds || spanIds.length === 0) && (
-            <span className="text-xs text-zinc-500 dark:text-zinc-400 font-mono ml-0">
-              No trace or spans selected
-            </span>
-          )}
+          {!traceId &&
+            traceIds.length === 0 &&
+            (!spanIds || spanIds.length === 0) && (
+              <span className="text-xs text-zinc-500 dark:text-zinc-400 font-mono ml-0">
+                No trace or spans selected
+              </span>
+            )}
         </div>
         <PromptInput
           onSubmit={onSendMessage}
@@ -170,11 +183,13 @@ export default function MessageInput({
             placeholder={
               isLoading
                 ? "Agent is thinking..."
-                : hasTraceOrSpans
-                  ? "Type your message..."
-                  : "Select a trace to start chatting"
+                : hasMultipleTraces
+                  ? "Agent is disabled when multiple traces are selected"
+                  : hasTraceOrSpans
+                    ? "Type your message..."
+                    : "Select a trace to start chatting"
             }
-            disabled={isLoading || !hasTraceOrSpans}
+            disabled={isLoading || !hasTraceOrSpans || hasMultipleTraces}
             minRows={1}
             maxRows={5}
             className="rounded-md border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 focus:ring-1 focus:ring-neutral-500 focus:border-neutral-500 transition-all duration-200"

--- a/ui/src/components/right-panel/log/LogDetail.tsx
+++ b/ui/src/components/right-panel/log/LogDetail.tsx
@@ -2,51 +2,78 @@
 
 import React, { useEffect, useState, useRef } from "react";
 import { TraceLog, LogEntry } from "@/models/log";
-import { Span } from "@/models/trace";
-import { FaGithub } from "react-icons/fa";
-import { IoCopyOutline } from "react-icons/io5";
-import { Plus, Minus, Download } from "lucide-react";
+import { Span, Trace as TraceModel } from "@/models/trace";
+import { FaGithub, FaPython, FaJava } from "react-icons/fa";
+import { IoCopyOutline, IoLogoJavascript } from "react-icons/io5";
+import { SiTypescript } from "react-icons/si";
+import {
+  Plus,
+  Minus,
+  Download,
+  Group,
+  Ungroup,
+  ArrowDownUp,
+} from "lucide-react";
 import { fadeInAnimationStyles } from "@/constants/animations";
 import ShowCodeToggle from "./ShowCodeToggle";
 import CodeContext from "./CodeContext";
 import { ViewType } from "../ModeToggle";
-import { useUser } from "@clerk/nextjs";
 import { useAuth } from "@clerk/nextjs";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/shadcn-io/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { getProviderInfo, appendProviderParams } from "@/utils/provider";
 
 interface LogDetailProps {
-  traceId: string;
+  traceIds: string[];
   spanIds?: string[];
   traceQueryStartTime?: Date;
   traceQueryEndTime?: Date;
   segments?: Span[];
+  allTraces?: TraceModel[];
   logSearchValue?: string;
   metadataSearchTerms?: { category: string; value: string }[];
   viewType?: ViewType;
 }
 
 export default function LogDetail({
-  traceId,
+  traceIds,
   spanIds = [],
   traceQueryStartTime,
   traceQueryEndTime,
   segments,
+  allTraces = [],
   logSearchValue = "",
   metadataSearchTerms = [],
   viewType,
 }: LogDetailProps) {
   const [allLogs, setAllLogs] = useState<TraceLog | null>(null);
   const [loading, setLoading] = useState(false);
+  const [loadingTraces, setLoadingTraces] = useState<Set<string>>(new Set());
   const [error, setError] = useState<string | null>(null);
   const [showCode, setShowCode] = useState(false);
   const [, forceUpdate] = useState({});
   const [expandedEntries, setExpandedEntries] = useState<Set<string>>(
     new Set(),
   );
+  const [isGrouped, setIsGrouped] = useState(false);
+  const [expandedTraceBlocks, setExpandedTraceBlocks] = useState<Set<string>>(
+    new Set(),
+  );
+  const [isSortDescending, setIsSortDescending] = useState(false);
   const { getToken } = useAuth();
+
+  // When switching to grouped mode, expand all trace blocks by default
+  useEffect(() => {
+    if (isGrouped && traceIds.length > 1) {
+      setExpandedTraceBlocks(new Set(traceIds));
+    }
+  }, [isGrouped, traceIds]);
 
   useEffect(() => {
     // Inject styles on client side only
@@ -60,7 +87,7 @@ export default function LogDetail({
     };
   }, []); // Empty dependency array means this only runs once on mount
 
-  // Reset showCode and clear code data when traceId or spanIds changes
+  // Reset showCode and clear code data when traceIds or spanIds changes
   useEffect(() => {
     setShowCode(false);
     // Clear code data from all log entries
@@ -77,7 +104,7 @@ export default function LogDetail({
         });
       });
     }
-  }, [traceId, spanIds, allLogs]);
+  }, [traceIds, spanIds, allLogs]);
 
   // Reset showCode when viewType is not 'log'
   useEffect(() => {
@@ -102,43 +129,101 @@ export default function LogDetail({
 
   useEffect(() => {
     const fetchLogs = async () => {
-      if (!traceId) {
+      if (!traceIds || traceIds.length === 0) {
         setAllLogs(null);
+        setLoadingTraces(new Set());
         return;
       }
+
       setLoading(true);
       setError(null);
+      setLoadingTraces(new Set(traceIds));
+
       try {
-        // Build URL with query parameters
-        const url = new URL("/api/get_trace_log", window.location.origin);
-        url.searchParams.append("traceId", traceId);
-
-        // DON'T send timestamps when querying by trace_id
-        // The backend will search without time constraints (30-day window)
-
-        // Add provider information from URL (always required)
         const { traceProvider, logProvider, traceRegion, logRegion } =
           getProviderInfo();
-        appendProviderParams(
-          url,
-          traceProvider,
-          traceRegion,
-          logProvider,
-          logRegion,
+        const token = await getToken();
+
+        // Fetch logs for all traces in parallel
+        type FetchResult =
+          | { traceId: string; data: TraceLog; success: true }
+          | { traceId: string; data: null; success: false; error: string };
+
+        const fetchPromises = traceIds.map(
+          async (traceId): Promise<FetchResult> => {
+            try {
+              const url = new URL("/api/get_trace_log", window.location.origin);
+              url.searchParams.append("traceId", traceId);
+
+              appendProviderParams(
+                url,
+                traceProvider,
+                traceRegion,
+                logProvider,
+                logRegion,
+              );
+
+              const response = await fetch(url.toString(), {
+                headers: {
+                  Authorization: `Bearer ${token}`,
+                },
+              });
+              const result = await response.json();
+
+              if (!result.success) {
+                throw new Error(result.error || "Failed to fetch logs");
+              }
+
+              return { traceId, data: result.data as TraceLog, success: true };
+            } catch (err) {
+              console.error(`LogDetail fetchLogs - error for ${traceId}:`, err);
+              return {
+                traceId,
+                data: null,
+                success: false,
+                error:
+                  err instanceof Error
+                    ? err.message
+                    : "An error occurred while fetching logs",
+              };
+            }
+          },
         );
 
-        const token = await getToken();
-        const response = await fetch(url.toString(), {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
+        // Wait for all requests to complete
+        const results = await Promise.all(fetchPromises);
+
+        // Merge all successful results
+        const mergedLogs: TraceLog = {};
+        let hasErrors = false;
+        let errorMessage = "";
+
+        results.forEach((result) => {
+          if (result.success && result.data) {
+            // Merge the trace logs
+            Object.entries(result.data).forEach(([traceId, spanLogs]) => {
+              mergedLogs[traceId] = spanLogs;
+            });
+          } else {
+            hasErrors = true;
+            errorMessage =
+              result.error || "Failed to fetch logs for some traces";
+          }
+
+          // Remove from loading set as we process each result
+          setLoadingTraces((prev) => {
+            const newSet = new Set(prev);
+            newSet.delete(result.traceId);
+            return newSet;
+          });
         });
-        const result = await response.json();
-        if (!result.success) {
-          throw new Error(result.error || "Failed to fetch logs");
+
+        setAllLogs(mergedLogs);
+
+        if (hasErrors && Object.keys(mergedLogs).length === 0) {
+          // Only set error if ALL requests failed
+          setError(errorMessage);
         }
-        // Always store the full logs data
-        setAllLogs(result.data);
       } catch (err) {
         console.error("LogDetail fetchLogs - error:", err);
         setError(
@@ -146,12 +231,13 @@ export default function LogDetail({
             ? err.message
             : "An error occurred while fetching logs",
         );
+        setLoadingTraces(new Set());
       } finally {
         setLoading(false);
       }
     };
     fetchLogs();
-  }, [traceId, traceQueryStartTime, traceQueryEndTime]);
+  }, [traceIds, traceQueryStartTime, traceQueryEndTime]);
 
   // Filter logs based on selected spans
   const logs = React.useMemo(() => {
@@ -159,43 +245,67 @@ export default function LogDetail({
       return allLogs;
     }
 
-    // If no spanIds selected, show all logs
+    // If no spanIds selected, show all logs for selected traces
     if (spanIds.length === 0) {
       return allLogs;
     }
 
-    // Check if any of the spanIds exist in the current trace data
-    const traceData = allLogs[traceId];
-    if (!traceData) {
-      return allLogs;
-    }
-
-    // Get all span IDs that exist in current trace
-    const existingSpanIds = new Set<string>();
-    traceData.forEach((spanLog: any) => {
-      Object.keys(spanLog).forEach((spanId) => existingSpanIds.add(spanId));
-    });
-
-    // Check if any of the selected spanIds exist in the current trace
-    const hasValidSpanIds = spanIds.some((spanId) =>
-      existingSpanIds.has(spanId),
-    );
-    if (!hasValidSpanIds) {
-      return {};
-    }
-
-    const filteredLogs: TraceLog = {};
-    Object.entries(allLogs).forEach(([traceId, spanLogs]) => {
-      const filteredSpanLogs = (spanLogs as any[]).filter((spanLog) => {
-        const spanId = Object.keys(spanLog)[0];
-        return spanIds.includes(spanId);
+    // Build a mapping of spanId -> traceId from allTraces
+    const spanToTraceMap = new Map<string, string>();
+    const collectSpanIds = (spans: Span[], traceId: string) => {
+      spans.forEach((span) => {
+        spanToTraceMap.set(span.id, traceId);
+        if (span.spans && span.spans.length > 0) {
+          collectSpanIds(span.spans, traceId);
+        }
       });
-      if (filteredSpanLogs.length > 0) {
-        filteredLogs[traceId] = filteredSpanLogs;
+    };
+
+    allTraces.forEach((trace) => {
+      if (trace.spans && trace.spans.length > 0) {
+        collectSpanIds(trace.spans, trace.id);
       }
     });
+
+    // Group selected spans by their trace
+    const spansByTrace = new Map<string, string[]>();
+    spanIds.forEach((spanId) => {
+      const traceId = spanToTraceMap.get(spanId);
+      if (traceId) {
+        if (!spansByTrace.has(traceId)) {
+          spansByTrace.set(traceId, []);
+        }
+        spansByTrace.get(traceId)!.push(spanId);
+      }
+    });
+
+    // Filter logs for each trace independently
+    const filteredLogs: TraceLog = {};
+    Object.entries(allLogs).forEach(([traceId, spanLogs]) => {
+      if (!traceIds.includes(traceId)) {
+        // Skip traces that are not selected
+        return;
+      }
+
+      const selectedSpansForThisTrace = spansByTrace.get(traceId);
+
+      if (selectedSpansForThisTrace && selectedSpansForThisTrace.length > 0) {
+        // This trace has selected spans - filter to show only those spans
+        const filteredSpanLogs = (spanLogs as any[]).filter((spanLog) => {
+          const spanId = Object.keys(spanLog)[0];
+          return selectedSpansForThisTrace.includes(spanId);
+        });
+        if (filteredSpanLogs.length > 0) {
+          filteredLogs[traceId] = filteredSpanLogs;
+        }
+      } else {
+        // This trace has no selected spans - show all logs
+        filteredLogs[traceId] = spanLogs;
+      }
+    });
+
     return filteredLogs;
-  }, [allLogs, spanIds, traceId]);
+  }, [allLogs, spanIds, traceIds, allTraces]);
 
   const formatTimestamp = (timestamp: number) => {
     const date = new Date(timestamp * 1000);
@@ -283,30 +393,161 @@ export default function LogDetail({
     return map;
   };
 
-  // Build flat list of log entries in the order of SpanLogs in LogFile
+  // Build flat list of log entries from all selected traces
   const buildOrderedLogEntries = (
     logs: TraceLog | null,
-    traceId: string | undefined,
+    traceIds: string[],
+    sortDescending: boolean,
   ) => {
-    const result: { entry: LogEntry; spanId: string }[] = [];
-    if (!logs || !traceId || !logs[traceId]) return result;
-    logs[traceId].forEach((spanLog: any) => {
-      Object.entries(spanLog).forEach(([spanId, entries]) => {
-        (entries as LogEntry[]).forEach((entry) => {
-          result.push({ entry, spanId });
+    const result: { entry: LogEntry; spanId: string; traceId: string }[] = [];
+    if (!logs) return result;
+
+    // Collect logs from all selected traces
+    traceIds.forEach((traceId) => {
+      if (!logs[traceId]) return;
+      logs[traceId].forEach((spanLog: any) => {
+        Object.entries(spanLog).forEach(([spanId, entries]) => {
+          (entries as LogEntry[]).forEach((entry) => {
+            result.push({ entry, spanId, traceId });
+          });
         });
       });
     });
+
+    // Sort all logs by timestamp
+    result.sort((a, b) => {
+      const diff = a.entry.time - b.entry.time;
+      return sortDescending ? -diff : diff;
+    });
+
     return result;
   };
 
-  // Compute spanId->depth map
+  // Build grouped log entries for grouped view
+  // NOTE: We pass in orderedEntries to reuse the same entry references
+  const buildGroupedLogEntries = (
+    orderedEntries: { entry: LogEntry; spanId: string; traceId: string }[],
+    traceIds: string[],
+    allTraces: TraceModel[],
+    sortDescending: boolean,
+  ) => {
+    const groupedData: Map<
+      string,
+      {
+        trace: TraceModel | undefined;
+        logs: { entry: LogEntry; spanId: string }[];
+        spanDepthMap: { [spanId: string]: number };
+      }
+    > = new Map();
+
+    if (!orderedEntries || orderedEntries.length === 0) return groupedData;
+
+    // Build the grouped data first
+    const entries: Array<
+      [
+        string,
+        {
+          trace: TraceModel | undefined;
+          logs: { entry: LogEntry; spanId: string }[];
+          spanDepthMap: { [spanId: string]: number };
+        },
+      ]
+    > = [];
+
+    traceIds.forEach((traceId) => {
+      // Find the trace metadata
+      const trace = allTraces.find((t) => t.id === traceId);
+
+      // Filter logs for this trace (reuses same entry references from orderedEntries)
+      const traceLogs = orderedEntries
+        .filter((item) => item.traceId === traceId)
+        .map(({ entry, spanId }) => ({ entry, spanId }));
+
+      // Build span depth map for this trace
+      const spanDepthMap = buildSpanDepthMap(trace?.spans);
+
+      if (traceLogs.length > 0) {
+        entries.push([
+          traceId,
+          {
+            trace,
+            logs: traceLogs,
+            spanDepthMap,
+          },
+        ]);
+      }
+    });
+
+    // Sort the entries by trace start time
+    entries.sort((a, b) => {
+      const traceA = a[1].trace;
+      const traceB = b[1].trace;
+      if (!traceA || !traceB) return 0;
+      const diff = traceA.start_time - traceB.start_time;
+      return sortDescending ? -diff : diff;
+    });
+
+    // Convert back to Map preserving the sorted order
+    entries.forEach(([traceId, data]) => {
+      groupedData.set(traceId, data);
+    });
+
+    return groupedData;
+  };
+
+  // Compute spanId->depth map (for single trace or ungrouped multi-trace)
   const spanDepthMap = buildSpanDepthMap(segments);
-  // Compute ordered log entries
-  const orderedLogEntries = buildOrderedLogEntries(logs, traceId);
+  // Compute ordered log entries (for ungrouped view)
+  const orderedLogEntries = buildOrderedLogEntries(
+    logs,
+    traceIds,
+    isSortDescending,
+  );
+  // Compute grouped log entries (for grouped view) - reuses same entry references from orderedLogEntries
+  const groupedLogEntries = buildGroupedLogEntries(
+    orderedLogEntries,
+    traceIds,
+    allTraces,
+    isSortDescending,
+  );
+
+  // Get all log entries for ShowCodeToggle (flattened from grouped view or ungrouped view)
+  const allLogEntriesForCodeToggle = React.useMemo(() => {
+    if (traceIds.length > 1 && isGrouped) {
+      // Flatten all logs from grouped entries
+      const flattened: { entry: LogEntry; spanId: string }[] = [];
+      groupedLogEntries.forEach(({ logs }) => {
+        flattened.push(...logs);
+      });
+      return flattened;
+    }
+    // For ungrouped view, remove traceId property to match expected format
+    return orderedLogEntries.map(({ entry, spanId }) => ({ entry, spanId }));
+  }, [traceIds, isGrouped, groupedLogEntries, orderedLogEntries]);
 
   // Calculate log level statistics
   const calculateLogStats = (
+    logEntries: { entry: LogEntry; spanId: string; traceId: string }[],
+  ) => {
+    const stats = {
+      DEBUG: 0,
+      INFO: 0,
+      WARNING: 0,
+      ERROR: 0,
+      CRITICAL: 0,
+    };
+
+    logEntries.forEach(({ entry }) => {
+      if (entry.level in stats) {
+        stats[entry.level as keyof typeof stats]++;
+      }
+    });
+
+    return stats;
+  };
+
+  // Calculate log level statistics for grouped traces
+  const calculateGroupedLogStats = (
     logEntries: { entry: LogEntry; spanId: string }[],
   ) => {
     const stats = {
@@ -374,18 +615,28 @@ export default function LogDetail({
       (a, b) => b.entry.time - a.entry.time,
     );
 
-    // CSV header
-    const headers = [
-      "Log Level",
-      "Timestamp (UTC)",
-      "Log Line",
-      "Method Name",
-      "Message",
-    ];
+    // CSV header - include Trace ID if multiple traces
+    const headers =
+      traceIds.length > 1
+        ? [
+            "Trace ID",
+            "Log Level",
+            "Timestamp (UTC)",
+            "Log Line",
+            "Method Name",
+            "Message",
+          ]
+        : [
+            "Log Level",
+            "Timestamp (UTC)",
+            "Log Line",
+            "Method Name",
+            "Message",
+          ];
     const csvRows = [headers.join(",")];
 
     // Add data rows
-    sortedEntries.forEach(({ entry }) => {
+    sortedEntries.forEach(({ entry, traceId }) => {
       // Convert timestamp to UTC
       const utcDate = new Date(entry.time * 1000).toISOString();
 
@@ -404,13 +655,23 @@ export default function LogDetail({
         return field;
       };
 
-      const row = [
-        escapeCSV(entry.level),
-        escapeCSV(utcDate),
-        escapeCSV(logLine),
-        escapeCSV(entry.function_name || ""),
-        escapeCSV(entry.message || ""),
-      ];
+      const row =
+        traceIds.length > 1
+          ? [
+              escapeCSV(traceId),
+              escapeCSV(entry.level),
+              escapeCSV(utcDate),
+              escapeCSV(logLine),
+              escapeCSV(entry.function_name || ""),
+              escapeCSV(entry.message || ""),
+            ]
+          : [
+              escapeCSV(entry.level),
+              escapeCSV(utcDate),
+              escapeCSV(logLine),
+              escapeCSV(entry.function_name || ""),
+              escapeCSV(entry.message || ""),
+            ];
 
       csvRows.push(row.join(","));
     });
@@ -424,7 +685,11 @@ export default function LogDetail({
     const url = URL.createObjectURL(blob);
 
     link.setAttribute("href", url);
-    link.setAttribute("download", `${traceId}.csv`);
+    const filename =
+      traceIds.length === 1
+        ? `${traceIds[0]}.csv`
+        : `traces_${traceIds.length}.csv`;
+    link.setAttribute("download", filename);
     link.style.visibility = "hidden";
     document.body.appendChild(link);
     link.click();
@@ -634,129 +899,443 @@ export default function LogDetail({
                 </div>
               </div>
               <div className="flex items-center gap-2 flex-shrink-0">
-                <Button
-                  onClick={downloadLogsAsCSV}
-                  variant="outline"
-                  size="sm"
-                  className="h-8 gap-1.5"
-                  title="Download logs as CSV"
-                >
-                  <Download className="w-3.5 h-3.5" />
-                </Button>
+                {traceIds.length > 1 && (
+                  <>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          onClick={() => setIsSortDescending(!isSortDescending)}
+                          variant="outline"
+                          size="sm"
+                          className="h-8 gap-1.5"
+                        >
+                          <ArrowDownUp className="w-3.5 h-3.5" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>
+                          {isGrouped
+                            ? "Reverse group order by trace timestamp"
+                            : "Reverse log order by logging timestamp"}
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          onClick={() => setIsGrouped(!isGrouped)}
+                          variant="outline"
+                          size="sm"
+                          className="h-8 gap-1.5"
+                        >
+                          {isGrouped ? (
+                            <Ungroup className="w-3.5 h-3.5" />
+                          ) : (
+                            <Group className="w-3.5 h-3.5" />
+                          )}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>
+                          {isGrouped
+                            ? "Flatten loggings"
+                            : "Group loggings according to traces"}
+                        </p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </>
+                )}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      onClick={downloadLogsAsCSV}
+                      variant="outline"
+                      size="sm"
+                      className="h-8 gap-1.5"
+                    >
+                      <Download className="w-3.5 h-3.5" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <p>
+                      {traceIds.length === 1
+                        ? `Download logs for ${traceIds[0].substring(0, 12)}...`
+                        : `Download logs for ${traceIds.length} traces`}
+                    </p>
+                  </TooltipContent>
+                </Tooltip>
                 <ShowCodeToggle
-                  logEntries={orderedLogEntries}
+                  logEntries={allLogEntriesForCodeToggle}
                   onLogEntriesUpdate={handleForceUpdate}
                   showCode={showCode}
                   onShowCodeChange={setShowCode}
                 />
-              </div>
+              </div>{" "}
             </div>
             <div
               className={`space-y-1 overflow-y-auto ${showCode ? "pb-20" : "pb-25"}`}
             >
-              {orderedLogEntries.map(({ entry, spanId }, idx) => {
-                const githubLink = getGitHubLink(entry);
-                const entryKey = `${spanId}-${idx}`;
-                const isExpanded = expandedEntries.has(entryKey);
-                const formattedMessage = formatMessage(entry.message);
-                const messageExpandable = isMessageExpandable(formattedMessage);
-                const displayMessage =
-                  messageExpandable && !isExpanded
-                    ? truncateMessage(formattedMessage)
-                    : formattedMessage;
-                return (
-                  <div
-                    key={entryKey}
-                    className={`relative p-1.5 rounded bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 transform transition-all duration-100 ease-in-out hover:shadow animate-fadeIn`}
-                    style={{
-                      ...getLogStyle(spanDepthMap[spanId] ?? 0),
-                      animationDelay: `${idx * 3}ms`,
-                    }}
-                  >
-                    <div className="flex items-start min-w-0">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex font-mono items-center space-x-2 text-xs flex-wrap min-w-0">
-                          <span
-                            className={`font-medium ${getLogLevelColor(entry.level)}`}
-                          >
-                            {entry.level}
-                          </span>
-                          <span className="text-gray-500 dark:text-gray-400">
-                            {formatTimestamp(entry.time)}
-                          </span>
-                          <span className="text-gray-400 dark:text-gray-500 font-mono">
-                            {entry.file_name}:{entry.line_number}
-                          </span>
-                          <span className="text-neutral-600 dark:text-neutral-300 italic break-all">
-                            {entry.function_name}
-                          </span>
-                          {githubLink && (
-                            <a
-                              href={githubLink}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-neutral-500 dark:text-neutral-300 hover:text-neutral-600 dark:hover:text-neutral-400 transition-colors"
-                              title="View on GitHub"
-                            >
-                              <FaGithub className="inline-block" />
-                            </a>
-                          )}
-                          <div className="relative font-mono p-1 bg-zinc-50 dark:bg-zinc-900 rounded text-neutral-800 dark:text-neutral-300 text-xs min-w-0 max-w-full overflow-hidden min-h-[1.5rem]">
-                            <Button
-                              onClick={() => copyToClipboard(entry.message)}
-                              variant="ghost"
-                              size="icon"
-                              className="absolute top-0.5 right-0.5 h-5 w-5 opacity-70 hover:opacity-100 transition-opacity z-10"
-                              title="Copy message"
-                            >
-                              <IoCopyOutline className="w-3 h-3" />
-                            </Button>
-                            <span className="whitespace-pre-wrap break-all word-break-break-all overflow-wrap-anywhere m-0 max-w-full pr-7 block">
-                              {logSearchValue || metadataSearchTerms.length > 0
-                                ? highlightText(
-                                    displayMessage,
-                                    logSearchValue,
-                                    metadataSearchTerms,
-                                  )
-                                : displayMessage}
-                            </span>
+              {/* Grouped View: Show logs grouped by trace */}
+              {traceIds.length > 1 && isGrouped
+                ? Array.from(groupedLogEntries.entries()).map(
+                    ([traceId, { trace, logs, spanDepthMap }]) => {
+                      const isTraceExpanded = expandedTraceBlocks.has(traceId);
+
+                      return (
+                        <div
+                          key={traceId}
+                          className="border border-neutral-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-zinc-950 overflow-hidden mb-2 mr-3 ml-3"
+                        >
+                          {/* Trace Block Header */}
+                          <div className="bg-white dark:bg-black p-1 border-b border-neutral-300 dark:border-neutral-700">
+                            <div className="flex items-center justify-between">
+                              <div className="flex items-center gap-0.5 flex-1">
+                                {/* Language Icon */}
+                                {trace?.telemetry_sdk_language &&
+                                  trace.telemetry_sdk_language.length > 0 && (
+                                    <div className="flex items-center flex-shrink-0 ml-1 mr-2">
+                                      {trace.telemetry_sdk_language.includes(
+                                        "python",
+                                      ) && (
+                                        <FaPython
+                                          className="text-neutral-800 dark:text-neutral-200"
+                                          size={14}
+                                        />
+                                      )}
+                                      {trace.telemetry_sdk_language.includes(
+                                        "ts",
+                                      ) && (
+                                        <SiTypescript
+                                          className="text-neutral-800 dark:text-neutral-200"
+                                          size={14}
+                                        />
+                                      )}
+                                      {trace.telemetry_sdk_language.includes(
+                                        "js",
+                                      ) && (
+                                        <IoLogoJavascript
+                                          className="text-neutral-800 dark:text-neutral-200"
+                                          size={14}
+                                        />
+                                      )}
+                                      {trace.telemetry_sdk_language.includes(
+                                        "java",
+                                      ) && (
+                                        <FaJava
+                                          className="text-neutral-800 dark:text-neutral-200"
+                                          size={14}
+                                        />
+                                      )}
+                                    </div>
+                                  )}
+                                <Badge
+                                  variant="default"
+                                  className="min-w-16 h-6 mr-2 justify-start font-mono font-normal max-w-full overflow-hidden text-ellipsis flex-shrink text-left"
+                                  title={traceId}
+                                >
+                                  {traceId.substring(0, 12)}...
+                                </Badge>
+                                {trace?.service_name && (
+                                  <Badge
+                                    variant="default"
+                                    className="min-w-16 h-6 mr-2 justify-start font-mono font-normal max-w-full overflow-hidden text-ellipsis flex-shrink text-left"
+                                    title={
+                                      trace.service_name.length > 25
+                                        ? trace.service_name
+                                        : undefined
+                                    }
+                                  >
+                                    {trace.service_name}
+                                  </Badge>
+                                )}
+                                {trace?.service_environment && (
+                                  <Badge
+                                    variant="outline"
+                                    className="h-6 mr-2 justify-center font-mono font-normal flex-shrink-0"
+                                  >
+                                    {trace.service_environment}
+                                  </Badge>
+                                )}
+                              </div>
+                              {trace?.start_time && (
+                                <span className="text-xs text-gray-500 dark:text-gray-400 font-mono mr-2">
+                                  {formatTimestamp(trace.start_time)}
+                                </span>
+                              )}
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={(e) => {
+                                  e.stopPropagation(); // Prevent trace selection
+                                  setExpandedTraceBlocks((prev) => {
+                                    const newSet = new Set(prev);
+                                    if (newSet.has(traceId)) {
+                                      newSet.delete(traceId);
+                                    } else {
+                                      newSet.add(traceId);
+                                    }
+                                    return newSet;
+                                  });
+                                }}
+                                className="h-8 w-8 p-0"
+                              >
+                                {isTraceExpanded ? (
+                                  <Minus className="w-4 h-4" />
+                                ) : (
+                                  <Plus className="w-4 h-4" />
+                                )}
+                              </Button>
+                            </div>
                           </div>
+
+                          {/* Trace Logs */}
+                          {isTraceExpanded && (
+                            <div className="p-2 space-y-1 bg-zinc-50 dark:bg-zinc-950">
+                              {logs.map(({ entry, spanId }, idx) => {
+                                const githubLink = getGitHubLink(entry);
+                                const entryKey = `${traceId}-${spanId}-${idx}`;
+                                const isExpanded =
+                                  expandedEntries.has(entryKey);
+                                const formattedMessage = formatMessage(
+                                  entry.message,
+                                );
+                                const messageExpandable =
+                                  isMessageExpandable(formattedMessage);
+                                const displayMessage =
+                                  messageExpandable && !isExpanded
+                                    ? truncateMessage(formattedMessage)
+                                    : formattedMessage;
+
+                                return (
+                                  <div
+                                    key={entryKey}
+                                    className={`relative p-1.5 rounded bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 transform transition-all duration-100 ease-in-out hover:shadow`}
+                                    style={getLogStyle(
+                                      spanDepthMap[spanId] ?? 0,
+                                    )}
+                                  >
+                                    <div className="flex items-start min-w-0">
+                                      <div className="flex-1 min-w-0">
+                                        <div className="flex font-mono items-center space-x-2 text-xs flex-wrap min-w-0">
+                                          <span
+                                            className={`font-medium ${getLogLevelColor(entry.level)}`}
+                                          >
+                                            {entry.level}
+                                          </span>
+                                          <span className="text-gray-500 dark:text-gray-400">
+                                            {formatTimestamp(entry.time)}
+                                          </span>
+                                          <span className="text-gray-400 dark:text-gray-500 font-mono">
+                                            {entry.file_name}:
+                                            {entry.line_number}
+                                          </span>
+                                          <span className="text-neutral-600 dark:text-neutral-300 italic break-all">
+                                            {entry.function_name}
+                                          </span>
+                                          {githubLink && (
+                                            <a
+                                              href={githubLink}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                              className="text-neutral-500 dark:text-neutral-300 hover:text-neutral-600 dark:hover:text-neutral-400 transition-colors"
+                                              title="View on GitHub"
+                                            >
+                                              <FaGithub className="inline-block" />
+                                            </a>
+                                          )}
+                                        </div>
+                                        <div className="relative font-mono p-1 bg-zinc-50 dark:bg-zinc-900 rounded text-neutral-800 dark:text-neutral-300 text-xs min-w-0 max-w-full overflow-hidden min-h-[1.5rem]">
+                                          <Button
+                                            onClick={() =>
+                                              copyToClipboard(entry.message)
+                                            }
+                                            variant="ghost"
+                                            size="icon"
+                                            className="absolute top-0.5 right-0.5 h-5 w-5 opacity-70 hover:opacity-100 transition-opacity z-10"
+                                            title="Copy message"
+                                          >
+                                            <IoCopyOutline className="w-3 h-3" />
+                                          </Button>
+                                          <span className="whitespace-pre-wrap break-all word-break-break-all overflow-wrap-anywhere m-0 max-w-full pr-7 block">
+                                            {logSearchValue ||
+                                            metadataSearchTerms.length > 0
+                                              ? highlightText(
+                                                  displayMessage,
+                                                  logSearchValue,
+                                                  metadataSearchTerms,
+                                                )
+                                              : displayMessage}
+                                          </span>
+                                        </div>
+                                        {/* Show code context if available */}
+                                        <CodeContext
+                                          entry={entry}
+                                          showCode={showCode}
+                                        />
+                                      </div>
+                                      {messageExpandable && (
+                                        <div className="ml-2 flex-shrink-0">
+                                          <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() => {
+                                              setExpandedEntries((prev) => {
+                                                const newSet = new Set(prev);
+                                                if (newSet.has(entryKey)) {
+                                                  newSet.delete(entryKey);
+                                                } else {
+                                                  newSet.add(entryKey);
+                                                }
+                                                return newSet;
+                                              });
+                                            }}
+                                            className="h-6 w-6 p-0"
+                                          >
+                                            {isExpanded ? (
+                                              <Minus className="w-3 h-3 transition-transform duration-200 ease-in-out" />
+                                            ) : (
+                                              <Plus className="w-3 h-3 transition-transform duration-200 ease-in-out" />
+                                            )}
+                                          </Button>
+                                        </div>
+                                      )}
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          )}
                         </div>
-                        {/* Show code context if available */}
-                        <CodeContext entry={entry} showCode={showCode} />
+                      );
+                    },
+                  )
+                : /* Ungrouped View: Show all logs merged chronologically */
+                  orderedLogEntries.map(({ entry, spanId, traceId }, idx) => {
+                    const githubLink = getGitHubLink(entry);
+                    const entryKey = `${traceId}-${spanId}-${idx}`;
+                    const isExpanded = expandedEntries.has(entryKey);
+                    const formattedMessage = formatMessage(entry.message);
+                    const messageExpandable =
+                      isMessageExpandable(formattedMessage);
+                    const displayMessage =
+                      messageExpandable && !isExpanded
+                        ? truncateMessage(formattedMessage)
+                        : formattedMessage;
+
+                    // For multiple traces, use flat layout (no indentation)
+                    // For single trace, use tree structure with indentation
+                    const logStyle =
+                      traceIds.length > 1
+                        ? { animationDelay: `${idx * 3}ms` }
+                        : {
+                            ...getLogStyle(spanDepthMap[spanId] ?? 0),
+                            animationDelay: `${idx * 3}ms`,
+                          };
+
+                    return (
+                      <div
+                        key={entryKey}
+                        className={`relative p-1.5 rounded bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 transform transition-all duration-100 ease-in-out hover:shadow animate-fadeIn ${traceIds.length > 1 ? "mx-3" : ""}`}
+                        style={logStyle}
+                      >
+                        <div className="flex items-start min-w-0">
+                          <div className="flex-1 min-w-0">
+                            <div className="flex font-mono items-center space-x-2 text-xs flex-wrap min-w-0">
+                              {traceIds.length > 1 && (
+                                <Badge
+                                  variant="default"
+                                  className="h-5 px-1.5 text-xs font-mono font-normal max-w-full overflow-hidden text-ellipsis flex-shrink text-left"
+                                  title={traceId}
+                                >
+                                  {traceId.substring(0, 8)}...
+                                </Badge>
+                              )}
+                              <span
+                                className={`font-medium ${getLogLevelColor(entry.level)}`}
+                              >
+                                {entry.level}
+                              </span>
+                              <span className="text-gray-500 dark:text-gray-400">
+                                {formatTimestamp(entry.time)}
+                              </span>
+                              <span className="text-gray-400 dark:text-gray-500 font-mono">
+                                {entry.file_name}:{entry.line_number}
+                              </span>
+                              <span className="text-neutral-600 dark:text-neutral-300 italic break-all">
+                                {entry.function_name}
+                              </span>
+                              {githubLink && (
+                                <a
+                                  href={githubLink}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-neutral-500 dark:text-neutral-300 hover:text-neutral-600 dark:hover:text-neutral-400 transition-colors"
+                                  title="View on GitHub"
+                                >
+                                  <FaGithub className="inline-block" />
+                                </a>
+                              )}
+                              <div className="relative font-mono p-1 bg-zinc-50 dark:bg-zinc-900 rounded text-neutral-800 dark:text-neutral-300 text-xs min-w-0 max-w-full overflow-hidden min-h-[1.5rem]">
+                                <Button
+                                  onClick={() => copyToClipboard(entry.message)}
+                                  variant="ghost"
+                                  size="icon"
+                                  className="absolute top-0.5 right-0.5 h-5 w-5 opacity-70 hover:opacity-100 transition-opacity z-10"
+                                  title="Copy message"
+                                >
+                                  <IoCopyOutline className="w-3 h-3" />
+                                </Button>
+                                <span className="whitespace-pre-wrap break-all word-break-break-all overflow-wrap-anywhere m-0 max-w-full pr-7 block">
+                                  {logSearchValue ||
+                                  metadataSearchTerms.length > 0
+                                    ? highlightText(
+                                        displayMessage,
+                                        logSearchValue,
+                                        metadataSearchTerms,
+                                      )
+                                    : displayMessage}
+                                </span>
+                              </div>
+                            </div>
+                            {/* Show code context if available */}
+                            <CodeContext entry={entry} showCode={showCode} />
+                          </div>
+                          {/* Expand/Collapse Icon - Only show if message is expandable */}
+                          {messageExpandable && (
+                            <div className="ml-2 flex-shrink-0 bg-zinc-100 dark:bg-zinc-800 rounded-md">
+                              <Button
+                                onClick={() => toggleExpandEntry(entryKey)}
+                                variant="ghost"
+                                size="icon"
+                                title={isExpanded ? "Collapse" : "Expand"}
+                                className="h-8 w-8"
+                              >
+                                {isExpanded ? (
+                                  <Minus className="w-3 h-3 transition-transform duration-200 ease-in-out" />
+                                ) : (
+                                  <Plus className="w-3 h-3 transition-transform duration-200 ease-in-out" />
+                                )}
+                              </Button>
+                            </div>
+                          )}
+                        </div>
                       </div>
-                      {/* Expand/Collapse Icon - Only show if message is expandable */}
-                      {messageExpandable && (
-                        <div className="ml-2 flex-shrink-0 bg-zinc-100 dark:bg-zinc-800 rounded-md">
-                          <Button
-                            onClick={() => toggleExpandEntry(entryKey)}
-                            variant="ghost"
-                            size="icon"
-                            title={isExpanded ? "Collapse" : "Expand"}
-                            className="h-8 w-8"
-                          >
-                            {isExpanded ? (
-                              <Minus className="w-3 h-3 transition-transform duration-200 ease-in-out" />
-                            ) : (
-                              <Plus className="w-3 h-3 transition-transform duration-200 ease-in-out" />
-                            )}
-                          </Button>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                );
-              })}
+                    );
+                  })}
             </div>
           </div>
         )}
-        {!loading && !error && traceId && orderedLogEntries.length === 0 && (
-          <div className="p-4 rounded-lg border border-gray-200 dark:border-gray-700">
-            <p className="text-gray-600 dark:text-gray-300">
-              No logs found for this trace or span
-            </p>
-          </div>
-        )}
+        {!loading &&
+          !error &&
+          traceIds.length > 0 &&
+          orderedLogEntries.length === 0 && (
+            <div className="p-4 rounded-lg border border-gray-200 dark:border-gray-700">
+              <p className="text-gray-600 dark:text-gray-300">
+                No logs found for the selected trace
+                {traceIds.length > 1 ? "s" : ""} or span
+              </p>
+            </div>
+          )}
       </div>
     </div>
   );

--- a/ui/src/components/right-panel/log/LogOverview.tsx
+++ b/ui/src/components/right-panel/log/LogOverview.tsx
@@ -22,7 +22,7 @@ interface LogOverviewProps {
   traceDurations?: number[]; // Array of durations in milliseconds
   tracePercentiles?: string[]; // Array of percentiles for each trace (e.g. 'P90', 'P50', ...)
   // Callback props
-  onTraceSelect?: (traceId: string) => void; // Add callback for trace selection
+  onTraceSelect?: (traceIds: string[]) => void; // Add callback for trace selection
 }
 
 export default function LogOverview({

--- a/ui/src/components/right-panel/log/LogPanelSwitch.tsx
+++ b/ui/src/components/right-panel/log/LogPanelSwitch.tsx
@@ -3,15 +3,16 @@
 import React from "react";
 import LogOverview from "./LogOverview";
 import LogDetail from "./LogDetail";
-import { Span } from "@/models/trace";
+import { Span, Trace as TraceModel } from "@/models/trace";
 import { ViewType } from "../ModeToggle";
 
 interface LogPanelSwitchProps {
-  traceId?: string;
+  traceIds?: string[];
   spanIds?: string[];
   traceQueryStartTime?: Date;
   traceQueryEndTime?: Date;
   segments?: Span[];
+  allTraces?: TraceModel[];
   traceDurations?: number[];
   traceStartTimes?: Date[];
   traceEndTimes?: Date[];
@@ -19,16 +20,17 @@ interface LogPanelSwitchProps {
   tracePercentiles?: string[];
   logSearchValue?: string;
   metadataSearchTerms?: { category: string; value: string }[];
-  onTraceSelect?: (traceId: string) => void;
+  onTraceSelect?: (traceIds: string[]) => void;
   viewType?: ViewType;
 }
 
 export default function LogPanelSwitch({
-  traceId,
+  traceIds = [],
   spanIds = [],
   traceQueryStartTime,
   traceQueryEndTime,
   segments,
+  allTraces = [],
   traceDurations = [],
   traceStartTimes = [],
   traceEndTimes = [],
@@ -41,13 +43,14 @@ export default function LogPanelSwitch({
 }: LogPanelSwitchProps) {
   return (
     <div className="h-screen flex flex-col dark:bg-zinc-950">
-      {traceId ? (
+      {traceIds.length > 0 ? (
         <LogDetail
-          traceId={traceId}
+          traceIds={traceIds}
           spanIds={spanIds}
           traceQueryStartTime={traceQueryStartTime}
           traceQueryEndTime={traceQueryEndTime}
           segments={segments}
+          allTraces={allTraces}
           logSearchValue={logSearchValue}
           metadataSearchTerms={metadataSearchTerms}
           viewType={viewType}

--- a/ui/src/components/right-panel/trace/TraceOverview.tsx
+++ b/ui/src/components/right-panel/trace/TraceOverview.tsx
@@ -22,7 +22,7 @@ interface TraceOverviewProps {
   traceDurations?: number[]; // Array of durations in milliseconds
   tracePercentiles?: string[]; // Array of percentiles for each trace (e.g. 'P90', 'P50', ...)
   // Callback props
-  onTraceSelect?: (traceId: string) => void; // Add callback for trace selection
+  onTraceSelect?: (traceIds: string[]) => void; // Add callback for trace selection
 }
 
 export default function TraceOverview({
@@ -235,6 +235,13 @@ export default function TraceOverview({
 
     const isPercentilePlot = tracePercentiles.length > 0;
 
+    // Wrapper to convert single traceId to array for parent callback
+    const handlePointClick = (traceId: string) => {
+      if (onTraceSelect) {
+        onTraceSelect([traceId]);
+      }
+    };
+
     return (
       <div className="max-w-full bg-white dark:bg-zinc-900 rounded-xl border border-zinc-200 dark:border-zinc-700">
         {/* Content */}
@@ -245,7 +252,7 @@ export default function TraceOverview({
             xAxisLabel="Start Time"
             yAxisLabel="Latency (s)"
             isPercentilePlot={isPercentilePlot}
-            onPointClick={onTraceSelect} // Pass the trace selection callback
+            onPointClick={handlePointClick} // Pass the wrapped callback
           />
         </div>
       </div>

--- a/ui/src/components/right-panel/trace/TracePanelSwitch.tsx
+++ b/ui/src/components/right-panel/trace/TracePanelSwitch.tsx
@@ -16,7 +16,7 @@ interface TracePanelSwitchProps {
   traceEndTimes?: Date[];
   traceIDs?: string[];
   tracePercentiles?: string[];
-  onTraceSelect?: (traceId: string) => void;
+  onTraceSelect?: (traceIds: string[]) => void;
 }
 
 export default function TracePanelSwitch({


### PR DESCRIPTION
## Summary

1. Automatically expand the first trace after list traces
2. Allow using CMD or SHIFT + selection (Mac) to select multiple traces (on windows Ctrl + selection)
3. Allow grouping the loggings according to traces
4. Allow sorting the loggings in grouped and ungrouped mode
5. Add some tooltips

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

https://www.loom.com/share/e248437b22ca44c9a1f3fe81a5718528?sid=b35150be-0053-4e08-9ba1-1303083e7a8e

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
