### PR TITLE
fix: Update docs URL from docs.traceroot.ai to traceroot.ai/docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,7 +108,7 @@ SANDBOX_PROVIDER=docker
 
 # --- Branding / Public URLs ---------------------------------------------------
 NEXT_PUBLIC_LOGO_URL=https://raw.githubusercontent.com/traceroot-ai/traceroot/main/frontend/ui/public/images/traceroot_icon.png
-NEXT_PUBLIC_DOCS_URL=https://docs.traceroot.ai
+NEXT_PUBLIC_DOCS_URL=https://traceroot.ai/docs
 NEXT_PUBLIC_GITHUB_REPO_URL=https://github.com/traceroot-ai/traceroot
 NEXT_PUBLIC_GITHUB_ISSUES_URL=https://github.com/traceroot-ai/traceroot/issues
 NEXT_PUBLIC_DISCORD_INVITE_URL=https://discord.com/invite/tPyffEZvvJ

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -180,7 +180,7 @@ sandboxProvider: "daytona"
 # --- Branding / Public URLs ---
 branding:
   logoUrl: "https://raw.githubusercontent.com/traceroot-ai/traceroot/main/frontend/ui/public/images/traceroot_icon.png"
-  docsUrl: "https://docs.traceroot.ai"
+  docsUrl: "https://traceroot.ai/docs"
   githubRepoUrl: "https://github.com/traceroot-ai/traceroot"
   githubIssuesUrl: "https://github.com/traceroot-ai/traceroot/issues"
   discordInviteUrl: "https://discord.com/invite/tPyffEZvvJ"

--- a/frontend/ui/src/env.client.ts
+++ b/frontend/ui/src/env.client.ts
@@ -4,7 +4,7 @@ const clientSchema = z.object({
   NEXT_PUBLIC_POSTHOG_KEY: z.string().optional(),
   NEXT_PUBLIC_POSTHOG_HOST: z.string().optional(),
   NEXT_PUBLIC_API_URL: z.string().default("/api/v1"),
-  NEXT_PUBLIC_DOCS_URL: z.string().default("https://docs.traceroot.ai"),
+  NEXT_PUBLIC_DOCS_URL: z.string().default("https://traceroot.ai/docs"),
   NEXT_PUBLIC_GITHUB_REPO_URL: z.string().default("https://github.com/traceroot-ai/traceroot"),
   NEXT_PUBLIC_GITHUB_ISSUES_URL: z
     .string()


### PR DESCRIPTION
## Summary
Update documentation URL references to use the new path-based URL structure instead of the subdomain.

## Changes
Updated `docs.traceroot.ai` → `traceroot.ai/docs` in:
- `frontend/ui/src/env.client.ts` - default value for NEXT_PUBLIC_DOCS_URL
- `deploy/helm/values.yaml` - helm chart default
- `.env.example` - example environment template

## Notes
- The README.md was already using the correct new URL.
- Removed accidentally included unrelated file (`run-billing-adhoc.ts`) from this PR.