### PR TITLE
[UI] Highlight the selected trace and spans better in the UI [2/n]

### DIFF
--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -14,7 +14,7 @@ const badgeVariants = cva(
           "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
+        outline: "text-foreground border-neutral-300 dark:border-neutral-600",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## Summary

bring back the bordering that got accidentally removed in https://github.com/traceroot-ai/traceroot/pull/337

<img width="844" height="533" alt="Screenshot 2025-11-21 at 12 10 05 AM" src="https://github.com/user-attachments/assets/b889f2bb-4ca4-41b3-ad47-3705e742c6be" />

<img width="1005" height="509" alt="Screenshot 2025-11-21 at 12 10 14 AM" src="https://github.com/user-attachments/assets/ee0f08b7-fe79-44b8-a3f1-49b8abe29455" />

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
