### PR TITLE
feat: add Gemini ReAct tool agent example with TraceRoot observability

### DIFF
--- a/examples/python/gemini-tool-agent/.env.example
+++ b/examples/python/gemini-tool-agent/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# Gemini
+GEMINI_API_KEY=your_openai_api_key_here

--- a/examples/python/gemini-tool-agent/.env.example
+++ b/examples/python/gemini-tool-agent/.env.example
@@ -4,4 +4,4 @@ TRACEROOT_API_KEY=your_traceroot_api_key_here
 # TRACEROOT_HOST_URL=http://localhost:8000
 
 # Gemini
-GEMINI_API_KEY=your_openai_api_key_here
+GEMINI_API_KEY=your_gemini_api_key_here

--- a/examples/python/gemini-tool-agent/.env.example
+++ b/examples/python/gemini-tool-agent/.env.example
@@ -4,4 +4,4 @@ TRACEROOT_API_KEY=your_traceroot_api_key_here
 # TRACEROOT_HOST_URL=http://localhost:8000
 
 # Gemini
-GEMINI_API_KEY=your_gemini_api_key_here
+GEMINI_API_KEY=your_google_genai_api_key_here

--- a/examples/python/gemini-tool-agent/README.md
+++ b/examples/python/gemini-tool-agent/README.md
@@ -1,0 +1,22 @@
+# Gemini Tool Agent
+
+ReAct-style agent with Gemini streaming and tool use, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+## What it does
+
+Runs two demo queries that exercise tool use:
+1. Weather comparison (San Francisco vs Tokyo)
+2. Stock price lookup + calculation (NVDA +10%)
+
+Tools: `get_weather`, `get_stock_price`, `calculate`, `get_current_time`

--- a/examples/python/gemini-tool-agent/README.md
+++ b/examples/python/gemini-tool-agent/README.md
@@ -1,6 +1,6 @@
 # Gemini Tool Agent
 
-ReAct-style agent with Gemini streaming and tool use, instrumented with [TraceRoot](https://traceroot.ai).
+ReAct-style agent with Gemini tool use and TraceRoot observability, instrumented with [TraceRoot](https://traceroot.ai).
 
 ## Setup
 

--- a/examples/python/gemini-tool-agent/main.py
+++ b/examples/python/gemini-tool-agent/main.py
@@ -7,9 +7,9 @@ Usage:
     python main.py
 """
 
-import os
 import json
 import logging
+import os
 from datetime import datetime
 
 from dotenv import find_dotenv, load_dotenv
@@ -123,7 +123,11 @@ TOOL_SCHEMAS = [
         description="Get current stock price for a ticker symbol",
         parameters=types.Schema(
             type="OBJECT",
-            properties={"symbol": types.Schema(type="STRING", description="Stock ticker symbol (e.g., AAPL)")},
+            properties={
+                "symbol": types.Schema(
+                    type="STRING", description="Stock ticker symbol (e.g., AAPL)"
+                )
+            },
             required=["symbol"],
         ),
     ),
@@ -132,7 +136,11 @@ TOOL_SCHEMAS = [
         description="Evaluate a mathematical expression",
         parameters=types.Schema(
             type="OBJECT",
-            properties={"expression": types.Schema(type="STRING", description="Math expression (e.g., '2 + 2 * 3')")},
+            properties={
+                "expression": types.Schema(
+                    type="STRING", description="Math expression (e.g., '2 + 2 * 3')"
+                )
+            },
             required=["expression"],
         ),
     ),
@@ -141,7 +149,9 @@ TOOL_SCHEMAS = [
         description="Get the current date and time",
         parameters=types.Schema(
             type="OBJECT",
-            properties={"timezone": types.Schema(type="STRING", description="Timezone (default: UTC)")},
+            properties={
+                "timezone": types.Schema(type="STRING", description="Timezone (default: UTC)")
+            },
         ),
     ),
 ]
@@ -190,15 +200,13 @@ class ReActAgent:
     @observe(name="agent_turn", type="agent")
     def run(self, query: str) -> str:
         # Append user message in Gemini's Content format
-        self.contents.append(
-            types.Content(role="user", parts=[types.Part(text=query)])
-        )
+        self.contents.append(types.Content(role="user", parts=[types.Part(text=query)]))
 
         for _ in range(5):
             response = self._get_completion()
             candidate = response.candidates[0]
             content = candidate.content
-            
+
             # Guard against None content
             if content is None or not content.parts:
                 return response.text or "No response generated."
@@ -236,9 +244,7 @@ class ReActAgent:
                 )
 
             # Append all tool results as a single user turn
-            self.contents.append(
-                types.Content(role="user", parts=tool_response_parts)
-            )
+            self.contents.append(types.Content(role="user", parts=tool_response_parts))
 
         return "I wasn't able to complete this task within the allowed steps."
 

--- a/examples/python/gemini-tool-agent/main.py
+++ b/examples/python/gemini-tool-agent/main.py
@@ -2,7 +2,7 @@
 Gemini ReAct agent with tool use and TraceRoot observability.
 
 Usage:
-    cp env.example .env
+    cp .env.example .env
     pip install -r requirements.txt
     python main.py
 """

--- a/examples/python/gemini-tool-agent/main.py
+++ b/examples/python/gemini-tool-agent/main.py
@@ -2,7 +2,7 @@
 Gemini ReAct agent with tool use, streaming, and TraceRoot observability.
 
 Usage:
-    cp env.example .env
+    cp .env.example .env
     pip install -r requirements.txt
     python main.py
 """
@@ -98,7 +98,10 @@ def calculate(expression: str) -> dict:
 @observe(name="get_current_time", type="tool")
 def get_current_time() -> dict:
     """Get current time in UTC."""
-    return {"time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"), "timezone": "UTC", }
+    return {
+        "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        "timezone": "UTC",
+    }
 
 
 TOOLS = {
@@ -201,10 +204,10 @@ class ReActAgent:
 
         for _ in range(5):
             response = self._get_completion()
-            
+
             if not response.candidates:
                 return response.text or "No response generated."
-            
+
             candidate = response.candidates[0]
             content = candidate.content
 

--- a/examples/python/gemini-tool-agent/main.py
+++ b/examples/python/gemini-tool-agent/main.py
@@ -1,0 +1,270 @@
+"""
+Gemini ReAct agent with tool use, streaming, and TraceRoot observability.
+
+Usage:
+    cp env.example .env
+    pip install -r requirements.txt
+    python main.py
+"""
+
+import os
+import json
+import logging
+from datetime import datetime
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found (find_dotenv returned None).\nUsing process environment variables.")
+
+from google import genai
+from google.genai import types
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.GEMINI])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@observe(name="get_weather", type="tool")
+def get_weather(city: str) -> dict:
+    """Get current weather for a city."""
+    weather_db = {
+        "san francisco": {"temp": 68, "condition": "foggy", "humidity": 75},
+        "new york": {"temp": 45, "condition": "cloudy", "humidity": 60},
+        "london": {"temp": 52, "condition": "rainy", "humidity": 85},
+        "tokyo": {"temp": 72, "condition": "sunny", "humidity": 50},
+    }
+    data = weather_db.get(city.lower(), {"temp": 70, "condition": "unknown", "humidity": 50})
+    return {"city": city, **data}
+
+
+@observe(name="get_stock_price", type="tool")
+def get_stock_price(symbol: str) -> dict:
+    """Get stock price for a symbol."""
+    stocks = {
+        "AAPL": {"price": 178.50, "change": +2.30, "percent": "+1.3%"},
+        "GOOGL": {"price": 141.20, "change": -0.80, "percent": "-0.6%"},
+        "MSFT": {"price": 378.90, "change": +4.50, "percent": "+1.2%"},
+        "NVDA": {"price": 495.20, "change": +12.30, "percent": "+2.5%"},
+    }
+    data = stocks.get(symbol.upper(), {"price": 0, "change": 0, "percent": "N/A"})
+    return {"symbol": symbol.upper(), **data}
+
+
+@observe(name="calculate", type="tool")
+def calculate(expression: str) -> dict:
+    """Evaluate a math expression safely using AST parsing."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval(node.operand)
+        raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+        result = _eval(tree)
+        return {"expression": expression, "result": result}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@observe(name="get_current_time", type="tool")
+def get_current_time(timezone: str = "UTC") -> dict:
+    """Get current time."""
+    return {"timezone": timezone, "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+
+
+TOOLS = {
+    "get_weather": get_weather,
+    "get_stock_price": get_stock_price,
+    "calculate": calculate,
+    "get_current_time": get_current_time,
+}
+
+TOOL_SCHEMAS = [
+    types.FunctionDeclaration(
+        name="get_weather",
+        description="Get current weather for a city",
+        parameters=types.Schema(
+            type="OBJECT",
+            properties={"city": types.Schema(type="STRING", description="City name")},
+            required=["city"],
+        ),
+    ),
+    types.FunctionDeclaration(
+        name="get_stock_price",
+        description="Get current stock price for a ticker symbol",
+        parameters=types.Schema(
+            type="OBJECT",
+            properties={"symbol": types.Schema(type="STRING", description="Stock ticker symbol (e.g., AAPL)")},
+            required=["symbol"],
+        ),
+    ),
+    types.FunctionDeclaration(
+        name="calculate",
+        description="Evaluate a mathematical expression",
+        parameters=types.Schema(
+            type="OBJECT",
+            properties={"expression": types.Schema(type="STRING", description="Math expression (e.g., '2 + 2 * 3')")},
+            required=["expression"],
+        ),
+    ),
+    types.FunctionDeclaration(
+        name="get_current_time",
+        description="Get the current date and time",
+        parameters=types.Schema(
+            type="OBJECT",
+            properties={"timezone": types.Schema(type="STRING", description="Timezone (default: UTC)")},
+        ),
+    ),
+]
+
+SYSTEM_INSTRUCTION = (
+    "You are a helpful AI assistant with access to tools. "
+    "Use available tools to gather information, then provide "
+    "a clear, comprehensive answer."
+)
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class ReActAgent:
+    """ReAct-style agent that reasons and acts in a loop with streaming."""
+
+    def __init__(self, model: str = "gemini-2.5-flash"):
+        self.client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
+        self.model = model
+        self.contents: list[types.Content] = []
+
+    @observe(name="execute_tool", type="span")
+    def _execute_tool(self, name: str, arguments: dict) -> str:
+        if name not in TOOLS:
+            return json.dumps({"error": f"Unknown tool: {name}"})
+        try:
+            return json.dumps(TOOLS[name](**arguments))
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @observe(name="llm_completion", type="span")
+    def _get_completion(self) -> types.GenerateContentResponse:
+        """Get a competion from Gemini."""
+        return self.client.models.generate_content(
+            model=self.model,
+            contents=self.contents,
+            config=types.GenerateContentConfig(
+                system_instruction=SYSTEM_INSTRUCTION,
+                tools=TOOL_SCHEMAS,
+            ),
+        )
+
+    @observe(name="agent_turn", type="agent")
+    def run(self, query: str) -> str:
+        # Append user message in Gemini's Content format
+        self.contents.append(
+            types.Content(role="user", parts=[types.Part(text=query)])
+        )
+
+        for _ in range(5):
+            response = self._get_completion()
+            candidate = response.candidates[0]
+            content = candidate.content
+            
+            # Guard against None content
+            if content is None or not content.parts:
+                return response.text or "No response generated."
+
+            # Collect any text and function calls from the response parts
+            text_parts = []
+            function_calls = []
+            for part in content.parts:
+                if part.text:
+                    text_parts.append(part.text)
+                if part.function_call:
+                    function_calls.append(part.function_call)
+
+            # Append model response to history
+            self.contents.append(content)
+
+            if not function_calls:
+                return "\n".join(text_parts)
+
+            # Execute each tool call and build function response parts
+            tool_response_parts = []
+            for fc in function_calls:
+                args = dict(fc.args)
+                logger.info(f"Tool call: {fc.name}({args})")
+                result = self._execute_tool(fc.name, args)
+                logger.info(f"Tool result: {result}")
+
+                tool_response_parts.append(
+                    types.Part(
+                        function_response=types.FunctionResponse(
+                            name=fc.name,
+                            response={"result": json.loads(result)},
+                        )
+                    )
+                )
+
+            # Append all tool results as a single user turn
+            self.contents.append(
+                types.Content(role="user", parts=tool_response_parts)
+            )
+
+        return "I wasn't able to complete this task within the allowed steps."
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+DEMO_QUERIES = [
+    "What's the weather in San Francisco and Tokyo? Compare them.",
+    "What's NVDA stock price? If it goes up 10%, what would the new price be?",
+]
+
+
+@observe(name="demo_session", type="agent")
+def run_demo():
+    for i, query in enumerate(DEMO_QUERIES, 1):
+        agent = ReActAgent()
+        print(f"\n{'=' * 60}")
+        print(f"Query {i}: {query}")
+        print("=" * 60)
+        result = agent.run(query)
+        print(f"\nAgent: {result}\n")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="tool-agent-session"):
+        run_demo()
+    traceroot.flush()

--- a/examples/python/gemini-tool-agent/main.py
+++ b/examples/python/gemini-tool-agent/main.py
@@ -96,9 +96,9 @@ def calculate(expression: str) -> dict:
 
 
 @observe(name="get_current_time", type="tool")
-def get_current_time(timezone: str = "UTC") -> dict:
-    """Get current time."""
-    return {"timezone": timezone, "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+def get_current_time() -> dict:
+    """Get current time in UTC."""
+    return {"time": datetime.now().strftime("%Y-%m-%d %H:%M:%S"), "timezone": "UTC", }
 
 
 TOOLS = {
@@ -149,9 +149,6 @@ TOOL_SCHEMAS = [
         description="Get the current date and time",
         parameters=types.Schema(
             type="OBJECT",
-            properties={
-                "timezone": types.Schema(type="STRING", description="Timezone (default: UTC)")
-            },
         ),
     ),
 ]
@@ -169,7 +166,7 @@ SYSTEM_INSTRUCTION = (
 
 
 class ReActAgent:
-    """ReAct-style agent that reasons and acts in a loop with streaming."""
+    """ReAct-style agent that reasons and acts in a loop."""
 
     def __init__(self, model: str = "gemini-2.5-flash"):
         self.client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
@@ -187,7 +184,7 @@ class ReActAgent:
 
     @observe(name="llm_completion", type="span")
     def _get_completion(self) -> types.GenerateContentResponse:
-        """Get a competion from Gemini."""
+        """Get a completion from Gemini."""
         return self.client.models.generate_content(
             model=self.model,
             contents=self.contents,
@@ -204,6 +201,10 @@ class ReActAgent:
 
         for _ in range(5):
             response = self._get_completion()
+            
+            if not response.candidates:
+                return response.text or "No response generated."
+            
             candidate = response.candidates[0]
             content = candidate.content
 

--- a/examples/python/gemini-tool-agent/main.py
+++ b/examples/python/gemini-tool-agent/main.py
@@ -1,8 +1,8 @@
 """
-Gemini ReAct agent with tool use, streaming, and TraceRoot observability.
+Gemini ReAct agent with tool use and TraceRoot observability.
 
 Usage:
-    cp .env.example .env
+    cp env.example .env
     pip install -r requirements.txt
     python main.py
 """
@@ -26,7 +26,7 @@ from google.genai import types
 import traceroot
 from traceroot import Integration, observe, using_attributes
 
-traceroot.initialize(integrations=[Integration.GEMINI])
+traceroot.initialize(integrations=[Integration.GOOGLE_GENAI])
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/examples/python/gemini-tool-agent/requirements.txt
+++ b/examples/python/gemini-tool-agent/requirements.txt
@@ -1,0 +1,4 @@
+google-genai>=1.0.0
+python-dotenv>=1.0.0
+
+traceroot==0.1.0

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -286,5 +286,65 @@
       "cacheRead": 0.000000175,
       "cacheWrite": null
     }
+  },
+  {
+    "id": "tr-gemini-2-5-flash",
+    "modelName": "gemini-2.5-flash",
+    "matchPattern": "(?i)^(google\\/|models\\/)?gemini-2\\.5-flash(-[\\d]+)?$",
+    "provider": "google",
+    "prices": {
+      "input": 0.00000015,
+      "output": 0.0000006,
+      "cacheRead": 0.0000000375,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gemini-2-5-pro",
+    "modelName": "gemini-2.5-pro",
+    "matchPattern": "(?i)^(google\\/|models\\/)?gemini-2\\.5-pro(-[\\d]+)?$",
+    "provider": "google",
+    "prices": {
+      "input": 0.00000125,
+      "output": 0.00001,
+      "cacheRead": 0.0000003125,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gemini-2-0-flash",
+    "modelName": "gemini-2.0-flash",
+    "matchPattern": "(?i)^(google\\/|models\\/)?gemini-2\\.0-flash(-[\\d]+)?$",
+    "provider": "google",
+    "prices": {
+      "input": 0.0000001,
+      "output": 0.0000004,
+      "cacheRead": 0.000000025,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gemini-1-5-flash",
+    "modelName": "gemini-1.5-flash",
+    "matchPattern": "(?i)^(google\\/|models\\/)?gemini-1\\.5-flash(-[\\d]+)?$",
+    "provider": "google",
+    "prices": {
+      "input": 0.000000075,
+      "output": 0.0000003,
+      "cacheRead": 0.00000001875,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gemini-1-5-pro",
+    "modelName": "gemini-1.5-pro",
+    "matchPattern": "(?i)^(google\\/|models\\/)?gemini-1\\.5-pro(-[\\d]+)?$",
+    "provider": "google",
+    "prices": {
+      "input": 0.00000125,
+      "output": 0.000005,
+      "cacheRead": 0.0000003125,
+      "cacheWrite": null
+    }
   }
 ]


### PR DESCRIPTION
## Summary

Adds a Gemini tool-use agent example to `examples/python/`, mirroring the existing `openai-tool-agent` structure. This is the companion example to traceroot-ai/traceroot-py#91 which adds `Integration.GOOGLE_GENAI` to the Python SDK. Also adding Gemini model pricing to `standard-model-prices.json` to enable cost tracking.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

Builds on Python SDK Gemini Integration PR: traceroot-ai/traceroot-py#91

- Added `examples/python/gemini-tool-agent/` with a ReAct-style agent using `google-genai` SDK and TraceRoot auto-instrumentation
- Uses `Integration.GEMINI` with `traceroot.initialize()` for OpenInference-based auto-instrumentation of Gemini API calls
- Manually declares `FunctionDeclaration` tool schemas (vs. automatic function calling) to keep the ReAct loop explicit and TraceRoot spans visible per tool execution
- Includes the same 2 demo queries as the OpenAI example: weather comparison and stock price + calculation
- TraceRoot correctly captures `demo_session → agent_turn → llm_completion → GenerateContent` span hierarchy
- Added Gemini model pricing to `frontend/packages/core/src/standard-model-prices.json` (`gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-2.0-flash`, `gemini-1.5-flash`, `gemini-1.5-pro`)
- Verified cost tracking working e2e with local stack

### References
- [google-genai Function Calling docs](https://googleapis.github.io/python-genai/#function-calling)

## Screenshots / Recordings (if applicable)

<img width="882" height="911" alt="image" src="https://github.com/user-attachments/assets/f9bd6191-edbc-4266-9a47-543f09abf258" />

<img width="892" height="467" alt="image" src="https://github.com/user-attachments/assets/bc5f5a50-b7f8-4ddc-82b5-5a1592f6a06b" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable (N/A; examples folder has no test suite)
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
