### PR TITLE
fix: provide github_token to skip OIDC app token exchange

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,6 +23,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Adds `github_token: ${{ secrets.GITHUB_TOKEN }}` to the Claude Code review action.

## Why

Even with `anthropic_api_key` correctly set, the action was still failing. It uses OIDC for **two** separate things:
1. ~~Getting an Anthropic API key~~ — fixed by switching to `anthropic_api_key` in #752
2. Getting a GitHub App token to post PR comments — this also rejects `pull_request_target` OIDC tokens

Providing `github_token` directly tells the action to use it for posting comments, bypassing the OIDC exchange entirely. `GITHUB_TOKEN` is automatically available in every Actions run — no secrets setup needed.

Fixes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)