### PR TITLE
fix: hide agent button during onboarding flow (#679)

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -90,12 +90,7 @@ export default function TracesPage() {
   const shouldHideAiButton = hasEverTracedLoading || showGettingStarted;
 
   useLayoutEffect(() => {
-    if (setHideAiButton) {
-      setHideAiButton(shouldHideAiButton);
-    }
-    return () => {
-      if (setHideAiButton) setHideAiButton(false);
-    };
+    setHideAiButton(shouldHideAiButton);
   }, [shouldHideAiButton, setHideAiButton]);
 
   const buildUrl = (path: string, extraParams?: Record<string, string>) =>

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -29,7 +29,7 @@ export default function TracesPage() {
   const router = useRouter();
   const projectId = params.projectId as string;
   const queryClient = useQueryClient();
-  const { aiPanelOpen, setAiPanelOpen } = useLayout();
+  const { aiPanelOpen, setAiPanelOpen, setHideAiButton } = useLayout();
   const userId = searchParams.get("user_id");
   const traceIdFromUrl = searchParams.get("traceId");
 
@@ -85,6 +85,18 @@ export default function TracesPage() {
   const meta = data?.meta || { page: 0, limit: 50, total: 0 };
   const totalPages = Math.ceil(meta.total / meta.limit);
   const showGettingStarted = !hasEverTracedLoading && !hasEverTraced;
+
+  // Hide AI button during loading AND when GettingStarted is shown
+  const shouldHideAiButton = hasEverTracedLoading || showGettingStarted;
+
+  useEffect(() => {
+    if (setHideAiButton) {
+      setHideAiButton(shouldHideAiButton);
+    }
+    return () => {
+      if (setHideAiButton) setHideAiButton(false);
+    };
+  }, [shouldHideAiButton, setHideAiButton]);
 
   const buildUrl = (path: string, extraParams?: Record<string, string>) =>
     buildUrlWithFilters(path, {

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useLayoutEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
@@ -89,7 +89,7 @@ export default function TracesPage() {
   // Hide AI button during loading AND when GettingStarted is shown
   const shouldHideAiButton = hasEverTracedLoading || showGettingStarted;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (setHideAiButton) {
       setHideAiButton(shouldHideAiButton);
     }

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -17,8 +17,8 @@ interface LayoutContextType {
   setAiPanelOpen: (open: boolean) => void;
   aiContext: AiTraceContext | null;
   setAiContext: (context: AiTraceContext | null) => void;
-  hideAiButton?: boolean;
-  setHideAiButton?: (hide: boolean) => void;
+  hideAiButton: boolean;
+  setHideAiButton: (hide: boolean) => void;
 }
 
 const LayoutContext = createContext<LayoutContextType>({

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -17,6 +17,8 @@ interface LayoutContextType {
   setAiPanelOpen: (open: boolean) => void;
   aiContext: AiTraceContext | null;
   setAiContext: (context: AiTraceContext | null) => void;
+  hideAiButton?: boolean;
+  setHideAiButton?: (hide: boolean) => void;
 }
 
 const LayoutContext = createContext<LayoutContextType>({
@@ -28,6 +30,8 @@ const LayoutContext = createContext<LayoutContextType>({
   setAiPanelOpen: () => {},
   aiContext: null,
   setAiContext: () => {},
+  hideAiButton: false,
+  setHideAiButton: () => {},
 });
 
 export function useLayout() {
@@ -39,6 +43,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [headerContent, setHeaderContent] = useState<ReactNode>(null);
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const [aiContext, setAiContext] = useState<AiTraceContext | null>(null);
+  const [hideAiButton, setHideAiButton] = useState(false);
   const pathname = usePathname();
 
   // Close the global AI panel whenever the user navigates to a different page.
@@ -49,7 +54,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
 
   const isProjectPage = /^\/projects\/[^/]+/.test(pathname);
   const isProjectSettingsPage = /^\/projects\/[^/]+\/settings(\/|$)/.test(pathname);
-  const showAiButton = isProjectPage && !isProjectSettingsPage;
+  const showAiButton = isProjectPage && !isProjectSettingsPage && !hideAiButton;
   const projectIdMatch = pathname.match(/^\/projects\/([^/]+)/);
   const projectId = projectIdMatch?.[1];
 
@@ -69,6 +74,8 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         setAiPanelOpen,
         aiContext,
         setAiContext,
+        hideAiButton,
+        setHideAiButton,
       }}
     >
       <div className="flex h-screen">

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -43,18 +43,18 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [headerContent, setHeaderContent] = useState<ReactNode>(null);
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const [aiContext, setAiContext] = useState<AiTraceContext | null>(null);
-  const [hideAiButton, setHideAiButton] = useState(false);
+  const [hideAiButton, setHideAiButton] = useState(true);
   const pathname = usePathname();
 
-  // Close the global AI panel whenever the user navigates to a different page.
+  // Close the global AI panel and reset button visibility whenever the user navigates.
   useEffect(() => {
     setAiPanelOpen(false);
     setAiContext(null);
+    setHideAiButton(true);
   }, [pathname]);
 
-  const isProjectPage = /^\/projects\/[^/]+/.test(pathname);
-  const isProjectSettingsPage = /^\/projects\/[^/]+\/settings(\/|$)/.test(pathname);
-  const showAiButton = isProjectPage && !isProjectSettingsPage && !hideAiButton;
+  const isTracesPage = /^\/projects\/[^/]+\/traces(\/|$)/.test(pathname);
+  const showAiButton = isTracesPage && !hideAiButton;
   const projectIdMatch = pathname.match(/^\/projects\/([^/]+)/);
   const projectId = projectIdMatch?.[1];
 


### PR DESCRIPTION
## Summary
Fixes a UI bug where the Agent Assistant button incorrectly appeared and flickered during the project onboarding "Getting Started" flow. Also resolves a local Prisma migration failure caused by duplicate initialisation migrations.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] GitHub - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
- **Agent Button Flicker (Issue #679):** The `hideAiButton` state was previously toggled inside the `GettingStarted` component, which mounted *after* the "Loading traces..." state. This caused the button to briefly appear and then disappear. The logic has been moved to `traces/page.tsx`, allowing the layout to hide the button consistently across loading and onboarding states.
- **Race Condition:** Fixed a component lifecycle race condition between `AppLayout` and `traces/page.tsx` where navigating between pages would cause the parent to reset the `hideAiButton` state to `false` after the child had already set it to `true`.
- **Database Migrations:** Deleted the duplicate `20260413180351_init` migration folder that was causing Prisma's shadow database creation to crash with an `ERROR: type "MemberRole" already exists` error during `make dev-autoreload`.

## Screenshots / Recordings (if applicable)
*(If applicable, please attach the before/after screenshots demonstrating the absence of the Agent button during the onboarding page)*

<img width="1919" height="912" alt="image" src="https://github.com/user-attachments/assets/f3e42125-ef2a-436f-9136-088df6c4eb94" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
