### PR TITLE
fix: add default model IDs for xAI, zAI and Moonshot

### DIFF
--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -518,6 +518,9 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                             "amazon-bedrock": "e.g. anthropic.claude-v2",
                             deepseek: "e.g. deepseek-chat, deepseek-reasoner",
                             openrouter: "e.g. openai/gpt-4o",
+                            xai: "e.g. grok-2, grok-beta",
+                            zai: "e.g. glm-4, glm-3-turbo",
+                            moonshot: "e.g. moonshot-v1-8k, moonshot-v1-32k",
                           }[adapter] || "Model ID"
                         }
                         className="flex-1"

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -518,9 +518,9 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                             "amazon-bedrock": "e.g. anthropic.claude-v2",
                             deepseek: "e.g. deepseek-chat, deepseek-reasoner",
                             openrouter: "e.g. openai/gpt-4o",
-                            xai: "e.g. grok-2, grok-beta",
-                            zai: "e.g. glm-4, glm-3-turbo",
-                            moonshot: "e.g. moonshot-v1-8k, moonshot-v1-32k",
+                            xai: "e.g. grok-4-1-fast-reasoning",
+                            zai: "e.g. glm-5, glm-4.7",
+                            moonshot: "e.g. kimi-k2.5, kimi-k2-thinking",
                           }[adapter] || "Model ID"
                         }
                         className="flex-1"


### PR DESCRIPTION
Fixes #552
Added the following model ID examples for xAI, GLM and Moonshot:

- xAI: grok-4-1-fast-reasoning
- zAI:glm-5, glm-4.7
 - moonshot:kimi-k2.5, kimi-k2-thinking

<img width="494" height="505" alt="image" src="https://github.com/user-attachments/assets/759d55f4-9ec9-419f-9451-4d4596e68852" />
<img width="466" height="467" alt="image copy" src="https://github.com/user-attachments/assets/3b1de6af-3ca7-4cc1-9656-88925cd55efc" />
<img width="480" height="484" alt="image copy 2" src="https://github.com/user-attachments/assets/d3ad09c2-1ed6-4679-a1ff-f6278dff798e" />
<img width="1533" height="822" alt="Screenshot 2026-03-24 at 12 59 41 AM" src="https://github.com/user-attachments/assets/88197cc0-e92b-4b9b-82f0-7dc4aadedea3" />

