### PR TITLE
[AgentOps][UI] UI support for pricing [1/n] 

### DIFF
--- a/ui/src/app/organizations/[orgId]/settings/page.tsx
+++ b/ui/src/app/organizations/[orgId]/settings/page.tsx
@@ -31,6 +31,8 @@ import {
   Trash2,
   SlidersHorizontal,
   Users,
+  CreditCard,
+  ArrowRight,
 } from "lucide-react";
 import Link from "next/link";
 
@@ -38,6 +40,7 @@ import Link from "next/link";
 const settingsTabs = [
   { id: "general", label: "General", icon: SlidersHorizontal },
   { id: "members", label: "Members", icon: Users },
+  { id: "billing", label: "Billing", icon: CreditCard },
 ] as const;
 
 type TabId = (typeof settingsTabs)[number]["id"];
@@ -115,6 +118,7 @@ export default function OrgSettingsPage() {
         <div>
           {activeTab === "general" && <GeneralTab orgId={orgId} />}
           {activeTab === "members" && <MembersTab orgId={orgId} />}
+          {activeTab === "billing" && <BillingTab orgId={orgId} />}
         </div>
       </div>
     </div>
@@ -504,6 +508,200 @@ function MembersTab({ orgId }: { orgId: string }) {
           </table>
         )}
       </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Billing Tab
+// =============================================================================
+
+const pricingPlans = [
+  {
+    id: "free",
+    name: "Free",
+    description: "Get started with basic features",
+    price: 0,
+    features: [
+      "1 seat only",
+      "10k trace + logs",
+      "100k LLM tokens",
+      "7d retention",
+      "AI agent with chat mode only",
+    ],
+    buttonText: "Current Plan",
+    highlighted: false,
+    disabled: true,
+  },
+  {
+    id: "starter",
+    name: "Starter",
+    description: "For individuals and small teams",
+    price: 49,
+    features: [
+      "Up to 1 organization",
+      "Up to 5 seats",
+      "100k trace + logs",
+      "1M LLM tokens",
+      "30d retention",
+      "Source code visible in UI",
+      "AI agent with chat mode only",
+    ],
+    buttonText: "Upgrade",
+    highlighted: false,
+  },
+  {
+    id: "pro",
+    name: "Pro",
+    description: "For all your extra messaging needs",
+    price: 99,
+    features: [
+      "Everything in Starter",
+      "Up to 1 organization",
+      "Unlimited users",
+      "AI agent has chat + agent mode",
+      "Optional full codebase access (GitHub integration)",
+      "AI Agent auto-triaging production issues",
+    ],
+    buttonText: "Upgrade",
+    highlighted: true,
+    badge: "Popular",
+  },
+  {
+    id: "startups",
+    name: "Startups",
+    description: "For those of you who are really serious",
+    price: 999,
+    features: [
+      "Everything in Pro",
+      "Up to 5 organizations",
+      "5M trace + logs",
+      "50M LLM tokens",
+      "Slack & Notion integration, full GitHub support with ticket/PR context",
+      "SOC2 & ISO27001 reports, BAA available (HIPAA)",
+    ],
+    buttonText: "Upgrade",
+    highlighted: false,
+  },
+];
+
+function BillingTab({ orgId: _orgId }: { orgId: string }) {
+  const [showPricingDialog, setShowPricingDialog] = useState(false);
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      {/* Header */}
+      <div>
+        <h2 className="text-xl font-semibold">Billing</h2>
+        <p className="text-sm text-muted-foreground">
+          Manage your subscription and billing details
+        </p>
+      </div>
+
+      {/* Current Plan Section */}
+      <div className="border p-4">
+        <h3 className="text-sm font-medium">Current plan</h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          You are currently on the <span className="font-medium text-foreground">Free</span> plan.
+        </p>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setShowPricingDialog(true)}
+          className="mt-3"
+        >
+          Change plan
+        </Button>
+      </div>
+
+      {/* Usage Section */}
+      <div className="border p-4">
+        <h3 className="text-sm font-medium">Usage</h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          Your usage statistics for the current billing period.
+        </p>
+        <div className="mt-3 space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Traces</span>
+            <span>0 / 1,000</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">LLM tokens</span>
+            <span>0 / 100,000</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Pricing Dialog */}
+      <Dialog open={showPricingDialog} onOpenChange={setShowPricingDialog}>
+        <DialogContent className="max-w-5xl">
+          <DialogHeader>
+            <DialogTitle>Choose a plan</DialogTitle>
+            <DialogDescription>
+              Select a plan that best fits your needs.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="py-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+              {pricingPlans.map((plan) => (
+                <div
+                  key={plan.id}
+                  className={cn(
+                    "border p-4 flex flex-col",
+                    plan.highlighted && "border-foreground shadow-md"
+                  )}
+                >
+                  {/* Plan header */}
+                  <div className="border-b pb-3">
+                    <div className="flex items-center justify-between">
+                      <h3 className="text-lg font-semibold">{plan.name}</h3>
+                      {plan.badge && (
+                        <span className="text-xs px-2 py-1 bg-muted rounded-full">
+                          {plan.badge}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-sm text-muted-foreground mt-1">
+                      {plan.description}
+                    </p>
+                  </div>
+
+                  {/* Price */}
+                  <div className="py-3 border-b">
+                    <span className="text-2xl font-bold">${plan.price}</span>
+                    <span className="text-muted-foreground"> per month</span>
+                  </div>
+
+                  {/* Features */}
+                  <div className="py-3 flex-1">
+                    <ul className="space-y-2">
+                      {plan.features.map((feature, index) => (
+                        <li key={index} className="text-sm">
+                          {feature}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  {/* CTA Button */}
+                  <Button
+                    variant={plan.highlighted ? "default" : "outline"}
+                    className="w-full mt-4 justify-between"
+                    disabled={plan.disabled}
+                    onClick={() => {
+                      // TODO: Implement plan selection
+                      setShowPricingDialog(false);
+                    }}
+                  >
+                    {plan.buttonText}
+                    {!plan.disabled && <ArrowRight className="h-4 w-4" />}
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Fixes https://github.com/traceroot-ai/traceroot/issues/385

- Add Billing tab to organization settings sidebar                                                                                                                             
- Add pricing plans modal with 4 tiers (Free, Starter, Pro, Startups)                                                                                                          
- Placeholder UI for current plan display and usage statistics

This is mostly a placeholder for further UI and backend development.    

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)
<img width="1054" height="636" alt="Screenshot 2026-01-31 at 5 09 29 PM" src="https://github.com/user-attachments/assets/5cbb18b4-5784-4360-b4fe-e9711c9a8c91" />
<img width="1060" height="648" alt="Screenshot 2026-01-31 at 5 09 19 PM" src="https://github.com/user-attachments/assets/14560603-c1d6-405b-acd6-892acf13b36f" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
