### PR TITLE
fix: switch to anthropic_api_key to fix Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/examples/typescript/openai-agents/.env.example
+++ b/examples/typescript/openai-agents/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenAI
+OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/typescript/openai-agents/agent.ts
+++ b/examples/typescript/openai-agents/agent.ts
@@ -1,0 +1,104 @@
+/**
+ * OpenAI Agents SDK — TraceRoot Observability
+ *
+ * A simple multi-tool agent using @openai/agents, with traces captured
+ * by TraceRoot via the built-in TracingProcessor bridge.
+ *
+ * Env vars required: OPENAI_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm demo
+ */
+
+import 'dotenv/config';
+import * as agents from '@openai/agents';
+import { Agent, run, tool } from '@openai/agents';
+import { TraceRoot } from '@traceroot-ai/traceroot';
+import { z } from 'zod/v4';
+
+// ── TraceRoot setup ───────────────────────────────────────────────────────────
+TraceRoot.initialize({
+  instrumentModules: { openaiAgents: agents },
+});
+console.log('[Observability: TraceRoot]');
+
+// ── Tools ─────────────────────────────────────────────────────────────────────
+
+const getWeather = tool({
+  name: 'get_weather',
+  description: 'Get current weather for a city.',
+  parameters: z.object({ city: z.string() }),
+  execute: async ({ city }) => {
+    const db: Record<string, { temp: number; condition: string; humidity: number }> = {
+      'san francisco': { temp: 68, condition: 'foggy', humidity: 75 },
+      'new york': { temp: 45, condition: 'cloudy', humidity: 60 },
+      'tokyo': { temp: 72, condition: 'sunny', humidity: 50 },
+      'london': { temp: 52, condition: 'rainy', humidity: 85 },
+    };
+    return db[city.toLowerCase()] ?? { temp: 70, condition: 'unknown', humidity: 50 };
+  },
+});
+
+const getStockPrice = tool({
+  name: 'get_stock_price',
+  description: 'Get current stock price for a ticker symbol.',
+  parameters: z.object({ symbol: z.string() }),
+  execute: async ({ symbol }) => {
+    const stocks: Record<string, { price: number; change: string }> = {
+      NVDA: { price: 495.2, change: '+2.1%' },
+      AAPL: { price: 178.5, change: '+1.3%' },
+      GOOGL: { price: 141.2, change: '-0.6%' },
+    };
+    return stocks[symbol.toUpperCase()] ?? { price: 0, change: 'N/A' };
+  },
+});
+
+const calculate = tool({
+  name: 'calculate',
+  description: 'Evaluate a math expression. Example: "178.5 * 1.1"',
+  parameters: z.object({ expression: z.string() }),
+  execute: async ({ expression }) => {
+    try {
+      // Safe eval for simple arithmetic
+      const result = Function(`"use strict"; return (${expression})`)();
+      return { expression, result };
+    } catch {
+      return { expression, error: 'Invalid expression' };
+    }
+  },
+});
+
+// ── Agent ─────────────────────────────────────────────────────────────────────
+
+const agent = new Agent({
+  name: 'Assistant',
+  instructions:
+    'You are a helpful assistant with access to weather, stock price, and calculator tools. ' +
+    'Use tools when needed to answer questions accurately.',
+  tools: [getWeather, getStockPrice, calculate],
+});
+
+// ── Demo ──────────────────────────────────────────────────────────────────────
+
+const DEMO_QUERIES = [
+  "What's the weather in San Francisco and Tokyo? Compare them.",
+  "What's NVDA stock price? If it goes up 10%, what would the new price be?",
+];
+
+async function main() {
+  console.log('============================================================');
+  console.log('OpenAI Agents SDK — Demo (TraceRoot)');
+  console.log('============================================================\n');
+
+  for (const query of DEMO_QUERIES) {
+    console.log(`Query: ${query}`);
+    const result = await run(agent, query);
+    console.log(`\nAgent: ${result.finalOutput}\n`);
+    console.log('------------------------------------------------------------\n');
+  }
+
+  await TraceRoot.shutdown();
+  console.log('[Traces exported]');
+}
+
+main().catch(console.error);

--- a/examples/typescript/openai-agents/agent.ts
+++ b/examples/typescript/openai-agents/agent.ts
@@ -58,8 +58,11 @@ const calculate = tool({
   description: 'Evaluate a math expression. Example: "178.5 * 1.1"',
   parameters: z.object({ expression: z.string() }),
   execute: async ({ expression }) => {
+    // Only allow digits, operators, parentheses, and whitespace
+    if (!/^[\d\s+\-*/().]+$/.test(expression)) {
+      return { expression, error: 'Invalid expression — only arithmetic allowed' };
+    }
     try {
-      // Safe eval for simple arithmetic
       const result = Function(`"use strict"; return (${expression})`)();
       return { expression, result };
     } catch {

--- a/examples/typescript/openai-agents/agent.ts
+++ b/examples/typescript/openai-agents/agent.ts
@@ -14,7 +14,7 @@ import 'dotenv/config';
 import * as agents from '@openai/agents';
 import { Agent, run, tool } from '@openai/agents';
 import { TraceRoot } from '@traceroot-ai/traceroot';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 // ── TraceRoot setup ───────────────────────────────────────────────────────────
 TraceRoot.initialize({

--- a/examples/typescript/openai-agents/package.json
+++ b/examples/typescript/openai-agents/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@traceroot/example-openai-agents",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "demo": "tsx agent.ts"
+  },
+  "dependencies": {
+    "@openai/agents": "^0.8.5",
+    "@traceroot-ai/traceroot": "0.1.3",
+    "dotenv": "^16.4.5",
+    "openai": "^6.34.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/typescript/openai-agents/tsconfig.json
+++ b/examples/typescript/openai-agents/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["."]
+}


### PR DESCRIPTION
## Summary

- Switches `claude_code_oauth_token` → `anthropic_api_key` in the Claude Code review workflow
- This is the final fix to make Claude review work on contributor fork PRs

## Why

`pull_request_target` (merged in #749) gets secrets to the runner, but Anthropic's OIDC exchange service rejects tokens minted for `pull_request_target` events — it only accepts `pull_request`. So the OIDC-based oauth flow is fundamentally incompatible with fork PRs.

`anthropic_api_key` bypasses OIDC entirely — the key is passed directly, no token exchange needed. Combined with `pull_request_target`, fork PRs now get secrets AND skip the broken OIDC dance.

Fixes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)