### PR TITLE
[AgentOps] Improve terraform and helm chart for production hosting [5/n]

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -114,21 +114,36 @@ terraform apply -var-file=staging.tfvars --target aws_ecr_repository.services
 export REGION=us-east-1
 export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 export REGISTRY=$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
-export TAG=$(git rev-parse --short HEAD)
+export TAG=sha-$(git rev-parse --short HEAD)
+export NAME=traceroot-staging   # or: traceroot-production
 
 # Login to ECR
 aws ecr get-login-password --region $REGION | docker login --username AWS --password-stdin $REGISTRY
 
 # From repo root — build & push all images (linux/amd64 for Fargate)
-for svc in web rest worker billing agent; do
-  docker build --platform linux/amd64 -f docker/Dockerfile.$svc -t $REGISTRY/traceroot-$svc:$TAG .
-  docker push $REGISTRY/traceroot-$svc:$TAG
+# For staging: no extra build args needed
+# For production: set PostHog key (NEXT_PUBLIC_* vars are baked at build time, not runtime)
+export NEXT_PUBLIC_APP_URL=https://app.traceroot.ai          # production
+# export NEXT_PUBLIC_APP_URL=https://staging.traceroot.ai   # staging
+export NEXT_PUBLIC_POSTHOG_KEY=phc_...                       # production only, leave unset for staging
+export NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com     # production only
+
+docker build --platform linux/amd64 \
+  --build-arg NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL \
+  --build-arg NEXT_PUBLIC_POSTHOG_KEY=$NEXT_PUBLIC_POSTHOG_KEY \
+  --build-arg NEXT_PUBLIC_POSTHOG_HOST=$NEXT_PUBLIC_POSTHOG_HOST \
+  -f docker/Dockerfile.web -t $REGISTRY/traceroot-$NAME-web:$TAG .
+docker push $REGISTRY/traceroot-$NAME-web:$TAG
+
+for svc in rest worker billing agent; do
+  docker build --platform linux/amd64 -f docker/Dockerfile.$svc -t $REGISTRY/traceroot-$NAME-$svc:$TAG .
+  docker push $REGISTRY/traceroot-$NAME-$svc:$TAG
 done
 
 # Migration images
 for svc in migrate-postgres migrate-clickhouse; do
-  docker build --platform linux/amd64 -f docker/Dockerfile.$svc -t $REGISTRY/traceroot-$svc:$TAG .
-  docker push $REGISTRY/traceroot-$svc:$TAG
+  docker build --platform linux/amd64 -f docker/Dockerfile.$svc -t $REGISTRY/traceroot-$NAME-$svc:$TAG .
+  docker push $REGISTRY/traceroot-$NAME-$svc:$TAG
 done
 ```
 
@@ -191,10 +206,17 @@ terraform apply -var-file=staging.tfvars
 # If you changed app code — rebuild with git SHA tag
 export TAG=sha-$(git rev-parse --short HEAD)
 
-for svc in web rest worker billing agent migrate-postgres migrate-clickhouse; do
+for svc in rest worker billing agent migrate-postgres migrate-clickhouse; do
   docker build --platform linux/amd64 -f docker/Dockerfile.$svc -t $REGISTRY/traceroot-$svc:$TAG .
   docker push $REGISTRY/traceroot-$svc:$TAG
 done
+
+# Web requires NEXT_PUBLIC_* vars baked in at build time
+docker build --platform linux/amd64 -f docker/Dockerfile.web \
+  --build-arg NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL} \
+  --build-arg NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-/api/v1} \
+  -t $REGISTRY/traceroot-web:$TAG .
+docker push $REGISTRY/traceroot-web:$TAG
 
 # Edit staging.tfvars: image_tag = "sha-<TAG>"
 terraform apply -var-file=staging.tfvars

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -204,19 +204,23 @@ terraform workspace select staging  # or: production
 terraform apply -var-file=staging.tfvars
 
 # If you changed app code — rebuild with git SHA tag
+export REGION=us-east-1
+export ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+export REGISTRY=$ACCOUNT_ID.dkr.ecr.$REGION.amazonaws.com
+export NAME=traceroot-staging   # or: traceroot-production
 export TAG=sha-$(git rev-parse --short HEAD)
 
 for svc in rest worker billing agent migrate-postgres migrate-clickhouse; do
-  docker build --platform linux/amd64 -f docker/Dockerfile.$svc -t $REGISTRY/traceroot-$svc:$TAG .
-  docker push $REGISTRY/traceroot-$svc:$TAG
+  docker build --platform linux/amd64 -f docker/Dockerfile.$svc -t $REGISTRY/traceroot-$NAME-$svc:$TAG .
+  docker push $REGISTRY/traceroot-$NAME-$svc:$TAG
 done
 
 # Web requires NEXT_PUBLIC_* vars baked in at build time
 docker build --platform linux/amd64 -f docker/Dockerfile.web \
   --build-arg NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL} \
   --build-arg NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-/api/v1} \
-  -t $REGISTRY/traceroot-web:$TAG .
-docker push $REGISTRY/traceroot-web:$TAG
+  -t $REGISTRY/traceroot-$NAME-web:$TAG .
+docker push $REGISTRY/traceroot-$NAME-web:$TAG
 
 # Edit staging.tfvars: image_tag = "sha-<TAG>"
 terraform apply -var-file=staging.tfvars

--- a/deploy/helm/templates/worker/deployment.yaml
+++ b/deploy/helm/templates/worker/deployment.yaml
@@ -23,6 +23,11 @@ spec:
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
           env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.postgresql.existingSecret }}
+                  key: {{ .Values.postgresql.secretKeys.databaseUrl }}
             - name: CLICKHOUSE_HOST
               value: {{ include "traceroot.clickhouse.hostname" . | quote }}
             - name: CLICKHOUSE_PORT

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -127,6 +127,7 @@ services:
       dockerfile: docker/Dockerfile.web
       args:
         BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-local-dev-secret-change-in-production}
+        NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000/api/v1}
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
Follow up of https://github.com/traceroot-ai/traceroot/pull/548

- **Fix worker pricing regression**: The Helm chart was missing `DATABASE_URL` in the worker deployment, causing the Python worker to fall back to `localhost:5432` and fail to load model pricing from PostgreSQL. As a result, all spans had `cost = None` on staging/production while localhost worked fine. Root cause: the `unify frontend and backend model price sources` commit (Mar 10) changed `pricing.py` to read from PostgreSQL but the Helm chart was never updated to inject the env var.
- **Update deploy/README.md**: Improve production deploy runbook with correct build commands, ECR repo naming (`traceroot-$NAME-$svc`), PostHog build args for the web image, and a cleaner Tear Down section.

## Type of Change

- [x] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

### Helm: worker missing DATABASE_URL
The worker pod was connecting to `localhost:5432` for pricing lookups because the secret ref was only wired up in `rest/deployment.yaml`, not `worker/deployment.yaml`. Fix adds:
```yaml
- name: DATABASE_URL
  valueFrom:
    secretKeyRef:
      name: {{ .Values.postgresql.existingSecret }}
      key: {{ .Values.postgresql.secretKeys.databaseUrl }}
```

## Screenshots / Recordings (if applicable)
<img width="1540" height="899" alt="Screenshot 2026-03-20 at 9 10 08 PM" src="https://github.com/user-attachments/assets/ca0f503e-bce3-4963-b1eb-f2b4347d0667" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
