### PR TITLE
fix: switch to anthropic_api_key to support fork PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

One-line change: `claude_code_oauth_token` → `anthropic_api_key` in `.github/workflows/claude-code-review.yml`.

## Why

`claude_code_oauth_token` authenticates via GitHub OIDC. Anthropic's token exchange service rejects OIDC tokens minted for `pull_request_target` events (only accepts `pull_request`). `anthropic_api_key` bypasses OIDC entirely — the key is used directly, no token exchange needed.

Combined with `pull_request_target` (merged in #749), this is the complete fix for contributor fork PRs.

Fixes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)