### PR TITLE
fix(ci): push docker images to staging and production ECR repos

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -65,7 +65,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.ECR_REGISTRY }}/traceroot-${{ matrix.service }}
+          images: |
+            ${{ env.ECR_REGISTRY }}/traceroot-staging-${{ matrix.service }}
+            ${{ env.ECR_REGISTRY }}/traceroot-production-${{ matrix.service }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=sha-


### PR DESCRIPTION
Fixes #782

## Summary
Fixes the Docker image publish workflow to target the correct ECR repositories.  
The workflow now pushes each service image to both `traceroot-staging-*` and `traceroot-production-*` repositories instead of the non-existent `traceroot-*` names.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [x] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
- Updated `.github/workflows/docker-images.yml`.
- Changed Docker metadata image targets from:
  - `${ECR_REGISTRY}/traceroot-${service}`
- To:
  - `${ECR_REGISTRY}/traceroot-staging-${service}`
  - `${ECR_REGISTRY}/traceroot-production-${service}`
- This aligns the default workflow with existing ECR repository naming and the behavior of `_docker-images-custom.yml`.

## Screenshots / Recordings (if applicable)
N/A (workflow-only change)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Docker image publish workflow to push service images to the correct ECR repos for staging and production. Prevents publishing to non-existent `traceroot-*` repos and aligns with the custom workflow.

- **Bug Fixes**
  - Updated `.github/workflows/docker-images.yml` to set `docker/metadata-action` images to `${{ env.ECR_REGISTRY }}/traceroot-staging-${{ matrix.service }}` and `${{ env.ECR_REGISTRY }}/traceroot-production-${{ matrix.service }}`.

<sup>Written for commit db3617cc2ab321c44da2ee6c526abdd05b830707. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/796?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

