### PR TITLE
fix: empty-state flash on pages (#786)

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
@@ -11,6 +11,7 @@ import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { SessionDetailPanel } from "@/features/traces/components/SessionDetailPanel";
 import { useSessions, useListPageState } from "@/features/traces/hooks";
+import { useSession as useAuthSession } from "@/lib/auth-client";
 import { formatDate, formatCost, formatTokens, cn, buildUrlWithFilters } from "@/lib/utils";
 import type { SessionListItem, SessionQueryOptions } from "@/types/api";
 
@@ -29,6 +30,7 @@ export default function SessionsPage() {
   const searchParams = useSearchParams();
   const projectId = params.projectId as string;
   const { aiPanelOpen, setAiPanelOpen, setHideAiButton } = useLayout();
+  const { isPending: authPending } = useAuthSession();
   const [itemsPerPageOpen, setItemsPerPageOpen] = useState(false);
   const sessionIdFromUrl = searchParams.get("sessionId");
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(sessionIdFromUrl);
@@ -58,7 +60,11 @@ export default function SessionsPage() {
     setHideAiButton(false);
   }, [setHideAiButton]);
 
-  const { data, isLoading, error } = useSessions(projectId, sessionQueryOptions);
+  const { data, isPending: dataPending, error } = useSessions(projectId, sessionQueryOptions);
+  // Auth-gated React Query reports isLoading: false while disabled (TanStack v5).
+  // Use isPending OR'd with auth pending so the loading branch shows during the
+  // auth-resolution window instead of falling through to the empty state.
+  const checking = authPending || dataPending;
 
   const sessions = data?.data || [];
   const meta = data?.meta || { page: 0, limit: 50, total: 0 };
@@ -116,7 +122,7 @@ export default function SessionsPage() {
 
         {/* Content */}
         <div className="flex-1 overflow-auto bg-background">
-          {isLoading ? (
+          {checking ? (
             <div className="flex h-64 items-center justify-center">
               <p className="text-[13px] text-muted-foreground">Loading sessions...</p>
             </div>

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -22,6 +22,7 @@ import type { TraceListItem } from "@/types/api";
 import { useTraces, useListPageState } from "@/features/traces/hooks";
 import { TraceViewerPanel, GettingStarted } from "@/features/traces/components";
 import { formatContentPreview } from "@/features/traces/utils";
+import { useSession as useAuthSession } from "@/lib/auth-client";
 
 // Tab definitions
 const tabs = [
@@ -37,6 +38,7 @@ export default function TracesPage() {
   const projectId = params.projectId as string;
   const queryClient = useQueryClient();
   const { aiPanelOpen, setAiPanelOpen, setHideAiButton } = useLayout();
+  const { isPending: authPending } = useAuthSession();
   const userId = searchParams.get("user_id");
   const traceIdFromUrl = searchParams.get("traceId");
 
@@ -70,7 +72,7 @@ export default function TracesPage() {
   // staleTime: Infinity because once a project has traces it always will (immutable fact).
   // refetchInterval polls every 3s while onboarding is shown so the page auto-transitions
   // when the first trace arrives, without requiring a manual refresh.
-  const { data: anyTracesData, isLoading: hasEverTracedLoading } = useTraces(
+  const { data: anyTracesData, isPending: hasEverTracedPending } = useTraces(
     projectId,
     { limit: 1 },
     {
@@ -84,6 +86,9 @@ export default function TracesPage() {
     },
   );
   const hasEverTraced = (anyTracesData?.data?.length ?? 0) > 0;
+  // Auth-gated React Query reports isLoading: false while disabled (TanStack v5),
+  // so derive a single "still figuring it out" flag from auth + the probe's isPending.
+  const checking = authPending || hasEverTracedPending;
   useEffect(() => {
     if (hasEverTraced) queryClient.invalidateQueries({ queryKey: ["traces", projectId] });
   }, [hasEverTraced, projectId, queryClient]);
@@ -91,10 +96,10 @@ export default function TracesPage() {
   const traces = data?.data || [];
   const meta = data?.meta || { page: 0, limit: 50, total: 0 };
   const totalPages = Math.ceil(meta.total / meta.limit);
-  const showGettingStarted = !hasEverTracedLoading && !hasEverTraced;
+  const showGettingStarted = !checking && !hasEverTraced;
 
   // Hide AI button during loading AND when GettingStarted is shown
-  const shouldHideAiButton = hasEverTracedLoading || showGettingStarted;
+  const shouldHideAiButton = checking || showGettingStarted;
 
   useLayoutEffect(() => {
     setHideAiButton(shouldHideAiButton);
@@ -115,7 +120,7 @@ export default function TracesPage() {
       {/* Main content */}
       <div className="flex flex-1 flex-col">
         {/* Tab navigation — hidden during onboarding or while checking */}
-        {!hasEverTracedLoading && !showGettingStarted && (
+        {!checking && !showGettingStarted && (
           <div className="border-b border-border bg-background">
             <div className="flex">
               {tabs.map((tab) => {
@@ -142,7 +147,7 @@ export default function TracesPage() {
         )}
 
         {/* Filters bar — hidden during onboarding or while checking */}
-        {!hasEverTracedLoading && !showGettingStarted && (
+        {!checking && !showGettingStarted && (
           <SearchFilterBar
             searchValue={state.keyword}
             onSearchChange={updateKeyword}
@@ -199,7 +204,7 @@ export default function TracesPage() {
 
         {/* Content */}
         <div className="flex-1 overflow-auto bg-background">
-          {isLoading || hasEverTracedLoading ? (
+          {isLoading || checking ? (
             <div className="flex h-64 items-center justify-center">
               <p className="text-[13px] text-muted-foreground">Loading traces...</p>
             </div>

--- a/frontend/ui/src/app/projects/[projectId]/users/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/users/page.tsx
@@ -10,6 +10,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { useUsers, useListPageState } from "@/features/traces/hooks";
+import { useSession as useAuthSession } from "@/lib/auth-client";
 import { formatDate, formatCost, formatTokens, cn, buildUrlWithFilters } from "@/lib/utils";
 import type { UserListItem } from "@/lib/api/users";
 import type { UserQueryOptions } from "@/lib/api/users";
@@ -25,6 +26,7 @@ export default function UsersPage() {
   const router = useRouter();
   const projectId = params.projectId as string;
   const { setHideAiButton } = useLayout();
+  const { isPending: authPending } = useAuthSession();
   const [itemsPerPageOpen, setItemsPerPageOpen] = useState(false);
 
   useLayoutEffect(() => {
@@ -54,7 +56,11 @@ export default function UsersPage() {
     [queryOptions],
   );
 
-  const { data, isLoading, error } = useUsers(projectId, userQueryOptions);
+  const { data, isPending: dataPending, error } = useUsers(projectId, userQueryOptions);
+  // Auth-gated React Query reports isLoading: false while disabled (TanStack v5).
+  // Use isPending OR'd with auth pending so the loading branch shows during the
+  // auth-resolution window instead of falling through to the empty state.
+  const checking = authPending || dataPending;
 
   const users = data?.data || [];
   const meta = data?.meta || { page: 0, limit: 50, total: 0 };
@@ -117,7 +123,7 @@ export default function UsersPage() {
 
         {/* Content */}
         <div className="flex-1 overflow-auto bg-background">
-          {isLoading ? (
+          {checking ? (
             <div className="flex h-64 items-center justify-center">
               <p className="text-[13px] text-muted-foreground">Loading users...</p>
             </div>

--- a/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
@@ -111,7 +111,11 @@ export function SessionDetailPanel({
     };
   }, [dateFilter, customStartDate, customEndDate]);
 
-  const { data, isPending: dataPending, error } = useSession(projectId, sessionId, sessionQueryOptions);
+  const {
+    data,
+    isPending: dataPending,
+    error,
+  } = useSession(projectId, sessionId, sessionQueryOptions);
   // Auth-gated React Query reports isLoading: false while disabled (TanStack v5).
   // Use isPending OR'd with auth pending so the loading branch shows during the
   // auth-resolution window instead of falling through to "Session not found".

--- a/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { ExpandableSection } from "@/components/ui/expandable-section";
 import { useSession } from "@/features/traces/hooks";
+import { useSession as useAuthSession } from "@/lib/auth-client";
 import { ContentRenderer } from "./ContentRenderer";
 import { formatDuration, formatCost, buildUrlWithFilters } from "@/lib/utils";
 import { toTimestampBounds } from "@/lib/date-filter";
@@ -94,6 +95,7 @@ export function SessionDetailPanel({
 }: SessionDetailPanelProps) {
   const router = useRouter();
   const [aiChatOpen, setAiChatOpen] = useState(false);
+  const { isPending: authPending } = useAuthSession();
 
   // Compute timestamps from date filter props
   const sessionQueryOptions = useMemo(() => {
@@ -109,7 +111,11 @@ export function SessionDetailPanel({
     };
   }, [dateFilter, customStartDate, customEndDate]);
 
-  const { data, isLoading, error } = useSession(projectId, sessionId, sessionQueryOptions);
+  const { data, isPending: dataPending, error } = useSession(projectId, sessionId, sessionQueryOptions);
+  // Auth-gated React Query reports isLoading: false while disabled (TanStack v5).
+  // Use isPending OR'd with auth pending so the loading branch shows during the
+  // auth-resolution window instead of falling through to "Session not found".
+  const checking = authPending || dataPending;
 
   const buildUrl = (basePath: string, extraParams?: Record<string, string>) =>
     buildUrlWithFilters(basePath, { dateFilter, customStartDate, customEndDate, extraParams });
@@ -221,7 +227,7 @@ export function SessionDetailPanel({
 
           {/* Trace list */}
           <div className="flex-1 overflow-auto p-4">
-            {isLoading ? (
+            {checking ? (
               <div className="flex h-64 items-center justify-center">
                 <p className="text-[13px] text-muted-foreground">Loading session...</p>
               </div>


### PR DESCRIPTION
## Environment                                                                             
                                                                         
  - **Reproduced on:** BOTH 1)`app.traceroot.ai` (hosted) and 2) local self-host via `make prod-lite`
  against current `main` (commit `def7da9`).                                                 
  - **Frontend stack:** Next.js 15.5.15, React Query 5.62.0 (`@tanstack/react-query`)
  - **Browser:** Chrome                 
  - **OS:** Reproduced on macOS, but the bug is in browser-side React state so no need to worry here
## Summary                                                                                 
                                                                                           
  Four dashboard pages briefly render their empty or onboarding state on hard refresh before 
  real data loads:                                                                           
                                                                                             
  - Trace list flashes "Get started with Tracing" (#786)
  - Users tab flashes "No users found"                                                       
  - Sessions tab flashes "No sessions found"                                               
  - Session detail panel flashes "Session not found" (#789)

**Closes #786** 
**Closes #789**

## Type of Change

- [x] fix - A bug fix

## Root cause                                                                              
Each affected page reads `isLoading` from a React Query hook that is gated on `enabled: sessionReady && ...`. While Better Auth is resolving the session on a hard refresh, the query stays disabled.  

## Fix                          
Switch each affected consumer from `isLoading` to `isPending`, and OR it with the auth session's own pending flag. The loading branches already exist in each file; they were just being fed the wrong signal.
## Screenshots / Recordings (if applicable)
https://github.com/user-attachments/assets/770f65bb-0e8c-439e-84e8-eabb58096e30

## Test plan                                                                               
                                                                                           
  Verified locally with `make prod-lite` against real agent run by `[openai-agents-sdk](https://github.com/traceroot-ai/traceroot/tree/main/examples/python/openai-agents-sdk)`                                                   
                                  
  - [x] Hard-refresh `/projects/<id>/traces` — loading state shows, no GettingStarted flash  
  - [x] Hard-refresh `/projects/<id>/users` — loading state shows, no "No users found" flash
  - [x] Hard-refresh `/projects/<id>/sessions` — loading state shows, no "No sessions found"
  flash                               
  - [x] Hard-refresh `/projects/<id>/sessions?sessionId=<existing>` — loading state shows, no
   "Session not found" flash                     
  - [x] Project with zero traces — onboarding still renders after loading completes          
  (regression check)                                                                       
  - [x] Same fresh project: users/sessions tabs still render their empty states (regression  
  check)                                        
  - [x] Stress test: DevTools → block `/api/auth/get-session` → hard-refresh each page →     
  loading branch holds indefinitely instead of falling through

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty-state flashes on Traces, Users, Sessions, and Session Detail during hard refresh by showing a proper loading state while auth and data queries resolve. Addresses the onboarding/“no results”/“not found” flicker reported in #786 and #789.

- **Bug Fixes**
  - Switched from `isLoading` to `isPending` for `@tanstack/react-query` v5 hooks on auth-gated queries.
  - Combined data `isPending` with auth `isPending` from `useSession` to form a single `checking` flag.
  - Applied to `traces`, `users`, `sessions` pages and `SessionDetailPanel`.
  - Traces page now hides tabs/filters and onboarding until `checking` completes.

<sup>Written for commit 8c240a3dacc4990cba51e513e63934d8cecbce34. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/790?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



