### PR TITLE
[Examples] Update TypeScript examples to @traceroot-ai/traceroot@0.1.0-alpha.3

### DIFF
--- a/examples/typescript/langchain/README.md
+++ b/examples/typescript/langchain/README.md
@@ -2,28 +2,17 @@
 
 Multi-agent code generator using LangGraph, instrumented with [TraceRoot](https://traceroot.ai).
 
-Orchestrates a pipeline with automatic retry on failure:
+Orchestrates 4 agents in a pipeline with automatic retry on failure:
 
 ```
 Plan → Code → Execute → Summarize (→ retry if failed)
 ```
 
-## Features
-
-- **Auto-instrumented**: All OpenAI calls via LangChain are automatically traced
-- **LangGraph workflow**: State machine with conditional edges for retry logic
-- **Python code execution**: Actually runs the generated code
-- **Demo mode**: Runs predefined queries to show the agent in action
-
 ## Setup
 
 ```bash
-# Install dependencies (from repo root)
+cp .env.example .env  # fill in your API keys
 pnpm install
-
-# Copy environment variables
-cp .env.example .env
-# Edit .env with your API keys
 ```
 
 ## Usage
@@ -32,24 +21,9 @@ cp .env.example .env
 pnpm demo
 ```
 
-## Example Queries
+## What it does
 
-- "Calculate the first 20 Fibonacci numbers and print them."
-- "Find all prime numbers up to 100 using the Sieve of Eratosthenes."
-- "Compute 15! (factorial of 15) and express it in scientific notation."
-
-## How It Works
-
-The agent uses a LangGraph state machine:
-
-1. **Planner**: Creates a step-by-step plan for solving the query
-2. **Coder**: Generates Python code based on the plan
-3. **Executor**: Runs the Python code and captures output
-4. **Retry Logic**: If execution fails, goes back to coder with error context
-5. **Summarizer**: Creates a human-readable summary of the results
-
-All steps are traced in TraceRoot with:
-- Full LLM call details (prompts, completions, tokens)
-- State transitions between nodes
-- Code execution results
-- Error handling and retry attempts
+Runs three demo queries:
+1. First 20 Fibonacci numbers
+2. Primes up to 100 (Sieve of Eratosthenes)
+3. 15! in scientific notation

--- a/examples/typescript/langchain/agent.ts
+++ b/examples/typescript/langchain/agent.ts
@@ -25,7 +25,7 @@ import { ChatOpenAI } from '@langchain/openai';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { Annotation, END, START, StateGraph } from '@langchain/langgraph';
 import * as lcCallbackManager from '@langchain/core/callbacks/manager';
-import { TraceRoot, observe } from '@traceroot/sdk';
+import { TraceRoot, observe } from '@traceroot-ai/traceroot';
 
 // ── TraceRoot setup ───────────────────────────────────────────────────────────
 // langchain: patches the LangChain callback manager to trace chain/node/LLM spans.

--- a/examples/typescript/langchain/package.json
+++ b/examples/typescript/langchain/package.json
@@ -7,12 +7,11 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "workspace:*",
+    "@traceroot-ai/traceroot": "0.1.0-alpha.3",
     "@langchain/core": "^0.3.0",
     "@langchain/langgraph": "^1.0.0",
     "@langchain/openai": "^0.3.0",
-    "dotenv": "^16.4.5",
-    "openai": "^4.77.0"
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/typescript/openai/README.md
+++ b/examples/typescript/openai/README.md
@@ -2,21 +2,11 @@
 
 ReAct-style agent with OpenAI tool calling, instrumented with [TraceRoot](https://traceroot.ai).
 
-## Features
-
-- **Auto-instrumented**: All OpenAI calls are automatically traced with token usage, latency, and model info
-- **Tool calling**: Weather, stock prices, calculator, web search, current time
-- **Demo mode**: Runs predefined queries to show the agent in action
-
 ## Setup
 
 ```bash
-# Install dependencies (from repo root)
+cp .env.example .env  # fill in your API keys
 pnpm install
-
-# Copy environment variables
-cp .env.example .env
-# Edit .env with your API keys
 ```
 
 ## Usage
@@ -25,21 +15,11 @@ cp .env.example .env
 pnpm demo
 ```
 
-## Example Queries
+## What it does
 
-- "What's the weather in San Francisco and Tokyo? Compare them."
-- "What's NVDA stock price? If it goes up 10%, what would the new price be?"
-- "Search for information about AI observability and summarize what you find."
+Runs three demo queries that exercise tool use:
+1. Weather comparison (San Francisco vs Tokyo)
+2. Stock price lookup + calculation (NVDA +10%)
+3. Web search + summarization
 
-## How It Works
-
-The agent uses a ReAct loop:
-1. Receives user input
-2. Decides which tool(s) to call (if any)
-3. Executes tools and feeds results back to the model
-4. Generates a final response
-
-All steps are automatically traced in TraceRoot, showing:
-- LLM calls with prompts, completions, and token usage
-- Tool executions with inputs and outputs
-- Full conversation flow with timing
+Tools: `get_weather`, `get_stock_price`, `calculate`, `search_web`, `get_current_time`

--- a/examples/typescript/openai/agent.ts
+++ b/examples/typescript/openai/agent.ts
@@ -12,7 +12,7 @@
 
 import 'dotenv/config';
 import OpenAI from 'openai';
-import { TraceRoot, observe } from '@traceroot/sdk';
+import { TraceRoot, observe } from '@traceroot-ai/traceroot';
 
 // ── TraceRoot setup ───────────────────────────────────────────────────────────
 TraceRoot.initialize({

--- a/examples/typescript/openai/package.json
+++ b/examples/typescript/openai/package.json
@@ -6,7 +6,7 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "workspace:*",
+    "@traceroot-ai/traceroot": "0.1.0-alpha.3",
     "dotenv": "^16.4.5",
     "openai": "^6.7.0"
   },


### PR DESCRIPTION
## Summary
- Update imports in both TS examples from `@traceroot/sdk` → `@traceroot-ai/traceroot`
- Pin both examples to published `0.1.0-alpha.3` (was `workspace:*`)
- Remove stray `openai@4.x` dep from langchain example (caused `APIPromise instanceof` bug with dual openai versions)

## Test plan
- [x] `cd examples/typescript/openai && pnpm install && pnpm demo` — traces appear in UI
- [x] `cd examples/typescript/langchain && pnpm install && pnpm demo` — traces appear in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)