### PR TITLE
chore: bump SDK versions to 0.1.1 in all examples

### DIFF
--- a/examples/python/anthropic-tool-agent/requirements.txt
+++ b/examples/python/anthropic-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 anthropic>=0.40.0
 python-dotenv>=1.0.0
-traceroot==0.1.0
+traceroot==0.1.1
 openinference-instrumentation-anthropic>=1.0.0

--- a/examples/python/deepagents/requirements.txt
+++ b/examples/python/deepagents/requirements.txt
@@ -2,4 +2,4 @@ deepagents>=0.4.0
 langchain>=0.3.0
 langchain-anthropic>=0.3.0
 python-dotenv>=1.0.0
-traceroot==0.1.0
+traceroot==0.1.1

--- a/examples/python/langgraph-code-agent/requirements.txt
+++ b/examples/python/langgraph-code-agent/requirements.txt
@@ -6,5 +6,4 @@ python-dotenv>=1.0.0
 fastapi==0.115.12
 uvicorn==0.34.3
 
-# When running from this repo, use the local SDK:
 traceroot==0.1.1

--- a/examples/python/langgraph-code-agent/requirements.txt
+++ b/examples/python/langgraph-code-agent/requirements.txt
@@ -7,4 +7,4 @@ fastapi==0.115.12
 uvicorn==0.34.3
 
 # When running from this repo, use the local SDK:
-traceroot==0.1.0
+traceroot==0.1.1

--- a/examples/python/openai-tool-agent/requirements.txt
+++ b/examples/python/openai-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.0
+traceroot==0.1.1

--- a/examples/typescript/anthropic/package.json
+++ b/examples/typescript/anthropic/package.json
@@ -7,7 +7,7 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "0.1.0",
+    "@traceroot-ai/traceroot": "0.1.1",
     "@anthropic-ai/sdk": "^0.40.0",
     "dotenv": "^16.4.5"
   },

--- a/examples/typescript/deepagents/package.json
+++ b/examples/typescript/deepagents/package.json
@@ -7,7 +7,7 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "0.1.0",
+    "@traceroot-ai/traceroot": "0.1.1",
     "deepagents": "^1.8.0",
     "@langchain/core": "^1.1.38",
     "@langchain/anthropic": "^1.3.26",

--- a/examples/typescript/langchain/package.json
+++ b/examples/typescript/langchain/package.json
@@ -7,7 +7,7 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "0.1.0",
+    "@traceroot-ai/traceroot": "0.1.1",
     "@langchain/core": "^0.3.0",
     "@langchain/langgraph": "^1.0.0",
     "@langchain/openai": "^0.3.0",

--- a/examples/typescript/openai/package.json
+++ b/examples/typescript/openai/package.json
@@ -7,7 +7,7 @@
     "streaming": "tsx streaming-pipeline.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "file:../../../../../.superset/worktrees/traceroot-ts/update-ts-vs-py-sdk-gaps-analysis-and-plan-improve/packages/traceroot",
+    "@traceroot-ai/traceroot": "0.1.1",
     "dotenv": "^16.4.5",
     "openai": "^6.7.0"
   },


### PR DESCRIPTION
## Summary
- Bumps `traceroot` (Python) from `0.1.0` → `0.1.1` in all 4 Python examples
- Bumps `@traceroot-ai/traceroot` (TypeScript) from `0.1.0` → `0.1.1` in all 4 TS examples
- Fixes `examples/typescript/openai/package.json` which was pointing to a local worktree `file:` path instead of a published version

## Test plan
- [x] Python: `pip install -r requirements.txt` works in each example dir
- [x] TypeScript: `pnpm install` works in each example dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)