### PR TITLE
docs: add AutoGen (ag2) documentation

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -139,7 +139,8 @@
             "pages": [
               "integrations/langchain",
               "integrations/langchain-deepagents",
-              "integrations/mastra"
+              "integrations/mastra",
+              "integrations/autogen"
             ]
           },
           {

--- a/docs/integrations/autogen.mdx
+++ b/docs/integrations/autogen.mdx
@@ -60,8 +60,29 @@ user_proxy.initiate_chat(
 Function registrations and local tool executions are automatically traced as nested child spans within the executing agent's workflow:
 
 ```python
+import os
+import autogen
 from typing import Annotated
 from autogen import register_function
+
+# Define the LLM and Agents
+llm_config = {
+    "config_list": [{
+        "model": "gemini-2.5-flash", 
+        "api_key": os.environ["GEMINI_API_KEY"],
+        "api_type": "google"
+    }]
+}
+
+assistant = autogen.AssistantAgent(
+    name="assistant", 
+    llm_config=llm_config
+)
+user_proxy = autogen.UserProxyAgent(
+    name="user_proxy", 
+    human_input_mode="NEVER", 
+    max_consecutive_auto_reply=2
+)
 
 def get_weather(city: Annotated[str, "City name"]) -> str:
     """Get current weather for a city."""
@@ -95,4 +116,4 @@ user_proxy.initiate_chat(
 | LLM calls* | Raw completion requests to the provider |
 | Tokens & Cost* | Aggregated usage and pricing for the chat session |
 
-*Requires initializing the corresponding LLM integration (e.g., `Integration.GOOGLE_GENAI`) alongside `Integration.AUTOGEN`
+*\*Requires initializing the corresponding LLM integration (e.g., `Integration.GOOGLE_GENAI`) alongside `Integration.AUTOGEN`

--- a/docs/integrations/autogen.mdx
+++ b/docs/integrations/autogen.mdx
@@ -1,0 +1,98 @@
+---
+title: AutoGen (AG2)
+description: Auto-instrument AutoGen multi-agent conversations and tool calls
+---
+
+Automatically capture agent loops, message histories, and tool executions within the AutoGen framework. 
+
+*Note: This integration supports `ag2` (v0.11.5+), the community-maintained continuation of the classic AutoGen framework.*
+
+## Setup
+
+To capture the complete picture—including both the agent orchestrations and the underlying token costs—we highly recommend initializing **both** the AutoGen integration and your specific LLM provider (e.g., Google GenAI, OpenAI, Anthropic).
+
+```python
+import traceroot
+from traceroot import Integration
+
+# Initialize AutoGen alongside your LLM provider to capture tokens and costs
+traceroot.initialize(integrations=[
+    Integration.AUTOGEN,
+    Integration.GOOGLE_GENAI  # Or OPENAI, ANTHROPIC, etc.
+])
+```
+
+## Usage
+
+Once initialized, the standard `initiate_chat` loop and internal agent reasoning steps are captured automatically:
+
+```python
+import os
+import autogen
+
+llm_config = {
+    "config_list": [{
+        "model": "gemini-2.5-flash", 
+        "api_key": os.environ["GEMINI_API_KEY"],
+        "api_type": "google"
+    }]
+}
+
+assistant = autogen.AssistantAgent(
+    name="assistant", 
+    llm_config=llm_config
+)
+user_proxy = autogen.UserProxyAgent(
+    name="user_proxy", 
+    human_input_mode="NEVER", 
+    max_consecutive_auto_reply=2
+)
+
+# The entire conversation hierarchy is automatically traced
+user_proxy.initiate_chat(
+    assistant,
+    message="Explain the difference between Python lists and tuples.",
+)
+```
+
+## Usage with Tools
+
+Function registrations and local tool executions are automatically traced as nested child spans within the executing agent's workflow:
+
+```python
+from typing import Annotated
+from autogen import register_function
+
+def get_weather(city: Annotated[str, "City name"]) -> str:
+    """Get current weather for a city."""
+    return f"The weather in {city} is 72 degrees and sunny."
+
+# Register the tool
+register_function(
+    get_weather,
+    caller=assistant,     # The agent that decides to use the tool
+    executor=user_proxy,  # The agent that actually runs the Python function
+    name="get_weather",
+    description="Get current weather for a city",
+)
+
+# Tool executions appear as 'tool' spans under the UserProxyAgent
+user_proxy.initiate_chat(
+    assistant,
+    message="What is the weather in Tokyo?",
+    max_turns=5,  # Add a guard to ensure an LLM response cap
+)
+```
+
+## What Gets Captured
+
+| Attribute | Description |
+|-----------|-------------|
+| Conversation Loop | The overarching `initiate_chat` session |
+| Agent Steps | Individual spans for each `AssistantAgent` or `UserProxyAgent` turn |
+| Messages | Full chat history, input messages, and agent replies |
+| Tool calls | Function names, input arguments, and execution outputs |
+| LLM calls* | Raw completion requests to the provider |
+| Tokens & Cost* | Aggregated usage and pricing for the chat session |
+
+*Requires initializing the corresponding LLM integration (e.g., `Integration.GOOGLE_GENAI`) alongside `Integration.AUTOGEN`

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -28,6 +28,9 @@ TraceRoot integrates with popular LLM providers and agent frameworks via auto-in
   <Card title="Mastra" icon="bolt" href="/integrations/mastra">
     Export traces from Mastra agents via the TraceRoot OTLP exporter.
   </Card>
+  <Card title="AutoGen (AG2)" icon="robot" href="/integrations/autogen">
+    Auto-instrument AutoGen multi-agent conversations and tool calls.
+  </Card>
 </CardGroup>
 
 ## Model Providers


### PR DESCRIPTION
## Summary

Closes #654 . Follow-up to #644.

Adds the official MDX documentation for the AutoGen (AG2) integration.

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [x] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
- Created the AutoGen integration page (`autogen.mdx`).
- Added a specific note clarifying support for the `ag2` community fork (v0.11.5+).
- Outlined the "dual-initialization" pattern (initializing both `Integration.AUTOGEN` and an LLM integration like `Integration.GOOGLE_GENAI` simultaneously) to ensure users successfully capture token counts and cost metrics.
- Provided complete Python code examples using `gemini-2.5-flash` for a standard multi-agent chat and a tool execution workflow (incorporating `max_turns` circuit breakers).
- Added a table breaking down captured attributes (Agent Steps, Messages, Tool Calls, etc.).
- Added `integrations/autogen` to `docs.json` navigation.
- Added AutoGen framework card to `overview.mdx`.

## Screenshots / Recordings (if applicable)

N/A (Markdown documentation).

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
