### PR TITLE
docs: improve contribution guide and add local developer checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,14 @@
 # Contributing to TraceRoot
 
-Thanks for your interest in contributing to TraceRoot. This guide is meant to help new contributors get from clone to pull request with a simple, low-friction workflow.
+Thanks for your interest in contributing! This guide will help you get started.
 
-## Before You Start
+## Development Requirements
 
-- Check for an existing issue before starting larger work, or open one first so the change has clear scope.
-- Keep each pull request focused on one problem. Small, reviewable PRs get merged faster.
-- Do not commit directly to `main`. Use a short-lived feature or fix branch for every change.
-
-## Requirements
-
-- Docker Desktop
-- `tmux`
-- `uv`
-- Node.js 20+
-- `pnpm` 10+
-- `goose` for local ClickHouse migrations used by `make dev`
+- Docker desktop app
+- uv: Python package manager
+- pnpm: Node.js package manager
+- tmux: terminal multiplexer
+- goose: ClickHouse migration tool
 
 ## Quick Start
 
@@ -26,36 +19,37 @@ cp .env.example .env
 make dev
 ```
 
-`make dev` is the fastest way to get started. It bootstraps the local developer workflow, starts the required services, runs migrations, and opens the app inside tmux-managed processes.
+## Before You Start
 
-If you only want to run checks without starting the full stack, install the local dependencies once:
+- Check for an existing issue before starting larger work, or open one first so the change has clear scope.
+- If you do not have push access, fork the repo, create your branch from `main`, and open the PR from your fork.
+- Keep each pull request focused on one problem to make review easier.
 
-```bash
-uv sync --dev
-pnpm --dir frontend install --frozen-lockfile
-```
-
-## Common Commands
+## Development Commands
 
 | Command | Description |
-| --- | --- |
-| `make dev` | Start the local development environment. Safe to rerun. |
-| `make dev-autoreload` | Start the local environment with backend autoreload enabled. |
-| `make dev-reset` | Reset local dev state, containers, and related dependencies. |
+|---------|-------------|
+| `make dev` | Start dev environment. Idempotent — reattaches to existing tmux session if running. |
+| `make dev-autoreload` | Same as `make dev`, but services auto-restart on code changes. |
+| `make dev-reset` | Nuclear reset: kills tmux, destroys containers/volumes/node_modules. Run `make dev` after. |
 | `make lint` | Run Python lint checks with Ruff and frontend lint checks with ESLint. |
 | `make format` | Apply Python formatting with Ruff and frontend formatting with Prettier. |
 | `make ci-check` | Run the local pre-PR checks: lint and backend tests. |
-| `make prod` | Start the production-style Docker workflow with tmux logs. |
-| `make prod-lite` | Run the Docker stack directly without tmux. |
+| `make prod` | Start all services in Docker with tmux log viewer. |
+| `make prod-lite` | Run the Docker stack directly without tmux. Helpful on Windows and in environments without tmux. |
 
-## Recommended Workflow
+All commands handle deps, Docker containers, migrations, and launch services in tmux (one window per service).
 
-1. Sync your branch with the latest `main`.
-2. Create a branch such as `fix/issue-581-contributing-guide` or `feat/add-ci-check-target`.
-3. Make the smallest change that fully solves the issue.
-4. Run `make format` and `make ci-check` before pushing.
-5. Update tests and docs when behavior, commands, or developer workflow changes.
-6. Open a pull request with a clear summary and link the issue when applicable.
+<div align="center">
+  <kbd><img src="docs/images/local_dev_mode_v1.png" alt="Local dev mode"></kbd>
+</div>
+
+## Workflow
+
+1. Create a branch from `main`.
+2. Make the smallest change that fully solves the issue.
+3. Run `make format` and `make ci-check` before pushing.
+4. Open a pull request and link the issue when applicable.
 
 ## Commit Message Best Practices
 
@@ -82,8 +76,6 @@ Helpful defaults:
 - Add screenshots or recordings for UI changes.
 - Reference the issue in the PR body when relevant, for example `Closes #581`.
 - Make sure `make ci-check` passes before requesting review.
-
-The repository also includes pre-commit protections such as blocking direct commits to `main`, so staying on a feature branch will save time.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,35 +1,89 @@
 # Contributing to TraceRoot
 
-Thanks for your interest in contributing! This guide will help you get started.
+Thanks for your interest in contributing to TraceRoot. This guide is meant to help new contributors get from clone to pull request with a simple, low-friction workflow.
 
-## Development Requirements
+## Before You Start
 
-- Docker desktop app
-- uv: Python package manager
-- pnpm: Node.js package manager
-- tmux: terminal multiplexer
-- goose: ClickHouse migration tool
+- Check for an existing issue before starting larger work, or open one first so the change has clear scope.
+- Keep each pull request focused on one problem. Small, reviewable PRs get merged faster.
+- Do not commit directly to `main`. Use a short-lived feature or fix branch for every change.
+
+## Requirements
+
+- Docker Desktop
+- `tmux`
+- `uv`
+- Node.js 20+
+- `pnpm` 10+
+- `goose` for local ClickHouse migrations used by `make dev`
 
 ## Quick Start
 
 ```bash
-cp .env.example .env  # First time only — then edit with your API keys
-make dev              # Start development environment
+git clone https://github.com/traceroot-ai/traceroot.git
+cd traceroot
+cp .env.example .env
+make dev
 ```
 
-## Development Commands
+`make dev` is the fastest way to get started. It bootstraps the local developer workflow, starts the required services, runs migrations, and opens the app inside tmux-managed processes.
+
+If you only want to run checks without starting the full stack, install the local dependencies once:
+
+```bash
+uv sync --dev
+pnpm --dir frontend install --frozen-lockfile
+```
+
+## Common Commands
 
 | Command | Description |
-|---------|-------------|
-| `make dev` | Start dev environment. Idempotent — reattaches to existing tmux session if running. |
-| `make dev-autoreload` | Same as `make dev`, but services auto-restart on code changes. |
-| `make dev-reset` | Nuclear reset: kills tmux, destroys containers/volumes/node_modules. Run `make dev` after. |
+| --- | --- |
+| `make dev` | Start the local development environment. Safe to rerun. |
+| `make dev-autoreload` | Start the local environment with backend autoreload enabled. |
+| `make dev-reset` | Reset local dev state, containers, and related dependencies. |
+| `make lint` | Run Python lint checks with Ruff and frontend lint checks with ESLint. |
+| `make format` | Apply Python formatting with Ruff and frontend formatting with Prettier. |
+| `make ci-check` | Run the local pre-PR checks: lint and backend tests. |
+| `make prod` | Start the production-style Docker workflow with tmux logs. |
+| `make prod-lite` | Run the Docker stack directly without tmux. |
 
-All commands handle deps, Docker containers, migrations, and launch services in tmux (one window per service).
+## Recommended Workflow
 
-<div align="center">
-  <kbd><img src="docs/images/local_dev_mode_v1.png" alt="Local dev mode"></kbd>
-</div>
+1. Sync your branch with the latest `main`.
+2. Create a branch such as `fix/issue-581-contributing-guide` or `feat/add-ci-check-target`.
+3. Make the smallest change that fully solves the issue.
+4. Run `make format` and `make ci-check` before pushing.
+5. Update tests and docs when behavior, commands, or developer workflow changes.
+6. Open a pull request with a clear summary and link the issue when applicable.
+
+## Commit Message Best Practices
+
+Please use Conventional Commit style for commit messages and PR titles when possible:
+
+- `feat: add ci-check make target`
+- `fix: handle missing ClickHouse migration binary`
+- `docs: improve contribution workflow`
+- `ci: align local checks with GitHub Actions`
+
+Helpful defaults:
+
+- Start with a type such as `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, or `chore`.
+- Add a scope when it helps, for example `feat(frontend): add trace filters`.
+- Use the imperative mood, for example `fix: avoid duplicate span writes`.
+- Keep the summary short and specific.
+
+## Pull Request Best Practices
+
+- Keep the PR scoped to one logical change.
+- Explain what changed, why it changed, and how it was validated.
+- Add or update tests for behavior changes.
+- Update documentation for setup, command, or UX changes.
+- Add screenshots or recordings for UI changes.
+- Reference the issue in the PR body when relevant, for example `Closes #581`.
+- Make sure `make ci-check` passes before requesting review.
+
+The repository also includes pre-commit protections such as blocking direct commits to `main`, so staying on a feature branch will save time.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ cp .env.example .env
 make dev
 ```
 
+On Windows or in environments without tmux, use `make dev-lite` instead.
+
 ## Before You Start
 
 - Check for an existing issue before starting larger work, or open one first so the change has clear scope.
@@ -30,16 +32,16 @@ make dev
 
 | Command | Description |
 |---------|-------------|
-| `make dev` | Start dev environment. Idempotent — reattaches to existing tmux session if running. |
+| `make dev` | Start dev environment. Idempotent - reattaches to existing tmux session if running and installs the pre-commit hook. |
 | `make dev-autoreload` | Same as `make dev`, but services auto-restart on code changes. |
+| `make dev-lite` | Start the local Docker workflow without tmux and install the pre-commit hook. Helpful on Windows. |
 | `make dev-reset` | Nuclear reset: kills tmux, destroys containers/volumes/node_modules. Run `make dev` after. |
-| `make lint` | Run Python lint checks with Ruff and frontend lint checks with ESLint. |
-| `make format` | Apply Python formatting with Ruff and frontend formatting with Prettier. |
-| `make ci-check` | Run the local pre-PR checks: lint and backend tests. |
 | `make prod` | Start all services in Docker with tmux log viewer. |
 | `make prod-lite` | Run the Docker stack directly without tmux. Helpful on Windows and in environments without tmux. |
 
-All commands handle deps, Docker containers, migrations, and launch services in tmux (one window per service).
+`make dev`, `make dev-autoreload`, and `make dev-lite` install the pre-commit hook automatically on first run.
+
+The tmux-based commands handle deps, Docker containers, migrations, and launch services in tmux (one window per service).
 
 <div align="center">
   <kbd><img src="docs/images/local_dev_mode_v1.png" alt="Local dev mode"></kbd>
@@ -49,8 +51,9 @@ All commands handle deps, Docker containers, migrations, and launch services in 
 
 1. Create a branch from `main`.
 2. Make the smallest change that fully solves the issue.
-3. Run `make format` and `make ci-check` before pushing.
-4. Open a pull request and link the issue when applicable.
+3. Commit your changes and let the pre-commit hook run automatically.
+4. Run the relevant tests for your change before pushing.
+5. Open a pull request and link the issue when applicable.
 
 ## Commit Message Best Practices
 
@@ -76,7 +79,7 @@ Helpful defaults:
 - Update documentation for setup, command, or UX changes.
 - Add screenshots or recordings for UI changes.
 - Reference the issue in the PR body when relevant, for example `Closes #581`.
-- Make sure `make ci-check` passes before requesting review.
+- Make sure pre-commit and the relevant tests pass before requesting review.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,9 @@ make dev
 ## Before You Start
 
 - Check for an existing issue before starting larger work, or open one first so the change has clear scope.
-- If you do not have push access, fork the repo, create your branch from `main`, and open the PR from your fork.
-- Keep each pull request focused on one problem to make review easier.
+- If you do not have push access, fork the repo first, create your branch from `main`, push to your fork, and open the PR back to `traceroot-ai/traceroot`.
+- If you have push access, still create a branch from `main` and open a PR instead of working directly on `main`.
+- Keep each pull request focused on one problem and link the related issue when possible.
 
 ## Development Commands
 

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,8 @@ format:
 ## Run the core checks contributors should pass before opening a PR.
 ci-check:
 	$(UV_RUN) ruff check .
-	$(UV_RUN) ruff format --check .
-	$(FRONTEND_PNPM) run lint
-	$(FRONTEND_PNPM) run format:check
+ci-check:
+	$(MAKE) lint
 	$(UV_RUN) coverage run -m pytest tests/ --durations=10
 	$(UV_RUN) coverage report
 

--- a/Makefile
+++ b/Makefile
@@ -2,23 +2,22 @@
 # Traceroot Development
 # =============================================================================
 
-UV_RUN := uv run
 PROD_COMPOSE := docker compose -f docker-compose.prod.yml
 
 .PHONY: install-hooks dev dev-lite dev-autoreload dev-reset prod prod-lite prod-reset
 
 ## Install repository git hooks for contributors.
 install-hooks:
-	$(UV_RUN) pre-commit install
+	uv run pre-commit install
 
 ## Start developing. Handles everything: deps, infra, migrations, tmux launch.
 ## Idempotent - safe to run repeatedly. Reattaches if already running.
 dev: install-hooks
-	$(UV_RUN) python tmux_tools/launcher.py
+	uv run python tmux_tools/launcher.py
 
 ## Same as dev, but with auto-reload for backend services (REST API + Celery).
 dev-autoreload: install-hooks
-	$(UV_RUN) python tmux_tools/launcher.py --autoreload
+	uv run python tmux_tools/launcher.py --autoreload
 
 ## Windows contributors: full dev env without tmux requirement.
 dev-lite: install-hooks
@@ -27,13 +26,13 @@ dev-lite: install-hooks
 
 ## Nuclear reset: kill tmux, destroy all containers/volumes/deps. Run `make dev` to start again.
 dev-reset:
-	$(UV_RUN) python tmux_tools/launcher.py --reset
+	uv run python tmux_tools/launcher.py --reset
 
 # --- Production (Docker) ---------------------------------------------------
 
 ## Start all services in Docker with tmux log viewer (builds on first run).
 prod:
-	$(UV_RUN) python tmux_tools/launcher.py --prod
+	uv run python tmux_tools/launcher.py --prod
 
 ## Self-hosting on any platform (Windows, CI, no tmux). Docker Desktop only.
 prod-lite:
@@ -42,4 +41,4 @@ prod-lite:
 
 ## Nuclear reset: stop containers, remove volumes, built images, and orphaned sandboxes.
 prod-reset:
-	$(UV_RUN) python tmux_tools/launcher.py --prod-reset
+	uv run python tmux_tools/launcher.py --prod-reset

--- a/Makefile
+++ b/Makefile
@@ -2,30 +2,47 @@
 # Traceroot Development
 # =============================================================================
 
-.PHONY: dev dev-autoreload dev-reset
+UV_RUN := uv run
+FRONTEND_PNPM := pnpm --dir frontend
+PROD_COMPOSE := docker compose -f docker-compose.prod.yml
+
+.PHONY: dev dev-autoreload dev-reset lint format ci-check prod prod-lite prod-reset
 
 ## Start developing. Handles everything: deps, infra, migrations, tmux launch.
-## Idempotent — safe to run repeatedly. Reattaches if already running.
+## Idempotent - safe to run repeatedly. Reattaches if already running.
 dev:
-	uv run python tmux_tools/launcher.py
+	$(UV_RUN) python tmux_tools/launcher.py
 
 ## Same as dev, but with auto-reload for backend services (REST API + Celery).
 dev-autoreload:
-	uv run python tmux_tools/launcher.py --autoreload
+	$(UV_RUN) python tmux_tools/launcher.py --autoreload
 
 ## Nuclear reset: kill tmux, destroy all containers/volumes/deps. Run `make dev` to start again.
 dev-reset:
-	uv run python tmux_tools/launcher.py --reset
+	$(UV_RUN) python tmux_tools/launcher.py --reset
+
+## Run local lint checks for Python and frontend code.
+lint:
+	$(UV_RUN) ruff check .
+	$(FRONTEND_PNPM) run lint
+
+## Auto-format Python and frontend code.
+format:
+	$(UV_RUN) ruff format .
+	$(FRONTEND_PNPM) run format
+
+## Run the core checks contributors should pass before opening a PR.
+ci-check:
+	$(UV_RUN) ruff check .
+	$(FRONTEND_PNPM) run lint
+	$(UV_RUN) coverage run -m pytest tests/ --durations=10
+	$(UV_RUN) coverage report
 
 # --- Production (Docker) ---------------------------------------------------
 
-PROD_COMPOSE := docker compose -f docker-compose.prod.yml
-
-.PHONY: prod prod-lite prod-reset
-
 ## Start all services in Docker with tmux log viewer (builds on first run).
 prod:
-	uv run python tmux_tools/launcher.py --prod
+	$(UV_RUN) python tmux_tools/launcher.py --prod
 
 ## Self-hosting on any platform (Windows, CI, no tmux). Docker Desktop only.
 prod-lite:
@@ -34,4 +51,4 @@ prod-lite:
 
 ## Nuclear reset: stop containers, remove volumes, built images, and orphaned sandboxes.
 prod-reset:
-	uv run python tmux_tools/launcher.py --prod-reset
+	$(UV_RUN) python tmux_tools/launcher.py --prod-reset

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,9 @@ format:
 ## Run the core checks contributors should pass before opening a PR.
 ci-check:
 	$(UV_RUN) ruff check .
+	$(UV_RUN) ruff format --check .
 	$(FRONTEND_PNPM) run lint
+	$(FRONTEND_PNPM) run format:check
 	$(UV_RUN) coverage run -m pytest tests/ --durations=10
 	$(UV_RUN) coverage report
 

--- a/Makefile
+++ b/Makefile
@@ -3,41 +3,31 @@
 # =============================================================================
 
 UV_RUN := uv run
-FRONTEND_PNPM := pnpm --dir frontend
 PROD_COMPOSE := docker compose -f docker-compose.prod.yml
 
-.PHONY: dev dev-autoreload dev-reset lint format ci-check prod prod-lite prod-reset
+.PHONY: install-hooks dev dev-lite dev-autoreload dev-reset prod prod-lite prod-reset
+
+## Install repository git hooks for contributors.
+install-hooks:
+	$(UV_RUN) pre-commit install
 
 ## Start developing. Handles everything: deps, infra, migrations, tmux launch.
 ## Idempotent - safe to run repeatedly. Reattaches if already running.
-dev:
+dev: install-hooks
 	$(UV_RUN) python tmux_tools/launcher.py
 
 ## Same as dev, but with auto-reload for backend services (REST API + Celery).
-dev-autoreload:
+dev-autoreload: install-hooks
 	$(UV_RUN) python tmux_tools/launcher.py --autoreload
+
+## Windows contributors: full dev env without tmux requirement.
+dev-lite: install-hooks
+	@echo "Starting Traceroot at http://localhost:3000 - Ctrl+C to stop"
+	$(PROD_COMPOSE) up --build
 
 ## Nuclear reset: kill tmux, destroy all containers/volumes/deps. Run `make dev` to start again.
 dev-reset:
 	$(UV_RUN) python tmux_tools/launcher.py --reset
-
-## Run local lint checks for Python and frontend code.
-lint:
-	$(UV_RUN) ruff check .
-	$(FRONTEND_PNPM) run lint
-
-## Auto-format Python and frontend code.
-format:
-	$(UV_RUN) ruff format .
-	$(FRONTEND_PNPM) run format
-
-## Run the core checks contributors should pass before opening a PR.
-ci-check:
-	$(UV_RUN) ruff check .
-ci-check:
-	$(MAKE) lint
-	$(UV_RUN) coverage run -m pytest tests/ --durations=10
-	$(UV_RUN) coverage report
 
 # --- Production (Docker) ---------------------------------------------------
 

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -22,6 +22,12 @@ export default [
     },
   },
   {
-    ignores: ["node_modules/", "dist/", ".next/", "packages/core/src/generated/", "**/*.config.js"],
+    ignores: [
+      "**/node_modules/**",
+      "**/dist/**",
+      "**/.next/**",
+      "packages/core/src/generated/**",
+      "**/*.config.js",
+    ],
   },
 ];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
     "coverage>=7.0",
+    "pre-commit>=4.0",
     "respx>=0.20",
     "ruff>=0.15.0",
     "mypy>=1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -130,6 +130,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -409,6 +418,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.128.0"
 source = { registry = "https://pypi.org/simple" }
@@ -421,6 +439,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
 ]
 
 [[package]]
@@ -494,6 +521,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/c4/7fb4db12296cdb11893d61c92048fe617ee853f8523b9b296ac03b43757e/identify-2.6.18.tar.gz", hash = "sha256:873ac56a5e3fd63e7438a7ecbc4d91aca692eb3fefa4534db2b7913f3fc352fd", size = 99580, upload-time = "2026-03-15T18:39:50.319Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/33/92ef41c6fad0233e41d3d84ba8e8ad18d1780f1e5d99b3c683e6d7f98b63/identify-2.6.18-py2.py3-none-any.whl", hash = "sha256:8db9d3c8ea9079db92cafb0ebf97abdc09d52e97f4dcf773a2e694048b7cd737", size = 99394, upload-time = "2026-03-15T18:39:48.915Z" },
 ]
 
 [[package]]
@@ -703,6 +739,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "opentelemetry-proto"
 version = "1.39.1"
 source = { registry = "https://pypi.org/simple" }
@@ -733,12 +778,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
 ]
 
 [[package]]
@@ -1008,6 +1078,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/88/815e53084c5079a59df912825a279f41dd2e0df82281770eadc732f5352c/python_discovery-1.2.1.tar.gz", hash = "sha256:180c4d114bff1c32462537eac5d6a332b768242b76b69c0259c7d14b1b680c9e", size = 58457, upload-time = "2026-03-26T22:30:44.496Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/0f/019d3949a40280f6193b62bc010177d4ce702d0fce424322286488569cd3/python_discovery-1.2.1-py3-none-any.whl", hash = "sha256:b6a957b24c1cd79252484d3566d1b49527581d46e789aaf43181005e56201502", size = 31674, upload-time = "2026-03-26T22:30:43.396Z" },
 ]
 
 [[package]]
@@ -1430,6 +1513,7 @@ dependencies = [
 dev = [
     { name = "coverage" },
     { name = "mypy" },
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -1462,6 +1546,7 @@ requires-dist = [
 dev = [
     { name = "coverage", specifier = ">=7.0" },
     { name = "mypy", specifier = ">=1.0" },
+    { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-asyncio", specifier = ">=0.21" },
     { name = "pytest-cov", specifier = ">=4.0" },
@@ -1589,6 +1674,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/e4/d07b5f29d283596b9727dd5275ccbceb63c44a1a82aa9e4bfd20426762ac/vine-5.1.0.tar.gz", hash = "sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0", size = 48980, upload-time = "2023-11-05T08:46:53.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/ff/7c0c86c43b3cbb927e0ccc0255cb4057ceba4799cd44ae95174ce8e8b5b2/vine-5.1.0-py3-none-any.whl", hash = "sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc", size = 9636, upload-time = "2023-11-05T08:46:51.205Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #581

## Summary

This PR improves the contributor experience by adding clearer onboarding guidance and a small set of local developer commands that are easy to discover and run before opening a PR.

## What changed

- improved `CONTRIBUTING.md` with:
  - clearer setup requirements
  - quick start steps
  - commonly used local commands
  - a simple contributor workflow for new developers
  - Conventional Commit examples
  - PR best practices

- added new `Makefile` targets:
  - `make lint`
  - `make format`
  - `make ci-check`

- updated frontend ESLint ignore patterns so generated build output such as `.next` does not pollute local lint results
