### PR TITLE
chore: update Discord invite link to new URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -111,5 +111,5 @@ NEXT_PUBLIC_LOGO_URL=https://raw.githubusercontent.com/traceroot-ai/traceroot/ma
 NEXT_PUBLIC_DOCS_URL=https://traceroot.ai/docs
 NEXT_PUBLIC_GITHUB_REPO_URL=https://github.com/traceroot-ai/traceroot
 NEXT_PUBLIC_GITHUB_ISSUES_URL=https://github.com/traceroot-ai/traceroot/issues
-NEXT_PUBLIC_DISCORD_INVITE_URL=https://discord.com/invite/tPyffEZvvJ
+NEXT_PUBLIC_DISCORD_INVITE_URL=https://discord.gg/TM2m3CtKuC
 NEXT_PUBLIC_FOUNDERS_CAL_URL=https://cal.com/traceroot/30min

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Special Thanks for [pi-mono](https://github.com/badlogic/pi-mono) project, which
 
 **Contributing** 🤝: If you're interested in contributing, you can check out our guide [here](/CONTRIBUTING.md). All types of help are appreciated :)
 
-**Support** 💬: If you need any type of support, we're typically most responsive on our [Discord channel](https://discord.gg/tPyffEZvvJ), but feel free to email us `founders@traceroot.ai` too!
+**Support** 💬: If you need any type of support, we're typically most responsive on our [Discord channel](https://discord.gg/TM2m3CtKuC), but feel free to email us `founders@traceroot.ai` too!
 
 ## License
 
@@ -187,7 +187,7 @@ This project is licensed under [Apache 2.0](LICENSE) with additional [Enterprise
 
 <!-- Links -->
 [discord-image]: https://img.shields.io/discord/1395844148568920114?logo=discord&labelColor=%235462eb&logoColor=%23f5f5f5&color=%235462eb
-[discord-url]: https://discord.gg/tPyffEZvvJ
+[discord-url]: https://discord.gg/TM2m3CtKuC
 [license-image]: https://img.shields.io/badge/License-Apache%202.0-blue.svg
 [license-url]: https://opensource.org/licenses/Apache-2.0
 [docs-image]: https://img.shields.io/badge/docs-traceroot.ai-0dbf43

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -183,7 +183,7 @@ branding:
   docsUrl: "https://traceroot.ai/docs"
   githubRepoUrl: "https://github.com/traceroot-ai/traceroot"
   githubIssuesUrl: "https://github.com/traceroot-ai/traceroot/issues"
-  discordInviteUrl: "https://discord.com/invite/tPyffEZvvJ"
+  discordInviteUrl: "https://discord.gg/TM2m3CtKuC"
 
 # --- Stripe (optional — set existingSecret to enable) ---
 stripe:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -45,7 +45,7 @@
       {
         "label": "Discord",
         "icon": "discord",
-        "href": "https://discord.gg/tPyffEZvvJ"
+        "href": "https://discord.gg/TM2m3CtKuC"
       }
     ],
     "primary": {
@@ -166,7 +166,7 @@
       "github": "https://github.com/traceroot-ai",
       "x": "https://x.com/TraceRootAI",
       "linkedin": "https://www.linkedin.com/company/traceroot-ai",
-      "discord": "https://discord.gg/tPyffEZvvJ"
+      "discord": "https://discord.gg/TM2m3CtKuC"
     }
   }
 }

--- a/frontend/ui/src/env.client.ts
+++ b/frontend/ui/src/env.client.ts
@@ -9,7 +9,7 @@ const clientSchema = z.object({
   NEXT_PUBLIC_GITHUB_ISSUES_URL: z
     .string()
     .default("https://github.com/traceroot-ai/traceroot/issues"),
-  NEXT_PUBLIC_DISCORD_INVITE_URL: z.string().default("https://discord.com/invite/tPyffEZvvJ"),
+  NEXT_PUBLIC_DISCORD_INVITE_URL: z.string().default("https://discord.gg/TM2m3CtKuC"),
   NEXT_PUBLIC_FOUNDERS_CAL_URL: z.string().default("https://cal.com/traceroot/30min"),
 });
 


### PR DESCRIPTION
## Summary
- Replace all occurrences of the old Discord link (`discord.com/invite/tPyffEZvvJ`) with the new link (`discord.gg/TM2m3CtKuC`)
- Updated files: `README.md`, `.env.example`, `docs/docs.json`, `deploy/helm/values.yaml`, `frontend/ui/src/env.client.ts`

## Test plan
- [x] Verify all Discord links in the repo point to `https://discord.gg/TM2m3CtKuC`

🤖 Generated with [Claude Code](https://claude.com/claude-code)