### PR TITLE
fix: live tracing 500 errors in production

### DIFF
--- a/deploy/helm/templates/web/deployment.yaml
+++ b/deploy/helm/templates/web/deployment.yaml
@@ -61,6 +61,8 @@ spec:
                   key: {{ .Values.secrets.keys.encryptionKey }}
             - name: AGENT_SERVICE_URL
               value: "http://{{ include "traceroot.fullname" . }}-agent:{{ .Values.agent.port }}"
+            - name: BACKEND_INTERNAL_URL
+              value: "http://{{ include "traceroot.fullname" . }}-rest:{{ .Values.rest.port }}"
             - name: NEXT_PUBLIC_API_URL
               value: "http://{{ include "traceroot.fullname" . }}-rest:{{ .Values.rest.port }}/api/v1"
             - name: HOSTNAME

--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/live/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/live/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from "next/server";
 import { requireAuth, requireProjectAccess } from "@/lib/auth-helpers";
 
-const NEXT_PUBLIC_API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api/v1";
+const BACKEND_INTERNAL_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
 
 type RouteParams = { params: Promise<{ projectId: string; traceId: string }> };
 
@@ -17,7 +17,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
   if (accessResult.error) return accessResult.error;
 
   const backendRes = await fetch(
-    `${NEXT_PUBLIC_API_URL}/projects/${projectId}/traces/${traceId}/live`,
+    `${BACKEND_INTERNAL_URL}/api/v1/projects/${projectId}/traces/${traceId}/live`,
     {
       headers: { "x-user-id": user.id },
     },


### PR DESCRIPTION
## Summary

- Live trace SSE route was using `TRACE_API_URL` (never set anywhere), falling back to `localhost:8000` — which doesn't exist on the web pod in Kubernetes → `ECONNREFUSED` → 500 on every live tracing request
- `NEXT_PUBLIC_*` vars can't be used as a substitute: Next.js inlines them at build time (`Dockerfile.web` bakes in `NEXT_PUBLIC_API_URL=/api/v1`), so the runtime Kubernetes value is silently ignored, producing a relative URL with no host → `Invalid URL` → 500
- Fix: use `BACKEND_INTERNAL_URL` — a server-only runtime var (same pattern as `AGENT_SERVICE_URL`) that Next.js never inlines. Added it to the Helm web deployment pointing at the internal REST service

## Changes

- `frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/live/route.ts` — switch to `BACKEND_INTERNAL_URL`
- `deploy/helm/templates/web/deployment.yaml` — inject `BACKEND_INTERNAL_URL` into web pod (same pattern as `AGENT_SERVICE_URL`)

## Test plan

- [x] Local `make dev` e2e — live tracing works
- [ ] Staging deploy + live tracing test with a real agent trace
- [ ] Prod deploy after staging confirms fix

Closes #792
Fixes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix live tracing SSE 500s by proxying through the internal REST service using `BACKEND_INTERNAL_URL` instead of `NEXT_PUBLIC_API_URL`, avoiding build-time inlining and localhost fallbacks in the web pod. Injects `BACKEND_INTERNAL_URL` into the Helm web deployment so it resolves at runtime.

<sup>Written for commit 082d48fa6e8e9261e4148d9a8f86d9578e3f613f. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/793?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

