### PR TITLE
fix: live tracing 500 errors in production (ECONNREFUSED)

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/live/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/live/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { requireAuth, requireProjectAccess } from "@/lib/auth-helpers";
 
-const TRACE_API_URL = process.env.TRACE_API_URL || "http://localhost:8000";
+const NEXT_PUBLIC_API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
 
 type RouteParams = { params: Promise<{ projectId: string; traceId: string }> };
 
@@ -17,7 +17,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
   if (accessResult.error) return accessResult.error;
 
   const backendRes = await fetch(
-    `${TRACE_API_URL}/api/v1/projects/${projectId}/traces/${traceId}/live`,
+    `${NEXT_PUBLIC_API_URL}/projects/${projectId}/traces/${traceId}/live`,
     {
       headers: { "x-user-id": user.id },
     },


### PR DESCRIPTION
## Summary

- The live trace SSE route (`/api/projects/[projectId]/traces/[traceId]/live`) used `TRACE_API_URL` which was never set in production, falling back to `http://localhost:8000`
- In Kubernetes, the web pod has no process on `localhost:8000` → every SSE connection got `ECONNREFUSED` → 500 → live tracing froze immediately
- Locally (`make dev`) everything runs on one machine so `localhost:8000` happened to work, making this impossible to reproduce locally
- Fix: replace `TRACE_API_URL` with the existing `NEXT_PUBLIC_API_URL` (already set in both `.env.example` and the Helm web deployment), following the same naming convention as other route handlers

## Test plan

- [x] Local `make dev` e2e — live tracing works
- [ ] Staging deploy + live tracing test with a real agent trace
- [ ] Prod deploy after staging confirms fix

Fixes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes production 500s in the live trace SSE route by replacing the unused `TRACE_API_URL` (defaulted to localhost) with the existing `NEXT_PUBLIC_API_URL`. This points `/api/projects/[projectId]/traces/[traceId]/live` to the correct backend and prevents ECONNREFUSED errors in Kubernetes.

<sup>Written for commit 54e56146a78a5b40b08a1cdddf1992d1138dc7e7. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/792?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

