### PR TITLE
[Docs] Introduce TS SDK Docs [1/n]

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -76,7 +76,8 @@
               {
                 "group": "SDKs",
                 "pages": [
-                  "tracing/python-sdk"
+                  "tracing/python-sdk",
+                  "tracing/typescript-sdk"
                 ]
               },
               {
@@ -129,7 +130,8 @@
           {
             "group": "SDK",
             "pages": [
-              "tracing/python-sdk"
+              "tracing/python-sdk",
+              "tracing/typescript-sdk"
             ]
           },
           {

--- a/docs/integrations/langchain.mdx
+++ b/docs/integrations/langchain.mdx
@@ -7,47 +7,113 @@ Automatically capture agent steps, tool calls, and LLM invocations within LangCh
 
 ## Setup
 
-```python
-import traceroot
-from traceroot import Integration
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import traceroot
+    from traceroot import Integration
 
-traceroot.initialize(integrations=[Integration.LANGCHAIN])
-```
+    traceroot.initialize(integrations=[Integration.LANGCHAIN])
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import * as lcCallbackManager from '@langchain/core/callbacks/manager';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { langchain: lcCallbackManager },
+    });
+    ```
+  </Tab>
+</Tabs>
 
 ## Usage with LangGraph
 
-```python
-from langchain_openai import ChatOpenAI
-from langgraph.prebuilt import create_react_agent
+<Tabs>
+  <Tab title="Python">
+    ```python
+    from langchain_openai import ChatOpenAI
+    from langgraph.prebuilt import create_react_agent
 
-llm = ChatOpenAI(model="gpt-4o")
+    llm = ChatOpenAI(model="gpt-4o")
 
-tools = [search_tool, calculator_tool]
-agent = create_react_agent(llm, tools=tools)
+    tools = [search_tool, calculator_tool]
+    agent = create_react_agent(llm, tools=tools)
 
-# All agent steps are automatically traced
-result = agent.invoke({
-    "messages": [{"role": "user", "content": "What is 2 + 2?"}]
-})
-```
+    # All agent steps are automatically traced
+    result = agent.invoke({
+        "messages": [{"role": "user", "content": "What is 2 + 2?"}]
+    })
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import { ChatOpenAI } from '@langchain/openai';
+    import { HumanMessage } from '@langchain/core/messages';
+    import { END, START, StateGraph, Annotation } from '@langchain/langgraph';
+
+    const llm = new ChatOpenAI({ model: 'gpt-4o', temperature: 0 });
+
+    const AgentState = Annotation.Root({
+      query: Annotation<string>({ reducer: (_, v) => v, default: () => '' }),
+      answer: Annotation<string>({ reducer: (_, v) => v, default: () => '' }),
+    });
+
+    // Build graph — all nodes are automatically traced
+    const app = new StateGraph(AgentState)
+      .addNode('answer', async (state) => {
+        const response = await llm.invoke([new HumanMessage(state.query)]);
+        return { answer: response.content as string };
+      })
+      .addEdge(START, 'answer')
+      .addEdge('answer', END)
+      .compile();
+
+    const result = await app.invoke({ query: 'What is 2 + 2?' });
+    console.log(result.answer);
+    ```
+  </Tab>
+</Tabs>
 
 ## Usage with LangChain
 
-```python
-from langchain_openai import ChatOpenAI
-from langchain_core.prompts import ChatPromptTemplate
+<Tabs>
+  <Tab title="Python">
+    ```python
+    from langchain_openai import ChatOpenAI
+    from langchain_core.prompts import ChatPromptTemplate
 
-llm = ChatOpenAI(model="gpt-4o")
-prompt = ChatPromptTemplate.from_messages([
-    ("system", "You are a helpful assistant."),
-    ("user", "{input}"),
-])
+    llm = ChatOpenAI(model="gpt-4o")
+    prompt = ChatPromptTemplate.from_messages([
+        ("system", "You are a helpful assistant."),
+        ("user", "{input}"),
+    ])
 
-chain = prompt | llm
+    chain = prompt | llm
 
-# Chain execution is automatically traced
-result = chain.invoke({"input": "Hello!"})
-```
+    # Chain execution is automatically traced
+    result = chain.invoke({"input": "Hello!"})
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import { ChatOpenAI } from '@langchain/openai';
+    import { ChatPromptTemplate } from '@langchain/core/prompts';
+
+    const llm = new ChatOpenAI({ model: 'gpt-4o' });
+    const prompt = ChatPromptTemplate.fromMessages([
+      ['system', 'You are a helpful assistant.'],
+      ['user', '{input}'],
+    ]);
+
+    const chain = prompt.pipe(llm);
+
+    // Chain execution is automatically traced
+    const result = await chain.invoke({ input: 'Hello!' });
+    ```
+  </Tab>
+</Tabs>
 
 ## What Gets Captured
 

--- a/docs/integrations/openai.mdx
+++ b/docs/integrations/openai.mdx
@@ -7,33 +7,71 @@ Automatically capture all OpenAI Chat Completions and Responses API calls.
 
 ## Setup
 
-```python
-import traceroot
-from traceroot import Integration
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import traceroot
+    from traceroot import Integration
 
-traceroot.initialize(integrations=[Integration.OPENAI])
-```
+    traceroot.initialize(integrations=[Integration.OPENAI])
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { openAI: OpenAI },
+    });
+
+    const openai = new OpenAI();
+    ```
+  </Tab>
+</Tabs>
 
 ## Usage
 
-Once initialized, all OpenAI calls are captured automatically:
+<Tabs>
+  <Tab title="Python">
+    Once initialized, all OpenAI calls are captured automatically:
 
-```python
-import openai
+    ```python
+    import openai
 
-client = openai.OpenAI()
+    client = openai.OpenAI()
 
-# This call is automatically traced
-response = client.chat.completions.create(
-    model="gpt-4o",
-    messages=[
-        {"role": "system", "content": "You are a helpful assistant."},
-        {"role": "user", "content": "What is the capital of France?"},
-    ],
-)
+    # This call is automatically traced
+    response = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "What is the capital of France?"},
+        ],
+    )
 
-print(response.choices[0].message.content)
-```
+    print(response.choices[0].message.content)
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import OpenAI from 'openai';
+
+    const openai = new OpenAI();
+
+    // This call is automatically traced
+    const response = await openai.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [
+        { role: 'system', content: 'You are a helpful assistant.' },
+        { role: 'user', content: 'What is the capital of France?' },
+      ],
+    });
+
+    console.log(response.choices[0].message.content);
+    ```
+  </Tab>
+</Tabs>
 
 ## What Gets Captured
 

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -11,6 +11,9 @@ TraceRoot integrates with popular LLM providers and agent frameworks via auto-in
   <Card title="Python SDK" icon="python" href="/tracing/python-sdk">
     The core SDK for tracing, decorators, and manual instrumentation.
   </Card>
+  <Card title="TypeScript SDK" icon="js" href="/tracing/typescript-sdk">
+    The core SDK for tracing, observe wrapper, and manual instrumentation.
+  </Card>
 </CardGroup>
 
 ## Frameworks

--- a/docs/tracing/get-started.mdx
+++ b/docs/tracing/get-started.mdx
@@ -9,19 +9,18 @@ Create API Keys either with [TraceRoot Cloud](https://app.traceroot.ai) or [Self
 
 ## 2. Install the SDK
 
-<CodeGroup>
-```bash pip
-pip install traceroot
-```
-
-```bash uv
-uv add traceroot
-```
-
-```bash poetry
-poetry add traceroot
-```
-</CodeGroup>
+<Tabs>
+  <Tab title="Python">
+    ```bash
+    pip install traceroot
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```bash
+    npm install @traceroot-ai/traceroot
+    ```
+  </Tab>
+</Tabs>
 
 ## 3. Set Environment Variables
 
@@ -32,20 +31,39 @@ TRACEROOT_HOST_URL=https://app.traceroot.ai  # or your self-hosted URL
 
 ## 4. Instrument Your Code
 
-Add a single line at the start of your application to instrument all OpenAI API calls.
+<Tabs>
+  <Tab title="Python">
+    Add a single line at the start of your application to instrument all OpenAI API calls.
 
-```python
-import traceroot
-from traceroot import Integration
-from openai import OpenAI
+    ```python
+    import traceroot
+    from traceroot import Integration
+    from openai import OpenAI
 
-# This single line instruments all OpenAI API calls
-traceroot.initialize(integrations=[Integration.OPENAI])
+    # This single line instruments all OpenAI API calls
+    traceroot.initialize(integrations=[Integration.OPENAI])
 
-client = OpenAI()
-```
+    client = OpenAI()
+    ```
 
-For full SDK details, see the [Python SDK](/tracing/python-sdk).
+    For full SDK details, see the [Python SDK](/tracing/python-sdk).
+  </Tab>
+  <Tab title="TypeScript">
+    Add a single line at the start of your application to instrument all OpenAI API calls.
+
+    ```typescript
+    import OpenAI from 'openai';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    // This single line instruments all OpenAI API calls
+    TraceRoot.initialize({ instrumentModules: { openAI: OpenAI } });
+
+    const openai = new OpenAI();
+    ```
+
+    For full SDK details, see the [TypeScript SDK](/tracing/typescript-sdk).
+  </Tab>
+</Tabs>
 
 ## 5. View Your Traces
 
@@ -56,8 +74,11 @@ Open [TraceRoot Cloud](https://app.traceroot.ai) (or your self-hosted dashboard)
 ## What's Next?
 
 <CardGroup cols={2}>
-  <Card title="Python SDK" icon="code" href="/tracing/python-sdk">
-    Full API reference for decorators, spans, and configuration.
+  <Card title="Python SDK" icon="python" href="/tracing/python-sdk">
+    Full API reference for the Python SDK.
+  </Card>
+  <Card title="TypeScript SDK" icon="js" href="/tracing/typescript-sdk">
+    Full API reference for the TypeScript SDK.
   </Card>
   <Card title="AI Agent" icon="brain" href="/ai-agent/overview">
     Auto-debug failing traces with the built-in AI agent.

--- a/docs/tracing/python-sdk.mdx
+++ b/docs/tracing/python-sdk.mdx
@@ -47,16 +47,28 @@ async def async_agent(query: str) -> str:
 
 ## Setting Trace Context
 
-Use `using_attributes` to set user and session context:
+Use `using_attributes` to set user and session context for all spans created within a block:
 
 ```python
 from traceroot import using_attributes
 
-with using_attributes(user_id="user-123", session_id="sess-456"):
+with using_attributes(
+    user_id="user-123",
+    session_id="sess-456",
+    tags=["production", "v2"],
+    metadata={"feature": "chat"},
+):
     result = run_agent("What is the weather?")
 ```
 
-All traces created within the block inherit the `user_id` and `session_id`.
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `user_id` | `str` | User identifier |
+| `session_id` | `str` | Session / conversation ID |
+| `tags` | `list[str]` | Tags to attach to all spans |
+| `metadata` | `dict` | Arbitrary metadata |
 
 ## Updating Spans and Traces
 

--- a/docs/tracing/typescript-sdk.mdx
+++ b/docs/tracing/typescript-sdk.mdx
@@ -28,7 +28,7 @@ Wrap any async function to create a span:
 import { observe } from '@traceroot-ai/traceroot';
 
 const result = await observe({ name: 'my_function', type: 'tool' }, async () => {
-  return doWork(query);
+  return doWork('your input here');
 });
 ```
 
@@ -37,7 +37,7 @@ const result = await observe({ name: 'my_function', type: 'tool' }, async () => 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `name` | `string` | function name | Span name |
-| `type` | `'span' \| 'agent' \| 'tool' \| 'llm'` | `'span'` | Span kind: `'llm'`, `'agent'`, `'tool'`, or `'span'` |
+| `type` | `'span' \| 'agent' \| 'tool' \| 'llm'` | `'span'` | Span kind — `'agent'` for multi-step agents, `'tool'` for function calls, `'llm'` for model inference, `'span'` for generic |
 | `metadata` | `Record<string, unknown>` | — | Static metadata to attach |
 | `tags` | `string[]` | — | Tags to attach |
 
@@ -57,7 +57,7 @@ await usingAttributes(
   },
   async () => {
     // All spans here inherit the attributes above
-    await runAgent(userMessage);
+    await runAgent('What is the weather?');
   },
 );
 ```

--- a/docs/tracing/typescript-sdk.mdx
+++ b/docs/tracing/typescript-sdk.mdx
@@ -1,0 +1,120 @@
+---
+title: TypeScript SDK
+description: Full API reference for the TraceRoot TypeScript SDK
+---
+
+The TraceRoot TypeScript SDK provides automatic and manual instrumentation for AI agents using OpenTelemetry.
+
+## Instrumentation
+
+Pass module instances to `initialize()` to instrument all calls automatically:
+
+```typescript
+import OpenAI from 'openai';
+import { TraceRoot } from '@traceroot-ai/traceroot';
+
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const openai = new OpenAI();
+```
+
+## The Observe Wrapper
+
+Wrap any async function to create a span:
+
+```typescript
+import { observe } from '@traceroot-ai/traceroot';
+
+const result = await observe({ name: 'my_function', type: 'tool' }, async () => {
+  return doWork(query);
+});
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `name` | `string` | function name | Span name |
+| `type` | `'span' \| 'agent' \| 'tool' \| 'llm'` | `'span'` | Span kind: `'llm'`, `'agent'`, `'tool'`, or `'span'` |
+| `metadata` | `Record<string, unknown>` | — | Static metadata to attach |
+| `tags` | `string[]` | — | Tags to attach |
+
+## Setting Trace Context
+
+Use `usingAttributes()` to set user and session context for all spans created within a block:
+
+```typescript
+import { usingAttributes } from '@traceroot-ai/traceroot';
+
+await usingAttributes(
+  {
+    sessionId: 'conv-123',
+    userId: 'user-456',
+    tags: ['production', 'v2'],
+    metadata: { feature: 'chat' },
+  },
+  async () => {
+    // All spans here inherit the attributes above
+    await runAgent(userMessage);
+  },
+);
+```
+
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `sessionId` | `string` | Session / conversation ID |
+| `userId` | `string` | User identifier |
+| `tags` | `string[]` | Tags to attach to all spans |
+| `metadata` | `Record<string, unknown>` | Arbitrary metadata |
+
+## Updating Spans and Traces
+
+Update the current span or trace programmatically:
+
+```typescript
+import { updateCurrentSpan, updateCurrentTrace } from '@traceroot-ai/traceroot';
+
+await observe({ name: 'my_agent', type: 'agent' }, async () => {
+  updateCurrentSpan({
+    input: { query: userInput },
+    output: { response: agentOutput },
+    metadata: { model: 'gpt-4o' },
+  });
+
+  updateCurrentTrace({
+    userId: 'user-123',
+    sessionId: 'sess-456',
+    tags: ['prod'],
+  });
+});
+```
+
+### `updateCurrentSpan` Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `input` | `unknown` | Input data |
+| `output` | `unknown` | Output data |
+| `metadata` | `Record<string, unknown>` | Custom metadata |
+
+### `updateCurrentTrace` Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `userId` | `string` | User identifier |
+| `sessionId` | `string` | Session identifier |
+| `tags` | `string[]` | Tags for the trace |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `TRACEROOT_API_KEY` | (required) | API key |
+| `TRACEROOT_HOST_URL` | `https://app.traceroot.ai` | API endpoint |
+| `TRACEROOT_ENABLED` | `true` | Enable/disable tracing |
+| `TRACEROOT_GIT_REPO` | auto-detected | Git repository (`owner/repo`) |
+| `TRACEROOT_GIT_REF` | auto-detected | Git reference |


### PR DESCRIPTION
## Summary
- Add TypeScript SDK reference page (`docs/tracing/typescript-sdk.mdx`) with full API reference: Instrumentation, Observe Wrapper, Setting Trace Context, Updating Spans and Traces, Environment Variables
- Add Python/TypeScript tabs to get-started, OpenAI integration, and LangChain/LangGraph integration pages
- Simplify TS code examples to match Python's conciseness — removed unnecessary `usingAttributes`/`observe`/`shutdown` wrappers from integration pages
- Expand `python-sdk.mdx` `using_attributes` to document all 4 supported params (`user_id`, `session_id`, `tags`, `metadata`)
- Update `docs.json` nav and integrations overview to include TypeScript SDK

## Test plan
- [x] Verify local Mintlify preview at `http://localhost:3001`
- [x] Check Python/TypeScript tabs render correctly on get-started, openai, langchain pages
- [x] Confirm TypeScript SDK page is accessible at `/tracing/typescript-sdk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)