### PR TITLE
docs: update LlamaIndex integration page style

### DIFF
--- a/docs/integrations/llamaindex.mdx
+++ b/docs/integrations/llamaindex.mdx
@@ -7,26 +7,30 @@ Automatically capture document ingestion, embedding, retrieval, and LLM synthesi
 
 ## Setup
 
+To capture the complete picture—including both the pipeline structure and the underlying token costs—we highly recommend initializing both the LlamaIndex integration and your specific LLM provider (e.g., OpenAI, Anthropic, Google GenAI).
+
 ```python
 import traceroot
 from traceroot import Integration
 
-traceroot.initialize(integrations=[Integration.LLAMA_INDEX])
+# Initialize LlamaIndex alongside your LLM provider to capture tokens and costs
+traceroot.initialize(integrations=[
+    Integration.LLAMA_INDEX,
+    Integration.OPENAI  # Or ANTHROPIC, GOOGLE_GENAI, etc.
+])
 ```
-
-Tokens and cost are captured automatically for LLM calls made through LlamaIndex's wrappers (e.g., `llama_index.llms.openai.OpenAI`). If you also make direct API calls outside LlamaIndex, initialize the corresponding provider integration (e.g., `Integration.OPENAI`) alongside `Integration.LLAMA_INDEX` to trace those too.
 
 ## Usage
 
-Once initialized, all LlamaIndex operations are captured automatically.
-
-*Note: The example below uses OpenAI for both the LLM and embeddings (LlamaIndex's default). It requires `pip install llama-index-llms-openai llama-index-embeddings-openai` and `OPENAI_API_KEY` in your environment. Swap in any other provider (Anthropic, Gemini, local models) as needed.*
+Once initialized, all LlamaIndex operations are captured automatically:
 
 ```python
 from llama_index.core import Document, Settings, VectorStoreIndex
 from llama_index.llms.openai import OpenAI
+from llama_index.embeddings.openai import OpenAIEmbedding
 
 Settings.llm = OpenAI(model="gpt-4o-mini")
+Settings.embed_model = OpenAIEmbedding(model="text-embedding-3-small")
 
 documents = [
     Document(text="TraceRoot is an open-source observability platform for AI agents."),
@@ -52,7 +56,3 @@ print(response)
 | LLM synthesis | Response generation with context and final answer |
 | Tokens & Cost | Input/output tokens and calculated cost per LLM call |
 | Latency | Duration of each pipeline stage |
-
-## Full Example
-
-See [`examples/python/llamaindex-rag`](https://github.com/traceroot-ai/traceroot/tree/main/examples/python/llamaindex-rag) for a complete runnable RAG pipeline with multiple documents, demo queries, `@observe` decoration, and `using_attributes` session/user tracking.


### PR DESCRIPTION
## Summary
- Recommends initializing both `Integration.LLAMA_INDEX` and an LLM provider (mirrors AutoGen/LangChain pattern)
- Removes awkward italic note before code example; adds explicit `embed_model` setting for completeness
- Removes one-off "Full Example" section not present in other integration docs

## Test plan
- [x] Review rendered doc at `/docs/integrations/llamaindex`
- [x] Verify style is consistent with AutoGen and LangChain pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)