### PR TITLE
Added data retention

### DIFF
--- a/backend/db/clickhouse/client.py
+++ b/backend/db/clickhouse/client.py
@@ -144,6 +144,10 @@ class ClickHouseClient:
         """Execute a query and return the result."""
         return self._client.query(query, parameters=parameters)
 
+    def command(self, cmd: str, parameters: dict[str, Any] | None = None) -> None:
+        """Execute a DDL/DML command (e.g. ALTER TABLE DELETE mutation)."""
+        self._client.command(cmd, parameters=parameters)
+
     def close(self) -> None:
         """Close the client connection."""
         self._client.close()

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -188,25 +188,48 @@ def _cleanup_clickhouse(project_ids: list[str], cutoff: datetime) -> None:
     )
 
 
+_S3_DELETE_BATCH_MAX = 1000  # AWS DeleteObjects limit
+
+
+def _delete_s3_object_batch(client, bucket: str, batch: list[dict]) -> int:
+    """Delete up to 1000 objects; returns count actually deleted (excludes failures)."""
+    if not batch:
+        return 0
+    response = client.delete_objects(
+        Bucket=bucket,
+        Delete={"Objects": batch, "Quiet": True},
+    )
+    errors = response.get("Errors", [])
+    if errors:
+        failed_keys = [e.get("Key", "?") for e in errors]
+        logger.warning(
+            "S3 delete_objects reported %d failure(s) (sample keys): %s",
+            len(errors),
+            failed_keys[:3],
+        )
+    return len(batch) - len(errors)
+
+
 def _cleanup_s3(project_ids: list[str], cutoff: datetime) -> int:
     """Delete S3 objects for the given projects that are older than cutoff.
 
     Object key format: events/otel/{project_id}/{yyyy}/{mm}/{dd}/{hh}/{uuid}.json
     Objects are matched by parsing the date components from their key.
-    Returns the total number of deleted objects.
+    Returns the total number of successfully deleted objects.
     """
     s3 = get_s3_service()
     client = s3._get_client()
+    bucket = s3._bucket_name
     cutoff_date = cutoff.date()
     total_deleted = 0
 
     for project_id in project_ids:
         prefix = f"events/otel/{project_id}/"
-        to_delete: list[dict] = []
+        pending: list[dict] = []
 
         paginator = client.get_paginator("list_objects_v2")
         try:
-            for page in paginator.paginate(Bucket=s3._bucket_name, Prefix=prefix):
+            for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
                 for obj in page.get("Contents", []):
                     key: str = obj["Key"]
                     # Parse: events/otel/{project_id}/{yyyy}/{mm}/{dd}/...
@@ -216,17 +239,19 @@ def _cleanup_s3(project_ids: list[str], cutoff: datetime) -> int:
                             obj_date_str = f"{parts[3]}-{parts[4]}-{parts[5]}"
                             obj_date = date.fromisoformat(obj_date_str)
                             if obj_date < cutoff_date:
-                                to_delete.append({"Key": key})
+                                pending.append({"Key": key})
+                                if len(pending) >= _S3_DELETE_BATCH_MAX:
+                                    total_deleted += _delete_s3_object_batch(
+                                        client,
+                                        bucket,
+                                        pending[:_S3_DELETE_BATCH_MAX],
+                                    )
+                                    pending = pending[_S3_DELETE_BATCH_MAX:]
                         except (ValueError, IndexError):
                             pass
 
-            for i in range(0, len(to_delete), 1000):
-                batch = to_delete[i : i + 1000]
-                client.delete_objects(
-                    Bucket=s3._bucket_name,
-                    Delete={"Objects": batch, "Quiet": True},
-                )
-                total_deleted += len(batch)
+            if pending:
+                total_deleted += _delete_s3_object_batch(client, bucket, pending)
 
         except Exception as exc:
             logger.warning("S3 cleanup failed for project %s: %s", project_id, exc, exc_info=True)

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -3,14 +3,18 @@
 These endpoints are protected by X-Internal-Secret header and not exposed publicly.
 """
 
-from datetime import datetime
+import logging
+from datetime import UTC, date, datetime, timedelta
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from db.clickhouse.client import get_clickhouse_client
+from rest.services.s3 import get_s3_service
 from shared.config import settings
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["internal"])
 
@@ -147,3 +151,130 @@ async def get_usage_details(
     spans = int(spans_result.result_rows[0][0]) if spans_result.result_rows else 0
 
     return UsageDetailsResponse(traces=traces, spans=spans)
+
+
+# =============================================================================
+# Data Retention Endpoints
+# =============================================================================
+
+
+class RetentionCleanupRequest(BaseModel):
+    project_ids: list[str] = Field(..., min_length=1)
+    ttl_days: int = Field(..., gt=0)
+
+
+class RetentionCleanupResponse(BaseModel):
+    status: str
+    project_ids: list[str]
+    ttl_days: int
+    cutoff_date: str
+    s3_objects_deleted: int
+
+
+def _cleanup_clickhouse(project_ids: list[str], cutoff: datetime) -> None:
+    """Submit ALTER TABLE DELETE mutations for traces and spans older than cutoff."""
+    ch = get_clickhouse_client()
+    cutoff_str = cutoff.strftime("%Y-%m-%d %H:%M:%S")
+
+    ch.command(
+        "ALTER TABLE traces DELETE WHERE project_id IN {project_ids:Array(String)}"
+        " AND trace_start_time < {cutoff:String}",
+        parameters={"project_ids": project_ids, "cutoff": cutoff_str},
+    )
+    ch.command(
+        "ALTER TABLE spans DELETE WHERE project_id IN {project_ids:Array(String)}"
+        " AND span_start_time < {cutoff:String}",
+        parameters={"project_ids": project_ids, "cutoff": cutoff_str},
+    )
+
+
+def _cleanup_s3(project_ids: list[str], cutoff: datetime) -> int:
+    """Delete S3 objects for the given projects that are older than cutoff.
+
+    Object key format: events/otel/{project_id}/{yyyy}/{mm}/{dd}/{hh}/{uuid}.json
+    Objects are matched by parsing the date components from their key.
+    Returns the total number of deleted objects.
+    """
+    s3 = get_s3_service()
+    client = s3._get_client()
+    cutoff_date = cutoff.date()
+    total_deleted = 0
+
+    for project_id in project_ids:
+        prefix = f"events/otel/{project_id}/"
+        to_delete: list[dict] = []
+
+        paginator = client.get_paginator("list_objects_v2")
+        try:
+            for page in paginator.paginate(Bucket=s3._bucket_name, Prefix=prefix):
+                for obj in page.get("Contents", []):
+                    key: str = obj["Key"]
+                    # Parse: events/otel/{project_id}/{yyyy}/{mm}/{dd}/...
+                    parts = key.split("/")
+                    if len(parts) >= 6:
+                        try:
+                            obj_date_str = f"{parts[3]}-{parts[4]}-{parts[5]}"
+                            obj_date = date.fromisoformat(obj_date_str)
+                            if obj_date < cutoff_date:
+                                to_delete.append({"Key": key})
+                        except (ValueError, IndexError):
+                            pass
+
+            for i in range(0, len(to_delete), 1000):
+                batch = to_delete[i : i + 1000]
+                client.delete_objects(
+                    Bucket=s3._bucket_name,
+                    Delete={"Objects": batch, "Quiet": True},
+                )
+                total_deleted += len(batch)
+
+        except Exception as exc:
+            logger.warning("S3 cleanup failed for project %s: %s", project_id, exc, exc_info=True)
+
+    return total_deleted
+
+
+@router.post(
+    "/retention/cleanup",
+    response_model=RetentionCleanupResponse,
+    dependencies=[Depends(verify_internal_secret)],
+)
+async def retention_cleanup(
+    request: RetentionCleanupRequest,
+) -> RetentionCleanupResponse:
+    """Delete traces, spans, and raw S3 objects older than ttl_days for the given projects.
+
+    ClickHouse deletions are submitted as asynchronous mutations (ALTER TABLE DELETE)
+    and processed by ClickHouse in the background.  S3 object deletions are performed
+    synchronously and the count is returned in the response.
+    """
+    project_ids = [p.strip() for p in request.project_ids if p.strip()]
+    if not project_ids:
+        raise HTTPException(status_code=422, detail="No valid project IDs provided")
+
+    cutoff = datetime.now(UTC) - timedelta(days=request.ttl_days)
+
+    logger.info(
+        "Data retention cleanup: %d project(s), ttl=%d days, cutoff=%s",
+        len(project_ids),
+        request.ttl_days,
+        cutoff.isoformat(),
+    )
+
+    _cleanup_clickhouse(project_ids, cutoff)
+
+    s3_deleted = _cleanup_s3(project_ids, cutoff)
+
+    logger.info(
+        "Data retention cleanup complete: %d S3 objects deleted for %d project(s)",
+        s3_deleted,
+        len(project_ids),
+    )
+
+    return RetentionCleanupResponse(
+        status="ok",
+        project_ids=project_ids,
+        ttl_days=request.ttl_days,
+        cutoff_date=cutoff.isoformat(),
+        s3_objects_deleted=s3_deleted,
+    )

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -62,6 +62,7 @@ billing:
     tag: "latest"
   replicas: 1
   usageMeteringCron: "5 * * * *"
+  dataRetentionCron: "0 2 * * *"
   resources:
     requests:
       cpu: "128m"

--- a/frontend/packages/core/src/ee/billing/index.ts
+++ b/frontend/packages/core/src/ee/billing/index.ts
@@ -33,4 +33,7 @@ export {
   // Free plan blocking
   isFreePlanBlocked,
   isAiRunBlocked,
+  // Data retention
+  RETENTION_DAYS,
+  getRetentionDays,
 } from "./plans";

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -237,6 +237,35 @@ export function requireEntitlement(
 }
 
 // =============================================================================
+// DATA RETENTION
+// =============================================================================
+
+// Retention window in days per plan (null = custom / no enforced limit)
+export const RETENTION_DAYS: Record<PlanType, number | null> = {
+  [PlanType.FREE]: 15,
+  [PlanType.STARTER]: 30,
+  [PlanType.PRO]: 90,
+  [PlanType.ENTERPRISE]: null,
+};
+
+/**
+ * Get the effective data retention TTL in days for a plan.
+ *
+ * Returns null when:
+ * - Billing is disabled (self-hosted, no limits enforced)
+ * - Enterprise plan without a custom TTL set on the project
+ *
+ * @param plan          The workspace's billing plan
+ * @param customTtlDays Per-project override (used for Enterprise plans)
+ */
+export function getRetentionDays(plan: PlanType, customTtlDays?: number | null): number | null {
+  if (!isBillingEnabled()) return null;
+  const planDays = RETENTION_DAYS[plan];
+  if (planDays !== null) return planDays;
+  return customTtlDays ?? null;
+}
+
+// =============================================================================
 // SEAT ENFORCEMENT
 // =============================================================================
 export function getSeatLimit(plan: PlanType): number {

--- a/frontend/worker/src/dataRetention.ts
+++ b/frontend/worker/src/dataRetention.ts
@@ -1,0 +1,122 @@
+/**
+ * Data Retention Worker
+ *
+ * Runs daily to enforce per-plan trace/span retention windows:
+ *   Free       → 15 days
+ *   Starter    → 30 days
+ *   Pro        → 90 days
+ *   Enterprise → custom (traceTtlDays on each Project), skipped if unset
+ *
+ * For each workspace the job groups projects by their effective TTL and calls
+ * the Python backend to delete ClickHouse rows and S3 raw objects older than
+ * the cutoff date.  The job is a no-op when billing is disabled (ENABLE_BILLING=false).
+ */
+
+import { prisma, PlanType, getRetentionDays } from "@traceroot/core";
+
+const BACKEND_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
+const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
+
+interface CleanupResponse {
+  status: string;
+  project_ids: string[];
+  ttl_days: number;
+  cutoff_date: string;
+  s3_objects_deleted: number;
+}
+
+async function callRetentionCleanup(
+  projectIds: string[],
+  ttlDays: number,
+): Promise<CleanupResponse> {
+  const url = new URL("/api/v1/internal/retention/cleanup", BACKEND_URL);
+  const response = await fetch(url.toString(), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Internal-Secret": INTERNAL_API_SECRET,
+    },
+    body: JSON.stringify({ project_ids: projectIds, ttl_days: ttlDays }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Backend retention cleanup error: ${response.status} - ${errorText}`);
+  }
+
+  return response.json() as Promise<CleanupResponse>;
+}
+
+/**
+ * Main data retention job.
+ *
+ * Iterates all workspaces, determines the effective retention window from
+ * the billing plan (and per-project traceTtlDays for Enterprise), and
+ * triggers cleanup via the Python backend.
+ */
+export async function runDataRetentionJob(): Promise<void> {
+  console.log("[Retention] Starting data retention job...");
+
+  const workspaces = await prisma.workspace.findMany({
+    include: {
+      projects: {
+        where: { deleteTime: null },
+        select: { id: true, traceTtlDays: true },
+      },
+    },
+  });
+
+  console.log(`[Retention] Processing ${workspaces.length} workspaces`);
+
+  let totalProjectsCleaned = 0;
+  let totalS3Deleted = 0;
+
+  for (const workspace of workspaces) {
+    if (workspace.projects.length === 0) continue;
+
+    const plan = workspace.billingPlan as PlanType;
+
+    try {
+      // Group projects by their effective TTL so we issue one API call per TTL value.
+      const byTtl = new Map<number, string[]>();
+
+      for (const project of workspace.projects) {
+        const ttlDays = getRetentionDays(plan, project.traceTtlDays);
+        if (ttlDays === null) {
+          // No retention limit (billing disabled or Enterprise without custom TTL)
+          continue;
+        }
+        const ids = byTtl.get(ttlDays) ?? [];
+        ids.push(project.id);
+        byTtl.set(ttlDays, ids);
+      }
+
+      if (byTtl.size === 0) continue;
+
+      for (const [ttlDays, projectIds] of byTtl) {
+        try {
+          const result = await callRetentionCleanup(projectIds, ttlDays);
+          totalProjectsCleaned += projectIds.length;
+          totalS3Deleted += result.s3_objects_deleted;
+          console.log(
+            `[Retention] Workspace ${workspace.id} (${plan}): ` +
+              `cleaned ${projectIds.length} project(s) with ttl=${ttlDays}d, ` +
+              `cutoff=${result.cutoff_date}, s3_deleted=${result.s3_objects_deleted}`,
+          );
+        } catch (err) {
+          console.error(
+            `[Retention] Failed cleanup for workspace ${workspace.id}, ttl=${ttlDays}d:`,
+            err,
+          );
+        }
+      }
+    } catch (err) {
+      console.error(`[Retention] Error processing workspace ${workspace.id}:`, err);
+    }
+  }
+
+  console.log(
+    `[Retention] Job completed: ${totalProjectsCleaned} project(s) cleaned, ` +
+      `${totalS3Deleted} S3 objects deleted`,
+  );
+}

--- a/frontend/worker/src/dataRetention.ts
+++ b/frontend/worker/src/dataRetention.ts
@@ -14,6 +14,9 @@
 
 import { prisma, PlanType, getRetentionDays } from "@traceroot/core";
 
+/** Valid workspace.billingPlan values from DB; guards against null/unknown plans. */
+const VALID_PLAN_VALUES = new Set<string>(Object.values(PlanType));
+
 const BACKEND_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
 const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
 
@@ -74,7 +77,14 @@ export async function runDataRetentionJob(): Promise<void> {
   for (const workspace of workspaces) {
     if (workspace.projects.length === 0) continue;
 
-    const plan = workspace.billingPlan as PlanType;
+    const rawPlan = workspace.billingPlan;
+    if (rawPlan == null || !VALID_PLAN_VALUES.has(rawPlan)) {
+      console.warn(
+        `[Retention] Workspace ${workspace.id} has unknown billingPlan: ${String(rawPlan)}, skipping`,
+      );
+      continue;
+    }
+    const plan = rawPlan as PlanType;
 
     try {
       // Group projects by their effective TTL so we issue one API call per TTL value.

--- a/frontend/worker/src/index.ts
+++ b/frontend/worker/src/index.ts
@@ -9,6 +9,7 @@
 import cron from "node-cron";
 import { prisma, syncStandardPrices } from "@traceroot/core";
 import { runBillingJob, closeClickHouseClient } from "./ee/billing";
+import { runDataRetentionJob } from "./dataRetention";
 
 // Graceful shutdown handling
 let isShuttingDown = false;
@@ -61,8 +62,22 @@ async function main(): Promise<void> {
     }
   });
 
+  // Schedule data retention job (default: daily at 02:00 UTC)
+  const retentionCron = process.env.DATA_RETENTION_CRON || "0 2 * * *";
+  cron.schedule(retentionCron, async () => {
+    if (isShuttingDown) return;
+
+    console.log("[Worker] Running scheduled data retention job...");
+    try {
+      await runDataRetentionJob();
+    } catch (error) {
+      console.error("[Worker] Data retention job failed:", error);
+    }
+  });
+
   console.log("[Worker] Scheduled jobs:");
-  console.log(`  - Billing: ${billingCron}`);
+  console.log(`  - Billing:        ${billingCron}`);
+  console.log(`  - Data Retention: ${retentionCron}`);
   console.log("[Worker] Worker is running. Press Ctrl+C to stop.");
 
   // Keep the process alive


### PR DESCRIPTION
## Summary

Fixes #560

Implements **trace and raw-ingest data retention** aligned with billing plans: a scheduled worker job computes each project’s effective TTL (Free / Starter / Pro / Enterprise + optional `traceTtlDays`), then calls an internal backend endpoint that deletes old rows in **ClickHouse** (`traces`, `spans`) and old objects under **S3** `events/otel/{project_id}/…` date prefixes. When cloud billing is disabled (`ENABLE_BILLING=false`), no retention window is enforced and cleanup is skipped.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

**Worker (`frontend/worker`)**
- New `dataRetention.ts`: loads workspaces and active projects, groups `project_id`s by effective TTL via `getRetentionDays()`, POSTs to `POST /api/v1/internal/retention/cleanup` with `X-Internal-Secret`.
- `index.ts`: schedules the job with `node-cron` (`DATA_RETENTION_CRON`, default `0 2 * * *`).

**Core (`frontend/packages/core`)**
- `RETENTION_DAYS` and `getRetentionDays()` in `ee/billing/plans.ts`: maps plan → days; Enterprise uses per-project `traceTtlDays` when set; returns `null` when billing is off or Enterprise has no custom TTL.

**Backend (`backend/rest`)**
- Internal route `retention/cleanup`: cutoff = now − `ttl_days`; ClickHouse `ALTER TABLE … DELETE` for old traces/spans; S3 list/delete by parsed `yyyy/mm/dd` in object keys.

**Deploy**
- Helm `values.yaml`: `dataRetentionCron` for the worker schedule.

**Configuration**
- Worker: `BACKEND_INTERNAL_URL`, `INTERNAL_API_SECRET`, `DATA_RETENTION_CRON`, `ENABLE_BILLING` (via core).
- API: `internal_api_secret` must match in production so the internal endpoint is not open.

## Screenshots / Recordings (if applicable)

N/A (background job + API; UI for `trace_ttl_days` may exist separately—add screenshots if this PR includes project settings changes).

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary