### PR TITLE
[AgentOps][Bugfix] keyword search, time range search, pagination support [3/n]

### DIFF
--- a/rest/routers/traces.py
+++ b/rest/routers/traces.py
@@ -19,7 +19,7 @@ async def list_traces(
     project_id: str,
     _access: ProjectAccess,  # Validates user has access to project
     page: int = Query(0, ge=0, description="Page number (0-indexed)"),
-    limit: int = Query(50, ge=1, le=100, description="Items per page"),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
     name: str | None = Query(None, description="Filter by trace name (partial match)"),
     user_id: str | None = Query(None, description="Filter by user ID (exact match)"),
     start_after: datetime | None = Query(None, description="Filter traces after this timestamp"),

--- a/rest/routers/users.py
+++ b/rest/routers/users.py
@@ -19,7 +19,7 @@ async def list_users(
     project_id: str,
     _access: ProjectAccess,  # Validates user has access to project
     page: int = Query(0, ge=0, description="Page number (0-indexed)"),
-    limit: int = Query(50, ge=1, le=100, description="Items per page"),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
     search_query: str | None = Query(None, description="Search by user_id"),
     start_after: datetime | None = Query(None, description="Filter traces after this time"),
     end_before: datetime | None = Query(None, description="Filter traces before this time"),

--- a/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -54,7 +54,7 @@ export default function TracesPage() {
   const totalPages = Math.ceil(meta.total / meta.limit)
 
   // Build URL with preserved date filter params
-  const buildUrlWithDateFilter = (path: string, extraParams?: Record<string, string>) => {
+  const buildUrlWithFilters = (path: string, extraParams?: Record<string, string>) => {
     const params = new URLSearchParams()
 
     // Add extra params
@@ -92,7 +92,7 @@ export default function TracesPage() {
               return (
                 <Link
                   key={tab.id}
-                  href={buildUrlWithDateFilter(`/projects/${projectId}/${tab.href}`)}
+                  href={buildUrlWithFilters(`/projects/${projectId}/${tab.href}`)}
                   className={cn(
                     'flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium border-b-2 transition-colors',
                     isActive
@@ -126,7 +126,7 @@ export default function TracesPage() {
               <span className="text-[12px] font-medium text-foreground">{userId}</span>
               <button
                 type="button"
-                onClick={() => router.push(buildUrlWithDateFilter(`/projects/${projectId}/traces`))}
+                onClick={() => router.push(buildUrlWithFilters(`/projects/${projectId}/traces`))}
                 className="ml-1 rounded hover:bg-muted p-0.5 transition-colors"
               >
                 <X className="h-3 w-3 text-muted-foreground" />

--- a/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -53,7 +53,7 @@ export default function TracesPage() {
   const meta = data?.meta || { page: 0, limit: 50, total: 0 }
   const totalPages = Math.ceil(meta.total / meta.limit)
 
-  // Build URL with preserved date filter params
+  // Build URL with preserved filter and pagination params
   const buildUrlWithFilters = (path: string, extraParams?: Record<string, string>) => {
     const params = new URLSearchParams()
 
@@ -63,6 +63,13 @@ export default function TracesPage() {
         params.set(key, value)
       }
     }
+
+    // Preserve pagination params
+    const pageIndex = searchParams.get('page_index')
+    const pageLimit = searchParams.get('page_limit')
+
+    if (pageIndex) params.set('page_index', pageIndex)
+    if (pageLimit) params.set('page_limit', pageLimit)
 
     // Preserve date filter params
     const dateFilter = searchParams.get('date_filter')

--- a/ui/src/app/projects/[projectId]/users/page.tsx
+++ b/ui/src/app/projects/[projectId]/users/page.tsx
@@ -52,7 +52,7 @@ export default function UsersPage() {
   const meta = data?.meta || { page: 0, limit: 50, total: 0 }
   const totalPages = Math.ceil(meta.total / meta.limit)
 
-  // Build URL with preserved date filter params
+  // Build URL with preserved filter and pagination params
   const buildUrlWithFilters = (path: string, extraParams?: Record<string, string>) => {
     const params = new URLSearchParams()
 
@@ -62,6 +62,13 @@ export default function UsersPage() {
         params.set(key, value)
       }
     }
+
+    // Preserve pagination params
+    const pageIndex = searchParams.get('page_index')
+    const pageLimit = searchParams.get('page_limit')
+
+    if (pageIndex) params.set('page_index', pageIndex)
+    if (pageLimit) params.set('page_limit', pageLimit)
 
     // Preserve date filter params
     const dateFilter = searchParams.get('date_filter')

--- a/ui/src/app/projects/[projectId]/users/page.tsx
+++ b/ui/src/app/projects/[projectId]/users/page.tsx
@@ -53,7 +53,7 @@ export default function UsersPage() {
   const totalPages = Math.ceil(meta.total / meta.limit)
 
   // Build URL with preserved date filter params
-  const buildUrlWithDateFilter = (path: string, extraParams?: Record<string, string>) => {
+  const buildUrlWithFilters = (path: string, extraParams?: Record<string, string>) => {
     const params = new URLSearchParams()
 
     // Add extra params (like user_id)
@@ -77,7 +77,7 @@ export default function UsersPage() {
   }
 
   const handleUserClick = (userId: string) => {
-    router.push(buildUrlWithDateFilter(`/projects/${projectId}/traces`, { user_id: userId }))
+    router.push(buildUrlWithFilters(`/projects/${projectId}/traces`, { user_id: userId }))
   }
 
   return (
@@ -95,7 +95,7 @@ export default function UsersPage() {
               return (
                 <Link
                   key={tab.id}
-                  href={buildUrlWithDateFilter(`/projects/${projectId}/${tab.href}`)}
+                  href={buildUrlWithFilters(`/projects/${projectId}/${tab.href}`)}
                   className={cn(
                     'flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium border-b-2 transition-colors',
                     isActive

--- a/ui/src/features/traces/hooks/index.ts
+++ b/ui/src/features/traces/hooks/index.ts
@@ -11,6 +11,7 @@ export { usePagination } from './use-pagination';
 export { useDateFilter } from './use-date-filter';
 export { useKeywordSearch } from './use-keyword-search';
 export { useUrlDateFilter } from './use-url-date-filter';
+export { useUrlPagination } from './use-url-pagination';
 
 // Composed state hooks
 export { useTraceListState } from './use-trace-list-state';

--- a/ui/src/features/traces/hooks/use-keyword-search.ts
+++ b/ui/src/features/traces/hooks/use-keyword-search.ts
@@ -1,26 +1,52 @@
 /**
- * Hook for managing keyword search state.
- * Single responsibility: search query with page reset callback.
+ * Hook for managing keyword search state with debouncing.
+ * Provides immediate input feedback while debouncing API queries.
  */
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+const DEBOUNCE_DELAY_MS = 300;
 
 interface UseKeywordSearchReturn {
   keyword: string;
   setKeyword: (value: string) => void;
-  searchQuery: string | undefined; // Ready for API (undefined if empty)
+  searchQuery: string | undefined; // Ready for API (undefined if empty), debounced
 }
 
 export function useKeywordSearch(onSearchChange?: () => void): UseKeywordSearchReturn {
   const [keyword, setKeywordState] = useState('');
+  const [debouncedKeyword, setDebouncedKeyword] = useState('');
+  const isFirstRender = useRef(true);
+  const onSearchChangeRef = useRef(onSearchChange);
+
+  // Keep ref updated
+  onSearchChangeRef.current = onSearchChange;
+
+  // Debounce the keyword for API queries
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedKeyword(keyword);
+    }, DEBOUNCE_DELAY_MS);
+
+    return () => clearTimeout(timer);
+  }, [keyword]);
+
+  // Call onSearchChange when debounced value changes (skip initial render)
+  // Use ref to avoid re-running effect when callback changes
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    onSearchChangeRef.current?.();
+  }, [debouncedKeyword]); // Only depend on debouncedKeyword, not the callback
 
   const setKeyword = useCallback((value: string) => {
     setKeywordState(value);
-    onSearchChange?.();
-  }, [onSearchChange]);
+  }, []);
 
   return {
     keyword,
     setKeyword,
-    searchQuery: keyword || undefined,
+    searchQuery: debouncedKeyword || undefined,
   };
 }

--- a/ui/src/features/traces/hooks/use-list-page-state.ts
+++ b/ui/src/features/traces/hooks/use-list-page-state.ts
@@ -2,6 +2,7 @@
  * Composed hook for list page state with URL-synced date filter.
  * Combines pagination, URL-based date filtering, and search with coordinated page resets.
  *
+ * URL params: date_filter, start, end (pagination is local state for simplicity)
  * Use this for pages that need shared date filter state (traces, users, sessions).
  */
 import { useMemo } from 'react';
@@ -46,7 +47,7 @@ interface UseListPageStateReturn {
 }
 
 export function useListPageState(defaultLimit = 50): UseListPageStateReturn {
-  // Pagination hook
+  // Pagination hook (local state - simpler and more reliable)
   const pagination = usePagination(defaultLimit);
 
   // URL-synced date filter hook - resets page on change

--- a/ui/src/features/traces/hooks/use-list-page-state.ts
+++ b/ui/src/features/traces/hooks/use-list-page-state.ts
@@ -1,12 +1,12 @@
 /**
- * Composed hook for list page state with URL-synced date filter.
+ * Composed hook for list page state with URL-synced date filter and pagination.
  * Combines pagination, URL-based date filtering, and search with coordinated page resets.
  *
- * URL params: date_filter, start, end (pagination is local state for simplicity)
- * Use this for pages that need shared date filter state (traces, users, sessions).
+ * URL params: page_index, page_limit, date_filter, start, end
+ * Use this for pages that need shared filter state (traces, users, sessions).
  */
 import { useMemo } from 'react';
-import { usePagination } from './use-pagination';
+import { useUrlPagination } from './use-url-pagination';
 import { useUrlDateFilter } from './use-url-date-filter';
 import { useKeywordSearch } from './use-keyword-search';
 
@@ -47,8 +47,8 @@ interface UseListPageStateReturn {
 }
 
 export function useListPageState(defaultLimit = 50): UseListPageStateReturn {
-  // Pagination hook (local state - simpler and more reliable)
-  const pagination = usePagination(defaultLimit);
+  // URL-synced pagination hook - persists page/limit in URL
+  const pagination = useUrlPagination(defaultLimit);
 
   // URL-synced date filter hook - resets page on change
   const {

--- a/ui/src/features/traces/hooks/use-url-date-filter.ts
+++ b/ui/src/features/traces/hooks/use-url-date-filter.ts
@@ -2,7 +2,7 @@
  * Hook for managing date filter state synchronized with URL parameters.
  * This allows date filter state to persist across page navigation.
  */
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import {
   DEFAULT_DATE_FILTER,
@@ -43,6 +43,10 @@ export function useUrlDateFilter(onFilterChange?: () => void): UseUrlDateFilterR
   const [customStartDate, setCustomStartDateState] = useState<Date | null>(initialCustomStart);
   const [customEndDate, setCustomEndDateState] = useState<Date | null>(initialCustomEnd);
   const [filterVersion, setFilterVersion] = useState(0);
+
+  // Use ref for callback to avoid dependency issues
+  const onFilterChangeRef = useRef(onFilterChange);
+  onFilterChangeRef.current = onFilterChange;
 
   // Sync state from URL when it changes (e.g., navigating from another page)
   useEffect(() => {
@@ -101,8 +105,8 @@ export function useUrlDateFilter(onFilterChange?: () => void): UseUrlDateFilterR
       updateUrl(option.id, null, null);
     }
 
-    onFilterChange?.();
-  }, [onFilterChange, updateUrl]);
+    onFilterChangeRef.current?.();
+  }, [updateUrl]);
 
   const setCustomRange = useCallback((start: Date, end: Date) => {
     setCustomStartDateState(start);
@@ -112,8 +116,8 @@ export function useUrlDateFilter(onFilterChange?: () => void): UseUrlDateFilterR
     setDateFilterState(customOption);
     updateUrl('custom', start, end);
 
-    onFilterChange?.();
-  }, [onFilterChange, updateUrl]);
+    onFilterChangeRef.current?.();
+  }, [updateUrl]);
 
   // Calculate timestamps
   const timestamps = useMemo(() => {

--- a/ui/src/features/traces/hooks/use-url-pagination.ts
+++ b/ui/src/features/traces/hooks/use-url-pagination.ts
@@ -94,11 +94,14 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
   }, [updateUrl]);
 
   const resetPage = useCallback(() => {
-    if (page !== DEFAULT_PAGE) {
-      setPageState(DEFAULT_PAGE);
-      updateUrl(DEFAULT_PAGE, limit);
-    }
-  }, [page, limit, updateUrl]);
+    setPageState((currentPage) => {
+      if (currentPage !== DEFAULT_PAGE) {
+        updateUrl(DEFAULT_PAGE, limit);
+        return DEFAULT_PAGE;
+      }
+      return currentPage;
+    });
+  }, [limit, updateUrl]);
 
   return {
     page,

--- a/ui/src/features/traces/hooks/use-url-pagination.ts
+++ b/ui/src/features/traces/hooks/use-url-pagination.ts
@@ -1,6 +1,8 @@
 /**
  * Hook for managing pagination state synchronized with URL parameters.
  * This allows pagination state to persist across page refresh and be shareable.
+ *
+ * URL params: page_index (0-indexed), page_limit (items per page)
  */
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
@@ -22,8 +24,8 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
   const pathname = usePathname();
 
   // Read initial state from URL
-  const urlPage = searchParams.get('page');
-  const urlLimit = searchParams.get('limit');
+  const urlPage = searchParams.get('page_index');
+  const urlLimit = searchParams.get('page_limit');
 
   const initialPage = urlPage ? parseInt(urlPage, 10) : DEFAULT_PAGE;
   const initialLimit = urlLimit ? parseInt(urlLimit, 10) : defaultLimit;
@@ -42,8 +44,8 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
       return;
     }
 
-    const urlPageStr = searchParams.get('page');
-    const urlLimitStr = searchParams.get('limit');
+    const urlPageStr = searchParams.get('page_index');
+    const urlLimitStr = searchParams.get('page_limit');
 
     // Parse URL values, defaulting to 0 and defaultLimit if not present
     const newPage = urlPageStr ? parseInt(urlPageStr, 10) : DEFAULT_PAGE;
@@ -64,15 +66,15 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
 
     // Only add to URL if not default values (keeps URL cleaner)
     if (newPage !== DEFAULT_PAGE) {
-      params.set('page', String(newPage));
+      params.set('page_index', String(newPage));
     } else {
-      params.delete('page');
+      params.delete('page_index');
     }
 
     if (newLimit !== DEFAULT_LIMIT) {
-      params.set('limit', String(newLimit));
+      params.set('page_limit', String(newLimit));
     } else {
-      params.delete('limit');
+      params.delete('page_limit');
     }
 
     // Mark as programmatic update to skip re-sync in useEffect

--- a/ui/src/features/traces/hooks/use-url-pagination.ts
+++ b/ui/src/features/traces/hooks/use-url-pagination.ts
@@ -1,0 +1,108 @@
+/**
+ * Hook for managing pagination state synchronized with URL parameters.
+ * This allows pagination state to persist across page refresh and be shareable.
+ */
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useSearchParams, useRouter, usePathname } from 'next/navigation';
+
+interface UseUrlPaginationReturn {
+  page: number;
+  limit: number;
+  goToPage: (page: number) => void;
+  setLimit: (limit: number) => void;
+  resetPage: () => void;
+}
+
+const DEFAULT_PAGE = 0;
+const DEFAULT_LIMIT = 50;
+
+export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPaginationReturn {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  // Read initial state from URL
+  const urlPage = searchParams.get('page');
+  const urlLimit = searchParams.get('limit');
+
+  const initialPage = urlPage ? parseInt(urlPage, 10) : DEFAULT_PAGE;
+  const initialLimit = urlLimit ? parseInt(urlLimit, 10) : defaultLimit;
+
+  const [page, setPageState] = useState(isNaN(initialPage) ? DEFAULT_PAGE : initialPage);
+  const [limit, setLimitState] = useState(isNaN(initialLimit) ? defaultLimit : initialLimit);
+
+  // Track if we're doing a programmatic update (to avoid re-syncing from URL)
+  const isProgrammaticUpdate = useRef(false);
+
+  // Sync state from URL when URL changes (e.g., browser back/forward)
+  useEffect(() => {
+    // Skip if this is our own programmatic update
+    if (isProgrammaticUpdate.current) {
+      isProgrammaticUpdate.current = false;
+      return;
+    }
+
+    const urlPageStr = searchParams.get('page');
+    const urlLimitStr = searchParams.get('limit');
+
+    // Parse URL values, defaulting to 0 and defaultLimit if not present
+    const newPage = urlPageStr ? parseInt(urlPageStr, 10) : DEFAULT_PAGE;
+    const newLimit = urlLimitStr ? parseInt(urlLimitStr, 10) : defaultLimit;
+
+    if (!isNaN(newPage)) {
+      setPageState(newPage);
+    }
+
+    if (!isNaN(newLimit)) {
+      setLimitState(newLimit);
+    }
+  }, [searchParams, defaultLimit]);
+
+  // Update URL with current pagination state
+  const updateUrl = useCallback((newPage: number, newLimit: number) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    // Only add to URL if not default values (keeps URL cleaner)
+    if (newPage !== DEFAULT_PAGE) {
+      params.set('page', String(newPage));
+    } else {
+      params.delete('page');
+    }
+
+    if (newLimit !== DEFAULT_LIMIT) {
+      params.set('limit', String(newLimit));
+    } else {
+      params.delete('limit');
+    }
+
+    // Mark as programmatic update to skip re-sync in useEffect
+    isProgrammaticUpdate.current = true;
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  }, [searchParams, router, pathname]);
+
+  const goToPage = useCallback((newPage: number) => {
+    setPageState(newPage);
+    updateUrl(newPage, limit);
+  }, [limit, updateUrl]);
+
+  const setLimit = useCallback((newLimit: number) => {
+    setLimitState(newLimit);
+    setPageState(DEFAULT_PAGE); // Reset to first page when changing limit
+    updateUrl(DEFAULT_PAGE, newLimit);
+  }, [updateUrl]);
+
+  const resetPage = useCallback(() => {
+    if (page !== DEFAULT_PAGE) {
+      setPageState(DEFAULT_PAGE);
+      updateUrl(DEFAULT_PAGE, limit);
+    }
+  }, [page, limit, updateUrl]);
+
+  return {
+    page,
+    limit,
+    goToPage,
+    setLimit,
+    resetPage,
+  };
+}


### PR DESCRIPTION
## Summary
follow up of https://github.com/traceroot-ai/traceroot/pull/415

  - Shared date filter across pages: Date filter state is now synced via URL parameters (date_filter, start, end), persisting when navigating between
  Traces, Users, and Sessions pages
  - Search with debouncing: Search input now waits 300ms before triggering API calls, reducing unnecessary requests while typing
  - Users page filtering: Added search and time range filtering to the Users page (search filters by user_id)
  - Increased pagination limit: Backend now supports up to 200 items per page (previously 100)

  New Components & Hooks

  - SearchFilterBar (ui/src/components/search-filter-bar.tsx): Reusable component combining search input and date range picker, used by both Traces and
  Users pages
  - useUrlDateFilter: Hook for URL-synced date filter state management
  - useListPageState: Composed hook combining pagination, URL-based date filtering, and debounced search with coordinated page resets
  - useUrlPagination: Hook for URL-synced pagination (available but not currently used)

  Backend Changes

  - Added search_query, start_after, end_before parameters to Users endpoint
  - Increased limit validation from le=100 to le=200 on both Traces and Users endpoints

  Refactoring

  - Simplified Traces and Users page components by extracting shared filter logic into reusable hooks
  - Used useRef pattern for callbacks in hooks to prevent unintended page resets

## Type of Change

- [x] feat - A new feature
- [x] fix - A bug fix

## Details

## Screenshots / Recordings (if applicable)

<img width="1717" height="876" alt="Screenshot 2026-02-03 at 10 59 00 PM" src="https://github.com/user-attachments/assets/0b343c9a-7420-43dd-bacc-9e557f8235b0" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
