### PR TITLE
fix: make model label equal to id for curated and system models

### DIFF
--- a/frontend/packages/core/src/__tests__/llm-providers.test.ts
+++ b/frontend/packages/core/src/__tests__/llm-providers.test.ts
@@ -11,14 +11,23 @@ describe("ADAPTER_MODELS", () => {
     }
   });
 
-  it("has non-empty label for every model", () => {
+  it("label equals id for every model", () => {
     for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
       if (!models) continue;
       for (const model of models) {
         expect(
-          model.label.trim().length,
-          `adapter "${adapter}", model "${model.id}" has empty label`,
-        ).toBeGreaterThan(0);
+          model.label,
+          `adapter "${adapter}", model "${model.id}" has label "${model.label}" — should equal id`,
+        ).toBe(model.id);
+      }
+    }
+
+    for (const system of SYSTEM_MODELS) {
+      for (const model of system.models) {
+        expect(
+          model.label,
+          `system provider "${system.provider}", model "${model.id}" has label "${model.label}" — should equal id`,
+        ).toBe(model.id);
       }
     }
   });

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -63,6 +63,7 @@ export const ADAPTER_API_PROTOCOL: Record<string, string> = {
 
 export interface LLMModelDef {
   id: string;
+  /** Display label — intentionally set equal to id so the UI shows the exact model ID sent to the API */
   label: string;
   /** Cost per 1M input tokens in USD */
   inputCostPer1M?: number;
@@ -89,11 +90,11 @@ export const SYSTEM_MODELS: {
     piAIProvider: "anthropic",
     apiProtocol: "anthropic-messages",
     models: [
-      { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
-      { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-      { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
-      { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
-      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+      { id: "claude-opus-4-6", label: "claude-opus-4-6" },
+      { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
+      { id: "claude-opus-4-5", label: "claude-opus-4-5" },
+      { id: "claude-sonnet-4-5", label: "claude-sonnet-4-5" },
+      { id: "claude-haiku-4-5", label: "claude-haiku-4-5" },
     ],
   },
   {
@@ -102,12 +103,12 @@ export const SYSTEM_MODELS: {
     piAIProvider: "openai",
     apiProtocol: "openai-completions",
     models: [
-      { id: "gpt-5", label: "GPT-5" },
-      { id: "gpt-5-mini", label: "GPT-5 Mini" },
+      { id: "gpt-5", label: "gpt-5" },
+      { id: "gpt-5-mini", label: "gpt-5-mini" },
       { id: "o3", label: "o3" },
       { id: "o4-mini", label: "o4-mini" },
       // Codex models require the Responses API (not Chat Completions)
-      { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", apiProtocol: "openai-responses" },
+      { id: "gpt-5.3-codex", label: "gpt-5.3-codex", apiProtocol: "openai-responses" },
     ],
   },
 ];
@@ -133,44 +134,44 @@ export const PROVIDER_PRIORITY: LLMAdapter[] = [
 // Adapters NOT listed here (azure, amazon-bedrock, openrouter) use free-text input.
 export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
   openai: [
-    { id: "gpt-5.4", label: "GPT-5.4" },
-    { id: "gpt-5.4-pro", label: "GPT-5.4 Pro" },
-    { id: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
-    { id: "gpt-5.4-nano", label: "GPT-5.4 Nano" },
-    { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", apiProtocol: "openai-responses" },
-    { id: "gpt-5.2", label: "GPT-5.2" },
-    { id: "gpt-5", label: "GPT-5" },
-    { id: "gpt-5-mini", label: "GPT-5 Mini" },
+    { id: "gpt-5.4", label: "gpt-5.4" },
+    { id: "gpt-5.4-pro", label: "gpt-5.4-pro" },
+    { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },
+    { id: "gpt-5.4-nano", label: "gpt-5.4-nano" },
+    { id: "gpt-5.3-codex", label: "gpt-5.3-codex", apiProtocol: "openai-responses" },
+    { id: "gpt-5.2", label: "gpt-5.2" },
+    { id: "gpt-5", label: "gpt-5" },
+    { id: "gpt-5-mini", label: "gpt-5-mini" },
     { id: "o3", label: "o3" },
     { id: "o4-mini", label: "o4-mini" },
   ],
   anthropic: [
-    { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
-    { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-    { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
-    { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
-    { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+    { id: "claude-opus-4-6", label: "claude-opus-4-6" },
+    { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
+    { id: "claude-opus-4-5", label: "claude-opus-4-5" },
+    { id: "claude-sonnet-4-5", label: "claude-sonnet-4-5" },
+    { id: "claude-haiku-4-5", label: "claude-haiku-4-5" },
   ],
   google: [
-    { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
-    { id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
-    { id: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 Flash Lite Preview" },
-    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
-    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    { id: "gemini-3.1-pro-preview", label: "gemini-3.1-pro-preview" },
+    { id: "gemini-3-flash-preview", label: "gemini-3-flash-preview" },
+    { id: "gemini-3.1-flash-lite-preview", label: "gemini-3.1-flash-lite-preview" },
+    { id: "gemini-2.5-flash", label: "gemini-2.5-flash" },
+    { id: "gemini-2.5-pro", label: "gemini-2.5-pro" },
   ],
-  deepseek: [{ id: "deepseek-chat", label: "DeepSeek Chat" }],
+  deepseek: [{ id: "deepseek-chat", label: "deepseek-chat" }],
   xai: [
-    { id: "grok-4.20", label: "Grok 4.20" },
-    { id: "grok-4", label: "Grok 4" },
+    { id: "grok-4.20", label: "grok-4.20" },
+    { id: "grok-4", label: "grok-4" },
   ],
   moonshot: [
-    { id: "kimi-k2.5", label: "Kimi K2.5" },
-    { id: "kimi-k2-thinking", label: "Kimi K2 Thinking" },
+    { id: "kimi-k2.5", label: "kimi-k2.5" },
+    { id: "kimi-k2-thinking", label: "kimi-k2-thinking" },
   ],
   zai: [
-    { id: "glm-4.5", label: "GLM-4.5" },
-    { id: "glm-4.5-air", label: "GLM-4.5 Air" },
-    { id: "glm-4.5-flash", label: "GLM-4.5 Flash" },
+    { id: "glm-4.5", label: "glm-4.5" },
+    { id: "glm-4.5-air", label: "glm-4.5-air" },
+    { id: "glm-4.5-flash", label: "glm-4.5-flash" },
   ],
 };
 

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       .map((id) => {
         const catalog = ADAPTER_MODELS[p.adapter as LLMAdapter];
         const match = catalog?.find((m) => m.id === id);
-        return { id, label: match?.label ?? id, supported: catalog ? !!match : true };
+        return { id, label: id, supported: catalog ? !!match : true };
       }),
   }));
 

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -246,8 +246,9 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     if (curatedModels) {
       const used = new Set(customModels);
       const next = curatedModels.find((m) => !used.has(m.id));
-      setCustomModels([...customModels, next?.id ?? ""]);
-      if (next) seedProtocolFromCatalog(next.id);
+      if (!next) return;
+      setCustomModels([...customModels, next.id]);
+      seedProtocolFromCatalog(next.id);
     } else {
       setCustomModels([...customModels, ""]);
     }


### PR DESCRIPTION
Fixes https://github.com/traceroot-ai/traceroot/issues/626

Show exact model IDs in UI dropdowns instead of human-friendly names, per owner request in PR #610. Also fix addCustomModel defensive guard when all curated models are exhausted.

## Summary
Set `label `equal to `id `for all 37 models across `SYSTEM_MODELS` (10 models) and `ADAPTER_MODELS` (27 models) so the UI shows exact model IDs sent to the API
Simplify dead label enrichment in the BYOK llm-models API route `(match?.label ?? id -> id`)
Fix` addCustomModel` defensive guard: early-return when all curated models are exhausted instead of appending an empty string
Add test enforcing` label === id` convention for both `ADAPTER_MODELS` and `SYSTEM_MODELS`
## Type of Change
- [x] fix - A bug fix

## Details
Follow-up PR to PR #610
Also fixes the addCustomModel empty-string append in #610.
## Screenshots / Recordings (if applicable)
NA

## Screenshots

<img width="1472" height="805" alt="Screenshot 2026-04-06 at 10 44 10 PM" src="https://github.com/user-attachments/assets/ff2882e9-9ace-4740-aeb2-f58511cef8f4" />
<img width="1472" height="806" alt="Screenshot 2026-04-06 at 10 43 34 PM" src="https://github.com/user-attachments/assets/7157dad7-3ec0-4191-9d5a-6cb00dff0ad8" />


## Test Plan
 `pnpm vitest run packages/core/src/__tests__/llm-providers.test.ts` passes (8/8)
 Model selector in AI assistant panel shows raw model IDs (e.g.` claude-sonnet-4-6`, not `Claude Sonnet 4.6`)
 BYOK provider settings dropdown shows raw model IDs
 "Add Model" button is disabled when all curated models are added; clicking does not append blank rows
## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
