### PR TITLE
[UI] Responsive assistant markdown overflow handling

### DIFF
--- a/frontend/ui/src/features/ai-assistant/components/message-list.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-list.tsx
@@ -1,48 +1,300 @@
 "use client";
 
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  Children,
+  isValidElement,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import ReactMarkdown from "react-markdown";
 import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ChevronRight, Loader2, CheckCircle2, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { AIMessage, ToolCallStep } from "../types";
+import { PANEL_MAX_WIDTH } from "../constants";
 
 // ---------------------------------------------------------------------------
-// Markdown renderer config — only override what prose can't handle
+// Lightweight markdown normalization for streamed, partial content.
+// Keeps rendering stable by auto-closing unbalanced fences.
 // ---------------------------------------------------------------------------
-const markdownComponents: Components = {
-  // Custom block/inline detection — prose styles pre/code but can't detect
-  // unlabelled fences (no language-* class) without this heuristic
-  code: ({ className, children, ...props }) => {
-    const isBlock = className?.includes("language-") || String(children).includes("\n");
-    return isBlock ? (
-      <code className="block overflow-x-auto" {...props}>
-        {children}
-      </code>
-    ) : (
-      <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]" {...props}>
-        {children}
-      </code>
-    );
-  },
-  // Open links in new tab
-  a: ({ href, children }) => (
-    <a
-      href={href}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="underline underline-offset-2 hover:opacity-80"
-    >
-      {children}
-    </a>
-  ),
-};
+function normalizeStreamingMarkdown(
+  input: string,
+  {
+    normalizeHeadings,
+    closeUnbalancedFences,
+  }: { normalizeHeadings: boolean; closeUnbalancedFences: boolean },
+): string {
+  let text = input || "";
+
+  if (normalizeHeadings) {
+    // Ensure headings that immediately follow text (no blank line) still parse.
+    text = text.replace(/(^|[^\n])(#{1,6} )/g, "$1\n\n$2");
+  }
+
+  if (closeUnbalancedFences) {
+    // Auto-close unbalanced fenced code blocks while streaming.
+    const backtickFenceCount = (text.match(/```/g) || []).length;
+    if (backtickFenceCount % 2 === 1) {
+      text = `${text}\n\`\`\``;
+    }
+
+    const tildeFenceCount = (text.match(/~~~/g) || []).length;
+    if (tildeFenceCount % 2 === 1) {
+      text = `${text}\n~~~`;
+    }
+  }
+
+  return text;
+}
+
+interface ParsedMarkdownTable {
+  headers: string[];
+  rows: ReactNode[][];
+  columnCount: number;
+  maxCellTextLength: number;
+}
+
+type TableRenderMode = "table" | "card" | "stacked";
+
+function isTagElement(
+  node: ReactNode,
+  tag: string,
+): node is ReactElement<{ children?: ReactNode }> {
+  return isValidElement(node) && typeof node.type === "string" && node.type === tag;
+}
+
+function flattenNodeText(node: ReactNode): string {
+  if (node == null || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(flattenNodeText).join("");
+  if (isValidElement<{ children?: ReactNode }>(node)) {
+    return flattenNodeText(node.props.children);
+  }
+  return "";
+}
+
+function getTableRowCells(trNode: ReactNode): ReactNode[] {
+  if (!isTagElement(trNode, "tr")) return [];
+  return Children.toArray(trNode.props.children)
+    .filter(
+      (cell): cell is ReactElement<{ children?: ReactNode }> =>
+        isTagElement(cell, "td") || isTagElement(cell, "th"),
+    )
+    .map((cell) => cell.props.children);
+}
+
+function parseMarkdownTable(children: ReactNode): ParsedMarkdownTable | null {
+  const headers: string[] = [];
+  const rows: ReactNode[][] = [];
+  let maxCellTextLength = 0;
+
+  for (const node of Children.toArray(children)) {
+    if (isTagElement(node, "thead")) {
+      const headerRow = Children.toArray(node.props.children).find((child) =>
+        isTagElement(child, "tr"),
+      );
+      if (headerRow) {
+        headers.push(
+          ...getTableRowCells(headerRow).map((cell, idx) => {
+            const text = flattenNodeText(cell).trim();
+            const resolvedText = text || `Column ${idx + 1}`;
+            maxCellTextLength = Math.max(maxCellTextLength, resolvedText.length);
+            return resolvedText;
+          }),
+        );
+      }
+      continue;
+    }
+
+    if (isTagElement(node, "tbody")) {
+      for (const tr of Children.toArray(node.props.children)) {
+        const cells = getTableRowCells(tr);
+        if (cells.length > 0) {
+          for (const cell of cells) {
+            maxCellTextLength = Math.max(maxCellTextLength, flattenNodeText(cell).trim().length);
+          }
+          rows.push(cells);
+        }
+      }
+      continue;
+    }
+  }
+
+  const columnCount = Math.max(headers.length, ...rows.map((row) => row.length), 0);
+  if (columnCount === 0 || rows.length === 0) return null;
+
+  const normalizedHeaders =
+    headers.length > 0
+      ? [
+          ...headers,
+          ...Array.from({ length: Math.max(0, columnCount - headers.length) }, (_, i) => {
+            return `Column ${headers.length + i + 1}`;
+          }),
+        ]
+      : Array.from({ length: columnCount }, (_, i) => `Column ${i + 1}`);
+
+  return {
+    headers: normalizedHeaders,
+    rows,
+    columnCount,
+    maxCellTextLength,
+  };
+}
+
+interface MarkdownLayoutOptions {
+  containerWidth: number;
+}
+
+const TABLE_MODE_WIDE_BREAKPOINT = Math.round(PANEL_MAX_WIDTH * 0.91);
+const TABLE_MODE_MEDIUM_BREAKPOINT = Math.round(PANEL_MAX_WIDTH * 0.69);
+const TABLE_MODE_NARROW_BREAKPOINT = Math.round(PANEL_MAX_WIDTH * 0.51);
+
+function getTableRenderMode(parsed: ParsedMarkdownTable, containerWidth: number): TableRenderMode {
+  if (containerWidth >= TABLE_MODE_WIDE_BREAKPOINT) {
+    if (parsed.columnCount <= 6 && parsed.maxCellTextLength <= 72) return "table";
+    if (parsed.columnCount <= 4) return "table";
+    return "card";
+  }
+
+  if (containerWidth >= TABLE_MODE_MEDIUM_BREAKPOINT) {
+    if (parsed.columnCount <= 4 && parsed.maxCellTextLength <= 52) return "table";
+    return "card";
+  }
+
+  if (containerWidth >= TABLE_MODE_NARROW_BREAKPOINT) {
+    if (parsed.columnCount <= 3 && parsed.maxCellTextLength <= 40) return "table";
+    return "stacked";
+  }
+
+  return "stacked";
+}
+
+function getCardLabelColumnWidth(containerWidth: number): number {
+  return Math.min(180, Math.max(84, Math.round(containerWidth * 0.24)));
+}
 
 // ---------------------------------------------------------------------------
-// AnimatedItem — grows from 0 height on mount so new items slide in smoothly
+// Markdown renderer config - only override what prose can't handle
 // ---------------------------------------------------------------------------
-function AnimatedItem({ children }: { children: React.ReactNode }) {
+function getMarkdownComponents(layout: MarkdownLayoutOptions): Components {
+  const labelColWidth = getCardLabelColumnWidth(layout.containerWidth);
+
+  return {
+    // Keep wide blocks constrained to bubble width and readable at all panel widths.
+    pre: ({ children, ...props }) => (
+      <pre
+        className="max-w-full whitespace-pre-wrap break-words rounded-md bg-muted/40 p-2 text-foreground [overflow-wrap:anywhere]"
+        {...props}
+      >
+        {children}
+      </pre>
+    ),
+    table: ({ children, ...props }) => {
+      const parsed = parseMarkdownTable(children);
+      const mode = parsed ? getTableRenderMode(parsed, layout.containerWidth) : "table";
+
+      if (parsed && mode === "stacked") {
+        return (
+          <div className="my-2 space-y-2">
+            {parsed.rows.map((row, rowIndex) => (
+              <div
+                key={rowIndex}
+                className="rounded-md border border-border/60 bg-muted/20 px-2 py-1.5"
+              >
+                {Array.from({ length: parsed.columnCount }).map((_, colIndex) => (
+                  <div key={colIndex} className="border-b border-border/40 py-1.5 last:border-b-0">
+                    <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                      {parsed.headers[colIndex]}
+                    </div>
+                    <div className="mt-0.5 min-w-0 break-words [overflow-wrap:anywhere]">
+                      {row[colIndex] ?? "-"}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        );
+      }
+
+      if (parsed && mode === "card") {
+        return (
+          <div className="my-2 space-y-2">
+            {parsed.rows.map((row, rowIndex) => (
+              <div
+                key={rowIndex}
+                className="rounded-md border border-border/60 bg-muted/20 px-2 py-1.5"
+              >
+                {Array.from({ length: parsed.columnCount }).map((_, colIndex) => (
+                  <div
+                    key={colIndex}
+                    className="grid gap-x-2 border-b border-border/40 py-1 last:border-b-0"
+                    style={{ gridTemplateColumns: `${labelColWidth}px minmax(0, 1fr)` }}
+                  >
+                    <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground/80">
+                      {parsed.headers[colIndex]}
+                    </span>
+                    <div className="min-w-0 break-words [overflow-wrap:anywhere]">
+                      {row[colIndex] ?? "-"}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        );
+      }
+
+      return (
+        <table
+          className="my-2 w-full table-auto border-collapse text-[11px] [&_td]:whitespace-normal [&_td]:break-words [&_td]:border [&_td]:border-border/60 [&_td]:px-2 [&_td]:py-1 [&_td]:align-top [&_td]:[overflow-wrap:anywhere] [&_th]:whitespace-normal [&_th]:break-words [&_th]:border [&_th]:border-border/60 [&_th]:px-2 [&_th]:py-1 [&_th]:text-left [&_th]:align-top [&_th]:[overflow-wrap:anywhere]"
+          {...props}
+        >
+          {children}
+        </table>
+      );
+    },
+    // Custom block/inline detection - prose styles pre/code but can't detect
+    // unlabelled fences (no language-* class) without this heuristic
+    code: ({ className, children, ...props }) => {
+      const isBlock = className?.includes("language-") || String(children).includes("\n");
+      return isBlock ? (
+        <code
+          className="block whitespace-pre-wrap break-words text-foreground [overflow-wrap:anywhere]"
+          {...props}
+        >
+          {children}
+        </code>
+      ) : (
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]" {...props}>
+          {children}
+        </code>
+      );
+    },
+    // Open links in new tab
+    a: ({ href, children }) => (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline underline-offset-2 hover:opacity-80"
+      >
+        {children}
+      </a>
+    ),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AnimatedItem - grows from 0 height on mount so new items slide in smoothly
+// ---------------------------------------------------------------------------
+function AnimatedItem({ children }: { children: ReactNode }) {
   const [visible, setVisible] = useState(false);
 
   useLayoutEffect(() => {
@@ -141,9 +393,22 @@ function ToolStepItem({ step, isActive }: { step: ToolCallStep; isActive: boolea
   );
 }
 
-function AssistantBubble({ msg }: { msg: AIMessage }) {
+function AssistantBubble({ msg, panelWidth }: { msg: AIMessage; panelWidth: number }) {
+  const normalizedContent = useMemo(
+    () =>
+      normalizeStreamingMarkdown(msg.content, {
+        normalizeHeadings: !!msg.isStreaming,
+        closeUnbalancedFences: !!msg.isStreaming,
+      }),
+    [msg.content, msg.isStreaming],
+  );
+  const markdownComponents = useMemo(
+    () => getMarkdownComponents({ containerWidth: Math.max(280, panelWidth) }),
+    [panelWidth],
+  );
+
   return (
-    <div className="break-words rounded-md border border-border bg-background px-3 py-1.5 text-xs text-foreground">
+    <div className="overflow-hidden break-words rounded-md border border-border bg-background px-3 py-1.5 text-xs text-foreground">
       {msg.thinking && (
         <details className="group mb-2 text-[11px]">
           <summary className="flex cursor-pointer select-none list-none items-center gap-1.5 text-muted-foreground/60 hover:text-muted-foreground">
@@ -155,12 +420,10 @@ function AssistantBubble({ msg }: { msg: AIMessage }) {
           </pre>
         </details>
       )}
-      <div className="prose prose-sm prose-neutral max-w-none dark:prose-invert [&_*]:text-xs">
+      <div className="prose prose-sm prose-neutral max-w-none dark:prose-invert [&_*]:text-xs [&_pre]:max-w-full">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
-          // Ensure headings that immediately follow text (no blank line) are
-          // still parsed as headings. LLMs often omit the preceding newline.
-          children={msg.content.replace(/(^|[^\n])(#{1,6} )/g, "$1\n\n$2")}
+          children={normalizedContent}
           components={markdownComponents}
         />
       </div>
@@ -183,17 +446,17 @@ function UsageFooter({ msg }: { msg: AIMessage }) {
   return (
     <div className="mt-1 flex items-center gap-2 px-1 text-[10px] text-muted-foreground/60">
       <span title="Input tokens">{msg.inputTokens!.toLocaleString()} in</span>
-      <span>·</span>
+      <span>&middot;</span>
       <span title="Output tokens">{msg.outputTokens!.toLocaleString()} out</span>
       {msg.totalTokens != null && (
         <>
-          <span>·</span>
+          <span>&middot;</span>
           <span title="Cumulative session tokens">{msg.totalTokens.toLocaleString()} session</span>
         </>
       )}
       {msg.costUsd != null && msg.costUsd > 0 && (
         <>
-          <span>·</span>
+          <span>&middot;</span>
           <span title="Estimated cost">${msg.costUsd.toFixed(4)}</span>
         </>
       )}
@@ -213,8 +476,9 @@ export function MessageList({ messages, sessionStreaming = false }: MessageListP
   const containerRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const userScrolledRef = useRef(false);
+  const [panelWidth, setPanelWidth] = useState(400);
   const isStreaming = messages.some((m) => m.isStreaming);
-  // True when the session is active but no text bubble is open — the LLM is processing
+  // True when the session is active but no text bubble is open - the LLM is processing
   // a tool result before it starts writing its next response.
   const isWaiting = sessionStreaming && !isStreaming;
   const lastToolStepIdx = messages.reduce((acc, m, i) => (m.role === "tool_step" ? i : acc), -1);
@@ -230,16 +494,33 @@ export function MessageList({ messages, sessionStreaming = false }: MessageListP
     userScrolledRef.current = el.scrollHeight - el.scrollTop - el.clientHeight > 80;
   };
 
-  // ResizeObserver on the inner content div: fires on every height change (streaming text,
-  // entry animations, accordion expand/collapse) so scroll follows frame-by-frame
+  // Shared ResizeObserver:
+  // - innerRef height changes: keep auto-scroll behavior frame-by-frame while streaming.
+  // - containerRef width changes: drive responsive markdown/table layouts.
   useEffect(() => {
-    const el = containerRef.current;
+    if (typeof ResizeObserver === "undefined") return;
+
+    const container = containerRef.current;
     const inner = innerRef.current;
-    if (!el || !inner) return;
-    const ro = new ResizeObserver(() => {
-      if (!userScrolledRef.current) el.scrollTop = el.scrollHeight;
+    if (!container || !inner) return;
+
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.target === inner) {
+          if (!userScrolledRef.current) container.scrollTop = container.scrollHeight;
+          continue;
+        }
+
+        if (entry.target === container) {
+          const next = Math.round(entry.contentRect.width || container.clientWidth);
+          if (next > 0) setPanelWidth(next);
+        }
+      }
     });
+
     ro.observe(inner);
+    ro.observe(container);
+    setPanelWidth(container.clientWidth);
     return () => ro.disconnect();
   }, []);
 
@@ -252,6 +533,9 @@ export function MessageList({ messages, sessionStreaming = false }: MessageListP
     }
   }, [sessionStreaming]);
 
+  const bubbleMaxWidth =
+    panelWidth >= 860 ? "96%" : panelWidth >= 700 ? "94%" : panelWidth >= 520 ? "92%" : "90%";
+
   return (
     <div ref={containerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto px-3 pt-3">
       <div ref={innerRef}>
@@ -260,7 +544,7 @@ export function MessageList({ messages, sessionStreaming = false }: MessageListP
             return (
               <AnimatedItem key={msg.id}>
                 <div className="flex justify-start">
-                  <div className="max-w-[85%]">
+                  <div className="min-w-0" style={{ maxWidth: bubbleMaxWidth }}>
                     <ToolStepItem step={msg.toolStep} isActive={msg.id === activeToolStepId} />
                   </div>
                 </div>
@@ -270,8 +554,12 @@ export function MessageList({ messages, sessionStreaming = false }: MessageListP
           return (
             <AnimatedItem key={msg.id}>
               <div className={cn("flex", msg.role === "user" ? "justify-end" : "justify-start")}>
-                <div className="flex max-w-[85%] flex-col">
-                  {msg.role === "user" ? <UserBubble msg={msg} /> : <AssistantBubble msg={msg} />}
+                <div className="flex min-w-0 flex-col" style={{ maxWidth: bubbleMaxWidth }}>
+                  {msg.role === "user" ? (
+                    <UserBubble msg={msg} />
+                  ) : (
+                    <AssistantBubble msg={msg} panelWidth={panelWidth} />
+                  )}
                   {msg.role === "assistant" && msg.inputTokens != null && !msg.isStreaming && (
                     <UsageFooter msg={msg} />
                   )}


### PR DESCRIPTION
## Summary

Fixes AI Assistant markdown overflow in trace chat by making rendering responsive to panel width, without relying on horizontal scrollbars.

Closes #578

### Environment: Local self-hosted (Docker) + Chrome
- Rebuilt web container:
  - `docker compose -f docker-compose.prod.yml up -d --build web`
- Verified app:
  - `http://localhost:3000` returns `200`

## Problem

Assistant-generated markdown (especially tables, long IDs, and long text/code blocks) could look broken or cramped in narrow chat panels, and did not adapt well as panel width changed.

## What Changed

Updated `frontend/ui/src/features/ai-assistant/components/message-list.tsx`:

1. Add responsive table rendering modes:
   - `stacked` for narrow panels
   - `card` for medium panels
   - native `table` for wide panels
2. Parse markdown table structure (headers/rows) and choose layout based on:
   - container width
   - column count
   - max cell text length
3. Keep assistant markdown inside bubble boundaries with wrap-first behavior:
   - `pre`/`code` blocks use wrapping (`whitespace-pre-wrap`, `break-words`, `overflow-wrap:anywhere`)
   - removed assistant markdown horizontal-scroll-first handling
4. Track panel width with `ResizeObserver` so layout updates when the assistant panel is resized.
5. Increase assistant bubble max width at larger panel sizes so expanded panels meaningfully show more content.
6. Keep streaming normalization logic (`normalizeStreamingMarkdown`) and preserve tool-step rendering behavior.

## Why This Approach

The goal is adaptive readability across panel sizes (small -> medium -> large), not static compression or forced horizontal scrolling.  
This keeps content contained while improving scanability and preserving table semantics on wider layouts.

## Type of Change

- [x] fix - A bug fix
- [ ] feat - A new feature
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] docs
- [ ] test
- [ ] build
- [ ] ci



### Manual QA checks
Tested in narrow / medium / wide assistant panel widths with:
1. Wide markdown table (6-8 columns, long cell content)
2. Long code fence line
3. Long unbroken token (UUID/URL/path)
4. Streamed partial markdown followed by completion

Observed:
- No assistant content escapes bubble/panel
- No horizontal scrollbar in assistant markdown path
- Tables adapt by width (stacked/card/table)
- Streaming cursor/autoscroll behavior remains functional

## Video Demo

https://github.com/user-attachments/assets/142eee9a-e8ad-40e9-8b68-c1fa316b622d

https://github.com/user-attachments/assets/b74d7f6f-89bb-4b0e-9d2f-0d5a7479e72f

##Notes

- Large tables on narrow panels are intentionally transformed for readability.
- This change is scoped to AI assistant message markdown rendering only.


- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
