### PR TITLE
docs: add AutoGen and LlamaIndex to README integrations table

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ The fastest way to get started. Ample storages and LLM tokens for testing, no cr
 | [LangChain & LangGraph](https://traceroot.ai/docs/integrations/langchain) | Python, JS/TS | Automated instrumentation by passing callback handler to LangChain application. |
 | [LangChain DeepAgents](https://traceroot.ai/docs/integrations/langchain-deepagents) | Python, JS/TS | Automated instrumentation by passing callback handler to DeepAgents pipeline. |
 | [CrewAI](https://traceroot.ai/docs/integrations/crewai) | Python | Automated instrumentation of multi-agent collaborative workflows and task executions. |
+| [AutoGen](https://traceroot.ai/docs/integrations/autogen) | Python | Automated instrumentation of multi-agent conversations, agent loops, and tool calls. |
+| [LlamaIndex](https://traceroot.ai/docs/integrations/llamaindex) | Python | Automated instrumentation of RAG pipelines, document ingestion, retrieval, and LLM synthesis. |
 | [Mastra](https://traceroot.ai/docs/integrations/mastra) | JS/TS | Automated instrumentation via the TraceRoot OTLP exporter. |
 
 > Don't see your framework or provider? [Request an integration](https://github.com/traceroot-ai/traceroot/issues).


### PR DESCRIPTION
## Summary

- Added **AutoGen** and **LlamaIndex** to the Agent Frameworks integrations table in README.md
- Both integrations already have full docs pages at `traceroot.ai/docs/integrations/autogen` and `traceroot.ai/docs/integrations/llamaindex`


## Screenshots
<img width="1784" height="904" alt="Screenshot 2026-04-17 at 12 46 40 PM" src="https://github.com/user-attachments/assets/974b565d-62dd-4b53-b135-4fc70f436daa" />



## Test plan

- [x] Verify links resolve correctly on the live docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)