### PR TITLE
feat: update TypeScript examples to @traceroot-ai/traceroot@0.1.0 with usingAttributes

### DIFF
--- a/examples/typescript/langchain/agent.ts
+++ b/examples/typescript/langchain/agent.ts
@@ -25,7 +25,7 @@ import { ChatOpenAI } from '@langchain/openai';
 import { HumanMessage, SystemMessage } from '@langchain/core/messages';
 import { Annotation, END, START, StateGraph } from '@langchain/langgraph';
 import * as lcCallbackManager from '@langchain/core/callbacks/manager';
-import { TraceRoot, observe } from '@traceroot-ai/traceroot';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
 
 // ── TraceRoot setup ───────────────────────────────────────────────────────────
 // langchain: patches the LangChain callback manager to trace chain/node/LLM spans.
@@ -170,21 +170,29 @@ const DEMO_QUERIES = [
 
 async function main() {
   try {
-    await observe({ name: 'demo_session' }, async () => {
-      console.log('='.repeat(60));
-      console.log('LangGraph Code Agent — Demo (TraceRoot)');
-      console.log('='.repeat(60));
-
-      for (let i = 0; i < DEMO_QUERIES.length; i++) {
-        const query = DEMO_QUERIES[i];
-        console.log(`\n${'='.repeat(60)}`);
-        console.log(`Query ${i + 1}: ${query}`);
+    await usingAttributes(
+      {
+        sessionId: 'langchain-demo-session',
+        userId: 'demo-user',
+        tags: ['demo', 'langchain', 'langgraph'],
+        metadata: { example: 'langchain-code-agent', sdkFeature: 'usingAttributes' },
+      },
+      () => observe({ name: 'demo_session' }, async () => {
         console.log('='.repeat(60));
-        const summary = await runAgent(query);
-        console.log('\nAgent: ' + summary);
-        console.log();
-      }
-    });
+        console.log('LangGraph Code Agent — Demo (TraceRoot)');
+        console.log('='.repeat(60));
+
+        for (let i = 0; i < DEMO_QUERIES.length; i++) {
+          const query = DEMO_QUERIES[i];
+          console.log(`\n${'='.repeat(60)}`);
+          console.log(`Query ${i + 1}: ${query}`);
+          console.log('='.repeat(60));
+          const summary = await runAgent(query);
+          console.log('\nAgent: ' + summary);
+          console.log();
+        }
+      }),
+    );
   } finally {
     await TraceRoot.shutdown();
     console.log('[Traces exported]');

--- a/examples/typescript/langchain/package.json
+++ b/examples/typescript/langchain/package.json
@@ -7,7 +7,7 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "0.1.0-alpha.3",
+    "@traceroot-ai/traceroot": "0.1.0",
     "@langchain/core": "^0.3.0",
     "@langchain/langgraph": "^1.0.0",
     "@langchain/openai": "^0.3.0",

--- a/examples/typescript/openai/agent.ts
+++ b/examples/typescript/openai/agent.ts
@@ -12,7 +12,7 @@
 
 import 'dotenv/config';
 import OpenAI from 'openai';
-import { TraceRoot, observe } from '@traceroot-ai/traceroot';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
 
 // ── TraceRoot setup ───────────────────────────────────────────────────────────
 TraceRoot.initialize({
@@ -210,23 +210,31 @@ const DEMO_QUERIES = [
 
 async function main() {
   try {
-    await observe({ name: 'demo_session' }, async () => {
-      console.log('='.repeat(60));
-      console.log('OpenAI ReAct Agent — Demo (TraceRoot)');
-      console.log('='.repeat(60));
-
-      for (let i = 0; i < DEMO_QUERIES.length; i++) {
-        const query = DEMO_QUERIES[i];
-        const agent = new ReActAgent();
-        console.log(`\n${'='.repeat(60)}`);
-        console.log(`Query ${i + 1}: ${query}`);
+    await usingAttributes(
+      {
+        sessionId: 'openai-demo-session',
+        userId: 'demo-user',
+        tags: ['demo', 'openai', 'react-agent'],
+        metadata: { example: 'openai-react-agent', sdkFeature: 'usingAttributes' },
+      },
+      () => observe({ name: 'demo_session' }, async () => {
         console.log('='.repeat(60));
-        process.stdout.write('\nAgent: ');
-        const response = await agent.runTurn(query);
-        console.log(response);
-        console.log();
-      }
-    });
+        console.log('OpenAI ReAct Agent — Demo (TraceRoot)');
+        console.log('='.repeat(60));
+
+        for (let i = 0; i < DEMO_QUERIES.length; i++) {
+          const query = DEMO_QUERIES[i];
+          const agent = new ReActAgent();
+          console.log(`\n${'='.repeat(60)}`);
+          console.log(`Query ${i + 1}: ${query}`);
+          console.log('='.repeat(60));
+          process.stdout.write('\nAgent: ');
+          const response = await agent.runTurn(query);
+          console.log(response);
+          console.log();
+        }
+      }),
+    );
   } finally {
     await TraceRoot.shutdown();
     console.log('[Traces exported]');

--- a/examples/typescript/openai/package.json
+++ b/examples/typescript/openai/package.json
@@ -6,7 +6,7 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "0.1.0-alpha.3",
+    "@traceroot-ai/traceroot": "0.1.0",
     "dotenv": "^16.4.5",
     "openai": "^6.7.0"
   },


### PR DESCRIPTION
## Summary
- Bump both TS examples from `0.1.0-alpha.3` to published `0.1.0`
- Wrap `demo_session` with `usingAttributes()` to propagate `sessionId`, `userId`, `tags`, and `metadata` to all downstream spans

## Screenshots
<img width="1723" height="926" alt="Screenshot 2026-04-01 at 10 55 24 PM" src="https://github.com/user-attachments/assets/ad02f44d-73dd-4136-9742-f75203fb7b3c" />
<img width="1721" height="921" alt="Screenshot 2026-04-01 at 10 55 09 PM" src="https://github.com/user-attachments/assets/069c5c37-2f6a-44fa-9c1f-a81c318692b0" />




## Test plan
- [x] `cd examples/typescript/openai && pnpm install && pnpm demo` — traces appear in UI with user/session attributes
- [x] `cd examples/typescript/langchain && pnpm install && pnpm demo` — traces appear in UI with user/session attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)