### PR TITLE
[Backend] Support more BYOK models (xAI, Kimi2.5 and GLM5)

### DIFF
--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -94,7 +94,7 @@ model Workspace {
 model ModelProvider {
   id                String    @id @default(cuid()) @db.VarChar
   workspaceId       String    @map("workspace_id") @db.VarChar
-  adapter           String    @db.VarChar        // "openai"|"anthropic"|"azure"|"google"|"amazon-bedrock"|"deepseek"|"openrouter"
+  adapter           String    @db.VarChar        // "openai"|"anthropic"|"azure"|"google"|"amazon-bedrock"|"deepseek"|"openrouter"|"xai"|"moonshot"|"zai"
   provider          String    @db.VarChar        // user-defined label: "My OpenAI", "DeepSeek", etc.
   keyCipher         String    @map("key_cipher") @db.Text
   keyPreview        String    @map("key_preview") @db.VarChar  // "xxxx...xxxx"

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -29,9 +29,9 @@ export const ADAPTER_TO_PI_AI: Record<string, string> = {
   "amazon-bedrock": "amazon-bedrock",
   deepseek: "openai", // OpenAI-compatible
   openrouter: "openrouter",
-  xai: "openai",       // OpenAI-compatible
-  moonshot: "openai",   // OpenAI-compatible
-  zai: "openai",        // OpenAI-compatible
+  xai: "openai", // OpenAI-compatible
+  moonshot: "openai", // OpenAI-compatible
+  zai: "openai", // OpenAI-compatible
 };
 
 // Default base URLs for adapters

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -14,6 +14,9 @@ export const LLMAdapter = {
   AMAZON_BEDROCK: "amazon-bedrock",
   DEEPSEEK: "deepseek",
   OPENROUTER: "openrouter",
+  XAI: "xai",
+  MOONSHOT: "moonshot",
+  ZAI: "zai",
 } as const;
 export type LLMAdapter = (typeof LLMAdapter)[keyof typeof LLMAdapter];
 
@@ -26,6 +29,9 @@ export const ADAPTER_TO_PI_AI: Record<string, string> = {
   "amazon-bedrock": "amazon-bedrock",
   deepseek: "openai", // OpenAI-compatible
   openrouter: "openrouter",
+  xai: "openai",       // OpenAI-compatible
+  moonshot: "openai",   // OpenAI-compatible
+  zai: "openai",        // OpenAI-compatible
 };
 
 // Default base URLs for adapters
@@ -35,6 +41,9 @@ export const ADAPTER_DEFAULT_BASE_URL: Record<string, string> = {
   google: "https://generativelanguage.googleapis.com/v1alpha",
   deepseek: "https://api.deepseek.com/v1",
   openrouter: "https://openrouter.ai/api/v1",
+  xai: "https://api.x.ai/v1",
+  moonshot: "https://api.moonshot.ai/v1",
+  zai: "https://open.bigmodel.cn/api/paas/v4",
 };
 
 // API protocol per adapter — used to build fallback model objects for BYOK models
@@ -47,6 +56,9 @@ export const ADAPTER_API_PROTOCOL: Record<string, string> = {
   "amazon-bedrock": "bedrock-converse-stream",
   deepseek: "openai-completions",
   openrouter: "openai-completions",
+  xai: "openai-completions",
+  moonshot: "openai-completions",
+  zai: "openai-completions",
 };
 
 export interface LLMModelDef {
@@ -118,6 +130,9 @@ export const ADAPTER_AVAILABLE_PROTOCOLS: Record<string, { value: string; label:
     { value: "openai-completions", label: "Chat Completions" },
     { value: "openai-responses", label: "Responses API" },
   ],
+  xai: [{ value: "openai-completions", label: "Chat Completions" }],
+  moonshot: [{ value: "openai-completions", label: "Chat Completions" }],
+  zai: [{ value: "openai-completions", label: "Chat Completions" }],
 };
 
 // Adapter UI metadata
@@ -170,6 +185,24 @@ export const ADAPTER_CONFIG: Record<
     label: "OpenRouter",
     requiresBaseUrl: false,
     requiresCustomModels: true,
+    credentialType: "api-key",
+  },
+  xai: {
+    label: "xAI",
+    requiresBaseUrl: false,
+    requiresCustomModels: false,
+    credentialType: "api-key",
+  },
+  moonshot: {
+    label: "Moonshot (Kimi)",
+    requiresBaseUrl: false,
+    requiresCustomModels: false,
+    credentialType: "api-key",
+  },
+  zai: {
+    label: "Z.AI (GLM)",
+    requiresBaseUrl: false,
+    requiresCustomModels: false,
     credentialType: "api-key",
   },
 };

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.ts
@@ -25,6 +25,9 @@ const ADAPTER_VALUES = [
   LLMAdapter.AMAZON_BEDROCK,
   LLMAdapter.DEEPSEEK,
   LLMAdapter.OPENROUTER,
+  LLMAdapter.XAI,
+  LLMAdapter.MOONSHOT,
+  LLMAdapter.ZAI,
 ] as const;
 
 const createSchema = z.object({

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -261,12 +261,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
             messages: [{ role: "user", content: "hi" }],
           }),
         });
-        if (!res.ok && res.status === 401) {
+        if (!res.ok) {
           const err = await res.json().catch(() => ({}));
           const errObj = err as Record<string, Record<string, unknown>>;
           return successResponse({
             success: false,
-            error: errObj.error?.message ? String(errObj.error.message) : "Invalid API key",
+            error: errObj.error?.message ? String(errObj.error.message) : `HTTP ${res.status}`,
           });
         }
         break;

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -249,24 +249,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
       case "zai": {
         const zaiBase = baseUrl || "https://open.bigmodel.cn/api/paas/v4";
-        const res = await fetch(`${zaiBase.replace(/\/$/, "")}/chat/completions`, {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${apiKey}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            model: "glm-4-flash",
-            max_tokens: 1,
-            messages: [{ role: "user", content: "hi" }],
-          }),
+        const res = await fetch(`${zaiBase.replace(/\/$/, "")}/models`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
         });
         if (!res.ok) {
           const err = await res.json().catch(() => ({}));
-          const errObj = err as Record<string, Record<string, unknown>>;
           return successResponse({
             success: false,
-            error: errObj.error?.message ? String(errObj.error.message) : `HTTP ${res.status}`,
+            error: (err as Record<string, Record<string, unknown>>).error?.message
+              ? String((err as Record<string, Record<string, unknown>>).error.message)
+              : `HTTP ${res.status}`,
           });
         }
         break;

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
-import { Role, LLMAdapter, prisma, decryptKey } from "@traceroot/core";
+import { Role, LLMAdapter, ADAPTER_DEFAULT_BASE_URL, prisma, decryptKey } from "@traceroot/core";
 import {
   requireAuth,
   requireWorkspaceMembership,
@@ -184,8 +184,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "deepseek": {
-        const deepseekBase = baseUrl || "https://api.deepseek.com";
-        const res = await fetch(`${deepseekBase.replace(/\/$/, "")}/v1/models`, {
+        const deepseekBase = baseUrl || ADAPTER_DEFAULT_BASE_URL.deepseek;
+        const res = await fetch(`${deepseekBase.replace(/\/$/, "")}/models`, {
           headers: { Authorization: `Bearer ${apiKey}` },
         });
         if (!res.ok) {
@@ -214,8 +214,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "xai": {
-        const xaiBase = baseUrl || "https://api.x.ai";
-        const res = await fetch(`${xaiBase.replace(/\/$/, "")}/v1/models`, {
+        const xaiBase = baseUrl || ADAPTER_DEFAULT_BASE_URL.xai;
+        const res = await fetch(`${xaiBase.replace(/\/$/, "")}/models`, {
           headers: { Authorization: `Bearer ${apiKey}` },
         });
         if (!res.ok) {
@@ -231,8 +231,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "moonshot": {
-        const moonshotBase = baseUrl || "https://api.moonshot.ai";
-        const res = await fetch(`${moonshotBase.replace(/\/$/, "")}/v1/models`, {
+        const moonshotBase = baseUrl || ADAPTER_DEFAULT_BASE_URL.moonshot;
+        const res = await fetch(`${moonshotBase.replace(/\/$/, "")}/models`, {
           headers: { Authorization: `Bearer ${apiKey}` },
         });
         if (!res.ok) {
@@ -248,7 +248,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "zai": {
-        const zaiBase = baseUrl || "https://open.bigmodel.cn/api/paas/v4";
+        const zaiBase = baseUrl || ADAPTER_DEFAULT_BASE_URL.zai;
         const res = await fetch(`${zaiBase.replace(/\/$/, "")}/models`, {
           headers: { Authorization: `Bearer ${apiKey}` },
         });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -16,6 +16,9 @@ const ADAPTER_VALUES = [
   LLMAdapter.AMAZON_BEDROCK,
   LLMAdapter.DEEPSEEK,
   LLMAdapter.OPENROUTER,
+  LLMAdapter.XAI,
+  LLMAdapter.MOONSHOT,
+  LLMAdapter.ZAI,
 ] as const;
 
 const testSchema = z.object({
@@ -205,6 +208,65 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           return successResponse({
             success: false,
             error: `HTTP ${res.status}: ${res.statusText}`,
+          });
+        }
+        break;
+      }
+
+      case "xai": {
+        const xaiBase = baseUrl || "https://api.x.ai";
+        const res = await fetch(`${xaiBase.replace(/\/$/, "")}/v1/models`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          return successResponse({
+            success: false,
+            error: (err as Record<string, Record<string, unknown>>).error?.message
+              ? String((err as Record<string, Record<string, unknown>>).error.message)
+              : `HTTP ${res.status}`,
+          });
+        }
+        break;
+      }
+
+      case "moonshot": {
+        const moonshotBase = baseUrl || "https://api.moonshot.ai";
+        const res = await fetch(`${moonshotBase.replace(/\/$/, "")}/v1/models`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          return successResponse({
+            success: false,
+            error: (err as Record<string, Record<string, unknown>>).error?.message
+              ? String((err as Record<string, Record<string, unknown>>).error.message)
+              : `HTTP ${res.status}`,
+          });
+        }
+        break;
+      }
+
+      case "zai": {
+        const zaiBase = baseUrl || "https://open.bigmodel.cn/api/paas/v4";
+        const res = await fetch(`${zaiBase.replace(/\/$/, "")}/chat/completions`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            model: "glm-4-flash",
+            max_tokens: 1,
+            messages: [{ role: "user", content: "hi" }],
+          }),
+        });
+        if (!res.ok && res.status === 401) {
+          const err = await res.json().catch(() => ({}));
+          const errObj = err as Record<string, Record<string, unknown>>;
+          return successResponse({
+            success: false,
+            error: errObj.error?.message ? String(errObj.error.message) : "Invalid API key",
           });
         }
         break;


### PR DESCRIPTION
## Summary   
  Add BYOK (Bring Your Own Key) support for three new LLM providers: xAI (Grok), Moonshot AI (Kimi), and Z.AI (GLM). Closes #533.
                                                                                                                                                                                                               
  ## Type of Change
                                                                                                                                                                                                               
  - [x] feat - A new feature                                                                                                                                                                                   
  
  ## Details                                                                                                                                                                                                   
                                                            
  All three providers use OpenAI-compatible chat completions APIs, following the same pattern as the existing DeepSeek adapter.                                                                                
  
  **Changes across 4 files:**                                                                                                                                                                                  
                                                            
  - **`frontend/packages/core/src/llm-providers.ts`** — Added `xai`, `moonshot`, `zai` to all 6 adapter registry maps (`LLMAdapter`, `ADAPTER_TO_PI_AI`, `ADAPTER_DEFAULT_BASE_URL`, `ADAPTER_API_PROTOCOL`,   
  `ADAPTER_AVAILABLE_PROTOCOLS`, `ADAPTER_CONFIG`)          
  - **`frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.ts`** — Added new adapters to Zod validation                                                                                     
  - **`frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts`** — Added test-connection switch cases (xAI/Moonshot: `GET /models`, Z.AI: lightweight `POST /chat/completions`)        
  - **`frontend/packages/core/prisma/schema.prisma`** — Updated adapter field comment                                                                                                                          
                                                                                                                                                                                                               
  **New provider details:**                                                                                                                                                                                    
                                                                                                                                                                                                               
  | Provider | API Base URL | Default Model | Test Method |                                                                                                                                                    
  |----------|-------------|---------------|-------------|
  | xAI | `https://api.x.ai/v1` | grok-3 | GET /models |                                                                                                                                                       
  | Moonshot (Kimi) | `https://api.moonshot.ai/v1` | kimi-k2-0905-preview | GET /models |                                                                                                                      
  | Z.AI (GLM) | `https://open.bigmodel.cn/api/paas/v4` | glm-5 | POST /chat/completions |                                                                                                                     
                                                                                                                                                                                                               
  ## Screenshots / Recordings (if applicable)                                                                                                                                                                  
                                                 

https://github.com/user-attachments/assets/014d0230-d8fb-452b-a679-4037cce62830

                                          
                                                                                                                                                                                                               
  ## Checklist
                                                                                                                                                                                                               
  - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)                                                                                                                                                  
  - [ ] I have added/updated tests where applicable
  - [x] I have added screenshots or recordings for UI changes (if applicable)                                                                                                                                  
  - [x] I have updated documentation where necessary        
                                                                                                              
