### PR TITLE
chore(claude): enable CLAUDE_CODE_FORK_SUBAGENT

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "CLAUDE_CODE_FORK_SUBAGENT": "1"
   },
   "permissions": {
     "defaultMode": "bypassPermissions"


### PR DESCRIPTION
## Summary
- Enables the latest Claude Code fork-subagent feature by adding `CLAUDE_CODE_FORK_SUBAGENT: "1"` to `.claude/settings.json`, alongside the existing `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` flag.

Closes #802

## Test plan
- [ ] Open the project in Claude Code and confirm the env var is picked up (no startup errors).
- [ ] Verify subagent dispatch still works with the fork-subagent path enabled.