### PR TITLE
Rename 'TR AI Token Cost' to 'Internal Models' on billing page

### DIFF
--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -271,7 +271,7 @@ export function BillingTab({
           {/* System Models */}
           <div>
             <div className="flex items-baseline justify-between">
-              <p className="text-sm font-medium">TR AI Token Cost</p>
+              <p className="text-sm font-medium">Internal Models</p>
               <span className="text-sm font-medium">
                 {formatCost(aiUsage?.systemUsage.cost ?? 0)}
               </span>


### PR DESCRIPTION
## Summary
- Renamed the label "TR AI Token Cost" to "Internal Models" in the workspace settings billing page AI Usage section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)