### PR TITLE
refactor(backend): Consolidate API schemas and enforce response_model

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -19,6 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from rest.routers.public.traces import router as public_traces_router
 from rest.routers.traces import router as traces_router
 from rest.routers.users import router as users_router
+from rest.schemas.common import HealthResponse
 from shared.config import settings
 
 app = FastAPI(
@@ -44,10 +45,10 @@ app.include_router(users_router, prefix="/api/v1")
 app.include_router(public_traces_router, prefix="/api/v1")
 
 
-@app.get("/health")
-async def health_check():
+@app.get("/health", response_model=HealthResponse)
+async def health_check() -> HealthResponse:
     """Health check endpoint."""
-    return {"status": "ok"}
+    return HealthResponse(status="ok")
 
 
 if __name__ == "__main__":

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -5,8 +5,8 @@ from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Query, status
 
-from rest.config.traces import TraceDetailResponse, TraceListResponse
 from rest.routers.deps import ProjectAccess
+from rest.schemas.traces import TraceDetailResponse, TraceListResponse
 from rest.services.trace_reader import get_trace_reader_service
 
 logger = logging.getLogger(__name__)

--- a/backend/rest/routers/users.py
+++ b/backend/rest/routers/users.py
@@ -3,10 +3,10 @@
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, Query, status
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, HTTPException, Query, status
 
 from rest.routers.deps import ProjectAccess
+from rest.schemas.users import UserListResponse
 from rest.services.trace_reader import get_trace_reader_service
 
 logger = logging.getLogger(__name__)
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/projects/{project_id}/users", tags=["Users"])
 
 
-@router.get("")
+@router.get("", response_model=UserListResponse)
 async def list_users(
     project_id: str,
     _access: ProjectAccess,  # Validates user has access to project
@@ -38,7 +38,7 @@ async def list_users(
         return result
     except Exception as e:
         logger.exception(f"Error listing users: {e}")
-        return JSONResponse(
+        raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content={"detail": "Failed to list users"},
-        )
+            detail="Failed to list users",
+        ) from e

--- a/backend/rest/schemas/__init__.py
+++ b/backend/rest/schemas/__init__.py
@@ -1,0 +1,21 @@
+"""REST API response schemas."""
+
+from rest.schemas.common import HealthResponse, PaginationMeta
+from rest.schemas.traces import (
+    SpanResponse,
+    TraceDetailResponse,
+    TraceListItem,
+    TraceListResponse,
+)
+from rest.schemas.users import UserItem, UserListResponse
+
+__all__ = [
+    "HealthResponse",
+    "PaginationMeta",
+    "SpanResponse",
+    "TraceDetailResponse",
+    "TraceListItem",
+    "TraceListResponse",
+    "UserItem",
+    "UserListResponse",
+]

--- a/backend/rest/schemas/common.py
+++ b/backend/rest/schemas/common.py
@@ -1,0 +1,17 @@
+"""Common API response schemas."""
+
+from pydantic import BaseModel
+
+
+class HealthResponse(BaseModel):
+    """Health check response."""
+
+    status: str
+
+
+class PaginationMeta(BaseModel):
+    """Pagination metadata for list responses."""
+
+    page: int
+    limit: int
+    total: int

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -1,8 +1,10 @@
-"""Trace schemas for request/response validation."""
+"""Trace-related response schemas."""
 
 from datetime import datetime
 
 from pydantic import BaseModel
+
+from rest.schemas.common import PaginationMeta
 
 
 class SpanResponse(BaseModel):
@@ -41,14 +43,6 @@ class TraceListItem(BaseModel):
     status: str  # "ok" or "error"
     input: str | None
     output: str | None
-
-
-class PaginationMeta(BaseModel):
-    """Pagination metadata."""
-
-    page: int
-    limit: int
-    total: int
 
 
 class TraceListResponse(BaseModel):

--- a/backend/rest/schemas/users.py
+++ b/backend/rest/schemas/users.py
@@ -1,0 +1,22 @@
+"""User-related response schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from rest.schemas.common import PaginationMeta
+
+
+class UserItem(BaseModel):
+    """Single user with trace statistics."""
+
+    user_id: str
+    trace_count: int
+    last_trace_time: datetime | None
+
+
+class UserListResponse(BaseModel):
+    """Paginated list of users."""
+
+    data: list[UserItem]
+    meta: PaginationMeta


### PR DESCRIPTION
## Summary

Consolidate all API response schemas into a single `rest/schemas/` directory and enforce typed response models across all REST endpoints.

## Changes

### Schema Consolidation
- **New:** `backend/rest/schemas/` directory with:
  - `common.py` - `HealthResponse`, `PaginationMeta`
  - `traces.py` - `TraceListResponse`, `TraceDetailResponse`, `SpanResponse`, `TraceListItem`
  - `users.py` - `UserListResponse`, `UserItem`
  - `__init__.py` - Clean exports
- **Removed:** Duplicate `backend/rest/config/traces.py`

### Endpoint Improvements
- Added `response_model` to `/health` endpoint
- Added `response_model` to `/projects/{project_id}/users` endpoint
- Changed `users.py` to use `HTTPException` (consistent with `traces.py`)

## Why
- **Single source of truth** for API contracts
- **Accurate OpenAPI schema** generation
- **Type safety** at API boundaries
- **Consistency** across routers

## Testing
- All 43 REST tests pass ✅
- Ruff lint/format pass ✅

## Risk
Low - No behavior changes, only contract formalization.