### PR TITLE
[Backend] Support New Price Strategy

### DIFF
--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -27,6 +27,7 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
 )
 from pydantic import BaseModel
 
+from ee.license import is_billing_enabled
 from rest.services.s3 import get_s3_service
 from shared.config import settings
 from worker.ingest_tasks import process_s3_traces
@@ -162,7 +163,8 @@ async def ingest_traces(
     """
     # Check if ingestion is blocked (free plan limit exceeded)
     # This flag is updated hourly by the billing worker
-    if auth.ingestion_blocked:
+    # Skip enforcement when billing is disabled (e.g. self-hosted)
+    if is_billing_enabled() and auth.ingestion_blocked:
         raise HTTPException(
             status_code=status.HTTP_402_PAYMENT_REQUIRED,
             detail="Free plan limit exceeded. Please upgrade to continue.",

--- a/frontend/packages/core/src/ee/billing/index.ts
+++ b/frontend/packages/core/src/ee/billing/index.ts
@@ -30,4 +30,5 @@ export {
   requireSeatAvailable,
   // Free plan blocking
   isFreePlanBlocked,
+  isAiRunBlocked,
 } from "./plans";

--- a/frontend/packages/core/src/ee/billing/index.ts
+++ b/frontend/packages/core/src/ee/billing/index.ts
@@ -28,6 +28,8 @@ export {
   getSeatLimit,
   canAddSeat,
   requireSeatAvailable,
+  // Billing gate
+  isBillingEnabled,
   // Free plan blocking
   isFreePlanBlocked,
   isAiRunBlocked,

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -34,12 +34,24 @@ export const AI_RUN_QUOTAS: Record<PlanType, { included: number; overageLabel: s
 // Legacy compat — used by usageMetering and free-plan blocking
 export const USAGE_CONFIG = {
   includedUnits: 50_000, // free plan span cap
-  aiIncludedCost: 5, // $5 free AI usage per billing period (legacy, backend will migrate to run-based)
 } as const;
 
 export function isFreePlanBlocked(currentUsage: number): boolean {
   if (!isBillingEnabled()) return false;
   return currentUsage >= USAGE_CONFIG.includedUnits;
+}
+
+/**
+ * Check if AI runs should be blocked for a given plan and usage.
+ * Free plan: hard cap at included runs (30).
+ * Paid plans: never blocked (overage is billed via Stripe).
+ */
+export function isAiRunBlocked(plan: PlanType, runsUsed: number): boolean {
+  if (!isBillingEnabled()) return false;
+  const quota = AI_RUN_QUOTAS[plan];
+  if (quota.included === Infinity) return false;
+  if (plan === PlanType.FREE) return runsUsed >= quota.included;
+  return false;
 }
 
 // =============================================================================

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -48,10 +48,10 @@ export function isFreePlanBlocked(currentUsage: number): boolean {
  */
 export function isAiRunBlocked(plan: PlanType, runsUsed: number): boolean {
   if (!isBillingEnabled()) return false;
-  const quota = AI_RUN_QUOTAS[plan];
-  if (quota.included === Infinity) return false;
-  if (plan === PlanType.FREE) return runsUsed >= quota.included;
-  return false;
+  if (plan === PlanType.FREE) {
+    return runsUsed >= AI_RUN_QUOTAS[plan].included;
+  }
+  return false; // paid plans: overage is billed via Stripe, never hard-blocked
 }
 
 // =============================================================================

--- a/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/messages/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/messages/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { prisma, ModelSource } from "@traceroot/core";
+import { prisma, ModelSource, isBillingEnabled } from "@traceroot/core";
 import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
 
 const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:8100";
@@ -66,7 +66,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     where: { id: accessResult.project.workspaceId },
     select: { aiBlocked: true },
   });
-  if (workspace?.aiBlocked) {
+  if (isBillingEnabled() && workspace?.aiBlocked) {
     return new Response(
       JSON.stringify({
         error: "AI run limit reached. Upgrade your plan to continue.",

--- a/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/messages/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/messages/route.ts
@@ -69,8 +69,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   if (workspace?.aiBlocked) {
     return new Response(
       JSON.stringify({
-        error:
-          "AI run limit reached. Upgrade your plan to continue.",
+        error: "AI run limit reached. Upgrade your plan to continue.",
       }),
       { status: 403, headers: { "Content-Type": "application/json" } },
     );

--- a/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/messages/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/messages/route.ts
@@ -61,21 +61,19 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
   }
 
-  // Check if AI usage is blocked (free allowance exceeded) — only for system models, BYOK always allowed
-  if (body.source !== ModelSource.BYOK) {
-    const workspace = await prisma.workspace.findUnique({
-      where: { id: accessResult.project.workspaceId },
-      select: { aiBlocked: true },
-    });
-    if (workspace?.aiBlocked) {
-      return new Response(
-        JSON.stringify({
-          error:
-            "AI token allowance exceeded. Upgrade your plan or use your own API key (BYOK) to continue.",
-        }),
-        { status: 403, headers: { "Content-Type": "application/json" } },
-      );
-    }
+  // Check if AI runs are blocked (free plan hard cap — applies to both system model and BYOK)
+  const workspace = await prisma.workspace.findUnique({
+    where: { id: accessResult.project.workspaceId },
+    select: { aiBlocked: true },
+  });
+  if (workspace?.aiBlocked) {
+    return new Response(
+      JSON.stringify({
+        error:
+          "AI run limit reached. Upgrade your plan to continue.",
+      }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
   }
 
   // Proxy to agent service, passthrough SSE stream

--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -256,9 +256,7 @@ export function BillingTab({
               <p className="text-sm font-medium">AI Runs</p>
               <span className="text-sm font-medium">
                 {aiUsage?.runsUsed ?? 0}
-                {aiRunQuota.included === Infinity
-                  ? ""
-                  : ` / ${aiRunQuota.included}`}
+                {aiRunQuota.included === Infinity ? "" : ` / ${aiRunQuota.included}`}
               </span>
             </div>
             <p className="text-xs text-muted-foreground">

--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -255,8 +255,9 @@ export function BillingTab({
             <div className="flex items-baseline justify-between">
               <p className="text-sm font-medium">AI Runs</p>
               <span className="text-sm font-medium">
-                {aiUsage?.runsUsed ?? 0}
-                {aiRunQuota.included === Infinity ? "" : ` / ${aiRunQuota.included}`}
+                {aiRunQuota.included === Infinity
+                  ? `${aiUsage?.runsUsed ?? 0} (Unlimited)`
+                  : `${aiUsage?.runsUsed ?? 0} / ${aiRunQuota.included}`}
               </span>
             </div>
             <p className="text-xs text-muted-foreground">

--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -254,10 +254,11 @@ export function BillingTab({
           <div>
             <div className="flex items-baseline justify-between">
               <p className="text-sm font-medium">AI Runs</p>
-              <span className="text-sm text-muted-foreground">
+              <span className="text-sm font-medium">
+                {aiUsage?.runsUsed ?? 0}
                 {aiRunQuota.included === Infinity
-                  ? "Unlimited"
-                  : `${aiRunQuota.included} included/mo`}
+                  ? ""
+                  : ` / ${aiRunQuota.included}`}
               </span>
             </div>
             <p className="text-xs text-muted-foreground">

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -229,6 +229,7 @@ export interface AIUsageByModel extends AIUsageCategory {
 }
 
 export interface AIUsageData {
+  runsUsed: number;
   systemUsage: AIUsageCategory;
   byokUsage: AIUsageCategory;
   byModel: AIUsageByModel[];

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -319,9 +319,7 @@ async function processWorkspace(
     const prevPeriodStart = previousUsage?.ai?.lastReportedPeriodStart ?? null;
     const currentPeriodStart = workspace.billingPeriodStart?.toISOString() ?? null;
     const lastReportedUnits =
-      prevPeriodStart === currentPeriodStart
-        ? (previousUsage?.ai?.lastReportedUnits ?? 0)
-        : 0;
+      prevPeriodStart === currentPeriodStart ? (previousUsage?.ai?.lastReportedUnits ?? 0) : 0;
     const deltaUnits = totalBillableUnits - lastReportedUnits;
 
     console.log(

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -164,12 +164,13 @@ async function processWorkspace(
     createTime: { gte: aiPeriodStart, lt: aiPeriodEnd },
   };
 
-  // BYOK models: always all-time (no billing cycle, for reference only)
+  // BYOK models: same billing period as system models (runs count toward quota)
   const byokWhere = {
     role: "assistant" as const,
     inputTokens: { not: null as null },
     isByok: true as const,
     session: { workspaceId: workspace.id },
+    createTime: { gte: aiPeriodStart, lt: aiPeriodEnd },
   };
 
   const [systemAgg, byokAgg, systemByModel, byokByModel] = await Promise.all([
@@ -359,7 +360,7 @@ async function processWorkspace(
       `${usage.traces} traces, ${usage.spans} spans | ` +
       `AI runs: ${runsUsed} | ` +
       `system: ${systemAgg._count.id} msgs ($${systemCost.toFixed(4)}) | ` +
-      `byok: ${byokAgg._count.id} msgs (all-time)`,
+      `byok: ${byokAgg._count.id} msgs`,
   );
 }
 

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -3,13 +3,20 @@
  *
  * Runs hourly to process all workspaces:
  * 1. Query usage (traces + spans) from ClickHouse ONCE per workspace
- * 2. Update currentUsage JSON (for billing page display)
- * 3. Update ingestionBlocked flag (free plan only)
- * 4. Update Stripe subscription quantity (paid plans only)
+ * 2. Count AI runs (assistant messages) from PostgreSQL
+ * 3. Update currentUsage JSON (for billing page display)
+ * 4. Update ingestionBlocked / aiBlocked flags
+ * 5. Report overage to Stripe (paid plans only)
+ *
+ * AI Run Billing:
+ * - Free plan: hard cap at 30 runs/month (blocked when reached)
+ * - Starter/Pro: first 100 runs free, then $10/100 runs + 1.05x system model token cost
+ * - BYOK runs: only run fee, no token markup (user pays their own API)
+ * - Stripe receives units at $0.01 each; TraceRoot calculates the unit count
  */
 
 import Stripe from "stripe";
-import { prisma, USAGE_CONFIG, PlanType } from "@traceroot/core";
+import { prisma, USAGE_CONFIG, PlanType, isAiRunBlocked, AI_RUN_QUOTAS } from "@traceroot/core";
 import { getWorkspaceUsageDetails } from "./clickhouse";
 
 let stripe: Stripe | null = null;
@@ -92,9 +99,12 @@ async function processWorkspace(
   },
 ): Promise<void> {
   const projectIds = workspace.projects.map((p) => p.id);
-  const isFreePlan = workspace.billingPlan === PlanType.FREE;
+  const plan = workspace.billingPlan as PlanType;
+  const isFreePlan = plan === PlanType.FREE;
 
-  // 1. Query usage ONCE
+  // =========================================================================
+  // 1. Query event usage (traces + spans) from ClickHouse
+  // =========================================================================
   let usage: { traces: number; spans: number };
   if (projectIds.length === 0) {
     usage = { traces: 0, spans: 0 };
@@ -126,21 +136,32 @@ async function processWorkspace(
 
   const totalEvents = usage.traces + usage.spans;
 
-  // 1b. Query AI token usage
-  // System models: use billing period (same as events) for cost tracking
-  const aiSystemStart = isFreePlan
+  // =========================================================================
+  // 2. Query AI usage from PostgreSQL
+  // =========================================================================
+  const aiPeriodStart = isFreePlan
     ? ctx.allTimeStart
     : (workspace.billingPeriodStart ?? new Date(ctx.now.getFullYear(), ctx.now.getMonth(), 1));
-  const aiSystemEnd = isFreePlan
+  const aiPeriodEnd = isFreePlan
     ? ctx.now
     : (workspace.billingPeriodEnd ?? new Date(ctx.now.getFullYear(), ctx.now.getMonth() + 1, 1));
 
+  // 2a. Count total AI runs in period (both BYOK and system model)
+  const runsUsed = await prisma.aIMessage.count({
+    where: {
+      role: "assistant",
+      session: { workspaceId: workspace.id },
+      createTime: { gte: aiPeriodStart, lt: aiPeriodEnd },
+    },
+  });
+
+  // 2b. Aggregate system model token usage (for cost display + Stripe metering)
   const systemWhere = {
     role: "assistant" as const,
     inputTokens: { not: null as null },
     isByok: false as const,
     session: { workspaceId: workspace.id },
-    createTime: { gte: aiSystemStart, lt: aiSystemEnd },
+    createTime: { gte: aiPeriodStart, lt: aiPeriodEnd },
   };
 
   // BYOK models: always all-time (no billing cycle, for reference only)
@@ -177,11 +198,11 @@ async function processWorkspace(
   ]);
 
   const byModel = [...systemByModel, ...byokByModel];
-
-  // Calculate total system cost (for free allowance check)
   const systemCost = Number(systemAgg._sum.cost ?? 0);
 
-  // 2. Build update data
+  // =========================================================================
+  // 3. Build update data
+  // =========================================================================
   const updateData: {
     currentUsage: object;
     ingestionBlocked?: boolean;
@@ -193,6 +214,7 @@ async function processWorkspace(
       tokens: 0,
       updatedAt: ctx.now.toISOString(),
       ai: {
+        runsUsed,
         systemUsage: {
           messages: systemAgg._count.id,
           inputTokens: systemAgg._sum.inputTokens ?? 0,
@@ -218,7 +240,11 @@ async function processWorkspace(
     },
   };
 
-  // 3. For free plan: update ingestionBlocked and aiBlocked
+  // =========================================================================
+  // 4. Update blocking flags
+  // =========================================================================
+
+  // 4a. Event ingestion blocking (free plan only)
   if (isFreePlan) {
     const shouldBeBlocked = totalEvents >= USAGE_CONFIG.includedUnits;
     if (workspace.ingestionBlocked !== shouldBeBlocked) {
@@ -227,24 +253,29 @@ async function processWorkspace(
         `[Billing] Workspace ${workspace.id}: ${totalEvents}/${USAGE_CONFIG.includedUnits} events, blocked: ${shouldBeBlocked}`,
       );
     }
+  }
 
-    // Block AI when free cost allowance exceeded (free plan has no subscription to bill)
-    const shouldBlockAi = systemCost >= USAGE_CONFIG.aiIncludedCost;
+  // 4b. AI run blocking
+  if (isFreePlan) {
+    // Free plan: hard cap based on run count
+    const shouldBlockAi = isAiRunBlocked(plan, runsUsed);
     if (workspace.aiBlocked !== shouldBlockAi) {
       updateData.aiBlocked = shouldBlockAi;
       console.log(
-        `[Billing] Workspace ${workspace.id}: $${systemCost.toFixed(4)}/$${USAGE_CONFIG.aiIncludedCost} AI cost, ai_blocked: ${shouldBlockAi}`,
+        `[Billing] Workspace ${workspace.id}: ${runsUsed}/${AI_RUN_QUOTAS[plan].included} AI runs, ai_blocked: ${shouldBlockAi}`,
       );
     }
   }
 
-  // 3b. For paid plans: always unblock AI (overage is billed, not blocked)
+  // 4c. Paid plans: always unblock AI (overage is billed, not blocked)
   if (!isFreePlan && workspace.aiBlocked) {
     updateData.aiBlocked = false;
     console.log(`[Billing] Workspace ${workspace.id}: unblocking AI (paid plan)`);
   }
 
-  // 4. For paid plans with subscription: update Stripe before DB write
+  // =========================================================================
+  // 5. Stripe metering (paid plans only)
+  // =========================================================================
   console.log(
     `[Billing] Stripe check: isFreePlan=${isFreePlan}, subscriptionId=${!!workspace.billingSubscriptionId}, customerId=${!!workspace.billingCustomerId}, stripeClient=${!!ctx.stripeClient}`,
   );
@@ -254,52 +285,111 @@ async function processWorkspace(
     workspace.billingCustomerId &&
     ctx.stripeClient
   ) {
+    // 5a. Update Stripe subscription quantity for event usage
     await updateStripeQuantity(workspace.billingSubscriptionId, totalEvents, ctx.stripeClient);
 
-    // 4b. Report AI usage delta (system models only — BYOK is not billed)
-    // First $5 of AI usage is free; bill anything above that
-    const billableCost = Math.max(0, systemCost - USAGE_CONFIG.aiIncludedCost);
+    // 5b. Report AI run overage to Stripe
+    const includedRuns = AI_RUN_QUOTAS[plan].included;
+    const overageRuns = Math.max(0, runsUsed - includedRuns);
 
-    // Meter events are additive, so only report the increase since last run
+    // Calculate total billable units:
+    // - Run overage: $10 per 100 runs = $0.10/run = 10 units/run @ $0.01/unit
+    // - System model token cost on overage runs: 1.05x markup, converted to $0.01 units
+    let totalBillableUnits = 0;
+    let overageSystemCost = 0;
+
+    if (overageRuns > 0) {
+      const runOverageUnits = overageRuns * 10;
+
+      // Get system model token cost for runs beyond the included quota
+      overageSystemCost = await getOverageSystemModelCost(
+        workspace.id,
+        includedRuns,
+        aiPeriodStart,
+        aiPeriodEnd,
+      );
+      const tokenMarkupUnits = Math.round(overageSystemCost * 1.05 * 100);
+
+      totalBillableUnits = runOverageUnits + tokenMarkupUnits;
+    }
+
+    // Delta calculation: only report the increase since last worker run
     // Reset tracking when billing period changes (prevents negative delta after period rollover)
     const previousUsage = workspace.currentUsage as any;
     const prevPeriodStart = previousUsage?.ai?.lastReportedPeriodStart ?? null;
     const currentPeriodStart = workspace.billingPeriodStart?.toISOString() ?? null;
-    const lastReportedCost =
-      prevPeriodStart === currentPeriodStart ? (previousUsage?.ai?.lastReportedCostUsd ?? 0) : 0;
-    const deltaCost = billableCost - lastReportedCost;
+    const lastReportedUnits =
+      prevPeriodStart === currentPeriodStart
+        ? (previousUsage?.ai?.lastReportedUnits ?? 0)
+        : 0;
+    const deltaUnits = totalBillableUnits - lastReportedUnits;
+
     console.log(
-      `[Billing] AI metering: systemCost=$${systemCost.toFixed(4)}, billable=$${billableCost.toFixed(4)}, lastReported=$${lastReportedCost.toFixed(4)}, delta=$${deltaCost.toFixed(4)}`,
+      `[Billing] AI run metering: runsUsed=${runsUsed}, included=${includedRuns}, overage=${overageRuns}, ` +
+        `overageSystemCost=$${overageSystemCost.toFixed(4)}, totalUnits=${totalBillableUnits}, ` +
+        `lastReported=${lastReportedUnits}, delta=${deltaUnits}`,
     );
 
-    if (deltaCost > 0) {
-      const reported = await reportAIUsageToStripe(
+    if (deltaUnits > 0) {
+      const reported = await reportAiRunOverageToStripe(
         workspace.id,
         workspace.billingCustomerId!,
-        deltaCost,
+        deltaUnits,
         ctx.stripeClient,
       );
       if (reported) {
-        // Track what we've reported so we don't double-report
-        (updateData.currentUsage as any).ai.lastReportedCostUsd = billableCost;
+        (updateData.currentUsage as any).ai.lastReportedUnits = totalBillableUnits;
         (updateData.currentUsage as any).ai.lastReportedPeriodStart = currentPeriodStart;
       }
     } else {
-      // Preserve last reported value (and period start for reset detection)
-      (updateData.currentUsage as any).ai.lastReportedCostUsd = lastReportedCost;
+      // Preserve last reported values
+      (updateData.currentUsage as any).ai.lastReportedUnits = lastReportedUnits;
       (updateData.currentUsage as any).ai.lastReportedPeriodStart = currentPeriodStart;
     }
   }
 
-  // 5. Update database (after Stripe so lastReportedCostUsd is accurate)
+  // =========================================================================
+  // 6. Write to database
+  // =========================================================================
   await prisma.workspace.update({
     where: { id: workspace.id },
     data: updateData,
   });
 
   console.log(
-    `[Billing] Workspace ${workspace.id} (${workspace.billingPlan}): ${usage.traces} traces, ${usage.spans} spans | system: ${systemAgg._count.id} msgs (${systemAgg._sum.inputTokens ?? 0} in / ${systemAgg._sum.outputTokens ?? 0} out, $${systemCost.toFixed(4)}) | byok: ${byokAgg._count.id} msgs (all-time, ${byokAgg._sum.inputTokens ?? 0} in / ${byokAgg._sum.outputTokens ?? 0} out)`,
+    `[Billing] Workspace ${workspace.id} (${workspace.billingPlan}): ` +
+      `${usage.traces} traces, ${usage.spans} spans | ` +
+      `AI runs: ${runsUsed} | ` +
+      `system: ${systemAgg._count.id} msgs ($${systemCost.toFixed(4)}) | ` +
+      `byok: ${byokAgg._count.id} msgs (all-time)`,
   );
+}
+
+/**
+ * Get the total system model token cost for AI runs beyond the included quota.
+ * Orders all assistant messages by time, skips the first `includedRuns`,
+ * then sums the cost of system model (non-BYOK) messages in the remainder.
+ */
+async function getOverageSystemModelCost(
+  workspaceId: string,
+  includedRuns: number,
+  start: Date,
+  end: Date,
+): Promise<number> {
+  const overageMessages = await prisma.aIMessage.findMany({
+    where: {
+      role: "assistant",
+      session: { workspaceId },
+      createTime: { gte: start, lt: end },
+    },
+    orderBy: { createTime: "asc" },
+    skip: includedRuns,
+    select: { isByok: true, cost: true },
+  });
+
+  return overageMessages
+    .filter((m) => m.isByok === false)
+    .reduce((sum, m) => sum + Number(m.cost ?? 0), 0);
 }
 
 async function updateStripeQuantity(
@@ -331,36 +421,36 @@ async function updateStripeQuantity(
 }
 
 /**
- * Report AI token usage cost to Stripe via meter events.
- * Converts cost to cents (units at $0.01 each).
- * Only reports system model usage — BYOK is not billed.
+ * Report AI run overage to Stripe via meter events.
+ * Units are at $0.01 each. The unit count includes both:
+ * - Run overage fee: $10/100 runs = 10 units per overage run
+ * - System model token markup: 1.05x of token cost on overage runs
  * Returns true if successfully reported.
  */
-async function reportAIUsageToStripe(
+async function reportAiRunOverageToStripe(
   workspaceId: string,
   customerId: string,
-  cost: number,
+  units: number,
   stripeClient: Stripe,
 ): Promise<boolean> {
-  const costCents = Math.round(cost * 100);
-  if (costCents <= 0) return false;
+  if (units <= 0) return false;
 
   try {
     await stripeClient.billing.meterEvents.create({
       event_name: "ai_token_usage",
       payload: {
         stripe_customer_id: customerId,
-        value: String(costCents),
+        value: String(units),
       },
       timestamp: Math.floor(Date.now() / 1000),
     });
     console.log(
-      `[Billing] Reported AI usage to Stripe: workspace=${workspaceId}, delta=$${cost.toFixed(2)} (${costCents} units @ $0.01)`,
+      `[Billing] Reported AI run overage to Stripe: workspace=${workspaceId}, delta=${units} units ($${(units * 0.01).toFixed(2)})`,
     );
     return true;
   } catch (error) {
     console.error(
-      `[Billing] Failed to report AI usage to Stripe for workspace ${workspaceId}:`,
+      `[Billing] Failed to report AI run overage to Stripe for workspace ${workspaceId}:`,
       error,
     );
     return false;

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -365,8 +365,10 @@ async function processWorkspace(
 
 /**
  * Get the total system model token cost for AI runs beyond the included quota.
- * Orders all assistant messages by time, skips the first `includedRuns`,
- * then sums the cost of system model (non-BYOK) messages in the remainder.
+ *
+ * Two-step approach to avoid loading all overage messages into memory:
+ * 1. Find the cutoff timestamp (createTime of the first overage message)
+ * 2. Aggregate system model cost from that timestamp onward
  */
 async function getOverageSystemModelCost(
   workspaceId: string,
@@ -374,7 +376,9 @@ async function getOverageSystemModelCost(
   start: Date,
   end: Date,
 ): Promise<number> {
-  const overageMessages = await prisma.aIMessage.findMany({
+  // Step 1: Find the cutoff timestamp — the createTime of the first message
+  // after the included quota (e.g., the 101st message for Starter/Pro)
+  const cutoff = await prisma.aIMessage.findMany({
     where: {
       role: "assistant",
       session: { workspaceId },
@@ -382,12 +386,24 @@ async function getOverageSystemModelCost(
     },
     orderBy: { createTime: "asc" },
     skip: includedRuns,
-    select: { isByok: true, cost: true },
+    take: 1,
+    select: { createTime: true },
   });
 
-  return overageMessages
-    .filter((m) => m.isByok === false)
-    .reduce((sum, m) => sum + Number(m.cost ?? 0), 0);
+  if (cutoff.length === 0) return 0;
+
+  // Step 2: Aggregate system model cost from the cutoff onward (DB-side sum)
+  const agg = await prisma.aIMessage.aggregate({
+    where: {
+      role: "assistant",
+      isByok: false,
+      session: { workspaceId },
+      createTime: { gte: cutoff[0].createTime, lt: end },
+    },
+    _sum: { cost: true },
+  });
+
+  return Number(agg._sum.cost ?? 0);
 }
 
 async function updateStripeQuantity(
@@ -435,7 +451,7 @@ async function reportAiRunOverageToStripe(
 
   try {
     await stripeClient.billing.meterEvents.create({
-      event_name: "ai_token_usage",
+      event_name: "ai_usage",
       payload: {
         stripe_customer_id: customerId,
         value: String(units),


### PR DESCRIPTION
  ## Summary   
  
  Fixes #526                                                                                                                                                                                              
                                                                                                                                                                                                               
   Implement AI run-based billing to replace the legacy cost-based AI metering system.                                                                                                                         
                                                                                                                                                                                                               
   **Pricing logic:**                                                                                                                                                                                          
   - **Free plan**: 30 AI runs/month hard cap (blocked when reached, both BYOK and system model)                                                                                                               
   - **Starter/Pro**: First 100 runs/month free. Overage: $10 per 100 runs + 1.05x system model token cost on overage runs                                                                                     
   - **Enterprise**: Unlimited runs, 1.05x system model token cost                                                                                                                                             
   - BYOK runs only incur run fees, no token markup (user pays their own API)                                                                                                                                  
   - Stripe receives units at $0.01 each; TraceRoot calculates the unit count                                                                                                                                  
                                                                                                                                                                                                               
   ## Type of Change                                                                                                                                                                                           
                                                                                                                                                                                                               
   - [x] feat - A new feature                                                                                                                                                                                  
                                                                                                                                                                                                               
   ## Details                                                                                                                                                                                                  
                                                                                                                                                                                                               
   ### Files Changed                                                                                                                                                                                           
                                                                                                                                                                                                               
   | File | Change |                                                                                                                                                                                           
   |------|--------|                                                                                                                                                                                           
   | `frontend/packages/core/src/ee/billing/plans.ts` | Removed legacy `aiIncludedCost` from `USAGE_CONFIG`, added `isAiRunBlocked()` helper |                                                                 
   | `frontend/packages/core/src/ee/billing/index.ts` | Exported `isAiRunBlocked` |                                                                                                                            
   | `frontend/worker/src/ee/billing/usageMetering.ts` | Rewrote AI billing: worker counts runs via `AIMessage` aggregate, free plan sets `aiBlocked` at 30 runs, paid plans report run overage + 1.05x token  
 markup to Stripe |                                                                                                                                                                                            
   | `frontend/ui/src/app/api/projects/[projectId]/ai/sessions/[sessionId]/messages/route.ts` | Removed BYOK exemption from AI blocking check (both BYOK and system model count toward run limit), updated     
 error message |                                                                                                                                                                                               
   | `frontend/ui/src/types/api.ts` | Added `runsUsed` field to `AIUsageData` interface |                                                                                                                      
   | `frontend/ui/src/ee/features/billing/BillingTab.tsx` | Bound `currentUsage.ai.runsUsed` to UI display (e.g. "25 / 30") |                                                                                  
                                                                                                                                                                                                               
   ### Architecture                                                                                                                                                                                            
                                                                                                                                                                                                               
 ```                                                                                                                                                                                                           
                                                                                                                                                                                                               
 Billing Worker (hourly)                                                                                                                                                                                       
   ├─ COUNT AIMessage WHERE role='assistant' in period → runsUsed                                                                                                                                              
   ├─ Write runsUsed to currentUsage.ai JSON                                                                                                                                                                   
   ├─ Free plan: SET aiBlocked = (runsUsed >= 30)                                                                                                                                                              
   └─ Paid plan: calculate overage units → report to Stripe                                                                                                                                                    
                                                                                                                                                                                                               
 Next.js API (messages/route.ts)                                                                                                                                                                               
   └─ Check workspace.aiBlocked → 403 (set by worker)                                                                                                                                                          
                                                                                                                                                                                                               
 UI (BillingTab.tsx)                                                                                                                                                                                           
   └─ Read currentUsage.ai.runsUsed for display                                                                                                                                                                
                                                                                                                                                                                                               
 ```                                                                                                                                                                                                           
                                                                                                                                                                                                               
   ### Stripe Metering (paid plans, overage only)                                                                                                                                                              
                                                                                                                                                                                                               
   - Run overage: $10/100 runs = $0.10/run = 10 units/run @ $0.01/unit                                                                                                                                         
   - System model token markup: `overageCost × 1.05 × 100` units                                                                                                                                               
   - Delta-based reporting (only reports increase since last worker run)                                                                                                                                       
   - Resets tracking on billing period rollover                                                                                                                                                                
                                                                                                                                                                                                               
   ### No Schema Changes                                                                                                                                                                                       
                                                                                                                                                                                                               
   Reuses existing fields:                                                                                                                                                                                     
   - `currentUsage` JSON → added `ai.runsUsed`                                                                                                                                                                 
   - `aiBlocked` Boolean → now set by run count instead of cost                                                                                                                                                
                                                                                                                                                                                                               
   ## Screenshots / Recordings (if applicable)                                                                                                                                                                 
                                                                                                                                                                                                               
    - Stripe Costs                  
<img width="593" height="175" alt="截屏2026-03-18 08 25 43" src="https://github.com/user-attachments/assets/ca34d53d-2ea4-408b-8d42-e552512cd1c9" />
<img width="917" height="656" alt="截屏2026-03-18 08 32 39" src="https://github.com/user-attachments/assets/393403c9-5c84-4b80-962a-61b841539e27" />
<img width="1008" height="215" alt="截屏2026-03-18 08 32 46" src="https://github.com/user-attachments/assets/d6e39ba9-4238-4a9e-8f4e-31c8ab2f86de" />
                                                                                                                                                                                     
                                                                                                                                                                                                               
   ## Checklist                                                                                                                                                                                                
                                                                                                                                                                                                               
   - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)                                                                                                                                                 
   - [ ] I have added/updated tests where applicable                                                                                                                                                           
   - [ ] I have added screenshots or recordings for UI changes (if applicable)                                                                                                                                 
   - [x] I have updated documentation where necessary                                