### PR TITLE
feat(ui): replace free-text model input with curated dropdown for BYOK providers

### DIFF
--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -15,7 +15,9 @@
     "db:migrate": "dotenv -e ../../../.env -- prisma migrate dev",
     "db:push": "dotenv -e ../../../.env -- prisma db push",
     "build": "dotenv -e ../../../.env -- prisma generate && tsc",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
@@ -25,6 +27,7 @@
     "@types/node": "^22.19.9",
     "prisma": "^5.22.0",
     "stripe": "^14.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/packages/core/src/__tests__/llm-providers.test.ts
+++ b/frontend/packages/core/src/__tests__/llm-providers.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  ADAPTER_MODELS,
-  SYSTEM_MODELS,
-  ADAPTER_API_PROTOCOL,
-  LLMAdapter,
-} from "../llm-providers";
+import { ADAPTER_MODELS, SYSTEM_MODELS, ADAPTER_API_PROTOCOL, LLMAdapter } from "../llm-providers";
 
 describe("ADAPTER_MODELS", () => {
   it("contains no duplicate model IDs within a single adapter", () => {
@@ -20,7 +15,10 @@ describe("ADAPTER_MODELS", () => {
     for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
       if (!models) continue;
       for (const model of models) {
-        expect(model.label.trim().length, `adapter "${adapter}", model "${model.id}" has empty label`).toBeGreaterThan(0);
+        expect(
+          model.label.trim().length,
+          `adapter "${adapter}", model "${model.id}" has empty label`,
+        ).toBeGreaterThan(0);
       }
     }
   });
@@ -85,10 +83,9 @@ describe("ADAPTER_MODELS", () => {
       for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
         if (!models) continue;
         for (const model of models) {
-          expect(
-            model.id,
-            `adapter "${adapter}" model "${model.id}" has whitespace`,
-          ).toBe(model.id.trim());
+          expect(model.id, `adapter "${adapter}" model "${model.id}" has whitespace`).toBe(
+            model.id.trim(),
+          );
         }
       }
     });

--- a/frontend/packages/core/src/__tests__/llm-providers.test.ts
+++ b/frontend/packages/core/src/__tests__/llm-providers.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  ADAPTER_MODELS,
+  SYSTEM_MODELS,
+  ADAPTER_API_PROTOCOL,
+  LLMAdapter,
+} from "../llm-providers";
+
+describe("ADAPTER_MODELS", () => {
+  it("contains no duplicate model IDs within a single adapter", () => {
+    for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
+      if (!models) continue;
+      const ids = models.map((m) => m.id);
+      const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
+      expect(dupes, `adapter "${adapter}" has duplicate IDs: ${dupes.join(", ")}`).toEqual([]);
+    }
+  });
+
+  it("has non-empty label for every model", () => {
+    for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
+      if (!models) continue;
+      for (const model of models) {
+        expect(model.label.trim().length, `adapter "${adapter}", model "${model.id}" has empty label`).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  describe("apiProtocol consistency with SYSTEM_MODELS", () => {
+    const systemModelMap = new Map<string, { apiProtocol: string; provider: string }>();
+    for (const system of SYSTEM_MODELS) {
+      for (const model of system.models) {
+        if (model.apiProtocol) {
+          systemModelMap.set(model.id, {
+            apiProtocol: model.apiProtocol,
+            provider: system.piAIProvider,
+          });
+        }
+      }
+    }
+
+    it("matches SYSTEM_MODELS apiProtocol overrides for shared model IDs", () => {
+      for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
+        if (!models) continue;
+        for (const model of models) {
+          const systemEntry = systemModelMap.get(model.id);
+          if (!systemEntry) continue;
+
+          expect(
+            model.apiProtocol,
+            `adapter "${adapter}", model "${model.id}" requires apiProtocol ` +
+              `"${systemEntry.apiProtocol}" (set in SYSTEM_MODELS for ${systemEntry.provider}) ` +
+              `but ADAPTER_MODELS has "${model.apiProtocol ?? "(none)"}"`,
+          ).toBe(systemEntry.apiProtocol);
+        }
+      }
+    });
+  });
+
+  describe("adapter coverage", () => {
+    const freeTextAdapters = new Set(["azure", "amazon-bedrock", "openrouter"]);
+
+    it("every non-free-text adapter has a curated model list", () => {
+      for (const adapter of Object.values(LLMAdapter)) {
+        if (freeTextAdapters.has(adapter)) continue;
+        expect(
+          ADAPTER_MODELS[adapter],
+          `adapter "${adapter}" is not free-text but has no entry in ADAPTER_MODELS`,
+        ).toBeDefined();
+        expect(ADAPTER_MODELS[adapter]!.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("free-text adapters do not have curated model lists", () => {
+      for (const adapter of freeTextAdapters) {
+        expect(
+          ADAPTER_MODELS[adapter as LLMAdapter],
+          `adapter "${adapter}" should use free-text input, not a curated list`,
+        ).toBeUndefined();
+      }
+    });
+  });
+
+  describe("model ID format", () => {
+    it("model IDs contain no leading or trailing whitespace", () => {
+      for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
+        if (!models) continue;
+        for (const model of models) {
+          expect(
+            model.id,
+            `adapter "${adapter}" model "${model.id}" has whitespace`,
+          ).toBe(model.id.trim());
+        }
+      }
+    });
+
+    it("model IDs are non-empty strings", () => {
+      for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
+        if (!models) continue;
+        for (const model of models) {
+          expect(model.id.length, `adapter "${adapter}" has empty model ID`).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
+
+  describe("protocol references are valid", () => {
+    it("every apiProtocol override in ADAPTER_MODELS references an existing protocol", () => {
+      const allProtocols = new Set(Object.values(ADAPTER_API_PROTOCOL));
+      for (const system of SYSTEM_MODELS) {
+        allProtocols.add(system.apiProtocol);
+        for (const m of system.models) {
+          if (m.apiProtocol) allProtocols.add(m.apiProtocol);
+        }
+      }
+
+      for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
+        if (!models) continue;
+        for (const model of models) {
+          if (!model.apiProtocol) continue;
+          expect(
+            allProtocols.has(model.apiProtocol),
+            `adapter "${adapter}", model "${model.id}" has unknown apiProtocol "${model.apiProtocol}"`,
+          ).toBe(true);
+        }
+      }
+    });
+  });
+});

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -158,9 +158,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
     { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   ],
-  deepseek: [
-    { id: "deepseek-v3.2", label: "DeepSeek V3.2" },
-  ],
+  deepseek: [{ id: "deepseek-v3.2", label: "DeepSeek V3.2" }],
   xai: [
     { id: "grok-4.20", label: "Grok 4.20" },
     { id: "grok-4", label: "Grok 4" },

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -158,7 +158,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
     { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
   ],
-  deepseek: [{ id: "deepseek-v3.2", label: "DeepSeek V3.2" }],
+  deepseek: [{ id: "deepseek-chat", label: "DeepSeek Chat" }],
   xai: [
     { id: "grok-4.20", label: "Grok 4.20" },
     { id: "grok-4", label: "Grok 4" },

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -129,7 +129,52 @@ export const PROVIDER_PRIORITY: LLMAdapter[] = [
   LLMAdapter.AMAZON_BEDROCK,
 ];
 
-// Default models per adapter (for BYOK providers)
+// Curated model catalog per adapter — used for dropdown selection in BYOK provider settings.
+// Adapters NOT listed here (azure, amazon-bedrock, openrouter) use free-text input.
+export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
+  openai: [
+    { id: "gpt-5.4", label: "GPT-5.4" },
+    { id: "gpt-5.4-pro", label: "GPT-5.4 Pro" },
+    { id: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
+    { id: "gpt-5.4-nano", label: "GPT-5.4 Nano" },
+    { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+    { id: "gpt-5.2", label: "GPT-5.2" },
+    { id: "gpt-5", label: "GPT-5" },
+    { id: "gpt-5-mini", label: "GPT-5 Mini" },
+    { id: "o3", label: "o3" },
+    { id: "o4-mini", label: "o4-mini" },
+  ],
+  anthropic: [
+    { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
+    { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+    { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
+    { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
+    { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+  ],
+  google: [
+    { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
+    { id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
+    { id: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 Flash Lite Preview" },
+    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
+    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+  ],
+  deepseek: [
+    { id: "deepseek-v3.2", label: "DeepSeek V3.2" },
+  ],
+  xai: [
+    { id: "grok-4.20", label: "Grok 4.20" },
+    { id: "grok-4", label: "Grok 4" },
+  ],
+  moonshot: [
+    { id: "kimi-k2.5", label: "Kimi K2.5" },
+    { id: "kimi-k2-thinking", label: "Kimi K2 Thinking" },
+  ],
+  zai: [
+    { id: "glm-4.5", label: "GLM-4.5" },
+    { id: "glm-4.5-air", label: "GLM-4.5 Air" },
+    { id: "glm-4.5-flash", label: "GLM-4.5 Flash" },
+  ],
+};
 
 // Available API protocols per adapter — shown in provider settings UI
 // When multiple protocols are available, user can choose; otherwise the default is used.
@@ -158,68 +203,57 @@ export const ADAPTER_CONFIG: Record<
   {
     label: string;
     requiresBaseUrl: boolean;
-    requiresCustomModels: boolean;
     credentialType: "api-key" | "aws";
   }
 > = {
   openai: {
     label: "OpenAI",
     requiresBaseUrl: false,
-    requiresCustomModels: false,
     credentialType: "api-key",
   },
   anthropic: {
     label: "Anthropic",
     requiresBaseUrl: false,
-    requiresCustomModels: false,
     credentialType: "api-key",
   },
   azure: {
     label: "Azure OpenAI",
     requiresBaseUrl: true,
-    requiresCustomModels: true,
     credentialType: "api-key",
   },
   google: {
     label: "Google Gemini",
     requiresBaseUrl: false,
-    requiresCustomModels: false,
     credentialType: "api-key",
   },
   "amazon-bedrock": {
     label: "AWS Bedrock",
     requiresBaseUrl: false,
-    requiresCustomModels: true,
     credentialType: "aws",
   },
   deepseek: {
     label: "DeepSeek",
     requiresBaseUrl: false,
-    requiresCustomModels: false,
     credentialType: "api-key",
   },
   openrouter: {
     label: "OpenRouter",
     requiresBaseUrl: false,
-    requiresCustomModels: true,
     credentialType: "api-key",
   },
   xai: {
     label: "xAI",
     requiresBaseUrl: false,
-    requiresCustomModels: false,
     credentialType: "api-key",
   },
   moonshot: {
     label: "Moonshot (Kimi)",
     requiresBaseUrl: false,
-    requiresCustomModels: false,
     credentialType: "api-key",
   },
   zai: {
     label: "Z.AI (GLM)",
     requiresBaseUrl: false,
-    requiresCustomModels: false,
     credentialType: "api-key",
   },
 };

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -137,7 +137,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "gpt-5.4-pro", label: "GPT-5.4 Pro" },
     { id: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
     { id: "gpt-5.4-nano", label: "GPT-5.4 Nano" },
-    { id: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
+    { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", apiProtocol: "openai-responses" },
     { id: "gpt-5.2", label: "GPT-5.2" },
     { id: "gpt-5", label: "GPT-5" },
     { id: "gpt-5-mini", label: "GPT-5 Mini" },

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/github:
     dependencies:
@@ -900,67 +903,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1044,24 +1059,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.1.0':
     resolution: {integrity: sha512-Qn6vOuwaTCx3pNwygpSGtdIu0TfS1KiaYLYXLH5zq1scoTXdwYfdZtwvJTpB1WrLgiQE2Ne2kt8MZok3HlFqmg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.1.0':
     resolution: {integrity: sha512-yeNh9ofMqzOZ5yTOk+2rwncBzucc6a1lyqtg8xZv0rH5znyjxHOWsoUtSq4cUTeeBIiXXX51QOOe+VoCjdXJRw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.1.0':
     resolution: {integrity: sha512-t9IfNkHQs/uKgPoyEtU912MG6a1j7Had37cSUyLTKx9MnUpjj+ZDKw9OyqTI9OwIIv0wmkr1pkZy+3T5pxhJPg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.1.0':
     resolution: {integrity: sha512-WEAoHyG14t5sTavZa1c6BnOIEukll9iqFRTavqRVPfYmfegOAd5MaZfXgOGG6kGo1RduyGdTHD4+YZQSdsNZXg==}
@@ -1758,36 +1777,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
@@ -1849,66 +1874,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -3362,24 +3400,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
@@ -47,7 +47,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       .map((id) => {
         const catalog = ADAPTER_MODELS[p.adapter as LLMAdapter];
         const match = catalog?.find((m) => m.id === id);
-        return { id, label: match?.label ?? id };
+        return { id, label: match?.label ?? id, supported: catalog ? !!match : true };
       }),
   }));
 

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
-import { prisma, SYSTEM_MODELS, ModelSource } from "@traceroot/core";
+import { prisma, SYSTEM_MODELS, ModelSource, ADAPTER_MODELS } from "@traceroot/core";
+import type { LLMAdapter } from "@traceroot/core";
 import { requireAuth, requireWorkspaceMembership, successResponse } from "@/lib/auth-helpers";
 
 type RouteParams = { params: Promise<{ workspaceId: string }> };
@@ -43,7 +44,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     models: (p.customModels || [])
       .map((id) => id.trim())
       .filter(Boolean)
-      .map((id) => ({ id, label: id })),
+      .map((id) => {
+        const catalog = ADAPTER_MODELS[p.adapter as LLMAdapter];
+        const match = catalog?.find((m) => m.id === id);
+        return { id, label: match?.label ?? id };
+      }),
   }));
 
   return successResponse({ systemModels, byokProviders });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
@@ -16,10 +16,6 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   if (membershipResult.error) return membershipResult.error;
 
   // System models: include entries where env var is set
-  console.log(
-    "[llm-models] Env check:",
-    SYSTEM_MODELS.map((s) => `${s.envVar}=${!!process.env[s.envVar]}`).join(", "),
-  );
   const systemModels = SYSTEM_MODELS.filter((s) => !!process.env[s.envVar]).map((s) => ({
     provider: s.provider,
     adapter: s.piAIProvider,

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -43,6 +43,12 @@ export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
     llmModels.systemModels.some((g) => g.models.length > 0) ||
     llmModels.byokProviders.some((g) => g.models.length > 0);
 
+  const unsupportedModels = llmModels
+    ? llmModels.byokProviders.flatMap((g) =>
+        g.models.filter((m) => !m.supported).map((m) => ({ id: m.id, provider: g.provider })),
+      )
+    : [];
+
   const {
     messages,
     isStreaming,
@@ -108,6 +114,30 @@ export function AiAssistantPanel({ open, onClose }: AiAssistantPanelProps) {
           <X className="h-4 w-4" />
         </Button>
       </div>
+
+      {/* Unsupported model warning */}
+      {unsupportedModels.length > 0 && (
+        <div className="mx-3 mt-2 flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-[12px] dark:border-yellow-900 dark:bg-yellow-950">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-600" />
+          <div>
+            <p className="font-medium text-yellow-800 dark:text-yellow-200">
+              Unsupported model{unsupportedModels.length > 1 ? "s" : ""} detected
+            </p>
+            <p className="mt-0.5 text-yellow-700 dark:text-yellow-300">
+              {unsupportedModels.map((m) => m.id).join(", ")}{" "}
+              {unsupportedModels.length > 1 ? "are" : "is"} no longer in the supported model list.
+              Update in{" "}
+              <a
+                href={`/workspaces/${workspaceId}/settings/model-providers`}
+                className="font-medium underline"
+              >
+                Settings &rarr; Model Providers
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Messages */}
       {!projectId ? (

--- a/frontend/ui/src/features/ai-assistant/components/ai-chat-overlay.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-chat-overlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { X, Plus, History, Square } from "lucide-react";
+import { X, Plus, History, Square, AlertTriangle } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -9,7 +9,7 @@ import { MessageInput } from "./message-input";
 import { SessionHistory } from "./session-history";
 import { useAiChat } from "../hooks/use-ai-chat";
 import { usePanelResize } from "../hooks/use-panel-resize";
-import { getProject } from "@/lib/api";
+import { getProject, getAvailableLLMModels } from "@/lib/api";
 
 interface AiChatOverlayProps {
   projectId: string;
@@ -30,6 +30,18 @@ export function AiChatOverlay({ projectId, traceId, onClose }: AiChatOverlayProp
     enabled: !!projectId,
   });
   const workspaceId = project?.workspace_id;
+
+  const { data: llmModels } = useQuery({
+    queryKey: ["llm-models", workspaceId],
+    queryFn: () => getAvailableLLMModels(workspaceId!),
+    enabled: !!workspaceId,
+  });
+
+  const unsupportedModels = llmModels
+    ? llmModels.byokProviders.flatMap((g) =>
+        g.models.filter((m) => !m.supported).map((m) => ({ id: m.id, provider: g.provider })),
+      )
+    : [];
 
   const {
     messages,
@@ -91,6 +103,30 @@ export function AiChatOverlay({ projectId, traceId, onClose }: AiChatOverlayProp
           <X className="h-3.5 w-3.5" />
         </Button>
       </div>
+
+      {/* Unsupported model warning */}
+      {unsupportedModels.length > 0 && (
+        <div className="mx-3 mt-2 flex items-start gap-2 rounded-md border border-yellow-200 bg-yellow-50 px-3 py-2 text-[12px] dark:border-yellow-900 dark:bg-yellow-950">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-600" />
+          <div>
+            <p className="font-medium text-yellow-800 dark:text-yellow-200">
+              Unsupported model{unsupportedModels.length > 1 ? "s" : ""} detected
+            </p>
+            <p className="mt-0.5 text-yellow-700 dark:text-yellow-300">
+              {unsupportedModels.map((m) => m.id).join(", ")}{" "}
+              {unsupportedModels.length > 1 ? "are" : "is"} no longer in the supported model list.
+              Update in{" "}
+              <a
+                href={`/workspaces/${workspaceId}/settings/model-providers`}
+                className="font-medium underline"
+              >
+                Settings &rarr; Model Providers
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      )}
 
       <MessageList messages={messages} sessionStreaming={isStreaming} />
       <MessageInput

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -43,7 +43,12 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
   const models: (AvailableLLMModel & { provider: string; source: "system" | "byok" })[] = (() => {
     if (!data) return FALLBACK_MODELS;
     const systemList = data.systemModels.flatMap((g) =>
-      g.models.map((m) => ({ ...m, provider: g.provider, source: "system" as const, supported: true })),
+      g.models.map((m) => ({
+        ...m,
+        provider: g.provider,
+        source: "system" as const,
+        supported: true,
+      })),
     );
     const byokList = data.byokProviders.flatMap((g) =>
       g.models.map((m) => ({ ...m, provider: g.provider, source: "byok" as const })),

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -23,7 +23,7 @@ interface ModelSelectorProps {
 
 // Flatten all system models into a single list with provider info attached
 const FALLBACK_MODELS = SYSTEM_MODELS.flatMap((s) =>
-  s.models.map((m) => ({ ...m, provider: s.provider, source: "system" as const })),
+  s.models.map((m) => ({ ...m, provider: s.provider, source: "system" as const, supported: true })),
 );
 
 function modelKey(m: { id?: string; model?: string; source: string; provider: string }) {
@@ -43,7 +43,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
   const models: (AvailableLLMModel & { provider: string; source: "system" | "byok" })[] = (() => {
     if (!data) return FALLBACK_MODELS;
     const systemList = data.systemModels.flatMap((g) =>
-      g.models.map((m) => ({ ...m, provider: g.provider, source: "system" as const })),
+      g.models.map((m) => ({ ...m, provider: g.provider, source: "system" as const, supported: true })),
     );
     const byokList = data.byokProviders.flatMap((g) =>
       g.models.map((m) => ({ ...m, provider: g.provider, source: "byok" as const })),
@@ -120,6 +120,9 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
                 <span className="flex items-center gap-1.5">
                   {isSelected && <span className="text-[11px]">&#10003;</span>}
                   {m.label}
+                  {m.source === "byok" && !m.supported && (
+                    <span className="text-[10px] text-yellow-600">(unsupported)</span>
+                  )}
                 </span>
                 {showProvider && (
                   <span className="shrink-0 text-[10px] text-muted-foreground">{m.provider}</span>

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -23,7 +23,13 @@ interface ModelSelectorProps {
 
 // Flatten all system models into a single list with provider info attached
 const FALLBACK_MODELS = SYSTEM_MODELS.flatMap((s) =>
-  s.models.map((m) => ({ ...m, provider: s.provider, source: "system" as const, supported: true })),
+  s.models.map((m) => ({
+    ...m,
+    provider: s.provider,
+    adapter: s.piAIProvider,
+    source: "system" as const,
+    supported: true,
+  })),
 );
 
 function modelKey(m: { id?: string; model?: string; source: string; provider: string }) {
@@ -40,18 +46,28 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
   });
 
   // Build flat model list: BYOK models first, then system models. No deduplication.
-  const models: (AvailableLLMModel & { provider: string; source: "system" | "byok" })[] = (() => {
+  const models: (AvailableLLMModel & {
+    provider: string;
+    adapter: string;
+    source: "system" | "byok";
+  })[] = (() => {
     if (!data) return FALLBACK_MODELS;
     const systemList = data.systemModels.flatMap((g) =>
       g.models.map((m) => ({
         ...m,
         provider: g.provider,
+        adapter: g.adapter,
         source: "system" as const,
         supported: true,
       })),
     );
     const byokList = data.byokProviders.flatMap((g) =>
-      g.models.map((m) => ({ ...m, provider: g.provider, source: "byok" as const })),
+      g.models.map((m) => ({
+        ...m,
+        provider: g.provider,
+        adapter: g.adapter,
+        source: "byok" as const,
+      })),
     );
     return [...byokList, ...systemList];
   })();
@@ -69,7 +85,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
       // Walk the priority list and return the first model we find.
       let found = false;
       for (const adapter of PROVIDER_PRIORITY) {
-        const match = models.find((m) => m.provider.toLowerCase() === adapter);
+        const match = models.find((m) => m.adapter === adapter);
         if (match) {
           onChange({ model: match.id, provider: match.provider, source: match.source });
           found = true;

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -231,12 +231,22 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     setModelProtocols({});
   }
 
+  function seedProtocolFromCatalog(modelId: string) {
+    const catalog = ADAPTER_MODELS[adapter as LLMAdapter];
+    if (!catalog) return;
+    const entry = catalog.find((m) => m.id === modelId);
+    if (entry?.apiProtocol) {
+      setModelProtocols((prev) => ({ ...prev, [modelId]: entry.apiProtocol! }));
+    }
+  }
+
   function addCustomModel() {
     const curatedModels = ADAPTER_MODELS[adapter as LLMAdapter];
     if (curatedModels) {
       const used = new Set(customModels);
       const next = curatedModels.find((m) => !used.has(m.id));
       setCustomModels([...customModels, next?.id ?? ""]);
+      if (next) seedProtocolFromCatalog(next.id);
     } else {
       setCustomModels([...customModels, ""]);
     }
@@ -250,6 +260,7 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     const updated = [...customModels];
     updated[index] = value;
     setCustomModels(updated);
+    seedProtocolFromCatalog(value);
   }
 
   if (isLoading) {

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -507,7 +507,13 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <label className="text-sm font-medium">Models</label>
-                  <Button type="button" variant="outline" size="sm" onClick={addCustomModel} disabled={isAddModelDisabled}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={addCustomModel}
+                    disabled={isAddModelDisabled}
+                  >
                     <Plus className="mr-1 h-3 w-3" />
                     Add Model
                   </Button>
@@ -522,10 +528,7 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                   return customModels.map((model, i) => (
                     <div key={i} className="flex items-center gap-2">
                       {curatedModels ? (
-                        <Select
-                          value={model}
-                          onValueChange={(v) => updateCustomModel(i, v)}
-                        >
+                        <Select value={model} onValueChange={(v) => updateCustomModel(i, v)}>
                           <SelectTrigger className="flex-1">
                             <SelectValue placeholder="Select a model" />
                           </SelectTrigger>

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -157,7 +157,7 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     setSaveError(null);
     // Build config with per-model protocol overrides (only non-default ones)
     const defaultProtocol = ADAPTER_API_PROTOCOL[adapter] || "";
-    const trimmedModels = customModels.map((m) => m.trim()).filter(Boolean);
+    const trimmedModels = [...new Set(customModels.map((m) => m.trim()).filter(Boolean))];
     const filteredProtocols: Record<string, string> = {};
     for (const modelId of trimmedModels) {
       const proto = modelProtocols[modelId];
@@ -297,6 +297,11 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
         : !!apiKey;
   const hasRequiredBaseUrl = adapterConfig?.requiresBaseUrl ? !!baseUrl : true;
   const canSave = adapter && providerName && hasCredentials && hasRequiredBaseUrl;
+
+  const curatedModelsForAdapter = adapter ? ADAPTER_MODELS[adapter as LLMAdapter] : null;
+  const isAddModelDisabled = curatedModelsForAdapter
+    ? curatedModelsForAdapter.every((m) => customModels.includes(m.id))
+    : false;
 
   const canTest =
     adapter &&
@@ -502,7 +507,7 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <label className="text-sm font-medium">Models</label>
-                  <Button type="button" variant="outline" size="sm" onClick={addCustomModel}>
+                  <Button type="button" variant="outline" size="sm" onClick={addCustomModel} disabled={isAddModelDisabled}>
                     <Plus className="mr-1 h-3 w-3" />
                     Add Model
                   </Button>
@@ -525,6 +530,11 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                             <SelectValue placeholder="Select a model" />
                           </SelectTrigger>
                           <SelectContent>
+                            {model && !curatedModels.some((m) => m.id === model) && (
+                              <SelectItem key={model} value={model} disabled>
+                                {model} (Unsupported)
+                              </SelectItem>
+                            )}
                             {curatedModels
                               .filter((m) => m.id === model || !customModels.includes(m.id))
                               .map((m) => (

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -228,6 +228,7 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     if (config && (!providerName || providerName === prevConfig?.label)) {
       setProviderName(config.label);
     }
+    setCustomModels([]);
     setModelProtocols({});
   }
 

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -28,7 +28,9 @@ import {
   ADAPTER_API_PROTOCOL,
   ADAPTER_AVAILABLE_PROTOCOLS,
   ADAPTER_DEFAULT_BASE_URL,
+  ADAPTER_MODELS,
 } from "@traceroot/core";
+import type { LLMAdapter } from "@traceroot/core";
 import {
   getModelProviders,
   createModelProvider,
@@ -230,7 +232,14 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
   }
 
   function addCustomModel() {
-    setCustomModels([...customModels, ""]);
+    const curatedModels = ADAPTER_MODELS[adapter as LLMAdapter];
+    if (curatedModels) {
+      const used = new Set(customModels);
+      const next = curatedModels.find((m) => !used.has(m.id));
+      setCustomModels([...customModels, next?.id ?? ""]);
+    } else {
+      setCustomModels([...customModels, ""]);
+    }
   }
 
   function removeCustomModel(index: number) {
@@ -503,28 +512,42 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                   const protocols = ADAPTER_AVAILABLE_PROTOCOLS[adapter];
                   const hasMultipleProtocols = protocols && protocols.length > 1;
                   const defaultProto = ADAPTER_API_PROTOCOL[adapter] || "";
+                  const curatedModels = ADAPTER_MODELS[adapter as LLMAdapter];
 
                   return customModels.map((model, i) => (
                     <div key={i} className="flex items-center gap-2">
-                      <Input
-                        value={model}
-                        onChange={(e) => updateCustomModel(i, e.target.value)}
-                        placeholder={
-                          {
-                            openai: "e.g. gpt-4o, gpt-5",
-                            anthropic: "e.g. claude-sonnet-4-5",
-                            azure: "e.g. my-gpt4-deployment",
-                            google: "e.g. gemini-2.5-flash",
-                            "amazon-bedrock": "e.g. anthropic.claude-v2",
-                            deepseek: "e.g. deepseek-chat, deepseek-reasoner",
-                            openrouter: "e.g. openai/gpt-4o",
-                            xai: "e.g. grok-4-1-fast-reasoning",
-                            zai: "e.g. glm-5, glm-4.7",
-                            moonshot: "e.g. kimi-k2.5, kimi-k2-thinking",
-                          }[adapter] || "Model ID"
-                        }
-                        className="flex-1"
-                      />
+                      {curatedModels ? (
+                        <Select
+                          value={model}
+                          onValueChange={(v) => updateCustomModel(i, v)}
+                        >
+                          <SelectTrigger className="flex-1">
+                            <SelectValue placeholder="Select a model" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {curatedModels
+                              .filter((m) => m.id === model || !customModels.includes(m.id))
+                              .map((m) => (
+                                <SelectItem key={m.id} value={m.id}>
+                                  {m.label}
+                                </SelectItem>
+                              ))}
+                          </SelectContent>
+                        </Select>
+                      ) : (
+                        <Input
+                          value={model}
+                          onChange={(e) => updateCustomModel(i, e.target.value)}
+                          placeholder={
+                            {
+                              azure: "e.g. my-gpt4-deployment",
+                              "amazon-bedrock": "e.g. anthropic.claude-v2",
+                              openrouter: "e.g. openai/gpt-4o",
+                            }[adapter] || "Model ID"
+                          }
+                          className="flex-1"
+                        />
+                      )}
                       {hasMultipleProtocols && (
                         <Select
                           value={modelProtocols[model] || defaultProto}

--- a/frontend/ui/src/lib/api/model-providers.ts
+++ b/frontend/ui/src/lib/api/model-providers.ts
@@ -21,6 +21,7 @@ export interface ModelProviderResponse {
 export interface AvailableLLMModel {
   id: string;
   label: string;
+  supported?: boolean;
 }
 
 export interface SystemModelGroup {


### PR DESCRIPTION
**In Settings -> Model Providers, extra-verfication is needed to test 1) API keys against DeepSeek, xAI, Moonshot, and Z.AI, 2) API keys of depreciated/retired models.**
Need help verifying:
**API key verification for DeepSeek, xAI, Moonshot, and Z.AI.**
notes: I do not have real API key to QA. Requesting collaboration.
**Chatbot warning banner for user with an existing configured API now deemed "legacy model,"**

## Summary
- Replace the free-text model name input with a curated Select dropdown for standard BYOK providers (OpenAI, Anthropic, Google, DeepSeek, xAI, Moonshot, Z.AI). Pass-through adapters (Azure, Bedrock, OpenRouter) keep free-text input.
- Add `ADAPTER_MODELS` catalog to `@traceroot/core` with per-adapter curated model lists and friendly labels
- Handle legacy/unsupported models gracefully: Settings Select shows "(Unsupported)" label, sidebar chatbot shows a warning banner linking to Settings
- Disable "Add Model" when all curated models are already selected; deduplicate model IDs on save

Closes #585

### Environment: Local self-hosted (Docker) + Chrome
- Rebuilt web container:
  - `docker compose -f docker-compose.prod.yml up -d --build web`
- Verified app:
  - `http://localhost:3000` returns `200`

## Problem

The BYOK model provider configuration expected users to type exact model ID strings (e.g. `gpt-5.4`). Typos or unrecognized syntax caused silent failures. Users had no way to discover valid model names until reaching error in the chats, and legacy model IDs that fell out of the curated list caused the Radix Select to render an empty placeholder instead of the saved value.

## What Changed

**Backend** (`llm-models/route.ts`):
- Look up friendly labels for BYOK custom model IDs against the new `ADAPTER_MODELS` catalog
- Return a `supported` boolean per model (`true` if the ID exists in the catalog or the adapter has no catalog)

**Core** (`llm-providers.ts`):
- Add `ADAPTER_MODELS` mapping: adapter -> curated model list with `{ id, label }` pairs
- Export `PROVIDER_PRIORITY` for model auto-selection in the chatbot

**Settings UI** (`ModelProvidersTab.tsx`):
- Replace `<Input>` with `<Select>` dropdown populated from `ADAPTER_MODELS`
- Inject a disabled "(Unsupported)" SelectItem when the current value is a legacy ID not in the catalog — fixes the critical Radix empty-placeholder bug
- Auto-select first unused model on add; filter already-selected models from dropdown
- Disable "Add Model" button when all curated models are exhausted
- Deduplicate model IDs on save with `[...new Set(...)]`

**Sidebar Chatbot** (`ai-assistant-panel.tsx`, `ai-chat-overlay.tsx`):
- Derive unsupported models from the `llm-models` API response
- Show a non-blocking yellow warning banner listing unsupported model IDs with a direct link to Settings > Model Providers

**Model Selector** (`model-selector.tsx`):
- Show "(unsupported)" badge next to BYOK models not in the curated list

## Why This Approach

A curated dropdown eliminates typo-driven failures and makes valid models discoverable. Rather than silently dropping legacy models, the UI surfaces them with clear affordances: "(Unsupported)" in the Settings Select so users can see and replace them, and a warning banner in the chatbot so users are prompted to act without blocking their workflow.

## Type of Change

- [x] feat - A new feature
- [x] fix - A bug fix (legacy model handling)

## Screenshots

**Verified:**
**1. Settings dropdown with all curated models**
https://github.com/user-attachments/assets/a91553bd-e341-49ec-9e50-7e0014513303
notes: all supported models are correctly shown in dropdown. in addition, Google, Anthropic, and OpenAI API keys connect successfully.
**2. Showing API authentication failure in API key configuration stage**
https://github.com/user-attachments/assets/4c0995af-4ab9-4bb3-b6f7-ee433ed0ba73
notes: I intentially used an Anthropic API key with empty balance, and the key is correctly rejected.
**3. Free-text input kept for Bedrock, Azure, OpenRouter, all highly-personalized models.**
https://github.com/user-attachments/assets/2d1da44e-fe77-4605-9894-42203df9478f

**Need help verifying:**
**4. API key verification for DeepSeek, xAI, Moonshot, and Z.AI.
notes: I do not have real API key to QA. Requesting collaboration.

**5. Chatbot warning banner for user with an existing configured API now deemed "legacy model,"**
notes: for example, Gemini 3.0 is no longer supported by Google and Traceroot no longer plan to support likewise. For a user pre-configured with such models, chatbot will show warning.


## Test plan

- [ ] Settings > Model Providers > Add Provider (OpenAI) — dropdown shows curated models, no free-text input
- [ ] Select a model, save — model persists correctly
- [ ] Add all curated models for an adapter (e.g. DeepSeek with 1 model) — "Add Model" button becomes disabled
- [ ] Edit a provider with a legacy model ID not in the curated list — Select shows `<model-id> (Unsupported)`, user can switch to a curated model
- [ ] Open AI assistant sidebar with an unsupported BYOK model configured — yellow warning banner appears with model ID and Settings link
- [ ] Open trace detail chatbot with an unsupported model — same warning banner appears
- [ ] Model selector popover shows "(unsupported)" badge next to legacy BYOK models
- [ ] Pass-through adapter (Azure, Bedrock, OpenRouter) — retains free-text input, no dropdown
- [ ] Duplicate model IDs in state — on save, only unique IDs are persisted

## Notes

- `ADAPTER_MODELS` is intentionally separate from runtime model discovery — it's a static catalog for UI convenience, not a source of truth for what the provider API accepts
- The `supported` field is only returned for BYOK models; system models implicitly have no unsupported state

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
