### PR TITLE
[Example] add Pydantic AI agent example

### DIFF
--- a/examples/python/pydantic-ai-agent/.env.example
+++ b/examples/python/pydantic-ai-agent/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenAI (used by Pydantic AI as the model provider)
+OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/python/pydantic-ai-agent/README.md
+++ b/examples/python/pydantic-ai-agent/README.md
@@ -1,0 +1,17 @@
+# Pydantic AI Agent
+
+Tool-use agent using Pydantic AI, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+## What it does
+Runs demo queries that exercise tool use with Pydantic AI.
+Tools: `get_weather`, `get_stock_price`, `calculate`

--- a/examples/python/pydantic-ai-agent/main.py
+++ b/examples/python/pydantic-ai-agent/main.py
@@ -1,0 +1,115 @@
+"""
+Pydantic AI agent with tool use, instrumented with TraceRoot observability.
+
+Pydantic AI has built-in OpenTelemetry support. We configure it to use
+TraceRoot's TracerProvider + the OpenInference span processor for
+enriched LLM attributes.
+
+Usage:
+    cp .env.example .env  # fill in your API keys
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+"""
+
+import asyncio
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found (find_dotenv returned None).\nUsing process environment variables.")
+
+import traceroot
+from traceroot import observe, using_attributes
+
+traceroot.initialize()
+
+# Pydantic AI has built-in OTel support — just configure instrumentation_settings
+from pydantic_ai import Agent
+
+agent = Agent(
+    "openai:gpt-4o-mini",
+    system_prompt="You are a helpful assistant with access to tools.",
+    instrument=True,  # enable built-in OpenTelemetry tracing
+)
+
+
+@agent.tool_plain
+def get_weather(city: str) -> str:
+    """Get weather for a city."""
+    weather_db = {
+        "san francisco": "68°F, foggy, humidity 75%",
+        "tokyo": "72°F, sunny, humidity 50%",
+        "new york": "45°F, cloudy, humidity 60%",
+    }
+    return weather_db.get(city.lower(), "Unknown city")
+
+
+@agent.tool_plain
+def get_stock_price(symbol: str) -> str:
+    """Get stock price."""
+    stocks = {
+        "AAPL": "$178.50 (+1.3%)",
+        "NVDA": "$495.20 (+2.5%)",
+        "GOOGL": "$141.20 (-0.6%)",
+    }
+    return stocks.get(symbol.upper(), "Unknown symbol")
+
+
+@agent.tool_plain
+def calculate(expression: str) -> str:
+    """Evaluate a math expression."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval(node.operand)
+        raise ValueError(f"Unsupported: {ast.dump(node)}")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+        return str(_eval(tree))
+    except Exception as e:
+        return f"Error: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+DEMO_QUERIES = [
+    "What's the weather in San Francisco and Tokyo? Compare them.",
+    "What's NVDA stock price? If it goes up 10%, what would the new price be?",
+]
+
+
+@observe(name="demo_session", type="agent")
+async def run_demo():
+    results = []
+    for query in DEMO_QUERIES:
+        print(f"\nQuery: {query}")
+        result = await agent.run(query)
+        print(f"Answer: {result.output}")
+        results.append(result.output)
+    return "\n".join(results)
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="pydantic-ai-session"):
+        asyncio.run(run_demo())
+    traceroot.flush()

--- a/examples/python/pydantic-ai-agent/requirements.txt
+++ b/examples/python/pydantic-ai-agent/requirements.txt
@@ -1,0 +1,4 @@
+pydantic-ai>=0.0.14
+python-dotenv>=1.0.0
+
+traceroot==0.1.0


### PR DESCRIPTION
## Summary
  Add Pydantic AI agent example with TraceRoot observability.

  ## Type of Change
  - [x] feat - A new feature

  ## Details
  New example at `examples/python/pydantic-ai-agent/` — tool-use agent using Pydantic AI with built-in OpenTelemetry tracing (`instrument=True`).

  - Tools: `get_weather`, `get_stock_price`, `calculate`
  - Uses Pydantic AI's native OTel support (no separate instrumentor needed)
  - Includes `using_attributes(user_id, session_id)` for trace context
  - Tested and working — traces confirmed on staging
  ## Screenshot
  
<img width="1762" height="811" alt="image" src="https://github.com/user-attachments/assets/0bcb6b11-e38d-4e9e-8457-1bf12df54357" />

  ## Checklist
  - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
  - [ ] I have added/updated tests where applicable
  - [ ] I have added screenshots or recordings for UI changes (if applicable)
  - [x] I have updated documentation where necessary
