### PR TITLE
fix: use pull_request_target for Claude Code review to support fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
 
 jobs:


### PR DESCRIPTION
## Summary

- Changes `pull_request` trigger to `pull_request_target` in `.github/workflows/claude-code-review.yml`
- Fixes Claude Code review failing on all PRs from external contributors (forks)

Fixes #750

## Root Cause

`pull_request` events from forked repos don't get secrets or OIDC tokens — GitHub blocks this intentionally for security. `CLAUDE_CODE_OAUTH_TOKEN` arrives empty, the action falls back to OIDC, that also fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`. This is why every contributor PR fails while PRs from branches on the main repo work fine.

## Why `pull_request_target` is safe here

`pull_request_target` runs in the base repo's context (secrets + OIDC always available). The only allowed tools are `gh pr diff`, `gh pr view`, `gh pr comment`, and inline comments — all GitHub API calls. No code from the fork is ever executed on the runner.

## For existing failed PRs

Ask contributors to push any small change or close/reopen their PR to re-trigger the workflow after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)