### PR TITLE
experiment: wire prod-lite into Coast for multi-instance isolation

### DIFF
--- a/Coastfile
+++ b/Coastfile
@@ -1,0 +1,142 @@
+# Coastfile — experimental wrapper around `make prod-lite`.
+#
+# `make prod-lite` runs `docker compose -f docker-compose.prod.yml up --build`
+# directly on the host. This Coastfile lets `coast` run that same compose stack
+# inside a DinD-isolated Coast instance, so multiple branches can boot the full
+# prod-lite stack side-by-side without colliding on host ports or volumes.
+
+[coast]
+name = "traceroot"
+compose = "./docker-compose.prod.yml"
+primary_port = "web"
+
+# Each Coast instance gets its own .next build cache. Without this, two
+# instances bind-mounting the same workspace fight over `frontend/ui/.next`.
+private_paths = [
+    "frontend/ui/.next",
+    "frontend/worker/dist",
+    "frontend/packages/core/dist",
+    "frontend/packages/core/node_modules/.prisma",
+]
+
+[coast.setup]
+# The DinD host doesn't run application code itself for prod-lite — compose
+# builds carry their own runtimes — but having bash + curl available makes
+# `coast exec` debugging tolerable.
+packages = ["bash", "curl", "ca-certificates"]
+
+# All ports the prod-lite stack publishes on the host. Each instance gets a
+# dynamic port; the checked-out instance also binds the canonical port.
+[ports]
+web = 3000           # Next.js UI
+rest = 8000          # FastAPI backend
+agent = 8100         # Agent service
+minio = 9090         # MinIO S3 API (host:9090 -> container:9000)
+minio-console = 9091 # MinIO console
+postgres = 5432
+clickhouse-http = 8123
+clickhouse-native = 9000
+redis = 6379
+
+[healthcheck]
+web = "/"
+rest = "/api/v1/health"
+
+# Branch-switch behavior. prod-lite builds images for app services, so the only
+# way to pick up code changes is to rebuild. Infra (postgres/clickhouse/redis/
+# minio) and one-shot migrations are left untouched on `coast assign`.
+[assign]
+default = "none"
+exclude_paths = [
+    ".coasts",
+    ".worktrees",
+    "node_modules",
+    "frontend/ui/.next",
+    "frontend/worker/dist",
+    "frontend/packages/core/dist",
+    "frontend/packages/core/node_modules",
+    "frontend/ui/node_modules",
+    "frontend/worker/node_modules",
+    ".venv",
+    "docs",
+    "examples",
+    "tests/__snapshots__",
+]
+
+[assign.services]
+web = "rebuild"
+rest = "rebuild"
+worker = "rebuild"
+billing = "rebuild"
+agent = "rebuild"
+migrate = "rebuild"
+migrate-clickhouse = "rebuild"
+
+# Avoid expensive image rebuilds when only docs/tests changed. Triggers cover
+# the Dockerfiles and the dependency manifests baked into each image.
+[assign.rebuild_triggers]
+web = [
+    "docker/Dockerfile.web",
+    "frontend/ui/package.json",
+    "frontend/packages/core/package.json",
+    "frontend/packages/core/prisma/schema.prisma",
+    "pnpm-lock.yaml",
+]
+rest = [
+    "docker/Dockerfile.rest",
+    "pyproject.toml",
+    "uv.lock",
+    "backend/rest/**",
+]
+worker = [
+    "docker/Dockerfile.worker",
+    "pyproject.toml",
+    "uv.lock",
+    "backend/worker/**",
+]
+billing = [
+    "docker/Dockerfile.billing",
+    "pyproject.toml",
+    "uv.lock",
+]
+agent = [
+    "docker/Dockerfile.agent",
+    "pyproject.toml",
+    "uv.lock",
+]
+migrate = [
+    "docker/Dockerfile.web",
+    "frontend/packages/core/prisma/**",
+]
+migrate-clickhouse = [
+    "docker/Dockerfile.migrate-clickhouse",
+    "backend/db/migrations/**",
+]
+
+# Forward host secrets needed for prod-lite into the Coast instance so the
+# inner `docker compose up` resolves them via `${VAR:-default}`. These are
+# only injected if present on the host.
+[inject]
+env = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "BETTER_AUTH_SECRET",
+    "ENCRYPTION_KEY",
+    "INTERNAL_API_SECRET",
+    "AUTH_GOOGLE_CLIENT_ID",
+    "AUTH_GOOGLE_CLIENT_SECRET",
+    "GITHUB_APP_ID",
+    "GITHUB_APP_NAME",
+    "GITHUB_APP_PRIVATE_KEY",
+    "GITHUB_APP_CLIENT_ID",
+    "GITHUB_APP_CLIENT_SECRET",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SIGNING_SECRET",
+    "STRIPE_PRICE_ID_STARTER",
+    "STRIPE_PRICE_ID_PRO",
+    "STRIPE_PRICE_ID_AI_USAGE",
+    "TRACEROOT_SMTP_URL",
+    "TRACEROOT_SMTP_MAIL_FROM",
+    "TRACEROOT_EE_LICENSE_KEY",
+    "DAYTONA_API_KEY",
+]

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 PROD_COMPOSE := docker compose -f docker-compose.prod.yml
 
-.PHONY: install-hooks dev dev-lite dev-autoreload dev-reset prod prod-lite prod-reset
+.PHONY: install-hooks dev dev-lite dev-autoreload dev-reset prod prod-lite prod-lite-coast prod-reset
 
 ## Install repository git hooks for contributors.
 install-hooks:
@@ -38,6 +38,17 @@ prod:
 prod-lite:
 	@echo "Starting TraceRoot at http://localhost:3000 - Ctrl+C to stop"
 	$(PROD_COMPOSE) up --build
+
+## Run prod-lite inside a Coast (isolated DinD instance via the Coastfile).
+## Lets multiple branches run the full prod stack side-by-side. Requires
+## the `coast` CLI (https://coasts.dev/install).
+prod-lite-coast:
+	@command -v coast >/dev/null 2>&1 || { \
+	  echo "coast CLI not found — install from https://coasts.dev/install"; exit 1; \
+	}
+	coast build
+	coast run
+	coast checkout
 
 ## Nuclear reset: stop containers, remove volumes, built images, and orphaned sandboxes.
 prod-reset:


### PR DESCRIPTION
## Summary

First attempt at making TraceRoot work with [Coasts](https://coasts.dev) — a tool for running multiple isolated instances of a full dev/prod environment side-by-side on one machine.

We're starting with `make prod-lite` because it should be the easiest path: it's already a single self-contained `docker compose -f docker-compose.prod.yml up --build` invocation, so wrapping it in a Coastfile is mostly about re-declaring the published ports and pointing Coast at the existing compose file. No app code changes, no compose changes — just a new `Coastfile` at the repo root and a new Makefile target.

The point of doing this: spin up `feat-x`, `feat-y`, and `main` versions of the full prod stack at the same time, flip which one owns `localhost:3000` with one command, and stop fighting over host ports / postgres volumes when working on multiple branches.

## What's in this PR

- **`Coastfile`** — declares all 9 ports the prod compose file publishes, marks `web` as the primary, configures `rebuild` on `coast assign` for the seven app images, leaves infra (postgres/clickhouse/redis/minio) untouched on branch switch, gives each instance private `.next` / `dist` / `.prisma` dirs so bind-mounted instances don't collide, and forwards the host env vars the prod compose file resolves via `${VAR:-default}`.
- **`Makefile`** — adds `make prod-lite-coast` which checks for the `coast` CLI (with an install hint if missing) and runs `coast build && coast run && coast checkout`.

## Status

It works end-to-end on macOS — full stack came up, UI loaded at `localhost:3000`, all migrations ran, fresh per-instance Postgres + ClickHouse. Couple of caveats worth knowing:

- Coast's image precache logs warnings for `postgres:${POSTGRES_VERSION:-17}` and `clickhouse-server:${CLICKHOUSE_VERSION:-24.3}` because it tries to `docker pull` the literal strings without expanding compose-style `${VAR:-default}` syntax. The build still succeeds, and the inner `docker compose up` pulls the right tags on first run — but you do pay one extra `docker pull` per instance for those two images. Cleanest fix later: drop the indirection in `docker-compose.prod.yml` for the version pins, or `export POSTGRES_VERSION=17 CLICKHOUSE_VERSION=24.3` before `coast build`.
- The `[healthcheck] rest = \"/api/v1/health\"` path is a guess and currently 404s every 5s in `coast logs`. Coast treats any HTTP response as healthy so it's harmless, but it's noise. Should be replaced with the real health path or dropped (TCP connect check is the fallback).
- This is opt-in. `make prod-lite` and `make dev` are unchanged.

## Test plan

- [ ] **Install Coast** — one-time, machine-wide:
  ```sh
  eval "$(curl -fsSL https://coasts.dev/install)"
  ```
  Restart shell so `~/.coast/bin` lands on PATH. Verify with `coast --version`.

- [ ] **Start the daemon** — one-time per machine:
  ```sh
  coast daemon start
  ```

- [ ] **Create a worktree off this branch (or just check it out) and put the real `.env` in it:**
  ```sh
  git worktree add ~/coast-test experimenting-with-make-prod-lite-in-new-worktree
  cd ~/coast-test
  cp /path/to/your/real/.env .
  ```

- [ ] **Build + run + check out the Coast** (from the worktree directory):
  ```sh
  coast build           # builds DinD image, runs `docker compose build` inside
  coast run my-test     # starts the Coast (autostart runs `compose up -d`)
  coast checkout my-test # binds canonical ports (3000, 8000, 8100, 9090, ...)
  ```
  First `coast build` is slow (DinD pulls infra images and builds 7 app images). Subsequent builds are mostly cached.

- [ ] **Verify it's serving:**
  ```sh
  coast ls                       # see your instance + checkout marker
  coast ports my-test            # canonical + dynamic port table
  curl -sS -o /dev/null -w \"%{http_code}\\n\" http://localhost:3000
  ```
  Open http://localhost:3000 in a browser. Expect a fresh empty database — sign up + create a workspace + project to actually use the UI. (If you reuse a `.env` with the same `BETTER_AUTH_SECRET` as another env, your old session cookie will partially \"log you in\" against an empty DB and you'll see 404s on the URL's project ID — clear cookies / use incognito.)

- [ ] **Open Coastguard:** http://localhost:31415 — local management UI for all coasts.

- [ ] **(Optional) Spin up a second instance to feel multi-coast UX:**
  ```sh
  coast run another-test
  coast ls                       # both visible
  coast checkout another-test    # localhost:3000 now points to the new one
  ```

- [ ] **Tear down when done:**
  ```sh
  coast checkout --none
  coast rm my-test               # destroys container + volumes for this instance
  coast daemon stop              # optional, stops the background daemon
  ```

## Out of scope (explicit non-goals)

- Wiring the local `make dev` (tmux + bare backend) flow into Coasts — Coasts is built around containerized stacks, so prod-lite is the natural starting point. We'll figure out whether `make dev` is worth Coast-ifying later.
- Per-instance OAuth callback URLs / GitHub App config / Stripe webhooks — those still need manual config per instance for now.
- Shared services (running one Postgres on the host across all coasts instead of one-per-instance) — possible follow-up to cut startup time and disk usage. See `references/productivity/coasts/docs/coastfiles/SHARED_SERVICES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
