### PR TITLE
fix: configure Celery SSL via broker_use_ssl instead of URL param

### DIFF
--- a/backend/worker/celery_app.py
+++ b/backend/worker/celery_app.py
@@ -6,6 +6,7 @@ Runs ClickHouse migrations on worker startup.
 
 import logging
 import os
+import ssl
 
 from celery import Celery
 from celery.signals import worker_ready
@@ -28,10 +29,15 @@ logging.basicConfig(
 
 app = Celery("traceroot")
 
+_use_ssl = settings.redis.url.startswith("rediss://")
+_ssl_config = {"ssl_cert_reqs": ssl.CERT_REQUIRED} if _use_ssl else None
+
 app.conf.update(
     # Broker and backend
     broker_url=settings.redis.url,
     result_backend=settings.redis.result_url,
+    broker_use_ssl=_ssl_config,
+    redis_backend_use_ssl=_ssl_config,
     # Reliability settings
     task_acks_late=True,  # ACK after task completes (not before)
     task_reject_on_worker_lost=True,  # Requeue if worker dies mid-task


### PR DESCRIPTION
## Summary

PR #794 removed `?ssl_cert_reqs=CERT_REQUIRED` from the ElastiCache Redis URL (fixing redis-py pub/sub). But Celery was silently relying on that URL param to enable SSL for its broker connection — removing it put the worker into CrashLoopBackOff.

Celery's proper mechanism for Redis SSL is `broker_use_ssl` and `redis_backend_use_ssl` dicts with `ssl.CERT_REQUIRED` as a Python constant (not a URL query string). This satisfies both Celery and redis-py from the same clean `rediss://` URL.

## Changes

- `backend/worker/celery_app.py` — add `broker_use_ssl` + `redis_backend_use_ssl` with `ssl.CERT_REQUIRED`

## Deploy note

Requires new image build + `terraform apply` (to pick up both this change and the updated Redis secret URL from PR #794).

Fixes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure `Celery` Redis SSL via `broker_use_ssl` and `redis_backend_use_ssl` using `ssl.CERT_REQUIRED`, instead of a `?ssl_cert_reqs` URL param. This restores the worker after PR #794 broke it by removing the query string.

- **Bug Fixes**
  - Enable SSL for broker and backend when the URL starts with `rediss://`, aligning `Celery` with `redis-py`.
  - Remove reliance on URL params to prevent worker CrashLoopBackOff.

- **Migration**
  - Build a new worker image and run `terraform apply` to pick up the config and the updated Redis secret.

<sup>Written for commit 5b547b9cd81afcad4349a045a3804f481ba1dbb2. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/795?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

