### PR TITLE
[AgentOps][Agent] Support local only AI assistant system [1/n]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,14 @@ STRIPE_PRICE_ID_STARTER=price_xxx  # CHANGEME - from Stripe Dashboard > Products
 STRIPE_PRICE_ID_PRO=price_xxx  # CHANGEME
 STRIPE_PRICE_ID_STARTUPS=price_xxx  # CHANGEME
 
+# --- AI Agent Service ---------------------------------------------------------
+AGENT_SERVICE_URL=http://localhost:8100
+SANDBOX_PROVIDER=docker
+ANTHROPIC_API_KEY=           # CHANGEME - required for Claude models (default)
+# OPENAI_API_KEY=            # CHANGEME - required if using GPT models
+# DAYTONA_API_KEY=           # TODO: Production only
+# DAYTONA_API_URL=           # TODO: Production only
+
 # --- Branding / Public URLs ---------------------------------------------------
 NEXT_PUBLIC_LOGO_URL=https://raw.githubusercontent.com/traceroot-ai/traceroot/pivot/agentops/frontend/ui/public/images/icon-v2.png
 NEXT_PUBLIC_DOCS_URL=https://docs.traceroot.ai

--- a/frontend/packages/agent/package.json
+++ b/frontend/packages/agent/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@traceroot/agent",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "dev": "dotenv -e ../../../.env -- tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "clean": "rm -rf dist",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@traceroot/core": "workspace:*",
+    "@mariozechner/pi-agent-core": "^0.52.0",
+    "@mariozechner/pi-ai": "^0.52.0",
+    "@sinclair/typebox": "^0.34.0",
+    "hono": "^4.0.0",
+    "@hono/node-server": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "dotenv-cli": "^11.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/frontend/packages/agent/src/agent.ts
+++ b/frontend/packages/agent/src/agent.ts
@@ -1,0 +1,140 @@
+import {
+  Agent,
+  type AgentEvent,
+  type AgentTool,
+  type AgentMessage,
+} from "@mariozechner/pi-agent-core";
+import { getModel, getEnvApiKey, type Message } from "@mariozechner/pi-ai";
+import { SessionManager } from "./session.js";
+
+// Agent cache: one Agent per conversation session (like Mom's channelRunners map)
+const sessionAgents = new Map<string, Agent>();
+// SessionManager cache: one per session, paired with the Agent
+const sessionManagers = new Map<string, SessionManager>();
+// Track which model each cached agent was created with
+const sessionModels = new Map<string, string>();
+
+function resolveModel(modelId?: string) {
+  switch (modelId) {
+    case "gpt-4.1":
+      return getModel("openai", "gpt-4.1");
+    case "gpt-4.1-mini":
+      return getModel("openai", "gpt-4.1-mini");
+    case "claude-haiku-4-5":
+      return getModel("anthropic", "claude-haiku-4-5");
+    case "claude-sonnet-4-5":
+    default:
+      return getModel("anthropic", "claude-sonnet-4-5");
+  }
+}
+
+export interface AgentRunnerConfig {
+  sessionId: string;
+  projectId: string;
+  workspaceId: string;
+  userId: string;
+  systemPrompt: string;
+  tools: AgentTool<any>[];
+  model?: string;
+}
+
+export interface AgentEventHandler {
+  onEvent: (event: AgentEvent) => void;
+  onError: (error: Error) => void;
+  onDone: () => void;
+}
+
+/**
+ * Get or create an Agent + SessionManager for a conversation session.
+ * Follows Mom's getOrCreateRunner() pattern — one agent per session, cached.
+ * SessionManager handles all Agent <-> DB sync (like Mom's SessionManager).
+ */
+export async function getOrCreateAgent(config: AgentRunnerConfig): Promise<{
+  agent: Agent;
+  sessionManager: SessionManager;
+}> {
+  const requestedModel = config.model || "claude-sonnet-4-5";
+  const cachedModel = sessionModels.get(config.sessionId);
+  const existingAgent = sessionAgents.get(config.sessionId);
+  const existingManager = sessionManagers.get(config.sessionId);
+
+  // Return cached agent if model hasn't changed
+  if (existingAgent && existingManager && cachedModel === requestedModel) {
+    return { agent: existingAgent, sessionManager: existingManager };
+  }
+
+  // Model changed mid-session — discard old agent (SessionManager stays, history is in DB)
+  if (existingAgent) {
+    sessionAgents.delete(config.sessionId);
+  }
+
+  const model = resolveModel(config.model);
+
+  const agent = new Agent({
+    initialState: {
+      systemPrompt: config.systemPrompt,
+      model,
+      thinkingLevel: "off",
+      tools: config.tools,
+    },
+    // For MVP, we only use standard LLM message types (user, assistant, tool),
+    // so identity conversion works. If we add custom AgentMessage types later
+    // (like Mom does for Slack), this needs a real implementation.
+    convertToLlm: (messages: AgentMessage[]) => messages as Message[],
+    // pi-ai's getEnvApiKey() handles all provider-specific env vars automatically:
+    // anthropic -> ANTHROPIC_API_KEY, openai -> OPENAI_API_KEY, etc.
+    getApiKey: async (provider: string) => getEnvApiKey(provider),
+  });
+
+  // SessionManager owns the Agent <-> DB sync (like Mom's SessionManager)
+  const sessionManager = new SessionManager(config.sessionId);
+
+  // Load existing conversation history from DB into agent context
+  const agentMessages = await sessionManager.buildContext();
+  if (agentMessages.length > 0) {
+    agent.replaceMessages(agentMessages);
+  }
+
+  sessionAgents.set(config.sessionId, agent);
+  sessionModels.set(config.sessionId, requestedModel);
+  if (!existingManager) {
+    sessionManagers.set(config.sessionId, sessionManager);
+  }
+  return { agent, sessionManager: existingManager || sessionManager };
+}
+
+/**
+ * Run a user message through the agent with event streaming.
+ * Follows Mom's pattern: subscribe to events, then prompt.
+ */
+export async function runAgent(
+  agent: Agent,
+  userMessage: string,
+  handler: AgentEventHandler,
+): Promise<void> {
+  const unsubscribe = agent.subscribe((event: AgentEvent) => {
+    try {
+      handler.onEvent(event);
+    } catch (err) {
+      console.error("[Agent] Error in event handler:", err);
+    }
+  });
+
+  try {
+    await agent.prompt(userMessage);
+    handler.onDone();
+  } catch (error) {
+    handler.onError(error instanceof Error ? error : new Error(String(error)));
+  } finally {
+    unsubscribe();
+  }
+}
+
+/**
+ * Remove a cached agent + session manager (on session delete).
+ */
+export function removeAgent(sessionId: string): void {
+  sessionAgents.delete(sessionId);
+  sessionManagers.delete(sessionId);
+  sessionModels.delete(sessionId);
+}

--- a/frontend/packages/agent/src/executors/daytona.ts
+++ b/frontend/packages/agent/src/executors/daytona.ts
@@ -1,0 +1,31 @@
+import type { Executor, ExecResult, ExecOptions } from "./interface.js";
+
+export class DaytonaExecutor implements Executor {
+  async init(): Promise<void> {
+    throw new Error("DaytonaExecutor not yet implemented. Use SANDBOX_PROVIDER=docker for dev.");
+  }
+
+  async exec(_command: string, _options?: ExecOptions): Promise<ExecResult> {
+    throw new Error("Not implemented");
+  }
+
+  getWorkspacePath(): string {
+    return "/workspace";
+  }
+
+  async writeFile(_path: string, _content: string): Promise<void> {
+    throw new Error("Not implemented");
+  }
+
+  async readFile(_path: string): Promise<string> {
+    throw new Error("Not implemented");
+  }
+
+  isReady(): boolean {
+    return false;
+  }
+
+  async destroy(): Promise<void> {
+    // No-op
+  }
+}

--- a/frontend/packages/agent/src/executors/docker.ts
+++ b/frontend/packages/agent/src/executors/docker.ts
@@ -1,0 +1,137 @@
+import { spawn, execFile } from "child_process";
+import { promisify } from "util";
+import type { Executor, ExecResult, ExecOptions } from "./interface.js";
+
+const execFileAsync = promisify(execFile);
+
+const DOCKER_IMAGE = process.env.SANDBOX_DOCKER_IMAGE || "ubuntu:24.04";
+const WORKSPACE_DIR = "/workspace";
+
+export class DockerExecutor implements Executor {
+  private containerId: string | null = null;
+
+  async init(): Promise<void> {
+    console.log("[DockerExecutor] Creating container...");
+
+    const { stdout } = await execFileAsync("docker", [
+      "run",
+      "-d",
+      "--name",
+      `traceroot-sandbox-${Date.now()}`,
+      "--network",
+      "none", // NO network access — fully isolated
+      "-w",
+      WORKSPACE_DIR,
+      DOCKER_IMAGE,
+      "sleep",
+      "infinity",
+    ]);
+
+    this.containerId = stdout.trim();
+
+    // Create workspace directories
+    await this.exec(`mkdir -p ${WORKSPACE_DIR}/traces ${WORKSPACE_DIR}/notes`);
+
+    // Install basic tools if not in image
+    await this.exec("apt-get update -qq && apt-get install -y -qq git jq > /dev/null 2>&1 || true");
+
+    console.log(`[DockerExecutor] Container ready: ${this.containerId.slice(0, 12)}`);
+  }
+
+  /**
+   * Execute a command in the container.
+   * Follows Mom's pattern: spawn shell, capture stdout/stderr, support
+   * timeout and AbortSignal, truncate output at 10MB.
+   */
+  async exec(command: string, options?: ExecOptions): Promise<ExecResult> {
+    if (!this.containerId) throw new Error("Container not initialized");
+
+    return new Promise((resolve) => {
+      const child = spawn("docker", ["exec", this.containerId!, "sh", "-c", command], {
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      let stdout = "";
+      let stderr = "";
+      let timedOut = false;
+      const MAX_BYTES = 10 * 1024 * 1024; // 10MB, matches Mom
+
+      // Timeout handling (like Mom's HostExecutor)
+      const timeoutMs = options?.timeout ? options.timeout * 1000 : 30000;
+      const timeoutHandle = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, timeoutMs);
+
+      // AbortSignal support (like Mom)
+      if (options?.signal) {
+        const onAbort = () => child.kill("SIGKILL");
+        if (options.signal.aborted) {
+          onAbort();
+        } else {
+          options.signal.addEventListener("abort", onAbort, { once: true });
+        }
+      }
+
+      child.stdout?.on("data", (data: Buffer) => {
+        stdout += data.toString();
+        if (stdout.length > MAX_BYTES) stdout = stdout.slice(0, MAX_BYTES);
+      });
+
+      child.stderr?.on("data", (data: Buffer) => {
+        stderr += data.toString();
+        if (stderr.length > MAX_BYTES) stderr = stderr.slice(0, MAX_BYTES);
+      });
+
+      child.on("close", (code) => {
+        clearTimeout(timeoutHandle);
+        if (timedOut) {
+          resolve({ stdout, stderr: `Command timed out after ${timeoutMs / 1000}s`, code: 1 });
+          return;
+        }
+        resolve({ stdout, stderr, code: code ?? 0 });
+      });
+
+      child.on("error", (err) => {
+        clearTimeout(timeoutHandle);
+        resolve({ stdout, stderr: err.message, code: 1 });
+      });
+    });
+  }
+
+  getWorkspacePath(): string {
+    return WORKSPACE_DIR; // Docker container always sees /workspace
+  }
+
+  async writeFile(path: string, content: string): Promise<void> {
+    if (!this.containerId) throw new Error("Container not initialized");
+    const dir = path.includes("/") ? path.substring(0, path.lastIndexOf("/")) : ".";
+    await this.exec(`mkdir -p ${shellEscape(dir)}`);
+    await this.exec(`printf '%s' ${shellEscape(content)} > ${shellEscape(path)}`);
+  }
+
+  async readFile(path: string): Promise<string> {
+    const result = await this.exec(`cat ${shellEscape(path)}`);
+    if (result.code !== 0) throw new Error(`File not found: ${path}`);
+    return result.stdout;
+  }
+
+  isReady(): boolean {
+    return this.containerId !== null;
+  }
+
+  async destroy(): Promise<void> {
+    if (!this.containerId) return;
+    console.log(`[DockerExecutor] Destroying container ${this.containerId.slice(0, 12)}`);
+    try {
+      await execFileAsync("docker", ["rm", "-f", this.containerId]);
+    } catch {
+      // Ignore errors during cleanup
+    }
+    this.containerId = null;
+  }
+}
+
+function shellEscape(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}

--- a/frontend/packages/agent/src/executors/index.ts
+++ b/frontend/packages/agent/src/executors/index.ts
@@ -1,0 +1,18 @@
+import type { Executor } from "./interface.js";
+import { DockerExecutor } from "./docker.js";
+import { DaytonaExecutor } from "./daytona.js";
+
+export type { Executor, ExecResult, ExecOptions } from "./interface.js";
+
+export function createExecutor(): Executor {
+  const provider = process.env.SANDBOX_PROVIDER || "docker";
+
+  switch (provider) {
+    case "docker":
+      return new DockerExecutor();
+    case "daytona":
+      return new DaytonaExecutor();
+    default:
+      throw new Error(`Unknown sandbox provider: ${provider}`);
+  }
+}

--- a/frontend/packages/agent/src/executors/interface.ts
+++ b/frontend/packages/agent/src/executors/interface.ts
@@ -1,0 +1,48 @@
+/**
+ * Matches Mom's ExecResult (sandbox.ts) — uses `code` not `exitCode`.
+ */
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+/**
+ * Matches Mom's ExecOptions — includes AbortSignal support.
+ */
+export interface ExecOptions {
+  timeout?: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Extends Mom's Executor with lifecycle and file ops.
+ *
+ * Mom's base interface: exec() + getWorkspacePath()
+ * Our extensions: init(), destroy(), writeFile(), readFile(), isReady()
+ * Reason: host-side tools (query_traces, download_trace) run on the host
+ * and need to write files into the sandbox via writeFile(), while the
+ * sandbox itself has no network access.
+ */
+export interface Executor {
+  /** Initialize the sandbox/container. Called lazily on first tool use. */
+  init(): Promise<void>;
+
+  /** Execute a shell command in the sandbox. Matches Mom's exec() signature. */
+  exec(command: string, options?: ExecOptions): Promise<ExecResult>;
+
+  /** Get the workspace path prefix. Host: actual path. Docker: /workspace. */
+  getWorkspacePath(): string;
+
+  /** Write a file in the sandbox (extension beyond Mom — for host-side tools). */
+  writeFile(path: string, content: string): Promise<void>;
+
+  /** Read a file from the sandbox (extension beyond Mom — for host-side tools). */
+  readFile(path: string): Promise<string>;
+
+  /** Check if the executor has been initialized. */
+  isReady(): boolean;
+
+  /** Tear down the sandbox/container. */
+  destroy(): Promise<void>;
+}

--- a/frontend/packages/agent/src/index.ts
+++ b/frontend/packages/agent/src/index.ts
@@ -1,0 +1,217 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
+import { prisma } from "@traceroot/core";
+import {
+  createSession,
+  getSession,
+  getSessionMessages,
+  listSessions,
+  deleteSession,
+  updateSessionTitle,
+} from "./session.js";
+import { getOrCreateAgent, runAgent, removeAgent } from "./agent.js";
+import { getSystemPrompt } from "./prompts/system.js";
+import { createExecutor } from "./executors/index.js";
+import { createTools } from "./tools/index.js";
+import type { Executor } from "./executors/interface.js";
+
+const app = new Hono();
+
+const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:8100";
+const PORT = parseInt(new URL(AGENT_SERVICE_URL).port || "8100", 10);
+
+// Per-session executor cache (executor lifecycle tied to session)
+const sessionExecutors = new Map<string, Executor>();
+
+// Health check
+app.get("/health", (c) => {
+  return c.json({ status: "ok", service: "traceroot-agent" });
+});
+
+// Session CRUD routes
+app.post("/api/v1/projects/:projectId/sessions", async (c) => {
+  const projectId = c.req.param("projectId");
+  const userId = c.req.header("x-user-id") || "";
+  const workspaceId = c.req.header("x-workspace-id") || "";
+  const body = await c.req.json<{ title?: string }>();
+
+  const session = await createSession({
+    projectId,
+    workspaceId,
+    userId,
+    title: body.title,
+  });
+  return c.json(session, 201);
+});
+
+app.get("/api/v1/projects/:projectId/sessions", async (c) => {
+  const projectId = c.req.param("projectId");
+  const userId = c.req.header("x-user-id") || "";
+  if (!userId) {
+    return c.json({ error: "x-user-id header required" }, 400);
+  }
+  const sessions = await listSessions({ projectId, userId });
+  return c.json({ sessions });
+});
+
+app.get("/api/v1/projects/:projectId/sessions/:sessionId", async (c) => {
+  const userId = c.req.header("x-user-id") || "";
+  const session = await getSession(c.req.param("sessionId"), userId);
+  if (!session) return c.json({ error: "not found" }, 404);
+  return c.json(session);
+});
+
+// GET messages for a session (for loading history in UI)
+app.get("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) => {
+  const userId = c.req.header("x-user-id") || "";
+  const messages = await getSessionMessages(c.req.param("sessionId"), userId);
+  if (!messages) return c.json({ error: "not found" }, 404);
+  return c.json({ messages });
+});
+
+app.delete("/api/v1/projects/:projectId/sessions/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  const userId = c.req.header("x-user-id") || "";
+
+  // Destroy executor if one exists for this session
+  const executor = sessionExecutors.get(sessionId);
+  if (executor) {
+    await executor.destroy();
+    sessionExecutors.delete(sessionId);
+  }
+
+  removeAgent(sessionId);
+  const result = await deleteSession(sessionId, userId);
+  if (!result) return c.json({ error: "not found" }, 404);
+  return c.json({ ok: true });
+});
+
+// Message route — SSE streaming via agent runner
+app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) => {
+  const projectId = c.req.param("projectId");
+  const sessionId = c.req.param("sessionId");
+  const userId = c.req.header("x-user-id") || "";
+  const workspaceId = c.req.header("x-workspace-id") || "";
+  const body = await c.req.json<{ message: string; model?: string; traceId?: string }>();
+
+  const systemPrompt = getSystemPrompt({ projectId, traceId: body.traceId });
+
+  // Get or create executor for this session (lazy — not initialized until tool use)
+  let executor = sessionExecutors.get(sessionId);
+  if (!executor) {
+    executor = createExecutor();
+    sessionExecutors.set(sessionId, executor);
+  }
+
+  const tools = createTools({ projectId, userId, executor });
+
+  const { agent, sessionManager } = await getOrCreateAgent({
+    sessionId,
+    projectId,
+    workspaceId,
+    userId,
+    systemPrompt,
+    tools,
+    model: body.model,
+  });
+
+  // Persist user message to DB via SessionManager
+  await sessionManager.appendMessage("user", body.message);
+
+  // Auto-generate session title from first user message
+  const session = await getSession(sessionId, userId);
+  if (session && !session.title) {
+    const title = body.message.slice(0, 80) + (body.message.length > 80 ? "..." : "");
+    await updateSessionTitle(sessionId, title);
+  }
+
+  return streamSSE(c, async (stream) => {
+    let assistantText = "";
+
+    await new Promise<void>((resolve) => {
+      runAgent(agent, body.message, {
+        onEvent: (event) => {
+          // Forward all events to the frontend
+          stream.writeSSE({
+            event: event.type,
+            data: JSON.stringify(event),
+          });
+
+          // Accumulate assistant text for DB persistence
+          if (event.type === "message_update") {
+            const msgEvent = event as any;
+            const delta = msgEvent.assistantMessageEvent;
+            if (delta?.type === "text_delta") {
+              assistantText += delta.delta;
+            }
+          }
+        },
+        onError: (error) => {
+          stream.writeSSE({
+            event: "error",
+            data: JSON.stringify({ message: error.message }),
+          });
+          resolve();
+        },
+        onDone: async () => {
+          // Persist assistant response to DB via SessionManager
+          if (assistantText) {
+            await sessionManager.appendMessage("assistant", assistantText);
+          }
+          stream.writeSSE({ event: "done", data: "{}" });
+          resolve();
+        },
+      });
+    });
+  });
+});
+
+// Graceful shutdown
+let isShuttingDown = false;
+
+async function shutdown(signal: string): Promise<void> {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  console.log(`\n[Agent] Received ${signal}, shutting down...`);
+  try {
+    // Destroy all active executors (sandbox containers)
+    for (const [id, executor] of sessionExecutors) {
+      await executor.destroy();
+      sessionExecutors.delete(id);
+    }
+    await prisma.$disconnect();
+    console.log("[Agent] Cleanup complete");
+    process.exit(0);
+  } catch (error) {
+    console.error("[Agent] Error during shutdown:", error);
+    process.exit(1);
+  }
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
+async function main(): Promise<void> {
+  console.log("[Agent] TraceRoot Agent Service starting...");
+
+  // Verify DB connection
+  try {
+    const count = await prisma.project.count();
+    console.log(`[Agent] Connected to database. Found ${count} projects.`);
+  } catch (error) {
+    console.error("[Agent] Failed to connect to database:", error);
+    process.exit(1);
+  }
+
+  serve({ fetch: app.fetch, port: PORT }, (info) => {
+    console.log(`[Agent] Listening on http://localhost:${info.port}`);
+  });
+}
+
+main().catch((error) => {
+  console.error("[Agent] Fatal error:", error);
+  process.exit(1);
+});
+
+export { app };

--- a/frontend/packages/agent/src/prompts/__tests__/system.test.ts
+++ b/frontend/packages/agent/src/prompts/__tests__/system.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { getSystemPrompt } from "../system.js";
+
+describe("getSystemPrompt", () => {
+  it("includes project ID", () => {
+    const prompt = getSystemPrompt({ projectId: "proj-123" });
+    expect(prompt).toContain("proj-123");
+  });
+
+  it("describes query_traces tool", () => {
+    const prompt = getSystemPrompt({ projectId: "proj-123" });
+    expect(prompt).toContain("query_traces");
+    expect(prompt).toContain("search and filter traces");
+  });
+
+  it("describes download_trace tool", () => {
+    const prompt = getSystemPrompt({ projectId: "proj-123" });
+    expect(prompt).toContain("download_trace");
+    expect(prompt).toContain("trace.jsonl");
+    expect(prompt).toContain("tree.json");
+    expect(prompt).toContain("spans.jsonl");
+  });
+
+  it("includes ClickHouse schema reference", () => {
+    const prompt = getSystemPrompt({ projectId: "proj-123" });
+    expect(prompt).toContain("observations table");
+    expect(prompt).toContain("GENERATION|SPAN|EVENT");
+  });
+});

--- a/frontend/packages/agent/src/prompts/system.ts
+++ b/frontend/packages/agent/src/prompts/system.ts
@@ -22,14 +22,14 @@ Parameters: filters (object) — optional filters like limit, userId, sessionId,
 Use this first to find relevant traces before diving deeper.
 
 ### Deep Investigation: download_trace
-Use this to download a full trace into your workspace for deep analysis. Creates 2 files per trace.
+Use this to download a full trace into your workspace for deep analysis. Creates 3 files per trace.
 Parameters: traceId (string) — the trace ID to download.
 After downloading, use bash/read tools to explore the 3 files:
 - /workspace/traces/{trace_id}_{name}/trace.jsonl — trace metadata (single line)
 - /workspace/traces/{trace_id}_{name}/tree.json — span hierarchy structure (pretty-printed)
 - /workspace/traces/{trace_id}_{name}/spans.jsonl — all spans, one JSON object per line
 
-### File Analysis: bash, read, write, edit
+### File Analysis: bash, read, write
 Standard tools for exploring downloaded trace data in /workspace/.
 Use grep/jq on spans.jsonl — each line is a complete span object.
 Examples: grep "ERROR" spans.jsonl, jq 'select(.span_kind == "GENERATION")' spans.jsonl

--- a/frontend/packages/agent/src/prompts/system.ts
+++ b/frontend/packages/agent/src/prompts/system.ts
@@ -1,0 +1,65 @@
+export interface SystemPromptContext {
+  projectId: string;
+  traceId?: string;
+}
+
+export function getSystemPrompt(ctx: SystemPromptContext): string {
+  const traceContext = ctx.traceId
+    ? `\n- Currently viewing Trace ID: ${ctx.traceId}\n  The user opened the AI assistant from this trace's detail view. They likely want to ask about this specific trace.`
+    : "";
+
+  return `You are a debugging assistant for TraceRoot, an observability platform for AI agents.
+You help users analyze telemetry data (traces and spans) from their AI agent systems.
+
+## Current Context
+- Project ID: ${ctx.projectId}${traceContext}
+
+## Available Tools
+
+### Discovery: query_traces
+Use this to search and filter traces. Returns a summary table (trace IDs, names, timestamps, status, error counts).
+Parameters: filters (object) — optional filters like limit, userId, sessionId, name, hasError, startTime, endTime.
+Use this first to find relevant traces before diving deeper.
+
+### Deep Investigation: download_trace
+Use this to download a full trace into your workspace for deep analysis. Creates 2 files per trace.
+Parameters: traceId (string) — the trace ID to download.
+After downloading, use bash/read tools to explore the 3 files:
+- /workspace/traces/{trace_id}_{name}/trace.jsonl — trace metadata (single line)
+- /workspace/traces/{trace_id}_{name}/tree.json — span hierarchy structure (pretty-printed)
+- /workspace/traces/{trace_id}_{name}/spans.jsonl — all spans, one JSON object per line
+
+### File Analysis: bash, read, write, edit
+Standard tools for exploring downloaded trace data in /workspace/.
+Use grep/jq on spans.jsonl — each line is a complete span object.
+Examples: grep "ERROR" spans.jsonl, jq 'select(.span_kind == "GENERATION")' spans.jsonl
+Read tree.json to see the full call hierarchy at a glance.
+
+## ClickHouse Schema Reference
+
+### traces table
+Key columns: id, project_id, name, user_id, session_id, timestamp, latency, input, output,
+metadata, tags, environment, release
+
+### observations table (spans)
+Key columns: id, trace_id, project_id, parent_observation_id, name, type (GENERATION|SPAN|EVENT),
+start_time, end_time, latency, level (DEFAULT|DEBUG|WARNING|ERROR),
+status_message, model, input, output, usage_details (JSON), cost_details (JSON),
+metadata
+
+## How to Analyze
+
+1. Start by understanding what the user is asking about
+2. Use query_traces to find relevant traces (search, filter, browse)
+3. Use download_trace to download specific traces for deep investigation
+4. Use bash/read/grep to explore downloaded trace data in /workspace/
+5. Look for: errors (level=ERROR), high latency, cost anomalies, pattern changes
+6. Explain findings clearly with specific span IDs and timestamps
+
+## Workspace
+- /workspace/traces/ — Downloaded trace data (created by download_trace tool)
+- /workspace/notes/ — Your investigation notes
+
+Keep your analysis focused and actionable. Show specific data points, not vague summaries.
+Users will paste trace IDs directly in chat when they want you to investigate specific traces.`;
+}

--- a/frontend/packages/agent/src/session.ts
+++ b/frontend/packages/agent/src/session.ts
@@ -1,0 +1,127 @@
+import { prisma } from "@traceroot/core";
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import type { UserMessage, Message } from "@mariozechner/pi-ai";
+
+// ============================================================
+// SessionManager — follows Mom's SessionManager pattern
+// Mom: context.jsonl file <-> Agent messages
+// Ours: PostgreSQL AISession/AIMessage <-> Agent messages
+// ============================================================
+
+export class SessionManager {
+  constructor(private sessionId: string) {}
+
+  /**
+   * Build conversation context for the Agent.
+   * Like Mom's sessionManager.buildSessionContext() — loads persisted
+   * messages from DB and converts them to AgentMessage format.
+   *
+   * We only restore user messages from DB. Assistant messages are not
+   * restored because they require full LLM metadata (api, provider, model,
+   * usage, stopReason). The agent will see user messages as context and
+   * generate fresh responses.
+   */
+  async buildContext(): Promise<AgentMessage[]> {
+    const session = await prisma.aISession.findUnique({
+      where: { id: this.sessionId },
+      include: { messages: { orderBy: { createTime: "asc" } } },
+    });
+
+    if (!session || session.messages.length === 0) {
+      return [];
+    }
+
+    // Only restore user messages — assistant messages lack required LLM metadata
+    return session.messages
+      .filter((m) => m.role === "user")
+      .map(
+        (m): UserMessage => ({
+          role: "user",
+          content: [{ type: "text", text: m.content }],
+          timestamp: m.createTime.getTime(),
+        }),
+      );
+  }
+
+  /**
+   * Append a message to the session.
+   * Like Mom's sessionManager.appendMessage() — persists to DB.
+   */
+  async appendMessage(
+    role: string,
+    content: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    await prisma.aIMessage.create({
+      data: {
+        sessionId: this.sessionId,
+        role,
+        content,
+        metadata: metadata as any,
+      },
+    });
+  }
+}
+
+// ============================================================
+// Low-level CRUD — used by HTTP routes
+// ============================================================
+
+export async function createSession(params: {
+  projectId: string;
+  workspaceId: string;
+  userId: string;
+  title?: string;
+}) {
+  return prisma.aISession.create({
+    data: {
+      projectId: params.projectId,
+      workspaceId: params.workspaceId,
+      userId: params.userId,
+      title: params.title,
+    },
+  });
+}
+
+export async function getSession(id: string, userId: string) {
+  return prisma.aISession.findFirst({
+    where: { id, userId },
+    include: { messages: { orderBy: { createTime: "asc" } } },
+  });
+}
+
+export async function getSessionMessages(sessionId: string, userId: string) {
+  const session = await prisma.aISession.findFirst({
+    where: { id: sessionId, userId },
+    include: { messages: { orderBy: { createTime: "asc" } } },
+  });
+  if (!session) return null;
+  return session.messages;
+}
+
+export async function listSessions(params: { projectId: string; userId: string; limit?: number }) {
+  return prisma.aISession.findMany({
+    where: {
+      projectId: params.projectId,
+      userId: params.userId,
+    },
+    orderBy: { createTime: "desc" },
+    take: params.limit || 50,
+  });
+}
+
+export async function deleteSession(id: string, userId: string) {
+  // Verify ownership before deleting
+  const session = await prisma.aISession.findFirst({
+    where: { id, userId },
+  });
+  if (!session) return null;
+  return prisma.aISession.delete({ where: { id } });
+}
+
+export async function updateSessionTitle(id: string, title: string) {
+  return prisma.aISession.update({
+    where: { id },
+    data: { title },
+  });
+}

--- a/frontend/packages/agent/src/tools/download-trace.ts
+++ b/frontend/packages/agent/src/tools/download-trace.ts
@@ -2,7 +2,7 @@ import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { Executor } from "../executors/interface.js";
 
-const FASTAPI_URL = process.env.FASTAPI_URL || "http://localhost:8000";
+const FASTAPI_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
 
 const downloadTraceSchema = Type.Object({
   label: Type.String({

--- a/frontend/packages/agent/src/tools/download-trace.ts
+++ b/frontend/packages/agent/src/tools/download-trace.ts
@@ -1,0 +1,125 @@
+import { Type, type Static } from "@sinclair/typebox";
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { Executor } from "../executors/interface.js";
+
+const FASTAPI_URL = process.env.FASTAPI_URL || "http://localhost:8000";
+
+const downloadTraceSchema = Type.Object({
+  label: Type.String({
+    description: "Brief description of what you're downloading (shown to user)",
+  }),
+  traceId: Type.String({ description: "The trace ID to download" }),
+});
+
+type DownloadTraceParams = Static<typeof downloadTraceSchema>;
+
+function sanitizeName(name: string): string {
+  return (
+    name
+      .replace(/[^a-zA-Z0-9_-]/g, "_")
+      .replace(/_+/g, "_")
+      .replace(/^_|_$/g, "") || "unnamed"
+  );
+}
+
+export function createDownloadTraceTool(
+  projectId: string,
+  userId: string,
+  executor: Executor,
+): AgentTool<any> {
+  return {
+    name: "download_trace",
+    label: "Download trace",
+    description:
+      "Download a full trace into the workspace for deep analysis. Creates 3 files: trace.jsonl (metadata), tree.json (hierarchy), spans.jsonl (all spans, one per line). Use grep/jq on spans.jsonl to analyze.",
+    parameters: downloadTraceSchema,
+    execute: async (
+      _toolCallId: string,
+      params: DownloadTraceParams,
+      signal?: AbortSignal,
+    ): Promise<AgentToolResult<undefined>> => {
+      // Ensure sandbox is initialized (lazy init)
+      if (!executor.isReady()) {
+        await executor.init();
+      }
+
+      // Fetch full trace from FastAPI
+      // Response: { trace_id, name, spans: SpanResponse[], ... }
+      const url = `${FASTAPI_URL}/api/v1/projects/${projectId}/traces/${params.traceId}`;
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-user-id": userId,
+      };
+
+      const res = await fetch(url, { headers, signal });
+      if (!res.ok) {
+        const text = await res.text();
+        return {
+          content: [{ type: "text", text: `Error downloading trace: HTTP ${res.status} ${text}` }],
+          details: undefined,
+        };
+      }
+
+      const trace = await res.json();
+      const spans = trace.spans || [];
+      const traceName = sanitizeName(trace.name || "unnamed");
+      const traceDir = `/workspace/traces/${params.traceId}_${traceName}`;
+
+      // 1. Write trace.jsonl — trace metadata as single JSONL line
+      const traceMetadata = { ...trace };
+      delete traceMetadata.spans;
+      await executor.writeFile(`${traceDir}/trace.jsonl`, JSON.stringify(traceMetadata) + "\n");
+
+      // 2. Build and write tree.json — hierarchy structure (pretty-printed)
+      const spanLookup = new Map(spans.map((s: any) => [s.span_id, s]));
+      const childrenMap = new Map<string | null, string[]>();
+      for (const span of spans) {
+        const parentId = span.parent_span_id || null;
+        if (!childrenMap.has(parentId)) childrenMap.set(parentId, []);
+        childrenMap.get(parentId)!.push(span.span_id);
+      }
+
+      function buildSubtree(spanId: string): Record<string, any> {
+        const children = childrenMap.get(spanId) || [];
+        const subtree: Record<string, any> = {};
+        for (const childId of children) {
+          const child = spanLookup.get(childId) as any;
+          const key = `${childId}_${sanitizeName(child.name || "unnamed")}`;
+          subtree[key] = buildSubtree(childId);
+        }
+        return subtree;
+      }
+
+      const tree: Record<string, any> = {};
+      for (const rootId of childrenMap.get(null) || []) {
+        const root = spanLookup.get(rootId) as any;
+        const key = `${rootId}_${sanitizeName(root.name || "unnamed")}`;
+        tree[key] = buildSubtree(rootId);
+      }
+
+      await executor.writeFile(`${traceDir}/tree.json`, JSON.stringify(tree, null, 2));
+
+      // 3. Write spans.jsonl — one span per line
+      const spanLines = spans.map((s: any) => JSON.stringify(s));
+      await executor.writeFile(`${traceDir}/spans.jsonl`, spanLines.join("\n") + "\n");
+
+      const resultText = [
+        `Downloaded trace ${params.traceId} to ${traceDir}/`,
+        `Files:`,
+        `  ${traceDir}/trace.jsonl  — trace metadata`,
+        `  ${traceDir}/tree.json    — span hierarchy`,
+        `  ${traceDir}/spans.jsonl  — ${spans.length} spans (one per line)`,
+        ``,
+        `Quick start:`,
+        `  cat ${traceDir}/tree.json | jq .           # View hierarchy`,
+        `  grep error ${traceDir}/spans.jsonl          # Find errors`,
+        `  grep GENERATION ${traceDir}/spans.jsonl     # Find LLM calls`,
+      ].join("\n");
+
+      return {
+        content: [{ type: "text", text: resultText }],
+        details: undefined,
+      };
+    },
+  };
+}

--- a/frontend/packages/agent/src/tools/index.ts
+++ b/frontend/packages/agent/src/tools/index.ts
@@ -1,0 +1,31 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+import type { Executor } from "../executors/interface.js";
+import { createQueryTracesTool } from "./query-traces.js";
+import { createDownloadTraceTool } from "./download-trace.js";
+import { createBashTool, createReadTool, createWriteTool } from "./sandbox.js";
+
+/**
+ * Create all tools for the agent. Follows Mom's createMomTools() pattern.
+ *
+ * Two types:
+ * - Host-side tools (query_traces, download_trace): run on host, call FastAPI directly
+ * - Sandbox-side tools (bash, read, write): run inside sandbox via executor
+ */
+export function createTools(params: {
+  projectId: string;
+  userId: string;
+  executor: Executor;
+}): AgentTool<any>[] {
+  const tools: AgentTool<any>[] = [];
+
+  // Host-side tools (run on host, call FastAPI directly)
+  tools.push(createQueryTracesTool(params.projectId, params.userId));
+  tools.push(createDownloadTraceTool(params.projectId, params.userId, params.executor));
+
+  // Sandbox-side tools (run inside Docker container via executor)
+  tools.push(createBashTool(params.executor));
+  tools.push(createReadTool(params.executor));
+  tools.push(createWriteTool(params.executor));
+
+  return tools;
+}

--- a/frontend/packages/agent/src/tools/query-traces.ts
+++ b/frontend/packages/agent/src/tools/query-traces.ts
@@ -1,0 +1,89 @@
+import { Type, type Static } from "@sinclair/typebox";
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+
+const FASTAPI_URL = process.env.FASTAPI_URL || "http://localhost:8000";
+
+const queryTracesSchema = Type.Object({
+  label: Type.String({
+    description: "Brief description of what you're searching for (shown to user)",
+  }),
+  limit: Type.Optional(Type.Number({ description: "Max results (default 20)" })),
+  userId: Type.Optional(Type.String({ description: "Filter by user ID" })),
+  name: Type.Optional(Type.String({ description: "Filter by trace name (partial match)" })),
+  searchQuery: Type.Optional(
+    Type.String({ description: "Search across trace_id, name, session_id, user_id" }),
+  ),
+  startAfter: Type.Optional(
+    Type.String({ description: "Filter traces after this time (ISO 8601)" }),
+  ),
+  endBefore: Type.Optional(
+    Type.String({ description: "Filter traces before this time (ISO 8601)" }),
+  ),
+});
+
+type QueryTracesParams = Static<typeof queryTracesSchema>;
+
+export function createQueryTracesTool(projectId: string, userId: string): AgentTool<any> {
+  return {
+    name: "query_traces",
+    label: "Query traces",
+    description:
+      "Search and filter traces for the current project. Returns a summary table of matching traces (IDs, names, timestamps, status, error counts). Use this for discovery before downloading specific traces.",
+    parameters: queryTracesSchema,
+    execute: async (
+      _toolCallId: string,
+      params: QueryTracesParams,
+      signal?: AbortSignal,
+    ): Promise<AgentToolResult<undefined>> => {
+      const queryParams = new URLSearchParams();
+      queryParams.set("limit", String(params.limit || 20));
+      if (params.userId) queryParams.set("user_id", params.userId);
+      if (params.name) queryParams.set("name", params.name);
+      if (params.searchQuery) queryParams.set("search_query", params.searchQuery);
+      if (params.startAfter) queryParams.set("start_after", params.startAfter);
+      if (params.endBefore) queryParams.set("end_before", params.endBefore);
+
+      const url = `${FASTAPI_URL}/api/v1/projects/${projectId}/traces?${queryParams}`;
+      const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+        "x-user-id": userId,
+      };
+
+      const res = await fetch(url, { headers, signal });
+      if (!res.ok) {
+        const text = await res.text();
+        return {
+          content: [{ type: "text", text: `Error querying traces: HTTP ${res.status} ${text}` }],
+          details: undefined,
+        };
+      }
+
+      const data = await res.json();
+      // FastAPI returns { data: TraceListItem[], meta: { page, limit, total } }
+      const traces = data.data || [];
+      const meta = data.meta || {};
+
+      if (!Array.isArray(traces) || traces.length === 0) {
+        return {
+          content: [{ type: "text", text: "No traces found matching the given filters." }],
+          details: undefined,
+        };
+      }
+
+      // Format as summary table for the agent
+      const lines = traces.map((t: any) => {
+        const duration = t.duration_ms != null ? `${Math.round(t.duration_ms)}ms` : "?";
+        return `- ${t.trace_id} | ${t.name || "(unnamed)"} | ${t.trace_start_time} | ${t.status} | ${t.span_count} spans | ${duration}`;
+      });
+
+      const totalInfo = meta.total ? ` (${meta.total} total, showing ${traces.length})` : "";
+
+      return {
+        content: [
+          { type: "text", text: `Found ${traces.length} traces${totalInfo}:\n${lines.join("\n")}` },
+        ],
+        details: undefined,
+      };
+    },
+  };
+}

--- a/frontend/packages/agent/src/tools/query-traces.ts
+++ b/frontend/packages/agent/src/tools/query-traces.ts
@@ -1,7 +1,7 @@
 import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 
-const FASTAPI_URL = process.env.FASTAPI_URL || "http://localhost:8000";
+const FASTAPI_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
 
 const queryTracesSchema = Type.Object({
   label: Type.String({

--- a/frontend/packages/agent/src/tools/sandbox.ts
+++ b/frontend/packages/agent/src/tools/sandbox.ts
@@ -1,0 +1,255 @@
+import { Type } from "@sinclair/typebox";
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { Executor } from "../executors/interface.js";
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  truncateHead,
+  truncateTail,
+  type TruncationResult,
+} from "./truncate.js";
+
+function shellEscape(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+// ---------------------------------------------------------------------------
+// bash
+// ---------------------------------------------------------------------------
+
+const bashSchema = Type.Object({
+  label: Type.String({
+    description: "Brief description of what this command does (shown to user)",
+  }),
+  command: Type.String({ description: "Bash command to execute" }),
+  timeout: Type.Optional(
+    Type.Number({ description: "Timeout in seconds (optional, no default timeout)" }),
+  ),
+});
+
+interface BashToolDetails {
+  truncation?: TruncationResult;
+}
+
+export function createBashTool(executor: Executor): AgentTool<any> {
+  return {
+    name: "bash",
+    label: "bash",
+    description:
+      `Execute a bash command in the sandbox. The sandbox has jq, grep, cat, and standard Unix tools. ` +
+      `Output is truncated to last ${DEFAULT_MAX_LINES} lines or ${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). ` +
+      `Working directory is /workspace. No network access.`,
+    parameters: bashSchema,
+    execute: async (
+      _toolCallId: string,
+      { command, timeout }: { label: string; command: string; timeout?: number },
+      signal?: AbortSignal,
+    ): Promise<AgentToolResult<BashToolDetails | undefined>> => {
+      if (!executor.isReady()) {
+        await executor.init();
+      }
+
+      const result = await executor.exec(command, { timeout, signal });
+
+      let output = "";
+      if (result.stdout) output += result.stdout;
+      if (result.stderr) {
+        if (output) output += "\n";
+        output += result.stderr;
+      }
+
+      // Apply tail truncation (keep end — errors/results are at the bottom)
+      const truncation = truncateTail(output);
+      let outputText = truncation.content || "(no output)";
+
+      let details: BashToolDetails | undefined;
+
+      if (truncation.truncated) {
+        details = { truncation };
+
+        const startLine = truncation.totalLines - truncation.outputLines + 1;
+        const endLine = truncation.totalLines;
+
+        if (truncation.lastLinePartial) {
+          const lastLineSize = formatSize(
+            Buffer.byteLength(output.split("\n").pop() || "", "utf-8"),
+          );
+          outputText += `\n\n[Showing last ${formatSize(truncation.outputBytes)} of line ${endLine} (line is ${lastLineSize}).]`;
+        } else if (truncation.truncatedBy === "lines") {
+          outputText += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines}.]`;
+        } else {
+          outputText += `\n\n[Showing lines ${startLine}-${endLine} of ${truncation.totalLines} (${formatSize(DEFAULT_MAX_BYTES)} limit).]`;
+        }
+      }
+
+      // Throw on non-zero exit (matches Mom's contract — pi-agent-core expects throws)
+      if (result.code !== 0) {
+        throw new Error(`${outputText}\n\nCommand exited with code ${result.code}`.trim());
+      }
+
+      return { content: [{ type: "text", text: outputText }], details };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// read
+// ---------------------------------------------------------------------------
+
+const readSchema = Type.Object({
+  label: Type.String({
+    description: "Brief description of what you're reading and why (shown to user)",
+  }),
+  path: Type.String({ description: "Path to the file to read" }),
+  offset: Type.Optional(
+    Type.Number({ description: "Line number to start reading from (1-indexed)" }),
+  ),
+  limit: Type.Optional(Type.Number({ description: "Maximum number of lines to read" })),
+});
+
+interface ReadToolDetails {
+  truncation?: TruncationResult;
+}
+
+export function createReadTool(executor: Executor): AgentTool<any> {
+  return {
+    name: "read",
+    label: "read",
+    description:
+      `Read the contents of a file. Output is truncated to ${DEFAULT_MAX_LINES} lines or ` +
+      `${DEFAULT_MAX_BYTES / 1024}KB (whichever is hit first). Use offset/limit for large files.`,
+    parameters: readSchema,
+    execute: async (
+      _toolCallId: string,
+      { path, offset, limit }: { label: string; path: string; offset?: number; limit?: number },
+      signal?: AbortSignal,
+    ): Promise<AgentToolResult<ReadToolDetails | undefined>> => {
+      if (!executor.isReady()) {
+        await executor.init();
+      }
+
+      // Get total line count first
+      const countResult = await executor.exec(`wc -l < ${shellEscape(path)}`, { signal });
+      if (countResult.code !== 0) {
+        throw new Error(countResult.stderr || `Failed to read file: ${path}`);
+      }
+      const totalFileLines = parseInt(countResult.stdout.trim(), 10) + 1; // wc -l counts newlines, not lines
+
+      const startLine = offset ? Math.max(1, offset) : 1;
+
+      if (startLine > totalFileLines) {
+        throw new Error(`Offset ${offset} is beyond end of file (${totalFileLines} lines total)`);
+      }
+
+      // Read content with offset
+      let cmd: string;
+      if (startLine === 1) {
+        cmd = `cat ${shellEscape(path)}`;
+      } else {
+        cmd = `tail -n +${startLine} ${shellEscape(path)}`;
+      }
+
+      const result = await executor.exec(cmd, { signal });
+      if (result.code !== 0) {
+        throw new Error(result.stderr || `Failed to read file: ${path}`);
+      }
+
+      let selectedContent = result.stdout;
+      let userLimitedLines: number | undefined;
+
+      // Apply user limit if specified
+      if (limit !== undefined) {
+        const lines = selectedContent.split("\n");
+        const endLine = Math.min(limit, lines.length);
+        selectedContent = lines.slice(0, endLine).join("\n");
+        userLimitedLines = endLine;
+      }
+
+      // Apply truncation (head — keep beginning of file)
+      const truncation = truncateHead(selectedContent);
+
+      let outputText: string;
+      let details: ReadToolDetails | undefined;
+
+      if (truncation.firstLineExceedsLimit) {
+        const firstLineSize = formatSize(
+          Buffer.byteLength(selectedContent.split("\n")[0], "utf-8"),
+        );
+        outputText = `[Line ${startLine} is ${firstLineSize}, exceeds ${formatSize(DEFAULT_MAX_BYTES)} limit. Use bash: sed -n '${startLine}p' ${path} | head -c ${DEFAULT_MAX_BYTES}]`;
+        details = { truncation };
+      } else if (truncation.truncated) {
+        const endLineDisplay = startLine + truncation.outputLines - 1;
+        const nextOffset = endLineDisplay + 1;
+
+        outputText = truncation.content;
+
+        if (truncation.truncatedBy === "lines") {
+          outputText += `\n\n[Showing lines ${startLine}-${endLineDisplay} of ${totalFileLines}. Use offset=${nextOffset} to continue]`;
+        } else {
+          outputText += `\n\n[Showing lines ${startLine}-${endLineDisplay} of ${totalFileLines} (${formatSize(DEFAULT_MAX_BYTES)} limit). Use offset=${nextOffset} to continue]`;
+        }
+        details = { truncation };
+      } else if (userLimitedLines !== undefined) {
+        const linesFromStart = startLine - 1 + userLimitedLines;
+        if (linesFromStart < totalFileLines) {
+          const remaining = totalFileLines - linesFromStart;
+          const nextOffset = startLine + userLimitedLines;
+
+          outputText = truncation.content;
+          outputText += `\n\n[${remaining} more lines in file. Use offset=${nextOffset} to continue]`;
+        } else {
+          outputText = truncation.content;
+        }
+      } else {
+        outputText = truncation.content;
+      }
+
+      return { content: [{ type: "text", text: outputText }], details };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// write
+// ---------------------------------------------------------------------------
+
+const writeSchema = Type.Object({
+  label: Type.String({ description: "Brief description of what you're writing (shown to user)" }),
+  path: Type.String({ description: "Path to the file to write" }),
+  content: Type.String({ description: "Content to write to the file" }),
+});
+
+export function createWriteTool(executor: Executor): AgentTool<any> {
+  return {
+    name: "write",
+    label: "write",
+    description:
+      "Write content to a file. Creates the file if it doesn't exist, overwrites if it does. " +
+      "Automatically creates parent directories.",
+    parameters: writeSchema,
+    execute: async (
+      _toolCallId: string,
+      { path, content }: { label: string; path: string; content: string },
+      signal?: AbortSignal,
+    ): Promise<AgentToolResult<undefined>> => {
+      if (!executor.isReady()) {
+        await executor.init();
+      }
+
+      // Use printf '%s' with shell escaping (matches Mom — safe for special chars)
+      const dir = path.includes("/") ? path.substring(0, path.lastIndexOf("/")) : ".";
+      const cmd = `mkdir -p ${shellEscape(dir)} && printf '%s' ${shellEscape(content)} > ${shellEscape(path)}`;
+
+      const result = await executor.exec(cmd, { signal });
+      if (result.code !== 0) {
+        throw new Error(result.stderr || `Failed to write file: ${path}`);
+      }
+
+      return {
+        content: [{ type: "text", text: `Successfully wrote ${content.length} bytes to ${path}` }],
+        details: undefined,
+      };
+    },
+  };
+}

--- a/frontend/packages/agent/src/tools/truncate.ts
+++ b/frontend/packages/agent/src/tools/truncate.ts
@@ -1,0 +1,204 @@
+/**
+ * Shared truncation utilities for tool outputs.
+ * Ported from Mom (pi-mono/packages/mom/src/tools/truncate.ts).
+ *
+ * Two independent limits — whichever is hit first wins:
+ * - Line limit (default: 2000 lines)
+ * - Byte limit (default: 50KB)
+ *
+ * Never returns partial lines (except bash tail truncation edge case).
+ */
+
+export const DEFAULT_MAX_LINES = 2000;
+export const DEFAULT_MAX_BYTES = 50 * 1024; // 50KB
+
+export interface TruncationResult {
+  content: string;
+  truncated: boolean;
+  truncatedBy: "lines" | "bytes" | null;
+  totalLines: number;
+  totalBytes: number;
+  outputLines: number;
+  outputBytes: number;
+  lastLinePartial: boolean;
+  firstLineExceedsLimit: boolean;
+}
+
+export interface TruncationOptions {
+  maxLines?: number;
+  maxBytes?: number;
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes}B`;
+  } else if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+  } else {
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  }
+}
+
+/**
+ * Truncate from head (keep first N lines/bytes).
+ * For file reads — you want to see the beginning.
+ */
+export function truncateHead(content: string, options: TruncationOptions = {}): TruncationResult {
+  const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+
+  const totalBytes = Buffer.byteLength(content, "utf-8");
+  const lines = content.split("\n");
+  const totalLines = lines.length;
+
+  if (totalLines <= maxLines && totalBytes <= maxBytes) {
+    return {
+      content,
+      truncated: false,
+      truncatedBy: null,
+      totalLines,
+      totalBytes,
+      outputLines: totalLines,
+      outputBytes: totalBytes,
+      lastLinePartial: false,
+      firstLineExceedsLimit: false,
+    };
+  }
+
+  const firstLineBytes = Buffer.byteLength(lines[0], "utf-8");
+  if (firstLineBytes > maxBytes) {
+    return {
+      content: "",
+      truncated: true,
+      truncatedBy: "bytes",
+      totalLines,
+      totalBytes,
+      outputLines: 0,
+      outputBytes: 0,
+      lastLinePartial: false,
+      firstLineExceedsLimit: true,
+    };
+  }
+
+  const outputLinesArr: string[] = [];
+  let outputBytesCount = 0;
+  let truncatedBy: "lines" | "bytes" = "lines";
+
+  for (let i = 0; i < lines.length && i < maxLines; i++) {
+    const line = lines[i];
+    const lineBytes = Buffer.byteLength(line, "utf-8") + (i > 0 ? 1 : 0);
+
+    if (outputBytesCount + lineBytes > maxBytes) {
+      truncatedBy = "bytes";
+      break;
+    }
+
+    outputLinesArr.push(line);
+    outputBytesCount += lineBytes;
+  }
+
+  if (outputLinesArr.length >= maxLines && outputBytesCount <= maxBytes) {
+    truncatedBy = "lines";
+  }
+
+  const outputContent = outputLinesArr.join("\n");
+  const finalOutputBytes = Buffer.byteLength(outputContent, "utf-8");
+
+  return {
+    content: outputContent,
+    truncated: true,
+    truncatedBy,
+    totalLines,
+    totalBytes,
+    outputLines: outputLinesArr.length,
+    outputBytes: finalOutputBytes,
+    lastLinePartial: false,
+    firstLineExceedsLimit: false,
+  };
+}
+
+/**
+ * Truncate from tail (keep last N lines/bytes).
+ * For bash output — you want to see errors/results at the end.
+ */
+export function truncateTail(content: string, options: TruncationOptions = {}): TruncationResult {
+  const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+
+  const totalBytes = Buffer.byteLength(content, "utf-8");
+  const lines = content.split("\n");
+  const totalLines = lines.length;
+
+  if (totalLines <= maxLines && totalBytes <= maxBytes) {
+    return {
+      content,
+      truncated: false,
+      truncatedBy: null,
+      totalLines,
+      totalBytes,
+      outputLines: totalLines,
+      outputBytes: totalBytes,
+      lastLinePartial: false,
+      firstLineExceedsLimit: false,
+    };
+  }
+
+  const outputLinesArr: string[] = [];
+  let outputBytesCount = 0;
+  let truncatedBy: "lines" | "bytes" = "lines";
+  let lastLinePartial = false;
+
+  for (let i = lines.length - 1; i >= 0 && outputLinesArr.length < maxLines; i--) {
+    const line = lines[i];
+    const lineBytes = Buffer.byteLength(line, "utf-8") + (outputLinesArr.length > 0 ? 1 : 0);
+
+    if (outputBytesCount + lineBytes > maxBytes) {
+      truncatedBy = "bytes";
+      if (outputLinesArr.length === 0) {
+        const truncatedLine = truncateStringToBytesFromEnd(line, maxBytes);
+        outputLinesArr.unshift(truncatedLine);
+        outputBytesCount = Buffer.byteLength(truncatedLine, "utf-8");
+        lastLinePartial = true;
+      }
+      break;
+    }
+
+    outputLinesArr.unshift(line);
+    outputBytesCount += lineBytes;
+  }
+
+  if (outputLinesArr.length >= maxLines && outputBytesCount <= maxBytes) {
+    truncatedBy = "lines";
+  }
+
+  const outputContent = outputLinesArr.join("\n");
+  const finalOutputBytes = Buffer.byteLength(outputContent, "utf-8");
+
+  return {
+    content: outputContent,
+    truncated: true,
+    truncatedBy,
+    totalLines,
+    totalBytes,
+    outputLines: outputLinesArr.length,
+    outputBytes: finalOutputBytes,
+    lastLinePartial,
+    firstLineExceedsLimit: false,
+  };
+}
+
+function truncateStringToBytesFromEnd(str: string, maxBytes: number): string {
+  const buf = Buffer.from(str, "utf-8");
+  if (buf.length <= maxBytes) {
+    return str;
+  }
+
+  let start = buf.length - maxBytes;
+
+  // Find valid UTF-8 boundary
+  while (start < buf.length && (buf[start] & 0xc0) === 0x80) {
+    start++;
+  }
+
+  return buf.slice(start).toString("utf-8");
+}

--- a/frontend/packages/agent/tsconfig.json
+++ b/frontend/packages/agent/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -97,6 +97,7 @@ model Project {
   createTime   DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
   updateTime   DateTime  @default(now()) @map("update_time") @db.Timestamp(6)
   accessKeys   AccessKey[]
+  aiSessions   AISession[]
   workspace    Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([workspaceId], map: "ix_project_workspace_id")
@@ -141,4 +142,38 @@ model Account {
 
   @@unique([provider, providerAccountId])
   @@map("accounts")
+}
+
+// AI Sessions - Conversation sessions for the AI debugging assistant
+model AISession {
+  id          String      @id @default(cuid()) @db.VarChar
+  projectId   String      @map("project_id") @db.VarChar
+  workspaceId String      @map("workspace_id") @db.VarChar
+  userId      String      @map("user_id") @db.VarChar
+  title       String?     @db.VarChar
+  status      String      @default("active") @db.VarChar  // active, completed, failed
+  metadata    Json?       @db.JsonB
+  createTime  DateTime    @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime  DateTime    @default(now()) @updatedAt @map("update_time") @db.Timestamp(6)
+  messages    AIMessage[]
+  project     Project     @relation(fields: [projectId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([projectId], map: "ix_ai_session_project_id")
+  @@index([workspaceId], map: "ix_ai_session_workspace_id")
+  @@index([userId], map: "ix_ai_session_user_id")
+  @@map("ai_sessions")
+}
+
+// AI Messages - Individual messages within an AI session
+model AIMessage {
+  id         String    @id @default(cuid()) @db.VarChar
+  sessionId  String    @map("session_id") @db.VarChar
+  role       String    @db.VarChar  // user, assistant, tool
+  content    String    @db.Text
+  metadata   Json?     @db.JsonB    // tool name, tool result, etc.
+  createTime DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
+  session    AISession @relation(fields: [sessionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+
+  @@index([sessionId], map: "ix_ai_message_session_id")
+  @@map("ai_messages")
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -33,6 +33,43 @@ importers:
         specifier: ^8.54.0
         version: 8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)
 
+  packages/agent:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.0.0
+        version: 1.19.9(hono@4.12.0)
+      '@mariozechner/pi-agent-core':
+        specifier: ^0.52.0
+        version: 0.52.12(ws@8.19.0)(zod@3.25.76)
+      '@mariozechner/pi-ai':
+        specifier: ^0.52.0
+        version: 0.52.12(ws@8.19.0)(zod@3.25.76)
+      '@sinclair/typebox':
+        specifier: ^0.34.0
+        version: 0.34.48
+      '@traceroot/core':
+        specifier: workspace:*
+        version: link:../core
+      hono:
+        specifier: ^4.0.0
+        version: 4.12.0
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.9
+      dotenv-cli:
+        specifier: ^11.0.0
+        version: 11.0.0
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.9)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/core:
     dependencies:
       '@prisma/client':
@@ -192,6 +229,15 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@anthropic-ai/sdk@0.73.0':
+    resolution: {integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@auth/core@0.41.1':
     resolution: {integrity: sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==}
     peerDependencies:
@@ -210,6 +256,155 @@ packages:
     resolution: {integrity: sha512-Ke7DXP0Fy0Mlmjz/ZJLXwQash2UkA4621xCM0rMtEczr1kppLc/njCbUkHkIQ/PnmILjqSPEKeTjDPsYruvkug==}
     peerDependencies:
       '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5 || >=6'
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.994.0':
+    resolution: {integrity: sha512-ag7Qx78m1K3Dv7xlFgeHS4jBdopGZUISgVBMUy7Cj4fIgVH9EBmsc5K4hWozL8BJQctWke8Wsl96O7Gd+HCGhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-sso@3.993.0':
+    resolution: {integrity: sha512-VLUN+wIeNX24fg12SCbzTUBnBENlL014yMKZvRhPkcn4wHR6LKgNrjsG3fZ03Xs0XoKaGtNFi1VVrq666sGBoQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.11':
+    resolution: {integrity: sha512-wdQ8vrvHkKIV7yNUKXyjPWKCdYEUrZTHJ8Ojd5uJxXp9vqPCkUR1dpi1NtOLcrDgueJH7MUH5lQZxshjFPSbDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.9':
+    resolution: {integrity: sha512-ZptrOwQynfupubvcngLkbdIq/aXvl/czdpEG8XJ8mN8Nb19BR0jaK0bR+tfuMU36Ez9q4xv7GGkHFqEEP2hUUQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.11':
+    resolution: {integrity: sha512-hECWoOoH386bGr89NQc9vA/abkGf5TJrMREt+lhNcnSNmoBS04fK7vc3LrJBSQAUGGVj0Tz3f4dHB3w5veovig==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.9':
+    resolution: {integrity: sha512-zr1csEu9n4eDiHMTYJabX1mDGuGLgjgUnNckIivvk43DocJC9/f6DefFrnUPZXE+GHtbW50YuXb+JIxKykU74A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.9':
+    resolution: {integrity: sha512-m4RIpVgZChv0vWS/HKChg1xLgZPpx8Z+ly9Fv7FwA8SOfuC6I3htcSaBz2Ch4bneRIiBUhwP4ziUo0UZgtJStQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.10':
+    resolution: {integrity: sha512-70nCESlvnzjo4LjJ8By8MYIiBogkYPSXl3WmMZfH9RZcB/Nt9qVWbFpYj6Fk1vLa4Vk8qagFVeXgxdieMxG1QA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.9':
+    resolution: {integrity: sha512-gOWl0Fe2gETj5Bk151+LYKpeGi2lBDLNu+NMNpHRlIrKHdBmVun8/AalwMK8ci4uRfG5a3/+zvZBMpuen1SZ0A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.9':
+    resolution: {integrity: sha512-ey7S686foGTArvFhi3ifQXmgptKYvLSGE2250BAQceMSXZddz7sUSNERGJT2S7u5KIe/kgugxrt01hntXVln6w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.9':
+    resolution: {integrity: sha512-8LnfS76nHXoEc9aRRiMMpxZxJeDG0yusdyo3NvPhCgESmBUgpMa4luhGbClW5NoX/qRcGxxM6Z/esqANSNMTow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.5':
+    resolution: {integrity: sha512-xEmd3dnyn83K6t4AJxBJA63wpEoCD45ERFG0XMTViD2E/Ohls9TLxjOWPb1PAxR9/46cKy/TImez1GoqP6xVNQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.3':
+    resolution: {integrity: sha512-pbvZ6Ye/Ks6BAZPa3RhsNjHrvxU9li25PMhSdDpbX0jzdpKpAkIR65gXSNKmA/REnSdEMWSD4vKUW+5eMFzB6w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    resolution: {integrity: sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    resolution: {integrity: sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    resolution: {integrity: sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.11':
+    resolution: {integrity: sha512-R8CvPsPHXwzIHCAza+bllY6PrctEk4lYq/SkHJz9NLoBHCcKQrbOcsfXxO6xmipSbUNIbNIUhH0lBsJGgsRdiw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.6':
+    resolution: {integrity: sha512-1DedO6N3m8zQ/vG6twNiHtsdwBgk773VdavLEbB3NXeKZDlzSK1BTviqWwvJdKx5UnIy4kGGP6WWpCEFEt/bhQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.993.0':
+    resolution: {integrity: sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.994.0':
+    resolution: {integrity: sha512-12Iv+U3qPBiKT6A2QKe0obkubxyGH90hyJIrht1KLxoz5OcIdWYafD7FtVGMwTtYRO73lvnVAsAkNkauZeupGQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    resolution: {integrity: sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.993.0':
+    resolution: {integrity: sha512-+35g4c+8r7sB9Sjp1KPdM8qxGn6B/shBjJtEUN4e+Edw9UEQlZKIzioOGu3UAbyE0a/s450LdLZr4wbJChtmww==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.994.0':
+    resolution: {integrity: sha512-Dm/MpsQ+aQs2+XDLbA928b8Ly1O0Pz7laTjX52mEah3xyd9/L3UghKSZ7XeLA65PElUp92Seei/bwhKX+KsfMw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.1':
+    resolution: {integrity: sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.993.0':
+    resolution: {integrity: sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.994.0':
+    resolution: {integrity: sha512-L2obUBw4ACMMd1F/SG5LdfPyZ0xJNs9Maifwr3w0uWO+4YvHmk9FfRskfSfE/SLZ9S387oSZ+1xiP7BfVCP/Og==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.3':
+    resolution: {integrity: sha512-n7F2ycckcKFXa01vAsT/SJdjFHfKH9s96QHcs5gn8AaaigASICeME8WdUL9uBp8XV/OVwEt8+6gzn6KFUgQa8g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    resolution: {integrity: sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    resolution: {integrity: sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==}
+
+  '@aws-sdk/util-user-agent-node@3.972.9':
+    resolution: {integrity: sha512-JNswdsLdQemxqaSIBL2HRhsHPUBBziAgoi5RQv6/9avmE5g5RSdt1hWr3mHJ7OxqRYf+KeB11ExWbiqfrnoeaA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.5':
+    resolution: {integrity: sha512-mCae5Ys6Qm1LDu0qdGwx2UQ63ONUe+FHw908fJzLDqFKTDBK4LDZUqKWm4OkTCNFq19bftjsBSESIGLD/s3/rA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.3':
+    resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -494,6 +689,21 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@google/genai@1.42.0':
+    resolution: {integrity: sha512-+3nlMTcrQufbQ8IumGkOphxD5Pd5kKyJOzLcnY0/1IuE8upJk5aLmoexZ2BJhBp1zAjRJMEB4a2CJwKI9e2EYw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
+  '@hono/node-server@1.19.9':
+    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
@@ -620,6 +830,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -635,6 +849,18 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mariozechner/pi-agent-core@0.52.12':
+    resolution: {integrity: sha512-fBQdwLMvTteHUP9nJxMjtMpEHH4I8tdGnkerOoCFnS9y03AHdqy96IhtL+zZjw9N3dmVCOVqh8gwGjAGLZT31Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@mariozechner/pi-ai@0.52.12':
+    resolution: {integrity: sha512-oF7OMJu1aUx7MXJeJoJ/3JDXzD2a5SqK9nHVK3mCA8DRQaykv9g+wcFZaANcCl0vAR2QSDr5KN3ZMARlFNWiVg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@mistralai/mistralai@1.10.0':
+    resolution: {integrity: sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg==}
 
   '@next/env@15.1.0':
     resolution: {integrity: sha512-UcCO481cROsqJuszPPXJnb7GGuLq617ve4xuAyyNG4VSSocJNtMU5Fsx+Lp6mlN8c7W58aZLc5y6D/2xNmaK+w==}
@@ -702,6 +928,10 @@ packages:
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
   '@prisma/client@5.22.0':
     resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
     engines: {node: '>=16.13'}
@@ -725,6 +955,36 @@ packages:
 
   '@prisma/get-platform@5.22.0':
     resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1194,6 +1454,201 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinclair/typebox@0.34.48':
+    resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
+
+  '@smithy/abort-controller@4.2.8':
+    resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.6':
+    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.2':
+    resolution: {integrity: sha512-HaaH4VbGie4t0+9nY3tNBRSxVTr96wzIqexUa6C2qx3MPePAuz7lIxPxYtt1Wc//SPfJLNoZJzfdt0B6ksj2jA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.8':
+    resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.8':
+    resolution: {integrity: sha512-jS/O5Q14UsufqoGhov7dHLOPCzkYJl9QDzusI2Psh4wyYx/izhzvX9P4D69aTxcdfVhEPhjK+wYyn/PzLjKbbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    resolution: {integrity: sha512-MTfQT/CRQz5g24ayXdjg53V0mhucZth4PESoA5IhvaWVDTOQLfo8qI9vzqHcPsdd2v6sqfTYqF5L/l+pea5Uyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    resolution: {integrity: sha512-ah12+luBiDGzBruhu3efNy1IlbwSEdNiw8fOZksoKoWW1ZHvO/04MQsdnws/9Aj+5b0YXSSN2JXKy/ClIsW8MQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    resolution: {integrity: sha512-cYpCpp29z6EJHa5T9WL0KAlq3SOKUQkcgSoeRfRVwjGgSFl7Uh32eYGt7IDYCX20skiEdRffyDpvF2efEZPC0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    resolution: {integrity: sha512-iJ6YNJd0bntJYnX6s52NC4WFYcZeKrPUr1Kmmr5AwZcwCSzVpS7oavAmxMR7pMq7V+D1G4s9F5NJK0xwOsKAlQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.9':
+    resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.8':
+    resolution: {integrity: sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.8':
+    resolution: {integrity: sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.0':
+    resolution: {integrity: sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.8':
+    resolution: {integrity: sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.16':
+    resolution: {integrity: sha512-L5GICFCSsNhbJ5JSKeWFGFy16Q2OhoBizb3X2DrxaJwXSEujVvjG9Jt386dpQn2t7jINglQl0b4K/Su69BdbMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.33':
+    resolution: {integrity: sha512-jLqZOdJhtIL4lnA9hXnAG6GgnJlo1sD3FqsTxm9wSfjviqgWesY/TMBVnT84yr4O0Vfe0jWoXlfFbzsBVph3WA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.9':
+    resolution: {integrity: sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.8':
+    resolution: {integrity: sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.8':
+    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.4.10':
+    resolution: {integrity: sha512-u4YeUwOWRZaHbWaebvrs3UhwQwj+2VNmcVCwXcYTvPIuVyM7Ex1ftAj+fdbG/P4AkBwLq/+SKn+ydOI4ZJE9PA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.8':
+    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.8':
+    resolution: {integrity: sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.8':
+    resolution: {integrity: sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.8':
+    resolution: {integrity: sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.8':
+    resolution: {integrity: sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.8':
+    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.11.5':
+    resolution: {integrity: sha512-xixwBRqoeP2IUgcAl3U9dvJXc+qJum4lzo3maaJxifsZxKUYLfVfCXvhT4/jD01sRrHg5zjd1cw2Zmjr4/SuKQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.12.0':
+    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.8':
+    resolution: {integrity: sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.0':
+    resolution: {integrity: sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.0':
+    resolution: {integrity: sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.1':
+    resolution: {integrity: sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.0':
+    resolution: {integrity: sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.0':
+    resolution: {integrity: sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.32':
+    resolution: {integrity: sha512-092sjYfFMQ/iaPH798LY/OJFBcYu0sSK34Oy9vdixhsU36zlZu8OcYjF3TD4e2ARupyK7xaxPXl+T0VIJTEkkg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.35':
+    resolution: {integrity: sha512-miz/ggz87M8VuM29y7jJZMYkn7+IErM5p5UgKIf8OtqVs/h2bXr1Bt3uTsREsI/4nK8a0PQERbAPsVPVNIsG7Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.2.8':
+    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.0':
+    resolution: {integrity: sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.8':
+    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.8':
+    resolution: {integrity: sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.12':
+    resolution: {integrity: sha512-D8tgkrmhAX/UNeCZbqbEO3uqyghUnEmmoO9YEvRuwxjlkKKUE7FOgCJnqpTlQPe9MApdWPky58mNQQHbnCzoNg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.0':
+    resolution: {integrity: sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.0':
+    resolution: {integrity: sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.0':
+    resolution: {integrity: sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
@@ -1210,6 +1665,9 @@ packages:
     resolution: {integrity: sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@types/bcryptjs@3.0.0':
     resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
@@ -1243,6 +1701,9 @@ packages:
 
   '@types/react@19.2.13':
     resolution: {integrity: sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
   '@typescript-eslint/eslint-plugin@8.55.0':
     resolution: {integrity: sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==}
@@ -1342,12 +1803,31 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
 
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
@@ -1382,6 +1862,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   autoprefixer@10.4.24:
     resolution: {integrity: sha512-uHZg7N9ULTVbutaIsDRoUkoS8/h3bdsmVJYZ5l3wv8Cp/6UIIoRDm90hZ+BwxUj/hGBEzLxdHNSKuFpn8WOyZw==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1392,17 +1876,30 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
+
+  basic-ftp@5.1.0:
+    resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
+    engines: {node: '>=10.0.0'}
 
   bcryptjs@3.0.3:
     resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
@@ -1418,6 +1915,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -1453,6 +1953,10 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
@@ -1527,6 +2031,14 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -1545,6 +2057,10 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
@@ -1579,11 +2095,23 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   electron-to-chromium@1.5.286:
     resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -1617,6 +2145,11 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
     engines: {node: '>=18'}
@@ -1649,6 +2182,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -1675,6 +2213,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1688,6 +2229,13 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-parser@5.3.6:
+    resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -1699,6 +2247,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -1719,6 +2271,14 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -1729,6 +2289,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.1.3:
+    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -1753,6 +2321,10 @@ packages:
   get-tsconfig@4.13.3:
     resolution: {integrity: sha512-vp8Cj/+9Q/ibZUrq1rhy8mCTQpCk31A3uu9wc1C50yAb3x2pFHOsGdAZQ7jD86ARayyxZUViYeIztW+GE8dcrg==}
 
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1761,13 +2333,30 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1787,6 +2376,18 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  hono@4.12.0:
+    resolution: {integrity: sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==}
+    engines: {node: '>=16.9.0'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1803,6 +2404,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
@@ -1818,6 +2423,10 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-fullwidth-code-point@5.1.0:
     resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
     engines: {node: '>=18'}
@@ -1832,6 +2441,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
@@ -1858,11 +2470,21 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1871,6 +2493,12 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -1906,8 +2534,14 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1915,6 +2549,10 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
 
   lucide-react@0.468.0:
     resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
@@ -1950,6 +2588,10 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1967,6 +2609,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  netmask@2.0.2:
+    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
+    engines: {node: '>= 0.4.0'}
 
   next-auth@4.24.13:
     resolution: {integrity: sha512-sgObCfcfL7BzIK76SS5TnQtc3yo2Oifp/yIpfv6fMfeBOiBJkDWF3A2y9+yqnmJ4JKc2C+nMjSjmgDeTwgN1rQ==}
@@ -2014,6 +2660,15 @@ packages:
     resolution: {integrity: sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==}
     engines: {node: '>=6.0.0'}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
@@ -2055,6 +2710,18 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  openai@6.10.0:
+    resolution: {integrity: sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   openid-client@5.7.1:
     resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
 
@@ -2070,9 +2737,27 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -2084,6 +2769,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -2255,6 +2944,17 @@ packages:
     engines: {node: '>=16.13'}
     hasBin: true
 
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2323,6 +3023,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2339,12 +3043,20 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
 
   rollup@4.57.1:
     resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
@@ -2353,6 +3065,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
@@ -2408,8 +3123,24 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   stackback@0.0.2:
@@ -2426,6 +3157,14 @@ packages:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -2433,6 +3172,10 @@ packages:
   string-width@8.1.1:
     resolution: {integrity: sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==}
     engines: {node: '>=20'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
@@ -2448,6 +3191,9 @@ packages:
   stripe@14.25.0:
     resolution: {integrity: sha512-wQS3GNMofCXwH8TSje8E1SE8zr6ODiGtHQgPtO95p9Mb4FhKC9jvXR2NUTpZ9ZINlckJcFidCmaTFV4P6vsb9g==}
     engines: {node: '>=12.*'}
+
+  strnum@2.1.2:
+    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -2516,6 +3262,9 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
     engines: {node: '>=18.12'}
@@ -2551,6 +3300,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@7.22.0:
+    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+    engines: {node: '>=20.18.1'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -2661,6 +3414,10 @@ packages:
       jsdom:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2675,9 +3432,29 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2694,11 +3471,19 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.1:
+    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+    peerDependencies:
+      zod: ^3.25 || ^4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -2706,6 +3491,12 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@anthropic-ai/sdk@0.73.0(zod@3.25.76)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 3.25.76
 
   '@auth/core@0.41.1(nodemailer@7.0.13)':
     dependencies:
@@ -2725,6 +3516,486 @@ snapshots:
       - '@simplewebauthn/browser'
       - '@simplewebauthn/server'
       - nodemailer
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-locate-window': 3.965.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.1
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.994.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/credential-provider-node': 3.972.10
+      '@aws-sdk/eventstream-handler-node': 3.972.5
+      '@aws-sdk/middleware-eventstream': 3.972.3
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/middleware-websocket': 3.972.6
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/token-providers': 3.994.0
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.994.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/eventstream-serde-config-resolver': 4.3.8
+      '@smithy/eventstream-serde-node': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-sso@3.993.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/xml-builder': 3.972.5
+      '@smithy/core': 3.23.2
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.11':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/credential-provider-env': 3.972.9
+      '@aws-sdk/credential-provider-http': 3.972.11
+      '@aws-sdk/credential-provider-login': 3.972.9
+      '@aws-sdk/credential-provider-process': 3.972.9
+      '@aws-sdk/credential-provider-sso': 3.972.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.9
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.10':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.9
+      '@aws-sdk/credential-provider-http': 3.972.11
+      '@aws-sdk/credential-provider-ini': 3.972.9
+      '@aws-sdk/credential-provider-process': 3.972.9
+      '@aws-sdk/credential-provider-sso': 3.972.9
+      '@aws-sdk/credential-provider-web-identity': 3.972.9
+      '@aws-sdk/types': 3.973.1
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.9':
+    dependencies:
+      '@aws-sdk/client-sso': 3.993.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/token-providers': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.9':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/eventstream-handler-node@3.972.5':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws/lambda-invoke-store': 0.2.3
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.11':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@smithy/core': 3.23.2
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.6':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-format-url': 3.972.3
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/eventstream-serde-browser': 4.2.8
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.993.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/nested-clients@3.994.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/middleware-host-header': 3.972.3
+      '@aws-sdk/middleware-logger': 3.972.3
+      '@aws-sdk/middleware-recursion-detection': 3.972.3
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/region-config-resolver': 3.972.3
+      '@aws-sdk/types': 3.973.1
+      '@aws-sdk/util-endpoints': 3.994.0
+      '@aws-sdk/util-user-agent-browser': 3.972.3
+      '@aws-sdk/util-user-agent-node': 3.972.9
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.23.2
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-retry': 4.4.33
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.32
+      '@smithy/util-defaults-mode-node': 4.2.35
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.993.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.994.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.11
+      '@aws-sdk/nested-clients': 3.994.0
+      '@aws-sdk/types': 3.973.1
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.1':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.993.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.994.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.3':
+    dependencies:
+      '@aws-sdk/types': 3.973.1
+      '@smithy/types': 4.12.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.972.9':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.11
+      '@aws-sdk/types': 3.973.1
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.5':
+    dependencies:
+      '@smithy/types': 4.12.0
+      fast-xml-parser: 5.3.6
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.3': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2974,6 +4245,21 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@google/genai@1.42.0':
+    dependencies:
+      google-auth-library: 10.5.0
+      p-retry: 4.6.2
+      protobufjs: 7.5.4
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@hono/node-server@1.19.9(hono@4.12.0)':
+    dependencies:
+      hono: 4.12.0
+
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.0.0))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -3065,6 +4351,15 @@ snapshots:
   '@img/sharp-win32-x64@0.33.5':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.2
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3083,6 +4378,47 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mariozechner/pi-agent-core@0.52.12(ws@8.19.0)(zod@3.25.76)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.52.12(ws@8.19.0)(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-ai@0.52.12(ws@8.19.0)(zod@3.25.76)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.73.0(zod@3.25.76)
+      '@aws-sdk/client-bedrock-runtime': 3.994.0
+      '@google/genai': 1.42.0
+      '@mistralai/mistralai': 1.10.0
+      '@sinclair/typebox': 0.34.48
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      chalk: 5.6.2
+      openai: 6.10.0(ws@8.19.0)(zod@3.25.76)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      undici: 7.22.0
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mistralai/mistralai@1.10.0':
+    dependencies:
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
 
   '@next/env@15.1.0': {}
 
@@ -3124,6 +4460,9 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
   '@prisma/client@5.22.0(prisma@5.22.0)':
     optionalDependencies:
       prisma: 5.22.0
@@ -3148,6 +4487,29 @@ snapshots:
   '@prisma/get-platform@5.22.0':
     dependencies:
       '@prisma/debug': 5.22.0
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -3575,6 +4937,312 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
+  '@sinclair/typebox@0.34.48': {}
+
+  '@smithy/abort-controller@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.6':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.2':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.12
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.8':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.8':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.8':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.8':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.16':
+    dependencies:
+      '@smithy/core': 3.23.2
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.33':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.8':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.4.10':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.8':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.11.5':
+    dependencies:
+      '@smithy/core': 3.23.2
+      '@smithy/middleware-endpoint': 4.4.16
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.12
+      tslib: 2.8.1
+
+  '@smithy/types@4.12.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.8':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.32':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.35':
+    dependencies:
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.11.5
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.12':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.10
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.0':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/utils@0.3.0': {}
 
   '@swc/counter@0.1.3': {}
@@ -3589,6 +5257,8 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.90.20
       react: 19.0.0
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@types/bcryptjs@3.0.0':
     dependencies:
@@ -3622,6 +5292,8 @@ snapshots:
   '@types/react@19.2.13':
     dependencies:
       csstype: 3.2.3
+
+  '@types/retry@0.12.0': {}
 
   '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.2(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
@@ -3762,6 +5434,12 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
+
   ajv@6.12.6:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3769,9 +5447,18 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
+
+  ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
 
@@ -3798,6 +5485,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   autoprefixer@10.4.24(postcss@8.5.6):
     dependencies:
       browserslist: 4.28.1
@@ -3809,11 +5500,19 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.19: {}
+
+  basic-ftp@5.1.0: {}
 
   bcryptjs@3.0.3: {}
 
+  bignumber.js@9.3.1: {}
+
   binary-extensions@2.3.0: {}
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -3835,6 +5534,8 @@ snapshots:
       electron-to-chromium: 1.5.286
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   busboy@1.6.0:
     dependencies:
@@ -3870,6 +5571,8 @@ snapshots:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  chalk@5.6.2: {}
 
   check-error@2.1.3: {}
 
@@ -3942,6 +5645,10 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
+  data-uri-to-buffer@6.0.2: {}
+
   date-fns@4.1.0: {}
 
   debug@4.4.3:
@@ -3951,6 +5658,12 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
 
   detect-libc@2.1.2:
     optional: true
@@ -3982,9 +5695,19 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   electron-to-chromium@1.5.286: {}
 
   emoji-regex@10.6.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   environment@1.1.0: {}
 
@@ -4030,6 +5753,14 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@1.21.7)):
     dependencies:
@@ -4098,6 +5829,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -4118,6 +5851,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -4132,6 +5867,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.0: {}
+
+  fast-xml-parser@5.3.6:
+    dependencies:
+      strnum: 2.1.2
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -4139,6 +5880,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -4160,12 +5906,38 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fraction.js@5.3.4: {}
 
   fsevents@2.3.3:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.3:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.3
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -4195,6 +5967,14 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.1.0
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -4203,9 +5983,39 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   globals@14.0.0: {}
 
+  google-auth-library@10.5.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.3
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      gtoken: 8.0.0
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
+
+  gtoken@8.0.0:
+    dependencies:
+      gaxios: 7.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   has-flag@4.0.0: {}
 
@@ -4221,6 +6031,22 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  hono@4.12.0: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -4231,6 +6057,8 @@ snapshots:
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  ip-address@10.1.0: {}
 
   is-arrayish@0.3.4:
     optional: true
@@ -4245,6 +6073,8 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-fullwidth-code-point@5.1.0:
     dependencies:
       get-east-asian-width: 1.4.0
@@ -4256,6 +6086,12 @@ snapshots:
   is-number@7.0.0: {}
 
   isexe@2.0.0: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   jiti@1.21.7: {}
 
@@ -4273,13 +6109,35 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.28.6
+      ts-algebra: 2.0.0
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -4327,7 +6185,11 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
+  long@5.3.2: {}
+
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -4336,6 +6198,8 @@ snapshots:
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  lru-cache@7.18.3: {}
 
   lucide-react@0.468.0(react@19.0.0):
     dependencies:
@@ -4366,6 +6230,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.3: {}
+
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -4379,6 +6245,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  netmask@2.0.2: {}
 
   next-auth@4.24.13(next@15.1.0(@babel/core@7.29.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(nodemailer@7.0.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -4431,6 +6299,14 @@ snapshots:
     dependencies:
       uuid: 8.3.2
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-releases@2.0.27: {}
 
   nodemailer@7.0.13: {}
@@ -4454,6 +6330,11 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openai@6.10.0(ws@8.19.0)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 3.25.76
 
   openid-client@5.7.1:
     dependencies:
@@ -4479,15 +6360,47 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.0.2
+
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  partial-json@0.1.7: {}
 
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -4579,6 +6492,36 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.19.9
+      long: 5.3.2
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
   punycode@2.3.1: {}
 
   qs@6.14.1:
@@ -4637,6 +6580,8 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -4652,9 +6597,15 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
 
   rollup@4.57.1:
     dependencies:
@@ -4690,6 +6641,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   scheduler@0.25.0: {}
 
@@ -4772,7 +6725,25 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
+
   source-map-js@1.2.1: {}
+
+  source-map@0.6.1:
+    optional: true
 
   stackback@0.0.2: {}
 
@@ -4781,6 +6752,18 @@ snapshots:
   streamsearch@1.1.0: {}
 
   string-argv@0.3.2: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.2
 
   string-width@7.2.0:
     dependencies:
@@ -4792,6 +6775,10 @@ snapshots:
     dependencies:
       get-east-asian-width: 1.4.0
       strip-ansi: 7.1.2
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   strip-ansi@7.1.2:
     dependencies:
@@ -4807,6 +6794,8 @@ snapshots:
     dependencies:
       '@types/node': 22.19.9
       qs: 6.14.1
+
+  strnum@2.1.2: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.0.0):
     dependencies:
@@ -4888,6 +6877,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  ts-algebra@2.0.0: {}
+
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -4921,6 +6912,8 @@ snapshots:
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  undici@7.22.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
@@ -5028,6 +7021,8 @@ snapshots:
       - tsx
       - yaml
 
+  web-streams-polyfill@3.3.3: {}
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -5039,11 +7034,25 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.1.2
+
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.1.2
+
+  ws@8.19.0: {}
 
   yallist@3.1.1: {}
 
@@ -5053,8 +7062,14 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
+  zod-to-json-schema@3.25.1(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}

--- a/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/messages/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/messages/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from "next/server";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+
+const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:8100";
+
+type RouteParams = { params: Promise<{ projectId: string; sessionId: string }> };
+
+// GET /api/projects/[projectId]/ai/sessions/[sessionId]/messages — Load message history
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId, sessionId } = await params;
+
+  const accessResult = await requireProjectAccess(user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const res = await fetch(
+    `${AGENT_SERVICE_URL}/api/v1/projects/${projectId}/sessions/${sessionId}/messages`,
+    {
+      headers: { "x-user-id": user.id },
+    },
+  );
+
+  if (!res.ok) {
+    return new Response(JSON.stringify({ error: "Failed to load messages" }), {
+      status: res.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const data = await res.json();
+  return successResponse(data);
+}
+
+// POST /api/projects/[projectId]/ai/sessions/[sessionId]/messages — SSE passthrough
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId, sessionId } = await params;
+
+  const accessResult = await requireProjectAccess(user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const body = await request.json();
+
+  // Proxy to agent service, passthrough SSE stream
+  const agentRes = await fetch(
+    `${AGENT_SERVICE_URL}/api/v1/projects/${projectId}/sessions/${sessionId}/messages`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-user-id": user.id,
+        "x-workspace-id": accessResult.project.workspaceId,
+      },
+      body: JSON.stringify({ message: body.message, model: body.model, traceId: body.traceId }),
+    },
+  );
+
+  if (!agentRes.ok || !agentRes.body) {
+    return new Response(JSON.stringify({ error: "Agent service error" }), {
+      status: agentRes.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Passthrough the SSE stream
+  return new Response(agentRes.body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+
+const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:8100";
+
+type RouteParams = { params: Promise<{ projectId: string; sessionId: string }> };
+
+// DELETE /api/projects/[projectId]/ai/sessions/[sessionId] — Delete session
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId, sessionId } = await params;
+
+  const accessResult = await requireProjectAccess(user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const res = await fetch(
+    `${AGENT_SERVICE_URL}/api/v1/projects/${projectId}/sessions/${sessionId}`,
+    {
+      method: "DELETE",
+      headers: { "x-user-id": user.id },
+    },
+  );
+
+  if (!res.ok) {
+    return new Response(JSON.stringify({ error: "Failed to delete session" }), {
+      status: res.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  return successResponse({ ok: true });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/route.ts
@@ -23,6 +23,13 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     },
   });
 
+  if (!res.ok) {
+    return new Response(JSON.stringify({ error: `Agent service error: ${res.status}` }), {
+      status: res.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   const data = await res.json();
   return successResponse(data);
 }
@@ -49,6 +56,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     },
     body: JSON.stringify({ title: body.title }),
   });
+
+  if (!res.ok) {
+    return new Response(JSON.stringify({ error: `Agent service error: ${res.status}` }), {
+      status: res.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 
   const data = await res.json();
   return successResponse(data, 201);

--- a/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest } from "next/server";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+
+const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:8100";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+// GET /api/projects/[projectId]/ai/sessions — List sessions
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId } = await params;
+
+  const accessResult = await requireProjectAccess(user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const res = await fetch(`${AGENT_SERVICE_URL}/api/v1/projects/${projectId}/sessions`, {
+    headers: {
+      "x-user-id": user.id,
+      "x-workspace-id": accessResult.project.workspaceId,
+    },
+  });
+
+  const data = await res.json();
+  return successResponse(data);
+}
+
+// POST /api/projects/[projectId]/ai/sessions — Create session
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId } = await params;
+
+  const accessResult = await requireProjectAccess(user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const body = await request.json();
+
+  const res = await fetch(`${AGENT_SERVICE_URL}/api/v1/projects/${projectId}/sessions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-user-id": user.id,
+      "x-workspace-id": accessResult.project.workspaceId,
+    },
+    body: JSON.stringify({ title: body.title }),
+  });
+
+  const data = await res.json();
+  return successResponse(data, 201);
+}

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -4,7 +4,8 @@ import { useState, createContext, useContext, ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { Button } from "@/components/ui/button";
-import { PanelLeft } from "lucide-react";
+import { PanelLeft, BotMessageSquare } from "lucide-react";
+import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
 
 interface LayoutContextType {
   sidebarCollapsed: boolean;
@@ -27,6 +28,7 @@ export function useLayout() {
 export function AppLayout({ children }: { children: React.ReactNode }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [headerContent, setHeaderContent] = useState<ReactNode>(null);
+  const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const pathname = usePathname();
 
   // Don't show layout on auth pages
@@ -45,7 +47,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
     >
       <div className="flex h-screen">
         <Sidebar collapsed={sidebarCollapsed} />
-        <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           {/* Top header bar */}
           <header className="flex h-14 items-center gap-2 border-b bg-background px-3">
             <Button
@@ -57,9 +59,21 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
               <PanelLeft className="h-4 w-4" />
             </Button>
             {headerContent}
+            <div className="ml-auto">
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 shrink-0"
+                onClick={() => setAiPanelOpen(!aiPanelOpen)}
+                title="AI Assistant"
+              >
+                <BotMessageSquare className="h-4 w-4" />
+              </Button>
+            </div>
           </header>
           <main className="flex-1 overflow-hidden">{children}</main>
         </div>
+        <AiAssistantPanel open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
       </div>
     </LayoutContext.Provider>
   );

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { X, Plus, History } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { MessageList } from "./message-list";
+import { MessageInput } from "./message-input";
+import { SessionHistory } from "./session-history";
+import { useAiChat } from "../hooks/use-ai-chat";
+
+interface AiAssistantPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
+  const params = useParams();
+  const projectId = params?.projectId as string | undefined;
+
+  const {
+    messages,
+    isStreaming,
+    sessions,
+    historyOpen,
+    currentSessionId,
+    setHistoryOpen,
+    handleSend,
+    handleNewSession,
+    handleOpenHistory,
+    handleSelectSession,
+    handleDeleteSession,
+  } = useAiChat({ projectId });
+
+  if (!open) return null;
+
+  return (
+    <div className="flex h-screen w-[400px] shrink-0 flex-col border-l bg-background">
+      {/* Header */}
+      <div className="flex h-14 items-center gap-1 border-b px-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          title="New session"
+          onClick={handleNewSession}
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+        <Popover open={historyOpen} onOpenChange={setHistoryOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              title="History"
+              onClick={handleOpenHistory}
+            >
+              <History className="h-4 w-4" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent side="bottom" align="start" className="w-[300px] p-1" sideOffset={4}>
+            <SessionHistory
+              sessions={sessions}
+              currentSessionId={currentSessionId}
+              projectId={projectId || ""}
+              onSelect={handleSelectSession}
+              onDelete={handleDeleteSession}
+            />
+          </PopoverContent>
+        </Popover>
+        <div className="flex-1" />
+        <Button variant="ghost" size="icon" className="h-8 w-8 shrink-0" onClick={onClose}>
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Messages */}
+      <MessageList messages={messages} />
+
+      {/* Input */}
+      <MessageInput onSend={handleSend} disabled={isStreaming} />
+    </div>
+  );
+}

--- a/frontend/ui/src/features/ai-assistant/components/ai-chat-overlay.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-chat-overlay.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { X, Plus, History } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { MessageList } from "./message-list";
+import { MessageInput } from "./message-input";
+import { SessionHistory } from "./session-history";
+import { useAiChat } from "../hooks/use-ai-chat";
+
+interface AiChatOverlayProps {
+  projectId: string;
+  traceId?: string;
+  onClose: () => void;
+}
+
+/**
+ * AI chat panel for use inside trace detail viewer.
+ * traceId is passed through to the agent so it knows which trace the user is viewing.
+ */
+export function AiChatOverlay({ projectId, traceId, onClose }: AiChatOverlayProps) {
+  const {
+    messages,
+    isStreaming,
+    sessions,
+    historyOpen,
+    currentSessionId,
+    setHistoryOpen,
+    handleSend,
+    handleNewSession,
+    handleOpenHistory,
+    handleSelectSession,
+    handleDeleteSession,
+  } = useAiChat({ projectId, traceId });
+
+  return (
+    <div className="flex h-full w-[400px] flex-col border-l bg-background">
+      {/* Header */}
+      <div className="flex h-10 items-center gap-1 border-b bg-muted/30 px-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0"
+          title="New session"
+          onClick={handleNewSession}
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </Button>
+        <Popover open={historyOpen} onOpenChange={setHistoryOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              title="History"
+              onClick={handleOpenHistory}
+            >
+              <History className="h-3.5 w-3.5" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent side="bottom" align="start" className="w-[300px] p-1" sideOffset={4}>
+            <SessionHistory
+              sessions={sessions}
+              currentSessionId={currentSessionId}
+              projectId={projectId}
+              onSelect={handleSelectSession}
+              onDelete={handleDeleteSession}
+            />
+          </PopoverContent>
+        </Popover>
+        <div className="flex-1" />
+        <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={onClose}>
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      <MessageList messages={messages} />
+      <MessageInput onSend={handleSend} disabled={isStreaming} />
+    </div>
+  );
+}

--- a/frontend/ui/src/features/ai-assistant/components/message-input.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-input.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useState, type KeyboardEvent } from "react";
+import { ModelSelector } from "./model-selector";
+
+interface MessageInputProps {
+  onSend: (message: string, model: string) => void;
+  disabled?: boolean;
+}
+
+export function MessageInput({ onSend, disabled }: MessageInputProps) {
+  const [input, setInput] = useState("");
+  const [model, setModel] = useState("claude-sonnet-4-5");
+
+  const handleSend = () => {
+    const trimmed = input.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed, model);
+    setInput("");
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div className="px-3 py-2">
+      <textarea
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder="Ask me about your traces, errors, or performance."
+        disabled={disabled}
+        rows={3}
+        className="w-full resize-none rounded-none border border-input bg-transparent px-3 py-2 text-[13px] shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+      />
+      <ModelSelector value={model} onChange={setModel} />
+    </div>
+  );
+}

--- a/frontend/ui/src/features/ai-assistant/components/message-list.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-list.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import type { AIMessage } from "../types";
+
+interface MessageListProps {
+  messages: AIMessage[];
+}
+
+export function MessageList({ messages }: MessageListProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll to bottom when messages change
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  return (
+    <div className="flex-1 space-y-3 overflow-y-auto px-3 py-3">
+      {messages.length === 0 && <div />}
+      {messages.map((msg) => (
+        <div
+          key={msg.id}
+          className={cn("flex", msg.role === "user" ? "justify-end" : "justify-start")}
+        >
+          <div
+            className={cn(
+              "max-w-[85%] whitespace-pre-wrap rounded-md px-3 py-1.5 text-[13px]",
+              msg.role === "user"
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-foreground",
+            )}
+          >
+            {msg.content}
+            {msg.isStreaming && (
+              <span className="ml-1 inline-block h-3.5 w-1.5 animate-pulse rounded-sm bg-current" />
+            )}
+          </div>
+        </div>
+      ))}
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+const PROVIDERS = [
+  {
+    id: "anthropic",
+    label: "Anthropic",
+    models: [
+      { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+    ],
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    models: [
+      { id: "gpt-4.1", label: "GPT-4.1" },
+      { id: "gpt-4.1-mini", label: "GPT-4.1 Mini" },
+    ],
+  },
+] as const;
+
+const ALL_MODELS = PROVIDERS.flatMap((p) => p.models);
+
+interface ModelSelectorProps {
+  value: string;
+  onChange: (model: string) => void;
+}
+
+export function ModelSelector({ value, onChange }: ModelSelectorProps) {
+  const [open, setOpen] = useState(false);
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(null);
+  const selectedModel = ALL_MODELS.find((m) => m.id === value);
+
+  const provider = selectedProvider ? PROVIDERS.find((p) => p.id === selectedProvider) : null;
+
+  return (
+    <div className="flex items-center">
+      <Popover
+        open={open}
+        onOpenChange={(isOpen) => {
+          setOpen(isOpen);
+          if (!isOpen) setSelectedProvider(null);
+        }}
+      >
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-7 gap-1 rounded-sm px-2 text-[11px] text-muted-foreground hover:text-foreground"
+          >
+            {selectedModel?.label || "Select model"}
+            <ChevronDown className="h-3 w-3" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent side="top" align="start" className="w-[180px] p-1" sideOffset={4}>
+          {!provider
+            ? // Page 1: Provider list
+              PROVIDERS.map((p) => (
+                <button
+                  key={p.id}
+                  className="flex w-full items-center rounded-md px-2.5 py-2 text-left text-[12px] transition-colors hover:bg-muted/50"
+                  onClick={() => setSelectedProvider(p.id)}
+                >
+                  {p.label}
+                </button>
+              ))
+            : // Page 2: Model list for selected provider
+              provider.models.map((m) => (
+                <button
+                  key={m.id}
+                  className={cn(
+                    "flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-[12px] transition-colors hover:bg-muted/50",
+                    m.id === value && "font-medium text-foreground",
+                  )}
+                  onClick={() => {
+                    onChange(m.id);
+                    setOpen(false);
+                    setSelectedProvider(null);
+                  }}
+                >
+                  {m.id === value && <span className="text-[11px]">✓</span>}
+                  {m.label}
+                </button>
+              ))}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/ai-assistant/components/session-history.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/session-history.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState } from "react";
+import { MessageSquare, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { AISession } from "../types";
+
+interface SessionHistoryProps {
+  sessions: AISession[];
+  currentSessionId: string | null;
+  projectId: string;
+  onSelect: (session: AISession) => void;
+  onDelete: (sessionId: string) => void;
+}
+
+function getTimeGroup(dateStr: string): string {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  const weeks = Math.floor(diffDays / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(diffDays / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(diffDays / 365)}y ago`;
+}
+
+export function SessionHistory({
+  sessions,
+  currentSessionId,
+  projectId,
+  onSelect,
+  onDelete,
+}: SessionHistoryProps) {
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const handleDelete = async (e: React.MouseEvent, sessionId: string) => {
+    e.stopPropagation();
+    setDeletingId(sessionId);
+    try {
+      const res = await fetch(`/api/projects/${projectId}/ai/sessions/${sessionId}`, {
+        method: "DELETE",
+      });
+      if (res.ok) {
+        onDelete(sessionId);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  if (sessions.length === 0) {
+    return (
+      <div className="px-2.5 py-3 text-center text-[12px] text-muted-foreground">
+        No past sessions
+      </div>
+    );
+  }
+
+  // Group sessions by time
+  const groups: { label: string; sessions: AISession[] }[] = [];
+  let currentGroup: string | null = null;
+
+  for (const session of sessions) {
+    const group = getTimeGroup(session.createTime);
+    if (group !== currentGroup) {
+      currentGroup = group;
+      groups.push({ label: group, sessions: [] });
+    }
+    groups[groups.length - 1].sessions.push(session);
+  }
+
+  return (
+    <div className="max-h-[400px] overflow-y-auto">
+      {groups.map((group) => (
+        <div key={group.label}>
+          <div className="px-2.5 py-1.5 text-[11px] font-medium text-muted-foreground">
+            {group.label}
+          </div>
+          {group.sessions.map((s) => (
+            <button
+              key={s.id}
+              className={cn(
+                "group flex w-full items-center gap-2 rounded-md px-2.5 py-1.5 text-left transition-colors hover:bg-muted/50",
+                s.id === currentSessionId && "bg-muted",
+              )}
+              onClick={() => onSelect(s)}
+              disabled={deletingId === s.id}
+            >
+              <MessageSquare className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate text-[12px]">
+                {s.title || "Untitled session"}
+              </span>
+              <Trash2
+                className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover:opacity-100"
+                onClick={(e) => handleDelete(e, s.id)}
+              />
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -1,0 +1,119 @@
+"use client";
+
+import { useRef, useState, useCallback } from "react";
+import { useAIStream } from "./use-ai-stream";
+import type { AISession, AIMessage } from "../types";
+
+interface UseAiChatOptions {
+  projectId: string | undefined;
+  traceId?: string;
+}
+
+export function useAiChat({ projectId, traceId }: UseAiChatOptions) {
+  const { messages, isStreaming, sendMessage, setMessages } = useAIStream();
+  const sessionIdRef = useRef<string | null>(null);
+  const [sessions, setSessions] = useState<AISession[]>([]);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  // Lazy session creation — only when first message is sent
+  const ensureSession = useCallback(async (): Promise<string | null> => {
+    if (sessionIdRef.current) return sessionIdRef.current;
+    if (!projectId) return null;
+    try {
+      const res = await fetch(`/api/projects/${projectId}/ai/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ traceId }),
+      });
+      const data = await res.json();
+      sessionIdRef.current = data.id;
+      return data.id;
+    } catch (err) {
+      console.error(err);
+      return null;
+    }
+  }, [projectId, traceId]);
+
+  const handleSend = useCallback(
+    async (message: string, model: string) => {
+      if (!projectId) return;
+      const sessionId = await ensureSession();
+      if (!sessionId) return;
+      sendMessage({ sessionId, message, projectId, model, traceId });
+    },
+    [projectId, traceId, ensureSession, sendMessage],
+  );
+
+  const handleNewSession = useCallback(() => {
+    sessionIdRef.current = null;
+    setMessages([]);
+  }, [setMessages]);
+
+  const handleOpenHistory = useCallback(async () => {
+    if (!projectId) return;
+    try {
+      const res = await fetch(`/api/projects/${projectId}/ai/sessions`);
+      const data = await res.json();
+      setSessions(data.sessions || []);
+      setHistoryOpen(true);
+    } catch (err) {
+      console.error(err);
+    }
+  }, [projectId]);
+
+  const handleSelectSession = useCallback(
+    async (session: AISession) => {
+      sessionIdRef.current = session.id;
+      setMessages([]);
+      setHistoryOpen(false);
+
+      if (!projectId) return;
+      try {
+        const res = await fetch(`/api/projects/${projectId}/ai/sessions/${session.id}/messages`);
+        if (res.ok) {
+          const data = await res.json();
+          const loaded = (data.messages || []).map((m: any) => ({
+            id: m.id,
+            role: m.role as "user" | "assistant",
+            content: m.content,
+            timestamp: m.createTime,
+          }));
+          setMessages(loaded);
+        }
+      } catch (err) {
+        console.error("[AI Chat] Failed to load session messages:", err);
+      }
+    },
+    [projectId, setMessages],
+  );
+
+  const handleDeleteSession = useCallback(
+    (sessionId: string) => {
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+      if (sessionIdRef.current === sessionId) {
+        sessionIdRef.current = null;
+        setMessages([]);
+      }
+    },
+    [setMessages],
+  );
+
+  return {
+    // State
+    messages,
+    isStreaming,
+    sessions,
+    historyOpen,
+    currentSessionId: sessionIdRef.current,
+
+    // Setters
+    setHistoryOpen,
+
+    // Actions
+    handleSend,
+    handleNewSession,
+    handleOpenHistory,
+    handleSelectSession,
+    handleDeleteSession,
+  };
+}

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-stream.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-stream.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import type { AIMessage } from "../types";
+
+export function useAIStream() {
+  const [messages, setMessages] = useState<AIMessage[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const sendMessage = useCallback(
+    async (params: {
+      sessionId: string;
+      message: string;
+      projectId: string;
+      model?: string;
+      traceId?: string;
+    }) => {
+      // Add user message
+      const userMsg: AIMessage = {
+        id: crypto.randomUUID(),
+        role: "user",
+        content: params.message,
+        timestamp: new Date().toISOString(),
+      };
+      setMessages((prev) => [...prev, userMsg]);
+
+      // Start streaming assistant response
+      setIsStreaming(true);
+      const assistantMsgId = crypto.randomUUID();
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: assistantMsgId,
+          role: "assistant",
+          content: "",
+          timestamp: new Date().toISOString(),
+          isStreaming: true,
+        },
+      ]);
+
+      const abortController = new AbortController();
+      abortRef.current = abortController;
+
+      try {
+        // Goes through Next.js proxy which handles auth + adds headers
+        const url = `/api/projects/${params.projectId}/ai/sessions/${params.sessionId}/messages`;
+        const response = await fetch(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            message: params.message,
+            model: params.model,
+            traceId: params.traceId,
+          }),
+          signal: abortController.signal,
+        });
+
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        if (!response.body) throw new Error("No response body");
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              try {
+                const eventData = JSON.parse(line.slice(6));
+                // pi-agent-core message_update events contain assistantMessageEvent
+                // with type "text_delta" and a delta string (the incremental text).
+                if (eventData.type === "message_update") {
+                  const delta = eventData.assistantMessageEvent;
+                  if (delta?.type === "text_delta" && delta.delta) {
+                    setMessages((prev) =>
+                      prev.map((msg) =>
+                        msg.id === assistantMsgId
+                          ? { ...msg, content: msg.content + delta.delta }
+                          : msg,
+                      ),
+                    );
+                  }
+                }
+              } catch {
+                // Skip unparseable lines
+              }
+            }
+          }
+        }
+      } catch (error) {
+        if ((error as Error).name !== "AbortError") {
+          console.error("[AI Stream] Error:", error);
+          setMessages((prev) =>
+            prev.map((msg) =>
+              msg.id === assistantMsgId
+                ? {
+                    ...msg,
+                    content: msg.content || "Error: Failed to get response.",
+                    isStreaming: false,
+                  }
+                : msg,
+            ),
+          );
+        }
+      } finally {
+        setIsStreaming(false);
+        setMessages((prev) =>
+          prev.map((msg) => (msg.id === assistantMsgId ? { ...msg, isStreaming: false } : msg)),
+        );
+        abortRef.current = null;
+      }
+    },
+    [],
+  );
+
+  const abort = useCallback(() => {
+    abortRef.current?.abort();
+  }, []);
+
+  return { messages, isStreaming, sendMessage, abort, setMessages };
+}

--- a/frontend/ui/src/features/ai-assistant/types/index.ts
+++ b/frontend/ui/src/features/ai-assistant/types/index.ts
@@ -1,0 +1,15 @@
+export interface AIMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  isStreaming?: boolean;
+}
+
+export interface AISession {
+  id: string;
+  projectId: string;
+  title: string | null;
+  status: string;
+  createTime: string;
+}

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -2,12 +2,13 @@
 
 import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Workflow, X, ArrowUp, ArrowDown } from "lucide-react";
+import { Workflow, X, ArrowUp, ArrowDown, BotMessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getTrace } from "@/lib/api";
 import type { TraceSelection } from "../types";
 import { SpanTreeView } from "./SpanTreeView";
 import { SpanInfoPanel } from "./SpanInfoPanel";
+import { AiChatOverlay } from "@/features/ai-assistant/components/ai-chat-overlay";
 
 interface TraceViewerPanelProps {
   projectId: string;
@@ -30,6 +31,7 @@ export function TraceViewerPanel({
   canNavigateDown,
 }: TraceViewerPanelProps) {
   const [selection, setSelection] = useState<TraceSelection>({ type: "trace" });
+  const [aiChatOpen, setAiChatOpen] = useState(false);
 
   const {
     data: trace,
@@ -77,6 +79,15 @@ export function TraceViewerPanel({
             <ArrowDown className="h-4 w-4" />
           </Button>
           <div className="w-2" /> {/* Spacer */}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAiChatOpen(!aiChatOpen)}
+            className="h-7 w-7 p-0"
+            title="AI Assistant"
+          >
+            <BotMessageSquare className="h-4 w-4" />
+          </Button>
           <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
             <X className="h-4 w-4" />
           </Button>
@@ -100,7 +111,7 @@ export function TraceViewerPanel({
           </div>
 
           {/* Right: Detail panel */}
-          <div className="flex-1 overflow-hidden bg-background">
+          <div className="min-w-0 flex-1 overflow-hidden bg-background">
             <SpanInfoPanel
               projectId={projectId}
               trace={trace}
@@ -108,6 +119,15 @@ export function TraceViewerPanel({
               onClose={onClose}
             />
           </div>
+
+          {/* AI Chat overlay */}
+          {aiChatOpen && (
+            <AiChatOverlay
+              projectId={projectId}
+              traceId={traceId}
+              onClose={() => setAiChatOpen(false)}
+            />
+          )}
         </div>
       )}
     </div>

--- a/tmux_tools/launcher.py
+++ b/tmux_tools/launcher.py
@@ -17,6 +17,7 @@ from tmux_tools import schema
 
 REST_PORT = 8000
 FRONTEND_PORT = 3000
+AGENT_PORT = 8100
 
 
 # ---------------------------------------------------------------------------
@@ -226,10 +227,18 @@ def make_driver(autoreload=False):
                 command="cd frontend/worker && pnpm build && pnpm dotenv -e ../../.env -- node dist/index.js",
                 web_urls=[],
             ),
+            schema.Service(
+                title="Agent",
+                command="cd frontend/packages/agent && pnpm dev",
+                web_urls=[
+                    ("Agent API", f"http://localhost:{AGENT_PORT}"),
+                ],
+            ),
         ]
         + infra_services(),
         prerequisites=(
-            tool_prerequisites() + [port_available(REST_PORT), port_available(FRONTEND_PORT)]
+            tool_prerequisites()
+            + [port_available(REST_PORT), port_available(FRONTEND_PORT), port_available(AGENT_PORT)]
         ),
     )
 


### PR DESCRIPTION
## Summary

Adds a full-stack **AI debugging assistant** to TraceRoot. Users can chat with an AI agent that queries, downloads, and analyzes their trace data inside an isolated sandbox. This is part 1 of the AI assistant feature — focused on core infrastructure and the MVP chat experience.

**Key capabilities:**
- Natural language trace investigation: query traces, download full trace data, and analyze spans
- Sandboxed execution: all file analysis happens inside a network-isolated Docker container
- Multi-model support: Claude Sonnet 4.5 (default), Claude Haiku 4.5, GPT-4.1, GPT-4.1 Mini
- Session persistence: chat history stored in PostgreSQL, sessions resumable across page loads
- Real-time streaming: end-to-end SSE from agent service → Next.js proxy → browser

## Type of Change
Fixes https://github.com/traceroot-ai/traceroot/issues/461

- [x] feat - A new feature

## Details

### Architecture

```
Browser (React) ←SSE→ Next.js API proxy ←SSE→ Agent Service (Hono :8100) → FastAPI backend
                                                    ↓
                                              Docker sandbox (--network none)
```

### New Package: `@traceroot/agent` (`frontend/packages/agent/`)

A standalone Hono HTTP microservice (port 8100) built on `@mariozechner/pi-agent-core` + `@mariozechner/pi-ai`:

- **Agent lifecycle** (`agent.ts`): Per-session agent caching with model hot-swap support
- **Session management** (`session.ts`): Bridges agent state with PostgreSQL via Prisma
- **System prompt** (`prompts/system.ts`): Configures the agent as a trace debugging assistant with ClickHouse schema reference
- **Tools**:
  - `query_traces` — searches/filters traces via FastAPI (host-side)
  - `download_trace` — downloads full trace into sandbox as 3 files: `trace.jsonl`, `tree.json`, `spans.jsonl` (host-side)
  - `bash`, `read`, `write` — sandbox file operations via Docker executor
- **Sandbox executors** (`executors/`): `DockerExecutor` for local dev (network-isolated), `DaytonaExecutor` stub for production

### Frontend UI (`frontend/ui/src/features/ai-assistant/`)

- **`AiAssistantPanel`**: Side panel (400px) toggled from global header
- **`AiChatOverlay`**: Compact variant embedded in TraceViewerPanel with trace context
- **`ModelSelector`**: Two-level popover (provider → model)
- **`SessionHistory`**: Time-grouped session list with delete
- **Hooks**: `useAiChat` (session lifecycle, lazy creation) + `useAiStream` (SSE parsing, delta accumulation)

### API Proxy Layer

Three Next.js route handlers under `/api/projects/[projectId]/ai/sessions/` that authenticate via `requireAuth()` + `requireProjectAccess()` and proxy to the agent service.

### Database

Two new Prisma models: `AISession` and `AIMessage` with cascade delete from Project.

### Infrastructure

- New tmux service entry for agent on port 8100
- `.env.example` updated with agent service config section

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary