### PR TITLE
feat(examples): add dspy-agent example with chain-of-thought QA

### DIFF
--- a/examples/python/dspy-agent/.env.example
+++ b/examples/python/dspy-agent/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenAI (used by DSPy as the underlying language model)
+OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/python/dspy-agent/README.md
+++ b/examples/python/dspy-agent/README.md
@@ -1,0 +1,30 @@
+# DSPy Agent
+
+A minimal [DSPy](https://dspy.ai/) chain-of-thought QA module, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+## What it does
+
+Defines a `CoTQA` module that wraps `dspy.ChainOfThought("question -> answer")` and runs it against three demo questions covering arithmetic word problems, scientific reasoning, and a classic logic puzzle. DSPy auto-generates the reasoning prompt; the OpenInference DSPy instrumentor turns each predictor invocation, language-model call, and reasoning step into spans that show up in your TraceRoot UI.
+
+## How instrumentation is wired
+
+```python
+import traceroot
+from traceroot import Integration
+
+traceroot.initialize(integrations=[Integration.DSPY])
+```
+
+That single call activates `openinference.instrumentation.dspy.DSPyInstrumentor`, which patches DSPy modules and predictors to emit OpenTelemetry spans. The `@observe` decorator wraps the demo entrypoint so the per-session span groups everything in a single trace.

--- a/examples/python/dspy-agent/main.py
+++ b/examples/python/dspy-agent/main.py
@@ -22,10 +22,10 @@ import dspy
 import traceroot
 from traceroot import Integration, observe, using_attributes
 
-traceroot.initialize(integrations=[Integration.DSPY])
-
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+traceroot.initialize(integrations=[Integration.DSPY])
 
 
 # ---------------------------------------------------------------------------
@@ -88,5 +88,7 @@ def run_demo():
 
 if __name__ == "__main__":
     with using_attributes(user_id="example-user", session_id="dspy-cot-session"):
-        run_demo()
-    traceroot.flush()
+        try:
+            run_demo()
+        finally:
+            traceroot.flush()

--- a/examples/python/dspy-agent/main.py
+++ b/examples/python/dspy-agent/main.py
@@ -1,0 +1,92 @@
+"""
+DSPy chain-of-thought QA agent, instrumented with TraceRoot.
+
+Usage:
+    cp .env.example .env
+    pip install -r requirements.txt
+    python main.py
+"""
+
+import logging
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found (find_dotenv returned None).\nUsing process environment variables.")
+
+import dspy
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.DSPY])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# DSPy configuration
+# ---------------------------------------------------------------------------
+
+# DSPy resolves the API key from OPENAI_API_KEY in the environment.
+# `cache=False` disables DSPy's local response cache so every run produces
+# real LLM latency in the trace — useful for the demo, drop the flag in
+# production to take advantage of caching.
+LM = dspy.LM("openai/gpt-4o-mini", max_tokens=1024, cache=False)
+dspy.configure(lm=LM)
+
+
+# ---------------------------------------------------------------------------
+# Module
+# ---------------------------------------------------------------------------
+
+
+class CoTQA(dspy.Module):
+    """A minimal chain-of-thought question-answering module.
+
+    The signature `question -> answer` tells DSPy to produce both an
+    intermediate reasoning chain and a final answer field; with
+    `ChainOfThought`, the reasoning is added to the prompt automatically.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.cot = dspy.ChainOfThought("question -> answer")
+
+    def forward(self, question: str):
+        return self.cot(question=question)
+
+
+# ---------------------------------------------------------------------------
+# Demo
+# ---------------------------------------------------------------------------
+
+DEMO_QUESTIONS = [
+    "If a train leaves city A at 9am traveling 60 mph and another leaves "
+    "city B at 10am traveling 80 mph toward A, and the cities are 280 miles "
+    "apart, at what time do they meet?",
+    "Why does ice float on water?",
+    "A farmer has 17 sheep, all but 9 die. How many are left?",
+]
+
+
+@observe(name="dspy_cot_demo", type="agent")
+def run_demo():
+    qa = CoTQA()
+    for i, question in enumerate(DEMO_QUESTIONS, 1):
+        print(f"\n{'=' * 60}")
+        print(f"Q{i}: {question}")
+        print("=" * 60)
+        result = qa(question=question)
+        print(f"\nReasoning: {result.reasoning}")
+        print(f"Answer: {result.answer}\n")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="dspy-cot-session"):
+        run_demo()
+    traceroot.flush()

--- a/examples/python/dspy-agent/main.py
+++ b/examples/python/dspy-agent/main.py
@@ -22,10 +22,9 @@ import dspy
 import traceroot
 from traceroot import Integration, observe, using_attributes
 
+traceroot.initialize(integrations=[Integration.DSPY])
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-traceroot.initialize(integrations=[Integration.DSPY])
 
 
 # ---------------------------------------------------------------------------

--- a/examples/python/dspy-agent/requirements.txt
+++ b/examples/python/dspy-agent/requirements.txt
@@ -1,2 +1,5 @@
+dspy>=2.6.22,<4.0
+openinference-instrumentation-dspy>=0.1.34,<1.0
 python-dotenv>=1.0.0
+
 traceroot==0.1.5

--- a/examples/python/dspy-agent/requirements.txt
+++ b/examples/python/dspy-agent/requirements.txt
@@ -2,4 +2,4 @@ python-dotenv>=1.0.0
 
 # `[dspy]` extra brings in dspy + openinference-instrumentation-dspy.
 # Bump to the first traceroot release that ships the DSPy integration.
-traceroot[dspy]==0.1.4
+traceroot[dspy]==0.1.5

--- a/examples/python/dspy-agent/requirements.txt
+++ b/examples/python/dspy-agent/requirements.txt
@@ -1,0 +1,5 @@
+python-dotenv>=1.0.0
+
+# `[dspy]` extra brings in dspy + openinference-instrumentation-dspy.
+# Bump to the first traceroot release that ships the DSPy integration.
+traceroot[dspy]==0.1.4

--- a/examples/python/dspy-agent/requirements.txt
+++ b/examples/python/dspy-agent/requirements.txt
@@ -1,5 +1,2 @@
 python-dotenv>=1.0.0
-
-# `[dspy]` extra brings in dspy + openinference-instrumentation-dspy.
-# Bump to the first traceroot release that ships the DSPy integration.
-traceroot[dspy]==0.1.5
+traceroot==0.1.5


### PR DESCRIPTION
## Summary

Adds examples/python/dspy-agent/ with main.py, requirements.txt, .env.example, and README.md. The script wraps
dspy.ChainOfThought("question -> answer") in a small CoTQA module and runs it against three demo questions covering arithmetic, science, and a logic puzzle. A single traceroot.initialize(integrations=[ Integration.DSPY]) call activates the OpenInference DSPy instrumentor; @observe wraps the demo entrypoint so the whole session shows up as one trace.

requirements.txt uses traceroot[dspy]==0.1.4 to showcase the [dspy] extra defined in the companion traceroot-py PR; the version pin will need to bump to the first traceroot release that ships the DSPy integration.

dspy.LM is configured with cache=False so traces show real LLM latency during the demo (DSPy 3.x caches by default), and max_tokens=1024 to avoid truncating chain-of-thought reasoning.

This PR is paired with traceroot-ai/traceroot-py#110, which wires the `Integration.DSPY` enum + registry + `[dspy]` extra in the SDK.

Fixes #735

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

### Files added

- `examples/python/dspy-agent/main.py` — the demo script (~90 lines)
- `examples/python/dspy-agent/requirements.txt` — uses `traceroot[dspy]==0.1.4` to showcase the `[dspy]` extra introduced in traceroot-ai/traceroot-py#110. The pin will need to bump to the first traceroot release that ships the DSPy integration.
- `examples/python/dspy-agent/.env.example` — TraceRoot + OpenAI keys
- `examples/python/dspy-agent/README.md` — setup + what-it-does

### Implementation choices worth flagging

- **`cache=False` on `dspy.LM`** — DSPy 3.x caches LM responses by default, which made repeated demo runs collapse to 0 ms in traces. Disabled so traces show real LLM latency. A comment in `main.py` notes that production code can re-enable it.
- **`max_tokens=1024`** — `512` truncated the chain-of-thought reasoning on one of the demo questions (DSPy logged a truncation warning).

### Note on the trace shape

The OpenInference DSPy instrumentor emits one span per layer of DSPy's predictor pipeline:

\`\`\`
dspy_cot_demo                       ← @observe wrapper
└─ CoTQA.forward                    ← our dspy.Module subclass
   └─ ChainOfThought.forward        ← DSPy's CoT module
      └─ Predict.forward            ← underlying predictor
         └─ Predict(StringSignature)
            └─ ChatAdapter.__call__
               └─ LM.__call__       ← LiteLLM completion
\`\`\`

The middle layers (`ChainOfThought` → `Predict` → `Predict(StringSignature)`) show very similar input/output because they are thin pass-through wrappers in DSPy. This shape is consistent with how the same OpenInference instrumentor surfaces traces in Phoenix, Langfuse, and MLflow — happy to adjust if you'd prefer a flatter shape (e.g. via a custom span processor).

## Screenshots / Recordings (if applicable)

<img width="1326" height="918" alt="Screenshot 2026-04-26 at 20 52 45" src="https://github.com/user-attachments/assets/2ca8c8d3-0bad-4989-9c08-7d41cd8b2bb4" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable: examples are not unit-tested; the script was run end-to-end locally against a self-hosted TraceRoot stack and produced the trace screenshot above. 
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary
