### PR TITLE
fix: correct ossf/scorecard-action SHA to commit hash

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2 # v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The SHA used in #722 was the tag object SHA (`99c09fe...`), not the underlying commit SHA. The scorecard action's `publish_results` verification rejected it as an "imposter commit".

Fixed to the correct commit SHA `4eaacf0...` obtained by dereferencing the annotated tag.

The scan itself worked and results are in the Security tab. This fix enables publishing to the public OpenSSF Scorecard database.

## Current score: 7.0/10

| Check | Score |
|---|---|
| Maintained | 10/10 |
| CI-Tests | 10/10 |
| Binary-Artifacts | 10/10 |
| Dangerous-Workflow | 10/10 |
| Packaging | 10/10 |
| Dependency-Update-Tool | 10/10 |
| Contributors | 10/10 |
| Security-Policy | 10/10 |
| License | 9/10 |
| Token-Permissions | 9/10 |
| Code-Review | 7/10 |
| SAST | 3/10 |
| Vulnerabilities | 0/10 (45 open Dependabot alerts) |
| Pinned-Dependencies | 0/10 |
| Fuzzing | 0/10 |
| CII-Best-Practices | 0/10 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)