### PR TITLE
fix: do not show agent chat button in all places(using path matching)

### DIFF
--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -31,7 +31,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const pathname = usePathname();
   const isProjectPage = /^\/projects\/[^/]+/.test(pathname);
-  const isProjectSettingsPage = /^\/projects\/[^/]+\/settings/.test(pathname);
+  const isProjectSettingsPage = /^\/projects\/[^/]+\/settings(\/|$)/.test(pathname);
   const showAiButton = isProjectPage && !isProjectSettingsPage;
 
   // Don't show layout on auth pages

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -30,6 +30,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [headerContent, setHeaderContent] = useState<ReactNode>(null);
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const pathname = usePathname();
+  const isProjectPage = /^\/projects\/[^/]/.test(pathname);
 
   // Don't show layout on auth pages
   if (pathname.startsWith("/auth/")) {
@@ -59,21 +60,25 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
               <PanelLeft className="h-4 w-4" />
             </Button>
             {headerContent}
-            <div className="ml-auto">
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-8 w-8 shrink-0"
-                onClick={() => setAiPanelOpen(!aiPanelOpen)}
-                title="AI Assistant"
-              >
-                <BotMessageSquare className="h-4 w-4" />
-              </Button>
-            </div>
+            {isProjectPage && (
+              <div className="ml-auto">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8 shrink-0"
+                  onClick={() => setAiPanelOpen(!aiPanelOpen)}
+                  title="AI Assistant"
+                >
+                  <BotMessageSquare className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
           </header>
           <main className="flex-1 overflow-hidden">{children}</main>
         </div>
-        <AiAssistantPanel open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+        {isProjectPage && (
+          <AiAssistantPanel open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
+        )}
       </div>
     </LayoutContext.Provider>
   );

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -30,7 +30,9 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [headerContent, setHeaderContent] = useState<ReactNode>(null);
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const pathname = usePathname();
-  const isProjectPage = /^\/projects\/[^/]/.test(pathname);
+  const isProjectPage = /^\/projects\/[^/]+/.test(pathname);
+  const isProjectSettingsPage = /^\/projects\/[^/]+\/settings/.test(pathname);
+  const showAiButton = isProjectPage && !isProjectSettingsPage;
 
   // Don't show layout on auth pages
   if (pathname.startsWith("/auth/")) {
@@ -60,7 +62,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
               <PanelLeft className="h-4 w-4" />
             </Button>
             {headerContent}
-            {isProjectPage && (
+            {showAiButton && (
               <div className="ml-auto">
                 <Button
                   variant="ghost"
@@ -76,7 +78,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           </header>
           <main className="flex-1 overflow-hidden">{children}</main>
         </div>
-        {isProjectPage && (
+        {showAiButton && (
           <AiAssistantPanel open={aiPanelOpen} onClose={() => setAiPanelOpen(false)} />
         )}
       </div>

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -96,7 +96,7 @@ export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
             <SessionHistory
               sessions={sessions}
               currentSessionId={currentSessionId}
-              projectId={projectId || ""}
+              projectId={projectId}
               onSelect={handleSelectSession}
               onDelete={handleDeleteSession}
             />
@@ -109,11 +109,7 @@ export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
       </div>
 
       {/* Messages */}
-      {!projectId ? (
-        <div className="flex flex-1 items-center justify-center px-6 text-center text-[13px] text-muted-foreground">
-          Open a project to start using the AI assistant.
-        </div>
-      ) : !hasModels ? (
+      {!hasModels ? (
         <div className="flex flex-1 items-center justify-center px-6">
           <div className="flex max-w-[280px] flex-col items-center gap-3 text-center">
             <AlertTriangle className="h-8 w-8 text-yellow-500" />

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -20,17 +20,16 @@ interface AiAssistantPanelProps {
 export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
   const { width, onMouseDown } = usePanelResize();
   const params = useParams();
-  const projectId = params?.projectId as string | undefined;
-  const workspaceIdFromUrl = params?.workspaceId as string | undefined;
+  const projectId = params?.projectId as string;
 
   const { data: project } = useQuery({
     queryKey: ["project", projectId],
-    queryFn: () => getProject(projectId!),
+    queryFn: () => getProject(projectId),
     enabled: !!projectId,
   });
 
-  // workspaceId from URL (workspace pages) or from project (project pages)
-  const workspaceId = workspaceIdFromUrl || project?.workspace_id;
+  // workspaceId from project (only available on project pages)
+  const workspaceId = project?.workspace_id;
 
   // Check if any models are available (system or BYOK)
   const { data: llmModels } = useQuery({


### PR DESCRIPTION
## Summary
Fixes #557 

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
**Changes Made:**
1. Added pathname regex checks in `AppLayout` to conditionally show AI button/panel only on project pages (excluding settings)
2. Removed workspace fallback logic from `AiAssistantPanel` - now only uses projectId and derives workspaceId from project

**How it works:**
- `isProjectPage` regex: `/^\/projects\/[^/]+/` → matches all `/projects/[projectId]/*` routes
- `isProjectSettingsPage` regex: `/^\/projects\/[^/]+\/settings/` → matches settings sub-routes
- AI button/panel only render when `isProjectPage && !isProjectSettingsPage`
- projectId is guaranteed to exist when panel renders

## Screenshots / Recordings (if applicable)
[Screencast from 2026-03-28 04-13-57.webm](https://github.com/user-attachments/assets/ea182fb7-dabd-4a48-bebc-28f778240715)


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
