### PR TITLE
[Example] add OpenAI Agents SDK example

### DIFF
--- a/examples/python/openai-agents-sdk/.env.example
+++ b/examples/python/openai-agents-sdk/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenAI
+OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/python/openai-agents-sdk/README.md
+++ b/examples/python/openai-agents-sdk/README.md
@@ -1,0 +1,17 @@
+# OpenAI Agents SDK
+
+Multi-tool agent using the OpenAI Agents SDK, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+## What it does
+Runs a demo query that exercises tool use with the OpenAI Agents SDK.
+Tools: `get_weather`, `calculate`

--- a/examples/python/openai-agents-sdk/main.py
+++ b/examples/python/openai-agents-sdk/main.py
@@ -1,0 +1,143 @@
+"""
+OpenAI Agents SDK with tool use and TraceRoot observability.
+
+Uses the OpenAI Agents SDK (openai-agents) which handles the agent loop,
+tool execution, and multi-turn conversations automatically.
+
+Usage:
+    cp .env.example .env
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+"""
+
+import asyncio
+import json
+import logging
+from datetime import datetime
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found (find_dotenv returned None).\nUsing process environment variables.")
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.OPENAI_AGENTS])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+from agents import Agent, Runner, function_tool
+
+
+@function_tool
+def get_weather(city: str) -> str:
+    """Get current weather for a city."""
+    weather_db = {
+        "san francisco": {"temp": 68, "condition": "foggy", "humidity": 75},
+        "new york": {"temp": 45, "condition": "cloudy", "humidity": 60},
+        "london": {"temp": 52, "condition": "rainy", "humidity": 85},
+        "tokyo": {"temp": 72, "condition": "sunny", "humidity": 50},
+    }
+    data = weather_db.get(city.lower(), {"temp": 70, "condition": "unknown", "humidity": 50})
+    return json.dumps({"city": city, **data})
+
+
+@function_tool
+def get_stock_price(symbol: str) -> str:
+    """Get stock price for a symbol."""
+    stocks = {
+        "AAPL": {"price": 178.50, "change": +2.30, "percent": "+1.3%"},
+        "GOOGL": {"price": 141.20, "change": -0.80, "percent": "-0.6%"},
+        "MSFT": {"price": 378.90, "change": +4.50, "percent": "+1.2%"},
+        "NVDA": {"price": 495.20, "change": +12.30, "percent": "+2.5%"},
+    }
+    data = stocks.get(symbol.upper(), {"price": 0, "change": 0, "percent": "N/A"})
+    return json.dumps({"symbol": symbol.upper(), **data})
+
+
+@function_tool
+def calculate(expression: str) -> str:
+    """Evaluate a math expression safely using AST parsing."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval(node.operand)
+        raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+        result = _eval(tree)
+        return json.dumps({"expression": expression, "result": result})
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@function_tool
+def get_current_time(timezone: str = "UTC") -> str:
+    """Get current time."""
+    return json.dumps({"timezone": timezone, "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")})
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    name="Assistant",
+    instructions=(
+        "You are a helpful AI assistant with access to tools. "
+        "Use available tools to gather information, then provide "
+        "a clear, comprehensive answer."
+    ),
+    model="gpt-4o-mini",
+    tools=[get_weather, get_stock_price, calculate, get_current_time],
+)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+DEMO_QUERIES = [
+    "What's the weather in San Francisco and Tokyo? Compare them.",
+    "What's NVDA stock price? If it goes up 10%, what would the new price be?",
+]
+
+
+@observe(name="demo_session", type="agent")
+async def run_demo():
+    for i, query in enumerate(DEMO_QUERIES, 1):
+        print(f"\n{'=' * 60}")
+        print(f"Query {i}: {query}")
+        print("=" * 60)
+        result = await Runner.run(agent, query)
+        print(f"\nAgent: {result.final_output}\n")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="openai-agents-session"):
+        asyncio.run(run_demo())
+    traceroot.flush()

--- a/examples/python/openai-agents-sdk/requirements.txt
+++ b/examples/python/openai-agents-sdk/requirements.txt
@@ -1,0 +1,4 @@
+openai-agents>=0.0.3
+python-dotenv>=1.0.0
+
+traceroot==0.1.0


### PR DESCRIPTION
## Summary
  Add OpenAI Agents SDK example with TraceRoot observability.

  ## Type of Change
  - [x] feat - A new feature

  ## Details
  New example at `examples/python/openai-agents-sdk/` — multi-tool agent using the OpenAI Agents SDK (`openai-agents` package) with auto-instrumentation via `OpenAIAgentsInstrumentor`.

  - Tools: `get_weather`, `calculate`
  - Auto-instrumented with `openinference-instrumentation-openai-agents`
  - Includes `using_attributes(user_id, session_id)` for trace context
  - Tested and working — traces confirmed on staging
  ## Screenshots
  
<img width="3332" height="1742" alt="image" src="https://github.com/user-attachments/assets/3dfa8506-36ad-4236-9fbe-86dcf676383e" />

  ## Checklist
  - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
  - [ ] I have added/updated tests where applicable
  - [ ] I have added screenshots or recordings for UI changes (if applicable)
  - [x] I have updated documentation where necessary
