### PR TITLE
fix: skip claude code review for dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   claude-review:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Adds `if: github.event.pull_request.user.login != 'dependabot[bot]'` to skip the job on bot PRs

## Why
After #729 landed, the action started failing on Dependabot PRs with:
> Workflow initiated by non-human actor: dependabot (type: Bot)

Dependabot PRs are automated version bumps — no need for AI code review on those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)