### PR TITLE
feat: add Google ADK agent examples

### DIFF
--- a/examples/python/google-adk-agent/.env.example
+++ b/examples/python/google-adk-agent/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# Gemini
+GEMINI_API_KEY=your_google_genai_api_key_here

--- a/examples/python/google-adk-agent/README.md
+++ b/examples/python/google-adk-agent/README.md
@@ -1,0 +1,19 @@
+# Google ADK Agent
+
+Multi-tool agent using the Google Agent Development Kit (ADK), instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+## What it does
+
+Runs demo queries using the Google ADK agent with Gemini.
+Tools: `get_weather`, `calculate`

--- a/examples/python/google-adk-agent/main.py
+++ b/examples/python/google-adk-agent/main.py
@@ -1,0 +1,141 @@
+"""
+Google ADK agent with tool use and TraceRoot observability.
+
+Uses the Google Agent Development Kit (ADK) which handles the agent loop,
+tool execution, and multi-turn conversations automatically.
+
+Usage:
+    cp .env.example .env
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+"""
+
+import asyncio
+import logging
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found. Using process environment variables.")
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.GOOGLE_ADK])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+from google.adk.agents import Agent
+from google.adk.runners import InMemoryRunner
+from google.genai import types
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+def get_weather(city: str) -> dict:
+    """Get current weather for a city."""
+    weather_db = {
+        "new york": {"temp": 45, "condition": "cloudy", "humidity": 60},
+        "san francisco": {"temp": 68, "condition": "foggy", "humidity": 75},
+        "london": {"temp": 52, "condition": "rainy", "humidity": 85},
+        "tokyo": {"temp": 72, "condition": "sunny", "humidity": 50},
+    }
+    data = weather_db.get(city.lower(), {"temp": 70, "condition": "unknown", "humidity": 50})
+    return {"status": "success", "city": city, **data}
+
+
+def calculate(expression: str) -> dict:
+    """Evaluate a math expression safely."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+        result = _eval(tree)
+        return {"status": "success", "expression": expression, "result": result}
+    except Exception as e:
+        return {"status": "error", "error_message": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    name="assistant",
+    model="gemini-2.5-flash",
+    description="Helpful assistant with access to tools.",
+    instruction=(
+        "You are a helpful AI assistant with access to tools. "
+        "Use available tools to gather information, then provide "
+        "a clear, comprehensive answer."
+    ),
+    tools=[get_weather, calculate],
+)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+DEMO_QUERIES = [
+    "What's the weather in San Francisco and Tokyo? Compare them.",
+    "What is 1234 multiplied by 5678?",
+]
+
+
+@observe(name="demo_session", type="agent")
+async def run_demo():
+    app_name = "traceroot-adk-demo"
+    user_id = "example-user"
+    session_id = "google-adk-agent-session"
+
+    runner = InMemoryRunner(agent=agent, app_name=app_name)
+    session_service = runner.session_service
+    await session_service.create_session(
+        app_name=app_name,
+        user_id=user_id,
+        session_id=session_id,
+    )
+
+    for i, query in enumerate(DEMO_QUERIES, 1):
+        print(f"\n{'=' * 60}")
+        print(f"Query {i}: {query}")
+        print("=" * 60)
+
+        async for event in runner.run_async(
+            user_id=user_id,
+            session_id=session_id,
+            new_message=types.Content(
+                role="user",
+                parts=[types.Part(text=query)],
+            ),
+        ):
+            if event.is_final_response():
+                print(f"\nAgent: {event.content.parts[0].text.strip()}\n")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="google-adk-agent-session"):
+        asyncio.run(run_demo())
+    traceroot.flush()

--- a/examples/python/google-adk-agent/main.py
+++ b/examples/python/google-adk-agent/main.py
@@ -36,6 +36,7 @@ from google.genai import types
 # Tools
 # ---------------------------------------------------------------------------
 
+
 def get_weather(city: str) -> dict:
     """Get current weather for a city."""
     weather_db = {
@@ -131,11 +132,19 @@ async def run_demo():
                 parts=[types.Part(text=query)],
             ),
         ):
-            if event.is_final_response():
+            if (
+                event.is_final_response()
+                and event.content
+                and event.content.parts
+                and event.content.parts[0].text
+            ):
                 print(f"\nAgent: {event.content.parts[0].text.strip()}\n")
 
 
 if __name__ == "__main__":
     with using_attributes(user_id="example-user", session_id="google-adk-agent-session"):
-        asyncio.run(run_demo())
+        try:
+            asyncio.run(run_demo())
+        finally:
+            traceroot.flush()
     traceroot.flush()

--- a/examples/python/google-adk-agent/requirements.txt
+++ b/examples/python/google-adk-agent/requirements.txt
@@ -1,0 +1,4 @@
+google-adk>=1.31.1
+python-dotenv>=1.0.0
+
+traceroot==0.1.4

--- a/examples/python/google-adk-agent/requirements.txt
+++ b/examples/python/google-adk-agent/requirements.txt
@@ -1,4 +1,4 @@
 google-adk>=1.31.1
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.5


### PR DESCRIPTION
Fixes #783 

## Summary

Adds a Google ADK agent example to `examples/python/`. This is the companion example to traceroot-ai/traceroot-py#112 adding `Integration.GOOGLE_ADK`.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

Builds on Python SDK Google ADK Integration PR: traceroot-ai/traceroot-py#112

- Added `examples/python/google-adk-agent/` with a multi-tool agent using the Google ADK and TraceRoot auto-instrumentation
- Uses `Integration.GOOGLE_ADK` with `traceroot.initialize()` for OpenInference-based auto-instrumentation
- Agent uses `gemini-2.5-flash` with two tools: `get_weather` and `calculate`
- ADK's instrumentor auto-captures full span hierarchy — invocation, agent_run, call_llm, and execute_tool spans — without needing `@observe` decorators
- Includes 2 demo queries: weather comparison and math calculation
- Uses `InMemoryRunner` with async execution via `runner.run_async()`

## Screenshots / Recordings (if applicable)

<img width="983" height="369" alt="image" src="https://github.com/user-attachments/assets/99a4d07d-3528-4b02-a5b5-07e4e1343617" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Google ADK multi-tool agent example under `examples/python/google-adk-agent/` with TraceRoot auto-instrumentation via `Integration.GOOGLE_ADK` and a Gemini (`gemini-2.5-flash`) agent. Includes an async demo and an optional session-level `@observe` for end-to-end tracing.

- **New Features**
  - Example agent with tools: `get_weather`, `calculate`.
  - Uses `traceroot.initialize(integrations=[Integration.GOOGLE_ADK])`; ADK instrumentor captures invocation, `agent_run`, `call_llm`, and `execute_tool` spans without `@observe`.
  - Demo via `InMemoryRunner.run_async()` with two queries; sets `user_id` and `session_id` using `using_attributes`.
  - Adds `.env.example` (supports `TRACEROOT_HOST_URL`) and README with `uv` run steps.
  - Includes `requirements.txt`: `google-adk>=1.31.1`, `python-dotenv>=1.0.0`, `traceroot==0.1.4`.

- **Bug Fixes**
  - Lint and formatting cleanup for the example.

<sup>Written for commit 88c5ef852eecc6e1bc5e336b6a2715d5b23ff452. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/798?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

