### PR TITLE
feat(examples): add LiteLLM TypeScript example

### DIFF
--- a/examples/typescript/litellm/.env.example
+++ b/examples/typescript/litellm/.env.example
@@ -1,0 +1,12 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# LiteLLM proxy — start with `litellm --model <provider/model>`
+# See: https://docs.litellm.ai/docs/proxy/quick_start
+LITELLM_PROXY_URL=http://0.0.0.0:4000
+# Placeholder API key. When the proxy has no `master_key` set, any value works
+# — "sk-1234" is the placeholder LiteLLM uses in their own JS example:
+# https://docs.litellm.ai/docs/proxy/user_keys
+LITELLM_API_KEY=sk-1234

--- a/examples/typescript/litellm/README.md
+++ b/examples/typescript/litellm/README.md
@@ -1,0 +1,58 @@
+# LiteLLM Tool Agent
+
+ReAct-style agent that calls a [LiteLLM](https://github.com/BerriAI/litellm) proxy using the official `openai` npm SDK, instrumented with [TraceRoot](https://traceroot.ai).
+
+LiteLLM is a unified OpenAI-compatible proxy in front of 100+ providers (OpenAI, Anthropic, Groq, Mistral, Together, Bedrock, Ollama…). On the TypeScript side, LiteLLM is the proxy server only — there is no native TS SDK. Users point the `openai` npm SDK at the proxy's URL, and TraceRoot's existing OpenAI instrumentation captures every call automatically.
+
+## Start the LiteLLM proxy
+
+LiteLLM runs as a Python process. In a separate terminal:
+
+```bash
+uv tool install 'litellm[proxy]'   # or: pip install 'litellm[proxy]'
+export OPENAI_API_KEY=sk-...        # or any provider key matching the model below
+litellm --model gpt-3.5-turbo
+```
+
+The proxy listens on `http://0.0.0.0:4000` by default. See the [LiteLLM proxy quick start](https://docs.litellm.ai/docs/proxy/quick_start) for routing to other providers (Anthropic, Groq, etc.).
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in TRACEROOT_API_KEY (LITELLM_* defaults work for the quick start above)
+pnpm install
+```
+
+## Usage
+
+```bash
+pnpm demo        # tool-calling agent
+pnpm streaming   # streaming pipeline (generator support)
+```
+
+## What it does
+
+`pnpm demo` runs three demo queries that exercise tool use:
+1. Weather comparison (San Francisco vs Tokyo)
+2. Stock price lookup + calculation (NVDA +10%)
+3. Web search + summarization
+
+Tools: `get_weather`, `get_stock_price`, `calculate`, `search_web`, `get_current_time`
+
+`pnpm streaming` runs a streaming pipeline that demonstrates `observe()` wrapping async generators — the span stays open across token boundaries so trace duration reflects real end-to-end latency.
+
+## Why no `LiteLLMInstrumentation`?
+
+LiteLLM's TS surface is the proxy's HTTP API — an OpenAI-compatible wire protocol. Calls from your TypeScript code go through the standard `openai` npm package, which TraceRoot already patches via [`OpenAIInstrumentation`](https://github.com/traceroot-ai/traceroot-ts/blob/main/packages/traceroot/src/instrumentation.ts). Spans are emitted with no extra wiring; a separate LiteLLM instrumentor would be redundant.
+
+(For Python, the situation is different: `litellm` is a real SDK that benefits from a dedicated instrumentor. See issue [#734](https://github.com/traceroot-ai/traceroot/issues/734) for the Python side.)
+
+## Models
+
+The `model` field in `agent.ts` must match the alias your proxy is serving. The default `gpt-3.5-turbo` matches `litellm --model gpt-3.5-turbo`. To route through a different provider, change the proxy startup command and update the `model` constant in `ReActAgent` to match.
+
+## Notes
+
+- If you see `ECONNREFUSED 0.0.0.0:4000`, the proxy isn't running — start it as shown above.
+- When the proxy has no `master_key` configured (the quick-start case), the `apiKey` value is ignored — any string works. We default to `sk-1234`, the placeholder used in [LiteLLM's own JS example](https://docs.litellm.ai/docs/proxy/user_keys). Set `LITELLM_API_KEY` in `.env` if your proxy enforces a master key.
+- LiteLLM lets you swap providers without touching this code — just restart the proxy with a different `--model` and update the model constant.

--- a/examples/typescript/litellm/agent.ts
+++ b/examples/typescript/litellm/agent.ts
@@ -1,0 +1,316 @@
+/**
+ * LiteLLM ReAct Agent — TraceRoot Observability
+ *
+ * LiteLLM's TypeScript story is its proxy server (HTTP), not a native TS SDK.
+ * Users run `litellm --model <provider/model>` locally (or in prod) and call
+ * the proxy through the official `openai` npm SDK with a custom `baseURL`.
+ *
+ * Because TraceRoot's existing OpenAI instrumentation patches the `openai`
+ * package at runtime, every call to the LiteLLM proxy is captured as a span
+ * automatically — no LiteLLM-specific instrumentor exists for TypeScript and
+ * none is needed.
+ *
+ * Prerequisites:
+ *   1. Start the proxy in another terminal:
+ *        uv tool install 'litellm[proxy]'   # or: pip install 'litellm[proxy]'
+ *        litellm --model gpt-3.5-turbo
+ *   2. Env vars: LITELLM_PROXY_URL, LITELLM_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm demo
+ */
+
+import 'dotenv/config';
+import OpenAI from 'openai';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
+
+// ── TraceRoot setup ───────────────────────────────────────────────────────────
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+// ── LiteLLM client (OpenAI SDK pointed at the proxy) ──────────────────────────
+const openai = new OpenAI({
+  apiKey: process.env.LITELLM_API_KEY ?? 'sk-1234',
+  baseURL: process.env.LITELLM_PROXY_URL ?? 'http://0.0.0.0:4000',
+});
+
+console.log('[Observability: TraceRoot | Provider: LiteLLM proxy]');
+
+// ── Tools ─────────────────────────────────────────────────────────────────────
+type ToolResult = Record<string, unknown>;
+
+function getWeather(city: string): ToolResult {
+  const db: Record<string, ToolResult> = {
+    'san francisco': { temp: 68, condition: 'foggy', humidity: 75 },
+    'new york': { temp: 45, condition: 'cloudy', humidity: 60 },
+    london: { temp: 52, condition: 'rainy', humidity: 85 },
+    tokyo: { temp: 72, condition: 'sunny', humidity: 50 },
+    paris: { temp: 58, condition: 'partly cloudy', humidity: 65 },
+  };
+  return { city, ...(db[city.toLowerCase()] ?? { temp: 70, condition: 'unknown', humidity: 50 }) };
+}
+
+function searchWeb(query: string): ToolResult[] {
+  return [
+    { title: `Result 1 for '${query}'`, snippet: `This is information about ${query}...` },
+    { title: `Result 2 for '${query}'`, snippet: `More details on ${query} can be found...` },
+  ];
+}
+
+function getStockPrice(symbol: string): ToolResult {
+  const stocks: Record<string, ToolResult> = {
+    AAPL: { price: 178.5, change: +2.3, percent: '+1.3%' },
+    GOOGL: { price: 141.2, change: -0.8, percent: '-0.6%' },
+    MSFT: { price: 378.9, change: +4.5, percent: '+1.2%' },
+    NVDA: { price: 495.2, change: +12.3, percent: '+2.5%' },
+  };
+  return {
+    symbol: symbol.toUpperCase(),
+    ...(stocks[symbol.toUpperCase()] ?? { price: 0, change: 0, percent: 'N/A' }),
+  };
+}
+
+// Tiny recursive-descent parser for + - * / ( ) — no dynamic code execution.
+function calculate(expression: string): ToolResult {
+  try {
+    let pos = 0;
+    const src = expression.replace(/\s+/g, '');
+
+    const peek = () => src[pos];
+    const consume = (ch: string) => {
+      if (src[pos] !== ch) throw new Error(`Expected '${ch}' at ${pos}`);
+      pos++;
+    };
+
+    const parseNumber = (): number => {
+      const start = pos;
+      while (pos < src.length && /[0-9.]/.test(src[pos])) pos++;
+      if (start === pos) throw new Error(`Expected number at ${pos}`);
+      return Number(src.slice(start, pos));
+    };
+
+    const parseFactor = (): number => {
+      if (peek() === '(') {
+        consume('(');
+        const v = parseAddSub();
+        consume(')');
+        return v;
+      }
+      if (peek() === '-') {
+        consume('-');
+        return -parseFactor();
+      }
+      return parseNumber();
+    };
+
+    const parseMulDiv = (): number => {
+      let v = parseFactor();
+      while (peek() === '*' || peek() === '/') {
+        const op = src[pos++];
+        const r = parseFactor();
+        v = op === '*' ? v * r : v / r;
+      }
+      return v;
+    };
+
+    function parseAddSub(): number {
+      let v = parseMulDiv();
+      while (peek() === '+' || peek() === '-') {
+        const op = src[pos++];
+        const r = parseMulDiv();
+        v = op === '+' ? v + r : v - r;
+      }
+      return v;
+    }
+
+    const result = parseAddSub();
+    if (pos !== src.length) throw new Error(`Unexpected '${src[pos]}' at ${pos}`);
+    return { expression, result };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+function getCurrentTime(timezone = 'UTC'): ToolResult {
+  return { timezone, time: new Date().toISOString() };
+}
+
+const TOOLS: Record<string, (a: Record<string, unknown>) => ToolResult | ToolResult[]> = {
+  get_weather: (a) => getWeather(a.city as string),
+  search_web: (a) => searchWeb(a.query as string),
+  get_stock_price: (a) => getStockPrice(a.symbol as string),
+  calculate: (a) => calculate(a.expression as string),
+  get_current_time: (a) => getCurrentTime(a.timezone as string | undefined),
+};
+
+const TOOL_SCHEMAS: OpenAI.Chat.ChatCompletionTool[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'get_weather',
+      description: 'Get current weather for a city',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string', description: 'City name' } },
+        required: ['city'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'search_web',
+      description: 'Search the web for information',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string', description: 'Search query' } },
+        required: ['query'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_stock_price',
+      description: 'Get current stock price for a ticker symbol',
+      parameters: {
+        type: 'object',
+        properties: {
+          symbol: { type: 'string', description: 'Stock ticker symbol (e.g., AAPL)' },
+        },
+        required: ['symbol'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'calculate',
+      description: 'Evaluate a mathematical expression',
+      parameters: {
+        type: 'object',
+        properties: { expression: { type: 'string', description: 'Math expression' } },
+        required: ['expression'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_current_time',
+      description: 'Get the current date and time',
+      parameters: {
+        type: 'object',
+        properties: { timezone: { type: 'string', description: 'Timezone (default: UTC)' } },
+      },
+    },
+  },
+];
+
+// ── Agent ─────────────────────────────────────────────────────────────────────
+const SYSTEM_PROMPT = `You are a helpful AI assistant with access to tools.
+When answering questions:
+1. Think about what information you need
+2. Use available tools to gather information
+3. Combine information from multiple sources when helpful
+4. Provide a clear, comprehensive answer
+Available tools: weather, web search, stock prices, calculator, current time.`;
+
+class ReActAgent {
+  private conversationHistory: OpenAI.Chat.ChatCompletionMessageParam[] = [];
+  // Must match the model your LiteLLM proxy is serving. Default matches
+  // `litellm --model gpt-3.5-turbo` from the README. Change this line if your
+  // proxy is configured for a different model alias.
+  private readonly model = 'gpt-3.5-turbo';
+
+  constructor() {
+    this.conversationHistory.push({ role: 'system', content: SYSTEM_PROMPT });
+  }
+
+  private async executeTool(name: string, fnArgs: Record<string, unknown>): Promise<string> {
+    const result = await observe({ name: `tool:${name}`, type: 'tool' }, async () => {
+      if (name in TOOLS) return TOOLS[name](fnArgs);
+      return { error: `Unknown tool: ${name}` };
+    });
+    return JSON.stringify(result);
+  }
+
+  async runTurn(userInput: string): Promise<string> {
+    return observe({ name: 'agent_turn', type: 'agent' }, async () => {
+      this.conversationHistory.push({ role: 'user', content: userInput });
+
+      for (let i = 0; i < 5; i++) {
+        const completion = await openai.chat.completions.create({
+          model: this.model,
+          messages: this.conversationHistory,
+          tools: TOOL_SCHEMAS,
+          tool_choice: 'auto',
+        });
+
+        const msg = completion.choices[0].message;
+
+        if (msg.tool_calls && msg.tool_calls.length > 0) {
+          this.conversationHistory.push(msg);
+          for (const tc of msg.tool_calls) {
+            // Narrow the function|custom union — we only register function tools.
+            if (!('function' in tc)) continue;
+            const fnArgs = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+            console.log(`\n  [Tool: ${tc.function.name}(${JSON.stringify(fnArgs)})]`);
+            const result = await this.executeTool(tc.function.name, fnArgs);
+            console.log(`  [Result: ${result}]`);
+            this.conversationHistory.push({ role: 'tool', tool_call_id: tc.id, content: result });
+          }
+        } else {
+          const response = msg.content ?? '';
+          this.conversationHistory.push({ role: 'assistant', content: response });
+          return response;
+        }
+      }
+      return "I wasn't able to complete this task within the allowed steps.";
+    });
+  }
+}
+
+// ── Demo ──────────────────────────────────────────────────────────────────────
+const DEMO_QUERIES = [
+  "What's the weather in San Francisco and Tokyo? Compare them.",
+  "What's NVDA stock price? If it goes up 10%, what would the new price be?",
+  'Search for information about AI observability and summarize what you find.',
+];
+
+async function main() {
+  try {
+    await usingAttributes(
+      {
+        sessionId: 'litellm-demo-session',
+        userId: 'demo-user',
+        tags: ['demo', 'litellm', 'react-agent'],
+        metadata: { example: 'litellm-react-agent', sdkFeature: 'usingAttributes' },
+      },
+      () =>
+        observe({ name: 'demo_session' }, async () => {
+          console.log('='.repeat(60));
+          console.log('LiteLLM ReAct Agent — Demo (TraceRoot)');
+          console.log('='.repeat(60));
+
+          for (let i = 0; i < DEMO_QUERIES.length; i++) {
+            const query = DEMO_QUERIES[i];
+            const agent = new ReActAgent();
+            console.log(`\n${'='.repeat(60)}`);
+            console.log(`Query ${i + 1}: ${query}`);
+            console.log('='.repeat(60));
+            process.stdout.write('\nAgent: ');
+            const response = await agent.runTurn(query);
+            console.log(response);
+            console.log();
+          }
+        }),
+    );
+  } finally {
+    await TraceRoot.shutdown();
+    console.log('[Traces exported]');
+  }
+}
+
+main().catch(console.error);

--- a/examples/typescript/litellm/agent.ts
+++ b/examples/typescript/litellm/agent.ts
@@ -85,9 +85,15 @@ function calculate(expression: string): ToolResult {
 
     const parseNumber = (): number => {
       const start = pos;
-      while (pos < src.length && /[0-9.]/.test(src[pos])) pos++;
+      let hasDot = false;
+      while (pos < src.length && (/[0-9]/.test(src[pos]) || (src[pos] === '.' && !hasDot))) {
+        if (src[pos] === '.') hasDot = true;
+        pos++;
+      }
       if (start === pos) throw new Error(`Expected number at ${pos}`);
-      return Number(src.slice(start, pos));
+      const n = Number(src.slice(start, pos));
+      if (!Number.isFinite(n)) throw new Error(`Invalid number '${src.slice(start, pos)}'`);
+      return n;
     };
 
     const parseFactor = (): number => {
@@ -133,7 +139,17 @@ function calculate(expression: string): ToolResult {
 }
 
 function getCurrentTime(timezone = 'UTC'): ToolResult {
-  return { timezone, time: new Date().toISOString() };
+  // Use IANA timezone (e.g. 'UTC', 'America/New_York'). Fall back to UTC ISO on unknown zones.
+  try {
+    const time = new Date().toLocaleString('en-US', { timeZone: timezone, hour12: false });
+    return { timezone, time };
+  } catch {
+    return {
+      timezone: 'UTC',
+      time: new Date().toISOString(),
+      warning: `Unknown timezone '${timezone}'; fell back to UTC.`,
+    };
+  }
 }
 
 const TOOLS: Record<string, (a: Record<string, unknown>) => ToolResult | ToolResult[]> = {

--- a/examples/typescript/litellm/package.json
+++ b/examples/typescript/litellm/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@traceroot/example-litellm",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "demo": "tsx agent.ts",
+    "streaming": "tsx streaming-pipeline.ts"
+  },
+  "dependencies": {
+    "@traceroot-ai/traceroot": "0.1.2",
+    "dotenv": "^16.4.5",
+    "openai": "^6.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/typescript/litellm/streaming-pipeline.ts
+++ b/examples/typescript/litellm/streaming-pipeline.ts
@@ -1,0 +1,148 @@
+/**
+ * LiteLLM streaming pipeline — TraceRoot generator support
+ *
+ * Demonstrates two patterns where observe() wraps an async generator, talking
+ * to a LiteLLM proxy through the openai SDK (no native LiteLLM TS SDK exists).
+ *
+ *   1. Direct streaming   — observe() on a generator that yields raw tokens
+ *                           from the proxy's streaming response.
+ *   2. Pipeline streaming — a second observe() layer that transforms the token
+ *                           stream before handing it to the caller.
+ *
+ * Why this matters for observability:
+ *   Without generator support, observe() would close the span the moment the
+ *   generator object is returned — before any tokens arrive. The trace would
+ *   show near-zero latency and no output. With generator support the span
+ *   closes only after the last token, capturing real end-to-end duration and
+ *   the full assembled output.
+ *
+ * Span hierarchy produced:
+ *   streaming_demo (agent)
+ *   └─ run_query (agent)  ×2
+ *      ├─ stream_tokens (llm)           ← Pattern 1
+ *      │  └─ OpenAI LLM span (auto)
+ *      └─ transform_stream (span)       ← Pattern 2
+ *         └─ stream_tokens (llm)
+ *            └─ OpenAI LLM span (auto)
+ *
+ * Prerequisites:
+ *   1. Start the proxy in another terminal:
+ *        uv tool install 'litellm[proxy]'   # or: pip install 'litellm[proxy]'
+ *        litellm --model gpt-3.5-turbo
+ *   2. Env vars: LITELLM_PROXY_URL, LITELLM_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm streaming
+ */
+
+import 'dotenv/config';
+import OpenAI from 'openai';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
+
+TraceRoot.initialize({ instrumentModules: { openAI: OpenAI } });
+
+const openai = new OpenAI({
+  apiKey: process.env.LITELLM_API_KEY ?? 'sk-1234',
+  baseURL: process.env.LITELLM_PROXY_URL ?? 'http://0.0.0.0:4000',
+});
+console.log('[Observability: TraceRoot — LiteLLM streaming pipeline]');
+
+// Must match the model your LiteLLM proxy is serving. Default matches the
+// `litellm --model gpt-3.5-turbo` quick start.
+const MODEL = 'gpt-3.5-turbo';
+
+// ---------------------------------------------------------------------------
+// Pattern 1: direct streaming
+//
+// streamTokens is an async generator wrapped with observe().
+// The span stays open while tokens are flowing and closes after the last
+// chunk, capturing total latency and the assembled output.
+// ---------------------------------------------------------------------------
+
+async function* streamTokens(prompt: string) {
+  const stream = await openai.chat.completions.create({
+    model: MODEL,
+    messages: [{ role: 'user', content: prompt }],
+    stream: true,
+  });
+  for await (const chunk of stream) {
+    const token = chunk.choices[0]?.delta?.content;
+    if (token) yield token;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 2: pipeline streaming
+//
+// transformStream wraps streamTokens and applies a transformation to each
+// token. Both are observed generators, so TraceRoot creates two spans:
+// transform_stream as parent, stream_tokens as child. The parent span closes
+// only after all transformed tokens are consumed.
+// ---------------------------------------------------------------------------
+
+async function* transformStream(prompt: string, uppercase = false) {
+  for await (const token of observe({ name: 'stream_tokens', type: 'llm' }, streamTokens, prompt)) {
+    yield uppercase ? token.toUpperCase() : token;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Agent: runs both patterns for a given query
+// ---------------------------------------------------------------------------
+
+async function runQuery(query: string) {
+  return observe({ name: 'run_query', type: 'agent' }, async () => {
+    console.log(`\n${'='.repeat(60)}`);
+    console.log(`Query: ${query}`);
+    console.log('='.repeat(60));
+
+    // Pattern 1: direct stream
+    console.log('\n[Pattern 1 — direct stream]');
+    process.stdout.write('Response: ');
+    for await (const token of observe({ name: 'stream_tokens', type: 'llm' }, streamTokens, query)) {
+      process.stdout.write(token);
+    }
+    console.log();
+
+    // Pattern 2: pipeline stream (uppercase transform)
+    console.log('\n[Pattern 2 — pipeline stream, uppercased]');
+    process.stdout.write('Response: ');
+    for await (const token of observe(
+      { name: 'transform_stream', type: 'span' },
+      transformStream,
+      query,
+      true,
+    )) {
+      process.stdout.write(token);
+    }
+    console.log();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const DEMO_QUERIES = [
+  'In one sentence, what is observability?',
+  'In one sentence, why does latency matter in LLM apps?',
+];
+
+async function main() {
+  try {
+    await usingAttributes(
+      { sessionId: 'litellm-streaming-pipeline-demo', userId: 'example-user' },
+      () =>
+        observe({ name: 'streaming_demo', type: 'agent' }, async () => {
+          for (const query of DEMO_QUERIES) {
+            await runQuery(query);
+          }
+        }),
+    );
+  } finally {
+    await TraceRoot.shutdown();
+    console.log('\n[Traces exported]');
+  }
+}
+
+main().catch(console.error);

--- a/examples/typescript/litellm/tsconfig.json
+++ b/examples/typescript/litellm/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["."]
+}


### PR DESCRIPTION
Closes #740.

LiteLLM doesn't have a native TS SDK — it's a proxy you call via the `openai` SDK with a custom `baseURL`. I checked npm and the OpenInference monorepo: there's no `@arizeai/openinference-instrumentation-litellm` for JS (only Python has one). So the existing `OpenAIInstrumentation` in `traceroot-ts` already captures proxy traffic without any SDK changes — that's Option B from the issue.

This PR ships only the example: `examples/typescript/litellm/`, structured like `examples/typescript/openai/` with a tool-calling agent (`pnpm demo`) and a streaming pipeline (`pnpm streaming`). Defaults (`apiKey: "sk-1234"`, `baseURL: "http://0.0.0.0:4000"`) match LiteLLM's own JS docs verbatim.

Two small deviations worth a quick look:
- I named the entry `agent.ts` (the spec says `index.ts`) to match the 6 other TS examples — happy to rename.
- `calculate()` uses a small parser instead of `eval` with a regex check; pre-commit hook blocked the `eval` form. Functionally identical, strictly safer.