### PR TITLE
security: harden web pod with readOnlyRootFilesystem and non-root context

### DIFF
--- a/deploy/helm/templates/web/deployment.yaml
+++ b/deploy/helm/templates/web/deployment.yaml
@@ -20,6 +20,8 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
       securityContext:
         runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 1001
       containers:
         - name: web
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
@@ -27,6 +29,9 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           ports:
             - containerPort: {{ .Values.web.port }}
           env:

--- a/deploy/helm/templates/web/deployment.yaml
+++ b/deploy/helm/templates/web/deployment.yaml
@@ -18,10 +18,15 @@ spec:
         app: web
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      securityContext:
+        runAsNonRoot: true
       containers:
         - name: web
           image: "{{ .Values.web.image.repository }}:{{ .Values.web.image.tag }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: {{ .Values.web.port }}
           env:
@@ -206,3 +211,9 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.web.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}


### PR DESCRIPTION
## Summary
- Add `runAsNonRoot: true` at pod level
- Add `readOnlyRootFilesystem: true` + `allowPrivilegeEscalation: false` at container level
- Mount `/tmp` as emptyDir so Next.js retains a writable scratch space

## Test plan
- [ ] Verify staging web pod starts cleanly after deploy (`kubectl get pods -n traceroot-staging`)
- [ ] Verify `/api/health` responds on staging
- [ ] Verify production deploy works the same way

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the web pod by dropping all Linux capabilities, running as non-root (UID/GID 1001), making the root filesystem read-only, and disabling privilege escalation. Added an ephemeral `/tmp` so Next.js has a writable scratch space without loosening the rest.

- **Security**
  - Pod: `runAsNonRoot: true`, `runAsUser: 1001`, `runAsGroup: 1001`
  - Container: `readOnlyRootFilesystem: true`, `allowPrivilegeEscalation: false`, `capabilities.drop: [ALL]`
  - Volumes: mount `/tmp` as `emptyDir` (wiped on restart)

<sup>Written for commit e6f1ddd787eca45f01b81245b52760af9f36cdea. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/760?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

