### PR TITLE
feat: add Claude Opus 4.7 to BYOK model catalog

### DIFF
--- a/docs/integrations/internal-models.mdx
+++ b/docs/integrations/internal-models.mdx
@@ -7,23 +7,24 @@ TraceRoot Cloud provides the following models out of the box — no API key requ
 
 ## Anthropic
 
-| Model | Description |
-|-------|-------------|
-| `claude-opus-4-6` | Most capable model for complex reasoning and debugging |
-| `claude-sonnet-4-6` | Balanced performance and speed |
-| `claude-opus-4-5` | Previous Opus generation |
-| `claude-sonnet-4-5` | Previous Sonnet generation |
-| `claude-haiku-4-5` | Fast and lightweight |
+| Model               | Description                                            |
+| ------------------- | ------------------------------------------------------ |
+| `claude-opus-4-7`   | Most capable model for complex reasoning and debugging |
+| `claude-opus-4-6`   | Previous Opus generation                               |
+| `claude-sonnet-4-6` | Balanced performance and speed                         |
+| `claude-opus-4-5`   | Earlier Opus generation                                |
+| `claude-sonnet-4-5` | Previous Sonnet generation                             |
+| `claude-haiku-4-5`  | Fast and lightweight                                   |
 
 ## OpenAI
 
-| Model | Description |
-|-------|-------------|
-| `gpt-5` | OpenAI's most capable model |
-| `gpt-5-mini` | Fast and cost-efficient GPT-5 variant |
+| Model           | Description                            |
+| --------------- | -------------------------------------- |
+| `gpt-5`         | OpenAI's most capable model            |
+| `gpt-5-mini`    | Fast and cost-efficient GPT-5 variant  |
 | `gpt-5.3-codex` | Code-optimized model via Responses API |
-| `o3` | Advanced reasoning model |
-| `o4-mini` | Lightweight reasoning model |
+| `o3`            | Advanced reasoning model               |
+| `o4-mini`       | Lightweight reasoning model            |
 
 ## Bring Your Own Key (BYOK)
 

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -90,6 +90,7 @@ export const SYSTEM_MODELS: {
     piAIProvider: "anthropic",
     apiProtocol: "anthropic-messages",
     models: [
+      { id: "claude-opus-4-7", label: "claude-opus-4-7" },
       { id: "claude-opus-4-6", label: "claude-opus-4-6" },
       { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
       { id: "claude-opus-4-5", label: "claude-opus-4-5" },
@@ -146,6 +147,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "o4-mini", label: "o4-mini" },
   ],
   anthropic: [
+    { id: "claude-opus-4-7", label: "claude-opus-4-7" },
     { id: "claude-opus-4-6", label: "claude-opus-4-6" },
     { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
     { id: "claude-opus-4-5", label: "claude-opus-4-5" },


### PR DESCRIPTION
Surface claude-opus-4-7 in both the Anthropic system-model list and the BYOK dropdown catalog, and document it in the internal-models docs table. No apiProtocol override needed - Opus uses the provider-level default anthropic-messages protocol. Closes #689.

## Summary
Anthropic released Claude Opus 4.7 as the new SOTA Opus model
  (https://www.anthropic.com/news/claude-opus-4-7). Traceroot's curated model dropdown and documented
   model catalog did not list it, so BYOK users couldn't pick it from Settings -> Model Providers -> 
  Anthropic without falling back to the (Unsupported) path introduced in #610.
## Type of Change

- [x] feat - A new feature


## Details
frontend/packages/core/src/llm-providers.ts
  - One entry added to SYSTEM_MODELS (Anthropic provider, line 93): { id: "claude-opus-4-7", label:  
  "claude-opus-4-7" }.
  - One entry added to ADAPTER_MODELS.anthropic (line 150): same shape.
  - Positioned at index 0 in each list, continuing the newest-first ordering already used for 4.6 and
   4.5. This promotes Opus 4.7 to the default-selected model — consistent with how 4.6 became the    
  default when it was added.
  - No apiProtocol override needed — Opus uses the provider-level default anthropic-messages (line   
  91).

  docs/integrations/internal-models.mdx
  - Added claude-opus-4-7 row at the top of the Anthropic table with the "Most capable" description. 
  - Demoted 4.6 to "Previous Opus generation" and 4.5 to "Earlier Opus generation" so only one row   
  holds the most-capable description, mirroring the 4.6 / 4.5 relationship before this change.       
  - Prettier also re-aligned the Anthropic and OpenAI table columns when it wrote the file; the      
  OpenAI alignment is a no-op semantic-wise but accounts for part of the diff.
## Screenshots / Recordings (if applicable)
[Help Wanted] I don't have an active Anthropic API key and would need extra help e2e test in production. 

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
