### PR TITLE
Docs/autogen formatting fix

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -141,7 +141,8 @@
               "integrations/langchain-deepagents",
               "integrations/mastra",
               "integrations/autogen",
-              "integrations/llamaindex"
+              "integrations/llamaindex",
+              "integrations/crewai"
             ]
           },
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -141,8 +141,12 @@
               "integrations/langchain-deepagents",
               "integrations/mastra",
               "integrations/autogen",
+<<<<<<< HEAD
               "integrations/llamaindex",
               "integrations/crewai"
+=======
+              "integrations/llamaindex"
+>>>>>>> c16abef (doc : fixed autogendoc formating)
             ]
           },
           {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -141,12 +141,7 @@
               "integrations/langchain-deepagents",
               "integrations/mastra",
               "integrations/autogen",
-<<<<<<< HEAD
-              "integrations/llamaindex",
-              "integrations/crewai"
-=======
               "integrations/llamaindex"
->>>>>>> c16abef (doc : fixed autogendoc formating)
             ]
           },
           {

--- a/docs/integrations/autogen.mdx
+++ b/docs/integrations/autogen.mdx
@@ -1,15 +1,13 @@
 ---
-title: AutoGen (AG2)
+title: AutoGen
 description: Auto-instrument AutoGen multi-agent conversations and tool calls
 ---
 
 Automatically capture agent loops, message histories, and tool executions within the AutoGen framework.
 
-*Note: This integration supports `ag2` (v0.11.5+), the community-maintained continuation of the classic AutoGen framework.*
-
 ## Setup
 
-To capture the complete picture—including both the agent orchestrations and the underlying token costs—we highly recommend initializing **both** the AutoGen integration and your specific LLM provider (e.g., Google GenAI, OpenAI, Anthropic).
+To capture the complete picture—including both the agent orchestrations and the underlying token costs—we highly recommend initializing both the AutoGen integration and your specific LLM provider (e.g., Google GenAI, OpenAI, Anthropic).
 
 ```python
 import traceroot
@@ -24,40 +22,7 @@ traceroot.initialize(integrations=[
 
 ## Usage
 
-Once initialized, the standard `initiate_chat` loop and internal agent reasoning steps are captured automatically:
-
-```python
-import os
-import autogen
-
-llm_config = {
-    "config_list": [{
-        "model": "gemini-2.5-flash",
-        "api_key": os.environ["GEMINI_API_KEY"],
-        "api_type": "google"
-    }]
-}
-
-assistant = autogen.AssistantAgent(
-    name="assistant",
-    llm_config=llm_config
-)
-user_proxy = autogen.UserProxyAgent(
-    name="user_proxy",
-    human_input_mode="NEVER",
-    max_consecutive_auto_reply=2
-)
-
-# The entire conversation hierarchy is automatically traced
-user_proxy.initiate_chat(
-    assistant,
-    message="Explain the difference between Python lists and tuples.",
-)
-```
-
-## Usage with Tools
-
-Function registrations and local tool executions are automatically traced as nested child spans within the executing agent's workflow:
+Once initialized, agent conversations and tool calls are captured automatically:
 
 ```python
 import os
@@ -65,7 +30,6 @@ import autogen
 from typing import Annotated
 from autogen import register_function
 
-# Define the LLM and Agents
 llm_config = {
     "config_list": [{
         "model": "gemini-2.5-flash",
@@ -81,27 +45,37 @@ assistant = autogen.AssistantAgent(
 user_proxy = autogen.UserProxyAgent(
     name="user_proxy",
     human_input_mode="NEVER",
-    max_consecutive_auto_reply=2
+    max_consecutive_auto_reply=5
 )
 
 def get_weather(city: Annotated[str, "City name"]) -> str:
     """Get current weather for a city."""
     return f"The weather in {city} is 72 degrees and sunny."
 
-# Register the tool
+def get_forecast(city: Annotated[str, "City name"], days: Annotated[int, "Number of days"]) -> str:
+    """Get a multi-day weather forecast for a city."""
+    return f"{days}-day forecast for {city}: mostly sunny with highs around 70-75°F."
+
+# Register tools — caller decides when to use them, executor runs the function
 register_function(
     get_weather,
-    caller=assistant,     # The agent that decides to use the tool
-    executor=user_proxy,  # The agent that actually runs the Python function
+    caller=assistant,
+    executor=user_proxy,
     name="get_weather",
     description="Get current weather for a city",
 )
+register_function(
+    get_forecast,
+    caller=assistant,
+    executor=user_proxy,
+    name="get_forecast",
+    description="Get a multi-day weather forecast for a city",
+)
 
-# Tool executions appear as 'tool' spans under the UserProxyAgent
+# The entire conversation hierarchy is automatically traced
 user_proxy.initiate_chat(
     assistant,
-    message="What is the weather in Tokyo?",
-    max_turns=5,  # Add a guard to ensure an LLM response cap
+    message="What's the weather in Tokyo today, and what does the 3-day forecast look like?",
 )
 ```
 

--- a/docs/integrations/autogen.mdx
+++ b/docs/integrations/autogen.mdx
@@ -113,7 +113,5 @@ user_proxy.initiate_chat(
 | Agent Steps | Individual spans for each `AssistantAgent` or `UserProxyAgent` turn |
 | Messages | Full chat history, input messages, and agent replies |
 | Tool calls | Function names, input arguments, and execution outputs |
-| LLM calls* | Raw completion requests to the provider |
-| Tokens & Cost* | Aggregated usage and pricing for the chat session |
-
-*\*Requires initializing the corresponding LLM integration (e.g., `Integration.GOOGLE_GENAI`) alongside `Integration.AUTOGEN`*
+| LLM calls | Raw completion requests to the provider |
+| Tokens & Cost | Aggregated usage and pricing for the chat session |

--- a/docs/integrations/autogen.mdx
+++ b/docs/integrations/autogen.mdx
@@ -3,7 +3,7 @@ title: AutoGen (AG2)
 description: Auto-instrument AutoGen multi-agent conversations and tool calls
 ---
 
-Automatically capture agent loops, message histories, and tool executions within the AutoGen framework. 
+Automatically capture agent loops, message histories, and tool executions within the AutoGen framework.
 
 *Note: This integration supports `ag2` (v0.11.5+), the community-maintained continuation of the classic AutoGen framework.*
 
@@ -32,19 +32,19 @@ import autogen
 
 llm_config = {
     "config_list": [{
-        "model": "gemini-2.5-flash", 
+        "model": "gemini-2.5-flash",
         "api_key": os.environ["GEMINI_API_KEY"],
         "api_type": "google"
     }]
 }
 
 assistant = autogen.AssistantAgent(
-    name="assistant", 
+    name="assistant",
     llm_config=llm_config
 )
 user_proxy = autogen.UserProxyAgent(
-    name="user_proxy", 
-    human_input_mode="NEVER", 
+    name="user_proxy",
+    human_input_mode="NEVER",
     max_consecutive_auto_reply=2
 )
 
@@ -68,19 +68,19 @@ from autogen import register_function
 # Define the LLM and Agents
 llm_config = {
     "config_list": [{
-        "model": "gemini-2.5-flash", 
+        "model": "gemini-2.5-flash",
         "api_key": os.environ["GEMINI_API_KEY"],
         "api_type": "google"
     }]
 }
 
 assistant = autogen.AssistantAgent(
-    name="assistant", 
+    name="assistant",
     llm_config=llm_config
 )
 user_proxy = autogen.UserProxyAgent(
-    name="user_proxy", 
-    human_input_mode="NEVER", 
+    name="user_proxy",
+    human_input_mode="NEVER",
     max_consecutive_auto_reply=2
 )
 
@@ -116,4 +116,4 @@ user_proxy.initiate_chat(
 | LLM calls* | Raw completion requests to the provider |
 | Tokens & Cost* | Aggregated usage and pricing for the chat session |
 
-*\*Requires initializing the corresponding LLM integration (e.g., `Integration.GOOGLE_GENAI`) alongside `Integration.AUTOGEN`
+*\*Requires initializing the corresponding LLM integration (e.g., `Integration.GOOGLE_GENAI`) alongside `Integration.AUTOGEN`*


### PR DESCRIPTION
## Summary
Fixes https://github.com/traceroot-ai/traceroot/issues/683

I have fixed the formatting issue of AutoGen Integration Doc 
## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [x] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)
<img width="1494" height="843" alt="Screenshot 2026-04-17 at 12 26 06 PM" src="https://github.com/user-attachments/assets/a75c654d-ee44-4533-9b7f-f09fecfea10c" />

## Checklist

- [X] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ X] I have added/updated tests where applicable
- [ X] I have added screenshots or recordings for UI changes (if applicable)
- [ X] I have updated documentation where necessary
