### PR TITLE
[User Experience] Improving onboarding flow [3/n]

### DIFF
--- a/frontend/ui/src/app/onboarding/page.tsx
+++ b/frontend/ui/src/app/onboarding/page.tsx
@@ -119,7 +119,7 @@ function OnboardingContent() {
 
       queryClient.invalidateQueries({ queryKey: ["workspaces"] });
 
-      router.push(`/projects/${project.id}/settings/accessKeys`);
+      router.push(`/projects/${project.id}/traces`);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
       setIsLoading(false);

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -52,10 +52,16 @@ export default function TracesPage() {
     user_id: userId || undefined,
   });
 
+  // Check if project has EVER sent traces (no date filter) — controls onboarding visibility
+  const { data: anyTracesData, isLoading: hasEverTracedLoading } = useTraces(projectId, {
+    limit: 1,
+  });
+  const hasEverTraced = (anyTracesData?.data?.length ?? 0) > 0;
+
   const traces = data?.data || [];
   const meta = data?.meta || { page: 0, limit: 50, total: 0 };
   const totalPages = Math.ceil(meta.total / meta.limit);
-  const showGettingStarted = !isLoading && !error && traces.length === 0;
+  const showGettingStarted = !hasEverTracedLoading && !hasEverTraced;
 
   const buildUrl = (path: string, extraParams?: Record<string, string>) =>
     buildUrlWithFilters(path, {
@@ -129,7 +135,7 @@ export default function TracesPage() {
 
         {/* Content */}
         <div className="flex-1 overflow-auto bg-background">
-          {isLoading ? (
+          {isLoading || hasEverTracedLoading ? (
             <div className="flex h-64 items-center justify-center">
               <p className="text-[13px] text-muted-foreground">Loading traces...</p>
             </div>

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
@@ -27,6 +28,7 @@ export default function TracesPage() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const projectId = params.projectId as string;
+  const queryClient = useQueryClient();
   const { aiPanelOpen, setAiPanelOpen } = useLayout();
   const userId = searchParams.get("user_id");
   const traceIdFromUrl = searchParams.get("traceId");
@@ -70,6 +72,9 @@ export default function TracesPage() {
     },
   );
   const hasEverTraced = (anyTracesData?.data?.length ?? 0) > 0;
+  useEffect(() => {
+    if (hasEverTraced) queryClient.invalidateQueries({ queryKey: ["traces", projectId] });
+  }, [hasEverTraced, projectId, queryClient]);
 
   const traces = data?.data || [];
   const meta = data?.meta || { page: 0, limit: 50, total: 0 };

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -12,7 +12,7 @@ import { ProjectBreadcrumb } from "@/features/projects/components";
 import { formatDuration, formatDate, cn, buildUrlWithFilters } from "@/lib/utils";
 import type { TraceListItem } from "@/types/api";
 import { useTraces, useListPageState } from "@/features/traces/hooks";
-import { TraceViewerPanel } from "@/features/traces/components";
+import { TraceViewerPanel, GettingStarted } from "@/features/traces/components";
 import { formatContentPreview } from "@/features/traces/utils";
 
 // Tab definitions
@@ -136,12 +136,7 @@ export default function TracesPage() {
               </p>
             </div>
           ) : traces.length === 0 ? (
-            <div className="flex h-64 flex-col items-center justify-center gap-3">
-              <p className="text-[13px] text-muted-foreground">No traces found</p>
-              <p className="text-[12px] text-muted-foreground">
-                Start sending traces using the SDK to see them here.
-              </p>
-            </div>
+            <GettingStarted projectId={projectId} />
           ) : (
             <div className="flex h-full flex-col">
               <div className="flex-1 overflow-auto">

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -55,6 +55,7 @@ export default function TracesPage() {
   const traces = data?.data || [];
   const meta = data?.meta || { page: 0, limit: 50, total: 0 };
   const totalPages = Math.ceil(meta.total / meta.limit);
+  const showGettingStarted = !isLoading && !error && traces.length === 0;
 
   const buildUrl = (path: string, extraParams?: Record<string, string>) =>
     buildUrlWithFilters(path, {
@@ -70,57 +71,61 @@ export default function TracesPage() {
 
       {/* Main content */}
       <div className="flex flex-1 flex-col">
-        {/* Tab navigation */}
-        <div className="border-b border-border bg-background">
-          <div className="flex">
-            {tabs.map((tab) => {
-              const Icon = tab.icon;
-              const isActive = tab.id === "traces";
-              return (
-                <Link
-                  key={tab.id}
-                  href={buildUrl(`/projects/${projectId}/${tab.href}`)}
-                  className={cn(
-                    "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
-                    isActive
-                      ? "border-foreground bg-muted text-foreground"
-                      : "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-                  )}
-                >
-                  <Icon className="h-3.5 w-3.5" />
-                  {tab.label}
-                </Link>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Filters bar */}
-        <SearchFilterBar
-          searchValue={state.keyword}
-          onSearchChange={updateKeyword}
-          searchPlaceholder="Search..."
-          dateFilter={state.dateFilter}
-          customStartDate={state.customStartDate}
-          customEndDate={state.customEndDate}
-          onDateFilterChange={updateDateFilter}
-          onCustomRangeChange={updateCustomRange}
-        >
-          {userId && (
-            <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 py-1 pl-2.5 pr-1.5">
-              <Users className="h-3 w-3 text-muted-foreground" />
-              <span className="text-[12px] text-muted-foreground">User:</span>
-              <span className="text-[12px] font-medium text-foreground">{userId}</span>
-              <button
-                type="button"
-                onClick={() => router.push(buildUrl(`/projects/${projectId}/traces`))}
-                className="ml-1 rounded p-0.5 transition-colors hover:bg-muted"
-              >
-                <X className="h-3 w-3 text-muted-foreground" />
-              </button>
+        {/* Tab navigation — hidden during onboarding */}
+        {!showGettingStarted && (
+          <div className="border-b border-border bg-background">
+            <div className="flex">
+              {tabs.map((tab) => {
+                const Icon = tab.icon;
+                const isActive = tab.id === "traces";
+                return (
+                  <Link
+                    key={tab.id}
+                    href={buildUrl(`/projects/${projectId}/${tab.href}`)}
+                    className={cn(
+                      "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
+                      isActive
+                        ? "border-foreground bg-muted text-foreground"
+                        : "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                    )}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                    {tab.label}
+                  </Link>
+                );
+              })}
             </div>
-          )}
-        </SearchFilterBar>
+          </div>
+        )}
+
+        {/* Filters bar — hidden during onboarding */}
+        {!showGettingStarted && (
+          <SearchFilterBar
+            searchValue={state.keyword}
+            onSearchChange={updateKeyword}
+            searchPlaceholder="Search..."
+            dateFilter={state.dateFilter}
+            customStartDate={state.customStartDate}
+            customEndDate={state.customEndDate}
+            onDateFilterChange={updateDateFilter}
+            onCustomRangeChange={updateCustomRange}
+          >
+            {userId && (
+              <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 py-1 pl-2.5 pr-1.5">
+                <Users className="h-3 w-3 text-muted-foreground" />
+                <span className="text-[12px] text-muted-foreground">User:</span>
+                <span className="text-[12px] font-medium text-foreground">{userId}</span>
+                <button
+                  type="button"
+                  onClick={() => router.push(buildUrl(`/projects/${projectId}/traces`))}
+                  className="ml-1 rounded p-0.5 transition-colors hover:bg-muted"
+                >
+                  <X className="h-3 w-3 text-muted-foreground" />
+                </button>
+              </div>
+            )}
+          </SearchFilterBar>
+        )}
 
         {/* Content */}
         <div className="flex-1 overflow-auto bg-background">

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -54,10 +54,20 @@ export default function TracesPage() {
 
   // Check if project has EVER sent traces (no date filter) — controls onboarding visibility.
   // staleTime: Infinity because once a project has traces it always will (immutable fact).
+  // refetchInterval polls every 3s while onboarding is shown so the page auto-transitions
+  // when the first trace arrives, without requiring a manual refresh.
   const { data: anyTracesData, isLoading: hasEverTracedLoading } = useTraces(
     projectId,
     { limit: 1 },
-    { staleTime: Infinity },
+    {
+      staleTime: Infinity,
+      refetchInterval: (query: unknown) => {
+        const hasTraces =
+          ((query as { state?: { data?: { data?: unknown[] } } })?.state?.data?.data?.length ?? 0) >
+          0;
+        return hasTraces ? false : 3000;
+      },
+    },
   );
   const hasEverTraced = (anyTracesData?.data?.length ?? 0) > 0;
 

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -52,10 +52,13 @@ export default function TracesPage() {
     user_id: userId || undefined,
   });
 
-  // Check if project has EVER sent traces (no date filter) — controls onboarding visibility
-  const { data: anyTracesData, isLoading: hasEverTracedLoading } = useTraces(projectId, {
-    limit: 1,
-  });
+  // Check if project has EVER sent traces (no date filter) — controls onboarding visibility.
+  // staleTime: Infinity because once a project has traces it always will (immutable fact).
+  const { data: anyTracesData, isLoading: hasEverTracedLoading } = useTraces(
+    projectId,
+    { limit: 1 },
+    { staleTime: Infinity },
+  );
   const hasEverTraced = (anyTracesData?.data?.length ?? 0) > 0;
 
   const traces = data?.data || [];

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -80,8 +80,8 @@ export default function TracesPage() {
 
       {/* Main content */}
       <div className="flex flex-1 flex-col">
-        {/* Tab navigation — hidden during onboarding */}
-        {!showGettingStarted && (
+        {/* Tab navigation — hidden during onboarding or while checking */}
+        {!hasEverTracedLoading && !showGettingStarted && (
           <div className="border-b border-border bg-background">
             <div className="flex">
               {tabs.map((tab) => {
@@ -107,8 +107,8 @@ export default function TracesPage() {
           </div>
         )}
 
-        {/* Filters bar — hidden during onboarding */}
-        {!showGettingStarted && (
+        {/* Filters bar — hidden during onboarding or while checking */}
+        {!hasEverTracedLoading && !showGettingStarted && (
           <SearchFilterBar
             searchValue={state.keyword}
             onSearchChange={updateKeyword}

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -146,8 +146,15 @@ export default function TracesPage() {
                 Make sure the API server is running and you have API keys configured.
               </p>
             </div>
-          ) : traces.length === 0 ? (
+          ) : showGettingStarted ? (
             <GettingStarted projectId={projectId} />
+          ) : traces.length === 0 ? (
+            <div className="flex h-64 flex-col items-center justify-center gap-3">
+              <p className="text-[13px] text-muted-foreground">No traces found</p>
+              <p className="text-[12px] text-muted-foreground">
+                Try adjusting your filters or date range.
+              </p>
+            </div>
           ) : (
             <div className="flex h-full flex-col">
               <div className="flex-1 overflow-auto">

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -62,13 +62,13 @@ export function GitHubStarWidget() {
         href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex rounded border border-border text-[11px] font-medium transition-colors hover:bg-muted/50"
+        className="flex w-full overflow-hidden rounded border border-border text-[11px] font-medium transition-colors hover:bg-muted/50"
       >
-        <span className="flex items-center gap-1.5 px-2.5 py-1.5">
+        <span className="flex items-center gap-1 px-1.5 py-1">
           <GitHubIcon className="h-3 w-3 shrink-0" />
           traceroot
         </span>
-        <span className="flex items-center gap-1 whitespace-nowrap border-l border-border px-2.5 py-1.5 text-muted-foreground">
+        <span className="flex shrink-0 items-center gap-1 border-l border-border px-1.5 py-1 text-muted-foreground">
           ★ {starCount !== null ? formatStarCount(starCount) : "—"}
         </span>
       </a>

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -1,19 +1,13 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { X } from "lucide-react";
+import { X, Github } from "lucide-react";
 import { clientEnv } from "@/env.client";
 
-const STORAGE_KEY = "github-star-widget-dismissed";
+const DISMISSED_KEY = "github-star-widget-dismissed";
+const STAR_CACHE_KEY = "github-star-count-cache";
+const STAR_CACHE_TTL = 60 * 60 * 1000; // 1 hour
 const REPO = "traceroot-ai/traceroot";
-
-function GitHubIcon({ className }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
-      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
-    </svg>
-  );
-}
 
 function formatStarCount(n: number): string {
   return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
@@ -24,15 +18,31 @@ export function GitHubStarWidget() {
   const [starCount, setStarCount] = useState<number | null>(null);
 
   useEffect(() => {
-    setDismissed(localStorage.getItem(STORAGE_KEY) === "true");
+    setDismissed(localStorage.getItem(DISMISSED_KEY) === "true");
   }, []);
 
   useEffect(() => {
+    const cached = localStorage.getItem(STAR_CACHE_KEY);
+    if (cached) {
+      try {
+        const { count, timestamp } = JSON.parse(cached) as { count: number; timestamp: number };
+        if (Date.now() - timestamp < STAR_CACHE_TTL) {
+          setStarCount(count);
+          return;
+        }
+      } catch {
+        // malformed cache entry — fall through to fetch
+      }
+    }
     fetch(`https://api.github.com/repos/${REPO}`)
       .then((r) => r.json())
       .then((data: { stargazers_count?: number }) => {
         if (typeof data.stargazers_count === "number") {
           setStarCount(data.stargazers_count);
+          localStorage.setItem(
+            STAR_CACHE_KEY,
+            JSON.stringify({ count: data.stargazers_count, timestamp: Date.now() }),
+          );
         }
       })
       .catch(() => {});
@@ -47,7 +57,7 @@ export function GitHubStarWidget() {
         <button
           className="flex h-4 w-4 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
           onClick={() => {
-            localStorage.setItem(STORAGE_KEY, "true");
+            localStorage.setItem(DISMISSED_KEY, "true");
             setDismissed(true);
           }}
           aria-label="Dismiss"
@@ -65,7 +75,7 @@ export function GitHubStarWidget() {
         className="flex w-full overflow-hidden rounded border border-border text-[11px] font-medium transition-colors hover:bg-muted/50"
       >
         <span className="flex items-center gap-1 px-1.5 py-1">
-          <GitHubIcon className="h-3 w-3 shrink-0" />
+          <Github className="h-3 w-3 shrink-0" />
           traceroot
         </span>
         <span className="flex shrink-0 items-center gap-1 border-l border-border py-1 pl-1.5 pr-2.5 text-muted-foreground">

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -76,7 +76,7 @@ export function GitHubStarWidget() {
       >
         <span className="flex items-center gap-1 px-1.5 py-1">
           <Github className="h-3 w-3 shrink-0" />
-          TraceRoot
+          traceroot
         </span>
         <span className="flex flex-1 items-center justify-center gap-1 border-l border-border py-1 text-muted-foreground">
           ★ {starCount !== null ? formatStarCount(starCount) : "—"}

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -62,13 +62,13 @@ export function GitHubStarWidget() {
         href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex overflow-hidden rounded border border-border text-[11px] font-medium transition-colors hover:bg-muted/50"
+        className="inline-flex rounded border border-border text-[11px] font-medium transition-colors hover:bg-muted/50"
       >
-        <span className="flex items-center gap-1.5 px-2 py-1.5">
+        <span className="flex items-center gap-1.5 px-2.5 py-1.5">
           <GitHubIcon className="h-3 w-3 shrink-0" />
           traceroot
         </span>
-        <span className="flex items-center gap-1 whitespace-nowrap border-l border-border px-2 py-1.5 text-muted-foreground">
+        <span className="flex items-center gap-1 whitespace-nowrap border-l border-border px-2.5 py-1.5 text-muted-foreground">
           ★ {starCount !== null ? formatStarCount(starCount) : "—"}
         </span>
       </a>

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -62,13 +62,13 @@ export function GitHubStarWidget() {
         href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="flex overflow-hidden rounded border text-[11px] font-medium transition-opacity hover:opacity-80"
+        className="flex overflow-hidden rounded border border-border text-[11px] font-medium transition-colors hover:bg-muted/50"
       >
-        <span className="flex flex-1 items-center gap-1.5 bg-muted px-2 py-1">
+        <span className="flex flex-1 items-center gap-1.5 px-2 py-1.5">
           <GitHubIcon className="h-3 w-3 shrink-0" />
           traceroot
         </span>
-        <span className="flex items-center gap-1 whitespace-nowrap border-l bg-muted px-2 py-1 text-muted-foreground">
+        <span className="flex items-center gap-1 whitespace-nowrap border-l border-border px-2 py-1.5 text-muted-foreground">
           ★ {starCount !== null ? formatStarCount(starCount) : "—"}
         </span>
       </a>

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -66,7 +66,8 @@ export function GitHubStarWidget() {
         </button>
       </div>
       <p className="mb-2 text-[11px] leading-snug text-muted-foreground">
-        Open source and shipping fast. Made with ❤️ by contributors.
+        Open source and shipping fast. <br />
+        Made with ❤️ by contributors.
       </p>
       <a
         href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -66,8 +66,7 @@ export function GitHubStarWidget() {
         </button>
       </div>
       <p className="mb-2 text-[11px] leading-snug text-muted-foreground">
-        Open source and shipping fast. <br />
-        Made with ❤️ by contributors.
+        Open source and shipping fast. Made with ❤️ by contributors.
       </p>
       <a
         href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -51,7 +51,7 @@ export function GitHubStarWidget() {
   if (dismissed) return null;
 
   return (
-    <div className="mx-1.5 mb-1 rounded-md border p-2">
+    <div className="mx-1.5 mb-1 rounded-md border p-1.5">
       <div className="mb-1.5 flex items-center justify-between">
         <span className="text-xs font-semibold">Star TraceRoot</span>
         <button

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -53,7 +53,7 @@ export function GitHubStarWidget() {
   return (
     <div className="mx-1.5 mb-1 rounded-md border p-2">
       <div className="mb-1.5 flex items-center justify-between">
-        <span className="text-xs font-semibold">Star traceroot</span>
+        <span className="text-xs font-semibold">Star TraceRoot</span>
         <button
           className="flex h-4 w-4 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
           onClick={() => {
@@ -77,9 +77,9 @@ export function GitHubStarWidget() {
       >
         <span className="flex items-center gap-1 px-1.5 py-1">
           <Github className="h-3 w-3 shrink-0" />
-          traceroot
+          TraceRoot
         </span>
-        <span className="flex shrink-0 items-center gap-1 border-l border-border py-1 pl-1.5 pr-2.5 text-muted-foreground">
+        <span className="flex flex-1 items-center justify-center gap-1 border-l border-border py-1 text-muted-foreground">
           ★ {starCount !== null ? formatStarCount(starCount) : "—"}
         </span>
       </a>

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -66,7 +66,7 @@ export function GitHubStarWidget() {
         </button>
       </div>
       <p className="mb-2 text-[11px] leading-snug text-muted-foreground">
-        If TraceRoot helps, a star goes a long way.
+        Open source and shipping fast. Made with ❤️ by contributors.
       </p>
       <a
         href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+import { clientEnv } from "@/env.client";
+
+const STORAGE_KEY = "github-star-widget-dismissed";
+const REPO = "traceroot-ai/traceroot";
+
+function GitHubIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+      <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
+    </svg>
+  );
+}
+
+function formatStarCount(n: number): string {
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n);
+}
+
+export function GitHubStarWidget() {
+  const [dismissed, setDismissed] = useState(true); // true initially to avoid flash
+  const [starCount, setStarCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    setDismissed(localStorage.getItem(STORAGE_KEY) === "true");
+  }, []);
+
+  useEffect(() => {
+    fetch(`https://api.github.com/repos/${REPO}`)
+      .then((r) => r.json())
+      .then((data: { stargazers_count?: number }) => {
+        if (typeof data.stargazers_count === "number") {
+          setStarCount(data.stargazers_count);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  if (dismissed) return null;
+
+  return (
+    <div className="mx-2 mb-1 rounded-md border p-2.5">
+      <div className="mb-1.5 flex items-center justify-between">
+        <span className="text-xs font-semibold">Star traceroot</span>
+        <button
+          className="flex h-4 w-4 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+          onClick={() => {
+            localStorage.setItem(STORAGE_KEY, "true");
+            setDismissed(true);
+          }}
+          aria-label="Dismiss"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+      <p className="mb-2 text-[11px] leading-snug text-muted-foreground">
+        See the latest releases and help grow the community on GitHub.
+      </p>
+      <a
+        href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex overflow-hidden rounded border text-[11px] font-medium transition-opacity hover:opacity-80"
+      >
+        <span className="flex flex-1 items-center gap-1.5 bg-muted px-2 py-1">
+          <GitHubIcon className="h-3 w-3 shrink-0" />
+          traceroot
+        </span>
+        <span className="flex items-center gap-1 whitespace-nowrap border-l bg-muted px-2 py-1 text-muted-foreground">
+          ★ {starCount !== null ? formatStarCount(starCount) : "—"}
+        </span>
+      </a>
+    </div>
+  );
+}

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -41,7 +41,7 @@ export function GitHubStarWidget() {
   if (dismissed) return null;
 
   return (
-    <div className="mx-2 mb-1 rounded-md border p-2.5">
+    <div className="mx-1.5 mb-1 rounded-md border p-2">
       <div className="mb-1.5 flex items-center justify-between">
         <span className="text-xs font-semibold">Star traceroot</span>
         <button

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -64,7 +64,7 @@ export function GitHubStarWidget() {
         rel="noopener noreferrer"
         className="flex overflow-hidden rounded border border-border text-[11px] font-medium transition-colors hover:bg-muted/50"
       >
-        <span className="flex flex-1 items-center gap-1.5 px-2 py-1.5">
+        <span className="flex items-center gap-1.5 px-2 py-1.5">
           <GitHubIcon className="h-3 w-3 shrink-0" />
           traceroot
         </span>

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -66,7 +66,7 @@ export function GitHubStarWidget() {
         </button>
       </div>
       <p className="mb-2 text-[11px] leading-snug text-muted-foreground">
-        See the latest releases and help grow the community on GitHub.
+        If TraceRoot helps, a star goes a long way.
       </p>
       <a
         href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -66,7 +66,9 @@ export function GitHubStarWidget() {
         </button>
       </div>
       <p className="mb-2 text-[11px] leading-snug text-muted-foreground">
-        Open source and shipping fast. Made with ❤️ by contributors.
+        Open source and shipping fast.
+        <br />
+        Made with ❤️ by contributors.
       </p>
       <a
         href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -80,7 +80,7 @@ export function GitHubStarWidget() {
           <Github className="h-3 w-3 shrink-0" />
           traceroot
         </span>
-        <span className="flex flex-1 items-center justify-center gap-1 border-l border-border py-1 text-muted-foreground">
+        <span className="flex shrink-0 items-center gap-1 border-l border-border px-2.5 py-1 text-muted-foreground">
           ★ {starCount !== null ? formatStarCount(starCount) : "—"}
         </span>
       </a>

--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -68,7 +68,7 @@ export function GitHubStarWidget() {
           <GitHubIcon className="h-3 w-3 shrink-0" />
           traceroot
         </span>
-        <span className="flex shrink-0 items-center gap-1 border-l border-border px-1.5 py-1 text-muted-foreground">
+        <span className="flex shrink-0 items-center gap-1 border-l border-border py-1 pl-1.5 pr-2.5 text-muted-foreground">
           ★ {starCount !== null ? formatStarCount(starCount) : "—"}
         </span>
       </a>

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -9,7 +9,6 @@ import {
   LayoutGrid,
   LifeBuoy,
   ChevronRight,
-  Github,
   Sun,
   Moon,
   Monitor,
@@ -20,7 +19,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Logo } from "@/components/Logo";
 import { cn } from "@/lib/utils";
-import { clientEnv } from "@/env.client";
+import { GitHubStarWidget } from "@/components/layout/GitHubStarWidget";
 
 // Check if we're in a project context by looking at the path structure
 function getProjectContext(pathname: string): { isProject: boolean; projectId: string | null } {
@@ -179,28 +178,8 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
 
         {/* Bottom section */}
         <div>
-          {/* Star on GitHub */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <a
-                href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={cn(
-                  "flex w-full items-center gap-2 py-2 text-[13px] transition-colors hover:bg-muted/50",
-                  collapsed ? "justify-center px-2" : "px-3",
-                )}
-              >
-                <Github className="h-3.5 w-3.5 shrink-0" />
-                {!collapsed && <span className="flex-1">GitHub</span>}
-              </a>
-            </TooltipTrigger>
-            {collapsed && (
-              <TooltipContent side="right" sideOffset={16}>
-                GitHub
-              </TooltipContent>
-            )}
-          </Tooltip>
+          {/* Star widget */}
+          {!collapsed && <GitHubStarWidget />}
 
           {/* Settings - only show when in project context */}
           {isProject && projectId && (

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   LayoutGrid,
   LifeBuoy,
   ChevronRight,
+  Github,
   Sun,
   Moon,
   Monitor,
@@ -20,6 +21,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { Logo } from "@/components/Logo";
 import { cn } from "@/lib/utils";
 import { GitHubStarWidget } from "@/components/layout/GitHubStarWidget";
+import { clientEnv } from "@/env.client";
 
 // Check if we're in a project context by looking at the path structure
 function getProjectContext(pathname: string): { isProject: boolean; projectId: string | null } {
@@ -180,6 +182,29 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
         <div>
           {/* Star widget */}
           {!collapsed && <GitHubStarWidget />}
+
+          {/* GitHub link */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <a
+                href={clientEnv.NEXT_PUBLIC_GITHUB_REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(
+                  "flex w-full items-center gap-2 py-2 text-[13px] transition-colors hover:bg-muted/50",
+                  collapsed ? "justify-center px-2" : "px-3",
+                )}
+              >
+                <Github className="h-3.5 w-3.5 shrink-0" />
+                {!collapsed && <span className="flex-1">GitHub</span>}
+              </a>
+            </TooltipTrigger>
+            {collapsed && (
+              <TooltipContent side="right" sideOffset={16}>
+                GitHub
+              </TooltipContent>
+            )}
+          </Tooltip>
 
           {/* Settings - only show when in project context */}
           {isProject && projectId && (

--- a/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
@@ -43,11 +43,11 @@ function CopyPromptButton({ value }: { value: string }) {
   );
 }
 
-interface AiTabProps {
+interface AITabProps {
   projectId: string;
 }
 
-export function AiTab({ projectId }: AiTabProps) {
+export function AITab({ projectId }: AITabProps) {
   return (
     <div className="space-y-6">
       <div className="space-y-2">

--- a/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
@@ -11,7 +11,8 @@ Please help me:
 1. Install the traceroot Python package (pip install traceroot)
 2. Initialize TraceRoot at the entry point of my application:
    import traceroot
-   traceroot.init()
+   from traceroot import Integration
+   traceroot.initialize(integrations=[Integration.OPENAI])  # or Integration.LANGCHAIN
 3. Instrument all OpenAI and LangChain calls in my codebase.
 
 The TRACEROOT_API_KEY environment variable is already set in my .env file.`;

--- a/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
@@ -20,9 +20,13 @@ function CopyPromptButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = async () => {
-    await navigator.clipboard.writeText(value);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable (insecure context or permission denied)
+    }
   };
 
   return (

--- a/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
@@ -30,12 +30,7 @@ function CopyPromptButton({ value }: { value: string }) {
   };
 
   return (
-    <Button
-      variant="outline"
-      size="sm"
-      className="ml-4 h-7 shrink-0 text-[11px]"
-      onClick={handleCopy}
-    >
+    <Button variant="outline" size="sm" className="ml-4 h-7 shrink-0 text-xs" onClick={handleCopy}>
       {copied ? (
         <>
           <Check className="mr-1 h-3 w-3 text-green-600" />

--- a/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
@@ -5,11 +5,11 @@ import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ApiKeyBlock } from "./ApiKeyBlock";
 
-const INSTRUMENT_PROMPT = `I want to add observability to my project using Traceroot.
+const INSTRUMENT_PROMPT = `I want to add observability to my project using TraceRoot.
 
 Please help me:
 1. Install the traceroot Python package (pip install traceroot)
-2. Initialize Traceroot at the entry point of my application:
+2. Initialize TraceRoot at the entry point of my application:
    import traceroot
    traceroot.init()
 3. Instrument all OpenAI and LangChain calls in my codebase.

--- a/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
@@ -56,20 +56,20 @@ export function AiTab({ projectId }: AiTabProps) {
   return (
     <div className="space-y-6">
       <div className="space-y-2">
-        <p className="text-[12px] font-medium text-foreground">1. Create an API key</p>
+        <p className="text-sm font-medium text-foreground">1. Create an API key</p>
         <ApiKeyBlock projectId={projectId} />
       </div>
 
       <div className="space-y-2">
-        <p className="text-[12px] font-medium text-foreground">
+        <p className="text-sm font-medium text-foreground">
           2. Paste a prompt to instrument your code
         </p>
-        <div className="flex items-start justify-between rounded-md border border-border bg-muted/30 px-4 py-3">
+        <div className="flex items-start justify-between rounded-sm border border-border bg-muted/30 px-4 py-3">
           <div>
-            <p className="text-[13px] font-medium text-foreground">
+            <p className="text-sm font-medium text-foreground">
               Install and instrument from scratch
             </p>
-            <p className="mt-0.5 text-[11px] text-muted-foreground">
+            <p className="mt-0.5 text-xs text-muted-foreground">
               Best for new projects or repos without existing observability.
             </p>
           </div>

--- a/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
@@ -61,11 +61,9 @@ export function AiTab({ projectId }: AiTabProps) {
         </p>
         <div className="flex items-start justify-between rounded-sm border border-border bg-muted/30 px-4 py-3">
           <div>
-            <p className="text-sm font-medium text-foreground">
-              Install and instrument from scratch
-            </p>
+            <p className="text-sm font-medium text-foreground">Auto-instrument your codebase</p>
             <p className="mt-0.5 text-xs text-muted-foreground">
-              Best for new projects or repos without existing observability.
+              Paste this prompt into your AI coding assistant to add tracing automatically.
             </p>
           </div>
           <CopyPromptButton value={INSTRUMENT_PROMPT} />

--- a/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AiTab.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ApiKeyBlock } from "./ApiKeyBlock";
+
+const INSTRUMENT_PROMPT = `I want to add observability to my project using Traceroot.
+
+Please help me:
+1. Install the traceroot Python package (pip install traceroot)
+2. Initialize Traceroot at the entry point of my application:
+   import traceroot
+   traceroot.init()
+3. Instrument all OpenAI and LangChain calls in my codebase.
+
+The TRACEROOT_API_KEY environment variable is already set in my .env file.`;
+
+function CopyPromptButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="ml-4 h-7 shrink-0 text-[11px]"
+      onClick={handleCopy}
+    >
+      {copied ? (
+        <>
+          <Check className="mr-1 h-3 w-3 text-green-600" />
+          copied!
+        </>
+      ) : (
+        "copy prompt"
+      )}
+    </Button>
+  );
+}
+
+interface AiTabProps {
+  projectId: string;
+}
+
+export function AiTab({ projectId }: AiTabProps) {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <p className="text-[12px] font-medium text-foreground">1. Create an API key</p>
+        <ApiKeyBlock projectId={projectId} />
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-[12px] font-medium text-foreground">
+          2. Paste a prompt to instrument your code
+        </p>
+        <div className="flex items-start justify-between rounded-md border border-border bg-muted/30 px-4 py-3">
+          <div>
+            <p className="text-[13px] font-medium text-foreground">
+              Install and instrument from scratch
+            </p>
+            <p className="mt-0.5 text-[11px] text-muted-foreground">
+              Best for new projects or repos without existing observability.
+            </p>
+          </div>
+          <CopyPromptButton value={INSTRUMENT_PROMPT} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Check } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import { createAccessKey } from "@/lib/api";
+
+interface ApiKeyBlockProps {
+  projectId: string;
+}
+
+export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
+  const queryClient = useQueryClient();
+  const [generatedKey, setGeneratedKey] = useState<string | null>(null);
+
+  const createMutation = useMutation({
+    mutationFn: () => createAccessKey(projectId),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: ["access-keys", projectId] });
+      setGeneratedKey(response.data.key);
+    },
+  });
+
+  if (generatedKey) {
+    return (
+      <div className="space-y-1.5">
+        <div className="flex items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-[12px]">
+          <span className="text-muted-foreground">TRACEROOT_API_KEY=</span>
+          <span className="flex-1 truncate text-foreground">&quot;{generatedKey}&quot;</span>
+          <CopyButton value={`TRACEROOT_API_KEY="${generatedKey}"`} className="h-6 w-6 shrink-0" />
+        </div>
+        <p className="flex items-center gap-1 text-[11px] text-muted-foreground">
+          <Check className="h-3 w-3 text-green-600" />
+          Copy this key — you won&apos;t see it again.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-2">
+      <div className="flex flex-1 items-center rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-[12px]">
+        <span className="text-muted-foreground">TRACEROOT_API_KEY=</span>
+        <span className="text-muted-foreground/50">&quot;your_key_here&quot;</span>
+      </div>
+      <Button
+        size="sm"
+        className="h-9 shrink-0 px-4 text-[12px]"
+        onClick={() => createMutation.mutate()}
+        disabled={createMutation.isPending}
+      >
+        {createMutation.isPending ? "Generating..." : "Generate"}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
@@ -14,12 +14,19 @@ interface ApiKeyBlockProps {
 export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
   const queryClient = useQueryClient();
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const createMutation = useMutation({
-    mutationFn: () => createAccessKey(projectId),
+    mutationFn: () => {
+      setError(null);
+      return createAccessKey(projectId);
+    },
     onSuccess: (response) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", projectId] });
       setGeneratedKey(response.data.key);
+    },
+    onError: () => {
+      setError("Failed to generate key. Please try again.");
     },
   });
 
@@ -40,19 +47,22 @@ export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
   }
 
   return (
-    <div className="flex gap-2">
-      <div className="flex flex-1 items-center rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-[12px]">
-        <span className="text-muted-foreground">TRACEROOT_API_KEY=</span>
-        <span className="text-muted-foreground/50">&quot;your_key_here&quot;</span>
+    <div className="space-y-1.5">
+      <div className="flex gap-2">
+        <div className="flex flex-1 items-center rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-[12px]">
+          <span className="text-muted-foreground">TRACEROOT_API_KEY=</span>
+          <span className="text-muted-foreground/50">&quot;your_key_here&quot;</span>
+        </div>
+        <Button
+          size="sm"
+          className="h-9 shrink-0 px-4 text-[12px]"
+          onClick={() => createMutation.mutate()}
+          disabled={createMutation.isPending}
+        >
+          {createMutation.isPending ? "Generating..." : "Generate"}
+        </Button>
       </div>
-      <Button
-        size="sm"
-        className="h-9 shrink-0 px-4 text-[12px]"
-        onClick={() => createMutation.mutate()}
-        disabled={createMutation.isPending}
-      >
-        {createMutation.isPending ? "Generating..." : "Generate"}
-      </Button>
+      {error && <p className="text-[11px] text-destructive">{error}</p>}
     </div>
   );
 }

--- a/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
@@ -17,9 +17,9 @@ export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
   const [error, setError] = useState<string | null>(null);
 
   const createMutation = useMutation({
-    mutationFn: () => {
+    mutationFn: () => createAccessKey(projectId),
+    onMutate: () => {
       setError(null);
-      return createAccessKey(projectId);
     },
     onSuccess: (response) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", projectId] });

--- a/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
@@ -38,7 +38,7 @@ export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
           <span className="flex-1 truncate text-foreground">&quot;{generatedKey}&quot;</span>
           <CopyButton value={`TRACEROOT_API_KEY="${generatedKey}"`} className="h-6 w-6 shrink-0" />
         </div>
-        <p className="flex items-center gap-1 text-[11px] text-muted-foreground">
+        <p className="flex items-center gap-1 text-xs text-muted-foreground">
           <Check className="h-3 w-3 text-green-600" />
           Copy this key — you won&apos;t see it again.
         </p>
@@ -55,14 +55,14 @@ export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
         </div>
         <Button
           size="sm"
-          className="h-9 shrink-0 px-4 text-[12px]"
+          className="h-9 shrink-0 px-4 text-xs"
           onClick={() => createMutation.mutate()}
           disabled={createMutation.isPending}
         >
           {createMutation.isPending ? "Generating..." : "Generate"}
         </Button>
       </div>
-      {error && <p className="text-[11px] text-destructive">{error}</p>}
+      {error && <p className="text-xs text-destructive">{error}</p>}
     </div>
   );
 }

--- a/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
@@ -33,7 +33,7 @@ export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
   if (generatedKey) {
     return (
       <div className="space-y-1.5">
-        <div className="flex items-center gap-2 rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-[12px]">
+        <div className="flex items-center gap-2 border border-border bg-muted px-3 py-2 font-mono text-xs">
           <span className="text-muted-foreground">TRACEROOT_API_KEY=</span>
           <span className="flex-1 truncate text-foreground">&quot;{generatedKey}&quot;</span>
           <CopyButton value={`TRACEROOT_API_KEY="${generatedKey}"`} className="h-6 w-6 shrink-0" />
@@ -49,7 +49,7 @@ export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
   return (
     <div className="space-y-1.5">
       <div className="flex gap-2">
-        <div className="flex flex-1 items-center rounded-md border border-border bg-muted/50 px-3 py-2 font-mono text-[12px]">
+        <div className="flex flex-1 items-center border border-border bg-muted px-3 py-2 font-mono text-xs">
           <span className="text-muted-foreground">TRACEROOT_API_KEY=</span>
           <span className="text-muted-foreground/50">&quot;your_key_here&quot;</span>
         </div>

--- a/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
@@ -54,6 +54,7 @@ export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
           <span className="text-muted-foreground/50">&quot;your_key_here&quot;</span>
         </div>
         <Button
+          variant="outline"
           size="sm"
           className="h-9 shrink-0 px-4 text-xs"
           onClick={() => createMutation.mutate()}

--- a/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ApiKeyBlock.tsx
@@ -23,6 +23,7 @@ export function ApiKeyBlock({ projectId }: ApiKeyBlockProps) {
     },
     onSuccess: (response) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", projectId] });
+      queryClient.invalidateQueries({ queryKey: ["traces", projectId] });
       setGeneratedKey(response.data.key);
     },
     onError: () => {

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -105,7 +105,7 @@ export function ManualTab({ projectId }: ManualTabProps) {
 
       {/* Step 4 */}
       <div className="space-y-2">
-        <p className="text-sm font-medium text-foreground">4. Initialize Traceroot</p>
+        <p className="text-sm font-medium text-foreground">4. Initialize TraceRoot</p>
         <LangTabs lang={initLang} onChange={setInitLang} />
         <div className="relative">
           <div className="border border-border">

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -61,11 +61,14 @@ export function ManualTab({ projectId }: ManualTabProps) {
         <p className="text-sm font-medium text-foreground">2. Install SDK</p>
         <LangTabs lang={installLang} onChange={setInstallLang} />
         <div className="relative">
-          <div className="flex items-center justify-between rounded-sm border border-border bg-muted px-3 py-2.5 font-mono text-xs">
-            <span>
+          <div className="border border-border">
+            <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+              <span className="text-xs text-muted-foreground">bash</span>
+              <CopyButton value="pip install traceroot" className="h-6 w-6" />
+            </div>
+            <div className="bg-muted px-3 py-2.5 font-mono text-xs">
               <span className="text-blue-600 dark:text-blue-400">pip</span> install traceroot
-            </span>
-            <CopyButton value="pip install traceroot" className="h-6 w-6" />
+            </div>
           </div>
           {installLang === "typescript" && <ComingSoonOverlay />}
         </div>
@@ -75,7 +78,7 @@ export function ManualTab({ projectId }: ManualTabProps) {
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">3. Select your integration</p>
         <div className="flex gap-2">
-          <div className="flex flex-col items-center gap-1.5 rounded-sm border border-border bg-muted/30 px-5 py-3">
+          <div className="flex w-24 flex-col items-center gap-1.5 border border-border bg-muted/30 py-3">
             <svg
               aria-hidden="true"
               width="24"
@@ -88,7 +91,7 @@ export function ManualTab({ projectId }: ManualTabProps) {
             </svg>
             <span className="text-xs font-medium text-foreground">OpenAI</span>
           </div>
-          <div className="flex flex-col items-center gap-1.5 rounded-sm border border-border bg-muted/30 px-5 py-3">
+          <div className="flex w-24 flex-col items-center gap-1.5 border border-border bg-muted/30 py-3">
             <Link className="h-6 w-6 text-foreground" />
             <span className="text-xs font-medium text-foreground">LangChain</span>
           </div>
@@ -100,16 +103,18 @@ export function ManualTab({ projectId }: ManualTabProps) {
         <p className="text-sm font-medium text-foreground">4. Initialize Traceroot</p>
         <LangTabs lang={initLang} onChange={setInitLang} />
         <div className="relative">
-          <div className="relative rounded-sm border border-border bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed">
-            <CopyButton
-              value={"import traceroot\ntraceroot.init()"}
-              className="absolute right-2 top-2 h-6 w-6"
-            />
-            <div>
-              <span className="text-blue-600 dark:text-blue-400">import</span> traceroot
+          <div className="border border-border">
+            <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+              <span className="text-xs text-muted-foreground">python</span>
+              <CopyButton value={"import traceroot\ntraceroot.init()"} className="h-6 w-6" />
             </div>
-            <div>
-              traceroot.<span className="text-purple-600 dark:text-purple-400">init</span>()
+            <div className="bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed">
+              <div>
+                <span className="text-blue-600 dark:text-blue-400">import</span> traceroot
+              </div>
+              <div>
+                traceroot.<span className="text-purple-600 dark:text-purple-400">init</span>()
+              </div>
             </div>
           </div>
           {initLang === "typescript" && <ComingSoonOverlay />}

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -11,21 +11,26 @@ type Lang = "python" | "typescript";
 function LangTabs({ lang, onChange }: { lang: Lang; onChange: (l: Lang) => void }) {
   return (
     <div className="flex border-b border-border">
-      {(["python", "typescript"] as Lang[]).map((l) => (
-        <button
-          key={l}
-          type="button"
-          onClick={() => onChange(l)}
-          className={cn(
-            "-mb-px border-b-2 px-3 py-1.5 text-xs font-medium transition-colors",
-            lang === l
-              ? "border-foreground text-foreground"
-              : "border-transparent text-muted-foreground hover:text-foreground",
-          )}
-        >
-          {l === "python" ? "Python" : "TypeScript"}
-        </button>
-      ))}
+      {(["python", "typescript"] as Lang[]).map((l) => {
+        const isTs = l === "typescript";
+        return (
+          <button
+            key={l}
+            type="button"
+            onClick={() => !isTs && onChange(l)}
+            disabled={isTs}
+            className={cn(
+              "-mb-px border-b-2 px-3 py-1.5 text-xs font-medium transition-colors",
+              lang === l
+                ? "border-foreground text-foreground"
+                : "border-transparent text-muted-foreground",
+              isTs && "cursor-not-allowed opacity-40",
+            )}
+          >
+            {l === "python" ? "Python" : "TypeScript"}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState } from "react";
+import { Link2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CopyButton } from "@/components/ui/copy-button";
+import { ApiKeyBlock } from "./ApiKeyBlock";
+
+type Lang = "python" | "typescript";
+
+function LangTabs({ lang, onChange }: { lang: Lang; onChange: (l: Lang) => void }) {
+  return (
+    <div className="flex gap-1">
+      {(["python", "typescript"] as Lang[]).map((l) => (
+        <button
+          key={l}
+          type="button"
+          onClick={() => onChange(l)}
+          className={cn(
+            "rounded px-2.5 py-1 text-[11px] font-medium transition-colors",
+            lang === l ? "bg-muted text-foreground" : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {l === "python" ? "Python" : "TypeScript"}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ComingSoonOverlay() {
+  return (
+    <div className="absolute inset-0 flex items-center justify-center rounded-md border border-dashed border-border bg-background/80">
+      <span className="rounded-full border border-border bg-muted px-3 py-1 text-[11px] text-muted-foreground">
+        coming soon
+      </span>
+    </div>
+  );
+}
+
+interface ManualTabProps {
+  projectId: string;
+}
+
+export function ManualTab({ projectId }: ManualTabProps) {
+  const [installLang, setInstallLang] = useState<Lang>("python");
+  const [initLang, setInitLang] = useState<Lang>("python");
+
+  return (
+    <div className="space-y-6">
+      {/* Step 1 */}
+      <div className="space-y-2">
+        <p className="text-[12px] font-medium text-foreground">1. Create an API key</p>
+        <ApiKeyBlock projectId={projectId} />
+      </div>
+
+      {/* Step 2 */}
+      <div className="space-y-2">
+        <p className="text-[12px] font-medium text-foreground">2. Install SDK</p>
+        <LangTabs lang={installLang} onChange={setInstallLang} />
+        <div className="relative">
+          <div className="flex items-center justify-between rounded-md border border-border bg-muted/50 px-3 py-2.5 font-mono text-[12px]">
+            <span>
+              <span className="text-blue-600 dark:text-blue-400">pip</span> install traceroot
+            </span>
+            <CopyButton value="pip install traceroot" className="h-6 w-6" />
+          </div>
+          {installLang === "typescript" && <ComingSoonOverlay />}
+        </div>
+      </div>
+
+      {/* Step 3 */}
+      <div className="space-y-2">
+        <p className="text-[12px] font-medium text-foreground">3. Select your integration</p>
+        <div className="flex gap-2">
+          <div className="flex flex-col items-center gap-1.5 rounded-md border border-border bg-muted/30 px-5 py-3">
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="text-foreground"
+            >
+              <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.843-3.372 2.02-1.168a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.402-.678zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+            </svg>
+            <span className="text-[11px] font-medium text-foreground">OpenAI</span>
+          </div>
+          <div className="flex flex-col items-center gap-1.5 rounded-md border border-border bg-muted/30 px-5 py-3">
+            <Link2 className="h-6 w-6 text-foreground" />
+            <span className="text-[11px] font-medium text-foreground">LangChain</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Step 4 */}
+      <div className="space-y-2">
+        <p className="text-[12px] font-medium text-foreground">4. Initialize Traceroot</p>
+        <LangTabs lang={initLang} onChange={setInitLang} />
+        <div className="relative">
+          <div className="relative rounded-md border border-border bg-muted/50 px-3 py-2.5 font-mono text-[12px] leading-relaxed">
+            <CopyButton
+              value={"import traceroot\ntraceroot.init()"}
+              className="absolute right-2 top-2 h-6 w-6"
+            />
+            <div>
+              <span className="text-blue-600 dark:text-blue-400">import</span> traceroot
+            </div>
+            <div>
+              traceroot.<span className="text-purple-600 dark:text-purple-400">init</span>()
+            </div>
+          </div>
+          {initLang === "typescript" && <ComingSoonOverlay />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -93,14 +93,24 @@ export function ManualTab({ projectId }: ManualTabProps) {
         <div className="border border-border">
           <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
             <span className="text-xs text-muted-foreground">python</span>
-            <CopyButton value={"import traceroot\ntraceroot.init()"} className="h-6 w-6" />
+            <CopyButton
+              value={
+                "import traceroot\nfrom traceroot import Integration\n\ntraceroot.initialize(integrations=[Integration.OPENAI])"
+              }
+              className="h-6 w-6"
+            />
           </div>
           <div className="bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed">
             <div>
               <span className="text-blue-600 dark:text-blue-400">import</span> traceroot
             </div>
             <div>
-              traceroot.<span className="text-purple-600 dark:text-purple-400">init</span>()
+              <span className="text-blue-600 dark:text-blue-400">from</span> traceroot{" "}
+              <span className="text-blue-600 dark:text-blue-400">import</span> Integration
+            </div>
+            <div className="mt-1">
+              traceroot.<span className="text-purple-600 dark:text-purple-400">initialize</span>
+              (integrations=[Integration.OPENAI])
             </div>
           </div>
         </div>

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -75,6 +75,7 @@ export function ManualTab({ projectId }: ManualTabProps) {
         <div className="flex gap-2">
           <div className="flex flex-col items-center gap-1.5 rounded-md border border-border bg-muted/30 px-5 py-3">
             <svg
+              aria-hidden="true"
               width="24"
               height="24"
               viewBox="0 0 24 24"

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Link } from "lucide-react";
+import { Link as LinkIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ApiKeyBlock } from "./ApiKeyBlock";
@@ -67,7 +67,12 @@ export function ManualTab({ projectId }: ManualTabProps) {
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">3. Select your integration</p>
         <div className="flex gap-2">
-          <div className="flex w-24 flex-col items-center gap-1.5 border border-border bg-muted/30 py-3">
+          <a
+            href="https://traceroot.ai/docs/integrations/openai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex w-24 flex-col items-center gap-1.5 border border-border bg-muted/30 py-3 transition-colors hover:bg-muted/60"
+          >
             <svg
               aria-hidden="true"
               width="24"
@@ -79,11 +84,16 @@ export function ManualTab({ projectId }: ManualTabProps) {
               <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.843-3.372 2.02-1.168a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.402-.678zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
             </svg>
             <span className="text-xs font-medium text-foreground">OpenAI</span>
-          </div>
-          <div className="flex w-24 flex-col items-center gap-1.5 border border-border bg-muted/30 py-3">
-            <Link className="h-6 w-6 text-foreground" />
+          </a>
+          <a
+            href="https://traceroot.ai/docs/integrations/langchain"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex w-24 flex-col items-center gap-1.5 border border-border bg-muted/30 py-3 transition-colors hover:bg-muted/60"
+          >
+            <LinkIcon className="h-6 w-6 text-foreground" />
             <span className="text-xs font-medium text-foreground">LangChain</span>
-          </div>
+          </a>
         </div>
       </div>
 

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Link2 } from "lucide-react";
+import { Link } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { CopyButton } from "@/components/ui/copy-button";
 import { ApiKeyBlock } from "./ApiKeyBlock";
@@ -17,7 +17,7 @@ function LangTabs({ lang, onChange }: { lang: Lang; onChange: (l: Lang) => void 
           type="button"
           onClick={() => onChange(l)}
           className={cn(
-            "rounded px-2.5 py-1 text-[11px] font-medium transition-colors",
+            "rounded-sm px-2.5 py-1 text-[11px] font-medium transition-colors",
             lang === l ? "bg-muted text-foreground" : "text-muted-foreground hover:text-foreground",
           )}
         >
@@ -50,16 +50,16 @@ export function ManualTab({ projectId }: ManualTabProps) {
     <div className="space-y-6">
       {/* Step 1 */}
       <div className="space-y-2">
-        <p className="text-[12px] font-medium text-foreground">1. Create an API key</p>
+        <p className="text-sm font-medium text-foreground">1. Create an API key</p>
         <ApiKeyBlock projectId={projectId} />
       </div>
 
       {/* Step 2 */}
       <div className="space-y-2">
-        <p className="text-[12px] font-medium text-foreground">2. Install SDK</p>
+        <p className="text-sm font-medium text-foreground">2. Install SDK</p>
         <LangTabs lang={installLang} onChange={setInstallLang} />
         <div className="relative">
-          <div className="flex items-center justify-between rounded-md border border-border bg-muted/50 px-3 py-2.5 font-mono text-[12px]">
+          <div className="flex items-center justify-between rounded-sm border border-border bg-muted px-3 py-2.5 font-mono text-[12px]">
             <span>
               <span className="text-blue-600 dark:text-blue-400">pip</span> install traceroot
             </span>
@@ -71,9 +71,9 @@ export function ManualTab({ projectId }: ManualTabProps) {
 
       {/* Step 3 */}
       <div className="space-y-2">
-        <p className="text-[12px] font-medium text-foreground">3. Select your integration</p>
+        <p className="text-sm font-medium text-foreground">3. Select your integration</p>
         <div className="flex gap-2">
-          <div className="flex flex-col items-center gap-1.5 rounded-md border border-border bg-muted/30 px-5 py-3">
+          <div className="flex flex-col items-center gap-1.5 rounded-sm border border-border bg-muted/30 px-5 py-3">
             <svg
               aria-hidden="true"
               width="24"
@@ -86,8 +86,8 @@ export function ManualTab({ projectId }: ManualTabProps) {
             </svg>
             <span className="text-[11px] font-medium text-foreground">OpenAI</span>
           </div>
-          <div className="flex flex-col items-center gap-1.5 rounded-md border border-border bg-muted/30 px-5 py-3">
-            <Link2 className="h-6 w-6 text-foreground" />
+          <div className="flex flex-col items-center gap-1.5 rounded-sm border border-border bg-muted/30 px-5 py-3">
+            <Link className="h-6 w-6 text-foreground" />
             <span className="text-[11px] font-medium text-foreground">LangChain</span>
           </div>
         </div>
@@ -95,10 +95,10 @@ export function ManualTab({ projectId }: ManualTabProps) {
 
       {/* Step 4 */}
       <div className="space-y-2">
-        <p className="text-[12px] font-medium text-foreground">4. Initialize Traceroot</p>
+        <p className="text-sm font-medium text-foreground">4. Initialize Traceroot</p>
         <LangTabs lang={initLang} onChange={setInitLang} />
         <div className="relative">
-          <div className="relative rounded-md border border-border bg-muted/50 px-3 py-2.5 font-mono text-[12px] leading-relaxed">
+          <div className="relative rounded-sm border border-border bg-muted px-3 py-2.5 font-mono text-[12px] leading-relaxed">
             <CopyButton
               value={"import traceroot\ntraceroot.init()"}
               className="absolute right-2 top-2 h-6 w-6"

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -35,16 +35,6 @@ function LangTabs({ lang, onChange }: { lang: Lang; onChange: (l: Lang) => void 
   );
 }
 
-function ComingSoonOverlay() {
-  return (
-    <div className="absolute inset-0 flex items-center justify-center rounded-md border border-dashed border-border bg-background/80">
-      <span className="rounded-full border border-border bg-muted px-3 py-1 text-[11px] text-muted-foreground">
-        coming soon
-      </span>
-    </div>
-  );
-}
-
 interface ManualTabProps {
   projectId: string;
 }
@@ -55,31 +45,25 @@ export function ManualTab({ projectId }: ManualTabProps) {
 
   return (
     <div className="space-y-6">
-      {/* Step 1 */}
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">1. Create an API key</p>
         <ApiKeyBlock projectId={projectId} />
       </div>
 
-      {/* Step 2 */}
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">2. Install SDK</p>
         <LangTabs lang={installLang} onChange={setInstallLang} />
-        <div className="relative">
-          <div className="border border-border">
-            <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
-              <span className="text-xs text-muted-foreground">bash</span>
-              <CopyButton value="pip install traceroot" className="h-6 w-6" />
-            </div>
-            <div className="bg-muted px-3 py-2.5 font-mono text-xs">
-              <span className="text-blue-600 dark:text-blue-400">pip</span> install traceroot
-            </div>
+        <div className="border border-border">
+          <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+            <span className="text-xs text-muted-foreground">bash</span>
+            <CopyButton value="pip install traceroot" className="h-6 w-6" />
           </div>
-          {installLang === "typescript" && <ComingSoonOverlay />}
+          <div className="bg-muted px-3 py-2.5 font-mono text-xs">
+            <span className="text-blue-600 dark:text-blue-400">pip</span> install traceroot
+          </div>
         </div>
       </div>
 
-      {/* Step 3 */}
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">3. Select your integration</p>
         <div className="flex gap-2">
@@ -103,26 +87,22 @@ export function ManualTab({ projectId }: ManualTabProps) {
         </div>
       </div>
 
-      {/* Step 4 */}
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">4. Initialize TraceRoot</p>
         <LangTabs lang={initLang} onChange={setInitLang} />
-        <div className="relative">
-          <div className="border border-border">
-            <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
-              <span className="text-xs text-muted-foreground">python</span>
-              <CopyButton value={"import traceroot\ntraceroot.init()"} className="h-6 w-6" />
+        <div className="border border-border">
+          <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+            <span className="text-xs text-muted-foreground">python</span>
+            <CopyButton value={"import traceroot\ntraceroot.init()"} className="h-6 w-6" />
+          </div>
+          <div className="bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed">
+            <div>
+              <span className="text-blue-600 dark:text-blue-400">import</span> traceroot
             </div>
-            <div className="bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed">
-              <div>
-                <span className="text-blue-600 dark:text-blue-400">import</span> traceroot
-              </div>
-              <div>
-                traceroot.<span className="text-purple-600 dark:text-purple-400">init</span>()
-              </div>
+            <div>
+              traceroot.<span className="text-purple-600 dark:text-purple-400">init</span>()
             </div>
           </div>
-          {initLang === "typescript" && <ComingSoonOverlay />}
         </div>
       </div>
     </div>

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -10,15 +10,17 @@ type Lang = "python" | "typescript";
 
 function LangTabs({ lang, onChange }: { lang: Lang; onChange: (l: Lang) => void }) {
   return (
-    <div className="flex gap-1">
+    <div className="flex border-b border-border">
       {(["python", "typescript"] as Lang[]).map((l) => (
         <button
           key={l}
           type="button"
           onClick={() => onChange(l)}
           className={cn(
-            "rounded-sm px-2.5 py-1 text-[11px] font-medium transition-colors",
-            lang === l ? "bg-muted text-foreground" : "text-muted-foreground hover:text-foreground",
+            "-mb-px border-b-2 px-3 py-1.5 text-xs font-medium transition-colors",
+            lang === l
+              ? "border-foreground text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground",
           )}
         >
           {l === "python" ? "Python" : "TypeScript"}
@@ -59,7 +61,7 @@ export function ManualTab({ projectId }: ManualTabProps) {
         <p className="text-sm font-medium text-foreground">2. Install SDK</p>
         <LangTabs lang={installLang} onChange={setInstallLang} />
         <div className="relative">
-          <div className="flex items-center justify-between rounded-sm border border-border bg-muted px-3 py-2.5 font-mono text-[12px]">
+          <div className="flex items-center justify-between rounded-sm border border-border bg-muted px-3 py-2.5 font-mono text-xs">
             <span>
               <span className="text-blue-600 dark:text-blue-400">pip</span> install traceroot
             </span>
@@ -84,11 +86,11 @@ export function ManualTab({ projectId }: ManualTabProps) {
             >
               <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.843-3.372 2.02-1.168a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.402-.678zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
             </svg>
-            <span className="text-[11px] font-medium text-foreground">OpenAI</span>
+            <span className="text-xs font-medium text-foreground">OpenAI</span>
           </div>
           <div className="flex flex-col items-center gap-1.5 rounded-sm border border-border bg-muted/30 px-5 py-3">
             <Link className="h-6 w-6 text-foreground" />
-            <span className="text-[11px] font-medium text-foreground">LangChain</span>
+            <span className="text-xs font-medium text-foreground">LangChain</span>
           </div>
         </div>
       </div>
@@ -98,7 +100,7 @@ export function ManualTab({ projectId }: ManualTabProps) {
         <p className="text-sm font-medium text-foreground">4. Initialize Traceroot</p>
         <LangTabs lang={initLang} onChange={setInitLang} />
         <div className="relative">
-          <div className="relative rounded-sm border border-border bg-muted px-3 py-2.5 font-mono text-[12px] leading-relaxed">
+          <div className="relative rounded-sm border border-border bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed">
             <CopyButton
               value={"import traceroot\ntraceroot.init()"}
               className="absolute right-2 top-2 h-6 w-6"

--- a/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
@@ -30,7 +30,7 @@ export function GettingStarted({ projectId }: GettingStartedProps) {
             type="button"
             onClick={() => setTab("ai")}
             className={cn(
-              "flex items-center gap-1.5 rounded px-3 py-1.5 text-[12px] font-medium transition-colors",
+              "flex items-center gap-1.5 rounded-none px-3 py-1.5 text-xs font-medium transition-colors",
               tab === "ai"
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",
@@ -43,7 +43,7 @@ export function GettingStarted({ projectId }: GettingStartedProps) {
             type="button"
             onClick={() => setTab("manual")}
             className={cn(
-              "flex items-center gap-1.5 rounded px-3 py-1.5 text-[12px] font-medium transition-colors",
+              "flex items-center gap-1.5 rounded-none px-3 py-1.5 text-xs font-medium transition-colors",
               tab === "manual"
                 ? "bg-background text-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground",

--- a/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkle, Code2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { AiTab } from "./AiTab";
+import { ManualTab } from "./ManualTab";
+
+type Tab = "ai" | "manual";
+
+interface GettingStartedProps {
+  projectId: string;
+}
+
+export function GettingStarted({ projectId }: GettingStartedProps) {
+  const [tab, setTab] = useState<Tab>("ai");
+
+  return (
+    <div className="flex flex-1 overflow-auto py-10">
+      <div className="mx-auto w-full max-w-[600px] px-7">
+        <h2 className="text-xl font-semibold tracking-tight text-foreground">
+          Get started with Tracing
+        </h2>
+        <p className="mt-1 text-[13px] text-muted-foreground">
+          You don&apos;t have any traces yet. Choose how you&apos;d like to set up.
+        </p>
+
+        <div className="mt-6 inline-flex gap-0.5 rounded-md border border-border bg-muted p-0.5">
+          <button
+            type="button"
+            onClick={() => setTab("ai")}
+            className={cn(
+              "flex items-center gap-1.5 rounded px-3 py-1.5 text-[12px] font-medium transition-colors",
+              tab === "ai"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <Sparkle className="h-3.5 w-3.5" />
+            Using AI
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab("manual")}
+            className={cn(
+              "flex items-center gap-1.5 rounded px-3 py-1.5 text-[12px] font-medium transition-colors",
+              tab === "manual"
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            <Code2 className="h-3.5 w-3.5" />
+            Manual
+          </button>
+        </div>
+
+        <div className="mt-6">
+          {tab === "ai" ? <AiTab projectId={projectId} /> : <ManualTab projectId={projectId} />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
@@ -21,11 +21,11 @@ export function GettingStarted({ projectId }: GettingStartedProps) {
         <h2 className="text-xl font-semibold tracking-tight text-foreground">
           Get started with Tracing
         </h2>
-        <p className="mt-1 text-[13px] text-muted-foreground">
+        <p className="mt-1 text-sm text-muted-foreground">
           You don&apos;t have any traces yet. Choose how you&apos;d like to set up.
         </p>
 
-        <div className="mt-6 inline-flex gap-0.5 rounded-md border border-border bg-muted p-0.5">
+        <div className="mt-6 inline-flex gap-0.5 rounded-sm border border-border bg-muted p-0.5">
           <button
             type="button"
             onClick={() => setTab("ai")}

--- a/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Sparkle, Code2 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { AiTab } from "./AiTab";
+import { AITab } from "./AITab";
 import { ManualTab } from "./ManualTab";
 
 type Tab = "ai" | "manual";
@@ -55,7 +55,7 @@ export function GettingStarted({ projectId }: GettingStartedProps) {
         </div>
 
         <div className="mt-6">
-          {tab === "ai" ? <AiTab projectId={projectId} /> : <ManualTab projectId={projectId} />}
+          {tab === "ai" ? <AITab projectId={projectId} /> : <ManualTab projectId={projectId} />}
         </div>
       </div>
     </div>

--- a/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
@@ -16,7 +16,7 @@ export function GettingStarted({ projectId }: GettingStartedProps) {
   const [tab, setTab] = useState<Tab>("ai");
 
   return (
-    <div className="flex flex-1 overflow-auto py-10">
+    <div className="w-full py-10">
       <div className="mx-auto w-full max-w-[600px] px-7">
         <h2 className="text-xl font-semibold tracking-tight text-foreground">
           Get started with Tracing

--- a/frontend/ui/src/features/traces/components/index.ts
+++ b/frontend/ui/src/features/traces/components/index.ts
@@ -10,3 +10,4 @@ export { ContentRenderer } from "./ContentRenderer";
 export { SpanInfoPanel } from "./SpanInfoPanel";
 export { TraceViewerPanel } from "./TraceViewerPanel";
 export { SessionDetailPanel } from "./SessionDetailPanel";
+export { GettingStarted } from "./GettingStarted";

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -24,7 +24,11 @@ export { useListPageState } from "./use-list-page-state";
 /**
  * Hook for fetching paginated traces list
  */
-export function useTraces(projectId: string, options: TraceQueryOptions = {}) {
+export function useTraces(
+  projectId: string,
+  options: TraceQueryOptions = {},
+  queryOptions: { staleTime?: number } = {},
+) {
   const { data: authSession, isPending } = useAuthSession();
   const sessionReady = !isPending && !!authSession?.user;
   const user: TraceApiUser | undefined = authSession?.user
@@ -44,6 +48,7 @@ export function useTraces(projectId: string, options: TraceQueryOptions = {}) {
     ],
     queryFn: () => getTraces(projectId, "", options, user),
     enabled: sessionReady && !!projectId,
+    ...queryOptions,
   });
 }
 

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -27,7 +27,10 @@ export { useListPageState } from "./use-list-page-state";
 export function useTraces(
   projectId: string,
   options: TraceQueryOptions = {},
-  queryOptions: { staleTime?: number } = {},
+  queryOptions: {
+    staleTime?: number;
+    refetchInterval?: number | false | ((query: unknown) => number | false);
+  } = {},
 ) {
   const { data: authSession, isPending } = useAuthSession();
   const sessionReady = !isPending && !!authSession?.user;


### PR DESCRIPTION
## Summary

- **GitHub Star Widget**: Dismissable sidebar widget showing live GitHub star count, fetched from the GitHub API and cached in localStorage (1h TTL) to avoid redundant requests on sidebar collapse/expand
- **GettingStarted Onboarding**: Setup flow shown when a project has *never* sent traces (checked via a separate `LIMIT 1` query with `staleTime: Infinity`). Includes AI tab (generate API key + copy instrument prompt) and Manual tab (4-step walkthrough: API key → install SDK → select integration → init)
- Tab navigation and search bar are hidden during onboarding; an explicit "No traces found" empty state is shown when filters return zero results on a project that has traces

## Behavior

- Onboarding check is independent of date filter — uses an unfiltered `LIMIT 1` query so returning users with old traces don't see onboarding after applying a narrow date range
- TypeScript tab in ManualTab is disabled (coming soon)
- Star widget persists dismissal state across sessions via localStorage

## Test plan

- [ ] Visit a project with no traces → GettingStarted shows, tabs/search bar hidden
- [ ] Send a trace → page transitions to trace table (staleTime: Infinity means refresh or navigation triggers re-check)
- [ ] Apply a date filter that returns zero results on a project with traces → "No traces found" shown, not onboarding
- [ ] Click Generate in AI tab → API key generated and displayed
- [ ] Click "copy prompt" → prompt copied to clipboard
- [ ] Expand sidebar → GitHub star widget visible with star count
- [ ] Dismiss widget → gone; survives page reload (localStorage)
- [ ] Collapse and re-expand sidebar within 1h → star count loaded from cache (no new network request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)