### PR TITLE
docs: fix Gemini tool integration example and observability wrappers

### DIFF
--- a/docs/integrations/gemini.mdx
+++ b/docs/integrations/gemini.mdx
@@ -11,6 +11,7 @@ Automatically capture all Gemini model calls made through the `google-genai` SDK
 import traceroot
 from traceroot import Integration
 
+# Initialize TraceRoot with the Google GENAI Integration
 traceroot.initialize(integrations=[Integration.GOOGLE_GENAI])
 ```
 
@@ -22,6 +23,14 @@ Once initialized, all Gemini calls are captured automatically:
 import os
 from google import genai
 from google.genai import types
+from dotenv import load_dotenv
+
+import traceroot
+from traceroot import Integration, observe
+
+load_dotenv()
+
+traceroot.initialize(integrations=[Integration.GOOGLE_GENAI])
 
 client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 
@@ -42,10 +51,23 @@ Tool calls and multi-turn conversations are fully traced:
 import os
 from google import genai
 from google.genai import types
+from dotenv import load_dotenv
+
+import traceroot
+from traceroot import Integration, observe
+
+load_dotenv()
+
+traceroot.initialize(integrations=[Integration.GOOGLE_GENAI])
 
 client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
 
-get_weather = types.FunctionDeclaration(
+# Use @observe(type="tool") to capture the actual execution as a child span
+@observe(name="get_weather", type="tool")
+def get_weather(city: str) -> str:
+    return f"The weather in {city} is sunny."
+
+get_weather_schema = types.FunctionDeclaration(
     name="get_weather",
     description="Get current weather for a city",
     parameters=types.Schema(
@@ -54,13 +76,29 @@ get_weather = types.FunctionDeclaration(
         required=["city"],
     ),
 )
+weather_tool = types.Tool(function_declarations=[get_weather_schema])
 
-# Tool calls are automatically traced as child spans
-response = client.models.generate_content(
-    model="gemini-2.5-flash",
-    contents="What's the weather in Tokyo?",
-    config=types.GenerateContentConfig(tools=[get_weather]),
-)
+# # Use @observe(type="agent") to create a parent span that links the LLM and Tool calls together
+@observe(name="weather_interaction", type="agent")
+def ask_about_weather(query: str):
+    response = client.models.generate_content(
+        model="gemini-2.5-flash",
+        contents=query,
+        config=types.GenerateContentConfig(tools=[weather_tool]),
+    )
+
+    if response.function_calls:
+        for tool_call in response.function_calls:
+            if tool_call.name == "get_weather":
+                result = get_weather(**tool_call.args)
+                
+                return result 
+                
+    return "No tool needed."
+
+if __name__ == "__main__":
+    ask_about_weather("What's the weather in Tokyo?")
+    traceroot.flush()
 ```
 
 ## What Gets Captured

--- a/docs/integrations/gemini.mdx
+++ b/docs/integrations/gemini.mdx
@@ -11,119 +11,40 @@ Automatically capture all Gemini model calls made through the `google-genai` SDK
 import traceroot
 from traceroot import Integration
 
-# Initialize TraceRoot with the Google GENAI Integration
 traceroot.initialize(integrations=[Integration.GOOGLE_GENAI])
 ```
 
 ## Usage
 
-Once initialized, all Gemini calls are captured automatically:
+Once initialized, all Gemini calls are captured automatically — including tool calls:
 
 ```python
 import os
 from google import genai
 from google.genai import types
-from dotenv import load_dotenv
-
-import traceroot
-from traceroot import Integration
-
-load_dotenv()
-
-traceroot.initialize(integrations=[Integration.GOOGLE_GENAI])
 
 client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+weather_tool = types.Tool(function_declarations=[
+    types.FunctionDeclaration(
+        name="get_weather",
+        description="Get current weather for a city",
+        parameters=types.Schema(
+            type="OBJECT",
+            properties={"city": types.Schema(type="STRING", description="City name")},
+            required=["city"],
+        ),
+    )
+])
 
 # This call is automatically traced
 response = client.models.generate_content(
     model="gemini-2.5-flash",
-    contents="What is the capital of France?",
+    contents="What's the weather in Tokyo?",
+    config=types.GenerateContentConfig(tools=[weather_tool]),
 )
 
 print(response.text)
-```
-
-## Usage with Tools
-
-Tool calls and multi-turn conversations are fully traced:
-
-```python
-import os
-from google import genai
-from google.genai import types
-from dotenv import load_dotenv
-
-import traceroot
-from traceroot import Integration, observe
-
-load_dotenv()
-
-traceroot.initialize(integrations=[Integration.GOOGLE_GENAI])
-
-client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
-
-# Use @observe(type="tool") to capture the actual execution as a child span
-@observe(name="get_weather", type="tool")
-def get_weather(city: str) -> str:
-    return f"The weather in {city} is sunny."
-
-get_weather_schema = types.FunctionDeclaration(
-    name="get_weather",
-    description="Get current weather for a city",
-    parameters=types.Schema(
-        type="OBJECT",
-        properties={"city": types.Schema(type="STRING", description="City name")},
-        required=["city"],
-    ),
-)
-weather_tool = types.Tool(function_declarations=[get_weather_schema])
-
-# Use @observe(type="agent") to create a parent span that links the LLM and Tool calls together
-@observe(name="weather_interaction", type="agent")
-def ask_about_weather(query: str):
-    
-    # Ask the LLM
-    response = client.models.generate_content(
-        model="gemini-2.5-flash",
-        contents=query,
-        config=types.GenerateContentConfig(tools=[weather_tool]),
-    )
-
-    if response.function_calls:
-        function_responses = []
-        for tool_call in response.function_calls:
-            if tool_call.name == "get_weather":
-                # This execution triggers the TraceRoot child span
-                result = get_weather(**tool_call.args)
-                
-                # Format the result for Gemini
-                function_responses.append(
-                    types.Part.from_function_response(
-                        name=tool_call.name,
-                        response={"result": result},
-                    )
-                )
-        
-        # Send the tool results back to the LLM for a final answer
-        final_response = client.models.generate_content(
-            model="gemini-2.5-flash",
-            # We must pass the conversation history so the LLM has context
-            contents=[
-                query, 
-                response.candidates[0].content, 
-                types.Content(role="user", parts=function_responses)
-            ],
-            config=types.GenerateContentConfig(tools=[weather_tool]),
-        )
-        return final_response.text
-
-    # Fallback if no tool was needed
-    return response.text
-
-if __name__ == "__main__":
-    answer = ask_about_weather("What's the weather in Tokyo?")
-    print(f"Final Answer: {answer}")
-    traceroot.flush()
 ```
 
 ## What Gets Captured
@@ -131,7 +52,7 @@ if __name__ == "__main__":
 | Attribute | Description |
 |-----------|-------------|
 | Model | `gemini-2.5-flash`, `gemini-2.0-pro`, etc. |
-| Contents | Input messages and multi-turn history |
+| Contents | Input messages |
 | Response | Generated text and function calls |
 | Tokens | Input and output token counts |
 | Cost | Calculated from token usage and model pricing |

--- a/docs/integrations/gemini.mdx
+++ b/docs/integrations/gemini.mdx
@@ -26,7 +26,7 @@ from google.genai import types
 from dotenv import load_dotenv
 
 import traceroot
-from traceroot import Integration, observe
+from traceroot import Integration
 
 load_dotenv()
 
@@ -78,9 +78,11 @@ get_weather_schema = types.FunctionDeclaration(
 )
 weather_tool = types.Tool(function_declarations=[get_weather_schema])
 
-# # Use @observe(type="agent") to create a parent span that links the LLM and Tool calls together
+# Use @observe(type="agent") to create a parent span that links the LLM and Tool calls together
 @observe(name="weather_interaction", type="agent")
 def ask_about_weather(query: str):
+    
+    # Ask the LLM
     response = client.models.generate_content(
         model="gemini-2.5-flash",
         contents=query,
@@ -88,16 +90,39 @@ def ask_about_weather(query: str):
     )
 
     if response.function_calls:
+        function_responses = []
         for tool_call in response.function_calls:
             if tool_call.name == "get_weather":
+                # This execution triggers the TraceRoot child span
                 result = get_weather(**tool_call.args)
                 
-                return result 
-                
-    return "No tool needed."
+                # Format the result for Gemini
+                function_responses.append(
+                    types.Part.from_function_response(
+                        name=tool_call.name,
+                        response={"result": result},
+                    )
+                )
+        
+        # Send the tool results back to the LLM for a final answer
+        final_response = client.models.generate_content(
+            model="gemini-2.5-flash",
+            # We must pass the conversation history so the LLM has context
+            contents=[
+                query, 
+                response.candidates[0].content, 
+                types.Content(role="user", parts=function_responses)
+            ],
+            config=types.GenerateContentConfig(tools=[weather_tool]),
+        )
+        return final_response.text
+
+    # Fallback if no tool was needed
+    return response.text
 
 if __name__ == "__main__":
-    ask_about_weather("What's the weather in Tokyo?")
+    answer = ask_about_weather("What's the weather in Tokyo?")
+    print(f"Final Answer: {answer}")
     traceroot.flush()
 ```
 


### PR DESCRIPTION
## Summary

Closes #660 

Fixes the Gemini integration documentation to correctly demonstrate tool tracing with the `google-genai` SDK. The previous example contained incorrect schema serialization and lacked the necessary `@observe` decorators to properly link child tool spans to the parent LLM call.

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [x] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
- Wraps the `FunctionDeclaration` in a `types.Tool` container within the config. Previously, passing the raw schema caused the SDK to serialize it as an empty dictionary, leading to silent hallucinations.
- Added `@observe(type="agent")` to the overarching interaction function and `@observe(type="tool")` to the local Python function to correctly demonstrate parent/child span nesting.
- Added necessary library imports and initializations to the code blocks to ensure the examples are fully self-contained and run successfully out of the box.
- Each example tested

## Screenshots / Recordings (if applicable)

**Usage with tools trace:**
<img width="861" height="443" alt="image" src="https://github.com/user-attachments/assets/aa41e387-41e1-4068-bcb9-b17f5fa80683" />

<img width="1722" height="901" alt="Screenshot 2026-04-13 at 6 55 44 PM" src="https://github.com/user-attachments/assets/43d64437-937c-4230-ba2a-bbae05b43f34" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
