### PR TITLE
[Bugfix] production bug fix - remove x-user-name header + session gating + CI ECR naming

### DIFF
--- a/.github/workflows/_docker-images-custom.yml
+++ b/.github/workflows/_docker-images-custom.yml
@@ -10,6 +10,11 @@ on:
         description: "Git branch, tag, or SHA to build images from"
         required: true
         type: string
+      environment:
+        description: "Environment prefix for ECR repos (e.g. traceroot-production)"
+        required: false
+        default: "traceroot-production"
+        type: string
 
 permissions:
   contents: read
@@ -71,7 +76,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.ECR_REGISTRY }}/traceroot-${{ matrix.service }}
+          images: ${{ env.ECR_REGISTRY }}/${{ inputs.environment }}-${{ matrix.service }}
           tags: |
             type=raw,value=latest,enable=${{ inputs.branch_ref == 'main' }}
             type=sha,prefix=sha-
@@ -85,6 +90,10 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }}
+            NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+            NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64

--- a/deploy/terraform/aws/traceroot.tf
+++ b/deploy/terraform/aws/traceroot.tf
@@ -131,6 +131,16 @@ clickhouse:
     enabled: true
     size: ${var.clickhouse_storage_size}
     storageClass: "efs"
+  resources:
+    requests:
+      cpu: "1"
+      memory: "2Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
+  extraEnvVars:
+    - name: MALLOC_CONF
+      value: "background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000"
 
 secrets:
   existingSecret: "traceroot"

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -2,10 +2,12 @@
  * Trace feature hooks
  */
 import { useQuery } from "@tanstack/react-query";
+import { useSession as useAuthSession } from "@/lib/auth-client";
 import { getTraces, getTrace } from "@/lib/api";
 import { getSessions, getSession, type SessionDetailOptions } from "@/lib/api/sessions";
 import { getUsers, type UserQueryOptions } from "@/lib/api/users";
 import type { SessionQueryOptions, TraceQueryOptions } from "@/types/api";
+import type { TraceApiUser } from "@/lib/api/client";
 
 // Individual state hooks (for fine-grained control)
 export { usePagination } from "./use-pagination";
@@ -23,6 +25,11 @@ export { useListPageState } from "./use-list-page-state";
  * Hook for fetching paginated traces list
  */
 export function useTraces(projectId: string, options: TraceQueryOptions = {}) {
+  const { data: authSession, isPending } = useAuthSession();
+  const sessionReady = !isPending && !!authSession?.user;
+  const user: TraceApiUser | undefined = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
   return useQuery({
     queryKey: [
       "traces",
@@ -35,7 +42,8 @@ export function useTraces(projectId: string, options: TraceQueryOptions = {}) {
       options.user_id,
       options.session_id,
     ],
-    queryFn: () => getTraces(projectId, "", options),
+    queryFn: () => getTraces(projectId, "", options, user),
+    enabled: sessionReady && !!projectId,
   });
 }
 
@@ -43,10 +51,15 @@ export function useTraces(projectId: string, options: TraceQueryOptions = {}) {
  * Hook for fetching a single trace with its spans
  */
 export function useTrace(projectId: string, traceId: string, enabled: boolean = true) {
+  const { data: authSession, isPending } = useAuthSession();
+  const sessionReady = !isPending && !!authSession?.user;
+  const user: TraceApiUser | undefined = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
   return useQuery({
     queryKey: ["trace", projectId, traceId],
-    queryFn: () => getTrace(projectId, traceId, ""),
-    enabled,
+    queryFn: () => getTrace(projectId, traceId, "", user),
+    enabled: sessionReady && enabled,
   });
 }
 
@@ -54,6 +67,11 @@ export function useTrace(projectId: string, traceId: string, enabled: boolean = 
  * Hook for fetching paginated users list
  */
 export function useUsers(projectId: string, options: UserQueryOptions = {}) {
+  const { data: authSession, isPending } = useAuthSession();
+  const sessionReady = !isPending && !!authSession?.user;
+  const user: TraceApiUser | undefined = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
   return useQuery({
     queryKey: [
       "users",
@@ -64,7 +82,8 @@ export function useUsers(projectId: string, options: UserQueryOptions = {}) {
       options.start_after,
       options.end_before,
     ],
-    queryFn: () => getUsers(projectId, options),
+    queryFn: () => getUsers(projectId, options, user),
+    enabled: sessionReady && !!projectId,
   });
 }
 
@@ -72,6 +91,11 @@ export function useUsers(projectId: string, options: UserQueryOptions = {}) {
  * Hook for fetching paginated sessions list
  */
 export function useSessions(projectId: string, options: SessionQueryOptions = {}) {
+  const { data: authSession, isPending } = useAuthSession();
+  const sessionReady = !isPending && !!authSession?.user;
+  const user: TraceApiUser | undefined = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
   return useQuery({
     queryKey: [
       "sessions",
@@ -82,7 +106,8 @@ export function useSessions(projectId: string, options: SessionQueryOptions = {}
       options.start_after,
       options.end_before,
     ],
-    queryFn: () => getSessions(projectId, options),
+    queryFn: () => getSessions(projectId, options, user),
+    enabled: sessionReady && !!projectId,
   });
 }
 
@@ -95,9 +120,14 @@ export function useSession(
   options: SessionDetailOptions = {},
   enabled: boolean = true,
 ) {
+  const { data: authSession, isPending } = useAuthSession();
+  const sessionReady = !isPending && !!authSession?.user;
+  const user: TraceApiUser | undefined = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
   return useQuery({
     queryKey: ["session", projectId, sessionId, options.start_after, options.end_before],
-    queryFn: () => getSession(projectId, sessionId, options),
-    enabled,
+    queryFn: () => getSession(projectId, sessionId, options, user),
+    enabled: sessionReady && enabled,
   });
 }

--- a/frontend/ui/src/lib/api/client.ts
+++ b/frontend/ui/src/lib/api/client.ts
@@ -31,20 +31,34 @@ export async function fetchNextApi<T>(endpoint: string, options: RequestInit = {
   return response.json();
 }
 
-/**
- * Fetch from Python backend (for traces - needs user headers)
- */
-export async function fetchTraceApi<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
-  const { data: session } = await authClient.getSession();
+export type TraceApiUser = { id: string; email?: string | null };
 
+/**
+ * Fetch from Python backend (for traces - needs user headers).
+ * Pass `user` from a React hook's session to avoid a redundant getSession() call.
+ */
+export async function fetchTraceApi<T>(
+  endpoint: string,
+  options: RequestInit = {},
+  user?: TraceApiUser,
+): Promise<T> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
 
-  if (session?.user) {
-    headers["x-user-id"] = session.user.id;
-    if (session.user.email) headers["x-user-email"] = session.user.email;
-    if (session.user.name) headers["x-user-name"] = session.user.name;
+  if (user?.id) {
+    headers["x-user-id"] = user.id;
+    if (user.email) headers["x-user-email"] = user.email;
+    // x-user-name intentionally omitted: HTTP headers must be ASCII and the
+    // backend does not use it. Non-ASCII names (e.g. Chinese characters) would
+    // cause a TypeError in the browser's fetch API.
+  } else {
+    // Fallback: fetch session imperatively (for non-hook callers)
+    const { data: session } = await authClient.getSession();
+    if (session?.user) {
+      headers["x-user-id"] = session.user.id;
+      if (session.user.email) headers["x-user-email"] = session.user.email;
+    }
   }
 
   const response = await fetch(`${TRACE_API_BASE}${endpoint}`, {

--- a/frontend/ui/src/lib/api/sessions.ts
+++ b/frontend/ui/src/lib/api/sessions.ts
@@ -2,11 +2,12 @@
  * Sessions API functions (Python backend - ClickHouse)
  */
 import type { SessionDetailResponse, SessionListResponse, SessionQueryOptions } from "@/types/api";
-import { fetchTraceApi } from "./client";
+import { fetchTraceApi, type TraceApiUser } from "./client";
 
 export async function getSessions(
   projectId: string,
   options: SessionQueryOptions = {},
+  user?: TraceApiUser,
 ): Promise<SessionListResponse> {
   const params = new URLSearchParams();
   if (options.page !== undefined) params.set("page", String(options.page));
@@ -18,7 +19,7 @@ export async function getSessions(
   const query = params.toString();
   const endpoint = `/projects/${projectId}/sessions${query ? `?${query}` : ""}`;
 
-  return fetchTraceApi<SessionListResponse>(endpoint);
+  return fetchTraceApi<SessionListResponse>(endpoint, {}, user);
 }
 
 export interface SessionDetailOptions {
@@ -30,6 +31,7 @@ export async function getSession(
   projectId: string,
   sessionId: string,
   options: SessionDetailOptions = {},
+  user?: TraceApiUser,
 ): Promise<SessionDetailResponse> {
   const params = new URLSearchParams();
   if (options.start_after) params.set("start_after", options.start_after);
@@ -38,5 +40,5 @@ export async function getSession(
   const query = params.toString();
   const endpoint = `/projects/${projectId}/sessions/${encodeURIComponent(sessionId)}${query ? `?${query}` : ""}`;
 
-  return fetchTraceApi<SessionDetailResponse>(endpoint);
+  return fetchTraceApi<SessionDetailResponse>(endpoint, {}, user);
 }

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -1,13 +1,14 @@
 /**
  * Trace API functions (Python backend - ClickHouse)
  */
-import { fetchTraceApi } from "./client";
+import { fetchTraceApi, type TraceApiUser } from "./client";
 import type { TraceDetail, TraceListResponse, TraceQueryOptions } from "@/types/api";
 
 export async function getTraces(
   projectId: string,
   _apiKey: string,
   options: TraceQueryOptions = {},
+  user?: TraceApiUser,
 ): Promise<TraceListResponse> {
   const params = new URLSearchParams();
   if (options.page !== undefined) params.set("page", String(options.page));
@@ -23,13 +24,14 @@ export async function getTraces(
   const query = params.toString();
   const endpoint = `/projects/${projectId}/traces${query ? `?${query}` : ""}`;
 
-  return fetchTraceApi<TraceListResponse>(endpoint);
+  return fetchTraceApi<TraceListResponse>(endpoint, {}, user);
 }
 
 export async function getTrace(
   projectId: string,
   traceId: string,
   _apiKey: string,
+  user?: TraceApiUser,
 ): Promise<TraceDetail> {
-  return fetchTraceApi<TraceDetail>(`/projects/${projectId}/traces/${traceId}`);
+  return fetchTraceApi<TraceDetail>(`/projects/${projectId}/traces/${traceId}`, {}, user);
 }

--- a/frontend/ui/src/lib/api/users.ts
+++ b/frontend/ui/src/lib/api/users.ts
@@ -1,7 +1,7 @@
 /**
  * Users API functions (Python backend - ClickHouse)
  */
-import { fetchTraceApi } from "./client";
+import { fetchTraceApi, type TraceApiUser } from "./client";
 
 export interface UserListItem {
   user_id: string;
@@ -29,6 +29,7 @@ export interface UserQueryOptions {
 export async function getUsers(
   projectId: string,
   options: UserQueryOptions = {},
+  user?: TraceApiUser,
 ): Promise<UserListResponse> {
   const params = new URLSearchParams();
   if (options.page !== undefined) params.set("page", String(options.page));
@@ -40,5 +41,5 @@ export async function getUsers(
   const query = params.toString();
   const endpoint = `/projects/${projectId}/users${query ? `?${query}` : ""}`;
 
-  return fetchTraceApi<UserListResponse>(endpoint);
+  return fetchTraceApi<UserListResponse>(endpoint, {}, user);
 }


### PR DESCRIPTION
## Overview

This PR contains exactly **7 file changes** — no more, no less. Each change is described in detail below.

---

## Files Changed

### 1. `frontend/ui/src/lib/api/client.ts`
**Root cause fix.**

- Removed `x-user-name` from the HTTP headers set on every `fetchTraceApi` call.
- Added `TraceApiUser` type (`{ id: string; email?: string | null }`) — name field intentionally excluded.
- `fetchTraceApi` now accepts an optional `user?: TraceApiUser` parameter. When provided, it uses the value directly instead of calling `authClient.getSession()` again.

**Why:** Non-ASCII characters in HTTP headers (e.g. Chinese name `王秋丹`, extended Latin `đ`, `ć`) cause a browser `TypeError` in the Fetch API. This silently killed the request before it ever reached the server, resulting in "Error loading traces" for affected users. Removing `x-user-name` fixes the crash. The backend does not use `x-user-name` at all.

---

### 2. `frontend/ui/src/features/traces/hooks/index.ts`
**Session race condition fix.**

All 5 data hooks (`useTraces`, `useTrace`, `useUsers`, `useSessions`, `useSession`) updated to:
1. Extract `user` from `useAuthSession()` hook.
2. Gate each query with `enabled: sessionReady && !!projectId` — prevents queries from firing before auth resolves.
3. Pass `user` directly to the API call — avoids a redundant imperative `authClient.getSession()` call inside `fetchTraceApi`.

---

### 3. `frontend/ui/src/lib/api/traces.ts`
**Plumbing.**

`getTraces` and `getTrace` now accept and forward an optional `user?: TraceApiUser` parameter to `fetchTraceApi`.

---

### 4. `frontend/ui/src/lib/api/sessions.ts`
**Plumbing.**

`getSessions` and `getSession` now accept and forward an optional `user?: TraceApiUser` parameter to `fetchTraceApi`.

---

### 5. `frontend/ui/src/lib/api/users.ts`
**Plumbing.**

`getUsers` now accepts and forwards an optional `user?: TraceApiUser` parameter to `fetchTraceApi`.

---

### 6. `.github/workflows/_docker-images-custom.yml`
**CI fix.**

- Added `environment` input (default: `traceroot-production`) — corrects ECR repo names from `traceroot-{service}` to `traceroot-production-{service}`.
- Added `NEXT_PUBLIC_APP_URL`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST` as Docker build args so these env vars are correctly baked into the Next.js client bundle at build time.

---

### 7. `deploy/terraform/aws/traceroot.tf`
**Ops stability.**

- Added ClickHouse CPU/memory resource limits (`cpu: 1–2 cores`, `memory: 2–4Gi`).
- Added `MALLOC_CONF` jemalloc tuning env var to reduce memory fragmentation and lower risk of `MEMORY_LIMIT_EXCEEDED` errors.

---

<img width="1496" height="938" alt="Screenshot 2026-03-26 at 3 57 38 PM" src="https://github.com/user-attachments/assets/6d05ae71-3306-472c-b667-e85c49351e05" />


## Test Plan
- [x] Deployed as `sha-40bc4f1` on branch `fix/auth-session-race-condition` — users with non-ASCII names now load traces successfully
- [x] Users with ASCII names continue to work as before
- [x] CI builds push to correct ECR repos (`traceroot-production-{service}`)