### PR TITLE
feat: add CrewAI example using traceroot-py SDK with Integration.CREWAI

### DIFF
--- a/examples/python/crewai-agent/.env.example
+++ b/examples/python/crewai-agent/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenAI (used by CrewAI as the default LLM)
+OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/python/crewai-agent/README.md
+++ b/examples/python/crewai-agent/README.md
@@ -1,0 +1,16 @@
+# CrewAI Agent
+
+Multi-agent crew using CrewAI, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+## What it does
+Runs a 2-agent crew (researcher + writer) that gathers weather data and writes a comparison report.

--- a/examples/python/crewai-agent/main.py
+++ b/examples/python/crewai-agent/main.py
@@ -1,0 +1,138 @@
+"""
+CrewAI Multi-Agent Crew, instrumented with TraceRoot observability.
+
+A simple 2-agent crew that:
+1. Uses a Researcher agent to gather weather data using tools
+2. Uses a Writer agent to produce a comparison report
+
+Usage:
+    cp .env.example .env  # fill in your API keys
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+"""
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found (find_dotenv returned None).\nUsing process environment variables.")
+
+# =============================================================================
+# TRACEROOT SETUP
+# Must be initialized BEFORE importing CrewAI so instrumentation hooks in
+# =============================================================================
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.CREWAI])
+
+# =============================================================================
+# CREWAI AGENTS
+# =============================================================================
+from crewai import Agent, Crew, Task
+from crewai.tools import tool
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@tool
+def get_weather(city: str) -> str:
+    """Get weather for a city."""
+    weather_db = {
+        "san francisco": "68°F, foggy",
+        "tokyo": "72°F, sunny",
+        "new york": "45°F, cloudy",
+    }
+    return weather_db.get(city.lower(), "Unknown city")
+
+
+@tool
+def calculate(expression: str) -> str:
+    """Evaluate a math expression safely using AST parsing."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval(node.operand)
+        raise ValueError(f"Unsupported: {ast.dump(node)}")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+        return str(_eval(tree))
+    except Exception as e:
+        return f"Error: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Agents
+# ---------------------------------------------------------------------------
+
+researcher = Agent(
+    role="Research Analyst",
+    goal="Gather and analyze information using available tools",
+    backstory="Expert researcher who uses tools to find accurate data.",
+    tools=[get_weather, calculate],
+    verbose=True,
+)
+
+writer = Agent(
+    role="Report Writer",
+    goal="Write clear, concise reports based on research findings",
+    backstory="Skilled writer who creates readable summaries.",
+    verbose=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tasks
+# ---------------------------------------------------------------------------
+
+research_task = Task(
+    description="What's the weather in San Francisco and Tokyo? Compare them and calculate the temperature difference.",
+    expected_output="Weather data with comparison and calculations",
+    agent=researcher,
+)
+
+report_task = Task(
+    description="Write a brief weather comparison report based on the research.",
+    expected_output="A short weather comparison report",
+    agent=writer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Crew
+# ---------------------------------------------------------------------------
+
+crew = Crew(agents=[researcher, writer], tasks=[research_task, report_task], verbose=True)
+
+
+@observe(name="crewai_run", type="agent")
+def run_crew():
+    result = crew.kickoff()
+    print(result)
+    return str(result)
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="crewai-session"):
+        run_crew()
+
+    traceroot.flush()

--- a/examples/python/crewai-agent/main.py
+++ b/examples/python/crewai-agent/main.py
@@ -25,7 +25,7 @@ else:
 import traceroot
 from traceroot import Integration, observe, using_attributes
 
-traceroot.initialize(integrations=[Integration.CREWAI])
+traceroot.initialize(integrations=[Integration.CREWAI, Integration.OPENAI])
 
 # =============================================================================
 # CREWAI AGENTS

--- a/examples/python/crewai-agent/requirements.txt
+++ b/examples/python/crewai-agent/requirements.txt
@@ -1,5 +1,4 @@
-crewai>=0.80.0
+crewai>=1.10.1
 python-dotenv>=1.0.0
 
-traceroot==0.1.2
-openinference-instrumentation-crewai>=0.1.0
+/Users/xinweihe/code/traceroot-py

--- a/examples/python/crewai-agent/requirements.txt
+++ b/examples/python/crewai-agent/requirements.txt
@@ -1,0 +1,5 @@
+crewai>=0.80.0
+python-dotenv>=1.0.0
+
+traceroot==0.1.2
+openinference-instrumentation-crewai>=0.1.0

--- a/examples/python/crewai-agent/requirements.txt
+++ b/examples/python/crewai-agent/requirements.txt
@@ -2,4 +2,3 @@ crewai>=1.10.1
 python-dotenv>=1.0.0
 
 traceroot==0.1.3
-openinference-instrumentation-crewai>=1.1.1

--- a/examples/python/crewai-agent/requirements.txt
+++ b/examples/python/crewai-agent/requirements.txt
@@ -1,4 +1,5 @@
 crewai>=1.10.1
 python-dotenv>=1.0.0
 
-/Users/xinweihe/code/traceroot-py
+traceroot==0.1.3
+openinference-instrumentation-crewai>=1.1.1

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -132,6 +132,54 @@
     }
   },
   {
+    "id": "tr-gpt-4.5-preview",
+    "modelName": "gpt-4.5-preview",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-4\\.5-preview)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.000075,
+      "output": 0.00015,
+      "cacheRead": 0.0000375,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gpt-4.1",
+    "modelName": "gpt-4.1",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-4\\.1)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.000002,
+      "output": 0.000008,
+      "cacheRead": 0.0000005,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gpt-4.1-mini",
+    "modelName": "gpt-4.1-mini",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-4\\.1-mini)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.0000004,
+      "output": 0.0000016,
+      "cacheRead": 0.0000001,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-gpt-4.1-nano",
+    "modelName": "gpt-4.1-nano",
+    "matchPattern": "(?i)^(openai\\/)?(gpt-4\\.1-nano)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.0000001,
+      "output": 0.0000004,
+      "cacheRead": 0.000000025,
+      "cacheWrite": null
+    }
+  },
+  {
     "id": "tr-gpt-4-turbo",
     "modelName": "gpt-4-turbo",
     "matchPattern": "(?i)^(openai\\/)?(gpt-4-turbo)(-[\\d-]+)?$",


### PR DESCRIPTION
## Summary

Ports PR #598 from contributor @shirleyai-co to use the traceroot-py SDK properly:

- **Before** (PR #598): Used `traceroot==0.1.0` + manually called `CrewAIInstrumentor().instrument()` from openinference directly
- **After**: Uses `traceroot==0.1.2` (latest) with `traceroot.initialize(integrations=[Integration.CREWAI])` — the SDK handles instrumentation internally

### What's included
- `examples/python/crewai-agent/main.py` — 2-agent crew (researcher + writer) with tool use
- `examples/python/crewai-agent/requirements.txt` — updated to `traceroot==0.1.2`
- `examples/python/crewai-agent/.env.example`
- `examples/python/crewai-agent/README.md`

### Key change
```python
# Before (PR #598)
traceroot.initialize()
from openinference.instrumentation.crewai import CrewAIInstrumentor
CrewAIInstrumentor().instrument()

# After (this PR)
traceroot.initialize(integrations=[Integration.CREWAI])
```

`Integration.CREWAI` was added in traceroot-py 0.1.2 and handles the OpenInference instrumentation internally, keeping examples consistent with all other traceroot examples.

## Screenshots

<img width="1723" height="899" alt="Screenshot 2026-04-13 at 9 23 03 PM" src="https://github.com/user-attachments/assets/41b3d4f7-be52-4668-976e-24fc6a878d09" />


## Test plan
- [x] `cp .env.example .env` and fill in API keys
- [x] `uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py`
- [x] Verify traces appear in TraceRoot dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)