### PR TITLE
[AgentOps][Python SDK] Simplify sdk user experience

### DIFF
--- a/traceroot-py/traceroot/__init__.py
+++ b/traceroot-py/traceroot/__init__.py
@@ -77,7 +77,16 @@ def initialize(
 
 
 def get_client() -> TracerootClient | None:
-    """Get the global Traceroot client (internal use)."""
+    """Get the global Traceroot client, auto-initializing if needed.
+
+    If no client exists and TRACEROOT_API_KEY is set, automatically
+    initializes a client with default settings from environment variables.
+    This enables the @observe decorator to work without explicit initialize().
+    """
+    global _client
+    if _client is None:
+        # Auto-initialize from env vars (TracerootClient reads them)
+        _client = TracerootClient()
     return _client
 
 


### PR DESCRIPTION
## Summary
1. For Python SDK, make it s.t. we no longer have to call `traceroot.initialize()`, directly using the `@observe()` decorator will auto initialize the traceroot sdk client.
2. Remove `'self'` and `'cls'` from the sdk collected results.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
