### PR TITLE
fix: use theme-aware Logo on auth pages

### DIFF
--- a/frontend/ui/src/app/auth/sign-in/page.tsx
+++ b/frontend/ui/src/app/auth/sign-in/page.tsx
@@ -4,7 +4,6 @@ import { Suspense, useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
 import { useRouter, useSearchParams } from "next/navigation";
-import Image from "next/image";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -12,6 +11,7 @@ import { z } from "zod/v3";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Logo } from "@/components/Logo";
 
 const signInSchema = z.object({
   email: z.string().email("Invalid email"),
@@ -72,13 +72,9 @@ function SignInContent() {
     <div className="flex h-full min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <Image
-            src="/images/traceroot_icon.png"
-            alt="TraceRoot"
-            width={48}
-            height={48}
-            className="mx-auto mb-2"
-          />
+          <div className="flex justify-center mb-2">
+            <Logo size="lg" />
+          </div>
           <CardTitle className="text-lg font-semibold">Sign in to product</CardTitle>
         </CardHeader>
         <CardContent className="space-y-5">

--- a/frontend/ui/src/app/auth/sign-in/page.tsx
+++ b/frontend/ui/src/app/auth/sign-in/page.tsx
@@ -72,7 +72,7 @@ function SignInContent() {
     <div className="flex h-full min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <div className="flex justify-center mb-2">
+          <div className="mb-2 flex justify-center">
             <Logo size="lg" />
           </div>
           <CardTitle className="text-lg font-semibold">Sign in to product</CardTitle>

--- a/frontend/ui/src/app/auth/sign-up/page.tsx
+++ b/frontend/ui/src/app/auth/sign-up/page.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { Eye, EyeOff } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
 import { useRouter } from "next/navigation";
-import Image from "next/image";
 import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -12,6 +11,7 @@ import { z } from "zod/v3";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Logo } from "@/components/Logo";
 
 const signUpSchema = z
   .object({
@@ -79,13 +79,9 @@ export default function SignUpPage() {
     <div className="flex h-full min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <Image
-            src="/images/traceroot_icon.png"
-            alt="TraceRoot"
-            width={48}
-            height={48}
-            className="mx-auto mb-2"
-          />
+          <div className="flex justify-center mb-2">
+            <Logo size="lg" />
+          </div>
           <CardTitle className="text-lg font-semibold">Create your account</CardTitle>
         </CardHeader>
         <CardContent className="space-y-5">

--- a/frontend/ui/src/app/auth/sign-up/page.tsx
+++ b/frontend/ui/src/app/auth/sign-up/page.tsx
@@ -79,7 +79,7 @@ export default function SignUpPage() {
     <div className="flex h-full min-h-screen items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
-          <div className="flex justify-center mb-2">
+          <div className="mb-2 flex justify-center">
             <Logo size="lg" />
           </div>
           <CardTitle className="text-lg font-semibold">Create your account</CardTitle>


### PR DESCRIPTION
The sign-in and sign-up pages used a PNG with a baked-in white background, which showed up as an ugly white square in dark mode. Swapped to the existing `Logo` component, which already flips its container color with the theme.

<img width="679" height="526" alt="Screenshot 2026-04-24 at 10 44 38 PM" src="https://github.com/user-attachments/assets/6d2924f0-b2ff-40ed-9823-8c56265628e8" />
<img width="679" height="669" alt="Screenshot 2026-04-24 at 10 44 54 PM" src="https://github.com/user-attachments/assets/c186309a-8041-40f8-8673-25148b6bc8ac" />


Closes #743