### PR TITLE
feat(examples): add Mistral AI tool agent Python example

### DIFF
--- a/examples/python/claude-agent-sdk/requirements.txt
+++ b/examples/python/claude-agent-sdk/requirements.txt
@@ -1,4 +1,4 @@
-claude-agent-sdk>=0.1.0
+claude-agent-sdk>=0.1.72
 python-dotenv>=1.0.0
 
 traceroot==0.1.4

--- a/examples/python/mistral-tool-agent/.env.example
+++ b/examples/python/mistral-tool-agent/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# Mistral AI
+MISTRAL_API_KEY=your_mistral_api_key_here

--- a/examples/python/mistral-tool-agent/README.md
+++ b/examples/python/mistral-tool-agent/README.md
@@ -1,0 +1,24 @@
+# Mistral AI Tool Agent
+
+ReAct-style agent with Mistral AI tool calling, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in your API keys
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python main.py
+```
+
+## What it does
+
+Runs two demo queries that exercise multi-step tool use:
+1. Weather comparison (San Francisco vs Tokyo)
+2. Stock price lookup + calculation (NVDA +10%)
+
+Tools: `get_weather`, `get_stock_price`, `calculate`, `get_current_time`

--- a/examples/python/mistral-tool-agent/main.py
+++ b/examples/python/mistral-tool-agent/main.py
@@ -228,28 +228,36 @@ class ReActAgent:
             msg = response.choices[0].message
 
             if msg.tool_calls:
-                self.messages.append({"role": "assistant", "content": msg.content or "", "tool_calls": [
+                self.messages.append(
                     {
-                        "id": tc.id,
-                        "type": "function",
-                        "function": {
-                            "name": tc.function.name,
-                            "arguments": tc.function.arguments,
-                        },
+                        "role": "assistant",
+                        "content": msg.content or "",
+                        "tool_calls": [
+                            {
+                                "id": tc.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tc.function.name,
+                                    "arguments": tc.function.arguments,
+                                },
+                            }
+                            for tc in msg.tool_calls
+                        ],
                     }
-                    for tc in msg.tool_calls
-                ]})
+                )
 
                 for tc in msg.tool_calls:
                     args = json.loads(tc.function.arguments)
                     logger.info(f"Tool call: {tc.function.name}({args})")
                     result = self._execute_tool(tc.function.name, args)
                     logger.info(f"Tool result: {result}")
-                    self.messages.append({
-                        "role": "tool",
-                        "tool_call_id": tc.id,
-                        "content": result,
-                    })
+                    self.messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc.id,
+                            "content": result,
+                        }
+                    )
             else:
                 self.messages.append({"role": "assistant", "content": msg.content})
                 return msg.content or ""

--- a/examples/python/mistral-tool-agent/main.py
+++ b/examples/python/mistral-tool-agent/main.py
@@ -1,0 +1,284 @@
+"""
+Mistral AI Tool Agent — TraceRoot Observability
+
+A ReAct-style agent built with the Mistral AI SDK, instrumented
+with TraceRoot via traceroot.initialize(integrations=[Integration.MISTRAL]).
+
+Env vars required: MISTRAL_API_KEY, TRACEROOT_API_KEY
+
+Run:
+    pip install -r requirements.txt
+    python main.py
+"""
+
+import json
+import logging
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found (find_dotenv returned None).\nUsing process environment variables.")
+
+from mistralai.client.sdk import Mistral
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.MISTRAL])
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@observe(name="get_weather", type="tool")
+def get_weather(city: str) -> dict:
+    """Get current weather for a city."""
+    weather_db = {
+        "san francisco": {"temp": 68, "condition": "foggy", "humidity": 75},
+        "new york": {"temp": 45, "condition": "cloudy", "humidity": 60},
+        "london": {"temp": 52, "condition": "rainy", "humidity": 85},
+        "tokyo": {"temp": 72, "condition": "sunny", "humidity": 50},
+    }
+    data = weather_db.get(city.lower(), {"temp": 70, "condition": "unknown", "humidity": 50})
+    return {"city": city, **data}
+
+
+@observe(name="get_stock_price", type="tool")
+def get_stock_price(symbol: str) -> dict:
+    """Get stock price for a symbol."""
+    stocks = {
+        "AAPL": {"price": 178.50, "change": +2.30, "percent": "+1.3%"},
+        "GOOGL": {"price": 141.20, "change": -0.80, "percent": "-0.6%"},
+        "MSFT": {"price": 378.90, "change": +4.50, "percent": "+1.2%"},
+        "NVDA": {"price": 495.20, "change": +12.30, "percent": "+2.5%"},
+    }
+    data = stocks.get(symbol.upper(), {"price": 0, "change": 0, "percent": "N/A"})
+    return {"symbol": symbol.upper(), **data}
+
+
+@observe(name="calculate", type="tool")
+def calculate(expression: str) -> dict:
+    """Evaluate a math expression safely using AST parsing."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval(node.operand)
+        raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+        result = _eval(tree)
+        return {"expression": expression, "result": result}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@observe(name="get_current_time", type="tool")
+def get_current_time(timezone_name: str = "UTC") -> dict:
+    """Get current time in the specified timezone."""
+    try:
+        zone = ZoneInfo(timezone_name)
+        current_time = datetime.now(zone).strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        current_time = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S")
+        timezone_name = "UTC"
+    return {"timezone": timezone_name, "time": current_time}
+
+
+TOOLS = {
+    "get_weather": get_weather,
+    "get_stock_price": get_stock_price,
+    "calculate": calculate,
+    "get_current_time": get_current_time,
+}
+
+TOOL_SCHEMAS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string", "description": "City name"}},
+                "required": ["city"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_stock_price",
+            "description": "Get current stock price for a ticker symbol",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "symbol": {
+                        "type": "string",
+                        "description": "Stock ticker symbol (e.g., AAPL)",
+                    }
+                },
+                "required": ["symbol"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "calculate",
+            "description": "Evaluate a mathematical expression",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {
+                        "type": "string",
+                        "description": "Math expression (e.g., '2 + 2 * 3')",
+                    }
+                },
+                "required": ["expression"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_current_time",
+            "description": "Get the current date and time",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "timezone_name": {
+                        "type": "string",
+                        "description": "Timezone name (e.g., UTC, America/New_York)",
+                    }
+                },
+            },
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class ReActAgent:
+    """ReAct-style agent using Mistral's tool calling API."""
+
+    def __init__(self, model: str = "mistral-large-latest"):
+        self.client = Mistral()
+        self.model = model
+        self.messages: list[dict] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful AI assistant with access to tools. "
+                    "Use available tools to gather information, then provide "
+                    "a clear, comprehensive answer."
+                ),
+            }
+        ]
+
+    @observe(name="execute_tool", type="span")
+    def _execute_tool(self, name: str, arguments: dict) -> str:
+        if name not in TOOLS:
+            return json.dumps({"error": f"Unknown tool: {name}"})
+        try:
+            return json.dumps(TOOLS[name](**arguments))
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @observe(name="agent_turn", type="agent")
+    def run(self, query: str) -> str:
+        self.messages.append({"role": "user", "content": query})
+
+        for _ in range(5):
+            response = self.client.chat.complete(
+                model=self.model,
+                messages=self.messages,
+                tools=TOOL_SCHEMAS,
+                tool_choice="auto",
+            )
+
+            msg = response.choices[0].message
+
+            if msg.tool_calls:
+                self.messages.append({"role": "assistant", "content": msg.content or "", "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                    for tc in msg.tool_calls
+                ]})
+
+                for tc in msg.tool_calls:
+                    args = json.loads(tc.function.arguments)
+                    logger.info(f"Tool call: {tc.function.name}({args})")
+                    result = self._execute_tool(tc.function.name, args)
+                    logger.info(f"Tool result: {result}")
+                    self.messages.append({
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": result,
+                    })
+            else:
+                self.messages.append({"role": "assistant", "content": msg.content})
+                return msg.content or ""
+
+        return "I wasn't able to complete this task within the allowed steps."
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+DEMO_QUERIES = [
+    "What's the weather in San Francisco and Tokyo? Compare them.",
+    "What's NVDA stock price? If it goes up 10%, what would the new price be?",
+]
+
+
+@observe(name="demo_session", type="agent")
+def run_demo():
+    for i, query in enumerate(DEMO_QUERIES, 1):
+        agent = ReActAgent()
+        print(f"\n{'=' * 60}")
+        print(f"Query {i}: {query}")
+        print("=" * 60)
+        result = agent.run(query)
+        print(f"\nAgent: {result}\n")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="mistral-agent-session"):
+        run_demo()
+    traceroot.flush()

--- a/examples/python/mistral-tool-agent/main.py
+++ b/examples/python/mistral-tool-agent/main.py
@@ -11,9 +11,9 @@ Run:
     python main.py
 """
 
-import os
 import json
 import logging
+import os
 from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 

--- a/examples/python/mistral-tool-agent/main.py
+++ b/examples/python/mistral-tool-agent/main.py
@@ -11,6 +11,7 @@ Run:
     python main.py
 """
 
+import os
 import json
 import logging
 from datetime import UTC, datetime
@@ -191,7 +192,7 @@ class ReActAgent:
     """ReAct-style agent using Mistral's tool calling API."""
 
     def __init__(self, model: str = "mistral-large-latest"):
-        self.client = Mistral()
+        self.client = Mistral(api_key=os.environ.get("MISTRAL_API_KEY"))
         self.model = model
         self.messages: list[dict] = [
             {

--- a/examples/python/mistral-tool-agent/main.py
+++ b/examples/python/mistral-tool-agent/main.py
@@ -25,7 +25,7 @@ if dotenv_path:
 else:
     print("No .env file found (find_dotenv returned None).\nUsing process environment variables.")
 
-from mistralai.client.sdk import Mistral
+from mistralai import Mistral
 
 import traceroot
 from traceroot import Integration, observe, using_attributes
@@ -248,7 +248,20 @@ class ReActAgent:
                 )
 
                 for tc in msg.tool_calls:
-                    args = json.loads(tc.function.arguments)
+                    try:
+                        args = json.loads(tc.function.arguments)
+                    except (json.JSONDecodeError, TypeError) as e:
+                        logger.warning(
+                            "Failed to parse tool arguments for %s: %s", tc.function.name, e
+                        )
+                        self.messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": tc.id,
+                                "content": json.dumps({"error": "Invalid tool arguments"}),
+                            }
+                        )
+                        continue
                     logger.info(f"Tool call: {tc.function.name}({args})")
                     result = self._execute_tool(tc.function.name, args)
                     logger.info(f"Tool result: {result}")

--- a/examples/python/mistral-tool-agent/requirements.txt
+++ b/examples/python/mistral-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 mistralai>=2.0.0
 python-dotenv>=1.0.0
 
-traceroot>=0.1.3
+traceroot>=0.1.5

--- a/examples/python/mistral-tool-agent/requirements.txt
+++ b/examples/python/mistral-tool-agent/requirements.txt
@@ -1,0 +1,4 @@
+mistralai>=2.0.0
+python-dotenv>=1.0.0
+
+traceroot>=0.1.3


### PR DESCRIPTION
## Summary
Adds a Python example demonstrating TraceRoot observability with the
[Mistral AI](https://mistral.ai/) SDK using `mistral-large-latest`.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

`examples/python/mistral-tool-agent/` — a ReAct-style tool-use agent
with multi-step tool calling, full span hierarchy visible in the
TraceRoot dashboard.

## Setup

```bash
cd examples/python/mistral-tool-agent
cp .env.example .env
pip install -r requirements.txt
python main.py
```

## Screenshots / Recordings (if applicable)
<img width="1342" height="817" alt="image" src="https://github.com/user-attachments/assets/8a95f291-8662-42f6-a1a9-e9d8d21c0f90" />

<br>

<img width="1342" height="867" alt="image" src="https://github.com/user-attachments/assets/6fce3c27-45c3-4fe1-b322-459fe1ffccb5" />

<br>

<img width="1343" height="866" alt="image" src="https://github.com/user-attachments/assets/af153467-a0c5-4e08-9747-4efecb82eee7" />

<br>

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

Depends on traceroot-ai/traceroot-py#111

Closes #733


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Python example of a Mistral tool agent instrumented with `traceroot` to demo traceable, multi-step tool use with `mistral-large-latest`.

- **New Features**
  - ReAct-style agent in `examples/python/mistral-tool-agent` with `mistralai` tool calling and `Integration.MISTRAL`.
  - Tools: `get_weather`, `get_stock_price`, `calculate`, `get_current_time`; runs two demo queries. Includes `README.md`, `.env.example`, `requirements.txt`, and `main.py`.

- **Bug Fixes**
  - Sets `Mistral(api_key=os.environ["MISTRAL_API_KEY"])` and hardens tool argument parsing to handle invalid JSON gracefully.
  - Fixes `mistralai` import path and import ordering for linter compliance.

<sup>Written for commit 67961ae6af57b43186f8b0f3392d42298ef9f7c6. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/791?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



