### PR TITLE
feat: add Claude Agent SDK TypeScript example and integration docs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -139,6 +139,7 @@
             "pages": [
               "integrations/langchain",
               "integrations/langchain-deepagents",
+              "integrations/claude-agent-sdk",
               "integrations/openai-agents-sdk",
               "integrations/mastra",
               "integrations/autogen",

--- a/docs/integrations/claude-agent-sdk.mdx
+++ b/docs/integrations/claude-agent-sdk.mdx
@@ -1,0 +1,96 @@
+---
+title: Claude Agent SDK
+description: Auto-instrument the Claude Agent SDK for agent and tool tracing
+---
+
+Automatically capture agent invocations, subagent delegations, tool calls, and token usage from the Claude Agent SDK (Claude Code as a library).
+
+## Setup
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    import traceroot
+    from traceroot import Integration
+
+    traceroot.initialize(integrations=[Integration.CLAUDE_AGENT_SDK])
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import * as claudeAgentSDK from '@anthropic-ai/claude-agent-sdk';
+    import { TraceRoot } from '@traceroot-ai/traceroot';
+
+    TraceRoot.initialize({
+      instrumentModules: { claudeAgentSDK },
+    });
+    ```
+  </Tab>
+</Tabs>
+
+## Usage
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    from claude_agent_sdk import query, ClaudeAgentOptions, AgentDefinition
+
+    # Define subagents
+    researcher = AgentDefinition(
+        description="Research specialist for gathering information.",
+        prompt="You are a research specialist. Use WebSearch to find info.",
+        tools=["WebSearch"],
+        model="haiku",
+    )
+
+    # Run the agent with subagents
+    async for message in query(
+        prompt="Research the latest trends in AI observability",
+        options=ClaudeAgentOptions(
+            allowed_tools=["Agent", "Bash", "Read", "Glob", "Grep"],
+            agents={"researcher": researcher},
+        ),
+    ):
+        if hasattr(message, "result"):
+            print(message.result)
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    import { query, AgentDefinition } from '@anthropic-ai/claude-agent-sdk';
+
+    const researcher: AgentDefinition = {
+      description: 'Research specialist for gathering information.',
+      prompt: 'You are a research specialist. Use WebSearch to find info.',
+      tools: ['WebSearch'],
+      model: 'haiku',
+    };
+
+    async function main() {
+      for await (const message of query({
+        prompt: 'Research the latest trends in AI observability',
+        options: {
+          allowedTools: ['Agent', 'Bash', 'Read', 'Glob', 'Grep'],
+          agents: { researcher },
+        },
+      })) {
+        if ('result' in message) {
+          console.log(message.result);
+        }
+      }
+    }
+    main().catch(console.error);
+    ```
+  </Tab>
+</Tabs>
+
+## What Gets Captured
+
+| Attribute | Description |
+|-----------|-------------|
+| Agent queries | Each `query()` call as a top-level agent span |
+| Subagent invocations | Each subagent delegation via the Agent tool |
+| Tool calls | Built-in tools (Read, Write, Bash, Glob, Grep, WebSearch) |
+| Token usage | Aggregated input/output tokens per query |
+| Cost | Total cost for the full query execution |
+| Model name | The model used (e.g., claude-sonnet-4-6, claude-haiku-4-5) |

--- a/examples/typescript/claude-agent-sdk/.env.example
+++ b/examples/typescript/claude-agent-sdk/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# Anthropic (used by Claude Agent SDK)
+ANTHROPIC_API_KEY=your_anthropic_api_key_here

--- a/examples/typescript/claude-agent-sdk/README.md
+++ b/examples/typescript/claude-agent-sdk/README.md
@@ -1,0 +1,25 @@
+# Claude Agent SDK
+
+Multi-agent research pipeline using Claude Code as a library, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in your API keys
+pnpm install
+```
+
+## Run
+
+```bash
+pnpm demo
+```
+
+## What it does
+
+Runs a research pipeline with 3 subagents:
+- **Researcher** — gathers info via WebSearch
+- **Analyst** — processes data via Bash/python3
+- **Writer** — synthesizes a summary report
+
+The lead agent coordinates the subagents using the Agent tool.

--- a/examples/typescript/claude-agent-sdk/README.md
+++ b/examples/typescript/claude-agent-sdk/README.md
@@ -7,19 +7,15 @@ Multi-agent research pipeline using Claude Code as a library, instrumented with 
 ```bash
 cp .env.example .env  # fill in your API keys
 pnpm install
-```
-
-## Run
-
-```bash
 pnpm demo
 ```
 
 ## What it does
 
-Runs a research pipeline with 3 subagents:
-- **Researcher** — gathers info via WebSearch
-- **Analyst** — processes data via Bash/python3
-- **Writer** — synthesizes a summary report
+Iterates over `DEMO_TOPICS` and for each topic runs a 3-subagent pipeline:
 
-The lead agent coordinates the subagents using the Agent tool.
+1. **researcher** — gathers info via WebSearch
+2. **analyst** — processes data via Bash / python3
+3. **writer** — synthesizes a final summary report
+
+The lead agent dispatches the subagents using the `Agent` tool. All topics share one `demo_session` trace.

--- a/examples/typescript/claude-agent-sdk/agent.ts
+++ b/examples/typescript/claude-agent-sdk/agent.ts
@@ -1,0 +1,128 @@
+/**
+ * Claude Agent SDK — TraceRoot Observability
+ *
+ * Multi-agent research pipeline using Claude Code as a library.
+ * Demonstrates subagents, multiple built-in tools, and TraceRoot tracing.
+ *
+ * Env vars required: ANTHROPIC_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm demo
+ */
+
+import 'dotenv/config';
+import * as claudeAgentSDK from '@anthropic-ai/claude-agent-sdk';
+import { TraceRoot, observe, usingAttributes, getPatchedModule } from '@traceroot-ai/traceroot';
+
+// ── TraceRoot setup ───────────────────────────────────────────────────────────
+TraceRoot.initialize({
+  instrumentModules: { claudeAgentSDK },
+});
+
+// Get the instrumented version of the SDK (ESM modules are frozen,
+// so the instrumentor returns a patched copy via getPatchedModule).
+const sdk = getPatchedModule('claudeAgentSDK', claudeAgentSDK);
+
+console.log('[Observability: TraceRoot]');
+
+// ── Subagent definitions ──────────────────────────────────────────────────────
+const RESEARCHER: claudeAgentSDK.AgentDefinition = {
+  description:
+    'Research specialist. Use when you need to gather information about a topic from the web.',
+  prompt:
+    'You are a research specialist. Use WebSearch to find relevant information. Provide a concise summary with key facts. Keep your response under 200 words.',
+  tools: ['WebSearch'],
+  model: 'haiku',
+};
+
+const ANALYST: claudeAgentSDK.AgentDefinition = {
+  description:
+    'Data analyst. Use for calculations, data processing, or generating statistics.',
+  prompt:
+    'You are a data analyst. Use Bash with python3 to perform calculations or data processing. Provide clear numerical results. Keep your response concise.',
+  tools: ['Bash'],
+  model: 'haiku',
+};
+
+const WRITER: claudeAgentSDK.AgentDefinition = {
+  description:
+    'Report writer. Synthesizes research findings and analysis into a clear summary report.',
+  prompt:
+    'You are a report writer. Synthesize the information provided into a clear, well-structured summary. Use bullet points and headers. Keep the report under 300 words.',
+  tools: [],
+  model: 'haiku',
+};
+
+// ── Agent ─────────────────────────────────────────────────────────────────────
+async function runResearch(topic: string): Promise<string> {
+  return observe({ name: 'research_pipeline', type: 'agent' }, async () => {
+    let resultText = '';
+
+    for await (const message of sdk.query({
+      prompt: [
+        `Research the following topic using a multi-step approach:\n\n`,
+        `Topic: ${topic}\n\n`,
+        `Steps:\n`,
+        `1. Use the researcher agent to gather key facts about this topic\n`,
+        `2. Use the analyst agent to calculate or process any relevant numbers\n`,
+        `3. Use the writer agent to produce a final summary report\n\n`,
+        `Coordinate the agents and present the final report.`,
+      ].join(''),
+      options: {
+        allowedTools: ['Agent'],
+        maxTurns: 15,
+        agents: {
+          researcher: RESEARCHER,
+          analyst: ANALYST,
+          writer: WRITER,
+        },
+      },
+    })) {
+      if ('result' in message && (message as any).result) {
+        resultText = (message as any).result;
+      }
+    }
+
+    return resultText;
+  });
+}
+
+// ── Demo ──────────────────────────────────────────────────────────────────────
+const DEMO_TOPICS = [
+  'What are the key features of OpenTelemetry for AI observability?',
+];
+
+async function main() {
+  try {
+    await usingAttributes(
+      {
+        sessionId: 'claude-agent-sdk-ts-session',
+        userId: 'demo-user',
+        tags: ['demo', 'claude-agent-sdk', 'research-pipeline'],
+      },
+      () =>
+        observe({ name: 'demo_session' }, async () => {
+          console.log('='.repeat(60));
+          console.log('Claude Agent SDK Research Pipeline — Demo (TraceRoot)');
+          console.log('='.repeat(60));
+
+          for (let i = 0; i < DEMO_TOPICS.length; i++) {
+            const topic = DEMO_TOPICS[i];
+            console.log(`\n${'='.repeat(60)}`);
+            console.log(`Research ${i + 1}: ${topic}`);
+            console.log('='.repeat(60));
+            const result = await runResearch(topic);
+            if (result) {
+              console.log(`\n${result}`);
+            }
+            console.log();
+          }
+        }),
+    );
+  } finally {
+    await TraceRoot.shutdown();
+    console.log('[Traces exported]');
+  }
+}
+
+main().catch(console.error);

--- a/examples/typescript/claude-agent-sdk/agent.ts
+++ b/examples/typescript/claude-agent-sdk/agent.ts
@@ -2,8 +2,7 @@
  * Claude Agent SDK — TraceRoot Observability
  *
  * Multi-agent research pipeline using Claude Code as a library.
- * Demonstrates subagents, multiple built-in tools, and TraceRoot tracing
- * (via @arizeai/openinference-instrumentation-claude-agent-sdk).
+ * Demonstrates subagents, multiple built-in tools, and TraceRoot tracing.
  *
  * Env vars: ANTHROPIC_API_KEY, TRACEROOT_API_KEY
  *           TRACEROOT_HOST_URL is optional (defaults to https://app.traceroot.ai)
@@ -14,23 +13,19 @@
  */
 
 import 'dotenv/config';
-import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrumentation-claude-agent-sdk';
-import * as ClaudeAgentSDKModule from '@anthropic-ai/claude-agent-sdk';
+import * as claudeAgentSDKModule from '@anthropic-ai/claude-agent-sdk';
 import type { AgentDefinition } from '@anthropic-ai/claude-agent-sdk';
 import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
 
-// Spread the read-only ESM namespace into a mutable object so the OpenInference
-// patcher can rewrite `query` in place. If you call the original namespace's
-// `query` after this point, your calls will NOT be traced.
-const ClaudeAgentSDK = { ...ClaudeAgentSDKModule };
+// Spread the read-only ESM namespace into a mutable object so the patcher
+// can rewrite `query` in place. If you call the original namespace's `query`
+// after this point, it will NOT be traced.
+const claudeAgentSDK = { ...claudeAgentSDKModule };
 
-// 1. Initialize TraceRoot first — registers the global TracerProvider.
-//    `disableBatch: true` switches to SimpleSpanProcessor for live tracing.
-TraceRoot.initialize({ disableBatch: true });
-
-// 2. Wire the OpenInference instrumentor manually against the spread namespace.
-//    Spans flow through TraceRoot's TracerProvider via the OpenTelemetry global.
-new ClaudeAgentSDKInstrumentation().manuallyInstrument(ClaudeAgentSDK);
+TraceRoot.initialize({
+  instrumentModules: { claudeAgentSDK },
+  disableBatch: true,
+});
 
 console.log('[Observability: TraceRoot]');
 
@@ -66,7 +61,7 @@ const WRITER: AgentDefinition = {
 async function runResearch(topic: string): Promise<string> {
   return observe({ name: 'research_pipeline', type: 'agent' }, async () => {
     let resultText = '';
-    for await (const message of ClaudeAgentSDK.query({
+    for await (const message of claudeAgentSDK.query({
       prompt: [
         `Research the following topic using a multi-step approach:\n\n`,
         `Topic: ${topic}\n\n`,

--- a/examples/typescript/claude-agent-sdk/agent.ts
+++ b/examples/typescript/claude-agent-sdk/agent.ts
@@ -2,63 +2,71 @@
  * Claude Agent SDK — TraceRoot Observability
  *
  * Multi-agent research pipeline using Claude Code as a library.
- * Demonstrates subagents, multiple built-in tools, and TraceRoot tracing.
+ * Demonstrates subagents, multiple built-in tools, and TraceRoot tracing
+ * (via @arizeai/openinference-instrumentation-claude-agent-sdk).
  *
- * Env vars required: ANTHROPIC_API_KEY, TRACEROOT_API_KEY
+ * Env vars: ANTHROPIC_API_KEY, TRACEROOT_API_KEY
+ *           TRACEROOT_HOST_URL is optional (defaults to https://app.traceroot.ai)
  *
  * Run:
+ *   pnpm install
  *   pnpm demo
  */
 
 import 'dotenv/config';
-import * as claudeAgentSDK from '@anthropic-ai/claude-agent-sdk';
-import { TraceRoot, observe, usingAttributes, getPatchedModule } from '@traceroot-ai/traceroot';
+import { ClaudeAgentSDKInstrumentation } from '@arizeai/openinference-instrumentation-claude-agent-sdk';
+import * as ClaudeAgentSDKModule from '@anthropic-ai/claude-agent-sdk';
+import type { AgentDefinition } from '@anthropic-ai/claude-agent-sdk';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
 
-// ── TraceRoot setup ───────────────────────────────────────────────────────────
-TraceRoot.initialize({
-  instrumentModules: { claudeAgentSDK },
-});
+// Spread the read-only ESM namespace into a mutable object so the OpenInference
+// patcher can rewrite `query` in place. If you call the original namespace's
+// `query` after this point, your calls will NOT be traced.
+const ClaudeAgentSDK = { ...ClaudeAgentSDKModule };
 
-// Get the instrumented version of the SDK (ESM modules are frozen,
-// so the instrumentor returns a patched copy via getPatchedModule).
-const sdk = getPatchedModule('claudeAgentSDK', claudeAgentSDK);
+// 1. Initialize TraceRoot first — registers the global TracerProvider.
+//    `disableBatch: true` switches to SimpleSpanProcessor for live tracing.
+TraceRoot.initialize({ disableBatch: true });
+
+// 2. Wire the OpenInference instrumentor manually against the spread namespace.
+//    Spans flow through TraceRoot's TracerProvider via the OpenTelemetry global.
+new ClaudeAgentSDKInstrumentation().manuallyInstrument(ClaudeAgentSDK);
 
 console.log('[Observability: TraceRoot]');
 
 // ── Subagent definitions ──────────────────────────────────────────────────────
-const RESEARCHER: claudeAgentSDK.AgentDefinition = {
+const RESEARCHER: AgentDefinition = {
   description:
-    'Research specialist. Use when you need to gather information about a topic from the web.',
+    'Research specialist. Use when you need to gather information about a topic from the web. Returns structured research notes.',
   prompt:
-    'You are a research specialist. Use WebSearch to find relevant information. Provide a concise summary with key facts. Keep your response under 200 words.',
+    'You are a research specialist. Use WebSearch to find relevant information about the given topic. Provide a concise summary with key facts and sources. Keep your response under 200 words.',
   tools: ['WebSearch'],
   model: 'haiku',
 };
 
-const ANALYST: claudeAgentSDK.AgentDefinition = {
+const ANALYST: AgentDefinition = {
   description:
-    'Data analyst. Use for calculations, data processing, or generating statistics.',
+    'Data analyst. Use when you need to perform calculations, data processing, or generate statistics from research findings.',
   prompt:
     'You are a data analyst. Use Bash with python3 to perform calculations or data processing. Provide clear numerical results. Keep your response concise.',
   tools: ['Bash'],
   model: 'haiku',
 };
 
-const WRITER: claudeAgentSDK.AgentDefinition = {
+const WRITER: AgentDefinition = {
   description:
-    'Report writer. Synthesizes research findings and analysis into a clear summary report.',
+    'Report writer. Use when you need to synthesize research findings and analysis into a clear, well-structured summary report.',
   prompt:
-    'You are a report writer. Synthesize the information provided into a clear, well-structured summary. Use bullet points and headers. Keep the report under 300 words.',
+    'You are a report writer. Synthesize the information provided into a clear, well-structured summary. Use bullet points and headers. Keep the report concise and under 300 words.',
   tools: [],
   model: 'haiku',
 };
 
-// ── Agent ─────────────────────────────────────────────────────────────────────
+// ── Pipeline ──────────────────────────────────────────────────────────────────
 async function runResearch(topic: string): Promise<string> {
   return observe({ name: 'research_pipeline', type: 'agent' }, async () => {
     let resultText = '';
-
-    for await (const message of sdk.query({
+    for await (const message of ClaudeAgentSDK.query({
       prompt: [
         `Research the following topic using a multi-step approach:\n\n`,
         `Topic: ${topic}\n\n`,
@@ -71,18 +79,16 @@ async function runResearch(topic: string): Promise<string> {
       options: {
         allowedTools: ['Agent'],
         maxTurns: 15,
-        agents: {
-          researcher: RESEARCHER,
-          analyst: ANALYST,
-          writer: WRITER,
-        },
+        // bypassPermissions auto-approves all tool calls. Demo-only — do NOT
+        // use this in production code that touches real systems.
+        permissionMode: 'bypassPermissions',
+        agents: { researcher: RESEARCHER, analyst: ANALYST, writer: WRITER },
       },
     })) {
       if ('result' in message && (message as any).result) {
         resultText = (message as any).result;
       }
     }
-
     return resultText;
   });
 }
@@ -90,6 +96,7 @@ async function runResearch(topic: string): Promise<string> {
 // ── Demo ──────────────────────────────────────────────────────────────────────
 const DEMO_TOPICS = [
   'What are the key features of OpenTelemetry for AI observability?',
+  'What is Model Context Protocol (MCP) and why does it matter?',
 ];
 
 async function main() {

--- a/examples/typescript/claude-agent-sdk/package.json
+++ b/examples/typescript/claude-agent-sdk/package.json
@@ -7,7 +7,6 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
-    "@arizeai/openinference-instrumentation-claude-agent-sdk": "^0.2.3",
     "@traceroot-ai/traceroot": "0.1.2",
     "dotenv": "^16.4.5",
     "openai": "^6.34.0"

--- a/examples/typescript/claude-agent-sdk/package.json
+++ b/examples/typescript/claude-agent-sdk/package.json
@@ -6,8 +6,9 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
-    "@traceroot-ai/traceroot": "0.1.1",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.0",
+    "@arizeai/openinference-instrumentation-claude-agent-sdk": "^0.2.3",
+    "@traceroot-ai/traceroot": "0.1.2",
     "dotenv": "^16.4.5",
     "openai": "^6.34.0"
   },

--- a/examples/typescript/claude-agent-sdk/package.json
+++ b/examples/typescript/claude-agent-sdk/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@traceroot/example-claude-agent-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "demo": "tsx agent.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.0",
+    "@traceroot-ai/traceroot": "0.1.1",
+    "dotenv": "^16.4.5",
+    "openai": "^6.34.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/typescript/claude-agent-sdk/tsconfig.json
+++ b/examples/typescript/claude-agent-sdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
## Summary
  Add Claude Agent SDK TypeScript example and integration docs page.
Fixes: #647 
                                                                                                                                                                                                                                        
  ## Type of Change
  - [x] feat - A new feature                                                                                                                                                                                                            
  - [x] docs - Documentation only changes                                                                                                                                                                                             

  ## Details

  **TypeScript example** (`examples/typescript/claude-agent-sdk/`):                                                                                                                                                                     
  - Multi-agent research pipeline using Claude Code as a library
  - 3 subagents: researcher (WebSearch), analyst (Bash/python3), writer (synthesis)                                                                                                                                                     
  - Lead agent coordinates via the Agent tool                                                                                                                                                                                           
  - Uses `TraceRoot.initialize({ instrumentModules: { claudeAgentSDK } })` for auto-instrumentation                                                                                                                                     
  - Tested and working — traces confirmed on staging                                                                                                                                                                                    
                                                                                                                                                                                                                                        
  **Integration docs** (`docs/integrations/claude-agent-sdk.mdx`):                                                                                                                                                                      
  - Setup with Python + TypeScript tabs                                                                                                                                                                                                 
  - Usage examples with subagent definitions                                                                                                                                                                                            
  - "What Gets Captured" reference table                                                                                                                                                                                                
   
  **Navigation** (`docs/docs.json`):                                                                                                                                                                                                    
  - Added `integrations/claude-agent-sdk` to Frameworks group
                                                                                                                                                                                                                                        
  ## Screenshots / Recordings (if applicable)               
  N/A

  ## Checklist                                                                                                                                                                                                                          
  - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
  - [ ] I have added/updated tests where applicable                                                                                                                                                                                     
  - [ ] I have added screenshots or recordings for UI changes (if applicable)
  - [x] I have updated documentation where necessary
