### PR TITLE
fix: add baseline prisma migration for fresh deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,8 +184,7 @@ traceroot.db
 /prisma/db.sqlite
 /prisma/db.sqlite-journal
 
-# Prisma migrations
-frontend/packages/core/prisma/migrations
+# NOTE: Prisma migration SQL files are NOT ignored -- prisma migrate deploy requires them.
 
 # ===================
 # Testing / Coverage

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Traceroot Development
 # =============================================================================
 
-.PHONY: dev dev-autoreload dev-reset
+.PHONY: dev dev-autoreload dev-lite dev-reset
 
 ## Start developing. Handles everything: deps, infra, migrations, tmux launch.
 ## Idempotent — safe to run repeatedly. Reattaches if already running.
@@ -12,6 +12,12 @@ dev:
 ## Same as dev, but with auto-reload for backend services (REST API + Celery).
 dev-autoreload:
 	uv run python tmux_tools/launcher.py --autoreload
+
+## Windows / no-tmux contributors: full dev env, Ctrl+C to stop.
+## Runs the same Docker stack as prod-lite (no hot-reload).
+dev-lite: install-hooks
+	@echo "Starting Traceroot at http://localhost:3000 - Ctrl+C to stop"
+	@$(MAKE) prod-lite
 
 ## Nuclear reset: kill tmux, destroy all containers/volumes/deps. Run `make dev` to start again.
 dev-reset:
@@ -27,11 +33,16 @@ dev-reset:
 
 PROD_COMPOSE := docker compose -f docker-compose.prod.yml
 
-.PHONY: prod prod-reset
+.PHONY: prod prod-lite prod-reset
 
 ## Start all services in Docker with tmux log viewer (builds on first run).
 prod:
 	uv run python tmux_tools/launcher.py --prod
+
+## Self-hosting on any platform (Windows, CI, no tmux). Docker Desktop only.
+prod-lite:
+	@echo "Starting Traceroot at http://localhost:3000 - Ctrl+C to stop"
+	$(PROD_COMPOSE) up --build
 
 ## Nuclear reset: stop containers, remove volumes, built images, and orphaned sandboxes.
 prod-reset:

--- a/frontend/packages/core/prisma/migrations/0_init/migration.sql
+++ b/frontend/packages/core/prisma/migrations/0_init/migration.sql
@@ -1,0 +1,350 @@
+-- Baseline migration: creates the full schema from scratch.
+--
+-- Existing databases that already have these tables should mark this
+-- migration as applied without running it:
+--
+--   npx prisma migrate resolve --applied 0_init
+--
+
+-- CreateEnum
+CREATE TYPE "MemberRole" AS ENUM ('VIEWER', 'MEMBER', 'ADMIN');
+
+-- CreateTable
+CREATE TABLE "access_keys" (
+    "id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "secret_hash" VARCHAR NOT NULL,
+    "key_hint" VARCHAR NOT NULL,
+    "name" VARCHAR,
+    "expire_time" TIMESTAMP(6),
+    "last_use_time" TIMESTAMP(6),
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "access_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "invites" (
+    "id" VARCHAR NOT NULL,
+    "email" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "role" "MemberRole" NOT NULL,
+    "invited_by_user_id" VARCHAR,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "invites_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "workspace_members" (
+    "id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "role" "MemberRole" NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "workspace_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "workspaces" (
+    "id" VARCHAR NOT NULL,
+    "name" VARCHAR NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "billing_customer_id" TEXT,
+    "billing_subscription_id" TEXT,
+    "billing_price_id" TEXT,
+    "billing_status" TEXT,
+    "billing_period_start" TIMESTAMP(3),
+    "billing_period_end" TIMESTAMP(3),
+    "billing_plan" TEXT NOT NULL DEFAULT 'free',
+    "ingestion_blocked" BOOLEAN NOT NULL DEFAULT false,
+    "ai_blocked" BOOLEAN NOT NULL DEFAULT false,
+    "current_usage" JSONB,
+
+    CONSTRAINT "workspaces_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "model_providers" (
+    "id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "adapter" VARCHAR NOT NULL,
+    "provider" VARCHAR NOT NULL,
+    "key_cipher" TEXT NOT NULL,
+    "key_preview" VARCHAR NOT NULL,
+    "base_url" VARCHAR,
+    "custom_models" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "with_default_models" BOOLEAN NOT NULL DEFAULT true,
+    "config" JSONB,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_by" VARCHAR NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "model_providers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "projects" (
+    "id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "name" VARCHAR NOT NULL,
+    "trace_ttl_days" INTEGER,
+    "delete_time" TIMESTAMP(6),
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "projects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" VARCHAR NOT NULL,
+    "email" VARCHAR NOT NULL,
+    "email_verified" BOOLEAN NOT NULL DEFAULT false,
+    "name" VARCHAR,
+    "image" VARCHAR,
+    "password" VARCHAR,
+    "role" VARCHAR,
+    "banned" BOOLEAN,
+    "ban_reason" VARCHAR,
+    "ban_expires" TIMESTAMP(6),
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "accounts" (
+    "id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "account_id" VARCHAR NOT NULL,
+    "provider_id" VARCHAR NOT NULL,
+    "access_token" TEXT,
+    "refresh_token" TEXT,
+    "access_token_expires_at" TIMESTAMP(6),
+    "refresh_token_expires_at" TIMESTAMP(6),
+    "scope" VARCHAR,
+    "id_token" TEXT,
+    "password" TEXT,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "token" VARCHAR NOT NULL,
+    "expires_at" TIMESTAMP(6) NOT NULL,
+    "ip_address" VARCHAR,
+    "user_agent" VARCHAR,
+    "impersonated_by" VARCHAR,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "verifications" (
+    "id" VARCHAR NOT NULL,
+    "identifier" VARCHAR NOT NULL,
+    "value" VARCHAR NOT NULL,
+    "expires_at" TIMESTAMP(6) NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "verifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "github_connections" (
+    "id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "github_user_id" VARCHAR NOT NULL,
+    "github_username" VARCHAR NOT NULL,
+    "access_token" TEXT NOT NULL,
+    "installation_id" VARCHAR,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "github_connections_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ai_sessions" (
+    "id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "title" VARCHAR,
+    "status" VARCHAR NOT NULL DEFAULT 'active',
+    "metadata" JSONB,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ai_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ai_messages" (
+    "id" VARCHAR NOT NULL,
+    "session_id" VARCHAR NOT NULL,
+    "role" VARCHAR NOT NULL,
+    "content" TEXT NOT NULL,
+    "metadata" JSONB,
+    "model" VARCHAR,
+    "provider" VARCHAR,
+    "is_byok" BOOLEAN,
+    "input_tokens" INTEGER,
+    "output_tokens" INTEGER,
+    "cost_usd" DECIMAL(10,6),
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ai_messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "standard_models" (
+    "id" VARCHAR NOT NULL,
+    "model_name" VARCHAR NOT NULL,
+    "match_pattern" VARCHAR NOT NULL,
+    "provider" VARCHAR NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "standard_models_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "standard_model_prices" (
+    "id" VARCHAR NOT NULL,
+    "model_id" VARCHAR NOT NULL,
+    "usage_type" VARCHAR NOT NULL,
+    "price" DECIMAL(18,12) NOT NULL,
+
+    CONSTRAINT "standard_model_prices_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "access_keys_secret_hash_key" ON "access_keys"("secret_hash");
+
+-- CreateIndex
+CREATE INDEX "ix_access_key_project_id" ON "access_keys"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_invite_workspace_id" ON "invites"("workspace_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_invite_email_workspace" ON "invites"("email", "workspace_id");
+
+-- CreateIndex
+CREATE INDEX "ix_workspace_member_workspace_id" ON "workspace_members"("workspace_id");
+
+-- CreateIndex
+CREATE INDEX "ix_workspace_member_user_id" ON "workspace_members"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_workspace_user" ON "workspace_members"("workspace_id", "user_id");
+
+-- CreateIndex
+CREATE INDEX "workspaces_billing_customer_id_idx" ON "workspaces"("billing_customer_id");
+
+-- CreateIndex
+CREATE INDEX "workspaces_billing_subscription_id_idx" ON "workspaces"("billing_subscription_id");
+
+-- CreateIndex
+CREATE INDEX "ix_model_provider_workspace_id" ON "model_providers"("workspace_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_model_provider_workspace_provider" ON "model_providers"("workspace_id", "provider");
+
+-- CreateIndex
+CREATE INDEX "ix_project_workspace_id" ON "projects"("workspace_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE INDEX "ix_account_user_id" ON "accounts"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_account_provider" ON "accounts"("account_id", "provider_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_token_key" ON "sessions"("token");
+
+-- CreateIndex
+CREATE INDEX "ix_session_user_id" ON "sessions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ix_verification_identifier" ON "verifications"("identifier");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "github_connections_user_id_key" ON "github_connections"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ix_ai_session_project_id" ON "ai_sessions"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_ai_session_workspace_id" ON "ai_sessions"("workspace_id");
+
+-- CreateIndex
+CREATE INDEX "ix_ai_session_user_id" ON "ai_sessions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ix_ai_message_session_id" ON "ai_messages"("session_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "standard_models_model_name_key" ON "standard_models"("model_name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "standard_model_prices_model_id_usage_type_key" ON "standard_model_prices"("model_id", "usage_type");
+
+-- AddForeignKey
+ALTER TABLE "access_keys" ADD CONSTRAINT "access_keys_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "invites" ADD CONSTRAINT "invites_invited_by_user_id_fkey" FOREIGN KEY ("invited_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "invites" ADD CONSTRAINT "invites_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "workspace_members" ADD CONSTRAINT "workspace_members_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "workspace_members" ADD CONSTRAINT "workspace_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "model_providers" ADD CONSTRAINT "model_providers_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "projects" ADD CONSTRAINT "projects_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "github_connections" ADD CONSTRAINT "github_connections_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ai_sessions" ADD CONSTRAINT "ai_sessions_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "ai_messages" ADD CONSTRAINT "ai_messages_session_id_fkey" FOREIGN KEY ("session_id") REFERENCES "ai_sessions"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "standard_model_prices" ADD CONSTRAINT "standard_model_prices_model_id_fkey" FOREIGN KEY ("model_id") REFERENCES "standard_models"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/frontend/packages/core/src/__tests__/llm-providers.test.ts
+++ b/frontend/packages/core/src/__tests__/llm-providers.test.ts
@@ -11,14 +11,23 @@ describe("ADAPTER_MODELS", () => {
     }
   });
 
-  it("has non-empty label for every model", () => {
+  it("label equals id for every model", () => {
     for (const [adapter, models] of Object.entries(ADAPTER_MODELS)) {
       if (!models) continue;
       for (const model of models) {
         expect(
-          model.label.trim().length,
-          `adapter "${adapter}", model "${model.id}" has empty label`,
-        ).toBeGreaterThan(0);
+          model.label,
+          `adapter "${adapter}", model "${model.id}" has label "${model.label}" — should equal id`,
+        ).toBe(model.id);
+      }
+    }
+
+    for (const system of SYSTEM_MODELS) {
+      for (const model of system.models) {
+        expect(
+          model.label,
+          `system provider "${system.provider}", model "${model.id}" has label "${model.label}" — should equal id`,
+        ).toBe(model.id);
       }
     }
   });

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -63,6 +63,7 @@ export const ADAPTER_API_PROTOCOL: Record<string, string> = {
 
 export interface LLMModelDef {
   id: string;
+  /** Display label — intentionally set equal to id so the UI shows the exact model ID sent to the API */
   label: string;
   /** Cost per 1M input tokens in USD */
   inputCostPer1M?: number;
@@ -89,11 +90,11 @@ export const SYSTEM_MODELS: {
     piAIProvider: "anthropic",
     apiProtocol: "anthropic-messages",
     models: [
-      { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
-      { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-      { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
-      { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
-      { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+      { id: "claude-opus-4-6", label: "claude-opus-4-6" },
+      { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
+      { id: "claude-opus-4-5", label: "claude-opus-4-5" },
+      { id: "claude-sonnet-4-5", label: "claude-sonnet-4-5" },
+      { id: "claude-haiku-4-5", label: "claude-haiku-4-5" },
     ],
   },
   {
@@ -102,12 +103,12 @@ export const SYSTEM_MODELS: {
     piAIProvider: "openai",
     apiProtocol: "openai-completions",
     models: [
-      { id: "gpt-5", label: "GPT-5" },
-      { id: "gpt-5-mini", label: "GPT-5 Mini" },
+      { id: "gpt-5", label: "gpt-5" },
+      { id: "gpt-5-mini", label: "gpt-5-mini" },
       { id: "o3", label: "o3" },
       { id: "o4-mini", label: "o4-mini" },
       // Codex models require the Responses API (not Chat Completions)
-      { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", apiProtocol: "openai-responses" },
+      { id: "gpt-5.3-codex", label: "gpt-5.3-codex", apiProtocol: "openai-responses" },
     ],
   },
 ];
@@ -133,44 +134,44 @@ export const PROVIDER_PRIORITY: LLMAdapter[] = [
 // Adapters NOT listed here (azure, amazon-bedrock, openrouter) use free-text input.
 export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
   openai: [
-    { id: "gpt-5.4", label: "GPT-5.4" },
-    { id: "gpt-5.4-pro", label: "GPT-5.4 Pro" },
-    { id: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
-    { id: "gpt-5.4-nano", label: "GPT-5.4 Nano" },
-    { id: "gpt-5.3-codex", label: "GPT-5.3 Codex", apiProtocol: "openai-responses" },
-    { id: "gpt-5.2", label: "GPT-5.2" },
-    { id: "gpt-5", label: "GPT-5" },
-    { id: "gpt-5-mini", label: "GPT-5 Mini" },
+    { id: "gpt-5.4", label: "gpt-5.4" },
+    { id: "gpt-5.4-pro", label: "gpt-5.4-pro" },
+    { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },
+    { id: "gpt-5.4-nano", label: "gpt-5.4-nano" },
+    { id: "gpt-5.3-codex", label: "gpt-5.3-codex", apiProtocol: "openai-responses" },
+    { id: "gpt-5.2", label: "gpt-5.2" },
+    { id: "gpt-5", label: "gpt-5" },
+    { id: "gpt-5-mini", label: "gpt-5-mini" },
     { id: "o3", label: "o3" },
     { id: "o4-mini", label: "o4-mini" },
   ],
   anthropic: [
-    { id: "claude-opus-4-6", label: "Claude Opus 4.6" },
-    { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
-    { id: "claude-opus-4-5", label: "Claude Opus 4.5" },
-    { id: "claude-sonnet-4-5", label: "Claude Sonnet 4.5" },
-    { id: "claude-haiku-4-5", label: "Claude Haiku 4.5" },
+    { id: "claude-opus-4-6", label: "claude-opus-4-6" },
+    { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
+    { id: "claude-opus-4-5", label: "claude-opus-4-5" },
+    { id: "claude-sonnet-4-5", label: "claude-sonnet-4-5" },
+    { id: "claude-haiku-4-5", label: "claude-haiku-4-5" },
   ],
   google: [
-    { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro Preview" },
-    { id: "gemini-3-flash-preview", label: "Gemini 3 Flash Preview" },
-    { id: "gemini-3.1-flash-lite-preview", label: "Gemini 3.1 Flash Lite Preview" },
-    { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash" },
-    { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro" },
+    { id: "gemini-3.1-pro-preview", label: "gemini-3.1-pro-preview" },
+    { id: "gemini-3-flash-preview", label: "gemini-3-flash-preview" },
+    { id: "gemini-3.1-flash-lite-preview", label: "gemini-3.1-flash-lite-preview" },
+    { id: "gemini-2.5-flash", label: "gemini-2.5-flash" },
+    { id: "gemini-2.5-pro", label: "gemini-2.5-pro" },
   ],
-  deepseek: [{ id: "deepseek-chat", label: "DeepSeek Chat" }],
+  deepseek: [{ id: "deepseek-chat", label: "deepseek-chat" }],
   xai: [
-    { id: "grok-4.20", label: "Grok 4.20" },
-    { id: "grok-4", label: "Grok 4" },
+    { id: "grok-4.20", label: "grok-4.20" },
+    { id: "grok-4", label: "grok-4" },
   ],
   moonshot: [
-    { id: "kimi-k2.5", label: "Kimi K2.5" },
-    { id: "kimi-k2-thinking", label: "Kimi K2 Thinking" },
+    { id: "kimi-k2.5", label: "kimi-k2.5" },
+    { id: "kimi-k2-thinking", label: "kimi-k2-thinking" },
   ],
   zai: [
-    { id: "glm-4.5", label: "GLM-4.5" },
-    { id: "glm-4.5-air", label: "GLM-4.5 Air" },
-    { id: "glm-4.5-flash", label: "GLM-4.5 Flash" },
+    { id: "glm-4.5", label: "glm-4.5" },
+    { id: "glm-4.5-air", label: "glm-4.5-air" },
+    { id: "glm-4.5-flash", label: "glm-4.5-flash" },
   ],
 };
 

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/llm-models/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       .map((id) => {
         const catalog = ADAPTER_MODELS[p.adapter as LLMAdapter];
         const match = catalog?.find((m) => m.id === id);
-        return { id, label: match?.label ?? id, supported: catalog ? !!match : true };
+        return { id, label: id, supported: catalog ? !!match : true };
       }),
   }));
 

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -246,8 +246,9 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     if (curatedModels) {
       const used = new Set(customModels);
       const next = curatedModels.find((m) => !used.has(m.id));
-      setCustomModels([...customModels, next?.id ?? ""]);
-      if (next) seedProtocolFromCatalog(next.id);
+      if (!next) return;
+      setCustomModels([...customModels, next.id]);
+      seedProtocolFromCatalog(next.id);
     } else {
       setCustomModels([...customModels, ""]);
     }


### PR DESCRIPTION
## Summary

- Un-ignore `frontend/packages/core/prisma/migrations/` in `.gitignore` so migration SQL files are tracked (Prisma requires them for `migrate deploy`)
- Add `0_init` baseline migration generated from `schema.prisma` via `prisma migrate diff --from-empty`
- Add `dev-lite` and `prod-lite` Makefile targets for Windows/no-tmux contributors

`dev-lite` depends on `install-hooks`, which already exists on main from #612. This PR just aligns it with `dev` and `dev-autoreload`.

Existing deployments with a populated postgres volume are unaffected. To adopt migration tracking on an existing database, run `prisma migrate resolve --applied 0_init`.

Closes #625

## Test plan

- [ ] `docker compose -f docker-compose.prod.yml down -v --rmi local` to wipe volumes
- [ ] `make prod-lite` on a fresh clone — migrate service should complete and app should start
- [ ] Verify existing deployments still work (no-op migration)