### PR TITLE
feat: add Python 3.14 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ dependencies = [
     "slowapi==0.1.9",
     "aiocache==0.12.3",
     "PyGithub==2.6.1",
-    "pydantic==2.11.7",
+    "pydantic>=2.11.7",
     "python-dotenv==1.1.1",
     "pydantic-settings==2.10.1",
     "dotenv==0.9.9",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ all = [
     "slowapi==0.1.9",
     "aiocache==0.12.3",
     "PyGithub==2.6.1",
-    "pydantic==2.11.7",
+    "pydantic>=2.11.7",
     "python-dotenv==1.1.1",
     "pydantic-settings==2.10.1",
     "dotenv==0.9.9",


### PR DESCRIPTION
## Summary
- Loosen pydantic version constraint from ==2.11.7 to >=2.11.7
- Enables compatibility with Python 3.14, which doesn't have pre-built wheels for pydantic 2.11.7. The >= constraint allows pip to install pydantic 2.12.5+ which includes Python 3.14 support.

## Type of Change

- [x] chore - Other changes that don't modify sc or test files

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)