### PR TITLE
chore: configure Dependabot with grouping, Docker and Actions monitoring

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    groups:
+      security-patches:
+        applies-to: security-updates
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      security-patches:
+        applies-to: security-updates
+        update-types:
+          - "patch"
+          - "minor"
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
Adds `.github/dependabot.yml` to extend Dependabot beyond GitHub's default npm-only behavior.

## Changes
- **Grouping** — security patches per ecosystem arrive as 1 grouped PR instead of N individual ones
- **Docker monitoring** — watches `docker/` for vulnerable base images (e.g. `node:20-alpine`)
- **GitHub Actions monitoring** — watches `.github/workflows/` for outdated action versions

## What this does NOT fix
Dependabot still cannot auto-PR **transitive** dependency vulnerabilities. Those require `pnpm.overrides` and were handled in #761.

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configures Dependabot to reduce PR noise and keep all ecosystems up to date. Adds `.github/dependabot.yml` with weekly grouped security updates and monitoring for `npm`, `pip`, `docker`, and `github-actions`.

- **Dependencies**
  - Group security updates into one PR per ecosystem (patch/minor).
  - Monitor `npm` in `/frontend` and `pip` in `/` weekly.
  - Enable weekly checks for `docker` images in `/docker` and `github-actions` in workflows.

Closes #764.

<sup>Written for commit 22253a95049cdadd1c4d6bf708bb3dc43fceadb4. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/765?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

