### PR TITLE
standardize .env.example filename and references across Python examples

### DIFF
--- a/examples/python/anthropic-tool-agent/main.py
+++ b/examples/python/anthropic-tool-agent/main.py
@@ -2,7 +2,7 @@
 Anthropic ReAct agent with tool use and Traceroot observability.
 
 Usage:
-    cp env.example .env
+    cp .env.example .env
     pip install -r requirements.txt
     python main.py
 """

--- a/examples/python/langgraph-code-agent/server.py
+++ b/examples/python/langgraph-code-agent/server.py
@@ -2,7 +2,7 @@
 Multi-agent code generator with TraceRoot observability.
 
 Usage:
-    cp env.example .env
+    cp .env.example .env
     pip install -r requirements.txt
     python server.py
 

--- a/examples/python/openai-tool-agent/main.py
+++ b/examples/python/openai-tool-agent/main.py
@@ -2,7 +2,7 @@
 OpenAI ReAct agent with tool use, streaming, and TraceRoot observability.
 
 Usage:
-    cp env.example .env
+    cp .env.example .env
     pip install -r requirements.txt
     python main.py
 """

--- a/examples/python/openai-tool-agent/streaming-pipeline.py
+++ b/examples/python/openai-tool-agent/streaming-pipeline.py
@@ -19,7 +19,7 @@ Why this matters for observability:
   the full assembled output.
 
 Usage:
-    cp env.example .env          # set OPENAI_API_KEY and TRACEROOT_API_KEY
+    cp .env.example .env          # set OPENAI_API_KEY and TRACEROOT_API_KEY
     pip install -r requirements.txt
     python streaming-pipeline.py
 """


### PR DESCRIPTION
## Summary
Closes #609 

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [x] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

This PR standardizes the .env.example filename and its references across all Python examples. It resolves an issue where some example source files incorrectly referenced env.example (missing the leading dot) in their Usage instructions or comments, even though the configuration files themselves were correctly named .env.example.

1. **Source Code Docstring Fixes:** Updated the Usage and Setup comments in the following files to use the standard .env.example filename:

- examples/python/openai-tool-agent/main.py
- examples/python/openai-tool-agent/streaming-pipeline.py
- examples/python/langgraph-code-agent/server.py
- examples/python/anthropic-tool-agent/main.py

2. **Filename Consistency:** Verified that all Python example subdirectories (Anthropic, DeepAgents, Gemini, LangGraph, and OpenAI) consistently use .env.example for their environment variable templates.

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
