### PR TITLE
UI: Replace italic styling with grey background for in-progress spans and traces

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -253,7 +253,11 @@ export default function TracesPage() {
                         }}
                         className={cn(
                           "cursor-pointer border-b border-border/50 transition-colors last:border-0",
-                          selectedTraceId === trace.trace_id ? "bg-muted" : "hover:bg-muted/50",
+                          selectedTraceId === trace.trace_id
+                            ? "bg-muted"
+                            : trace.duration_ms === null
+                              ? "bg-muted/30 hover:bg-muted/50"
+                              : "hover:bg-muted/50",
                         )}
                       >
                         <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -253,11 +253,7 @@ export default function TracesPage() {
                         }}
                         className={cn(
                           "cursor-pointer border-b border-border/50 transition-colors last:border-0",
-                          selectedTraceId === trace.trace_id
-                            ? "bg-muted"
-                            : trace.duration_ms === null
-                              ? "bg-muted/30 hover:bg-muted/50"
-                              : "hover:bg-muted/50",
+                          selectedTraceId === trace.trace_id ? "bg-muted" : "hover:bg-muted/50",
                         )}
                       >
                         <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -81,9 +81,7 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
       <div
         className={cn(
           "flex cursor-pointer items-center rounded-sm transition-colors",
-          isTraceSelected
-            ? "bg-muted"
-            : "hover:bg-muted/50",
+          isTraceSelected ? "bg-muted" : "hover:bg-muted/50",
         )}
         style={{ height: TREE_LAYOUT.ROW_HEIGHT, paddingLeft: TREE_LAYOUT.LEFT_PADDING }}
         onClick={() => onSelect({ type: "trace" })}
@@ -91,10 +89,7 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
         <div className="flex min-w-0 flex-1 items-center gap-1.5 pr-2">
           <SpanKindIcon kind="trace" inTree />
           <span
-            className={cn(
-              "truncate text-xs",
-              traceDuration === null && "text-muted-foreground/60",
-            )}
+            className={cn("truncate text-xs", traceDuration === null && "text-muted-foreground/60")}
           >
             {trace.name}
           </span>
@@ -157,9 +152,7 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
               key={span.span_id}
               className={cn(
                 "flex cursor-pointer items-center rounded-r-sm pr-2 transition-colors",
-                isSelected
-                  ? "bg-muted"
-                  : "hover:bg-muted/50",
+                isSelected ? "bg-muted" : "hover:bg-muted/50",
               )}
               style={{ height: TREE_LAYOUT.ROW_HEIGHT }}
               onClick={() => onSelect({ type: "span", span })}
@@ -172,10 +165,7 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
               <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <SpanKindIcon kind={span.span_kind} inTree />
                 <span
-                  className={cn(
-                    "truncate text-xs",
-                    span.pending && "text-muted-foreground/60",
-                  )}
+                  className={cn("truncate text-xs", span.pending && "text-muted-foreground/60")}
                 >
                   {span.name}
                 </span>

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -70,6 +70,12 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
   const spanRows = buildSpanTree(spans);
   const isTraceSelected = selection.type === "trace";
   const traceDuration = getTraceDuration(trace);
+  const traceBgClass = isTraceSelected
+    ? "bg-muted"
+    : traceDuration === null
+      ? "bg-muted/30 hover:bg-muted/50"
+      : "hover:bg-muted/50";
+
   const traceTotalCost = getTraceTotalCost(trace);
   const traceTokenUsage = getTraceTokenUsage(trace);
   const traceHasChildren = hasChildren(null);
@@ -81,7 +87,7 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
       <div
         className={cn(
           "flex cursor-pointer items-center rounded-sm transition-colors",
-          isTraceSelected ? "bg-muted" : "hover:bg-muted/50",
+          traceBgClass,
         )}
         style={{ height: TREE_LAYOUT.ROW_HEIGHT, paddingLeft: TREE_LAYOUT.LEFT_PADDING }}
         onClick={() => onSelect({ type: "trace" })}
@@ -138,6 +144,11 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
           if (!isVisible(span)) return null;
 
           const isSelected = selection.type === "span" && selection.span.span_id === span.span_id;
+          const spanBgClass = isSelected
+            ? "bg-muted"
+            : span.pending
+              ? "bg-muted/30 hover:bg-muted/50"
+              : "hover:bg-muted/50";
           const adjustedLevel = level + 1;
           const adjustedParentLevels = parentLevels.map((l) => l + 1);
           const spanHasChildren = hasChildren(span.span_id);
@@ -148,7 +159,7 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
               key={span.span_id}
               className={cn(
                 "flex cursor-pointer items-center rounded-r-sm pr-2 transition-colors",
-                isSelected ? "bg-muted" : "hover:bg-muted/50",
+                spanBgClass,
               )}
               style={{ height: TREE_LAYOUT.ROW_HEIGHT }}
               onClick={() => onSelect({ type: "span", span })}

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -83,16 +83,16 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
           "flex cursor-pointer items-center rounded-sm transition-colors",
           isTraceSelected
             ? "bg-muted"
-            : traceDuration === null
-              ? "bg-muted/30 hover:bg-muted/50"
-              : "hover:bg-muted/50",
+            : "hover:bg-muted/50",
         )}
         style={{ height: TREE_LAYOUT.ROW_HEIGHT, paddingLeft: TREE_LAYOUT.LEFT_PADDING }}
         onClick={() => onSelect({ type: "trace" })}
       >
         <div className="flex min-w-0 flex-1 items-center gap-1.5 pr-2">
           <SpanKindIcon kind="trace" inTree />
-          <span className="truncate text-xs">{trace.name}</span>
+          <span className={cn("truncate text-xs", traceDuration === null && "text-muted-foreground/60")}>
+            {trace.name}
+          </span>
           <span className="whitespace-nowrap font-mono text-[10px] text-muted-foreground">
             {formatDuration(traceDuration)}
           </span>
@@ -154,9 +154,7 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
                 "flex cursor-pointer items-center rounded-r-sm pr-2 transition-colors",
                 isSelected
                   ? "bg-muted"
-                  : span.pending
-                    ? "bg-muted/30 hover:bg-muted/50"
-                    : "hover:bg-muted/50",
+                  : "hover:bg-muted/50",
               )}
               style={{ height: TREE_LAYOUT.ROW_HEIGHT }}
               onClick={() => onSelect({ type: "span", span })}

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -90,7 +90,12 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
       >
         <div className="flex min-w-0 flex-1 items-center gap-1.5 pr-2">
           <SpanKindIcon kind="trace" inTree />
-          <span className={cn("truncate text-xs", traceDuration === null && "text-muted-foreground/60")}>
+          <span
+            className={cn(
+              "truncate text-xs",
+              traceDuration === null && "text-muted-foreground/60",
+            )}
+          >
             {trace.name}
           </span>
           <span className="whitespace-nowrap font-mono text-[10px] text-muted-foreground">
@@ -166,7 +171,12 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
               />
               <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <SpanKindIcon kind={span.span_kind} inTree />
-                <span className={cn("truncate text-xs", span.pending && "text-muted-foreground/60")}>
+                <span
+                  className={cn(
+                    "truncate text-xs",
+                    span.pending && "text-muted-foreground/60",
+                  )}
+                >
                   {span.name}
                 </span>
                 {!span.pending && (

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -70,12 +70,6 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
   const spanRows = buildSpanTree(spans);
   const isTraceSelected = selection.type === "trace";
   const traceDuration = getTraceDuration(trace);
-  const traceBgClass = isTraceSelected
-    ? "bg-muted"
-    : traceDuration === null
-      ? "bg-muted/30 hover:bg-muted/50"
-      : "hover:bg-muted/50";
-
   const traceTotalCost = getTraceTotalCost(trace);
   const traceTokenUsage = getTraceTokenUsage(trace);
   const traceHasChildren = hasChildren(null);
@@ -87,7 +81,11 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
       <div
         className={cn(
           "flex cursor-pointer items-center rounded-sm transition-colors",
-          traceBgClass,
+          isTraceSelected
+            ? "bg-muted"
+            : traceDuration === null
+              ? "bg-muted/30 hover:bg-muted/50"
+              : "hover:bg-muted/50",
         )}
         style={{ height: TREE_LAYOUT.ROW_HEIGHT, paddingLeft: TREE_LAYOUT.LEFT_PADDING }}
         onClick={() => onSelect({ type: "trace" })}
@@ -144,11 +142,6 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
           if (!isVisible(span)) return null;
 
           const isSelected = selection.type === "span" && selection.span.span_id === span.span_id;
-          const spanBgClass = isSelected
-            ? "bg-muted"
-            : span.pending
-              ? "bg-muted/30 hover:bg-muted/50"
-              : "hover:bg-muted/50";
           const adjustedLevel = level + 1;
           const adjustedParentLevels = parentLevels.map((l) => l + 1);
           const spanHasChildren = hasChildren(span.span_id);
@@ -159,7 +152,11 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
               key={span.span_id}
               className={cn(
                 "flex cursor-pointer items-center rounded-r-sm pr-2 transition-colors",
-                spanBgClass,
+                isSelected
+                  ? "bg-muted"
+                  : span.pending
+                    ? "bg-muted/30 hover:bg-muted/50"
+                    : "hover:bg-muted/50",
               )}
               style={{ height: TREE_LAYOUT.ROW_HEIGHT }}
               onClick={() => onSelect({ type: "span", span })}
@@ -171,12 +168,7 @@ export function SpanTreeView({ trace, selection, onSelect }: SpanTreeViewProps) 
               />
               <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <SpanKindIcon kind={span.span_kind} inTree />
-                <span
-                  className={cn(
-                    "truncate text-xs",
-                    span.pending && "italic text-muted-foreground/60",
-                  )}
-                >
+                <span className={cn("truncate text-xs", span.pending && "text-muted-foreground/60")}>
                   {span.name}
                 </span>
                 {!span.pending && (


### PR DESCRIPTION
Fixes #706 

## Summary
This PR replaces the italic typography with a subtle grey background (bg-muted/30) for all in-progress items. This approach is more consistent with standard UI patterns for "pending" states and ensures that ongoing traces and spans are immediately identifiable without relying on typographic tricks.

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [x] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
1. **Traces Table:** Applied a subtle grey background to rows where the trace is still in progress (duration is null).
2. **Span Tree View:** 
- Removed italic styling from the names of pending spans.
- Applied the grey background to both the root trace row and individual pending span rows.
3. **State Management:** Updated the conditional styling to ensure that in-progress backgrounds layer correctly with hover and selected states.

## Screenshots / Recordings (if applicable)
<img width="1919" height="1027" alt="image" src="https://github.com/user-attachments/assets/87434128-00a1-4488-a6a2-6ea1bd4ad081" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
