### PR TITLE
fix: show AI agent button on users and sessions pages

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useLayoutEffect } from "react";
 import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
@@ -34,7 +34,7 @@ export default function SessionsPage() {
   const params = useParams();
   const searchParams = useSearchParams();
   const projectId = params.projectId as string;
-  const { aiPanelOpen, setAiPanelOpen } = useLayout();
+  const { aiPanelOpen, setAiPanelOpen, setHideAiButton } = useLayout();
   const [itemsPerPageOpen, setItemsPerPageOpen] = useState(false);
   const sessionIdFromUrl = searchParams.get("sessionId");
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(sessionIdFromUrl);
@@ -59,6 +59,10 @@ export default function SessionsPage() {
     }),
     [queryOptions],
   );
+
+  useLayoutEffect(() => {
+    setHideAiButton(false);
+  }, [setHideAiButton]);
 
   const { data, isLoading, error } = useSessions(projectId, sessionQueryOptions);
 

--- a/frontend/ui/src/app/projects/[projectId]/users/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/users/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useLayoutEffect } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
+import { useLayout } from "@/components/layout/app-layout";
 import { Workflow, Users, Layers, ChevronLeft, ChevronRight, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -23,7 +24,12 @@ export default function UsersPage() {
   const params = useParams();
   const router = useRouter();
   const projectId = params.projectId as string;
+  const { setHideAiButton } = useLayout();
   const [itemsPerPageOpen, setItemsPerPageOpen] = useState(false);
+
+  useLayoutEffect(() => {
+    setHideAiButton(false);
+  }, [setHideAiButton]);
 
   // Use URL-synced state management (shares date filter with other pages)
   const {

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -46,15 +46,20 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [hideAiButton, setHideAiButton] = useState(true);
   const pathname = usePathname();
 
-  // Close the global AI panel and reset button visibility whenever the user navigates.
+  // Close the global AI panel whenever the user navigates.
+  // NOTE: do NOT reset hideAiButton here. TracesPage.useLayoutEffect is the sole
+  // owner of that flag. Resetting it here creates a race: useLayoutEffect (child,
+  // synchronous) fires before useEffect (parent, async), so this reset always
+  // overwrites the correct value set by TracesPage — hiding the button in prod
+  // (Strict Mode's double-invoke masked the bug locally). The isTracesPage guard
+  // in showAiButton already prevents the button from rendering on other pages.
   useEffect(() => {
     setAiPanelOpen(false);
     setAiContext(null);
-    setHideAiButton(true);
   }, [pathname]);
 
-  const isTracesPage = /^\/projects\/[^/]+\/traces(\/|$)/.test(pathname);
-  const showAiButton = isTracesPage && !hideAiButton;
+  const isObservabilityPage = /^\/projects\/[^/]+\/(traces|users|sessions)(\/|$)/.test(pathname);
+  const showAiButton = isObservabilityPage && !hideAiButton;
   const projectIdMatch = pathname.match(/^\/projects\/([^/]+)/);
   const projectId = projectIdMatch?.[1];
 


### PR DESCRIPTION
## Summary

- Extends the AI agent button from traces-only to all three observability tabs (traces, users, sessions)
- Fixes the button disappearing after navigating to users/sessions and back to traces (the prod regression in #785)

## Root cause

Two bugs combined to produce the reported behavior:

1. **Race condition in `app-layout.tsx`**: `useEffect([pathname])` called `setHideAiButton(true)` on every route change. Since `useEffect` fires async (after paint) and `TracesPage.useLayoutEffect` fires sync (before paint), the layout's reset always overwrote the correct value — permanently hiding the button after any navigation in prod. (React Strict Mode's double-invoke accidentally masked this locally.)

2. **Regex too narrow**: `isTracesPage` only matched `/traces` routes, so the button could never render on `/users` or `/sessions` even when `hideAiButton` was `false`.

## Changes

**`app-layout.tsx`**
- Removed `setHideAiButton(true)` from the pathname `useEffect` — `isObservabilityPage` already prevents the button from rendering on other pages
- Renamed `isTracesPage` → `isObservabilityPage`, regex now matches `traces|users|sessions`

**`users/page.tsx`** / **`sessions/page.tsx`**
- Added `useLayoutEffect(() => setHideAiButton(false))` on mount — these pages have no onboarding gate, so the button should always show when they're reachable

## Behavior after fix

| State | traces | users | sessions |
|-------|--------|-------|---------|
| No traces (onboarding) | ❌ hidden | n/a | n/a |
| Has traces | ✅ shown | ✅ shown | ✅ shown |
| Navigate away and back | ✅ shown | ✅ shown | ✅ shown |

Closes #785

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the AI agent button on Traces, Users, and Sessions, and fix it disappearing after navigation. Fixes #785.

- **New Features**
  - Button now visible on Users and Sessions (when eligible).

- **Bug Fixes**
  - Removed the route-change reset that hid the button after navigating; we now only close the panel on navigation.
  - Users/Sessions set the button visible on mount; route guard now matches traces|users|sessions for consistent rendering.

<sup>Written for commit 17c1768d45b67976503b4a7aba8dc8fbaec7d615. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/787?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

