### PR TITLE
fix(ui): increase Trace ID column width to prevent truncation

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -179,13 +179,19 @@ export default function TracesPage() {
                 <table className="w-full">
                   <thead className="sticky top-0 bg-background">
                     <tr className="border-b border-border bg-muted/50">
-                      <th className="w-[140px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th
+                        className="w-[140px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
+                      >
                         Timestamp
                       </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th
+                        className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
+                      >
                         Name
                       </th>
-                      <th className="min-w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th
+                        className="min-w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
+                      >
                         Trace ID
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
@@ -194,10 +200,14 @@ export default function TracesPage() {
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Spans
                       </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th
+                        className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
+                      >
                         Input
                       </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th
+                        className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
+                      >
                         Output
                       </th>
                       <th className="px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
@@ -218,20 +228,24 @@ export default function TracesPage() {
                           selectedTraceId === trace.trace_id ? "bg-muted" : "hover:bg-muted/50",
                         )}
                       >
-                        <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                        <td
+                          className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground"
+                        >
                           {formatDate(trace.trace_start_time)}
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
                           {trace.name}
                         </td>
-                        <td className="min-w-[280px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                          <span title={trace.trace_id}>
-                            {trace.trace_id}
-                          </span>
+                        <td
+                          className="min-w-[280px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground"
+                        >
+                          <span title={trace.trace_id}>{trace.trace_id}</span>
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5">
                           {trace.status === "error" ? (
-                            <span className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
+                            <span
+                              className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400"
+                            >
                               ERROR
                             </span>
                           ) : (

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -185,7 +185,7 @@ export default function TracesPage() {
                       <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Name
                       </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="min-w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Trace ID
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
@@ -224,8 +224,10 @@ export default function TracesPage() {
                         <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
                           {trace.name}
                         </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                          {trace.trace_id.substring(0, 8)}...
+                        <td className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
+                          <span className="block truncate" title={trace.trace_id}>
+                            {trace.trace_id}
+                          </span>
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5">
                           {trace.status === "error" ? (

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -179,19 +179,13 @@ export default function TracesPage() {
                 <table className="w-full">
                   <thead className="sticky top-0 bg-background">
                     <tr className="border-b border-border bg-muted/50">
-                      <th
-                        className="w-[140px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
-                      >
+                      <th className="w-[140px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Timestamp
                       </th>
-                      <th
-                        className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
-                      >
+                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Name
                       </th>
-                      <th
-                        className="min-w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
-                      >
+                      <th className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Trace ID
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
@@ -200,14 +194,10 @@ export default function TracesPage() {
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Spans
                       </th>
-                      <th
-                        className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
-                      >
+                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Input
                       </th>
-                      <th
-                        className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground"
-                      >
+                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Output
                       </th>
                       <th className="px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
@@ -228,24 +218,18 @@ export default function TracesPage() {
                           selectedTraceId === trace.trace_id ? "bg-muted" : "hover:bg-muted/50",
                         )}
                       >
-                        <td
-                          className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground"
-                        >
+                        <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                           {formatDate(trace.trace_start_time)}
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
                           {trace.name}
                         </td>
-                        <td
-                          className="min-w-[280px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground"
-                        >
+                        <td className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
                           <span title={trace.trace_id}>{trace.trace_id}</span>
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5">
                           {trace.status === "error" ? (
-                            <span
-                              className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400"
-                            >
+                            <span className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
                               ERROR
                             </span>
                           ) : (

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -185,7 +185,7 @@ export default function TracesPage() {
                       <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Name
                       </th>
-                      <th className="min-w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Trace ID
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
@@ -225,9 +225,7 @@ export default function TracesPage() {
                           {trace.name}
                         </td>
                         <td className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                          <span className="block truncate" title={trace.trace_id}>
-                            {trace.trace_id}
-                          </span>
+                          <span title={trace.trace_id}>{trace.trace_id}</span>
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5">
                           {trace.status === "error" ? (

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -65,8 +65,8 @@ export default function TracesPage() {
       staleTime: Infinity,
       refetchInterval: (query: unknown) => {
         const hasTraces =
-          ((query as { state?: { data?: { data?: unknown[] } } })?.state?.data?.data?.length ??
-            0) > 0;
+          ((query as { state?: { data?: { data?: unknown[] } } })?.state?.data?.data?.length ?? 0) >
+          0;
         return hasTraces ? false : 3000;
       },
     },
@@ -185,7 +185,7 @@ export default function TracesPage() {
                       <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Name
                       </th>
-                      <th className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="min-w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Trace ID
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
@@ -225,7 +225,9 @@ export default function TracesPage() {
                           {trace.name}
                         </td>
                         <td className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                          <span title={trace.trace_id}>{trace.trace_id}</span>
+                          <span className="block truncate" title={trace.trace_id}>
+                            {trace.trace_id}
+                          </span>
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5">
                           {trace.status === "error" ? (

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -65,8 +65,8 @@ export default function TracesPage() {
       staleTime: Infinity,
       refetchInterval: (query: unknown) => {
         const hasTraces =
-          ((query as { state?: { data?: { data?: unknown[] } } })?.state?.data?.data?.length ?? 0) >
-          0;
+          ((query as { state?: { data?: { data?: unknown[] } } })?.state?.data?.data?.length ??
+            0) > 0;
         return hasTraces ? false : 3000;
       },
     },

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -185,7 +185,7 @@ export default function TracesPage() {
                       <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Name
                       </th>
-                      <th className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="min-w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Trace ID
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
@@ -225,7 +225,9 @@ export default function TracesPage() {
                           {trace.name}
                         </td>
                         <td className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                          <span title={trace.trace_id}>{trace.trace_id}</span>
+                          <span className="block truncate" title={trace.trace_id}>
+                            {trace.trace_id}
+                          </span>
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5">
                           {trace.status === "error" ? (

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -224,8 +224,8 @@ export default function TracesPage() {
                         <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
                           {trace.name}
                         </td>
-                        <td className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                          <span className="block truncate" title={trace.trace_id}>
+                        <td className="min-w-[280px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
+                          <span title={trace.trace_id}>
                             {trace.trace_id}
                           </span>
                         </td>


### PR DESCRIPTION
## Summary
closes - #603 

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

Trace IDs in the tracing table were consistently truncated (e.g., a6f302ce...) due to restrictive column width constraints, even when sufficient horizontal space was available. This fix ensures that standard 36-character UUIDs are fully displayed by default while maintaining a responsive fallback for extremely narrow screens.

Changes
- **Traces Page:** Updated the table layout in frontend/ui/src/app/projects/[projectId]/traces/page.tsx.
- **Width Adjustments:** Changed the "Trace ID" column from a fixed w-[140px] to a more appropriate min-w-[280px] and max-w-[400px].
- **Visibility:** These changes allow the column to expand to fit the full ID on most desktop resolutions before resorting to truncation.

## Screenshots / Recordings (if applicable)
<img width="1919" height="1024" alt="image" src="https://github.com/user-attachments/assets/48033ee6-48ba-4515-8692-e496c4555105" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
