### PR TITLE
feat: add DeepSeek V4 to BYOK model catalog

### DIFF
--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -161,7 +161,11 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "gemini-2.5-flash", label: "gemini-2.5-flash" },
     { id: "gemini-2.5-pro", label: "gemini-2.5-pro" },
   ],
-  deepseek: [{ id: "deepseek-chat", label: "deepseek-chat" }],
+  deepseek: [
+    { id: "deepseek-v4-pro", label: "deepseek-v4-pro" },
+    { id: "deepseek-v4-flash", label: "deepseek-v4-flash" },
+    { id: "deepseek-chat", label: "deepseek-chat" },
+  ],
   xai: [
     { id: "grok-4.20", label: "grok-4.20" },
     { id: "grok-4", label: "grok-4" },


### PR DESCRIPTION
Adding deepseek-v4-pro and deepseek-v4-flash in the BYOK dropdown catalog so users can pick them from Settings -> Model Providers -> DeepSeek without falling through to the (Unsupported) path from #610.

DeepSeek released V4 on 2026-04-24
(https://api-docs.deepseek.com/news/news260424) with two new model IDs, both 1M context, both OpenAI ChatCompletions-compatible. No apiProtocol override needed - V4 inherits openai-completions from ADAPTER_API_PROTOCOL["deepseek"]. Same base URL as before. Positioned newest-first so deepseek-v4-pro becomes the default-selected model on "Add Provider -> DeepSeek", consistent with #691 (Opus 4.7) and #703 (Kimi K2.6).

deepseek-chat is kept in the list - it still works until its 2026-07-24 retirement, after which the legacy-model UX from #610 will flag it as Unsupported.

No changes to SYSTEM_MODELS, PROVIDER_PRIORITY, or docs/integrations/internal-models.mdx - DeepSeek is BYOK-only and not listed in the system-models tables.

Closes #756

Fixes <issue-id>

## Type of Change

- [x] feat - A new feature

## Screenshots / Recordings (if applicable):
<img width="1707" height="864" alt="Screenshot 2026-04-25 at 3 16 10 PM" src="https://github.com/user-attachments/assets/fb21b38e-c950-43f1-94c6-32922de9f994" />

(Additional help wanted) to test e2e with DeekSeep V4 API in traceroot settings -> model provider -> deekseek


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
