### PR TITLE
fix: Use cached logs instead of refetch when switching views

### DIFF
--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -27,6 +27,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "@radix-ui/react-use-controllable-state": "^1.2.2",
         "@stripe/stripe-js": "^7.5.0",
+        "@tanstack/react-query": "^5.90.7",
         "ai": "^5.0.39",
         "autumn-js": "^0.1.5",
         "class-variance-authority": "^0.7.1",
@@ -722,6 +723,10 @@
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.14", "", { "os": "win32", "cpu": "x64" }, "sha512-ttblVGHgf68kEE4om1n/n44I0yGPkCPbLsqzjvybhpwa6mKKtgFfAzy6btc3HRmuW7nHe0OOrSeNP9sQmmH9XA=="],
 
     "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.14", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.14", "@tailwindcss/oxide": "4.1.14", "postcss": "^8.4.41", "tailwindcss": "4.1.14" } }, "sha512-BdMjIxy7HUNThK87C7BC8I1rE8BVUsfNQSI5siQ4JK3iIa3w0XyVvVL9SXLWO//CtYTcp1v7zci0fYwJOjB+Zg=="],
+
+    "@tanstack/query-core": ["@tanstack/query-core@5.90.7", "", {}, "sha512-6PN65csiuTNfBMXqQUxQhCNdtm1rV+9kC9YwWAIKcaxAauq3Wu7p18j3gQY3YIBJU70jT/wzCCZ2uqto/vQgiQ=="],
+
+    "@tanstack/react-query": ["@tanstack/react-query@5.90.7", "", { "dependencies": { "@tanstack/query-core": "5.90.7" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-wAHc/cgKzW7LZNFloThyHnV/AX9gTg3w5yAv0gvQHPZoCnepwqCMtzbuPbb2UvfvO32XZ46e8bPOYbfZhzVnnQ=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
     "@stripe/stripe-js": "^7.5.0",
+    "@tanstack/react-query": "^5.90.7",
     "ai": "^5.0.39",
     "autumn-js": "^0.1.5",
     "class-variance-authority": "^0.7.1",

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Toaster } from "react-hot-toast";
 import { ThemeProvider } from "@/providers/theme-provider";
 import { ClerkProvider } from "@clerk/nextjs";
+import { QueryProvider } from "@/providers/QueryProvider";
 import RootLayoutClient from "./layout-client";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -30,44 +31,46 @@ export default function RootLayout({
     >
       <html lang="en" suppressHydrationWarning>
         <body className={`${inter.className} h-screen overflow-hidden`}>
-          <ThemeProvider
-            attribute="class"
-            defaultTheme="system"
-            enableSystem
-            disableTransitionOnChange
-          >
-            <RootLayoutClient>{children}</RootLayoutClient>
-            <Toaster
-              position="top-right"
-              toastOptions={{
-                duration: 4000,
-                style: {
-                  background: "#363636",
-                  color: "#fff",
-                },
-                success: {
-                  duration: 3000,
-                  iconTheme: {
-                    primary: "#4ade80",
-                    secondary: "#fff",
+          <QueryProvider>
+            <ThemeProvider
+              attribute="class"
+              defaultTheme="system"
+              enableSystem
+              disableTransitionOnChange
+            >
+              <RootLayoutClient>{children}</RootLayoutClient>
+              <Toaster
+                position="top-right"
+                toastOptions={{
+                  duration: 4000,
+                  style: {
+                    background: "#363636",
+                    color: "#fff",
                   },
-                },
-                error: {
-                  duration: 5000,
-                  iconTheme: {
-                    primary: "#ef4444",
-                    secondary: "#fff",
+                  success: {
+                    duration: 3000,
+                    iconTheme: {
+                      primary: "#4ade80",
+                      secondary: "#fff",
+                    },
                   },
-                },
-                loading: {
-                  iconTheme: {
-                    primary: "#3b82f6",
-                    secondary: "#fff",
+                  error: {
+                    duration: 5000,
+                    iconTheme: {
+                      primary: "#ef4444",
+                      secondary: "#fff",
+                    },
                   },
-                },
-              }}
-            />
-          </ThemeProvider>
+                  loading: {
+                    iconTheme: {
+                      primary: "#3b82f6",
+                      secondary: "#fff",
+                    },
+                  },
+                }}
+              />
+            </ThemeProvider>
+          </QueryProvider>
         </body>
       </html>
     </ClerkProvider>

--- a/ui/src/components/right-panel/log/LogDetail.tsx
+++ b/ui/src/components/right-panel/log/LogDetail.tsx
@@ -64,11 +64,11 @@ export default function LogDetail({
   const [showCode, setShowCode] = useState(false);
   const [, forceUpdate] = useState({});
   const [expandedEntries, setExpandedEntries] = useState<Set<string>>(
-    new Set()
+    new Set(),
   );
   const [isGrouped, setIsGrouped] = useState(false);
   const [expandedTraceBlocks, setExpandedTraceBlocks] = useState<Set<string>>(
-    new Set()
+    new Set(),
   );
   const [isSortDescending, setIsSortDescending] = useState(false);
 
@@ -187,7 +187,7 @@ export default function LogDetail({
           (spanLog: SpanLog) => {
             const spanId = Object.keys(spanLog)[0];
             return selectedSpansForThisTrace.includes(spanId);
-          }
+          },
         );
         if (filteredSpanLogs.length > 0) {
           filteredLogs[traceId] = filteredSpanLogs;
@@ -293,7 +293,7 @@ export default function LogDetail({
   const buildOrderedLogEntries = (
     logs: TraceLog | null,
     traceIds: string[],
-    sortDescending: boolean
+    sortDescending: boolean,
   ) => {
     const result: { entry: LogEntry; spanId: string; traceId: string }[] = [];
     if (!logs) return result;
@@ -307,7 +307,7 @@ export default function LogDetail({
             entries.forEach((entry) => {
               result.push({ entry, spanId, traceId });
             });
-          }
+          },
         );
       });
     });
@@ -327,7 +327,7 @@ export default function LogDetail({
     orderedEntries: { entry: LogEntry; spanId: string; traceId: string }[],
     traceIds: string[],
     allTraces: TraceModel[],
-    sortDescending: boolean
+    sortDescending: boolean,
   ) => {
     const groupedData: Map<
       string,
@@ -399,14 +399,14 @@ export default function LogDetail({
   const orderedLogEntries = buildOrderedLogEntries(
     logs,
     traceIds,
-    isSortDescending
+    isSortDescending,
   );
   // Compute grouped log entries (for grouped view) - reuses same entry references from orderedLogEntries
   const groupedLogEntries = buildGroupedLogEntries(
     orderedLogEntries,
     traceIds,
     allTraces,
-    isSortDescending
+    isSortDescending,
   );
 
   // Get all log entries for ShowCodeToggle (flattened from grouped view or ungrouped view)
@@ -425,7 +425,7 @@ export default function LogDetail({
 
   // Calculate log level statistics
   const calculateLogStats = (
-    logEntries: { entry: LogEntry; spanId: string; traceId: string }[]
+    logEntries: { entry: LogEntry; spanId: string; traceId: string }[],
   ) => {
     const stats = {
       TRACE: 0,
@@ -490,7 +490,7 @@ export default function LogDetail({
 
     // Sort by timestamp (latest to most recent, i.e., descending order)
     const sortedEntries = [...orderedLogEntries].sort(
-      (a, b) => b.entry.time - a.entry.time
+      (a, b) => b.entry.time - a.entry.time,
     );
 
     // CSV header - include Trace ID if multiple traces
@@ -637,7 +637,7 @@ export default function LogDetail({
   const highlightText = (
     text: string,
     logSearchTerm: string,
-    metadataTerms: { category: string; value: string }[]
+    metadataTerms: { category: string; value: string }[],
   ) => {
     // Collect all search patterns
     const searchPatterns: RegExp[] = [];
@@ -653,7 +653,7 @@ export default function LogDetail({
       if (term.category.trim() && term.value.trim()) {
         const escapedCategory = term.category.replace(
           /[.*+?^${}()|[\]\\]/g,
-          "\\$&"
+          "\\$&",
         );
         const escapedValue = term.value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         // Match pattern: "key": "value" (with optional whitespace)
@@ -668,7 +668,7 @@ export default function LogDetail({
     // Create a combined pattern that captures all search terms
     const combinedPattern = new RegExp(
       `(${searchPatterns.map((p) => p.source.slice(1, -1)).join("|")})`,
-      "gi"
+      "gi",
     );
 
     const parts = text.split(combinedPattern);
@@ -884,7 +884,7 @@ export default function LogDetail({
                                   trace.telemetry_sdk_language.length > 0 && (
                                     <div className="flex items-center flex-shrink-0 ml-1 mr-2 hidden [@media(min-width:433px)]:flex">
                                       {trace.telemetry_sdk_language.includes(
-                                        "python"
+                                        "python",
                                       ) && (
                                         <FaPython
                                           className="text-neutral-800 dark:text-neutral-200"
@@ -892,7 +892,7 @@ export default function LogDetail({
                                         />
                                       )}
                                       {trace.telemetry_sdk_language.includes(
-                                        "ts"
+                                        "ts",
                                       ) && (
                                         <SiTypescript
                                           className="text-neutral-800 dark:text-neutral-200"
@@ -900,7 +900,7 @@ export default function LogDetail({
                                         />
                                       )}
                                       {trace.telemetry_sdk_language.includes(
-                                        "js"
+                                        "js",
                                       ) && (
                                         <IoLogoJavascript
                                           className="text-neutral-800 dark:text-neutral-200"
@@ -908,7 +908,7 @@ export default function LogDetail({
                                         />
                                       )}
                                       {trace.telemetry_sdk_language.includes(
-                                        "java"
+                                        "java",
                                       ) && (
                                         <FaJava
                                           className="text-neutral-800 dark:text-neutral-200"
@@ -1017,7 +1017,7 @@ export default function LogDetail({
                                 const isExpanded =
                                   expandedEntries.has(entryKey);
                                 const formattedMessage = formatMessage(
-                                  entry.message
+                                  entry.message,
                                 );
                                 const messageExpandable =
                                   isMessageExpandable(formattedMessage);
@@ -1031,7 +1031,7 @@ export default function LogDetail({
                                     key={entryKey}
                                     className={`relative p-1.5 rounded bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-700 transform transition-all duration-100 ease-in-out hover:shadow`}
                                     style={getLogStyle(
-                                      spanDepthMap[spanId] ?? 0
+                                      spanDepthMap[spanId] ?? 0,
                                     )}
                                   >
                                     <div className="flex items-start min-w-0">
@@ -1082,7 +1082,7 @@ export default function LogDetail({
                                               ? highlightText(
                                                   displayMessage,
                                                   logSearchValue,
-                                                  metadataSearchTerms
+                                                  metadataSearchTerms,
                                                 )
                                               : displayMessage}
                                           </span>
@@ -1127,7 +1127,7 @@ export default function LogDetail({
                           )}
                         </div>
                       );
-                    }
+                    },
                   )
                 : /* Ungrouped View: Show all logs merged chronologically */
                   orderedLogEntries.map(({ entry, spanId, traceId }, idx) => {
@@ -1211,7 +1211,7 @@ export default function LogDetail({
                                     ? highlightText(
                                         displayMessage,
                                         logSearchValue,
-                                        metadataSearchTerms
+                                        metadataSearchTerms,
                                       )
                                     : displayMessage}
                                 </span>

--- a/ui/src/hooks/useLogs.ts
+++ b/ui/src/hooks/useLogs.ts
@@ -1,0 +1,127 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "@clerk/nextjs";
+import { TraceLog } from "@/models/log";
+import { Trace as TraceModel } from "@/models/trace";
+import { initializeProviders, appendProviderParams } from "@/utils/provider";
+
+interface UseLogsOptions {
+  traceIds: string[];
+  allTraces?: TraceModel[];
+  enabled?: boolean;
+}
+
+async function fetchLogs(
+  traceIds: string[],
+  allTraces: TraceModel[],
+  getToken: () => Promise<string | null>,
+): Promise<TraceLog> {
+  if (!traceIds || traceIds.length === 0) {
+    return {};
+  }
+
+  const { traceProvider, logProvider, traceRegion, logRegion } =
+    initializeProviders();
+  const token = await getToken();
+
+  // Fetch logs for all traces in parallel
+  type FetchResult =
+    | { traceId: string; data: TraceLog; success: true }
+    | { traceId: string; data: null; success: false; error: string };
+
+  const fetchPromises = traceIds.map(async (traceId): Promise<FetchResult> => {
+    try {
+      const url = new URL("/api/get_trace_log", window.location.origin);
+      url.searchParams.append("traceId", traceId);
+
+      // Find the trace in allTraces to get its timestamps
+      const trace = allTraces.find((t) => t.id === traceId);
+      if (
+        trace &&
+        trace.start_time &&
+        trace.end_time &&
+        trace.start_time !== 0
+      ) {
+        const startTime = new Date(trace.start_time * 1000).toISOString();
+        const endTime = new Date(trace.end_time * 1000).toISOString();
+        url.searchParams.append("start_time", startTime);
+        url.searchParams.append("end_time", endTime);
+      }
+
+      appendProviderParams(
+        url,
+        traceProvider,
+        traceRegion,
+        logProvider,
+        logRegion,
+      );
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      const result = await response.json();
+
+      if (!result.success) {
+        throw new Error(result.error || "Failed to fetch logs");
+      }
+
+      return { traceId, data: result.data as TraceLog, success: true };
+    } catch (err) {
+      console.error(`useLogs fetchLogs - error for ${traceId}:`, err);
+      return {
+        traceId,
+        data: null,
+        success: false,
+        error:
+          err instanceof Error
+            ? err.message
+            : "An error occurred while fetching logs",
+      };
+    }
+  });
+
+  const results = await Promise.all(fetchPromises);
+
+  // Merge all successful results
+  const mergedLogs: TraceLog = {};
+  let hasErrors = false;
+  let errorMessage = "";
+
+  results.forEach((result) => {
+    if (result.success && result.data) {
+      Object.entries(result.data).forEach(([traceId, spanLogs]) => {
+        mergedLogs[traceId] = spanLogs;
+      });
+    } else {
+      hasErrors = true;
+      errorMessage = result.error || "Failed to fetch logs for some traces";
+    }
+  });
+
+  if (hasErrors && Object.keys(mergedLogs).length === 0) {
+    throw new Error(errorMessage);
+  }
+
+  return mergedLogs;
+}
+
+export function useLogs({
+  traceIds,
+  allTraces = [],
+  enabled = true,
+}: UseLogsOptions) {
+  const { getToken } = useAuth();
+
+  return useQuery({
+    queryKey: [
+      "logs",
+      traceIds,
+      allTraces.map((t) => ({ id: t.id, start: t.start_time })),
+    ],
+    queryFn: () => fetchLogs(traceIds, allTraces, getToken),
+    enabled: enabled && traceIds.length > 0,
+  });
+}

--- a/ui/src/providers/QueryProvider.tsx
+++ b/ui/src/providers/QueryProvider.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  // query client config
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // Cache TTL for 10 minutes
+            staleTime: 10 * 60 * 1000,
+            // Cache data for 15 minutes after last use
+            gcTime: 15 * 60 * 1000,
+            // No auto refetching on window focus
+            refetchOnWindowFocus: false,
+            // Retry only once after failure
+            retry: 1,
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/ui/src/providers/QueryProvider.tsx
+++ b/ui/src/providers/QueryProvider.tsx
@@ -20,7 +20,7 @@ export function QueryProvider({ children }: { children: React.ReactNode }) {
             retry: 1,
           },
         },
-      })
+      }),
   );
 
   return (


### PR DESCRIPTION
## Summary

Fixes #311: Implements client side caching for log details using TanStack Query to prevent unnecessary refetches when switching between views

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

This PR implements **TanStack Query** for log data fetching to enable client side caching and prevent unnecessary refetches when switching between views.

### Why TanStack Query?

TanStack Query provides automatic client side caching with a 10-minute TTL, request deduplication, and smart cache invalidation. This eliminates manual cache management and ensures log data persists across component remounts when users switch views.

### Changes

- **Added** `@tanstack/react-query` dependency
- **Added** `src/providers/QueryProvider.tsx`(Global query client with 10 minute cache TTL)
- **Added** `src/hooks/useLogs.ts`(Reusable hook that encapsulates log fetching logic with caching)
- **Modified** `src/app/layout.tsx`(Wrapped app with QueryProvider)
- **Modified** `src/components/right-panel/log/LogDetail.tsx`(Replaced 130+ lines of `useEffect` fetch logic with 4 lines `useLogs` hook call, fixed TypeScript `any` types with proper `SpanLog` typing)

### Future Work

Following this pattern, remaining `useEffect` + `fetch` calls should be migrated to TanStack Query hooks for
consistency and performance benefits, including: `Trace.tsx`, `LogModeDetail.tsx`, `Agent.tsx`, `chat-reasoning.tsx`, and settings components.

## Screenshots / Recordings (if applicable)

https://www.loom.com/share/fc893510651e4664bbf499e3802131f4

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
