### PR TITLE
feat: add AutoGen multi-agent example with TraceRoot observability

### DIFF
--- a/examples/python/autogen-tool-agent/.env.example
+++ b/examples/python/autogen-tool-agent/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# Gemini
+GEMINI_API_KEY=your_google_genai_api_key_here

--- a/examples/python/autogen-tool-agent/README.md
+++ b/examples/python/autogen-tool-agent/README.md
@@ -1,0 +1,24 @@
+# AutoGen Agent (AG2)
+
+Multi-agent conversation using the AutoGen framework with LLM tool use, instrumented with [TraceRoot](https://traceroot.ai).
+
+*Note: This example utilizes `ag2[gemini]`, the community-maintained continuation of the AutoGen framework, configured to use Google's Gemini models.*
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+## What it does
+
+Runs a multi-agent loop (`AssistantAgent` and `UserProxyAgent`) to exercise tool use:
+1. Weather comparison (San Francisco vs Tokyo)
+2. Math evaluation (15 multiplied by 24)
+
+Tools: `get_weather`, `calculate`

--- a/examples/python/autogen-tool-agent/main.py
+++ b/examples/python/autogen-tool-agent/main.py
@@ -131,6 +131,7 @@ def run_demo():
             assistant,
             message=query,
             clear_history=True,
+            max_turns=10,
         )
 
 

--- a/examples/python/autogen-tool-agent/main.py
+++ b/examples/python/autogen-tool-agent/main.py
@@ -1,0 +1,140 @@
+"""
+AutoGen multi-agent conversation with tool use and TraceRoot observability.
+
+Usage:
+    cp .env.example .env
+    pip install -r requirements.txt
+    python main.py
+"""
+
+import json
+import logging
+import os
+from typing import Annotated
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found. Using process environment variables.")
+
+import autogen
+from autogen import register_function
+
+import traceroot
+from traceroot import Integration, using_attributes
+
+traceroot.initialize(integrations=[Integration.AUTOGEN, Integration.GOOGLE_GENAI])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def get_weather(city: Annotated[str, "City name"]) -> str:
+    """Get current weather for a city."""
+    weather_db = {
+        "san francisco": {"temp": 68, "condition": "foggy", "humidity": 75},
+        "new york": {"temp": 45, "condition": "cloudy", "humidity": 60},
+        "london": {"temp": 52, "condition": "rainy", "humidity": 85},
+        "tokyo": {"temp": 72, "condition": "sunny", "humidity": 50},
+    }
+    data = weather_db.get(city.lower(), {"temp": 70, "condition": "unknown", "humidity": 50})
+    return json.dumps({"city": city, **data})
+
+
+def calculate(expression: Annotated[str, "Math expression (e.g., '2 + 2 * 3')"]) -> str:
+    """Evaluate a math expression safely using AST parsing."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval(node.operand)
+        raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+        result = _eval(tree)
+        return json.dumps({"expression": expression, "result": result})
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+DEMO_QUERIES = [
+    "What's the weather in San Francisco and Tokyo? Compare them.",
+    "Calculate 15 multiplied by 24.",
+]
+
+
+def run_demo():
+    config_list = [
+        {
+            "model": "gemini-2.5-flash",
+            "api_key": os.environ.get("GEMINI_API_KEY"),
+            "api_type": "google",
+        }
+    ]
+    llm_config = {"config_list": config_list, "temperature": 0.0}
+
+    assistant = autogen.AssistantAgent(
+        name="assistant",
+        system_message="You are a helpful AI assistant. Use the tools provided to answer questions. When you have fully answered the user's request, you must append the word 'TERMINATE' to the very end of your response.",
+        llm_config=llm_config,
+    )
+
+    executor = autogen.UserProxyAgent(
+        name="executor",
+        human_input_mode="NEVER",
+        code_execution_config=False,
+        is_termination_msg=lambda x: (
+            x.get("content", "") and x.get("content", "").rstrip().endswith("TERMINATE")
+        ),
+    )
+
+    register_function(
+        get_weather,
+        caller=assistant,
+        executor=executor,
+        name="get_weather",
+        description="Get current weather for a city",
+    )
+
+    register_function(
+        calculate,
+        caller=assistant,
+        executor=executor,
+        name="calculate",
+        description="Evaluate a mathematical expression",
+    )
+
+    for i, query in enumerate(DEMO_QUERIES, 1):
+        print(f"\n{'=' * 60}")
+        print(f"Query {i}: {query}")
+        print("=" * 60)
+
+        executor.initiate_chat(
+            assistant,
+            message=query,
+            clear_history=True,
+        )
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="autogen-session"):
+        run_demo()
+    traceroot.flush()

--- a/examples/python/autogen-tool-agent/requirements.txt
+++ b/examples/python/autogen-tool-agent/requirements.txt
@@ -1,0 +1,4 @@
+ag2[Gemini]>=0.11.5
+python-dotenv>=1.0.0
+
+traceroot==0.1.2


### PR DESCRIPTION
## Summary

Closes #644 

Adds an AutoGen (ag2) multi-agent example to `examples/python/`. This is the companion example to traceroot-ai/traceroot-py#101 adding `Integration.AUTOGEN`.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
Builds on Python SDK AutoGen Integration PR: traceroot-ai/traceroot-py#101
- Added `examples/python/autogen-tool-agent/` with a multi-agent conversation using `ag2` SDK and TraceRoot auto-instrumentation
- Uses `Integration.AUTOGEN` and `Integration.GOOGLE_GENAI` with `traceroot.initialize()` for OpenInference-based auto-instrumentation
- Two-agent setup: `AssistantAgent` (LLM-powered) + `UserProxyAgent` (tool executor), with `register_function` for tool registration
- Includes 2 demo queries: weather comparison and math calculation
- AutoGen's instrumentor auto-captures agent conversation spans without needing `@observe` decorators

## Screenshots / Recordings (if applicable)

<img width="890" height="427" alt="image" src="https://github.com/user-attachments/assets/725c297c-cb00-498c-924a-bc697292816e" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
