### PR TITLE
Code clean up after merging from `pivot/agentops` branch [1/n]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,7 @@ SANDBOX_PROVIDER=docker
 # OPENAI_API_KEY=           CHANGEME - required if using GPT models
 
 # --- Branding / Public URLs ---------------------------------------------------
-NEXT_PUBLIC_LOGO_URL=https://raw.githubusercontent.com/traceroot-ai/traceroot/pivot/agentops/frontend/ui/public/images/traceroot_icon.png
+NEXT_PUBLIC_LOGO_URL=https://raw.githubusercontent.com/traceroot-ai/traceroot/main/frontend/ui/public/images/traceroot_icon.png
 NEXT_PUBLIC_DOCS_URL=https://docs.traceroot.ai
 NEXT_PUBLIC_GITHUB_REPO_URL=https://github.com/traceroot-ai/traceroot
 NEXT_PUBLIC_GITHUB_ISSUES_URL=https://github.com/traceroot-ai/traceroot/issues

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -6,7 +6,7 @@ name: Build Validation
 
 on:
   push:
-    branches: [main, pivot/agentops]
+    branches: [main]
   pull_request:
   merge_group:
   workflow_dispatch:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ permissions:
 
 on:
   push:
-    branches: [main, pivot/agentops]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -179,7 +179,7 @@ sandboxProvider: "daytona"
 
 # --- Branding / Public URLs ---
 branding:
-  logoUrl: "https://raw.githubusercontent.com/traceroot-ai/traceroot/pivot/agentops/frontend/ui/public/images/traceroot_icon.png"
+  logoUrl: "https://raw.githubusercontent.com/traceroot-ai/traceroot/main/frontend/ui/public/images/traceroot_icon.png"
   docsUrl: "https://docs.traceroot.ai"
   githubRepoUrl: "https://github.com/traceroot-ai/traceroot"
   githubIssuesUrl: "https://github.com/traceroot-ai/traceroot/issues"

--- a/frontend/ui/src/lib/email/send-invite-email.ts
+++ b/frontend/ui/src/lib/email/send-invite-email.ts
@@ -99,7 +99,7 @@ function buildHtmlEmail(params: EmailContentParams): string {
       <!-- Logo section -->
       <tr>
         <td style="padding: 40px 40px 32px 40px; text-align: center;">
-          <img src="${env.NEXT_PUBLIC_LOGO_URL || "https://raw.githubusercontent.com/traceroot-ai/traceroot/pivot/agentops/frontend/ui/public/images/traceroot_icon.png"}" alt="TraceRoot" width="72" height="72" style="display: block; margin: 0 auto; border-radius: 14px;" />
+          <img src="${env.NEXT_PUBLIC_LOGO_URL || "https://raw.githubusercontent.com/traceroot-ai/traceroot/main/frontend/ui/public/images/traceroot_icon.png"}" alt="TraceRoot" width="72" height="72" style="display: block; margin: 0 auto; border-radius: 14px;" />
         </td>
       </tr>
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   ./scripts/build_images.sh <BRANCH>
-#   ./scripts/build_images.sh my-feature-branch
+#   ./scripts/build_images.sh <BRANCH>
 #
 set -euo pipefail
 
@@ -21,7 +21,6 @@ if [ -z "$BRANCH" ]; then
   echo
   echo "Examples:"
   echo "  ./scripts/build_images.sh main"
-  echo "  ./scripts/build_images.sh some-feature-branch"
   echo "  ./scripts/build_images.sh my-feature-branch"
   echo
   exit 1

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #   ./scripts/build_images.sh <BRANCH>
-#   ./scripts/build_images.sh pivot/agentops
+#   ./scripts/build_images.sh my-feature-branch
 #
 set -euo pipefail
 
@@ -21,7 +21,7 @@ if [ -z "$BRANCH" ]; then
   echo
   echo "Examples:"
   echo "  ./scripts/build_images.sh main"
-  echo "  ./scripts/build_images.sh pivot/agentops"
+  echo "  ./scripts/build_images.sh some-feature-branch"
   echo "  ./scripts/build_images.sh my-feature-branch"
   echo
   exit 1


### PR DESCRIPTION
## Summary

Post-merge cleanup after `pivot/agentops` → `main`. This PR addresses two categories:

1. **Remove stale `pivot/agentops` branch references** from CI workflows, branding URLs, and scripts
2. **Fix CodeQL security warnings** with targeted suppression comments and a regex-based rewrite for git remote parsing

## Type of Change

- [x] fix - A bug fix
- [x] ci - Changes to our CI configuration files and scripts
- [x] chore - Other changes that don't modify src or test files

## Details

### Branch reference cleanup

| File | Change |
|------|--------|
| `.github/workflows/build-test.yml` | `branches: [main, pivot/agentops]` → `branches: [main]` |
| `.github/workflows/lint.yml` | `branches: [main, pivot/agentops]` → `branches: [main]` |
| `.env.example` | Logo URL branch: `pivot/agentops` → `main` |
| `deploy/helm/values.yaml` | Logo URL branch: `pivot/agentops` → `main` |
| `frontend/ui/src/lib/email/send-invite-email.ts` | Fallback logo URL branch: `pivot/agentops` → `main` |
| `scripts/build_images.sh` | Removed `pivot/agentops` from usage examples |

### CodeQL warning fixes

| File | Warning | Fix |
|------|---------|-----|
| `backend/rest/routers/public/traces.py` | `py/weak-sensitive-data-hashing` — SHA256 for API keys | Added `codeql` suppression comment explaining SHA256 is appropriate for high-entropy random keys (not passwords) |
| `frontend/ui/src/lib/api-keys.ts` | `js/insufficient-password-hash` — SHA256 for API keys | Same rationale; added `codeql` suppression comment |
| `traceroot-py/traceroot/git_context.py` | `py/incomplete-url-substring-sanitization` — string-split URL parsing | Replaced fragile `split("github.com")` parsing with a proper regex that handles `https://`, `git@`, and `ssh://` remote URL formats |

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have updated documentation where necessary