### PR TITLE
[AgentOps][REST] Recover the hex trace/span id from base64

### DIFF
--- a/rest/routers/public/traces.py
+++ b/rest/routers/public/traces.py
@@ -118,39 +118,29 @@ def decode_otlp_id(b64_value: str) -> str:
 def decode_span_ids(trace_data: dict[str, Any]) -> dict[str, Any]:
     """Decode all trace_id, span_id, and parent_span_id fields from base64 to hex.
 
-    Recursively traverses the OTLP trace data structure and converts
-    all ID fields from base64 to hex for easier debugging and readability.
+    Traverses the OTLP trace data structure and converts all ID fields
+    from base64 to hex for easier debugging and readability.
 
     Args:
         trace_data: OTLP trace data dict from MessageToDict
 
     Returns:
         Modified trace data with hex-encoded IDs
+
+    Raises:
+        ValueError: If any ID field cannot be decoded (ensures consistent format)
     """
-    # Process resource_spans -> scope_spans -> spans
     for resource_span in trace_data.get("resource_spans", []):
         for scope_span in resource_span.get("scope_spans", []):
             for span in scope_span.get("spans", []):
-                # Decode trace_id
                 if "trace_id" in span and span["trace_id"]:
-                    try:
-                        span["trace_id"] = decode_otlp_id(span["trace_id"])
-                    except Exception as e:
-                        logger.warning(f"Failed to decode trace_id: {e}")
+                    span["trace_id"] = decode_otlp_id(span["trace_id"])
 
-                # Decode span_id
                 if "span_id" in span and span["span_id"]:
-                    try:
-                        span["span_id"] = decode_otlp_id(span["span_id"])
-                    except Exception as e:
-                        logger.warning(f"Failed to decode span_id: {e}")
+                    span["span_id"] = decode_otlp_id(span["span_id"])
 
-                # Decode parent_span_id
                 if "parent_span_id" in span and span["parent_span_id"]:
-                    try:
-                        span["parent_span_id"] = decode_otlp_id(span["parent_span_id"])
-                    except Exception as e:
-                        logger.warning(f"Failed to decode parent_span_id: {e}")
+                    span["parent_span_id"] = decode_otlp_id(span["parent_span_id"])
 
     return trace_data
 

--- a/rest/tests/test_traces.py
+++ b/rest/tests/test_traces.py
@@ -1,0 +1,261 @@
+"""Integration tests for the public traces endpoint.
+
+Tests that OTLP protobuf data is correctly decoded and IDs are
+converted from base64 to hex format before storage.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+from opentelemetry.proto.trace.v1.trace_pb2 import (
+    ResourceSpans,
+    ScopeSpans,
+    Span,
+)
+
+from rest.main import app
+from rest.routers.public.traces import authenticate_api_key
+
+
+@pytest.fixture
+def mock_s3():
+    """Mock S3 service to capture uploaded data."""
+    captured = {"key": None, "data": None}
+
+    mock_service = MagicMock()
+
+    def capture_upload(s3_key, data):
+        captured["key"] = s3_key
+        captured["data"] = data
+
+    mock_service.upload_json.side_effect = capture_upload
+    mock_service.ensure_bucket_exists.return_value = None
+
+    with patch("rest.routers.public.traces.get_s3_service") as mock:
+        mock.return_value = mock_service
+        yield captured
+
+
+@pytest.fixture
+def client():
+    """Create test client with mocked auth."""
+    # Override the auth dependency to skip DB lookup
+    app.dependency_overrides[authenticate_api_key] = lambda: "test-project-123"
+
+    with TestClient(app, raise_server_exceptions=False) as c:
+        yield c
+
+    # Clean up
+    app.dependency_overrides.clear()
+
+
+def create_test_protobuf(
+    trace_id: bytes,
+    span_id: bytes,
+    parent_span_id: bytes | None = None,
+    span_name: str = "test-span",
+) -> bytes:
+    """Create a test OTLP protobuf payload with specific IDs.
+
+    Args:
+        trace_id: 16-byte trace ID
+        span_id: 8-byte span ID
+        parent_span_id: Optional 8-byte parent span ID
+        span_name: Name for the span
+
+    Returns:
+        Serialized protobuf bytes
+    """
+    span = Span(
+        trace_id=trace_id,
+        span_id=span_id,
+        name=span_name,
+        start_time_unix_nano=1700000000000000000,
+        end_time_unix_nano=1700000001000000000,
+    )
+
+    if parent_span_id:
+        span.parent_span_id = parent_span_id
+
+    scope_spans = ScopeSpans(spans=[span])
+
+    resource = Resource(
+        attributes=[
+            KeyValue(key="service.name", value=AnyValue(string_value="test-service"))
+        ]
+    )
+    resource_spans = ResourceSpans(
+        resource=resource,
+        scope_spans=[scope_spans],
+    )
+
+    request = ExportTraceServiceRequest(resource_spans=[resource_spans])
+    return request.SerializeToString()
+
+
+class TestTraceIdDecoding:
+    """Test that trace/span IDs are decoded from base64 to hex."""
+
+    def test_trace_id_decoded_to_hex(self, client, mock_s3):
+        """Test that trace_id is stored as hex, not base64."""
+        # Known trace_id: 16 bytes
+        # Hex: 0123456789abcdef0123456789abcdef
+        trace_id = bytes.fromhex("0123456789abcdef0123456789abcdef")
+        span_id = bytes.fromhex("fedcba9876543210")
+
+        protobuf_data = create_test_protobuf(trace_id, span_id)
+
+        response = client.post(
+            "/api/v1/public/traces",
+            content=protobuf_data,
+            headers={
+                "Content-Type": "application/x-protobuf",
+                "Authorization": "Bearer test-key",
+            },
+        )
+
+        assert response.status_code == 200
+
+        # Check the captured S3 data
+        stored_data = mock_s3["data"]
+        assert stored_data is not None
+
+        # Navigate to the span
+        span = stored_data["resource_spans"][0]["scope_spans"][0]["spans"][0]
+
+        # Verify trace_id is hex (not base64)
+        assert span["trace_id"] == "0123456789abcdef0123456789abcdef"
+        assert span["span_id"] == "fedcba9876543210"
+
+    def test_parent_span_id_decoded_to_hex(self, client, mock_s3):
+        """Test that parent_span_id is also decoded to hex."""
+        trace_id = bytes.fromhex("aaaabbbbccccddddeeeeffffaaaabbbb")
+        span_id = bytes.fromhex("1111222233334444")
+        parent_span_id = bytes.fromhex("5555666677778888")
+
+        protobuf_data = create_test_protobuf(trace_id, span_id, parent_span_id)
+
+        response = client.post(
+            "/api/v1/public/traces",
+            content=protobuf_data,
+            headers={
+                "Content-Type": "application/x-protobuf",
+                "Authorization": "Bearer test-key",
+            },
+        )
+
+        assert response.status_code == 200
+
+        span = mock_s3["data"]["resource_spans"][0]["scope_spans"][0]["spans"][0]
+
+        assert span["trace_id"] == "aaaabbbbccccddddeeeeffffaaaabbbb"
+        assert span["span_id"] == "1111222233334444"
+        assert span["parent_span_id"] == "5555666677778888"
+
+    def test_s3_key_contains_project_id(self, client, mock_s3):
+        """Test that the S3 key includes the project ID."""
+        trace_id = bytes.fromhex("0" * 32)
+        span_id = bytes.fromhex("0" * 16)
+
+        protobuf_data = create_test_protobuf(trace_id, span_id)
+
+        response = client.post(
+            "/api/v1/public/traces",
+            content=protobuf_data,
+            headers={
+                "Content-Type": "application/x-protobuf",
+                "Authorization": "Bearer test-key",
+            },
+        )
+
+        assert response.status_code == 200
+
+        s3_key = mock_s3["key"]
+        assert "test-project-123" in s3_key
+        assert s3_key.startswith("events/otel/")
+        assert s3_key.endswith(".json")
+
+
+class TestContentTypeValidation:
+    """Test that only protobuf content type is accepted."""
+
+    def test_rejects_json_content_type(self, client, mock_s3):
+        """Test that application/json is rejected with 415."""
+        response = client.post(
+            "/api/v1/public/traces",
+            content=b'{"resourceSpans": []}',
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer test-key",
+            },
+        )
+
+        assert response.status_code == 415
+        assert "Unsupported content type" in response.json()["detail"]
+
+    def test_rejects_missing_content_type(self, client, mock_s3):
+        """Test that missing content type is rejected."""
+        response = client.post(
+            "/api/v1/public/traces",
+            content=b"some data",
+            headers={
+                "Authorization": "Bearer test-key",
+            },
+        )
+
+        assert response.status_code == 415
+
+    def test_accepts_protobuf_content_type(self, client, mock_s3):
+        """Test that application/x-protobuf is accepted."""
+        trace_id = bytes.fromhex("0" * 32)
+        span_id = bytes.fromhex("0" * 16)
+        protobuf_data = create_test_protobuf(trace_id, span_id)
+
+        response = client.post(
+            "/api/v1/public/traces",
+            content=protobuf_data,
+            headers={
+                "Content-Type": "application/x-protobuf",
+                "Authorization": "Bearer test-key",
+            },
+        )
+
+        assert response.status_code == 200
+
+
+class TestErrorHandling:
+    """Test error handling for invalid requests."""
+
+    def test_empty_body_returns_400(self, client, mock_s3):
+        """Test that empty body returns 400."""
+        response = client.post(
+            "/api/v1/public/traces",
+            content=b"",
+            headers={
+                "Content-Type": "application/x-protobuf",
+                "Authorization": "Bearer test-key",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "Empty request body" in response.json()["detail"]
+
+    def test_invalid_protobuf_returns_400(self, client, mock_s3):
+        """Test that invalid protobuf data returns 400."""
+        response = client.post(
+            "/api/v1/public/traces",
+            content=b"not valid protobuf data",
+            headers={
+                "Content-Type": "application/x-protobuf",
+                "Authorization": "Bearer test-key",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "Failed to parse OTLP protobuf" in response.json()["detail"]


### PR DESCRIPTION
## Summary
Fixes https://github.com/traceroot-ai/traceroot/issues/370
Decode the protobuf base64 format of trace id and span id to the original hexadecimal number in blob storage

## Type of Change

- [x] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)
Before
<img width="1010" height="672" alt="Screenshot 2026-01-25 at 9 46 56 PM" src="https://github.com/user-attachments/assets/57869c86-3611-41e1-b99a-71bef9328393" />

After
<img width="1010" height="663" alt="Screenshot 2026-01-25 at 9 47 13 PM" src="https://github.com/user-attachments/assets/c809d347-1a16-48de-8500-994bc0d0f62a" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
