### PR TITLE
fix: abbreviate large token counts in sessions and users tables

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
@@ -11,7 +11,7 @@ import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { SessionDetailPanel } from "@/features/traces/components/SessionDetailPanel";
 import { useSessions, useListPageState } from "@/features/traces/hooks";
-import { formatDate, formatCost, cn, buildUrlWithFilters } from "@/lib/utils";
+import { formatDate, formatCost, formatTokens, cn, buildUrlWithFilters } from "@/lib/utils";
 import type { SessionListItem, SessionQueryOptions } from "@/types/api";
 
 const tabs = [
@@ -19,12 +19,6 @@ const tabs = [
   { id: "users", label: "Users", icon: Users, href: "users" },
   { id: "sessions", label: "Sessions", icon: Layers, href: "sessions" },
 ];
-
-function formatTokens(session: SessionListItem): string {
-  const input = session.total_input_tokens ?? 0;
-  const output = session.total_output_tokens ?? 0;
-  return input + output > 0 ? `${input.toLocaleString()} / ${output.toLocaleString()}` : "-";
-}
 
 function getTotalCost(session: SessionListItem): number | null {
   return session.total_cost ?? null;
@@ -192,7 +186,17 @@ export default function SessionsPage() {
                           {session.user_ids.length > 0 ? session.user_ids.join(", ") : "-"}
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
-                          {formatTokens(session)}
+                          {(session.total_input_tokens ?? 0) + (session.total_output_tokens ?? 0) >
+                          0 ? (
+                            <span
+                              title={`${(session.total_input_tokens ?? 0).toLocaleString()} / ${(session.total_output_tokens ?? 0).toLocaleString()}`}
+                            >
+                              {formatTokens(session.total_input_tokens ?? 0)} /{" "}
+                              {formatTokens(session.total_output_tokens ?? 0)}
+                            </span>
+                          ) : (
+                            "-"
+                          )}
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                           {formatCost(getTotalCost(session))}

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -10,7 +10,14 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import { formatDuration, formatDate, formatCost, cn, buildUrlWithFilters } from "@/lib/utils";
+import {
+  formatDuration,
+  formatDate,
+  formatCost,
+  formatTokens,
+  cn,
+  buildUrlWithFilters,
+} from "@/lib/utils";
 import type { TraceListItem } from "@/types/api";
 import { useTraces, useListPageState } from "@/features/traces/hooks";
 import { TraceViewerPanel, GettingStarted } from "@/features/traces/components";
@@ -297,9 +304,11 @@ export default function TracesPage() {
                         <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                           {(trace.total_input_tokens ?? 0) + (trace.total_output_tokens ?? 0) >
                           0 ? (
-                            <span>
-                              {trace.total_input_tokens?.toLocaleString()} /{" "}
-                              {trace.total_output_tokens?.toLocaleString() || 0}
+                            <span
+                              title={`${(trace.total_input_tokens ?? 0).toLocaleString()} / ${(trace.total_output_tokens ?? 0).toLocaleString()}`}
+                            >
+                              {formatTokens(trace.total_input_tokens ?? 0)} /{" "}
+                              {formatTokens(trace.total_output_tokens ?? 0)}
                             </span>
                           ) : (
                             "-"

--- a/frontend/ui/src/app/projects/[projectId]/users/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/users/page.tsx
@@ -10,7 +10,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { useUsers, useListPageState } from "@/features/traces/hooks";
-import { formatDate, formatCost, cn, buildUrlWithFilters } from "@/lib/utils";
+import { formatDate, formatCost, formatTokens, cn, buildUrlWithFilters } from "@/lib/utils";
 import type { UserListItem } from "@/lib/api/users";
 import type { UserQueryOptions } from "@/lib/api/users";
 
@@ -173,9 +173,16 @@ export default function UsersPage() {
                           {user.trace_count}
                         </td>
                         <td className="border-r border-border/50 px-3 py-2 text-[12px] text-muted-foreground">
-                          {(user.total_input_tokens ?? 0) + (user.total_output_tokens ?? 0) > 0
-                            ? `${(user.total_input_tokens ?? 0).toLocaleString()} / ${(user.total_output_tokens ?? 0).toLocaleString()}`
-                            : "-"}
+                          {(user.total_input_tokens ?? 0) + (user.total_output_tokens ?? 0) > 0 ? (
+                            <span
+                              title={`${(user.total_input_tokens ?? 0).toLocaleString()} / ${(user.total_output_tokens ?? 0).toLocaleString()}`}
+                            >
+                              {formatTokens(user.total_input_tokens ?? 0)} /{" "}
+                              {formatTokens(user.total_output_tokens ?? 0)}
+                            </span>
+                          ) : (
+                            "-"
+                          )}
                         </td>
                         <td className="border-r border-border/50 px-3 py-2 text-[12px] text-muted-foreground">
                           {formatCost(user.total_cost)}

--- a/frontend/ui/src/lib/utils.ts
+++ b/frontend/ui/src/lib/utils.ts
@@ -64,22 +64,15 @@ export function formatDuration(ms: number | null | undefined): string {
   return `${minutes}m ${seconds}s`;
 }
 
-/**
- * Format token count to human readable string.
- * e.g., 1500 -> "1.5k", 1500000 -> "1.5M"
- */
+const _compactTokenFormatter = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  compactDisplay: "short",
+  maximumFractionDigits: 1,
+});
+
 export function formatTokens(count: number | null | undefined): string {
   if (count === null || count === undefined) return "-";
-
-  if (count < 1000) {
-    return String(count);
-  }
-
-  if (count < 999_950) {
-    return `${(count / 1000).toFixed(1)}k`;
-  }
-
-  return `${(count / 1000000).toFixed(1)}M`;
+  return _compactTokenFormatter.format(count);
 }
 
 /**

--- a/frontend/ui/src/lib/utils.ts
+++ b/frontend/ui/src/lib/utils.ts
@@ -75,7 +75,7 @@ export function formatTokens(count: number | null | undefined): string {
     return String(count);
   }
 
-  if (count < 1000000) {
+  if (count < 999_950) {
     return `${(count / 1000).toFixed(1)}k`;
   }
 


### PR DESCRIPTION
Fixes #704 

## Summary

  - Replace raw toLocaleString() token display with formatTokens() from utils so large counts show as e.g. 378.5k / 7.8k instead of 378,549 / 7,842
   - Add title tooltip on the cell so the full exact count is visible on hover
   - Null-coalesce each side independently to avoid showing "-" for partial data
   - Fix formatTokens boundary: use 999_950 cutoff so values that round to 1000.0k are promoted to 1.0M instead

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

  frontend/ui/src/lib/utils.ts                                       
  - Fixed a boundary bug in formatTokens where values in the range
  999,950–999,999 would round to 1000.0k. Changed the k range cutoff 
  from < 1_000_000 to < 999_950 so those values are correctly       
  promoted to 1.0M.                                                  
                   
  frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
  - Removed the local formatTokens helper that used                  
  .toLocaleString().                                                 
  - Imported and used formatTokens from lib/utils for abbreviated    
  display.                                                           
  - Each token side is null-coalesced to 0 independently, so partial 
  data renders as 0 / 5.0k instead of - / 5.0k.                     
  - Added a title attribute on the cell so hovering shows the full   
  raw count (e.g. 378,549 / 7,842).                               
                                                                     
  frontend/ui/src/app/projects/[projectId]/users/page.tsx
  - Same changes as sessions page — replaced inline .toLocaleString()
   logic with formatTokens + null-coalescing + hover tooltip

## Screenshots / Recordings (if applicable)

<img width="1912" height="943" alt="image" src="https://github.com/user-attachments/assets/e3219d64-1339-4aca-97c0-7f38f5662025" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary