### PR TITLE
fix: track Prisma migrations and fix prod startup ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,8 +184,6 @@ traceroot.db
 /prisma/db.sqlite
 /prisma/db.sqlite-journal
 
-# Prisma migrations
-frontend/packages/core/prisma/migrations
 
 # ===================
 # Testing / Coverage

--- a/frontend/packages/core/prisma/migrations/20260413180351_init/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260413180351_init/migration.sql
@@ -1,0 +1,341 @@
+-- CreateEnum
+CREATE TYPE "MemberRole" AS ENUM ('VIEWER', 'MEMBER', 'ADMIN');
+
+-- CreateTable
+CREATE TABLE "access_keys" (
+    "id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "secret_hash" VARCHAR NOT NULL,
+    "key_hint" VARCHAR NOT NULL,
+    "name" VARCHAR,
+    "expire_time" TIMESTAMP(6),
+    "last_use_time" TIMESTAMP(6),
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "access_keys_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "invites" (
+    "id" VARCHAR NOT NULL,
+    "email" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "role" "MemberRole" NOT NULL,
+    "invited_by_user_id" VARCHAR,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "invites_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "workspace_members" (
+    "id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "role" "MemberRole" NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "workspace_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "workspaces" (
+    "id" VARCHAR NOT NULL,
+    "name" VARCHAR NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "billing_customer_id" TEXT,
+    "billing_subscription_id" TEXT,
+    "billing_price_id" TEXT,
+    "billing_status" TEXT,
+    "billing_period_start" TIMESTAMP(3),
+    "billing_period_end" TIMESTAMP(3),
+    "billing_plan" TEXT NOT NULL DEFAULT 'free',
+    "ingestion_blocked" BOOLEAN NOT NULL DEFAULT false,
+    "ai_blocked" BOOLEAN NOT NULL DEFAULT false,
+    "current_usage" JSONB,
+
+    CONSTRAINT "workspaces_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "model_providers" (
+    "id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "adapter" VARCHAR NOT NULL,
+    "provider" VARCHAR NOT NULL,
+    "key_cipher" TEXT NOT NULL,
+    "key_preview" VARCHAR NOT NULL,
+    "base_url" VARCHAR,
+    "custom_models" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "with_default_models" BOOLEAN NOT NULL DEFAULT true,
+    "config" JSONB,
+    "enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_by" VARCHAR NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "model_providers_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "projects" (
+    "id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "name" VARCHAR NOT NULL,
+    "trace_ttl_days" INTEGER,
+    "delete_time" TIMESTAMP(6),
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "projects_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" VARCHAR NOT NULL,
+    "email" VARCHAR NOT NULL,
+    "email_verified" BOOLEAN NOT NULL DEFAULT false,
+    "name" VARCHAR,
+    "image" VARCHAR,
+    "password" VARCHAR,
+    "role" VARCHAR,
+    "banned" BOOLEAN,
+    "ban_reason" VARCHAR,
+    "ban_expires" TIMESTAMP(6),
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "accounts" (
+    "id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "account_id" VARCHAR NOT NULL,
+    "provider_id" VARCHAR NOT NULL,
+    "access_token" TEXT,
+    "refresh_token" TEXT,
+    "access_token_expires_at" TIMESTAMP(6),
+    "refresh_token_expires_at" TIMESTAMP(6),
+    "scope" VARCHAR,
+    "id_token" TEXT,
+    "password" TEXT,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "accounts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "sessions" (
+    "id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "token" VARCHAR NOT NULL,
+    "expires_at" TIMESTAMP(6) NOT NULL,
+    "ip_address" VARCHAR,
+    "user_agent" VARCHAR,
+    "impersonated_by" VARCHAR,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "verifications" (
+    "id" VARCHAR NOT NULL,
+    "identifier" VARCHAR NOT NULL,
+    "value" VARCHAR NOT NULL,
+    "expires_at" TIMESTAMP(6) NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "verifications_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "github_connections" (
+    "id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "github_user_id" VARCHAR NOT NULL,
+    "github_username" VARCHAR NOT NULL,
+    "access_token" TEXT NOT NULL,
+    "installation_id" VARCHAR,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "github_connections_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ai_sessions" (
+    "id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "user_id" VARCHAR NOT NULL,
+    "title" VARCHAR,
+    "status" VARCHAR NOT NULL DEFAULT 'active',
+    "metadata" JSONB,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ai_sessions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ai_messages" (
+    "id" VARCHAR NOT NULL,
+    "session_id" VARCHAR NOT NULL,
+    "role" VARCHAR NOT NULL,
+    "content" TEXT NOT NULL,
+    "metadata" JSONB,
+    "model" VARCHAR,
+    "provider" VARCHAR,
+    "is_byok" BOOLEAN,
+    "input_tokens" INTEGER,
+    "output_tokens" INTEGER,
+    "cost_usd" DECIMAL(10,6),
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ai_messages_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "standard_models" (
+    "id" VARCHAR NOT NULL,
+    "model_name" VARCHAR NOT NULL,
+    "match_pattern" VARCHAR NOT NULL,
+    "provider" VARCHAR NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "standard_models_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "standard_model_prices" (
+    "id" VARCHAR NOT NULL,
+    "model_id" VARCHAR NOT NULL,
+    "usage_type" VARCHAR NOT NULL,
+    "price" DECIMAL(18,12) NOT NULL,
+
+    CONSTRAINT "standard_model_prices_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "access_keys_secret_hash_key" ON "access_keys"("secret_hash");
+
+-- CreateIndex
+CREATE INDEX "ix_access_key_project_id" ON "access_keys"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_invite_workspace_id" ON "invites"("workspace_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_invite_email_workspace" ON "invites"("email", "workspace_id");
+
+-- CreateIndex
+CREATE INDEX "ix_workspace_member_workspace_id" ON "workspace_members"("workspace_id");
+
+-- CreateIndex
+CREATE INDEX "ix_workspace_member_user_id" ON "workspace_members"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_workspace_user" ON "workspace_members"("workspace_id", "user_id");
+
+-- CreateIndex
+CREATE INDEX "workspaces_billing_customer_id_idx" ON "workspaces"("billing_customer_id");
+
+-- CreateIndex
+CREATE INDEX "workspaces_billing_subscription_id_idx" ON "workspaces"("billing_subscription_id");
+
+-- CreateIndex
+CREATE INDEX "ix_model_provider_workspace_id" ON "model_providers"("workspace_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_model_provider_workspace_provider" ON "model_providers"("workspace_id", "provider");
+
+-- CreateIndex
+CREATE INDEX "ix_project_workspace_id" ON "projects"("workspace_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE INDEX "ix_account_user_id" ON "accounts"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_account_provider" ON "accounts"("account_id", "provider_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "sessions_token_key" ON "sessions"("token");
+
+-- CreateIndex
+CREATE INDEX "ix_session_user_id" ON "sessions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ix_verification_identifier" ON "verifications"("identifier");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "github_connections_user_id_key" ON "github_connections"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ix_ai_session_project_id" ON "ai_sessions"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_ai_session_workspace_id" ON "ai_sessions"("workspace_id");
+
+-- CreateIndex
+CREATE INDEX "ix_ai_session_user_id" ON "ai_sessions"("user_id");
+
+-- CreateIndex
+CREATE INDEX "ix_ai_message_session_id" ON "ai_messages"("session_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "standard_models_model_name_key" ON "standard_models"("model_name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "standard_model_prices_model_id_usage_type_key" ON "standard_model_prices"("model_id", "usage_type");
+
+-- AddForeignKey
+ALTER TABLE "access_keys" ADD CONSTRAINT "access_keys_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "invites" ADD CONSTRAINT "invites_invited_by_user_id_fkey" FOREIGN KEY ("invited_by_user_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "invites" ADD CONSTRAINT "invites_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "workspace_members" ADD CONSTRAINT "workspace_members_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "workspace_members" ADD CONSTRAINT "workspace_members_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "model_providers" ADD CONSTRAINT "model_providers_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "projects" ADD CONSTRAINT "projects_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "github_connections" ADD CONSTRAINT "github_connections_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ai_sessions" ADD CONSTRAINT "ai_sessions_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "ai_messages" ADD CONSTRAINT "ai_messages_session_id_fkey" FOREIGN KEY ("session_id") REFERENCES "ai_sessions"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "standard_model_prices" ADD CONSTRAINT "standard_model_prices_model_id_fkey" FOREIGN KEY ("model_id") REFERENCES "standard_models"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/tmux_tools/launcher.py
+++ b/tmux_tools/launcher.py
@@ -132,13 +132,11 @@ def run_prod_setup():
     # minio-init is a one-shot container — start it separately (--wait fails on exit-0 containers)
     _run(f"{PROD_COMPOSE} up -d minio-init")
 
-    print("Running database migrations (PostgreSQL)...")
-    _run(f"{PROD_COMPOSE} run --rm migrate")
-
-    print("Running database migrations (ClickHouse)...")
-    _run(f"{PROD_COMPOSE} run --rm migrate-clickhouse")
-
-    print("Starting application services (web, rest, worker, billing, agent)...")
+    # Migrations run as a dependency of each app service via depends_on:
+    # service_completed_successfully in docker-compose.prod.yml. Starting the
+    # services here causes Compose to run migrate/migrate-clickhouse first and
+    # only bring up each app container after its migration dependency exits 0.
+    print("Starting application services (migrations run automatically before app services)...")
     _run(f"{PROD_COMPOSE} up -d web rest worker billing agent")
 
     print("\nAll containers started. Launching log viewer...\n")


### PR DESCRIPTION
## Summary
- Remove `frontend/packages/core/prisma/migrations` from `.gitignore` — migration files were never shipping with the repo, causing `prisma migrate deploy` to find nothing and leave the database empty on fresh clones
- Add auto-generated baseline migration `20260413180351_init` covering the full current schema (generated via `prisma migrate dev --name init` against a clean empty database — not hand-written)
- Remove redundant `docker compose run --rm migrate` calls from `run_prod_setup` in `launcher.py`; `billing` and `agent` already declare `depends_on: service_completed_successfully` so Compose handles ordering without the one-off containers that were bypassing its state tracking

## Root Cause
`prisma migrate dev` generates migration SQL files locally but those files were gitignored, so they never made it into the repo. `prisma migrate deploy` (used in Docker) found an empty `migrations/` directory, applied nothing, and billing/agent started against a schema-less database.

## Test Plan
- [x] `make prod` on a fresh clone with no prior volumes — billing and agent start successfully
- [x] Migration applies cleanly: `1 migration found... All migrations have been successfully applied`

## Note for existing contributors
If your local dev database already has the schema from previous `make dev` runs, mark the baseline as applied once to avoid a conflict:
```bash
cd frontend/packages/core
npx prisma migrate resolve --applied 20260413180351_init
```

Closes #625
<img width="1720" height="940" alt="Screenshot 2026-04-13 at 12 09 46 PM" src="https://github.com/user-attachments/assets/4c4435ce-7d4f-4e20-a81b-f7946e8c06f7" />


