### PR TITLE
micro-fix(docker): ignore workspace build artifacts in image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,9 +4,12 @@
 .vscode
 .claude
 node_modules
+**/node_modules
 __pycache__
 *.pyc
 .next
+**/.next
+**/dist
 .env
 .env.*
 *.md


### PR DESCRIPTION
## Why

Docker builds were picking up generated workspace artifacts from the host machine, especially nested `node_modules` folders inside `frontend/...`.

Those host-side folders contained platform-specific pnpm links, which overwrote the clean Linux dependencies installed inside the Docker image during the build. That caused Prisma-related image builds to fail with errors like:

`Cannot find module '/app/packages/core/node_modules/prisma/build/index.js'`

## What changed

- Updated `.dockerignore` to exclude nested build artifacts:
  - `**/node_modules`
  - `**/.next`
  - `**/dist`

## Why this fix is needed

This keeps Docker build contexts limited to source files and prevents local machine artifacts from leaking into container builds.

That makes the Docker builds deterministic across environments and fixes the Prisma failure seen during `make prod-lite` / production image builds.

## Validation

- Reproduced the original Docker build failure
- Confirmed the billing Docker builder succeeds after the fix
- Confirmed the agent Docker builder succeeds after the fix
- Confirmed local package builds and Prisma generation still work
