### PR TITLE
chore: upgrade traceroot SDK to 0.1.2 in all Python examples

### DIFF
--- a/examples/python/anthropic-tool-agent/requirements.txt
+++ b/examples/python/anthropic-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 anthropic>=0.40.0
 python-dotenv>=1.0.0
-traceroot==0.1.1
+traceroot==0.1.2
 openinference-instrumentation-anthropic>=1.0.0

--- a/examples/python/claude-agent-sdk/requirements.txt
+++ b/examples/python/claude-agent-sdk/requirements.txt
@@ -1,4 +1,4 @@
 claude-agent-sdk>=0.1.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.0
+traceroot==0.1.2

--- a/examples/python/deepagents/requirements.txt
+++ b/examples/python/deepagents/requirements.txt
@@ -2,4 +2,4 @@ deepagents>=0.4.0
 langchain>=0.3.0
 langchain-anthropic>=0.3.0
 python-dotenv>=1.0.0
-traceroot==0.1.1
+traceroot==0.1.2

--- a/examples/python/gemini-tool-agent/requirements.txt
+++ b/examples/python/gemini-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 google-genai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.0
+traceroot==0.1.2

--- a/examples/python/langgraph-code-agent/requirements.txt
+++ b/examples/python/langgraph-code-agent/requirements.txt
@@ -6,4 +6,4 @@ python-dotenv>=1.0.0
 fastapi==0.115.12
 uvicorn==0.34.3
 
-traceroot==0.1.1
+traceroot==0.1.2

--- a/examples/python/openai-agents-sdk/requirements.txt
+++ b/examples/python/openai-agents-sdk/requirements.txt
@@ -1,4 +1,4 @@
 openai-agents>=0.0.3
 python-dotenv>=1.0.0
 
-traceroot==0.1.0
+traceroot==0.1.2

--- a/examples/python/openai-tool-agent/requirements.txt
+++ b/examples/python/openai-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.1
+traceroot==0.1.2


### PR DESCRIPTION
## Summary
- Bumps `traceroot` from `0.1.0`/`0.1.1` to `0.1.2` across all 7 Python example projects
- Affected: `deepagents`, `openai-tool-agent`, `anthropic-tool-agent`, `openai-agents-sdk`, `langgraph-code-agent`, `claude-agent-sdk`, `gemini-tool-agent`

## Test plan
- [ ] Verify each example installs cleanly with `pip install -r requirements.txt`
- [ ] Spot-check that traceroot 0.1.2 is available on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)