### PR TITLE
fix: remove ssl_cert_reqs query param from ElastiCache Redis URL

### DIFF
--- a/deploy/terraform/aws/secrets.tf
+++ b/deploy/terraform/aws/secrets.tf
@@ -42,7 +42,7 @@ resource "kubernetes_secret" "app" {
     "internal-api-secret" = random_password.internal_api_secret.result
     "clickhouse-password" = random_password.clickhouse.result
     "database-url"        = "postgresql://traceroot:${random_password.postgres.result}@${aws_rds_cluster.postgres.endpoint}:5432/${local.database_name}"
-    "redis-url"           = "rediss://:${random_password.redis.result}@${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379/0?ssl_cert_reqs=CERT_REQUIRED"
+    "redis-url"           = "rediss://:${random_password.redis.result}@${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379/0"
     "encryption-key"      = random_id.encryption_key.hex
   }
 


### PR DESCRIPTION
## Summary

- The ElastiCache `REDIS_URL` in `secrets.tf` had `?ssl_cert_reqs=CERT_REQUIRED` appended as a query param
- `redis-py` rejects the string `"CERT_REQUIRED"` — it requires `ssl.CERT_*` integer constants passed as kwargs, not strings in the URL
- This caused pub/sub reconnects (e.g. `pubsub.unsubscribe` in the SSE `finally` block) to crash with `RedisError: Invalid SSL Certificate Requirements Flag: CERT_REQUIRED`, killing every live trace stream
- The param was redundant: `redis-py` already applies `ssl.CERT_REQUIRED` by default for `rediss://` URLs
- Fix: drop the query param, let the library handle SSL from the scheme — same approach used by lmnr and langfuse

## Changes

- `deploy/terraform/aws/secrets.tf` — remove `?ssl_cert_reqs=CERT_REQUIRED` from the Redis URL

## Deploy note

`terraform apply` is required to update the Kubernetes secret with the new URL value, which will trigger a pod restart.

Fixes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `ssl_cert_reqs=CERT_REQUIRED` param from the ElastiCache `rediss://` URL to stop `redis-py` crashes on pub/sub reconnects that broke live trace SSE streams. The library already enforces certificate checks for `rediss://`, so the URL is now clean and stable (fixes #788).

- **Migration**
  - Run `terraform apply` to update the Kubernetes secret and restart pods.

<sup>Written for commit 35e50ef120a89884b99c17916ccc257a0ff71516. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/794?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

