### PR TITLE
feat: add Kimi K2.6 to BYOK model catalog

### DIFF
--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -167,6 +167,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "grok-4", label: "grok-4" },
   ],
   moonshot: [
+    { id: "kimi-k2.6", label: "kimi-k2.6" },
     { id: "kimi-k2.5", label: "kimi-k2.5" },
     { id: "kimi-k2-thinking", label: "kimi-k2-thinking" },
   ],


### PR DESCRIPTION
Closes issue #702 

## Summary
 Moonshot released Kimi K2.6 in April 2026 as the new flagship Kimi model (https://kimi.com/blog/kimi-k2-6,  
  https://platform.kimi.ai/docs/guide/kimi-k2-6-quickstart). Traceroot's curated model dropdown (`ADAPTER_MODELS.moonshot`) did not list it, so BYOK users couldn't pick it from Settings -> Model Providers -> Moonshot without falling back to the `(Unsupported)` path from #610.

## Type of Change
  - [x] feat - A new feature

## Details
`frontend/packages/core/src/llm-providers.ts`
  - One entry added to `ADAPTER_MODELS.moonshot` (line 170): `{ id: "kimi-k2.6", label: "kimi-k2.6" }`.
  - Positioned at index 0, continuing the newest-first ordering already used for `kimi-k2.5` and `kimi-k2-thinking`. This       promotes K2.6 to the default-selected model on "Add Provider >  Moonshot" — consistent with how Opus 4.7 became the default Anthropic model in #691.
  - `label` equals `id`, following the convention established in #627.
  - No `apiProtocol` override needed — `kimi-k2.6` inherits `openai-completions` from `ADAPTER_API_PROTOCOL["moonshot"]` (line 60), matching Moonshot's OpenAI-compatible API at `https://api.moonshot.ai/v1`.

  No changes to `SYSTEM_MODELS`, `PROVIDER_PRIORITY`, `docs/integrations/internal-models.mdx`, or the provider-test   
route — Moonshot is BYOK-only and is not listed in the system-models docs table, so the scope is a single-file, one-line insertion (smaller than #691).
## Screenshots / Recordings (if applicable)
<img width="1135" height="820" alt="702PR" src="https://github.com/user-attachments/assets/b5b82841-9762-4614-a1a5-da3145d2299f" /> Local dropdown behavior verified against the built web container.
[Help Wanted] I don't have an active Moonshot API key and would need extra help to e2e test `kimi-k2.6` chat completions in production.

## Checklist
  - [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)     
  - [x] I have added/updated tests where applicable
  - [ ] I have added screenshots or recordings for UI changes (if 
  applicable)
  - [x] I have updated documentation where necessary

