### PR TITLE
docs(readme): add Claude Agent SDK, OpenAI Agents SDK, Agno, DSPy, Google ADK, Mistral

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The fastest way to get started. Ample storages and LLM tokens for testing, no cr
 | [OpenAI](https://traceroot.ai/docs/integrations/openai) | Python, JS/TS | Automated instrumentation of Chat Completions and Responses API. |
 | [Anthropic](https://traceroot.ai/docs/integrations/anthropic) | Python, JS/TS | Automated instrumentation of the Messages API. |
 | [Google Gemini](https://traceroot.ai/docs/integrations/gemini) | Python | Automated instrumentation via the Google GenAI SDK. |
+| [Mistral](https://traceroot.ai/docs/integrations/mistral) | Python | Automated instrumentation of Mistral chat completions, tool calls, and streaming responses. |
 
 ### Agent Frameworks
 
@@ -94,10 +95,15 @@ The fastest way to get started. Ample storages and LLM tokens for testing, no cr
 | ----------- | -------- | ----------- |
 | [LangChain & LangGraph](https://traceroot.ai/docs/integrations/langchain) | Python, JS/TS | Automated instrumentation by passing callback handler to LangChain application. |
 | [LangChain DeepAgents](https://traceroot.ai/docs/integrations/langchain-deepagents) | Python, JS/TS | Automated instrumentation by passing callback handler to DeepAgents pipeline. |
-| [CrewAI](https://traceroot.ai/docs/integrations/crewai) | Python | Automated instrumentation of multi-agent collaborative workflows and task executions. |
+| [Claude Agent SDK](https://traceroot.ai/docs/integrations/claude-agent-sdk) | Python, JS/TS | Automated instrumentation of agent invocations, subagent delegations, tool calls, and token usage. |
+| [OpenAI Agents SDK](https://traceroot.ai/docs/integrations/openai-agents-sdk) | Python, JS/TS | Automated instrumentation of agent runs, tool executions, and handoff transitions. |
+| [Mastra](https://traceroot.ai/docs/integrations/mastra) | JS/TS | Automated instrumentation via the TraceRoot OTLP exporter. |
 | [AutoGen](https://traceroot.ai/docs/integrations/autogen) | Python | Automated instrumentation of multi-agent conversations, agent loops, and tool calls. |
 | [LlamaIndex](https://traceroot.ai/docs/integrations/llamaindex) | Python | Automated instrumentation of RAG pipelines, document ingestion, retrieval, and LLM synthesis. |
-| [Mastra](https://traceroot.ai/docs/integrations/mastra) | JS/TS | Automated instrumentation via the TraceRoot OTLP exporter. |
+| [CrewAI](https://traceroot.ai/docs/integrations/crewai) | Python | Automated instrumentation of multi-agent collaborative workflows and task executions. |
+| [Agno](https://traceroot.ai/docs/integrations/agno) | Python | Automated instrumentation of agent runs, tool calls, and multi-step reasoning. |
+| [DSPy](https://traceroot.ai/docs/integrations/dspy) | Python | Automated instrumentation of module executions, signature predictions, and underlying LLM calls. |
+| [Google ADK](https://traceroot.ai/docs/integrations/google-adk) | Python | Automated instrumentation of agent runs, tool executions, and the multi-turn agent loop. |
 
 > Don't see your framework or provider? [Request an integration](https://github.com/traceroot-ai/traceroot/issues).
 


### PR DESCRIPTION
## Summary

Closes #816. Follow-up to #815 — brings the root `README.md` integrations tables in sync with the docs site.

- Add **Mistral** under **Model Providers**.
- Add **Claude Agent SDK**, **OpenAI Agents SDK**, **Agno**, **DSPy**, **Google ADK** under **Agent Frameworks**.
- Reorder both tables to match the sidebar order in `docs/docs.json`.

Each row links to the corresponding `traceroot.ai/docs/integrations/*` page added in #815 (and earlier).

## Test plan

- [x] `git diff README.md` reviewed — table rows render
- [ ] Rendered README on GitHub shows all integrations and links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the README integrations tables with the docs site by adding new entries and reordering to match the docs sidebar.

Adds Mistral under Model Providers, and Claude Agent SDK, OpenAI Agents SDK, Agno, DSPy, and Google ADK under Agent Frameworks, each linking to its integration docs page.

<sup>Written for commit b46e959257b714b2ae378e505348eb1b408c78d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

