### PR TITLE
[AgentOps] Billing with stripe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,12 @@ NEXT_PUBLIC_API_URL=http://localhost:8000/api/v1
 # TRACEROOT_SMTP_URL=smtp://user:pass@host:port
 # TRACEROOT_SMTP_MAIL_FROM=noreply@yourdomain.com
 
+# --- Billing Toggle -----------------------------------------------------------
+# Set to "false" for self-hosted deployments to unlock all features, skip seat
+# limits, and never block ingestion. When "false", you don't need to run the
+# billing worker or configure Stripe keys below.
+ENABLE_BILLING=true
+
 # --- Stripe Billing -----------------------------------------------------------
 STRIPE_SECRET_KEY=sk_test_xxx  # CHANGEME - from Stripe Dashboard > Developers > API keys
 STRIPE_WEBHOOK_SIGNING_SECRET=whsec_xxx  # CHANGEME - from Stripe CLI or Dashboard > Webhooks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -404,6 +404,7 @@ See `.env.example` for all configuration options:
 | `INTERNAL_API_SECRET` | `dev-internal-secret` | Shared secret for internal API auth |
 | `NEXTAUTH_URL` | `http://localhost:3000` | NextAuth callback URL |
 | `NEXT_PUBLIC_API_URL` | `http://localhost:8000/api/v1` | Frontend API endpoint |
+| `ENABLE_BILLING` | `true` | Set to `false` for self-hosted deployments to disable billing, unlock all entitlements, remove seat limits, and never block ingestion. When `false`, you don't need Stripe keys or the billing worker. |
 
 ---
 

--- a/frontend/packages/core/src/billing/plans.ts
+++ b/frontend/packages/core/src/billing/plans.ts
@@ -1,4 +1,14 @@
 // =============================================================================
+// BILLING TOGGLE
+// =============================================================================
+// When ENABLE_BILLING is "false", all entitlements are unlocked, seat limits
+// are removed, and ingestion is never blocked. Self-hosted deployments should
+// set this to "false" and skip running the billing worker.
+export function isBillingEnabled(): boolean {
+  return process.env.ENABLE_BILLING !== "false";
+}
+
+// =============================================================================
 // PLAN TYPES
 // =============================================================================
 export const PlanType = {
@@ -22,6 +32,7 @@ export const USAGE_CONFIG = {
 } as const;
 
 export function isFreePlanBlocked(currentUsage: number): boolean {
+  if (!isBillingEnabled()) return false;
   return currentUsage >= USAGE_CONFIG.includedUnits;
 }
 
@@ -180,6 +191,7 @@ export function isDowngrade(currentPlan: PlanType, newPlan: PlanType): boolean {
 // ENTITLEMENT HELPERS
 // =============================================================================
 export function hasEntitlement(plan: PlanType, entitlement: Entitlement): boolean {
+  if (!isBillingEnabled()) return true;
   return (ENTITLEMENT_CONFIG[entitlement] as readonly string[]).includes(plan);
 }
 
@@ -205,6 +217,7 @@ export function getSeatLimit(plan: PlanType): number {
 }
 
 export function canAddSeat(plan: PlanType, currentSeatCount: number): boolean {
+  if (!isBillingEnabled()) return true;
   const limit = SEAT_LIMITS[plan];
   return currentSeatCount < limit;
 }

--- a/frontend/ui/src/env.ts
+++ b/frontend/ui/src/env.ts
@@ -9,6 +9,8 @@ const serverSchema = z.object({
   TRACEROOT_SMTP_URL: z.string().optional(),
   TRACEROOT_SMTP_MAIL_FROM: z.string().optional(),
   NEXT_PUBLIC_LOGO_URL: z.string().optional(),
+  // Billing toggle — set to "false" for self-hosted deployments to unlock all features
+  ENABLE_BILLING: z.string().default("true"),
   // Stripe Billing
   STRIPE_SECRET_KEY: z.string().default(""),
   STRIPE_WEBHOOK_SIGNING_SECRET: z.string().default(""),


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                
                                         
  Add `ENABLE_BILLING` env var so self-hosted deployments can disable all billing/plan restrictions without needing Stripe or the billing worker.                                                                                           
                                                                                                                                                                                                                                            
  When `ENABLE_BILLING=false`:
  - `hasEntitlement()` returns `true` for all plans
  - `canAddSeat()` returns `true` regardless of seat count
  - `isFreePlanBlocked()` returns `false` regardless of usage

  ## Type of Change

  - [x] feat - A new feature

  ## Details

  **Problem:** Self-hosted users are blocked by billing restrictions (seat limits, entitlement checks, ingestion blocking) that don't apply to their deployment.

  **Solution:** Added an `isBillingEnabled()` helper in `plans.ts` that checks `process.env.ENABLE_BILLING !== "false"`. Three gating functions short-circuit when billing is off:

  | Function | Billing ON (default) | Billing OFF |
  |----------|---------------------|-------------|
  | `hasEntitlement(plan, entitlement)` | Checks plan config | `true` |
  | `canAddSeat(plan, count)` | Checks seat limit | `true` |
  | `isFreePlanBlocked(usage)` | Checks usage cap | `false` |

  **Files changed:**
  - `frontend/packages/core/src/billing/plans.ts` — Added `isBillingEnabled()` and early returns in 3 functions
  - `frontend/ui/src/env.ts` — Added `ENABLE_BILLING` to server schema (default `"true"`)
  - `.env.example` — Added `ENABLE_BILLING=true` with documentation
  - `CONTRIBUTING.md` — Added `ENABLE_BILLING` to env var reference table

  **What does NOT change:**
  - Database schema — billing fields stay, just unused when off
  - Backend Python code — no changes
  - Billing worker — simply don't run it; `ingestionBlocked` stays `false` in DB naturally
  - Billing UI/API routes — still exist but non-functional without Stripe keys

  ## Screenshots / Recordings (if applicable)


https://github.com/user-attachments/assets/32ebb2c2-826f-4ad8-9063-3cc7fb5b4fb1


  ## Checklist

  - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
  - [ ] I have added/updated tests where applicable
  - [x] I have added screenshots or recordings for UI changes (if applicable)
  - [x] I have updated documentation where necessary

