### PR TITLE
Do not show agent chat button in all places

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/layout.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/layout.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { BotMessageSquare } from "lucide-react";
+import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
+
+export default function ProjectLayout({ children }: { children: React.ReactNode }) {
+  const params = useParams();
+  const projectId = params.projectId as string;
+  const [aiPanelOpen, setAiPanelOpen] = useState(false);
+
+  return (
+    <div className="flex h-full">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        {/* Project header with AI button */}
+        <header className="flex h-14 items-center justify-end gap-2 border-b bg-background px-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            onClick={() => setAiPanelOpen(!aiPanelOpen)}
+            title="AI Assistant"
+          >
+            <BotMessageSquare className="h-4 w-4" />
+          </Button>
+        </header>
+        <main className="flex-1 overflow-hidden">{children}</main>
+      </div>
+      <AiAssistantPanel open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+    </div>
+  );
+}

--- a/frontend/ui/src/app/projects/[projectId]/layout.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/layout.tsx
@@ -1,34 +1,42 @@
 "use client";
 
 import { useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { BotMessageSquare } from "lucide-react";
 import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
 
 export default function ProjectLayout({ children }: { children: React.ReactNode }) {
   const params = useParams();
+  const pathname = usePathname();
   const projectId = params.projectId as string;
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
+
+  // Hide AI button on settings pages
+  const showAiButton = !pathname.includes("/settings");
 
   return (
     <div className="flex h-full">
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         {/* Project header with AI button */}
         <header className="flex h-14 items-center justify-end gap-2 border-b bg-background px-3">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 shrink-0"
-            onClick={() => setAiPanelOpen(!aiPanelOpen)}
-            title="AI Assistant"
-          >
-            <BotMessageSquare className="h-4 w-4" />
-          </Button>
+          {showAiButton && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0"
+              onClick={() => setAiPanelOpen(!aiPanelOpen)}
+              title="AI Assistant"
+            >
+              <BotMessageSquare className="h-4 w-4" />
+            </Button>
+          )}
         </header>
         <main className="flex-1 overflow-hidden">{children}</main>
       </div>
-      <AiAssistantPanel open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      {showAiButton && (
+        <AiAssistantPanel open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+      )}
     </div>
   );
 }

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -4,8 +4,7 @@ import { useState, createContext, useContext, ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { Button } from "@/components/ui/button";
-import { PanelLeft, BotMessageSquare } from "lucide-react";
-import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
+import { PanelLeft } from "lucide-react";
 
 interface LayoutContextType {
   sidebarCollapsed: boolean;
@@ -28,7 +27,6 @@ export function useLayout() {
 export function AppLayout({ children }: { children: React.ReactNode }) {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [headerContent, setHeaderContent] = useState<ReactNode>(null);
-  const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const pathname = usePathname();
 
   // Don't show layout on auth pages
@@ -59,21 +57,9 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
               <PanelLeft className="h-4 w-4" />
             </Button>
             {headerContent}
-            <div className="ml-auto">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 shrink-0"
-                onClick={() => setAiPanelOpen(!aiPanelOpen)}
-                title="AI Assistant"
-              >
-                <BotMessageSquare className="h-4 w-4" />
-              </Button>
-            </div>
           </header>
           <main className="flex-1 overflow-hidden">{children}</main>
         </div>
-        <AiAssistantPanel open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
       </div>
     </LayoutContext.Provider>
   );

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -20,17 +20,16 @@ interface AiAssistantPanelProps {
 export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
   const { width, onMouseDown } = usePanelResize();
   const params = useParams();
-  const projectId = params?.projectId as string | undefined;
-  const workspaceIdFromUrl = params?.workspaceId as string | undefined;
+  const projectId = params.projectId as string;
 
   const { data: project } = useQuery({
     queryKey: ["project", projectId],
-    queryFn: () => getProject(projectId!),
+    queryFn: () => getProject(projectId),
     enabled: !!projectId,
   });
 
-  // workspaceId from URL (workspace pages) or from project (project pages)
-  const workspaceId = workspaceIdFromUrl || project?.workspace_id;
+  // workspaceId derived from project (always available in project context)
+  const workspaceId = project?.workspace_id || "";
 
   // Check if any models are available (system or BYOK)
   const { data: llmModels } = useQuery({


### PR DESCRIPTION
## Summary
Fixes #557.

**Before:** AI chat button was globally floating and visible on all pages, allowing users to open chat without selecting a project(this was violating the api constraint that `projectId` is mandatory for AI sessions)

**After:** AI button only appears within `/projects/[projectId]/*` routes (traces, users, sessions pages) and is hidden on settings pages. The button is now properly scoped to projects.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
**Changes Made:**
1. Removed AI panel and button from global `AppLayout` (`frontend/ui/src/components/layout/app-layout.tsx`)
2. Created new `/projects/[projectId]/layout.tsx` that wraps all project pages with AI button and panel
3. Added `usePathname()` check to conditionally hide button on `/settings/*` routes
4. Modified `ai-assistant-panel.tsx` to require `projectId` as non-optional and removed `workspaceId` fallback logic

**Known Trade-off:**
- Traces page has its own `AiChatOverlay` component with trace context, while the layout also renders `AiAssistantPanel` with project context. This is redundant but causes no UI conflict (overlay takes precedence when trace modal opens). Can be addressed in future work.

## Screenshots / Recordings (if applicable)
[Screencast from 2026-03-28 02-54-42.webm](https://github.com/user-attachments/assets/21eacbc9-1776-4b4d-b354-f165e451077b)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
