### PR TITLE
feat(ui): update onboarding with TypeScript support and skills section

### DIFF
--- a/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
@@ -3,19 +3,75 @@
 import { useState } from "react";
 import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { ApiKeyBlock } from "./ApiKeyBlock";
 
 const INSTRUMENT_PROMPT = `I want to add observability to my project using TraceRoot.
 
-Please help me:
-1. Install the traceroot Python package (pip install traceroot)
-2. Initialize TraceRoot at the entry point of my application:
+My project uses [Python / TypeScript/Node.js] — adjust the instructions to match my stack.
+
+**Python setup:**
+1. Install: pip install traceroot
+2. Initialize at the entry point, before any LLM imports:
+   from dotenv import load_dotenv
+   load_dotenv()
    import traceroot
    from traceroot import Integration
-   traceroot.initialize(integrations=[Integration.OPENAI])  # or Integration.LANGCHAIN
-3. Instrument all OpenAI and LangChain calls in my codebase.
+   traceroot.initialize(integrations=[
+       Integration.OPENAI,      # if using OpenAI
+       Integration.LANGCHAIN,   # if using LangChain/LangGraph
+       Integration.ANTHROPIC,   # if using Anthropic
+   ])
+3. Add @observe on agent entrypoints and tool functions:
+   from traceroot import observe
+   @observe(name="my_agent", type="agent")
+   def run(query): ...
+4. Wrap request handlers with using_attributes to attach user/session context:
+   from traceroot import using_attributes
+   with using_attributes(user_id="u-123", session_id="s-456"):
+       result = run(query)
+5. Call traceroot.flush() at the end of short-lived scripts.
+
+**TypeScript/Node.js setup:**
+1. Install: npm install @traceroot-ai/traceroot
+2. Initialize at the entry point, before any LLM imports:
+   import { TraceRoot } from '@traceroot-ai/traceroot';
+   import OpenAI from 'openai';
+   import Anthropic from '@anthropic-ai/sdk';
+   TraceRoot.initialize({
+     instrumentModules: {
+       openAI: OpenAI,       // if using OpenAI
+       anthropic: Anthropic, // if using Anthropic
+     },
+   });
+3. Wrap agent entrypoints and tool functions with observe():
+   import { observe } from '@traceroot-ai/traceroot';
+   const result = await observe({ name: 'my_agent', type: 'agent' }, async () => {
+     return await runPipeline(query);
+   });
+4. Wrap request handlers with usingAttributes to attach user/session context:
+   import { usingAttributes } from '@traceroot-ai/traceroot';
+   const result = await usingAttributes(
+     { userId: 'u-123', sessionId: 's-456' },
+     async () => await runAgent(query),
+   );
+5. Call await TraceRoot.flush() at the end of short-lived scripts.
 
 The TRACEROOT_API_KEY environment variable is already set in my .env file.`;
+
+const SKILLS = [
+  {
+    name: "Send your first trace",
+    description:
+      "Verify your API key and SDK are wired up correctly with a minimal working example.",
+    command: "npx skills add traceroot-ai/traceroot-skills --skill traceroot-quickstart",
+  },
+  {
+    name: "Instrument your project",
+    description: "Automatically add TraceRoot tracing to your LLM calls, agents, and tools.",
+    command: "npx skills add traceroot-ai/traceroot-skills --skill traceroot-instrument-repo",
+  },
+];
 
 function CopyPromptButton({ value }: { value: string }) {
   const [copied, setCopied] = useState(false);
@@ -68,6 +124,22 @@ export function AITab({ projectId }: AITabProps) {
             </p>
           </div>
           <CopyPromptButton value={INSTRUMENT_PROMPT} />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">3. Or install and run a skill</p>
+        <div className="space-y-2">
+          {SKILLS.map((skill) => (
+            <div key={skill.name} className="rounded-sm border border-border bg-muted/30 px-4 py-3">
+              <p className="text-xs font-medium text-primary">{skill.name}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">{skill.description}</p>
+              <div className="mt-2 flex items-center justify-between border border-border bg-muted px-3 py-2">
+                <span className="font-mono text-xs text-foreground">{skill.command}</span>
+                <CopyButton value={skill.command} className="ml-3 h-6 w-6 shrink-0" />
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -11,26 +11,21 @@ type Lang = "python" | "typescript";
 function LangTabs({ lang, onChange }: { lang: Lang; onChange: (l: Lang) => void }) {
   return (
     <div className="flex border-b border-border">
-      {(["python", "typescript"] as Lang[]).map((l) => {
-        const isTs = l === "typescript";
-        return (
-          <button
-            key={l}
-            type="button"
-            onClick={() => !isTs && onChange(l)}
-            disabled={isTs}
-            className={cn(
-              "-mb-px border-b-2 px-3 py-1.5 text-xs font-medium transition-colors",
-              lang === l
-                ? "border-foreground text-foreground"
-                : "border-transparent text-muted-foreground",
-              isTs && "cursor-not-allowed opacity-40",
-            )}
-          >
-            {l === "python" ? "Python" : "TypeScript"}
-          </button>
-        );
-      })}
+      {(["python", "typescript"] as Lang[]).map((l) => (
+        <button
+          key={l}
+          type="button"
+          onClick={() => onChange(l)}
+          className={cn(
+            "-mb-px border-b-2 px-3 py-1.5 text-xs font-medium transition-colors",
+            lang === l
+              ? "border-foreground text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {l === "python" ? "Python" : "TypeScript"}
+        </button>
+      ))}
     </div>
   );
 }
@@ -53,15 +48,28 @@ export function ManualTab({ projectId }: ManualTabProps) {
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">2. Install SDK</p>
         <LangTabs lang={installLang} onChange={setInstallLang} />
-        <div className="border border-border">
-          <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
-            <span className="text-xs text-muted-foreground">bash</span>
-            <CopyButton value="pip install traceroot" className="h-6 w-6" />
+        {installLang === "python" ? (
+          <div className="border border-border">
+            <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+              <span className="text-xs text-muted-foreground">bash</span>
+              <CopyButton value="pip install traceroot" className="h-6 w-6" />
+            </div>
+            <div className="bg-muted px-3 py-2.5 font-mono text-xs">
+              <span className="text-blue-600 dark:text-blue-400">pip</span> install traceroot
+            </div>
           </div>
-          <div className="bg-muted px-3 py-2.5 font-mono text-xs">
-            <span className="text-blue-600 dark:text-blue-400">pip</span> install traceroot
+        ) : (
+          <div className="border border-border">
+            <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+              <span className="text-xs text-muted-foreground">bash</span>
+              <CopyButton value="npm install @traceroot-ai/traceroot" className="h-6 w-6" />
+            </div>
+            <div className="bg-muted px-3 py-2.5 font-mono text-xs">
+              <span className="text-blue-600 dark:text-blue-400">npm</span> install
+              @traceroot-ai/traceroot
+            </div>
           </div>
-        </div>
+        )}
       </div>
 
       <div className="space-y-2">
@@ -94,36 +102,101 @@ export function ManualTab({ projectId }: ManualTabProps) {
             <LinkIcon className="h-6 w-6 text-foreground" />
             <span className="text-xs font-medium text-foreground">LangChain</span>
           </a>
+          <a
+            href="https://traceroot.ai/docs/integrations/anthropic"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex w-24 flex-col items-center gap-1.5 border border-border bg-muted/30 py-3 transition-colors hover:bg-muted/60"
+          >
+            <svg
+              aria-hidden="true"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="text-foreground"
+            >
+              <path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" />
+            </svg>
+            <span className="text-xs font-medium text-foreground">Anthropic</span>
+          </a>
         </div>
       </div>
 
       <div className="space-y-2">
         <p className="text-sm font-medium text-foreground">4. Initialize TraceRoot</p>
         <LangTabs lang={initLang} onChange={setInitLang} />
-        <div className="border border-border">
-          <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
-            <span className="text-xs text-muted-foreground">python</span>
-            <CopyButton
-              value={
-                "import traceroot\nfrom traceroot import Integration\n\ntraceroot.initialize(integrations=[Integration.OPENAI])"
-              }
-              className="h-6 w-6"
-            />
+        {initLang === "python" ? (
+          <div className="border border-border">
+            <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+              <span className="text-xs text-muted-foreground">python</span>
+              <CopyButton
+                value={
+                  "from dotenv import load_dotenv\nload_dotenv()\n\nimport traceroot\nfrom traceroot import Integration\n\ntraceroot.initialize(integrations=[Integration.OPENAI])"
+                }
+                className="h-6 w-6"
+              />
+            </div>
+            <div className="bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed">
+              <div>
+                <span className="text-blue-600 dark:text-blue-400">from</span> dotenv{" "}
+                <span className="text-blue-600 dark:text-blue-400">import</span> load_dotenv
+              </div>
+              <div>load_dotenv()</div>
+              <div className="mt-1">
+                <span className="text-blue-600 dark:text-blue-400">import</span> traceroot
+              </div>
+              <div>
+                <span className="text-blue-600 dark:text-blue-400">from</span> traceroot{" "}
+                <span className="text-blue-600 dark:text-blue-400">import</span> Integration
+              </div>
+              <div className="mt-1">
+                traceroot.<span className="text-purple-600 dark:text-purple-400">initialize</span>
+                (integrations=[Integration.OPENAI])
+              </div>
+            </div>
           </div>
-          <div className="bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed">
-            <div>
-              <span className="text-blue-600 dark:text-blue-400">import</span> traceroot
+        ) : (
+          <div className="border border-border">
+            <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
+              <span className="text-xs text-muted-foreground">typescript</span>
+              <CopyButton
+                value={
+                  "import 'dotenv/config';\nimport { TraceRoot } from '@traceroot-ai/traceroot';\nimport OpenAI from 'openai';\n\nTraceRoot.initialize({\n  instrumentModules: { openAI: OpenAI },\n});"
+                }
+                className="h-6 w-6"
+              />
             </div>
-            <div>
-              <span className="text-blue-600 dark:text-blue-400">from</span> traceroot{" "}
-              <span className="text-blue-600 dark:text-blue-400">import</span> Integration
-            </div>
-            <div className="mt-1">
-              traceroot.<span className="text-purple-600 dark:text-purple-400">initialize</span>
-              (integrations=[Integration.OPENAI])
+            <div className="bg-muted px-3 py-2.5 font-mono text-xs leading-relaxed">
+              <div>
+                <span className="text-blue-600 dark:text-blue-400">import</span>{" "}
+                <span className="text-orange-600 dark:text-orange-400">
+                  &apos;dotenv/config&apos;
+                </span>
+                ;
+              </div>
+              <div>
+                <span className="text-blue-600 dark:text-blue-400">import</span> {"{ TraceRoot }"}{" "}
+                <span className="text-blue-600 dark:text-blue-400">from</span>{" "}
+                <span className="text-orange-600 dark:text-orange-400">
+                  &apos;@traceroot-ai/traceroot&apos;
+                </span>
+                ;
+              </div>
+              <div>
+                <span className="text-blue-600 dark:text-blue-400">import</span> OpenAI{" "}
+                <span className="text-blue-600 dark:text-blue-400">from</span>{" "}
+                <span className="text-orange-600 dark:text-orange-400">&apos;openai&apos;</span>;
+              </div>
+              <div className="mt-1">
+                TraceRoot.<span className="text-purple-600 dark:text-purple-400">initialize</span>(
+                {"{"}
+              </div>
+              <div className="pl-4">instrumentModules: {"{ openAI: OpenAI }"},</div>
+              <div>{"});"}</div>
             </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
@@ -17,7 +17,7 @@ export function GettingStarted({ projectId }: GettingStartedProps) {
 
   return (
     <div className="w-full py-10">
-      <div className="mx-auto w-full max-w-[600px] px-7">
+      <div className="mx-auto w-full max-w-[600px] px-7 lg:max-w-3xl xl:max-w-4xl">
         <h2 className="text-xl font-semibold tracking-tight text-foreground">
           Get started with Tracing
         </h2>


### PR DESCRIPTION
## Summary

- **TypeScript support**: Enable the disabled TypeScript tab in ManualTab with proper install (`npm install @traceroot-ai/traceroot`) and init snippets (`TraceRoot.initialize`)
- **Anthropic integration card**: Added alongside OpenAI and LangChain, using the official Anthropic SVG mark
- **Skills section**: New step 3 in the AI tab — "Send your first trace" and "Instrument your project" with copyable `npx skills add` commands backed by `traceroot-ai/traceroot-skills`
- **Expanded AI prompt**: Updated `INSTRUMENT_PROMPT` to cover both Python and TypeScript stacks with full instrumentation guidance (`@observe`/`observe()`, `using_attributes`/`usingAttributes`, `flush`)
- **Responsive layout**: `GettingStarted` container now expands at `lg` (max-w-3xl) and `xl` (max-w-4xl) breakpoints instead of staying capped at 600px on large screens
- **Cleanup**: Removed `python-dotenv` / `dotenv` from install commands

## Screenshots

<img width="1728" height="926" alt="Screenshot 2026-04-03 at 12 50 24 PM" src="https://github.com/user-attachments/assets/2111b6e7-956a-40f6-872e-fc14833b818d" />
<img width="1722" height="935" alt="Screenshot 2026-04-03 at 12 50 17 PM" src="https://github.com/user-attachments/assets/c9587ff3-7604-4921-90af-3d1ecc60e22c" />


## Test plan

- [x] Visit a project's traces page with no traces — GettingStarted should render
- [x] AI tab: "copy prompt" copies the combined Python+TypeScript prompt; skills cards copy the correct `npx skills add` commands
- [x] Manual tab: Python/TypeScript tabs both switch correctly with matching install and init snippets; Anthropic card links out
- [x] On a wide viewport (≥1280px) content expands beyond the old 600px cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)