### PR TITLE
[Example] add CrewAI multi-agent example

### DIFF
--- a/examples/python/crewai-agent/.env.example
+++ b/examples/python/crewai-agent/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenAI (used by CrewAI as the default LLM)
+OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/python/crewai-agent/README.md
+++ b/examples/python/crewai-agent/README.md
@@ -1,0 +1,16 @@
+# CrewAI Agent
+
+Multi-agent crew using CrewAI, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+## What it does
+Runs a 2-agent crew (researcher + writer) that gathers weather data and writes a comparison report.

--- a/examples/python/crewai-agent/main.py
+++ b/examples/python/crewai-agent/main.py
@@ -1,0 +1,142 @@
+"""
+CrewAI Multi-Agent Crew, instrumented with TraceRoot observability.
+
+A simple 2-agent crew that:
+1. Uses a Researcher agent to gather weather data using tools
+2. Uses a Writer agent to produce a comparison report
+
+Usage:
+    cp .env.example .env  # fill in your API keys
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+"""
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found (find_dotenv returned None).\nUsing process environment variables.")
+
+# =============================================================================
+# TRACEROOT SETUP
+# Must be initialized BEFORE importing CrewAI so instrumentation hooks in
+# =============================================================================
+import traceroot
+from traceroot import observe, using_attributes
+
+traceroot.initialize()
+
+from openinference.instrumentation.crewai import CrewAIInstrumentor
+
+CrewAIInstrumentor().instrument()
+
+# =============================================================================
+# CREWAI AGENTS
+# =============================================================================
+from crewai import Agent, Crew, Task
+from crewai.tools import tool
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get weather for a city."""
+    weather_db = {
+        "san francisco": "68°F, foggy",
+        "tokyo": "72°F, sunny",
+        "new york": "45°F, cloudy",
+    }
+    return weather_db.get(city.lower(), "Unknown city")
+
+
+@tool
+def calculate(expression: str) -> str:
+    """Evaluate a math expression safely using AST parsing."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval(node.operand)
+        raise ValueError(f"Unsupported: {ast.dump(node)}")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+        return str(_eval(tree))
+    except Exception as e:
+        return f"Error: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Agents
+# ---------------------------------------------------------------------------
+
+researcher = Agent(
+    role="Research Analyst",
+    goal="Gather and analyze information using available tools",
+    backstory="Expert researcher who uses tools to find accurate data.",
+    tools=[get_weather, calculate],
+    verbose=True,
+)
+
+writer = Agent(
+    role="Report Writer",
+    goal="Write clear, concise reports based on research findings",
+    backstory="Skilled writer who creates readable summaries.",
+    verbose=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tasks
+# ---------------------------------------------------------------------------
+
+research_task = Task(
+    description="What's the weather in San Francisco and Tokyo? Compare them and calculate the temperature difference.",
+    expected_output="Weather data with comparison and calculations",
+    agent=researcher,
+)
+
+report_task = Task(
+    description="Write a brief weather comparison report based on the research.",
+    expected_output="A short weather comparison report",
+    agent=writer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Crew
+# ---------------------------------------------------------------------------
+
+crew = Crew(agents=[researcher, writer], tasks=[research_task, report_task], verbose=True)
+
+
+@observe(name="crewai_run", type="agent")
+def run_crew():
+    result = crew.kickoff()
+    print(result)
+    return str(result)
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="crewai-session"):
+        run_crew()
+
+    traceroot.flush()

--- a/examples/python/crewai-agent/requirements.txt
+++ b/examples/python/crewai-agent/requirements.txt
@@ -1,0 +1,5 @@
+crewai>=0.80.0
+python-dotenv>=1.0.0
+
+traceroot==0.1.0
+openinference-instrumentation-crewai>=0.1.0


### PR DESCRIPTION
  ## Summary
  Add CrewAI multi-agent crew example with TraceRoot observability.

  ## Type of Change
  - [x] feat - A new feature

  ## Details
  New example at `examples/python/crewai-agent/` — 2-agent crew (researcher + writer) with tool use, auto-instrumented via `CrewAIInstrumentor`.

  - Agents: Research Analyst (with tools), Report Writer
  - Tools: `get_weather`, `calculate`
  - Auto-instrumented with `openinference-instrumentation-crewai`
  - Wrapped with `@observe` for session/user context propagation
  - Tested and working — traces confirmed on staging
  ## Screenshot
<img width="1772" height="806" alt="image" src="https://github.com/user-attachments/assets/01267c96-cc0d-422e-950f-a399419ad2d5" />

  ## Checklist
  - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
  - [ ] I have added/updated tests where applicable
  - [ ] I have added screenshots or recordings for UI changes (if applicable)
  - [x] I have updated documentation where necessary