### PR TITLE
feat: add live trace streaming via SSE + Redis pub/sub

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -17,6 +17,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from rest.routers.internal import router as internal_router
+from rest.routers.live import router as live_router
 from rest.routers.public.traces import router as public_traces_router
 from rest.routers.sessions import router as sessions_router
 from rest.routers.traces import router as traces_router
@@ -43,6 +44,9 @@ app.add_middleware(
 app.include_router(traces_router, prefix="/api/v1")
 app.include_router(users_router, prefix="/api/v1")
 app.include_router(sessions_router, prefix="/api/v1")
+
+# Live trace streaming (SSE, user auth)
+app.include_router(live_router, prefix="/api/v1")
 
 # Public API for SDK ingestion (API key auth)
 app.include_router(public_traces_router, prefix="/api/v1")

--- a/backend/rest/routers/live.py
+++ b/backend/rest/routers/live.py
@@ -7,6 +7,7 @@ span updates to the client in real time.
 import asyncio
 import json
 import logging
+import time
 
 from fastapi import APIRouter, Request
 from starlette.responses import StreamingResponse
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/projects/{project_id}/traces/{trace_id}", tags=["Live"])
 
 HEARTBEAT_INTERVAL = 15  # seconds
+MAX_STREAM_SECONDS = 600  # 10 minutes — hard ceiling for idle connections
 
 
 @router.get("/live")
@@ -45,8 +47,9 @@ async def live_trace_stream(
         try:
             await pubsub.subscribe(channel)
             logger.info(f"SSE client subscribed to {channel}")
+            deadline = time.monotonic() + MAX_STREAM_SECONDS
 
-            while True:
+            while time.monotonic() < deadline:
                 # Check if client disconnected
                 if await request.is_disconnected():
                     break
@@ -68,6 +71,9 @@ async def live_trace_stream(
                 else:
                     # No message within timeout — send heartbeat
                     yield ": heartbeat\n\n"
+            else:
+                # Deadline reached — close the stream
+                yield "event: stream_timeout\ndata: {}\n\n"
 
         except asyncio.CancelledError:
             pass

--- a/backend/rest/routers/live.py
+++ b/backend/rest/routers/live.py
@@ -1,0 +1,87 @@
+"""Live trace streaming via Server-Sent Events (SSE).
+
+Subscribes to a Redis pub/sub channel for a specific trace and streams
+span updates to the client in real time.
+"""
+
+import asyncio
+import json
+import logging
+
+from fastapi import APIRouter, Request
+from starlette.responses import StreamingResponse
+
+from rest.routers.deps import ProjectAccess
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/projects/{project_id}/traces/{trace_id}", tags=["Live"])
+
+HEARTBEAT_INTERVAL = 15  # seconds
+
+
+@router.get("/live")
+async def live_trace_stream(
+    request: Request,
+    project_id: str,
+    trace_id: str,
+    _access: ProjectAccess,
+):
+    """Stream live span updates for a trace via SSE.
+
+    The client receives:
+    - `event: spans` with span data as each batch is ingested
+    - `event: trace_complete` when the root span finishes
+    - Heartbeat comments every 15s to keep the connection alive
+    """
+
+    async def event_generator():
+        from shared.redis import get_async_redis_client
+
+        redis_client = get_async_redis_client()
+        pubsub = redis_client.pubsub()
+        channel = f"trace:live:{project_id}:{trace_id}"
+
+        try:
+            await pubsub.subscribe(channel)
+            logger.info(f"SSE client subscribed to {channel}")
+
+            while True:
+                # Check if client disconnected
+                if await request.is_disconnected():
+                    break
+
+                # Poll for messages with a timeout (enables heartbeat + disconnect check)
+                message = await pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=HEARTBEAT_INTERVAL,
+                )
+
+                if message is not None and message["type"] == "message":
+                    data = json.loads(message["data"])
+                    event_type = data.get("type", "spans")
+
+                    yield f"event: {event_type}\ndata: {message['data']}\n\n"
+
+                    if event_type == "trace_complete":
+                        break
+                else:
+                    # No message within timeout — send heartbeat
+                    yield ": heartbeat\n\n"
+
+        except asyncio.CancelledError:
+            pass
+        finally:
+            await pubsub.unsubscribe(channel)
+            await pubsub.close()
+            logger.info(f"SSE client disconnected from {channel}")
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/rest/routers/live.py
+++ b/backend/rest/routers/live.py
@@ -22,6 +22,24 @@ HEARTBEAT_INTERVAL = 15  # seconds
 MAX_STREAM_SECONDS = 600  # 10 minutes — hard ceiling for idle connections
 
 
+def _is_trace_complete_in_clickhouse(project_id: str, trace_id: str) -> bool:
+    """Return True if ClickHouse has a root span (no parent) with an end_time for this trace."""
+    from db.clickhouse.client import get_clickhouse_client
+
+    ch_client = get_clickhouse_client()
+    result = ch_client.query(
+        """
+        SELECT count() FROM spans FINAL
+        WHERE project_id = {project_id:String}
+          AND trace_id   = {trace_id:String}
+          AND isNull(parent_span_id)
+          AND isNotNull(span_end_time)
+        """,
+        parameters={"project_id": project_id, "trace_id": trace_id},
+    )
+    return result.result_rows[0][0] > 0
+
+
 @router.get("/live")
 async def live_trace_stream(
     request: Request,
@@ -35,6 +53,10 @@ async def live_trace_stream(
     - `event: spans` with span data as each batch is ingested
     - `event: trace_complete` when the root span finishes
     - Heartbeat comments every 15s to keep the connection alive
+
+    For traces that are already complete when the client connects, this
+    endpoint detects that via ClickHouse and emits trace_complete immediately,
+    after forwarding any span events that arrived on Redis concurrently.
     """
 
     async def event_generator():
@@ -45,16 +67,41 @@ async def live_trace_stream(
         channel = f"trace:live:{project_id}:{trace_id}"
 
         try:
+            # Subscribe BEFORE checking ClickHouse so we don't miss events from
+            # Celery tasks that publish between the check and the subscribe.
             await pubsub.subscribe(channel)
             logger.info(f"SSE client subscribed to {channel}")
+
+            # Check whether the trace is already done in ClickHouse.
+            already_complete = await asyncio.to_thread(
+                _is_trace_complete_in_clickhouse, project_id, trace_id
+            )
+
+            if already_complete:
+                # Forward any span events that were published to Redis while we
+                # were doing the ClickHouse check (concurrent Celery tasks).
+                # These spans are guaranteed to be in ClickHouse already because
+                # process_s3_traces always writes to ClickHouse before publishing
+                # to Redis.
+                while True:
+                    msg = await pubsub.get_message(ignore_subscribe_messages=True, timeout=0)
+                    if msg is None:
+                        break
+                    if msg["type"] == "message":
+                        data = json.loads(msg["data"])
+                        if data.get("type") == "spans":
+                            yield f"event: spans\ndata: {msg['data']}\n\n"
+
+                yield "event: trace_complete\ndata: {}\n\n"
+                return
+
+            # Live trace: stream normally until trace_complete or timeout.
             deadline = time.monotonic() + MAX_STREAM_SECONDS
 
             while time.monotonic() < deadline:
-                # Check if client disconnected
                 if await request.is_disconnected():
                     break
 
-                # Poll for messages with a timeout (enables heartbeat + disconnect check)
                 message = await pubsub.get_message(
                     ignore_subscribe_messages=True,
                     timeout=HEARTBEAT_INTERVAL,
@@ -69,10 +116,8 @@ async def live_trace_stream(
                     if event_type == "trace_complete":
                         break
                 else:
-                    # No message within timeout — send heartbeat
                     yield ": heartbeat\n\n"
             else:
-                # Deadline reached — close the stream
                 yield "event: stream_timeout\ndata: {}\n\n"
 
         except asyncio.CancelledError:

--- a/backend/shared/redis.py
+++ b/backend/shared/redis.py
@@ -17,7 +17,12 @@ def get_redis_client() -> redis.Redis:
     """Get a sync Redis client (for use in Celery workers)."""
     global _sync_client
     if _sync_client is None:
-        _sync_client = redis.from_url(settings.redis.url, decode_responses=True)
+        _sync_client = redis.from_url(
+            settings.redis.url,
+            decode_responses=True,
+            retry_on_error=[redis.ConnectionError, redis.TimeoutError],
+            health_check_interval=30,
+        )
     return _sync_client
 
 
@@ -25,5 +30,10 @@ def get_async_redis_client() -> redis.asyncio.Redis:
     """Get an async Redis client (for use in FastAPI SSE endpoints)."""
     global _async_client
     if _async_client is None:
-        _async_client = redis.asyncio.from_url(settings.redis.url, decode_responses=True)
+        _async_client = redis.asyncio.from_url(
+            settings.redis.url,
+            decode_responses=True,
+            retry_on_error=[redis.ConnectionError, redis.TimeoutError],
+            health_check_interval=30,
+        )
     return _async_client

--- a/backend/shared/redis.py
+++ b/backend/shared/redis.py
@@ -1,0 +1,29 @@
+"""Redis client helpers for pub/sub (live trace streaming).
+
+Provides lazy-singleton factories for both sync and async Redis clients,
+separate from the Celery broker connection.
+"""
+
+import redis
+import redis.asyncio
+
+from shared.config import settings
+
+_sync_client: redis.Redis | None = None
+_async_client: redis.asyncio.Redis | None = None
+
+
+def get_redis_client() -> redis.Redis:
+    """Get a sync Redis client (for use in Celery workers)."""
+    global _sync_client
+    if _sync_client is None:
+        _sync_client = redis.from_url(settings.redis.url, decode_responses=True)
+    return _sync_client
+
+
+def get_async_redis_client() -> redis.asyncio.Redis:
+    """Get an async Redis client (for use in FastAPI SSE endpoints)."""
+    global _async_client
+    if _async_client is None:
+        _async_client = redis.asyncio.from_url(settings.redis.url, decode_responses=True)
+    return _async_client

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -110,8 +110,29 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
             ch_client = get_clickhouse_client()
 
             if traces:
-                ch_client.insert_traces_batch(traces)
-                logger.info(f"Inserted {len(traces)} traces into ClickHouse")
+                # Only insert a trace record if this batch contains the root span
+                # OR the trace is genuinely new (no existing ClickHouse record).
+                # Intermediate batches without the root span must not overwrite a
+                # correctly-named trace record with a wrong name.
+                traces_with_root = {s["trace_id"] for s in spans if s.get("parent_span_id") is None}
+                traces_without_root = [t for t in traces if t["trace_id"] not in traces_with_root]
+                if traces_without_root:
+                    ids = [t["trace_id"] for t in traces_without_root]
+                    result = ch_client.query(
+                        "SELECT DISTINCT trace_id FROM traces FINAL"
+                        " WHERE trace_id IN {ids:Array(String)}",
+                        parameters={"ids": ids},
+                    )
+                    existing_ids = {row[0] for row in result.result_rows}
+                    traces = [
+                        t
+                        for t in traces
+                        if t["trace_id"] in traces_with_root or t["trace_id"] not in existing_ids
+                    ]
+
+                if traces:
+                    ch_client.insert_traces_batch(traces)
+                    logger.info(f"Inserted {len(traces)} traces into ClickHouse")
 
             if spans:
                 ch_client.insert_spans_batch(spans)

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -27,9 +27,13 @@ def _publish_live_spans(spans: list[dict], project_id: str) -> None:
     Never raises — Redis failures must not break the ingest pipeline.
     """
     try:
-        from shared.redis import get_redis_client
+        import redis as redis_lib
+        from shared.config import settings
 
-        redis_client = get_redis_client()
+        # Create a fresh Redis connection per call — do NOT use the singleton
+        # get_redis_client() here because Celery uses prefork and module-level
+        # singletons created before/across fork() crash on macOS (SIGABRT).
+        redis_client = redis_lib.from_url(settings.redis.url, decode_responses=True)
 
         # Group spans by trace_id
         by_trace: dict[str, list[dict]] = defaultdict(list)
@@ -54,6 +58,8 @@ def _publish_live_spans(spans: list[dict], project_id: str) -> None:
                         json.dumps({"type": "trace_complete"}),
                     )
                     break
+
+        redis_client.close()
 
     except Exception:
         logger.warning("Failed to publish live spans to Redis", exc_info=True)

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -3,11 +3,60 @@
 This module defines the async tasks that process trace data from S3 to ClickHouse.
 """
 
+import json
 import logging
+from collections import defaultdict
+from datetime import datetime
 
 from worker.celery_app import app
 
 logger = logging.getLogger(__name__)
+
+
+def _json_serializer(obj: object) -> str:
+    """JSON serializer for datetime objects in span dicts."""
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+
+def _publish_live_spans(spans: list[dict], project_id: str) -> None:
+    """Publish spans to Redis for live trace streaming.
+
+    Groups spans by trace_id and publishes to per-trace channels.
+    Never raises — Redis failures must not break the ingest pipeline.
+    """
+    try:
+        from shared.redis import get_redis_client
+
+        redis_client = get_redis_client()
+
+        # Group spans by trace_id
+        by_trace: dict[str, list[dict]] = defaultdict(list)
+        for span in spans:
+            by_trace[span["trace_id"]].append(span)
+
+        for trace_id, trace_spans in by_trace.items():
+            channel = f"trace:live:{project_id}:{trace_id}"
+
+            # Publish spans
+            payload = json.dumps(
+                {"type": "spans", "spans": trace_spans},
+                default=_json_serializer,
+            )
+            redis_client.publish(channel, payload)
+
+            # Check if trace is complete (root span with end time)
+            for span in trace_spans:
+                if span.get("parent_span_id") is None and span.get("span_end_time") is not None:
+                    redis_client.publish(
+                        channel,
+                        json.dumps({"type": "trace_complete"}),
+                    )
+                    break
+
+    except Exception:
+        logger.warning("Failed to publish live spans to Redis", exc_info=True)
 
 
 @app.task(
@@ -60,6 +109,10 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
             if spans:
                 ch_client.insert_spans_batch(spans)
                 logger.info(f"Inserted {len(spans)} spans into ClickHouse")
+
+        # 4. Publish to Redis for live trace streaming
+        if spans:
+            _publish_live_spans(spans, project_id)
 
         return {
             "s3_key": s3_key,

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -28,6 +28,7 @@ def _publish_live_spans(spans: list[dict], project_id: str) -> None:
     """
     try:
         import redis as redis_lib
+
         from shared.config import settings
 
         # Create a fresh Redis connection per call — do NOT use the singleton

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -444,14 +444,12 @@ def transform_otel_to_clickhouse(
                         trace_attrs[trace_id]["session_id"] or span_session_id
                     )
 
-                # Only create trace record when we find a root span (no parent)
-                # This prevents batches without root spans from creating trace
-                # records with incorrect names that would overwrite the correct one
-                if not parent_span_id:
-                    # Extract git context for trace
-                    git_ref = span_attrs.get("traceroot.git.ref")
-                    git_repo = span_attrs.get("traceroot.git.repo")
-
+                # Eager trace creation (Langfuse-style):
+                # Create a "shallow" trace record on the FIRST span we see for
+                # a trace_id, so it appears in the UI immediately. When the root
+                # span arrives later, upgrade to a "full" trace with rich metadata.
+                if trace_id not in traces:
+                    # Shallow trace — minimal record so the trace list shows it
                     traces[trace_id] = {
                         "trace_id": trace_id,
                         "project_id": project_id,
@@ -460,6 +458,20 @@ def transform_otel_to_clickhouse(
                         "user_id": trace_attrs[trace_id]["user_id"],
                         "session_id": trace_attrs[trace_id]["session_id"],
                     }
+
+                if not parent_span_id:
+                    # Root span arrived — upgrade to full trace with rich metadata
+                    git_ref = span_attrs.get("traceroot.git.ref")
+                    git_repo = span_attrs.get("traceroot.git.repo")
+
+                    traces[trace_id].update(
+                        {
+                            "trace_start_time": start_time,
+                            "name": span_name,
+                            "user_id": trace_attrs[trace_id]["user_id"],
+                            "session_id": trace_attrs[trace_id]["session_id"],
+                        }
+                    )
 
                     if git_ref is not None:
                         traces[trace_id]["git_ref"] = git_ref

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -48,6 +48,7 @@ _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.type",
     "traceroot.span.metadata",
     "traceroot.span.tags",
+    "traceroot.sdk.",
     "traceroot.llm.",
     "traceroot.trace.",
     "traceroot.environment",
@@ -236,6 +237,11 @@ def transform_otel_to_clickhouse(
     trace_attrs: dict[
         str, dict[str, str | None]
     ] = {}  # trace_id -> {"user_id": ..., "session_id": ...}
+
+    # Best-known root name per trace: (ids_path_length, name).
+    # Shortest ids_path = closest to root. Used to correct eager trace names
+    # when the first span in a batch isn't the closest-to-root span for that trace.
+    _trace_name_candidates: dict[str, tuple[int, str]] = {}
 
     # camelCase: resourceSpans
     resource_spans = otel_data.get("resourceSpans", [])
@@ -449,7 +455,10 @@ def transform_otel_to_clickhouse(
                 # a trace_id, so it appears in the UI immediately. When the root
                 # span arrives later, upgrade to a "full" trace with rich metadata.
                 if trace_id not in traces:
-                    # Shallow trace — minimal record so the trace list shows it
+                    # Shallow trace — minimal placeholder so the trace appears in the
+                    # list immediately. The post-loop _trace_name_candidates correction
+                    # always overwrites "name" with the authoritative value, so there
+                    # is no need to compute path[0] here.
                     traces[trace_id] = {
                         "trace_id": trace_id,
                         "project_id": project_id,
@@ -458,6 +467,26 @@ def transform_otel_to_clickhouse(
                         "user_id": trace_attrs[trace_id]["user_id"],
                         "session_id": trace_attrs[trace_id]["session_id"],
                     }
+
+                # Track the best-known root name for this trace using the span
+                # closest to the root (shortest ids_path). Batches may contain
+                # spans out of depth order, so the first span processed might not
+                # be the shallowest one.
+                if not parent_span_id:
+                    # Actual root span — definitive, depth 0.
+                    _trace_name_candidates[trace_id] = (0, span_name)
+                else:
+                    span_path_c = span_attrs.get("traceroot.span.path")
+                    ids_path_c = span_attrs.get("traceroot.span.ids_path")
+                    candidate_name = (
+                        span_path_c[0]
+                        if isinstance(span_path_c, (list, tuple)) and span_path_c
+                        else span_name
+                    )
+                    depth = len(ids_path_c) if isinstance(ids_path_c, (list, tuple)) else 1
+                    existing = _trace_name_candidates.get(trace_id)
+                    if existing is None or depth < existing[0]:
+                        _trace_name_candidates[trace_id] = (depth, candidate_name)
 
                 if not parent_span_id:
                     # Root span arrived — upgrade to full trace with rich metadata
@@ -500,6 +529,12 @@ def transform_otel_to_clickhouse(
                             if not isinstance(span_output, str)
                             else span_output
                         )
+
+    # Correct eager trace names: the first span processed may not be the shallowest.
+    # Apply the best candidate (shortest ids_path) found across all spans in this batch.
+    for trace_id, (_, best_name) in _trace_name_candidates.items():
+        if trace_id in traces:
+            traces[trace_id]["name"] = best_name
 
     # Update trace records with user_id/session_id collected from child spans
     # (in case child spans with these attrs came after the root span was processed)

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -48,7 +48,6 @@ _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.type",
     "traceroot.span.metadata",
     "traceroot.span.tags",
-    "traceroot.sdk.",
     "traceroot.llm.",
     "traceroot.trace.",
     "traceroot.environment",

--- a/backend/worker/tests/test_otel_transform_trace_naming.py
+++ b/backend/worker/tests/test_otel_transform_trace_naming.py
@@ -238,8 +238,8 @@ def test_span_path_preserved_in_metadata():
     )
 
 
-def test_sdk_name_version_stripped_from_metadata():
-    """traceroot.sdk.* attributes ARE stripped — they're internal bookkeeping."""
+def test_sdk_name_version_preserved_in_metadata():
+    """traceroot.sdk.* attributes are preserved in metadata for visibility."""
     tid = _tid(0x05)
 
     span = _span(
@@ -257,6 +257,6 @@ def test_sdk_name_version_stripped_from_metadata():
     _, spans = transform_otel_to_clickhouse(_payload(span), project_id="proj-1")
 
     meta = json.loads(spans[0]["metadata"])
-    assert "traceroot.sdk.name" not in meta
-    assert "traceroot.sdk.version" not in meta
+    assert meta.get("traceroot.sdk.name") == "traceroot-py"
+    assert meta.get("traceroot.sdk.version") == "1.2.3"
     assert meta.get("my.custom.attr") == "keep-me"

--- a/backend/worker/tests/test_otel_transform_trace_naming.py
+++ b/backend/worker/tests/test_otel_transform_trace_naming.py
@@ -1,0 +1,262 @@
+"""Tests for trace naming logic in otel_transform.
+
+Covers the corner cases introduced during live-trace-streaming work:
+  - Eager trace name should use traceroot.span.path[0], not the span's own name
+  - When a batch has spans at multiple depths, the shallowest span's path[0] wins
+  - traceroot.span.path / traceroot.span.ids_path must be preserved in span metadata
+    (enrichSpansWithPending on the frontend reads them to create phantom ancestor spans)
+"""
+
+import base64
+import json
+
+from worker.otel_transform import transform_otel_to_clickhouse
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _tid(byte: int = 0x01) -> str:
+    return base64.b64encode(bytes([byte] * 16)).decode()
+
+
+def _sid(byte: int = 0x02) -> str:
+    return base64.b64encode(bytes([byte] * 8)).decode()
+
+
+def _str_attr(key: str, value: str) -> dict:
+    return {"key": key, "value": {"stringValue": value}}
+
+
+def _arr_attr(key: str, values: list[str]) -> dict:
+    return {
+        "key": key,
+        "value": {"arrayValue": {"values": [{"stringValue": v} for v in values]}},
+    }
+
+
+def _span(
+    name: str,
+    *,
+    trace_id: str,
+    span_id: str,
+    parent_span_id: str | None = None,
+    attributes: list[dict] | None = None,
+    start_ns: str = "1700000000000000000",
+    end_ns: str = "1700000001000000000",
+) -> dict:
+    s = {
+        "traceId": trace_id,
+        "spanId": span_id,
+        "name": name,
+        "kind": "SPAN_KIND_INTERNAL",
+        "startTimeUnixNano": start_ns,
+        "endTimeUnixNano": end_ns,
+        "attributes": attributes or [],
+        "status": {},
+    }
+    if parent_span_id is not None:
+        s["parentSpanId"] = parent_span_id
+    return s
+
+
+def _payload(*spans: dict) -> dict:
+    return {
+        "resourceSpans": [
+            {
+                "resource": {"attributes": []},
+                "scopeSpans": [{"scope": {"name": "test"}, "spans": list(spans)}],
+            }
+        ]
+    }
+
+
+# ── Eager trace naming ─────────────────────────────────────────────────────────
+
+
+def test_eager_trace_uses_path0_not_span_name():
+    """When the first span in a batch is a child, trace name = path[0], not span name."""
+    tid = _tid(0x01)
+    parent_sid = _sid(0x10)  # phantom parent not in batch
+
+    child = _span(
+        "ChatAnthropic",
+        trace_id=tid,
+        span_id=_sid(0x02),
+        parent_span_id=parent_sid,
+        attributes=[
+            _arr_attr("traceroot.span.path", ["research_session", "model", "ChatAnthropic"]),
+            _arr_attr(
+                "traceroot.span.ids_path",
+                [_sid(0x10).encode().hex()[:16], _sid(0x11).encode().hex()[:16]],
+            ),
+        ],
+    )
+
+    traces, _ = transform_otel_to_clickhouse(_payload(child), project_id="proj-1")
+
+    assert len(traces) == 1
+    assert traces[0]["name"] == "research_session", (
+        f"Expected 'research_session' from path[0], got {traces[0]['name']!r}"
+    )
+
+
+def test_eager_trace_falls_back_to_span_name_when_no_path():
+    """When path attribute is absent, trace name falls back to the span's own name."""
+    tid = _tid(0x01)
+    parent_sid = _sid(0x10)
+
+    child = _span(
+        "SomeChildSpan",
+        trace_id=tid,
+        span_id=_sid(0x02),
+        parent_span_id=parent_sid,
+    )
+
+    traces, _ = transform_otel_to_clickhouse(_payload(child), project_id="proj-1")
+
+    assert traces[0]["name"] == "SomeChildSpan"
+
+
+def test_root_span_always_sets_trace_name():
+    """Root span (no parent) overrides any eager name from path[0]."""
+    tid = _tid(0x01)
+
+    root = _span(
+        "actual_root",
+        trace_id=tid,
+        span_id=_sid(0x01),
+        # root span may also carry a path attribute — its own name still wins
+        attributes=[
+            _arr_attr("traceroot.span.path", ["actual_root"]),
+            _arr_attr("traceroot.span.ids_path", []),
+        ],
+    )
+
+    traces, _ = transform_otel_to_clickhouse(_payload(root), project_id="proj-1")
+
+    assert traces[0]["name"] == "actual_root"
+
+
+# ── Shallowest-span-wins (batch contains multiple depths) ──────────────────────
+
+
+def test_shallowest_span_wins_when_deep_span_arrives_first():
+    """Even if a deep span is first in the batch, the shallowest span's path[0] is used."""
+    tid = _tid(0x02)
+    root_sid_hex = base64.b64decode(_sid(0x10)).hex()
+    mid_sid_hex = base64.b64decode(_sid(0x11)).hex()
+
+    # Depth-3 span arrives first
+    deep = _span(
+        "ChatAnthropic",
+        trace_id=tid,
+        span_id=_sid(0x03),
+        parent_span_id=_sid(0x11),
+        start_ns="1700000000100000000",
+        attributes=[
+            _arr_attr("traceroot.span.path", ["research_session", "model", "ChatAnthropic"]),
+            _arr_attr("traceroot.span.ids_path", [root_sid_hex, mid_sid_hex]),
+        ],
+    )
+    # Depth-1 span arrives second
+    shallow = _span(
+        "model",
+        trace_id=tid,
+        span_id=_sid(0x11),
+        parent_span_id=_sid(0x10),
+        start_ns="1700000000000000000",
+        attributes=[
+            _arr_attr("traceroot.span.path", ["research_session", "model"]),
+            _arr_attr("traceroot.span.ids_path", [root_sid_hex]),
+        ],
+    )
+
+    traces, _ = transform_otel_to_clickhouse(_payload(deep, shallow), project_id="proj-1")
+
+    assert len(traces) == 1
+    assert traces[0]["name"] == "research_session", (
+        f"Expected shallowest span's path[0], got {traces[0]['name']!r}"
+    )
+
+
+def test_batch_with_root_span_uses_root_name():
+    """When the root span is present in a batch, its name is always used."""
+    tid = _tid(0x03)
+
+    deep = _span(
+        "ChatAnthropic",
+        trace_id=tid,
+        span_id=_sid(0x03),
+        parent_span_id=_sid(0x02),
+        attributes=[
+            _arr_attr("traceroot.span.path", ["research_session", "model", "ChatAnthropic"]),
+            _arr_attr("traceroot.span.ids_path", [_sid(0x01), _sid(0x02)]),
+        ],
+    )
+    root = _span(
+        "research_session",
+        trace_id=tid,
+        span_id=_sid(0x01),
+        # no parent → this is the root
+    )
+
+    traces, _ = transform_otel_to_clickhouse(_payload(deep, root), project_id="proj-1")
+
+    assert traces[0]["name"] == "research_session"
+
+
+# ── path / ids_path preserved in metadata ──────────────────────────────────────
+
+
+def test_span_path_preserved_in_metadata():
+    """traceroot.span.path must NOT be stripped — enrichSpansWithPending reads it."""
+    tid = _tid(0x04)
+    path = ["research_session", "model", "ChatAnthropic"]
+    ids_path = ["aabbccdd11223344", "aabbccdd11223345"]
+
+    child = _span(
+        "ChatAnthropic",
+        trace_id=tid,
+        span_id=_sid(0x02),
+        parent_span_id=_sid(0x10),
+        attributes=[
+            _arr_attr("traceroot.span.path", path),
+            _arr_attr("traceroot.span.ids_path", ids_path),
+        ],
+    )
+
+    _, spans = transform_otel_to_clickhouse(_payload(child), project_id="proj-1")
+
+    assert len(spans) == 1
+    assert "metadata" in spans[0], "span should have metadata when path attrs are present"
+    meta = json.loads(spans[0]["metadata"])
+    assert meta.get("traceroot.span.path") == path, (
+        "traceroot.span.path must be preserved in metadata for enrichSpansWithPending"
+    )
+    assert meta.get("traceroot.span.ids_path") == ids_path, (
+        "traceroot.span.ids_path must be preserved in metadata for enrichSpansWithPending"
+    )
+
+
+def test_sdk_name_version_stripped_from_metadata():
+    """traceroot.sdk.* attributes ARE stripped — they're internal bookkeeping."""
+    tid = _tid(0x05)
+
+    span = _span(
+        "my-span",
+        trace_id=tid,
+        span_id=_sid(0x02),
+        parent_span_id=_sid(0x10),
+        attributes=[
+            _str_attr("traceroot.sdk.name", "traceroot-py"),
+            _str_attr("traceroot.sdk.version", "1.2.3"),
+            _str_attr("my.custom.attr", "keep-me"),
+        ],
+    )
+
+    _, spans = transform_otel_to_clickhouse(_payload(span), project_id="proj-1")
+
+    meta = json.loads(spans[0]["metadata"])
+    assert "traceroot.sdk.name" not in meta
+    assert "traceroot.sdk.version" not in meta
+    assert meta.get("my.custom.attr") == "keep-me"

--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/live/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/live/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from "next/server";
+import { requireAuth, requireProjectAccess } from "@/lib/auth-helpers";
+
+const TRACE_API_URL = process.env.TRACE_API_URL || "http://localhost:8000";
+
+type RouteParams = { params: Promise<{ projectId: string; traceId: string }> };
+
+// GET /api/projects/[projectId]/traces/[traceId]/live — SSE proxy for live trace streaming
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId, traceId } = await params;
+
+  const accessResult = await requireProjectAccess(user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const backendRes = await fetch(
+    `${TRACE_API_URL}/api/v1/projects/${projectId}/traces/${traceId}/live`,
+    {
+      headers: { "x-user-id": user.id },
+    },
+  );
+
+  if (!backendRes.ok || !backendRes.body) {
+    return new Response(JSON.stringify({ error: "Failed to connect to live stream" }), {
+      status: backendRes.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  // Passthrough the SSE stream
+  return new Response(backendRes.body, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -5,7 +5,16 @@ import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
-import { ChevronLeft, ChevronRight, ChevronDown, Workflow, Users, Layers, X } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  Workflow,
+  Users,
+  Layers,
+  X,
+  RefreshCw,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SearchFilterBar } from "@/components/search-filter-bar";
@@ -47,12 +56,17 @@ export default function TracesPage() {
   // UI state for popovers
   const [itemsPerPageOpen, setItemsPerPageOpen] = useState(false);
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(traceIdFromUrl);
+  const [autoRefresh, setAutoRefresh] = useState(false);
 
   // Fetch traces with combined query options + user filter from URL
-  const { data, isLoading, error } = useTraces(projectId, {
-    ...queryOptions,
-    user_id: userId || undefined,
-  });
+  const { data, isLoading, error } = useTraces(
+    projectId,
+    {
+      ...queryOptions,
+      user_id: userId || undefined,
+    },
+    { refetchInterval: autoRefresh ? 5000 : false },
+  );
 
   // Check if project has EVER sent traces (no date filter) — controls onboarding visibility.
   // staleTime: Infinity because once a project has traces it always will (immutable fact).
@@ -134,6 +148,18 @@ export default function TracesPage() {
             onDateFilterChange={updateDateFilter}
             onCustomRangeChange={updateCustomRange}
           >
+            <Button
+              variant={autoRefresh ? "default" : "outline"}
+              size="sm"
+              onClick={() => setAutoRefresh(!autoRefresh)}
+              className="h-7 gap-1.5 text-[12px]"
+              title={autoRefresh ? "Auto-refresh on (every 5s)" : "Auto-refresh off"}
+            >
+              <RefreshCw
+                className={cn("h-3 w-3", autoRefresh && "animate-spin")}
+              />
+              {autoRefresh ? "Live" : "Auto-refresh"}
+            </Button>
             {userId && (
               <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 py-1 pl-2.5 pr-1.5">
                 <Users className="h-3 w-3 text-muted-foreground" />

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -155,9 +155,7 @@ export default function TracesPage() {
               className="h-7 gap-1.5 text-[12px]"
               title={autoRefresh ? "Auto-refresh on (every 5s)" : "Auto-refresh off"}
             >
-              <Radio
-                className={cn("h-3 w-3", autoRefresh && "animate-pulse text-green-500")}
-              />
+              <Radio className={cn("h-3 w-3", autoRefresh && "animate-pulse text-green-500")} />
               {autoRefresh ? "Live" : "Auto-refresh"}
             </Button>
             {userId && (

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -5,16 +5,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
-import {
-  ChevronLeft,
-  ChevronRight,
-  ChevronDown,
-  Workflow,
-  Users,
-  Layers,
-  X,
-  Radio,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight, ChevronDown, Workflow, Users, Layers, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SearchFilterBar } from "@/components/search-filter-bar";
@@ -148,16 +139,33 @@ export default function TracesPage() {
             onDateFilterChange={updateDateFilter}
             onCustomRangeChange={updateCustomRange}
           >
-            <Button
-              variant={autoRefresh ? "default" : "outline"}
-              size="sm"
+            <button
+              type="button"
+              role="switch"
+              aria-checked={autoRefresh}
               onClick={() => setAutoRefresh(!autoRefresh)}
-              className="h-7 gap-1.5 text-[12px]"
-              title={autoRefresh ? "Auto-refresh on (every 5s)" : "Auto-refresh off"}
+              title={
+                autoRefresh
+                  ? "Live list refresh on (every 5s) — click to disable"
+                  : "Enable live list refresh"
+              }
+              className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1 text-[12px] text-foreground transition-colors hover:border-foreground/40 hover:bg-muted"
             >
-              <Radio className={cn("h-3 w-3", autoRefresh && "animate-pulse text-green-500")} />
-              {autoRefresh ? "Live" : "Auto-refresh"}
-            </Button>
+              Live
+              <span
+                className={cn(
+                  "relative inline-flex h-4 w-7 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200",
+                  autoRefresh ? "bg-foreground" : "bg-input",
+                )}
+              >
+                <span
+                  className={cn(
+                    "block h-3 w-3 rounded-full bg-background shadow-sm transition-transform duration-200",
+                    autoRefresh ? "translate-x-3" : "translate-x-0",
+                  )}
+                />
+              </span>
+            </button>
             {userId && (
               <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 py-1 pl-2.5 pr-1.5">
                 <Users className="h-3 w-3 text-muted-foreground" />

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -13,7 +13,7 @@ import {
   Users,
   Layers,
   X,
-  RefreshCw,
+  Radio,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -155,8 +155,8 @@ export default function TracesPage() {
               className="h-7 gap-1.5 text-[12px]"
               title={autoRefresh ? "Auto-refresh on (every 5s)" : "Auto-refresh off"}
             >
-              <RefreshCw
-                className={cn("h-3 w-3", autoRefresh && "animate-spin")}
+              <Radio
+                className={cn("h-3 w-3", autoRefresh && "animate-pulse text-green-500")}
               />
               {autoRefresh ? "Live" : "Auto-refresh"}
             </Button>

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -139,7 +139,7 @@ export function SpanInfoPanel({
               </span>
             </div>
           )}
-          {!isTrace && selection.span.cost != null && (
+          {!isTrace && selection.span.cost != null && Number.isFinite(selection.span.cost) && (
             <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
               <CircleDollarSign className="h-3 w-3 text-muted-foreground" />
               <span className="font-medium">{selection.span.cost.toFixed(6)}</span>

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -57,7 +57,19 @@ export function SpanInfoPanel({
   const timestamp = isTrace ? trace.trace_start_time : selection.span.span_start_time;
   const input = isTrace ? trace.input : selection.span.input;
   const output = isTrace ? trace.output : selection.span.output;
-  const metadata = isTrace ? trace.metadata : selection.span.metadata;
+  const rawMetadata = isTrace ? trace.metadata : selection.span.metadata;
+  const metadata = (() => {
+    if (!rawMetadata) return rawMetadata;
+    try {
+      const parsed = JSON.parse(rawMetadata);
+      const filtered = Object.fromEntries(
+        Object.entries(parsed).filter(([k]) => !k.startsWith("traceroot.span.")),
+      );
+      return JSON.stringify(filtered);
+    } catch {
+      return rawMetadata;
+    }
+  })();
 
   // Trace-level aggregates
   const traceTotalCost = isTrace ? getTraceTotalCost(trace) : null;

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -9,6 +9,7 @@ import type { TraceSelection } from "../types";
 import {
   buildSpanTree,
   buildChildrenMap,
+  enrichSpansWithPending,
   getSpanDuration,
   getTraceDuration,
   getTraceTotalCost,
@@ -30,7 +31,12 @@ interface SpanTreeViewProps {
 export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) {
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(new Set());
 
-  const childrenByParent = buildChildrenMap(trace.spans);
+  // Enrich with placeholder spans for any missing ancestors — handles both
+  // live-streaming gaps (parent not yet arrived) and permanently dropped spans.
+  // Mirrors lmnr's approach of calling enrichSpansWithPending on every render.
+  const spans = enrichSpansWithPending(trace.spans);
+
+  const childrenByParent = buildChildrenMap(spans);
 
   const hasChildren = (spanId: string | null) => {
     const children = childrenByParent.get(spanId) || [];
@@ -55,13 +61,13 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
     let currentId = span.parent_span_id;
     while (currentId) {
       if (collapsedIds.has(currentId)) return false;
-      const parent = trace.spans.find((s) => s.span_id === currentId);
+      const parent = spans.find((s) => s.span_id === currentId);
       currentId = parent?.parent_span_id || null;
     }
     return true;
   };
 
-  const spanRows = buildSpanTree(trace.spans);
+  const spanRows = buildSpanTree(spans);
   const isTraceSelected = selection.type === "trace";
   const traceDuration = getTraceDuration(trace);
   const traceTotalCost = getTraceTotalCost(trace);
@@ -154,10 +160,19 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
               />
               <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <SpanKindIcon kind={span.span_kind} inTree />
-                <span className="truncate text-xs">{span.name}</span>
-                <span className="whitespace-nowrap font-mono text-[10px] text-muted-foreground">
-                  {formatDuration(getSpanDuration(span))}
+                <span
+                  className={cn(
+                    "truncate text-xs",
+                    span.pending && "italic text-muted-foreground/60",
+                  )}
+                >
+                  {span.name}
                 </span>
+                {!span.pending && (
+                  <span className="whitespace-nowrap font-mono text-[10px] text-muted-foreground">
+                    {formatDuration(getSpanDuration(span))}
+                  </span>
+                )}
                 {span.status === SpanStatus.ERROR && (
                   <span className="whitespace-nowrap rounded bg-red-100 px-1 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
                     ERROR
@@ -169,12 +184,14 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
                     {formatTokens(span.total_tokens)}
                   </span>
                 )}
-                {span.span_kind === SpanKind.LLM && span.cost != null && (
-                  <span className="inline-flex items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground">
-                    <CircleDollarSign className="h-2.5 w-2.5" />
-                    {span.cost.toFixed(4)}
-                  </span>
-                )}
+                {span.span_kind === SpanKind.LLM &&
+                  span.cost != null &&
+                  Number.isFinite(span.cost) && (
+                    <span className="inline-flex items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground">
+                      <CircleDollarSign className="h-2.5 w-2.5" />
+                      {span.cost.toFixed(4)}
+                    </span>
+                  )}
                 <div className="flex-1" />
                 {spanHasChildren && (
                   <button

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -49,8 +49,10 @@ export function TraceViewerPanel({
     queryFn: () => getTrace(projectId, traceId, ""),
   });
 
-  // Live trace streaming — merges incoming spans into the React Query cache
-  const { isStreaming } = useTraceStream(projectId, traceId, true);
+  // Only stream if the trace has not yet completed (no root span with end time).
+  const isTraceComplete =
+    trace?.spans.some((s) => s.parent_span_id === null && s.span_end_time !== null) ?? false;
+  const { isStreaming } = useTraceStream(projectId, traceId, !isTraceComplete);
 
   // Reset selection when navigating to a different trace
   useEffect(() => {

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Workflow, X, ArrowUp, ArrowDown, BotMessageSquare, Radio } from "lucide-react";
+import { Workflow, X, ArrowUp, ArrowDown, BotMessageSquare } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getTrace } from "@/lib/api";
 import type { TraceSelection } from "../types";
@@ -49,10 +49,10 @@ export function TraceViewerPanel({
     queryFn: () => getTrace(projectId, traceId, ""),
   });
 
-  // Only stream if the trace has not yet completed (no root span with end time).
-  const isTraceComplete =
-    trace?.spans.some((s) => s.parent_span_id === null && s.span_end_time !== null) ?? false;
-  const { isStreaming } = useTraceStream(projectId, traceId, !isTraceComplete);
+  // Always stream — the backend is authoritative about when the trace is complete.
+  // live.py will immediately emit trace_complete for already-finished traces,
+  // so there is no cost to opening a connection for completed traces.
+  useTraceStream(projectId, traceId, true);
 
   // Reset selection when navigating to a different trace
   useEffect(() => {
@@ -67,12 +67,6 @@ export function TraceViewerPanel({
           <Workflow className="h-4 w-4 text-muted-foreground" />
           <span className="text-sm font-medium">Trace</span>
           <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
-          {isStreaming && (
-            <span className="flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
-              <Radio className="h-3 w-3 animate-pulse" />
-              Live
-            </span>
-          )}
         </div>
         <div className="flex items-center gap-1">
           {/* Navigation buttons */}

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -2,13 +2,14 @@
 
 import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Workflow, X, ArrowUp, ArrowDown, BotMessageSquare } from "lucide-react";
+import { Workflow, X, ArrowUp, ArrowDown, BotMessageSquare, Radio } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getTrace } from "@/lib/api";
 import type { TraceSelection } from "../types";
 import { SpanTreeView } from "./SpanTreeView";
 import { SpanInfoPanel } from "./SpanInfoPanel";
 import { AiChatOverlay } from "@/features/ai-assistant/components/ai-chat-overlay";
+import { useTraceStream } from "../hooks/use-trace-stream";
 
 interface TraceViewerPanelProps {
   projectId: string;
@@ -48,6 +49,9 @@ export function TraceViewerPanel({
     queryFn: () => getTrace(projectId, traceId, ""),
   });
 
+  // Live trace streaming — merges incoming spans into the React Query cache
+  const { isStreaming } = useTraceStream(projectId, traceId, true);
+
   // Reset selection when navigating to a different trace
   useEffect(() => {
     setSelection({ type: "trace" });
@@ -61,6 +65,12 @@ export function TraceViewerPanel({
           <Workflow className="h-4 w-4 text-muted-foreground" />
           <span className="text-sm font-medium">Trace</span>
           <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
+          {isStreaming && (
+            <span className="flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
+              <Radio className="h-3 w-3 animate-pulse" />
+              Live
+            </span>
+          )}
         </div>
         <div className="flex items-center gap-1">
           {/* Navigation buttons */}

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -21,6 +21,9 @@ export { useTraceListState } from "./use-trace-list-state";
 // URL-synced version for shared date filter across pages
 export { useListPageState } from "./use-list-page-state";
 
+// Live trace streaming
+export { useTraceStream } from "./use-trace-stream";
+
 /**
  * Hook for fetching paginated traces list
  */

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -44,16 +44,16 @@ export function useTraceStream(
     const es = new EventSource(url);
     eventSourceRef.current = es;
 
-    es.onopen = () => {
-      setIsStreaming(true);
-    };
-
     es.addEventListener("spans", (event) => {
       try {
         const data = JSON.parse(event.data);
         const newSpans: Span[] = data.spans ?? [];
 
         if (newSpans.length === 0) return;
+
+        // Only show "Live" badge when actual real-time data arrives,
+        // not on connection open — avoids spurious badge on historical traces.
+        setIsStreaming(true);
 
         // Merge into React Query cache
         queryClient.setQueryData<TraceDetail>(

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -3,11 +3,11 @@
 import { useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Span, TraceDetail } from "@/types/api";
+import { enrichSpansWithPending } from "../utils";
 
 /**
  * Merge incoming spans into existing spans array.
- * Incoming spans replace existing ones with the same span_id (they may have updated fields
- * like span_end_time or output). New spans are appended.
+ * Incoming spans replace existing ones with the same span_id — real spans replace placeholders.
  */
 function mergeSpans(existing: Span[], incoming: Span[]): Span[] {
   const incomingIds = new Set(incoming.map((s) => s.span_id));
@@ -51,16 +51,14 @@ export function useTraceStream(
 
         if (newSpans.length === 0) return;
 
-        // Only show "Live" badge when actual real-time data arrives,
-        // not on connection open — avoids spurious badge on historical traces.
         setIsStreaming(true);
 
-        // Merge into React Query cache
         queryClient.setQueryData<TraceDetail>(["trace", projectId, traceId], (prev) => {
           if (!prev) return prev;
+          const merged = mergeSpans(prev.spans, newSpans);
           return {
             ...prev,
-            spans: mergeSpans(prev.spans, newSpans),
+            spans: enrichSpansWithPending(merged),
           };
         });
       } catch {
@@ -78,7 +76,6 @@ export function useTraceStream(
     });
 
     es.onerror = () => {
-      // EventSource auto-reconnects on error; just update UI state
       setIsStreaming(false);
     };
 

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -56,16 +56,13 @@ export function useTraceStream(
         setIsStreaming(true);
 
         // Merge into React Query cache
-        queryClient.setQueryData<TraceDetail>(
-          ["trace", projectId, traceId],
-          (prev) => {
-            if (!prev) return prev;
-            return {
-              ...prev,
-              spans: mergeSpans(prev.spans, newSpans),
-            };
-          },
-        );
+        queryClient.setQueryData<TraceDetail>(["trace", projectId, traceId], (prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            spans: mergeSpans(prev.spans, newSpans),
+          };
+        });
       } catch {
         // Ignore malformed events
       }

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { Span, TraceDetail } from "@/types/api";
+
+/**
+ * Merge incoming spans into existing spans array.
+ * Incoming spans replace existing ones with the same span_id (they may have updated fields
+ * like span_end_time or output). New spans are appended.
+ */
+function mergeSpans(existing: Span[], incoming: Span[]): Span[] {
+  const incomingIds = new Set(incoming.map((s) => s.span_id));
+  return [...existing.filter((s) => !incomingIds.has(s.span_id)), ...incoming];
+}
+
+interface UseTraceStreamResult {
+  isStreaming: boolean;
+}
+
+/**
+ * Hook that connects to the live trace SSE endpoint and merges incoming spans
+ * into the React Query cache for the trace detail.
+ *
+ * When new spans arrive via SSE, the existing useQuery data for
+ * ["trace", projectId, traceId] is updated in-place, causing SpanTreeView
+ * and SpanInfoPanel to re-render automatically.
+ */
+export function useTraceStream(
+  projectId: string,
+  traceId: string,
+  enabled: boolean,
+): UseTraceStreamResult {
+  const queryClient = useQueryClient();
+  const [isStreaming, setIsStreaming] = useState(false);
+  const eventSourceRef = useRef<EventSource | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !projectId || !traceId) {
+      return;
+    }
+
+    const url = `/api/projects/${projectId}/traces/${traceId}/live`;
+    const es = new EventSource(url);
+    eventSourceRef.current = es;
+
+    es.onopen = () => {
+      setIsStreaming(true);
+    };
+
+    es.addEventListener("spans", (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        const newSpans: Span[] = data.spans ?? [];
+
+        if (newSpans.length === 0) return;
+
+        // Merge into React Query cache
+        queryClient.setQueryData<TraceDetail>(
+          ["trace", projectId, traceId],
+          (prev) => {
+            if (!prev) return prev;
+            return {
+              ...prev,
+              spans: mergeSpans(prev.spans, newSpans),
+            };
+          },
+        );
+      } catch {
+        // Ignore malformed events
+      }
+    });
+
+    es.addEventListener("trace_complete", () => {
+      setIsStreaming(false);
+      es.close();
+      eventSourceRef.current = null;
+
+      // Refetch to get the final consistent state from ClickHouse
+      queryClient.invalidateQueries({ queryKey: ["trace", projectId, traceId] });
+    });
+
+    es.onerror = () => {
+      // EventSource auto-reconnects on error; just update UI state
+      setIsStreaming(false);
+    };
+
+    return () => {
+      es.close();
+      eventSourceRef.current = null;
+      setIsStreaming(false);
+    };
+  }, [projectId, traceId, enabled, queryClient]);
+
+  return { isStreaming };
+}

--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from "vitest";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { Span } from "@/types/api";
+import { enrichSpansWithPending } from "./index";
+
+// Minimal span factory — only fields relevant to enrichSpansWithPending.
+function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
+  return {
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: overrides.span_id,
+    span_kind: SpanKind.SPAN,
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:01.000Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    input: null,
+    output: null,
+    metadata: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...overrides,
+  };
+}
+
+function metadataWith(idsPath: string[], namePath: string[]): string {
+  return JSON.stringify({
+    "traceroot.span.ids_path": idsPath,
+    "traceroot.span.path": namePath,
+  });
+}
+
+describe("enrichSpansWithPending", () => {
+  it("returns empty array unchanged", () => {
+    expect(enrichSpansWithPending([])).toEqual([]);
+  });
+
+  it("returns root-only trace unchanged (no metadata, no parent)", () => {
+    const root = makeSpan({ span_id: "root" });
+    const result = enrichSpansWithPending([root]);
+    expect(result).toHaveLength(1);
+    expect(result[0].pending).toBeFalsy();
+  });
+
+  it("creates a placeholder for a missing direct parent", () => {
+    // child knows its parent is 'parent-id' but parent hasn't arrived yet
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: "parent-id",
+      metadata: metadataWith(["parent-id"], ["parent-name", "child"]),
+    });
+
+    const result = enrichSpansWithPending([child]);
+    const placeholder = result.find((s) => s.span_id === "parent-id");
+
+    expect(placeholder).toBeDefined();
+    expect(placeholder!.pending).toBe(true);
+    expect(placeholder!.name).toBe("parent-name");
+    expect(placeholder!.parent_span_id).toBeNull();
+  });
+
+  it("creates placeholders for all missing ancestors (regression: demo_session + agent_turn gap)", () => {
+    // Simulates the exact race condition: first SSE batch arrives with a deeply
+    // nested span but root (demo_session) and intermediate (agent_turn) are missing.
+    const rootId = "demo-session-id";
+    const midId = "agent-turn-id";
+    const child = makeSpan({
+      span_id: "llm-completion",
+      parent_span_id: midId,
+      metadata: metadataWith([rootId, midId], ["demo_session", "agent_turn", "llm_completion"]),
+    });
+
+    const result = enrichSpansWithPending([child]);
+    const ids = result.map((s) => s.span_id);
+
+    expect(ids).toContain(rootId);
+    expect(ids).toContain(midId);
+    expect(result.find((s) => s.span_id === rootId)!.pending).toBe(true);
+    expect(result.find((s) => s.span_id === midId)!.pending).toBe(true);
+    expect(result.find((s) => s.span_id === midId)!.parent_span_id).toBe(rootId);
+  });
+
+  it("does not create duplicate placeholders when multiple spans share ancestors", () => {
+    const rootId = "root-id";
+    const child1 = makeSpan({
+      span_id: "child-1",
+      parent_span_id: rootId,
+      metadata: metadataWith([rootId], ["root", "child-1"]),
+    });
+    const child2 = makeSpan({
+      span_id: "child-2",
+      parent_span_id: rootId,
+      metadata: metadataWith([rootId], ["root", "child-2"]),
+    });
+
+    const result = enrichSpansWithPending([child1, child2]);
+    const rootPlaceholders = result.filter((s) => s.span_id === rootId);
+
+    expect(rootPlaceholders).toHaveLength(1);
+  });
+
+  it("does not create a placeholder when the parent is already present", () => {
+    const parent = makeSpan({ span_id: "parent" });
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: "parent",
+      metadata: metadataWith(["parent"], ["parent", "child"]),
+    });
+
+    const result = enrichSpansWithPending([parent, child]);
+    expect(result.filter((s) => s.pending)).toHaveLength(0);
+  });
+
+  it("replaces an existing pending span with updated start_time when a child with earlier start arrives", () => {
+    const placeholderId = "mid-id";
+    const existingPending = makeSpan({
+      span_id: placeholderId,
+      span_start_time: "2024-01-01T00:00:05.000Z",
+      pending: true,
+    });
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: placeholderId,
+      span_start_time: "2024-01-01T00:00:01.000Z",
+      metadata: metadataWith([placeholderId], ["mid", "child"]),
+    });
+
+    const result = enrichSpansWithPending([existingPending, child]);
+    const updated = result.find((s) => s.span_id === placeholderId)!;
+
+    expect(updated.span_start_time).toBe("2024-01-01T00:00:01.000Z");
+  });
+
+  it("does not backdate a pending span if existing start_time is already earlier", () => {
+    const placeholderId = "mid-id";
+    const existingPending = makeSpan({
+      span_id: placeholderId,
+      span_start_time: "2024-01-01T00:00:01.000Z",
+      pending: true,
+    });
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: placeholderId,
+      span_start_time: "2024-01-01T00:00:05.000Z",
+      metadata: metadataWith([placeholderId], ["mid", "child"]),
+    });
+
+    const result = enrichSpansWithPending([existingPending, child]);
+    const updated = result.find((s) => s.span_id === placeholderId)!;
+
+    expect(updated.span_start_time).toBe("2024-01-01T00:00:01.000Z");
+  });
+
+  it("skips spans with no metadata or missing ids_path", () => {
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: "missing-parent",
+      metadata: null,
+    });
+
+    const result = enrichSpansWithPending([child]);
+    expect(result.filter((s) => s.pending)).toHaveLength(0);
+  });
+
+  it("strips existing pending spans from the real spans list before merging", () => {
+    // If a real span arrives to replace a pending placeholder, the pending one
+    // should not appear in the output alongside the real one.
+    const realSpan = makeSpan({ span_id: "s1", pending: false });
+    const pendingSpan = makeSpan({ span_id: "s1", pending: true });
+
+    const result = enrichSpansWithPending([pendingSpan, realSpan]);
+    const s1s = result.filter((s) => s.span_id === "s1");
+
+    expect(s1s).toHaveLength(1);
+    expect(s1s[0].pending).toBeFalsy();
+  });
+});

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -1,9 +1,94 @@
 /**
  * Trace feature utilities
  */
-import { SpanStatus } from "@traceroot/core";
+import { SpanKind, SpanStatus } from "@traceroot/core";
 import type { Span, TraceDetail } from "@/types/api";
 import type { SpanTreeRow } from "../types";
+
+function parseMetadata(metadata: string | null): Record<string, unknown> {
+  if (!metadata) return {};
+  try {
+    return JSON.parse(metadata) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * For every span that carries traceroot.span.ids_path (ancestor IDs, root→parent)
+ * and traceroot.span.path (root→current names) in its metadata, create lightweight
+ * placeholder spans for any missing ancestors.
+ *
+ * Works for both live SSE streaming AND completed traces loaded from ClickHouse,
+ * because both carry the same metadata JSON.
+ */
+export function enrichSpansWithPending(spans: Span[]): Span[] {
+  const existingSpanIds = new Set(spans.map((s) => s.span_id));
+  const pendingSpans = new Map<string, Span>();
+
+  for (const span of spans) {
+    if (span.pending) pendingSpans.set(span.span_id, span);
+  }
+
+  for (const span of spans) {
+    if (!span.parent_span_id) continue;
+
+    const meta = parseMetadata(span.metadata);
+    const idsPath = meta["traceroot.span.ids_path"] as string[] | undefined;
+    const namePath = meta["traceroot.span.path"] as string[] | undefined;
+
+    if (!idsPath || !namePath || idsPath.length === 0) continue;
+    const ancestorNames = namePath.slice(0, -1);
+    if (idsPath.length !== ancestorNames.length) continue;
+
+    for (let i = 0; i < idsPath.length; i++) {
+      const spanId = idsPath[i];
+      const spanName = ancestorNames[i];
+
+      if (existingSpanIds.has(spanId) && !pendingSpans.has(spanId)) continue;
+
+      if (pendingSpans.has(spanId)) {
+        const existing = pendingSpans.get(spanId)!;
+        const existStart = new Date(existing.span_start_time).getTime();
+        const curStart = new Date(span.span_start_time).getTime();
+        if (curStart < existStart) {
+          pendingSpans.set(spanId, { ...existing, span_start_time: span.span_start_time });
+        }
+        continue;
+      }
+
+      const parentId = i > 0 ? idsPath[i - 1] : null;
+      pendingSpans.set(spanId, {
+        span_id: spanId,
+        trace_id: span.trace_id,
+        parent_span_id: parentId,
+        name: spanName,
+        span_kind: SpanKind.SPAN,
+        span_start_time: span.span_start_time,
+        span_end_time: null,
+        status: SpanStatus.OK,
+        status_message: null,
+        model_name: null,
+        cost: null,
+        input_tokens: null,
+        output_tokens: null,
+        total_tokens: null,
+        input: null,
+        output: null,
+        metadata: null,
+        git_source_file: null,
+        git_source_line: null,
+        git_source_function: null,
+        pending: true,
+      });
+    }
+  }
+
+  const nonPendingSpans = spans.filter((s) => !s.pending);
+  const nonPendingIds = new Set(nonPendingSpans.map((s) => s.span_id));
+  const newPending = [...pendingSpans.values()].filter((s) => !nonPendingIds.has(s.span_id));
+  return [...nonPendingSpans, ...newPending];
+}
 
 // Layout constants for tree alignment
 export const TREE_LAYOUT = {
@@ -22,16 +107,26 @@ export function getSpanDuration(span: Span): number | null {
 }
 
 /**
- * Calculate trace duration from all spans
+ * Calculate trace duration from all spans.
+ * Langfuse-aligned: prefer root span's own start/end to avoid skew from
+ * child spans with bad timestamps (e.g. LangGraph task spans).
+ * Falls back to trace_start_time anchor + max real child end time.
  */
 export function getTraceDuration(trace: TraceDetail): number | null {
   if (!trace.spans.length) return null;
-  const startTimes = trace.spans.map((s) => new Date(s.span_start_time).getTime());
+  const rootSpan = trace.spans.find((s) => s.parent_span_id === null && !s.pending);
+  if (rootSpan?.span_end_time) {
+    return (
+      new Date(rootSpan.span_end_time).getTime() - new Date(rootSpan.span_start_time).getTime()
+    );
+  }
+  const anchorMs = new Date(trace.trace_start_time).getTime();
   const endTimes = trace.spans
-    .filter((s) => s.span_end_time)
-    .map((s) => new Date(s.span_end_time!).getTime());
+    .filter((s) => s.span_end_time && !s.pending)
+    .map((s) => new Date(s.span_end_time!).getTime())
+    .filter((t) => t > anchorMs);
   if (!endTimes.length) return null;
-  return Math.max(...endTimes) - Math.min(...startTimes);
+  return Math.max(...endTimes) - anchorMs;
 }
 
 /**
@@ -47,6 +142,14 @@ export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
     childrenByParent.get(pid)!.push(span);
   });
 
+  // Sort children within each parent by start_time so connector lines
+  // (isTerminal / parentLevels) are stable regardless of SSE arrival order.
+  for (const children of childrenByParent.values()) {
+    children.sort(
+      (a, b) => new Date(a.span_start_time).getTime() - new Date(b.span_start_time).getTime(),
+    );
+  }
+
   const rows: SpanTreeRow[] = [];
 
   function traverse(span: Span, level: number, isTerminal: boolean, parentLevels: number[]) {
@@ -59,23 +162,17 @@ export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
     });
   }
 
-  // Start with true root spans (parent_span_id === null)
-  const roots = childrenByParent.get(null) || [];
-  roots.forEach((root, idx) => {
-    traverse(root, 0, idx === roots.length - 1, []);
+  // Combine true roots with orphan spans (parent not yet arrived) into a single
+  // top-level list sorted by start_time. This ensures:
+  // 1. Connector lines are correct across all top-level items.
+  // 2. Orphans are always visible, not silently dropped when root exists.
+  const orphans = spans.filter((s) => s.parent_span_id !== null && !spanIds.has(s.parent_span_id));
+  const topLevel = [...(childrenByParent.get(null) ?? []), ...orphans].sort(
+    (a, b) => new Date(a.span_start_time).getTime() - new Date(b.span_start_time).getTime(),
+  );
+  topLevel.forEach((span, idx) => {
+    traverse(span, 0, idx === topLevel.length - 1, []);
   });
-
-  // Handle orphan spans whose parent hasn't arrived yet (live streaming).
-  // Spans whose parent_span_id is set but not present in the current span list
-  // are treated as temporary roots so they still appear in the tree.
-  if (roots.length === 0) {
-    const orphans = spans.filter(
-      (s) => s.parent_span_id !== null && !spanIds.has(s.parent_span_id),
-    );
-    orphans.forEach((orphan, idx) => {
-      traverse(orphan, 0, idx === orphans.length - 1, []);
-    });
-  }
 
   return rows;
 }
@@ -123,7 +220,9 @@ export function formatContentPreview(text: string | null): string {
  * Calculate total cost from all spans in a trace
  */
 export function getTraceTotalCost(trace: TraceDetail): number | null {
-  const costs = trace.spans.filter((s) => s.cost !== null).map((s) => s.cost!);
+  const costs = trace.spans
+    .filter((s) => s.cost != null && Number.isFinite(s.cost))
+    .map((s) => s.cost!);
   if (costs.length === 0) return null;
   return costs.reduce((sum, cost) => sum + cost, 0);
 }

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -39,6 +39,8 @@ export function getTraceDuration(trace: TraceDetail): number | null {
  */
 export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
   const childrenByParent = new Map<string | null, Span[]>();
+  const spanIds = new Set(spans.map((s) => s.span_id));
+
   spans.forEach((span) => {
     const pid = span.parent_span_id;
     if (!childrenByParent.has(pid)) childrenByParent.set(pid, []);
@@ -57,10 +59,23 @@ export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
     });
   }
 
+  // Start with true root spans (parent_span_id === null)
   const roots = childrenByParent.get(null) || [];
   roots.forEach((root, idx) => {
     traverse(root, 0, idx === roots.length - 1, []);
   });
+
+  // Handle orphan spans whose parent hasn't arrived yet (live streaming).
+  // Spans whose parent_span_id is set but not present in the current span list
+  // are treated as temporary roots so they still appear in the tree.
+  if (roots.length === 0) {
+    const orphans = spans.filter(
+      (s) => s.parent_span_id !== null && !spanIds.has(s.parent_span_id),
+    );
+    orphans.forEach((orphan, idx) => {
+      traverse(orphan, 0, idx === orphans.length - 1, []);
+    });
+  }
 
   return rows;
 }

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -125,6 +125,7 @@ export interface Span {
   git_source_file: string | null;
   git_source_line: number | null;
   git_source_function: string | null;
+  pending?: boolean;
 }
 
 export interface TraceDetail {

--- a/tests/rest/test_live_router.py
+++ b/tests/rest/test_live_router.py
@@ -1,0 +1,192 @@
+"""Unit tests for the live trace SSE streaming endpoint.
+
+All tests mock ClickHouse and Redis — no external services needed.
+
+Key invariants under test:
+- Already-complete traces emit trace_complete immediately (regression for the
+  Celery concurrency race condition where demo_session arrived in ClickHouse
+  before sibling spans, causing the old frontend isTraceComplete gate to
+  disable SSE entirely).
+- Redis subscription happens BEFORE the ClickHouse check so no concurrent
+  span events are missed.
+- Concurrent span events queued in Redis during the ClickHouse check are
+  forwarded before trace_complete on the already-complete path.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from rest.routers.deps import ProjectAccessInfo, get_project_access
+
+PROJECT_ID = "project-123"
+TRACE_ID = "trace-abc"
+ENDPOINT = f"/api/v1/projects/{PROJECT_ID}/traces/{TRACE_ID}/live"
+
+
+class MockPubSub:
+    """Async pubsub that yields a fixed sequence of messages then returns None."""
+
+    def __init__(self, messages: list):
+        self._messages = list(messages)
+        self._idx = 0
+        self.subscribe = AsyncMock()
+        self.unsubscribe = AsyncMock()
+        self.close = AsyncMock()
+
+    async def get_message(self, *, ignore_subscribe_messages=True, timeout=0):
+        if self._idx < len(self._messages):
+            msg = self._messages[self._idx]
+            self._idx += 1
+            return msg
+        return None
+
+
+def redis_message(payload: dict) -> dict:
+    return {"type": "message", "data": json.dumps(payload)}
+
+
+@pytest.fixture()
+def client():
+    async def mock_access(project_id: str, x_user_id=None):
+        return ProjectAccessInfo(project_id=project_id, user_id="u1", role="ADMIN")
+
+    app.dependency_overrides[get_project_access] = mock_access
+    yield TestClient(app)
+
+
+def parse_sse_events(text: str) -> list[str]:
+    """Return all `event: X` lines from an SSE response body."""
+    return [line for line in text.splitlines() if line.startswith("event:")]
+
+
+class TestAlreadyCompleteTrace:
+    def test_emits_trace_complete_immediately(self, client):
+        """Regression: when ClickHouse has a root span with end_time, the endpoint
+        must emit trace_complete without waiting — prevents the case where the old
+        isTraceComplete frontend gate would disable SSE and leave the tree broken."""
+        pubsub = MockPubSub([])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        with (
+            patch("rest.routers.live._is_trace_complete_in_clickhouse", return_value=True),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        assert resp.status_code == 200
+        events = parse_sse_events(resp.text)
+        assert events == ["event: trace_complete"]
+
+    def test_drains_concurrent_redis_spans_before_trace_complete(self, client):
+        """Spans published to Redis between subscribe and ClickHouse check must be
+        forwarded to the client before trace_complete is emitted.
+
+        This covers the concurrent-task edge case: Celery worker A publishes spans
+        to Redis while live.py is doing the ClickHouse check — those spans are
+        already in ClickHouse (process_s3_traces writes before publishing), so they
+        must arrive at the client before the final invalidateQueries refetch."""
+        spans_msg = redis_message({"type": "spans", "spans": [{"span_id": "s1"}]})
+        pubsub = MockPubSub([spans_msg])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        with (
+            patch("rest.routers.live._is_trace_complete_in_clickhouse", return_value=True),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events[0] == "event: spans"
+        assert events[-1] == "event: trace_complete"
+
+    def test_does_not_forward_non_span_events_during_drain(self, client):
+        """On the already-complete path, only 'spans' events should be drained from
+        Redis — other event types (e.g. a redundant trace_complete) are skipped so
+        that the client receives exactly one trace_complete."""
+        redundant_complete = redis_message({"type": "trace_complete"})
+        pubsub = MockPubSub([redundant_complete])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        with (
+            patch("rest.routers.live._is_trace_complete_in_clickhouse", return_value=True),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events.count("event: trace_complete") == 1
+
+
+class TestLiveTrace:
+    def test_relays_span_events_then_trace_complete(self, client):
+        """Live traces: Redis span events are forwarded in order, and the stream
+        closes when trace_complete arrives."""
+        spans_msg = redis_message({"type": "spans", "spans": [{"span_id": "s1"}]})
+        complete_msg = redis_message({"type": "trace_complete"})
+        pubsub = MockPubSub([spans_msg, complete_msg])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        with (
+            patch("rest.routers.live._is_trace_complete_in_clickhouse", return_value=False),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events[0] == "event: spans"
+        assert events[-1] == "event: trace_complete"
+
+    def test_multiple_span_batches_before_complete(self, client):
+        """Multiple span batches (from different Celery tasks) are all forwarded."""
+        batch1 = redis_message({"type": "spans", "spans": [{"span_id": "s1"}]})
+        batch2 = redis_message({"type": "spans", "spans": [{"span_id": "s2"}]})
+        complete_msg = redis_message({"type": "trace_complete"})
+        pubsub = MockPubSub([batch1, batch2, complete_msg])
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        with (
+            patch("rest.routers.live._is_trace_complete_in_clickhouse", return_value=False),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            resp = client.get(ENDPOINT)
+
+        events = parse_sse_events(resp.text)
+        assert events.count("event: spans") == 2
+        assert events[-1] == "event: trace_complete"
+
+
+class TestSubscribeBeforeCheckInvariant:
+    def test_redis_subscribe_happens_before_clickhouse_check(self, client):
+        """Verifies the subscribe-first invariant: the Redis subscription must be
+        established before ClickHouse is queried so that concurrent Celery span
+        events published during the check are not missed."""
+        call_order = []
+
+        async def tracked_subscribe(channel):
+            call_order.append("subscribe")
+
+        def tracked_check(project_id, trace_id):
+            call_order.append("clickhouse_check")
+            return True
+
+        pubsub = MockPubSub([])
+        pubsub.subscribe.side_effect = tracked_subscribe
+        mock_redis = MagicMock()
+        mock_redis.pubsub.return_value = pubsub
+
+        with (
+            patch("rest.routers.live._is_trace_complete_in_clickhouse", side_effect=tracked_check),
+            patch("shared.redis.get_async_redis_client", return_value=mock_redis),
+        ):
+            client.get(ENDPOINT)
+
+        assert call_order.index("subscribe") < call_order.index("clickhouse_check")

--- a/tmux_tools/launcher.py
+++ b/tmux_tools/launcher.py
@@ -293,7 +293,9 @@ def make_driver(autoreload=False):
 
     # macOS fork safety — Celery's prefork pool + Redis triggers an Objective-C
     # runtime crash (SIGABRT) unless this is set before the process starts.
-    objc_prefix = "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES " if os.uname().sysname == "Darwin" else ""
+    objc_prefix = (
+        "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES " if os.uname().sysname == "Darwin" else ""
+    )
 
     if autoreload:
         rest_command = (

--- a/tmux_tools/launcher.py
+++ b/tmux_tools/launcher.py
@@ -291,18 +291,23 @@ def infra_services():
 def make_driver(autoreload=False):
     """Full stack: Frontend + REST API + Celery Worker + Infra logs."""
 
+    # macOS fork safety — Celery's prefork pool + Redis triggers an Objective-C
+    # runtime crash (SIGABRT) unless this is set before the process starts.
+    objc_prefix = "OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES " if os.uname().sysname == "Darwin" else ""
+
     if autoreload:
         rest_command = (
             "uv run uvicorn rest.main:app --host 0.0.0.0 --port 8000 --reload --reload-dir backend"
         )
         celery_command = (
+            f"{objc_prefix}"
             "uv run watchfiles --filter python "
             "'celery -A worker.celery_app worker --loglevel=info' "
             "backend/worker"
         )
     else:
         rest_command = "uv run python backend/rest/main.py"
-        celery_command = "uv run celery -A worker.celery_app worker --loglevel=info"
+        celery_command = f"{objc_prefix}uv run celery -A worker.celery_app worker --loglevel=info"
 
     return schema.Driver(
         name="traceroot",


### PR DESCRIPTION
## Summary                                                
                                                                                                                                                                                                                                     
  When a long-running AI agent trace executes over minutes, TraceRoot currently shows nothing until the entire trace completes. This PR adds real-time span streaming so users can watch spans populate as they arrive (~5-10s
  end-to-end latency).                    

  ### Architecture                                                                                                                                                                                                                   
   
  SDK flushes every 5s → Backend REST → S3 → Celery Worker → ClickHouse                                                                                                                                                              
    → [NEW] Redis PUBLISH to trace:live:{project_id}:{trace_id}
      → [NEW] FastAPI SSE endpoint subscribes, streams to browser
        → [NEW] Next.js SSE proxy forwards with auth                                                                                                                                                                                 
          → [NEW] useTraceStream hook merges spans into React Query cache
                                                                                                                                                                                                                                     
  ### Changes                                               
                                                                                                                                                                                                                                     
  **Backend (3 files)**                                     
  - `backend/shared/redis.py` — New Redis client helper (sync + async singletons)                                                                                                                                                    
  - `backend/worker/ingest_tasks.py` — Publish spans to Redis after ClickHouse insert
  - `backend/rest/routers/live.py` — New SSE endpoint (`GET /projects/{pid}/traces/{tid}/live`)                                                                                                                                      
  - `backend/rest/main.py` — Register live router
                                                                                                                                                                                                                                     
  **Frontend (5 files)**                                                                                                                                                                                                             
  - `frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/live/route.ts` — SSE proxy route                                                                                                                                  
  - `frontend/ui/src/features/traces/hooks/use-trace-stream.ts` — EventSource hook, merges spans into React Query cache                                                                                                              
  - `frontend/ui/src/features/traces/components/TraceViewerPanel.tsx` — Pulsing "Live" badge                                                                                                                                         
  - `frontend/ui/src/app/projects/[projectId]/traces/page.tsx` — Auto-refresh toggle (5s polling)
  - `frontend/ui/src/features/traces/hooks/index.ts` — Re-export                                                                                                                                                                     
                                                                                                                                                                                                                                     
  ### Design decisions                                                                                                                                                                                                               
                                                                                                                                                                                                                                     
  - **SSE over WebSocket** — server→client push only, simpler                                                                                                                                                                        
  - **No new infrastructure** — Redis already exists for Celery                                                                                                                                                                      
  - **No schema changes** — just adds Redis PUBLISH after existing ClickHouse inserts                                                                                                                                                
  - **React Query cache merge** — SpanTreeView/SpanInfoPanel re-render automatically with zero changes                                                                                                                               
  - **Redis failures never break ingest** — wrapped in try/except

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)


https://github.com/user-attachments/assets/be0c6aa7-ad40-40c8-a9f7-4bea3e735c62



## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary                                             
