### PR TITLE
feat(byok): add latest GLM models (4.6, 4.7, 5, 5-turbo, 5.1) to Z.AI provider

### DIFF
--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -170,8 +170,8 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
   ],
   zai: [
     { id: "glm-5.1", label: "glm-5.1" },
-    { id: "glm-5-turbo", label: "glm-5-turbo" },
     { id: "glm-5", label: "glm-5" },
+    { id: "glm-5-turbo", label: "glm-5-turbo" },
     { id: "glm-4.7", label: "glm-4.7" },
     { id: "glm-4.6", label: "glm-4.6" },
     { id: "glm-4.5", label: "glm-4.5" },

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -169,6 +169,11 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "kimi-k2-thinking", label: "kimi-k2-thinking" },
   ],
   zai: [
+    { id: "glm-5.1", label: "glm-5.1" },
+    { id: "glm-5-turbo", label: "glm-5-turbo" },
+    { id: "glm-5", label: "glm-5" },
+    { id: "glm-4.7", label: "glm-4.7" },
+    { id: "glm-4.6", label: "glm-4.6" },
     { id: "glm-4.5", label: "glm-4.5" },
     { id: "glm-4.5-air", label: "glm-4.5-air" },
     { id: "glm-4.5-flash", label: "glm-4.5-flash" },


### PR DESCRIPTION
## Summary

Adds the latest GLM models to the Z.AI (ZAI) BYOK provider dropdown, as requested in #641. Users can now select GLM 4.6, 4.7, 5, 5-turbo, and 5.1 when configuring their own Z.AI API key.

## Type of Change
- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

Single-file change to `frontend/packages/core/src/llm-providers.ts` — adds 5 new entries to the `zai` array in `ADAPTER_MODELS`:

| Model ID | Notes |
|---|---|
| `glm-5.1` | Latest flagship, #1 on SWE-Bench Pro |
| `glm-5-turbo` | Fast flagship variant |
| `glm-5` | Full GLM-5 |
| `glm-4.7` | Strong coding + reasoning |
| `glm-4.6` | Previous generation flagship |

Existing models (`glm-4.5`, `glm-4.5-air`, `glm-4.5-flash`) are retained for backwards compatibility. Model IDs verified against the official [BigModel API documentation](https://docs.bigmodel.cn).

## Screenshots / Recordings (if applicable)

N/A — dropdown data change only, no visual diff beyond the new model options appearing in the Z.AI provider selector.

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable (no tests needed — pure data change, no logic)
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary (model IDs self-documented in the catalog)

Closes #641