### PR TITLE
fix: Remove max-width constraints from workspace settings tabs

### DIFF
--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -118,7 +118,7 @@ export function BillingTab({
   }
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="space-y-6">
       {/* Header */}
       <div>
         <h2 className="text-xl font-semibold">Billing</h2>

--- a/frontend/ui/src/features/settings/workspace/components/GeneralTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/GeneralTab.tsx
@@ -73,7 +73,7 @@ export function GeneralTab({ workspaceId }: GeneralTabProps) {
   const isAdmin = workspace?.role === Role.ADMIN;
 
   return (
-    <div className="max-w-2xl space-y-6">
+    <div className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold">General</h2>
         <p className="text-sm text-muted-foreground">Manage your workspace settings</p>

--- a/frontend/ui/src/features/settings/workspace/components/IntegrationsTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/IntegrationsTab.tsx
@@ -8,7 +8,7 @@ interface IntegrationsTabProps {
 
 export function IntegrationsTab({ workspaceId: _workspaceId }: IntegrationsTabProps) {
   return (
-    <div className="max-w-3xl space-y-6">
+    <div className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold">Integrations</h2>
         <p className="text-sm text-muted-foreground">

--- a/frontend/ui/src/features/settings/workspace/components/MembersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/MembersTab.tsx
@@ -111,7 +111,7 @@ export function MembersTab({ workspaceId }: MembersTabProps) {
   const canManageMembers = workspace?.role === Role.ADMIN;
 
   return (
-    <div className="max-w-3xl space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-semibold">Members</h2>

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -249,7 +249,7 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
   // Upgrade prompt if BYOK is not enabled
   if (data && !data.byokEnabled) {
     return (
-      <div className="max-w-3xl space-y-6">
+      <div className="space-y-6">
         <div>
           <h2 className="text-xl font-semibold">Model Providers</h2>
           <p className="text-sm text-muted-foreground">Configure your own LLM API keys</p>
@@ -295,7 +295,7 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
       : !!(apiKey || editProvider));
 
   return (
-    <div className="max-w-3xl space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-semibold">Model Providers</h2>


### PR DESCRIPTION
## Summary
Remove `max-w-2xl` and `max-w-3xl` constraints from workspace settings components so they expand to fill available width, matching the behavior of project settings pages.

## Problem
Workspace settings panels (General, Members, Model Providers, Integrations, Billing) were constrained to a fixed max-width, causing them not to utilize the full available screen width as the window grows. This was inconsistent with project settings which properly expanded to fill the available space.

## Solution
Removed the `max-w-*` classes from the root container divs in all workspace settings tab components:
- `GeneralTab.tsx`: removed `max-w-2xl`
- `ModelProvidersTab.tsx`: removed `max-w-3xl` (2 places - upgrade prompt and main view)
- `IntegrationsTab.tsx`: removed `max-w-3xl`
- `MembersTab.tsx`: removed `max-w-3xl`
- `BillingTab.tsx`: removed `max-w-2xl`

## After

<img width="1441" height="748" alt="Screenshot 2026-03-17 at 8 59 26 PM" src="https://github.com/user-attachments/assets/9ea272cc-3929-4e95-a0e9-0e2dc3d8a78a" />


The workspace settings panels now properly expand to fill the available width.

## Testing
- Verified workspace settings pages (General, Members, Model Providers, Integrations, Billing) now expand to full width
- Verified behavior matches project settings pages