### PR TITLE
docs(integrations): link each integration page to its runnable e2e example

### DIFF
--- a/docs/integrations/agno.mdx
+++ b/docs/integrations/agno.mdx
@@ -65,3 +65,12 @@ traceroot.flush()
 | LLM calls | Raw completion requests to the underlying provider |
 | Tokens & Cost | Aggregated token usage and pricing |
 | Latency | Duration per agent run and per span |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/agno-tool-agent">
+    Run the Python example
+  </Card>

--- a/docs/integrations/anthropic.mdx
+++ b/docs/integrations/anthropic.mdx
@@ -82,3 +82,17 @@ Once initialized, all Anthropic calls are captured automatically:
 | Tokens | Input and output tokens |
 | Cost | Calculated from token usage and model pricing |
 | Latency | Request duration |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/anthropic-tool-agent">
+    Run the Python example
+  </Card>
+  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/anthropic">
+    Run the TypeScript example
+  </Card>
+</CardGroup>

--- a/docs/integrations/autogen.mdx
+++ b/docs/integrations/autogen.mdx
@@ -89,3 +89,12 @@ user_proxy.initiate_chat(
 | Tool calls | Function names, input arguments, and execution outputs |
 | LLM calls | Raw completion requests to the provider |
 | Tokens & Cost | Aggregated usage and pricing for the chat session |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/autogen-tool-agent">
+    Run the Python example
+  </Card>

--- a/docs/integrations/claude-agent-sdk.mdx
+++ b/docs/integrations/claude-agent-sdk.mdx
@@ -94,3 +94,17 @@ Automatically capture agent invocations, subagent delegations, tool calls, and t
 | Token usage | Aggregated input/output tokens per query |
 | Cost | Total cost for the full query execution |
 | Model name | The model used (e.g., claude-sonnet-4-6, claude-haiku-4-5) |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/claude-agent-sdk">
+    Run the Python example
+  </Card>
+  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/claude-agent-sdk">
+    Run the TypeScript example
+  </Card>
+</CardGroup>

--- a/docs/integrations/crewai.mdx
+++ b/docs/integrations/crewai.mdx
@@ -68,3 +68,12 @@ result = crew.kickoff()
 | Delegation hierarchy | Manager-agent relationships and task assignments |
 | Token usage | Aggregated across all LLM calls |
 | Cost | Total cost for the full crew execution |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/crewai-agent">
+    Run the Python example
+  </Card>

--- a/docs/integrations/dspy.mdx
+++ b/docs/integrations/dspy.mdx
@@ -64,3 +64,12 @@ traceroot.flush()
 | LLM calls | Raw completion requests to the configured `dspy.LM` |
 | Tokens & Cost | Aggregated token usage and pricing |
 | Latency | Duration per module call and per LLM call |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/dspy-agent">
+    Run the Python example
+  </Card>

--- a/docs/integrations/gemini.mdx
+++ b/docs/integrations/gemini.mdx
@@ -57,3 +57,12 @@ print(response.text)
 | Tokens | Input and output token counts |
 | Cost | Calculated from token usage and model pricing |
 | Latency | Request duration |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/gemini-tool-agent">
+    Run the Python example
+  </Card>

--- a/docs/integrations/google-adk.mdx
+++ b/docs/integrations/google-adk.mdx
@@ -83,3 +83,12 @@ if __name__ == "__main__":
 | LLM calls | Raw Gemini calls made by the ADK runtime |
 | Tokens & Cost | Aggregated token usage and pricing |
 | Latency | Duration per agent run and per span |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/google-adk-agent">
+    Run the Python example
+  </Card>

--- a/docs/integrations/langchain-deepagents.mdx
+++ b/docs/integrations/langchain-deepagents.mdx
@@ -108,3 +108,17 @@ Automatically capture the full multi-agent hierarchy of [DeepAgents](https://git
 | LLM calls | All LLM calls across the full agent hierarchy |
 | Token usage | Aggregated across all agents and LLM calls |
 | Cost | Total cost for the full multi-agent run |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/deepagents">
+    Run the Python example
+  </Card>
+  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/deepagents">
+    Run the TypeScript example
+  </Card>
+</CardGroup>

--- a/docs/integrations/langchain.mdx
+++ b/docs/integrations/langchain.mdx
@@ -125,3 +125,17 @@ Automatically capture agent steps, tool calls, and LLM invocations within LangCh
 | Graph structure | Parent-child relationships between steps |
 | Token usage | Aggregated across all LLM calls |
 | Cost | Total cost for the full chain/graph execution |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/langgraph-code-agent">
+    Run the Python example
+  </Card>
+  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/langchain">
+    Run the TypeScript example
+  </Card>
+</CardGroup>

--- a/docs/integrations/llamaindex.mdx
+++ b/docs/integrations/llamaindex.mdx
@@ -56,3 +56,12 @@ print(response)
 | LLM synthesis | Response generation with context and final answer |
 | Tokens & Cost | Input/output tokens and calculated cost per LLM call |
 | Latency | Duration of each pipeline stage |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/llamaindex-rag">
+    Run the Python example
+  </Card>

--- a/docs/integrations/mastra.mdx
+++ b/docs/integrations/mastra.mdx
@@ -91,3 +91,12 @@ await exporter.flush();
 | Tokens | Input and output token counts |
 | Cost | Calculated from token usage and model pricing |
 | Latency | Request duration per span |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/mastra">
+    Run the TypeScript example
+  </Card>

--- a/docs/integrations/mistral.mdx
+++ b/docs/integrations/mistral.mdx
@@ -55,3 +55,12 @@ print(response.choices[0].message.content)
 | Tokens | Input and output tokens |
 | Cost | Calculated from token usage and model pricing |
 | Latency | Request duration |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/mistral-tool-agent">
+    Run the Python example
+  </Card>

--- a/docs/integrations/openai-agents-sdk.mdx
+++ b/docs/integrations/openai-agents-sdk.mdx
@@ -116,3 +116,17 @@ Once initialized, all agent runs and tool calls are captured automatically:
 | LLM calls | Raw completion requests to OpenAI |
 | Tokens & Cost | Aggregated token usage and pricing |
 | Latency | Duration per agent run and per span |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/openai-agents-sdk">
+    Run the Python example
+  </Card>
+  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/openai-agents">
+    Run the TypeScript example
+  </Card>
+</CardGroup>

--- a/docs/integrations/openai.mdx
+++ b/docs/integrations/openai.mdx
@@ -83,3 +83,16 @@ Automatically capture all OpenAI Chat Completions and Responses API calls.
 | Tokens | Prompt, completion, and total tokens |
 | Cost | Calculated from token usage and model pricing |
 | Latency | Request duration |
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+<CardGroup cols={2}>
+  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/openai-tool-agent">
+    Run the Python example
+  </Card>
+  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/openai">
+    Run the TypeScript example
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## Summary
- Add a `## Run the example` section to all 15 integration docs in `docs/integrations/` linking to the matching `examples/python/<folder>` and/or `examples/typescript/<folder>` on GitHub.
- Uses Mintlify `<CardGroup cols={2}>` with `<Card>` components (icons `python` / `js`), matching the style already used in `docs/integrations/overview.mdx`.
- Falls back to a single `<Card>` when only one language has an example. `internal-models.mdx` and `overview.mdx` are intentionally skipped.

## Format

```mdx
## Run the example

Clone the repo and run a complete agent end-to-end.

<CardGroup cols={2}>
  <Card title="Python" icon="python" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/python/<folder>">
    Run the Python example
  </Card>
  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/<folder>">
    Run the TypeScript example
  </Card>
</CardGroup>
```

## Screenshots

<img width="1325" height="777" alt="Screenshot 2026-05-01 at 5 11 05 PM" src="https://github.com/user-attachments/assets/aaa9dc99-8490-457c-8a19-ae5768050212" />

Closes #820

## Test plan
- [ ] `mint dev` renders without MDX errors
- [ ] Spot check pages with both langs (anthropic, openai, claude-agent-sdk), Python-only (agno, llamaindex), and TS-only (mastra)
- [x] Each card link resolves to the correct `examples/...` folder on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a “Run the example” section to 15 integration docs, linking each page to its runnable end-to-end example on GitHub to make trying integrations faster. Supports Python and/or TypeScript with clear, consistent cards.

- **New Features**
  - Added Mintlify cards linking to `examples/python/<folder>` and `examples/typescript/<folder>`.
  - Uses two-card layout when both languages exist; single card otherwise.
  - Matches the style in `docs/integrations/overview.mdx`; `internal-models.mdx` and `overview.mdx` are unchanged.

<sup>Written for commit 84e63ba2d8363ee10af71bd27946af034d517183. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

