### PR TITLE
[Backend]  Dynamic Default Model Selection Based on Provider Priority

### DIFF
--- a/frontend/packages/agent/src/agent.ts
+++ b/frontend/packages/agent/src/agent.ts
@@ -195,11 +195,8 @@ function getDefaultSystemModel(): {
 }
 
 function resolveModel(modelId?: string, providerConfig?: ProviderConfig | null) {
-  let effectiveModelId = modelId;
-  if (!effectiveModelId) {
-    const defaultModel = getDefaultSystemModel();
-    effectiveModelId = defaultModel?.modelId || "claude-sonnet-4-5";
-  }
+  const defaultSystemModel = !modelId ? getDefaultSystemModel() : null;
+  const effectiveModelId = modelId || defaultSystemModel?.modelId || "claude-sonnet-4-5";
 
   // 1. BYOK: always build model from adapter config (don't trust pi-ai registry —
   //    it may assign a wrong API protocol for custom/BYOK models)
@@ -229,13 +226,12 @@ function resolveModel(modelId?: string, providerConfig?: ProviderConfig | null) 
     return buildFallbackModel(effectiveModelId, sysInfo.apiProtocol, sysInfo.piAIProvider);
   }
 
-  // 3. Default — pick best available system model by priority
-  const defaultModel = getDefaultSystemModel();
-  if (defaultModel) {
+  // 3. Unknown model — fall back to the best available system model
+  if (defaultSystemModel) {
     return buildFallbackModel(
-      defaultModel.modelId,
-      defaultModel.apiProtocol,
-      defaultModel.piAIProvider,
+      defaultSystemModel.modelId,
+      defaultSystemModel.apiProtocol,
+      defaultSystemModel.piAIProvider,
     );
   }
   return getModel("anthropic", "claude-sonnet-4-5");

--- a/frontend/packages/agent/src/agent.ts
+++ b/frontend/packages/agent/src/agent.ts
@@ -9,6 +9,7 @@ import {
   prisma,
   decryptKey,
   SYSTEM_MODELS,
+  PROVIDER_PRIORITY,
   ADAPTER_TO_PI_AI,
   ADAPTER_DEFAULT_BASE_URL,
   ADAPTER_API_PROTOCOL,
@@ -174,8 +175,31 @@ function buildFallbackModel(modelId: string, apiProtocol: string, provider: stri
   };
 }
 
+/** Pick the first available system model by provider priority */
+function getDefaultSystemModel(): {
+  modelId: string;
+  piAIProvider: string;
+  apiProtocol: string;
+} | null {
+  for (const adapter of PROVIDER_PRIORITY) {
+    const sys = SYSTEM_MODELS.find((s) => s.piAIProvider === adapter && process.env[s.envVar]);
+    if (sys && sys.models.length > 0) {
+      return {
+        modelId: sys.models[0].id,
+        piAIProvider: sys.piAIProvider,
+        apiProtocol: sys.models[0].apiProtocol || sys.apiProtocol,
+      };
+    }
+  }
+  return null;
+}
+
 function resolveModel(modelId?: string, providerConfig?: ProviderConfig | null) {
-  const effectiveModelId = modelId || "claude-sonnet-4-5";
+  let effectiveModelId = modelId;
+  if (!effectiveModelId) {
+    const defaultModel = getDefaultSystemModel();
+    effectiveModelId = defaultModel?.modelId || "claude-sonnet-4-5";
+  }
 
   // 1. BYOK: always build model from adapter config (don't trust pi-ai registry —
   //    it may assign a wrong API protocol for custom/BYOK models)
@@ -205,7 +229,15 @@ function resolveModel(modelId?: string, providerConfig?: ProviderConfig | null) 
     return buildFallbackModel(effectiveModelId, sysInfo.apiProtocol, sysInfo.piAIProvider);
   }
 
-  // 3. Default
+  // 3. Default — pick best available system model by priority
+  const defaultModel = getDefaultSystemModel();
+  if (defaultModel) {
+    return buildFallbackModel(
+      defaultModel.modelId,
+      defaultModel.apiProtocol,
+      defaultModel.piAIProvider,
+    );
+  }
   return getModel("anthropic", "claude-sonnet-4-5");
 }
 

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -112,6 +112,21 @@ export const SYSTEM_MODELS: {
   },
 ];
 
+// Provider priority for default model selection (highest first).
+// When no specific model is chosen, pick the first available provider's first model.
+export const PROVIDER_PRIORITY: string[] = [
+  "anthropic",
+  "openai",
+  "deepseek",
+  "xai",
+  "moonshot",
+  "zai",
+  "google",
+  "openrouter",
+  "azure",
+  "amazon-bedrock",
+];
+
 // Default models per adapter (for BYOK providers)
 
 // Available API protocols per adapter — shown in provider settings UI

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -113,7 +113,9 @@ export const SYSTEM_MODELS: {
 ];
 
 // Provider priority for default model selection (highest first).
-// When no specific model is chosen, pick the first available provider's first model.
+// Used by both the frontend ModelSelector (matches all providers including BYOK)
+// and the backend getDefaultSystemModel() (only matches SYSTEM_MODELS entries;
+// entries without a matching system provider are silently skipped server-side).
 export const PROVIDER_PRIORITY: string[] = [
   "anthropic",
   "openai",

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -116,17 +116,17 @@ export const SYSTEM_MODELS: {
 // Used by both the frontend ModelSelector (matches all providers including BYOK)
 // and the backend getDefaultSystemModel() (only matches SYSTEM_MODELS entries;
 // entries without a matching system provider are silently skipped server-side).
-export const PROVIDER_PRIORITY: string[] = [
-  "anthropic",
-  "openai",
-  "deepseek",
-  "xai",
-  "moonshot",
-  "zai",
-  "google",
-  "openrouter",
-  "azure",
-  "amazon-bedrock",
+export const PROVIDER_PRIORITY: LLMAdapter[] = [
+  LLMAdapter.ANTHROPIC,
+  LLMAdapter.OPENAI,
+  LLMAdapter.DEEPSEEK,
+  LLMAdapter.XAI,
+  LLMAdapter.MOONSHOT,
+  LLMAdapter.ZAI,
+  LLMAdapter.GOOGLE,
+  LLMAdapter.OPENROUTER,
+  LLMAdapter.AZURE,
+  LLMAdapter.AMAZON_BEDROCK,
 ];
 
 // Default models per adapter (for BYOK providers)

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { X, Plus, History, Square } from "lucide-react";
+import { X, Plus, History, Square, AlertTriangle } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -10,7 +10,7 @@ import { MessageInput } from "./message-input";
 import { SessionHistory } from "./session-history";
 import { useAiChat } from "../hooks/use-ai-chat";
 import { usePanelResize } from "../hooks/use-panel-resize";
-import { getProject } from "@/lib/api";
+import { getProject, getAvailableLLMModels } from "@/lib/api";
 
 interface AiAssistantPanelProps {
   open: boolean;
@@ -31,6 +31,17 @@ export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
 
   // workspaceId from URL (workspace pages) or from project (project pages)
   const workspaceId = workspaceIdFromUrl || project?.workspace_id;
+
+  // Check if any models are available (system or BYOK)
+  const { data: llmModels } = useQuery({
+    queryKey: ["llm-models", workspaceId],
+    queryFn: () => getAvailableLLMModels(workspaceId!),
+    enabled: !!workspaceId,
+  });
+  const hasModels =
+    !llmModels ||
+    llmModels.systemModels.some((g) => g.models.length > 0) ||
+    llmModels.byokProviders.some((g) => g.models.length > 0);
 
   const {
     messages,
@@ -103,6 +114,21 @@ export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
         <div className="flex flex-1 items-center justify-center px-6 text-center text-[13px] text-muted-foreground">
           Open a project to start using the AI assistant.
         </div>
+      ) : !hasModels ? (
+        <div className="flex flex-1 items-center justify-center px-6">
+          <div className="flex max-w-[280px] flex-col items-center gap-3 text-center">
+            <AlertTriangle className="h-8 w-8 text-yellow-500" />
+            <p className="text-[13px] font-medium">No LLM models available</p>
+            <p className="text-[12px] text-muted-foreground">
+              To use the AI assistant, configure a system API key (e.g. Anthropic, OpenAI) in your
+              environment, or add a BYOK provider in{" "}
+              <span className="font-medium text-foreground">
+                Workspace Settings &rarr; Model Providers
+              </span>
+              .
+            </p>
+          </div>
+        </div>
       ) : (
         <MessageList messages={messages} sessionStreaming={isStreaming} />
       )}
@@ -110,7 +136,7 @@ export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
       {/* Input */}
       <MessageInput
         onSend={handleSend}
-        disabled={!projectId}
+        disabled={!projectId || !hasModels}
         workspaceId={workspaceId}
         actions={
           isStreaming && (

--- a/frontend/ui/src/features/ai-assistant/components/message-input.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-input.tsx
@@ -40,11 +40,7 @@ export function MessageInput({ onSend, disabled, workspaceId, actions }: Message
         value={input}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder={
-          noModelSelected
-            ? "No models available. Configure a system API key or add a BYOK provider."
-            : "Ask me about your traces, errors, or performance."
-        }
+        placeholder="Ask me about your traces, errors, or performance."
         disabled={disabled || noModelSelected}
         rows={3}
         className="w-full resize-none rounded-none border border-input bg-transparent px-3 py-2 text-[13px] shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"

--- a/frontend/ui/src/features/ai-assistant/components/message-input.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-input.tsx
@@ -13,8 +13,8 @@ interface MessageInputProps {
 export function MessageInput({ onSend, disabled, workspaceId, actions }: MessageInputProps) {
   const [input, setInput] = useState("");
   const [modelSelection, setModelSelection] = useState<ModelSelection>({
-    model: "claude-sonnet-4-5",
-    provider: "Anthropic",
+    model: "",
+    provider: "",
     source: "system",
   });
 

--- a/frontend/ui/src/features/ai-assistant/components/message-input.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-input.tsx
@@ -18,9 +18,11 @@ export function MessageInput({ onSend, disabled, workspaceId, actions }: Message
     source: "system",
   });
 
+  const noModelSelected = !modelSelection.model;
+
   const handleSend = () => {
     const trimmed = input.trim();
-    if (!trimmed || disabled) return;
+    if (!trimmed || disabled || noModelSelected) return;
     onSend(trimmed, modelSelection);
     setInput("");
   };
@@ -38,8 +40,12 @@ export function MessageInput({ onSend, disabled, workspaceId, actions }: Message
         value={input}
         onChange={(e) => setInput(e.target.value)}
         onKeyDown={handleKeyDown}
-        placeholder="Ask me about your traces, errors, or performance."
-        disabled={disabled}
+        placeholder={
+          noModelSelected
+            ? "No models available. Configure a system API key or add a BYOK provider."
+            : "Ask me about your traces, errors, or performance."
+        }
+        disabled={disabled || noModelSelected}
         rows={3}
         className="w-full resize-none rounded-none border border-input bg-transparent px-3 py-2 text-[13px] shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
       />

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ChevronDown } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { SYSTEM_MODELS } from "@traceroot/core";
+import { SYSTEM_MODELS, PROVIDER_PRIORITY } from "@traceroot/core";
 import { getAvailableLLMModels, type AvailableLLMModel } from "@/lib/api";
 
 export interface ModelSelection {
@@ -50,6 +50,28 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
     );
     return [...byokList, ...systemList];
   })();
+
+  // Auto-select the best available model if current selection isn't in the list
+  const hasAutoSelected = useRef(false);
+  useEffect(() => {
+    if (hasAutoSelected.current || models.length === 0) return;
+    const currentExists = models.some(
+      (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,
+    );
+    if (!currentExists) {
+      // Pick the first model from the highest-priority provider
+      const sorted = [...models].sort((a, b) => {
+        const aIdx = PROVIDER_PRIORITY.indexOf(a.provider.toLowerCase());
+        const bIdx = PROVIDER_PRIORITY.indexOf(b.provider.toLowerCase());
+        return (aIdx === -1 ? 999 : aIdx) - (bIdx === -1 ? 999 : bIdx);
+      });
+      const best = sorted[0];
+      if (best) {
+        onChange({ model: best.id, provider: best.provider, source: best.source });
+      }
+    }
+    hasAutoSelected.current = true;
+  }, [models, value, onChange]);
 
   const selectedKey = modelKey({ id: value.model, source: value.source, provider: value.provider });
   const selectedModel = models.find((m) => modelKey(m) === selectedKey);

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -60,15 +60,21 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
       (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,
     );
     if (!currentExists) {
-      // Pick the first model from the highest-priority provider
-      const sorted = [...models].sort((a, b) => {
-        const aIdx = PROVIDER_PRIORITY.indexOf(a.provider.toLowerCase());
-        const bIdx = PROVIDER_PRIORITY.indexOf(b.provider.toLowerCase());
-        return (aIdx === -1 ? 999 : aIdx) - (bIdx === -1 ? 999 : bIdx);
-      });
-      const best = sorted[0];
-      if (best) {
-        onChange({ model: best.id, provider: best.provider, source: best.source });
+      // Pick the first model from the highest-priority provider.
+      // Walk the priority list and return the first model we find.
+      for (const adapter of PROVIDER_PRIORITY) {
+        const match = models.find((m) => m.provider.toLowerCase() === adapter);
+        if (match) {
+          onChange({ model: match.id, provider: match.provider, source: match.source });
+          break;
+        }
+      }
+      // If no priority match, fall back to the first model in the list
+      if (!models.find((m) => PROVIDER_PRIORITY.includes(m.provider.toLowerCase()))) {
+        const first = models[0];
+        if (first) {
+          onChange({ model: first.id, provider: first.provider, source: first.source });
+        }
       }
     }
   }, [models, value, onChange]);

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -62,19 +62,18 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
     if (!currentExists) {
       // Pick the first model from the highest-priority provider.
       // Walk the priority list and return the first model we find.
+      let found = false;
       for (const adapter of PROVIDER_PRIORITY) {
         const match = models.find((m) => m.provider.toLowerCase() === adapter);
         if (match) {
           onChange({ model: match.id, provider: match.provider, source: match.source });
+          found = true;
           break;
         }
       }
       // If no priority match, fall back to the first model in the list
-      if (!models.find((m) => PROVIDER_PRIORITY.includes(m.provider.toLowerCase()))) {
-        const first = models[0];
-        if (first) {
-          onChange({ model: first.id, provider: first.provider, source: first.source });
-        }
+      if (!found && models[0]) {
+        onChange({ model: models[0].id, provider: models[0].provider, source: models[0].source });
       }
     }
   }, [models, value, onChange]);

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { ChevronDown } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -51,10 +51,11 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
     return [...byokList, ...systemList];
   })();
 
-  // Auto-select the best available model if current selection isn't in the list
-  const hasAutoSelected = useRef(false);
+  // Auto-select the best available model if current selection is not in the list.
+  // This handles: initial empty state, provider becoming unavailable, and the
+  // transition from FALLBACK_MODELS to real API data.
   useEffect(() => {
-    if (hasAutoSelected.current || models.length === 0) return;
+    if (models.length === 0) return;
     const currentExists = models.some(
       (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,
     );
@@ -70,7 +71,6 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
         onChange({ model: best.id, provider: best.provider, source: best.source });
       }
     }
-    hasAutoSelected.current = true;
   }, [models, value, onChange]);
 
   const selectedKey = modelKey({ id: value.model, source: value.source, provider: value.provider });


### PR DESCRIPTION
Closes #522

  ## Summary
  Dynamic default model selection based on provider priority instead of hardcoding `claude-sonnet-4-5`.

  ## Type of Change

  - [x] feat - A new feature

  ## Details

  When Anthropic API key is not configured, the AI assistant no longer defaults to an unavailable `claude-sonnet-4-5`. Instead, it dynamically selects the first available model using a configurable priority
  order.

  **Priority order:** Anthropic > OpenAI > DeepSeek > xAI > Moonshot > Z.AI > Google > OpenRouter > Azure > AWS Bedrock

  **Changes across 4 files:**

  - **`frontend/packages/core/src/llm-providers.ts`** — Added `PROVIDER_PRIORITY` constant defining the provider selection order
  - **`frontend/ui/src/features/ai-assistant/components/model-selector.tsx`** — Auto-selects the best available model when current selection is not in the available list (e.g., on first load or when provider
   becomes unavailable)
  - **`frontend/ui/src/features/ai-assistant/components/message-input.tsx`** — Removed hardcoded `claude-sonnet-4-5` default; initial state is now empty, letting ModelSelector auto-pick
  - **`frontend/packages/agent/src/agent.ts`** — New `getDefaultSystemModel()` function checks which system providers have API keys set and picks the first model by priority. Used in both initial and final
  fallback in `resolveModel()`

  **Self-hosting scenario:** If neither Anthropic nor OpenAI is configured but a user has added a Kimi BYOK provider, the model selector will auto-select a Kimi model as the default.

  ## Screenshots / Recordings (if applicable)
  No internal models:
<img width="1278" height="749" alt="截屏2026-03-21 11 40 39" src="https://github.com/user-attachments/assets/03db3d24-62e8-4bd0-bc41-b423ded241da" />
No internal models and no BYOK models:
<img width="1275" height="745" alt="截屏2026-03-21 11 41 42" src="https://github.com/user-attachments/assets/c71b4007-9b2b-45a2-b8e4-cf7eae0fcd28" />
No anthropotic internal model but openAI model:

https://github.com/user-attachments/assets/fea9bf66-403a-4038-920f-bf67aa239757


  ## Checklist

  - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
  - [ ] I have added/updated tests where applicable
  - [ ] I have added screenshots or recordings for UI changes (if applicable)
  - [x] I have updated documentation where necessary