### PR TITLE
fix(worker): detector eval via pi-ai and shared resolvePiModel

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 9.15.9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 9.15.9
 
       - uses: actions/setup-node@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,10 @@ ci:
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'
   autoupdate_schedule: monthly
 
+# Stop after the first failing hook. Otherwise `mixed-line-ending` can rewrite the
+# working tree and a later `lint-staged` pass still sees the old index → restore conflict.
+fail_fast: true
+
 repos:
   # General file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -34,7 +34,7 @@ RUN cd packages/core && npx prisma generate \
 RUN cd packages/core && \
     node -e "const t=JSON.parse(require('fs').readFileSync('tsconfig.json','utf8')); t.compilerOptions.module='CommonJS'; t.compilerOptions.moduleResolution='node'; require('fs').writeFileSync('tsconfig.json',JSON.stringify(t,null,2))" && \
     pnpm build && \
-    node -e "const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{'types':'./dist/index.d.ts','default':'./dist/index.js'}}; require('fs').writeFileSync('package.json',JSON.stringify(p,null,2))"
+    node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.main='./dist/index.js';p.exports={'.':{types:'./dist/index.d.ts',default:'./dist/index.js'},'./pi-model':{types:'./dist/pi-model.d.ts',default:'./dist/pi-model.js'}};fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN cd packages/agent && pnpm build
 
 FROM node:20-alpine AS runner

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,7 +1,7 @@
 # docker/Dockerfile.agent
 FROM node:20-alpine AS base
 RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+    corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.billing
+++ b/docker/Dockerfile.billing
@@ -33,7 +33,7 @@ RUN cd packages/core && npx prisma generate \
 RUN cd packages/core && \
     node -e "const t=JSON.parse(require('fs').readFileSync('tsconfig.json','utf8')); t.compilerOptions.module='CommonJS'; t.compilerOptions.moduleResolution='node'; require('fs').writeFileSync('tsconfig.json',JSON.stringify(t,null,2))" && \
     pnpm build && \
-    node -e "const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{'types':'./dist/index.d.ts','default':'./dist/index.js'}}; require('fs').writeFileSync('package.json',JSON.stringify(p,null,2))"
+    node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.main='./dist/index.js';p.exports={'.':{types:'./dist/index.d.ts',default:'./dist/index.js'},'./pi-model':{types:'./dist/pi-model.d.ts',default:'./dist/pi-model.js'}};fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN cd worker && pnpm build
 
 FROM node:20-alpine AS runner

--- a/docker/Dockerfile.billing
+++ b/docker/Dockerfile.billing
@@ -1,7 +1,7 @@
 # docker/Dockerfile.billing
 FROM node:20-alpine AS base
 RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+    corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.migrate-postgres
+++ b/docker/Dockerfile.migrate-postgres
@@ -3,7 +3,7 @@
 # Build with: docker build --platform linux/amd64 -f docker/Dockerfile.migrate-postgres .
 FROM node:20-alpine AS base
 RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+    corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,7 +1,7 @@
 # docker/Dockerfile.web
 FROM node:20-alpine AS base
 RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+    corepack enable && corepack prepare pnpm@9.15.9 --activate
 
 # --- Dependencies stage ---
 FROM base AS deps

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "traceroot-frontend",
   "private": true,
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/frontend/packages/agent/src/agent.ts
+++ b/frontend/packages/agent/src/agent.ts
@@ -4,18 +4,15 @@ import {
   type AgentTool,
   type AgentMessage,
 } from "@mariozechner/pi-agent-core";
-import { getModel, getEnvApiKey, type Message } from "@mariozechner/pi-ai";
+import { getEnvApiKey, type Message } from "@mariozechner/pi-ai";
 import {
   prisma,
   decryptKey,
-  SYSTEM_MODELS,
-  PROVIDER_PRIORITY,
   ADAPTER_TO_PI_AI,
-  ADAPTER_DEFAULT_BASE_URL,
-  ADAPTER_API_PROTOCOL,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
   ModelSource,
 } from "@traceroot/core";
+import { resolvePiModel } from "@traceroot/core/pi-model";
 import { SessionManager } from "./session.js";
 
 interface ProviderConfig {
@@ -133,110 +130,6 @@ const sessionAgents = new Map<string, Agent>();
 const sessionManagers = new Map<string, SessionManager>();
 const sessionModels = new Map<string, string>();
 
-// Build system model lookup from SYSTEM_MODELS
-// Per-model apiProtocol overrides the provider-level default (e.g. Codex needs openai-responses)
-const systemModelLookup = new Map<string, { piAIProvider: string; apiProtocol: string }>();
-for (const sys of SYSTEM_MODELS) {
-  for (const m of sys.models) {
-    systemModelLookup.set(m.id, {
-      piAIProvider: sys.piAIProvider,
-      apiProtocol: m.apiProtocol || sys.apiProtocol,
-    });
-  }
-}
-
-/**
- * Build a model object that overrides the API protocol while preserving
- * pi-ai's registry data (pricing, context window, etc.) when available.
- * Falls back to a manual object for models not in the registry.
- */
-function buildFallbackModel(modelId: string, apiProtocol: string, provider: string) {
-  // Try to get the model from pi-ai's registry for pricing data
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const registryModel = getModel(provider as any, modelId as any);
-  console.log(
-    `[Agent] pi-ai registry lookup: provider=${provider}, model=${modelId}, found=${!!registryModel}`,
-    registryModel ? JSON.stringify(registryModel.cost) : "N/A",
-  );
-  if (registryModel) {
-    return { ...registryModel, api: apiProtocol };
-  }
-  return {
-    id: modelId,
-    name: modelId,
-    api: apiProtocol,
-    provider,
-    baseUrl: "",
-    reasoning: false,
-    input: ["text", "image"] as ("text" | "image")[],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 200000,
-    maxTokens: 64000,
-  };
-}
-
-/** Pick the first available system model by provider priority */
-function getDefaultSystemModel(): {
-  modelId: string;
-  piAIProvider: string;
-  apiProtocol: string;
-} | null {
-  for (const adapter of PROVIDER_PRIORITY) {
-    const sys = SYSTEM_MODELS.find((s) => s.piAIProvider === adapter && process.env[s.envVar]);
-    if (sys && sys.models.length > 0) {
-      return {
-        modelId: sys.models[0].id,
-        piAIProvider: sys.piAIProvider,
-        apiProtocol: sys.models[0].apiProtocol || sys.apiProtocol,
-      };
-    }
-  }
-  return null;
-}
-
-function resolveModel(modelId?: string, providerConfig?: ProviderConfig | null) {
-  const defaultSystemModel = !modelId ? getDefaultSystemModel() : null;
-  const effectiveModelId = modelId || defaultSystemModel?.modelId || "claude-sonnet-4-5";
-
-  // 1. BYOK: always build model from adapter config (don't trust pi-ai registry —
-  //    it may assign a wrong API protocol for custom/BYOK models)
-  if (providerConfig) {
-    const piAIProvider = ADAPTER_TO_PI_AI[providerConfig.adapter];
-    if (piAIProvider) {
-      const modelProtocols = (providerConfig.config as Record<string, unknown>)?.modelProtocols as
-        | Record<string, string>
-        | undefined;
-      const apiProtocol =
-        modelProtocols?.[effectiveModelId] ||
-        ADAPTER_API_PROTOCOL[providerConfig.adapter] ||
-        "openai-completions";
-      const model = buildFallbackModel(effectiveModelId, apiProtocol, piAIProvider);
-      const baseUrl = providerConfig.baseUrl || ADAPTER_DEFAULT_BASE_URL[providerConfig.adapter];
-      if (baseUrl) {
-        model.baseUrl = baseUrl;
-      }
-      return model;
-    }
-  }
-
-  // 2. System models: use buildFallbackModel with per-model protocol
-  //    (most OpenAI models use completions; Codex models require responses)
-  const sysInfo = systemModelLookup.get(effectiveModelId);
-  if (sysInfo) {
-    return buildFallbackModel(effectiveModelId, sysInfo.apiProtocol, sysInfo.piAIProvider);
-  }
-
-  // 3. Unknown model — fall back to the best available system model
-  if (defaultSystemModel) {
-    return buildFallbackModel(
-      defaultSystemModel.modelId,
-      defaultSystemModel.apiProtocol,
-      defaultSystemModel.piAIProvider,
-    );
-  }
-  return getModel("anthropic", "claude-sonnet-4-5");
-}
-
 export interface AgentRunnerConfig {
   sessionId: string;
   projectId: string;
@@ -290,9 +183,9 @@ export async function getOrCreateAgent(config: AgentRunnerConfig): Promise<{
     }
   }
 
-  const model = resolveModel(config.model, providerConfig);
+  const model = resolvePiModel(config.model, providerConfig);
   console.log(
-    `[Agent] Using model="${config.model || "claude-sonnet-4-5"}" source=${config.source || ModelSource.SYSTEM} provider=${config.providerName || "—"}`,
+    `[Agent] Using model="${config.model || "claude-sonnet-4-5"}" source=${config.source || ModelSource.SYSTEM} provider=${config.providerName || "—"} api=${model.api}`,
     JSON.stringify(model),
   );
 

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -8,6 +8,10 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./pi-model": {
+      "types": "./src/pi-model.ts",
+      "default": "./src/pi-model.ts"
     }
   },
   "scripts": {
@@ -20,6 +24,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@mariozechner/pi-ai": "0.57.1",
     "@prisma/client": "^5.22.0",
     "zod": "^4.3.6"
   },

--- a/frontend/packages/core/src/__tests__/pi-model.test.ts
+++ b/frontend/packages/core/src/__tests__/pi-model.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { resolvePiModel, type ProviderModelConfig } from "../pi-model";
+
+describe("resolvePiModel", () => {
+  it("uses openai-responses for system gpt-5.3-codex (Codex / GPT-5.x reasoning path)", () => {
+    const m = resolvePiModel("gpt-5.3-codex", null);
+    expect(m.api).toBe("openai-responses");
+    expect(m.provider).toBe("openai");
+    expect(m.id).toBe("gpt-5.3-codex");
+  });
+
+  it("uses anthropic-messages for system Claude", () => {
+    const m = resolvePiModel("claude-sonnet-4-5", null);
+    expect(m.api).toBe("anthropic-messages");
+    expect(m.provider).toBe("anthropic");
+  });
+
+  it("keys BYOK DeepSeek off adapter protocol (openai-completions on openai provider)", () => {
+    const cfg: ProviderModelConfig = {
+      adapter: "deepseek",
+      key: "sk-test",
+      baseUrl: null,
+      config: null,
+    };
+    const m = resolvePiModel("deepseek-chat", cfg);
+    expect(m.api).toBe("openai-completions");
+    expect(m.provider).toBe("openai");
+    expect(m.baseUrl).toContain("deepseek");
+  });
+
+  it("uses catalog apiProtocol for BYOK OpenAI Codex when modelProtocols is unset", () => {
+    const cfg: ProviderModelConfig = {
+      adapter: "openai",
+      key: "sk-test",
+      baseUrl: null,
+      config: null,
+    };
+    const m = resolvePiModel("gpt-5.3-codex", cfg);
+    expect(m.api).toBe("openai-responses");
+  });
+
+  it("respects per-model modelProtocols override over adapter default", () => {
+    const cfg: ProviderModelConfig = {
+      adapter: "openai",
+      key: "sk-test",
+      baseUrl: null,
+      config: {
+        modelProtocols: { "gpt-5": "openai-responses" },
+      },
+    };
+    const m = resolvePiModel("gpt-5", cfg);
+    expect(m.api).toBe("openai-responses");
+  });
+});

--- a/frontend/packages/core/src/__tests__/pi-model.test.ts
+++ b/frontend/packages/core/src/__tests__/pi-model.test.ts
@@ -28,6 +28,19 @@ describe("resolvePiModel", () => {
     expect(m.baseUrl).toContain("deepseek");
   });
 
+  it("uses adapter-specific default when BYOK model id is missing (not Anthropic fallback)", () => {
+    const cfg: ProviderModelConfig = {
+      adapter: "deepseek",
+      key: "sk-test",
+      baseUrl: null,
+      config: null,
+    };
+    const m = resolvePiModel(undefined, cfg);
+    expect(m.provider).toBe("openai");
+    expect(m.id).toMatch(/^deepseek-/);
+    expect(m.id).not.toMatch(/claude/i);
+  });
+
   it("uses catalog apiProtocol for BYOK OpenAI Codex when modelProtocols is unset", () => {
     const cfg: ProviderModelConfig = {
       adapter: "openai",

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -6,7 +6,7 @@ export * from "./ee/billing/index";
 // Encryption
 export { encryptKey, decryptKey, maskKey } from "./lib/encryption";
 
-// BYOK key resolution
+// Workspace API keys (BYOK + env)
 export { resolveWorkspaceApiKey } from "./lib/workspace-api-key";
 
 // Re-export Prisma types
@@ -18,7 +18,7 @@ export type {
   AccessKey,
   Invite,
   Account,
-  GitHubInstallation,
+  GitHubConnection,
   ModelProvider,
 } from "@prisma/client";
 

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -18,7 +18,6 @@ export type {
   AccessKey,
   Invite,
   Account,
-  GitHubConnection,
   ModelProvider,
 } from "@prisma/client";
 

--- a/frontend/packages/core/src/lib/workspace-api-key.ts
+++ b/frontend/packages/core/src/lib/workspace-api-key.ts
@@ -4,8 +4,6 @@ import { decryptKey } from "./encryption";
 /** Cache: `${workspaceId}:${provider}` → { key, expiresAt } */
 const keyCache = new Map<string, { key: string; expiresAt: number }>();
 const CACHE_TTL_MS = 60_000;
-// Sweep expired entries when the cache grows past this size — bounds memory
-// without paying a sweep cost on every lookup.
 const CACHE_SWEEP_AT = 256;
 
 function evictExpired(now: number): void {
@@ -15,15 +13,12 @@ function evictExpired(now: number): void {
 }
 
 /**
- * Resolve an API key for a workspace + provider.
- * Checks BYOK (modelProvider table) first, then falls back to env var.
- * Throws if neither source produces a key — silently returning "" would let
- * SDK constructors accept an empty string and fail later with a misleading
- * authentication error far from the configuration mistake.
+ * Resolve an API key for a workspace + model-provider row label.
+ * Checks BYOK (`model_providers.provider` equals `provider`) first, then env.
  *
  * @param workspaceId - workspace to look up BYOK for
- * @param provider    - "anthropic" | "openai" (matches modelProvider.provider in DB)
- * @param envVar      - env var name to fall back to (e.g. "ANTHROPIC_API_KEY")
+ * @param provider    - value of `ModelProvider.provider` (e.g. user label or legacy `"openai"`)
+ * @param envVar      - env var name to fall back to (e.g. `ANTHROPIC_API_KEY`)
  */
 export async function resolveWorkspaceApiKey(
   workspaceId: string,

--- a/frontend/packages/core/src/pi-model.ts
+++ b/frontend/packages/core/src/pi-model.ts
@@ -80,6 +80,27 @@ function getDefaultSystemModel(): {
   return null;
 }
 
+/** When BYOK has no explicit model id, pick a sensible default for that adapter (never Anthropic IDs for OpenAI-tunnel adapters). */
+function defaultModelIdForByokAdapter(adapter: string): string {
+  const catalog = ADAPTER_MODELS[adapter as LLMAdapter];
+  if (catalog?.length) {
+    const cheap =
+      catalog.find((m) => /haiku|mini|flash|lite|turbo|chat/i.test(m.id)) ??
+      catalog[catalog.length - 1];
+    return cheap.id;
+  }
+  if (adapter === "openai") return "gpt-5-mini";
+  if (adapter === "google") return "gemini-2.5-flash";
+  if (adapter === "anthropic") return "claude-haiku-4-5";
+  if (adapter === "deepseek") return "deepseek-chat";
+  if (adapter === "xai") return "grok-4";
+  if (adapter === "moonshot") return "kimi-k2.5";
+  if (adapter === "zai") return "glm-5-turbo";
+  if (adapter === "openrouter") return "openai/gpt-4o-mini";
+  if (adapter === "azure") return "gpt-5-mini";
+  return "claude-haiku-4-5";
+}
+
 /**
  * Resolve the pi-ai {@link Model} for a request: BYOK (adapter + protocol + base URL),
  * TraceRoot system catalog model, or best-effort default — matching agent behavior.
@@ -88,8 +109,14 @@ export function resolvePiModel(
   modelId: string | undefined,
   providerConfig: ProviderModelConfig | null,
 ): Model<Api> {
-  const defaultSystemModel = !modelId ? getDefaultSystemModel() : null;
-  const effectiveModelId = modelId || defaultSystemModel?.modelId || "claude-sonnet-4-5";
+  const trimmed = modelId?.trim() ?? "";
+  const defaultSystemModel = !trimmed && !providerConfig ? getDefaultSystemModel() : null;
+
+  const effectiveModelId = trimmed
+    ? trimmed
+    : providerConfig
+      ? defaultModelIdForByokAdapter(providerConfig.adapter)
+      : (defaultSystemModel?.modelId ?? "claude-sonnet-4-5");
 
   if (providerConfig) {
     const piAIProvider = ADAPTER_TO_PI_AI[providerConfig.adapter];

--- a/frontend/packages/core/src/pi-model.ts
+++ b/frontend/packages/core/src/pi-model.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared pi-ai model construction for agent, detector sandbox eval, and other workers.
+ * Dispatch is driven by {@link ADAPTER_API_PROTOCOL} and {@link ADAPTER_DEFAULT_BASE_URL}
+ * (not vendor-specific branching beyond adapter → pi-ai provider mapping).
+ */
+import { getModel } from "@mariozechner/pi-ai";
+import type { Api, Model, Provider } from "@mariozechner/pi-ai";
+import {
+  SYSTEM_MODELS,
+  PROVIDER_PRIORITY,
+  ADAPTER_TO_PI_AI,
+  ADAPTER_DEFAULT_BASE_URL,
+  ADAPTER_API_PROTOCOL,
+  ADAPTER_MODELS,
+  type LLMAdapter,
+} from "./llm-providers";
+
+/** Workspace BYOK row (decrypted key) — same shape as agent `ProviderConfig`. */
+export interface ProviderModelConfig {
+  adapter: string;
+  key: string;
+  baseUrl: string | null;
+  config: Record<string, unknown> | null;
+}
+
+const systemModelLookup = new Map<string, { piAIProvider: string; apiProtocol: string }>();
+for (const sys of SYSTEM_MODELS) {
+  for (const m of sys.models) {
+    systemModelLookup.set(m.id, {
+      piAIProvider: sys.piAIProvider,
+      apiProtocol: m.apiProtocol || sys.apiProtocol,
+    });
+  }
+}
+
+/**
+ * Build a model object with the correct `api` protocol while preserving pi-ai registry
+ * metadata (pricing, context window) when available.
+ */
+export function buildFallbackModel(
+  modelId: string,
+  apiProtocol: string,
+  provider: string,
+): Model<Api> {
+  // pi-ai registry is typed to known provider IDs; BYOK maps (e.g. deepseek → openai) are all valid lookups.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const registryModel = getModel(provider as any, modelId as any);
+  if (registryModel) {
+    return { ...registryModel, api: apiProtocol as Api };
+  }
+  return {
+    id: modelId,
+    name: modelId,
+    api: apiProtocol as Api,
+    provider: provider as Provider,
+    baseUrl: "",
+    reasoning: false,
+    input: ["text", "image"] as ("text" | "image")[],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 64000,
+  };
+}
+
+function getDefaultSystemModel(): {
+  modelId: string;
+  piAIProvider: string;
+  apiProtocol: string;
+} | null {
+  for (const adapter of PROVIDER_PRIORITY) {
+    const sys = SYSTEM_MODELS.find((s) => s.piAIProvider === adapter && process.env[s.envVar]);
+    if (sys && sys.models.length > 0) {
+      return {
+        modelId: sys.models[0].id,
+        piAIProvider: sys.piAIProvider,
+        apiProtocol: sys.models[0].apiProtocol || sys.apiProtocol,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve the pi-ai {@link Model} for a request: BYOK (adapter + protocol + base URL),
+ * TraceRoot system catalog model, or best-effort default — matching agent behavior.
+ */
+export function resolvePiModel(
+  modelId: string | undefined,
+  providerConfig: ProviderModelConfig | null,
+): Model<Api> {
+  const defaultSystemModel = !modelId ? getDefaultSystemModel() : null;
+  const effectiveModelId = modelId || defaultSystemModel?.modelId || "claude-sonnet-4-5";
+
+  if (providerConfig) {
+    const piAIProvider = ADAPTER_TO_PI_AI[providerConfig.adapter];
+    if (piAIProvider) {
+      const modelProtocols = providerConfig.config?.modelProtocols as
+        | Record<string, string>
+        | undefined;
+      const catalog = ADAPTER_MODELS[providerConfig.adapter as LLMAdapter];
+      const catalogProtocol = catalog?.find((m) => m.id === effectiveModelId)?.apiProtocol;
+      const apiProtocol =
+        modelProtocols?.[effectiveModelId] ||
+        catalogProtocol ||
+        ADAPTER_API_PROTOCOL[providerConfig.adapter] ||
+        "openai-completions";
+      const model = buildFallbackModel(effectiveModelId, apiProtocol, piAIProvider);
+      const baseUrl = providerConfig.baseUrl || ADAPTER_DEFAULT_BASE_URL[providerConfig.adapter];
+      if (baseUrl) {
+        model.baseUrl = baseUrl;
+      }
+      return model;
+    }
+  }
+
+  const sysInfo = systemModelLookup.get(effectiveModelId);
+  if (sysInfo) {
+    return buildFallbackModel(effectiveModelId, sysInfo.apiProtocol, sysInfo.piAIProvider);
+  }
+
+  if (defaultSystemModel) {
+    return buildFallbackModel(
+      defaultSystemModel.modelId,
+      defaultSystemModel.apiProtocol,
+      defaultSystemModel.piAIProvider,
+    );
+  }
+  return getModel("anthropic", "claude-sonnet-4-5");
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@mariozechner/pi-ai':
+        specifier: 0.57.1
+        version: 0.57.1(ws@8.19.0)(zod@4.3.6)
       '@prisma/client':
         specifier: ^5.22.0
         version: 5.22.0(prisma@5.22.0)
@@ -245,27 +248,15 @@ importers:
 
   worker:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.87.0
-        version: 0.87.0(zod@4.3.6)
+      '@mariozechner/pi-ai':
+        specifier: 0.57.1
+        version: 0.57.1(ws@8.19.0)(zod@4.3.6)
       '@traceroot/core':
         specifier: workspace:*
         version: link:../packages/core
-      bullmq:
-        specifier: ^5.73.3
-        version: 5.73.3
-      ioredis:
-        specifier: ^5.10.1
-        version: 5.10.1
       node-cron:
         specifier: ^3.0.0
         version: 3.0.3
-      nodemailer:
-        specifier: ^6.10.0
-        version: 6.10.1
-      openai:
-        specifier: ^4.98.0
-        version: 4.104.0(ws@8.19.0)(zod@4.3.6)
       stripe:
         specifier: 14.25.0
         version: 14.25.0
@@ -276,9 +267,6 @@ importers:
       '@types/node-cron':
         specifier: ^3.0.0
         version: 3.0.11
-      '@types/nodemailer':
-        specifier: ^6.4.14
-        version: 6.4.23
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -297,15 +285,6 @@ packages:
 
   '@anthropic-ai/sdk@0.73.0':
     resolution: {integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==}
-    hasBin: true
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    peerDependenciesMeta:
-      zod:
-        optional: true
-
-  '@anthropic-ai/sdk@0.87.0':
-    resolution: {integrity: sha512-ZvBWT5VkPTW6b8LIpugpuAkpcYPSLOXdWTcgQrpUqf4IeJ5ZrH5rT8sTsUDvxPCHAlRG3nF4VIWfjw6uLhJ18g==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -1049,9 +1028,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@ioredis/commands@1.5.1':
-    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
-
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1093,36 +1069,6 @@ packages:
 
   '@mongodb-js/saslprep@1.4.9':
     resolution: {integrity: sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA==}
-
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
-    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
-    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
-    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
-    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
-    cpu: [arm]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
-    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
-    cpu: [x64]
-    os: [win32]
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -2330,17 +2276,8 @@ packages:
   '@types/node-cron@3.0.11':
     resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
 
-  '@types/node-fetch@2.6.13':
-    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
-
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
-
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
-
-  '@types/nodemailer@6.4.23':
-    resolution: {integrity: sha512-aFV3/NsYFLSx9mbb5gtirBSXJnAlrusoKNuPbxsASWc7vrKLmIrTQRpdcxNcSFL3VW2A2XpeLEavwb2qMi6nlQ==}
 
   '@types/nodemailer@7.0.11':
     resolution: {integrity: sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==}
@@ -2462,10 +2399,6 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  abort-controller@3.0.0:
-    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
-    engines: {node: '>=6.5'}
-
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -2484,10 +2417,6 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
-
-  agentkeepalive@4.6.0:
-    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
-    engines: {node: '>= 8.0.0'}
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -2696,9 +2625,6 @@ packages:
   buffer@5.6.0:
     resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
-  bullmq@5.73.3:
-    resolution: {integrity: sha512-WnwQYYJ6UKdyPXS1OkEp7QY+vFE3nblDLMTwYSqXRym9l+7KC0tAkODITC9mxxCFZGx5jrfAist9p8cZTIZIaQ==}
-
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -2797,10 +2723,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cluster-key-slot@1.1.2:
-    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
-    engines: {node: '>=0.10.0'}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2834,10 +2756,6 @@ packages:
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
-
-  cron-parser@4.9.0:
-    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
-    engines: {node: '>=12.0.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2891,10 +2809,6 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-
-  denque@2.1.0:
-    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
-    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3068,10 +2982,6 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
-  event-target-shim@5.0.1:
-    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
-    engines: {node: '>=6'}
-
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -3164,16 +3074,9 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data-encoder@1.7.2:
-    resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
-
-  formdata-node@4.4.1:
-    resolution: {integrity: sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==}
-    engines: {node: '>= 12.20'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -3308,9 +3211,6 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  humanize-ms@1.2.1:
-    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
-
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -3338,10 +3238,6 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
-
-  ioredis@5.10.1:
-    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
-    engines: {node: '>=12.22.0'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -3566,14 +3462,8 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
-  lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
-
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
-
-  lodash.isarguments@3.1.0:
-    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -3623,10 +3513,6 @@ packages:
     resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
-
-  luxon@3.7.2:
-    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
-    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3849,13 +3735,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msgpackr-extract@3.0.3:
-    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
-    hasBin: true
-
-  msgpackr@1.11.5:
-    resolution: {integrity: sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==}
-
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -3902,9 +3781,6 @@ packages:
       sass:
         optional: true
 
-  node-abort-controller@3.1.1:
-    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
-
   node-cron@3.0.3:
     resolution: {integrity: sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==}
     engines: {node: '>=6.0.0'}
@@ -3914,29 +3790,12 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  node-gyp-build-optional-packages@5.2.2:
-    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
-    hasBin: true
-
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
-
-  nodemailer@6.10.1:
-    resolution: {integrity: sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==}
-    engines: {node: '>=6.0.0'}
 
   nodemailer@8.0.5:
     resolution: {integrity: sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==}
@@ -3964,18 +3823,6 @@ packages:
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
-
-  openai@4.104.0:
-    resolution: {integrity: sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==}
-    hasBin: true
-    peerDependencies:
-      ws: ^8.18.0
-      zod: ^3.23.8
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
 
   openai@6.26.0:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
@@ -4304,14 +4151,6 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  redis-errors@1.2.0:
-    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
-    engines: {node: '>=4'}
-
-  redis-parser@3.0.0:
-    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
-    engines: {node: '>=4'}
-
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -4477,9 +4316,6 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  standard-as-callback@2.1.0:
-    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
-
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -4619,9 +4455,6 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
@@ -4667,9 +4500,6 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4727,10 +4557,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -4867,15 +4693,8 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  web-streams-polyfill@4.0.0-beta.3:
-    resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
-    engines: {node: '>= 14'}
-
   web-vitals@5.1.0:
     resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
@@ -4884,9 +4703,6 @@ packages:
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4976,12 +4792,6 @@ snapshots:
   '@alloc/quick-lru@5.2.0': {}
 
   '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
-    dependencies:
-      json-schema-to-ts: 3.1.1
-    optionalDependencies:
-      zod: 4.3.6
-
-  '@anthropic-ai/sdk@0.87.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -6025,8 +5835,6 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@ioredis/commands@1.5.1': {}
-
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -6109,24 +5917,6 @@ snapshots:
   '@mongodb-js/saslprep@1.4.9':
     dependencies:
       sparse-bitfield: 3.0.3
-
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
-    optional: true
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -7415,22 +7205,9 @@ snapshots:
 
   '@types/node-cron@3.0.11': {}
 
-  '@types/node-fetch@2.6.13':
-    dependencies:
-      '@types/node': 22.19.15
-      form-data: 4.0.5
-
-  '@types/node@18.19.130':
-    dependencies:
-      undici-types: 5.26.5
-
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
-
-  '@types/nodemailer@6.4.23':
-    dependencies:
-      '@types/node': 22.19.15
 
   '@types/nodemailer@7.0.11':
     dependencies:
@@ -7603,10 +7380,6 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  abort-controller@3.0.0:
-    dependencies:
-      event-target-shim: 5.0.1
-
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -7618,10 +7391,6 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
-
-  agentkeepalive@4.6.0:
-    dependencies:
-      humanize-ms: 1.2.1
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
@@ -7788,18 +7557,6 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bullmq@5.73.3:
-    dependencies:
-      cron-parser: 4.9.0
-      ioredis: 5.10.1
-      msgpackr: 1.11.5
-      node-abort-controller: 3.1.1
-      semver: 7.7.4
-      tslib: 2.8.1
-      uuid: 11.1.0
-    transitivePeerDependencies:
-      - supports-color
-
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -7892,8 +7649,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cluster-key-slot@1.1.2: {}
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -7917,10 +7672,6 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   core-js@3.49.0: {}
-
-  cron-parser@4.9.0:
-    dependencies:
-      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7959,8 +7710,6 @@ snapshots:
       esprima: 4.0.1
 
   delayed-stream@1.0.0: {}
-
-  denque@2.1.0: {}
 
   dequal@2.0.3: {}
 
@@ -8168,8 +7917,6 @@ snapshots:
 
   esutils@2.0.3: {}
 
-  event-target-shim@5.0.1: {}
-
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
@@ -8251,8 +7998,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data-encoder@1.7.2: {}
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -8260,11 +8005,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-
-  formdata-node@4.4.1:
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 4.0.0-beta.3
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -8432,10 +8172,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  humanize-ms@1.2.1:
-    dependencies:
-      ms: 2.1.3
-
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -8459,20 +8195,6 @@ snapshots:
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
-
-  ioredis@5.10.1:
-    dependencies:
-      '@ioredis/commands': 1.5.1
-      cluster-key-slot: 1.1.2
-      debug: 4.4.3
-      denque: 2.1.0
-      lodash.defaults: 4.2.0
-      lodash.isarguments: 3.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
 
   ip-address@10.1.0: {}
 
@@ -8671,11 +8393,7 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
-  lodash.defaults@4.2.0: {}
-
   lodash.includes@4.3.0: {}
-
-  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -8716,8 +8434,6 @@ snapshots:
   lucide-react@0.468.0(react@19.0.0):
     dependencies:
       react: 19.0.0
-
-  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -9125,22 +8841,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msgpackr-extract@3.0.3:
-    dependencies:
-      node-gyp-build-optional-packages: 5.2.2
-    optionalDependencies:
-      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
-      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
-    optional: true
-
-  msgpackr@1.11.5:
-    optionalDependencies:
-      msgpackr-extract: 3.0.3
-
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -9184,17 +8884,11 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  node-abort-controller@3.1.1: {}
-
   node-cron@3.0.3:
     dependencies:
       uuid: 8.3.2
 
   node-domexception@1.0.0: {}
-
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -9202,14 +8896,7 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  node-gyp-build-optional-packages@5.2.2:
-    dependencies:
-      detect-libc: 2.1.2
-    optional: true
-
   node-releases@2.0.36: {}
-
-  nodemailer@6.10.1: {}
 
   nodemailer@8.0.5: {}
 
@@ -9226,21 +8913,6 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
-
-  openai@4.104.0(ws@8.19.0)(zod@4.3.6):
-    dependencies:
-      '@types/node': 18.19.130
-      '@types/node-fetch': 2.6.13
-      abort-controller: 3.0.0
-      agentkeepalive: 4.6.0
-      form-data-encoder: 1.7.2
-      formdata-node: 4.4.1
-      node-fetch: 2.7.0
-    optionalDependencies:
-      ws: 8.19.0
-      zod: 4.3.6
-    transitivePeerDependencies:
-      - encoding
 
   openai@6.26.0(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:
@@ -9534,12 +9206,6 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
-  redis-errors@1.2.0: {}
-
-  redis-parser@3.0.0:
-    dependencies:
-      redis-errors: 1.2.0
-
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -9788,8 +9454,6 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  standard-as-callback@2.1.0: {}
-
   std-env@3.10.0: {}
 
   stream-browserify@3.0.0:
@@ -9952,8 +9616,6 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  tr46@0.0.3: {}
-
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
@@ -9995,8 +9657,6 @@ snapshots:
       - supports-color
 
   typescript@5.9.3: {}
-
-  undici-types@5.26.5: {}
 
   undici-types@6.21.0: {}
 
@@ -10061,8 +9721,6 @@ snapshots:
       '@types/react': 19.2.14
 
   util-deprecate@1.0.2: {}
-
-  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 
@@ -10276,11 +9934,7 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
-  web-streams-polyfill@4.0.0-beta.3: {}
-
   web-vitals@5.1.0: {}
-
-  webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
 
@@ -10288,11 +9942,6 @@ snapshots:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -254,9 +254,18 @@ importers:
       '@traceroot/core':
         specifier: workspace:*
         version: link:../packages/core
+      bullmq:
+        specifier: ^5.76.5
+        version: 5.76.5
+      ioredis:
+        specifier: ^5.10.1
+        version: 5.10.1
       node-cron:
         specifier: ^3.0.0
         version: 3.0.3
+      nodemailer:
+        specifier: ^8.0.5
+        version: 8.0.5
       stripe:
         specifier: 14.25.0
         version: 14.25.0
@@ -267,6 +276,9 @@ importers:
       '@types/node-cron':
         specifier: ^3.0.0
         version: 3.0.11
+      '@types/nodemailer':
+        specifier: ^7.0.9
+        version: 7.0.11
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -1028,6 +1040,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1069,6 +1084,36 @@ packages:
 
   '@mongodb-js/saslprep@1.4.9':
     resolution: {integrity: sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA==}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    resolution: {integrity: sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    resolution: {integrity: sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    resolution: {integrity: sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    resolution: {integrity: sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    resolution: {integrity: sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -2625,6 +2670,10 @@ packages:
   buffer@5.6.0:
     resolution: {integrity: sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==}
 
+  bullmq@5.76.5:
+    resolution: {integrity: sha512-2OKJP2+ckc+TygsWdxxeZYYgM9xYnVXgIAx+perflhamZ6FEBu/cSrvpqM8++fJI5OgsIFLfxA9UO7BDZ74Inw==}
+    engines: {node: '>=12.22.0'}
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -2723,6 +2772,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2756,6 +2809,10 @@ packages:
 
   core-js@3.49.0:
     resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2809,6 +2866,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -3239,6 +3300,10 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
@@ -3462,8 +3527,14 @@ packages:
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -3513,6 +3584,10 @@ packages:
     resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3735,6 +3810,13 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msgpackr-extract@3.0.3:
+    resolution: {integrity: sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==}
+    hasBin: true
+
+  msgpackr@1.11.12:
+    resolution: {integrity: sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg==}
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -3781,6 +3863,9 @@ packages:
       sass:
         optional: true
 
+  node-abort-controller@3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
   node-cron@3.0.3:
     resolution: {integrity: sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==}
     engines: {node: '>=6.0.0'}
@@ -3793,6 +3878,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
@@ -4151,6 +4240,14 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -4315,6 +4412,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -5835,6 +5935,8 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@ioredis/commands@1.5.1': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -5917,6 +6019,24 @@ snapshots:
   '@mongodb-js/saslprep@1.4.9':
     dependencies:
       sparse-bitfield: 3.0.3
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
+    optional: true
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -7557,6 +7677,17 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bullmq@5.76.5:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.10.1
+      msgpackr: 1.11.12
+      node-abort-controller: 3.1.1
+      semver: 7.7.4
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -7649,6 +7780,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -7672,6 +7805,10 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   core-js@3.49.0: {}
+
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -7710,6 +7847,8 @@ snapshots:
       esprima: 4.0.1
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   dequal@2.0.3: {}
 
@@ -8196,6 +8335,20 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   ip-address@10.1.0: {}
 
   is-alphabetical@2.0.1: {}
@@ -8393,7 +8546,11 @@ snapshots:
 
   lodash.camelcase@4.3.0: {}
 
+  lodash.defaults@4.2.0: {}
+
   lodash.includes@4.3.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -8434,6 +8591,8 @@ snapshots:
   lucide-react@0.468.0(react@19.0.0):
     dependencies:
       react: 19.0.0
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -8841,6 +9000,22 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msgpackr-extract@3.0.3:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.3
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.3
+    optional: true
+
+  msgpackr@1.11.12:
+    optionalDependencies:
+      msgpackr-extract: 3.0.3
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -8884,6 +9059,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-abort-controller@3.1.1: {}
+
   node-cron@3.0.3:
     dependencies:
       uuid: 8.3.2
@@ -8895,6 +9072,11 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
 
   node-releases@2.0.36: {}
 
@@ -9206,6 +9388,12 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
@@ -9453,6 +9641,8 @@ snapshots:
       memory-pager: 1.5.0
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@3.10.0: {}
 

--- a/frontend/worker/package.json
+++ b/frontend/worker/package.json
@@ -19,12 +19,16 @@
   "dependencies": {
     "@mariozechner/pi-ai": "0.57.1",
     "@traceroot/core": "workspace:*",
+    "bullmq": "^5.76.5",
+    "ioredis": "^5.10.1",
     "node-cron": "^3.0.0",
+    "nodemailer": "^8.0.5",
     "stripe": "14.25.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-cron": "^3.0.0",
+    "@types/nodemailer": "^7.0.9",
     "tsx": "^4.21.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0"

--- a/frontend/worker/package.json
+++ b/frontend/worker/package.json
@@ -6,12 +6,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "dev": "dotenv -e ../../.env -- tsx watch src/index.ts",
-    "dev:billing": "dotenv -e ../../.env -- tsx watch src/index.ts",
-    "dev:detectors": "dotenv -e ../../.env -- tsx watch src/detector-main.ts",
     "build": "tsc",
     "start": "node dist/index.js",
-    "start:billing": "node dist/index.js",
-    "start:detectors": "node dist/detector-main.js",
     "clean": "rm -rf dist",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -21,19 +17,14 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.87.0",
+    "@mariozechner/pi-ai": "0.57.1",
     "@traceroot/core": "workspace:*",
-    "bullmq": "^5.73.3",
-    "ioredis": "^5.10.1",
-    "nodemailer": "^6.10.0",
     "node-cron": "^3.0.0",
-    "openai": "^4.98.0",
     "stripe": "14.25.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/node-cron": "^3.0.0",
-    "@types/nodemailer": "^6.4.14",
     "tsx": "^4.21.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0"

--- a/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
+++ b/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
@@ -1,20 +1,47 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const mockCreate = vi.fn();
+const mockComplete = vi.fn();
 
-// Mock Anthropic before importing the module under test
-vi.mock("@anthropic-ai/sdk", () => {
+vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-ai")>();
   return {
-    default: vi.fn().mockImplementation(() => ({
-      messages: { create: mockCreate },
-    })),
+    ...actual,
+    complete: (...args: unknown[]) => mockComplete(...args),
+    getEnvApiKey: vi.fn(() => "sk-test"),
   };
 });
 
-// Mock @traceroot/core so tests don't need a real DB
-vi.mock("@traceroot/core", () => ({
-  resolveWorkspaceApiKey: vi.fn().mockResolvedValue("test-api-key"),
+vi.mock("@traceroot/core/pi-model", () => ({
+  resolvePiModel: vi.fn(() => ({
+    id: "claude-haiku-4-5",
+    name: "claude-haiku-4-5",
+    api: "anthropic-messages",
+    provider: "anthropic",
+    baseUrl: "",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200000,
+    maxTokens: 64000,
+  })),
 }));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  const findUnique = vi.fn().mockResolvedValue(null);
+  const findMany = vi.fn().mockResolvedValue([]);
+  return {
+    ...actual,
+    prisma: new Proxy(actual.prisma, {
+      get(target, prop, receiver) {
+        if (prop === "modelProvider") {
+          return { findUnique, findMany };
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+    }),
+  };
+});
 
 import { runDetectionForTrace } from "../sandbox-eval";
 
@@ -25,26 +52,48 @@ const DETECTOR = {
   outputSchema: [{ name: "category", type: "string" }],
 };
 
+const emptyUsage = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function assistantWithTool(args: Record<string, unknown>) {
+  return {
+    role: "assistant" as const,
+    content: [
+      {
+        type: "toolCall" as const,
+        id: "toolu_1",
+        name: "submit_result",
+        arguments: args,
+      },
+    ],
+    api: "anthropic-messages",
+    provider: "anthropic",
+    model: "claude-haiku-4-5",
+    usage: emptyUsage,
+    stopReason: "toolUse" as const,
+    timestamp: Date.now(),
+  };
+}
+
 describe("runDetectionForTrace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("returns identified=true when LLM calls submit_result with identified=true", async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [
-        {
-          type: "tool_use",
-          name: "submit_result",
-          input: {
-            identified: true,
-            summary: "Tool errored 3 times",
-            data: { category: "tool_error" },
-          },
-        },
-      ],
-      stop_reason: "tool_use",
-    });
+    mockComplete.mockResolvedValueOnce(
+      assistantWithTool({
+        identified: true,
+        summary: "Tool errored 3 times",
+        data: { category: "tool_error" },
+      }),
+    );
 
     const result = await runDetectionForTrace({
       traceId: "trace-abc",
@@ -60,16 +109,9 @@ describe("runDetectionForTrace", () => {
   });
 
   it("returns identified=false when LLM calls submit_result with identified=false", async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [
-        {
-          type: "tool_use",
-          name: "submit_result",
-          input: { identified: false, summary: "No errors found", data: {} },
-        },
-      ],
-      stop_reason: "tool_use",
-    });
+    mockComplete.mockResolvedValueOnce(
+      assistantWithTool({ identified: false, summary: "No errors found", data: {} }),
+    );
 
     const result = await runDetectionForTrace({
       traceId: "trace-abc",
@@ -82,23 +124,20 @@ describe("runDetectionForTrace", () => {
     expect(result.summary).toBe("No errors found");
   });
 
-  it("retries when LLM responds with plain text (end_turn without tool_use)", async () => {
-    // First call: plain text response
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: "text", text: "I think there is an error." }],
-      stop_reason: "end_turn",
+  it("retries when LLM responds with plain text (no tool call)", async () => {
+    mockComplete.mockResolvedValueOnce({
+      role: "assistant" as const,
+      content: [{ type: "text" as const, text: "I think there is an error." }],
+      api: "anthropic-messages",
+      provider: "anthropic",
+      model: "claude-haiku-4-5",
+      usage: emptyUsage,
+      stopReason: "stop" as const,
+      timestamp: Date.now(),
     });
-    // Second call: proper tool use
-    mockCreate.mockResolvedValueOnce({
-      content: [
-        {
-          type: "tool_use",
-          name: "submit_result",
-          input: { identified: true, summary: "Found on retry", data: {} },
-        },
-      ],
-      stop_reason: "tool_use",
-    });
+    mockComplete.mockResolvedValueOnce(
+      assistantWithTool({ identified: true, summary: "Found on retry", data: {} }),
+    );
 
     const result = await runDetectionForTrace({
       traceId: "trace-abc",
@@ -109,20 +148,13 @@ describe("runDetectionForTrace", () => {
 
     expect(result.identified).toBe(true);
     expect(result.summary).toBe("Found on retry");
-    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(mockComplete).toHaveBeenCalledTimes(2);
   });
 
   it("truncates spansJsonl at 40000 chars", async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [
-        {
-          type: "tool_use",
-          name: "submit_result",
-          input: { identified: false, summary: "Clean", data: {} },
-        },
-      ],
-      stop_reason: "tool_use",
-    });
+    mockComplete.mockResolvedValueOnce(
+      assistantWithTool({ identified: false, summary: "Clean", data: {} }),
+    );
 
     const longSpans = "x".repeat(50000);
     await runDetectionForTrace({
@@ -132,14 +164,13 @@ describe("runDetectionForTrace", () => {
       workspaceId: "",
     });
 
-    const callArg = mockCreate.mock.calls[0][0];
+    const callArg = mockComplete.mock.calls[0][1] as { messages: { content: string }[] };
     const userMessage = callArg.messages[0].content as string;
-    // The spans portion should be truncated to 40000 chars
     expect(userMessage.length).toBeLessThan(42000);
   });
 
-  it("returns error when Anthropic throws", async () => {
-    mockCreate.mockRejectedValueOnce(new Error("API rate limit"));
+  it("returns error when complete throws", async () => {
+    mockComplete.mockRejectedValueOnce(new Error("API rate limit"));
 
     const result = await runDetectionForTrace({
       traceId: "trace-abc",

--- a/frontend/worker/src/detection/__tests__/submit-result-tool.test.ts
+++ b/frontend/worker/src/detection/__tests__/submit-result-tool.test.ts
@@ -42,4 +42,14 @@ describe("buildSubmitResultTool", () => {
     expect(dataProps.count.type).toBe("number");
     expect(dataProps.flagged.type).toBe("boolean");
   });
+
+  it("ignores prototype-polluting field names", () => {
+    const tool = buildSubmitResultTool([
+      { name: "__proto__", type: "string" },
+      { name: "safe", type: "string" },
+    ]);
+    const dataProps = tool.input_schema.properties.data.properties;
+    expect(dataProps).not.toHaveProperty("__proto__");
+    expect(dataProps).toHaveProperty("safe");
+  });
 });

--- a/frontend/worker/src/detection/clickhouse-writer.ts
+++ b/frontend/worker/src/detection/clickhouse-writer.ts
@@ -1,8 +1,6 @@
 /**
- * Internal API client for writing detector results to ClickHouse.
- * The TypeScript worker calls the Python backend's internal API,
- * which handles the actual ClickHouse writes.
- * Pattern matches frontend/worker/src/ee/billing/clickhouse.ts
+ * Internal API client for writing detector results to ClickHouse (via Python backend).
+ * Same pattern as `ee/billing/clickhouse.ts`.
  */
 
 const BACKEND_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";

--- a/frontend/worker/src/detection/index.ts
+++ b/frontend/worker/src/detection/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Detector background jobs (sandbox LLM eval, etc.).
+ *
+ * @example
+ * import { runDetectionForTrace } from "./detection";
+ */
+export {
+  completeDetectorSandboxEval,
+  runDetectionForTrace,
+  type DetectorSandboxEvalInput,
+  type DetectorConfig,
+  type EvalResult,
+} from "./sandbox-eval";
+export {
+  buildSubmitResultTool,
+  buildSubmitResultToolForPiAi,
+  type SubmitResultInput,
+} from "./submit-result-tool";
+export { writeDetectorRun, writeDetectorFinding } from "./clickhouse-writer";

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -1,7 +1,29 @@
-import Anthropic from "@anthropic-ai/sdk";
-import OpenAI from "openai";
-import { resolveWorkspaceApiKey } from "@traceroot/core";
-import { buildSubmitResultTool, type SubmitResultInput } from "./submit-result-tool.js";
+/**
+ * Detector sandbox LLM evaluation — routes through pi-ai (`complete`) using the same
+ * model resolution as the agent ({@link resolvePiModel} on `@traceroot/core/pi-model`),
+ * keyed by API protocol (not per-vendor SDK forks). {@link runDetectionForTrace} enforces
+ * structured output via the `submit_result` tool.
+ */
+import {
+  complete,
+  getEnvApiKey,
+  type Api,
+  type AssistantMessage,
+  type Message,
+  type Model,
+  type ToolCall,
+} from "@mariozechner/pi-ai";
+import {
+  prisma,
+  decryptKey,
+  ADAPTER_TO_PI_AI,
+  ADAPTER_MODELS,
+  BEDROCK_USE_DEFAULT_CREDENTIALS,
+  ModelSource,
+  type LLMAdapter,
+} from "@traceroot/core";
+import { resolvePiModel, type ProviderModelConfig } from "@traceroot/core/pi-model";
+import { buildSubmitResultToolForPiAi, type SubmitResultInput } from "./submit-result-tool";
 
 export interface DetectorConfig {
   id: string;
@@ -9,8 +31,11 @@ export interface DetectorConfig {
   prompt: string;
   outputSchema: Array<{ name: string; type: string }>;
   detectionModel?: string | null;
+  /** Workspace model provider row label, or legacy `"openai"` / `"anthropic"` for env/BYOK lookup. */
   detectionProvider?: string | null;
   detectionAdapter?: string | null;
+  /** When `byok`, {@link detectionProvider} must match `ModelProvider.provider` in the workspace. */
+  detectionModelSource?: import("@traceroot/core").ModelSource;
 }
 
 export interface EvalResult {
@@ -20,158 +45,157 @@ export interface EvalResult {
   error?: string;
 }
 
-// Adapter-aware defaults: a detector may set adapter without setting
-// model/provider. Anthropic defaults to claude-haiku; OpenAI defaults to
-// gpt-4o-mini. Without this split, an OpenAI detector with a blank model
-// would route to the OpenAI SDK with a Claude model name and fail.
-const DETECTION_DEFAULTS: Record<string, { model: string; provider: string }> = {
-  anthropic: { model: "claude-haiku-4-5-20251001", provider: "anthropic" },
-  openai: { model: "gpt-4o-mini", provider: "openai" },
-};
-const DEFAULT_ADAPTER = "anthropic";
-
-async function runDetectionWithAnthropic(params: {
-  traceId: string;
-  userMessage: string;
+export interface DetectorSandboxEvalInput {
+  workspaceId: string;
+  model?: string;
+  providerName?: string;
+  source?: import("@traceroot/core").ModelSource;
   systemPrompt: string;
-  model: string;
-  apiKey: string;
-  submitTool: ReturnType<typeof buildSubmitResultTool>;
-}): Promise<EvalResult> {
-  const client = new Anthropic({ apiKey: params.apiKey });
-
-  let identified = false;
-  let summary = "Analysis failed";
-  let data: Record<string, unknown> = {};
-  let error: string | undefined;
-
-  try {
-    let continueLoop = true;
-    let messages: Anthropic.MessageParam[] = [{ role: "user", content: params.userMessage }];
-    let attempts = 0;
-
-    while (continueLoop && attempts < 5) {
-      attempts++;
-      const response = await client.messages.create({
-        model: params.model,
-        max_tokens: 1024,
-        system: params.systemPrompt,
-        tools: [params.submitTool as Anthropic.Tool],
-        tool_choice: { type: "any" }, // force tool use
-        messages,
-      });
-
-      // Look for submit_result tool call
-      const toolUse = response.content.find(
-        (block): block is Anthropic.ToolUseBlock =>
-          block.type === "tool_use" && block.name === "submit_result",
-      );
-
-      if (toolUse) {
-        const input = toolUse.input as SubmitResultInput;
-        identified = input.identified;
-        summary = input.summary;
-        data = input.data || {};
-        continueLoop = false;
-      } else if (response.stop_reason === "end_turn") {
-        // LLM gave plain text — retry with reminder
-        messages = [
-          ...messages,
-          { role: "assistant", content: response.content },
-          { role: "user", content: "You must call submit_result. Do not respond with text." },
-        ];
-      } else {
-        continueLoop = false;
-      }
-    }
-  } catch (e) {
-    error = e instanceof Error ? e.message : String(e);
-  }
-
-  return { identified, summary, data, error };
+  messages: Message[];
+  signal?: AbortSignal;
+  maxTokens?: number;
 }
 
-async function runDetectionWithOpenAI(params: {
-  traceId: string;
-  userMessage: string;
-  systemPrompt: string;
-  model: string;
-  apiKey: string;
-  submitTool: ReturnType<typeof buildSubmitResultTool>;
-}): Promise<EvalResult> {
-  const client = new OpenAI({ apiKey: params.apiKey });
+const DEFAULT_ADAPTER = "anthropic";
 
-  // Convert Anthropic tool schema to OpenAI format
-  const tool: OpenAI.Chat.ChatCompletionTool = {
-    type: "function",
-    function: {
-      name: "submit_result",
-      description: params.submitTool.description,
-      parameters: params.submitTool.input_schema as Record<string, unknown>,
-    },
-  };
+/** Defaults when `detectionModel` is unset — prefer small / fast models (not first catalog SKU). */
+const DETECTION_DEFAULT_MODEL: Record<string, string> = {
+  anthropic: "claude-haiku-4-5",
+  openai: "gpt-5-mini",
+  google: "gemini-2.5-flash",
+  deepseek: "deepseek-chat",
+  openrouter: "openai/gpt-4o-mini",
+  xai: "grok-4",
+  moonshot: "kimi-k2.5",
+  zai: "glm-5-turbo",
+  azure: "gpt-5-mini",
+};
 
-  let identified = false;
-  let summary = "Analysis failed";
-  let data: Record<string, unknown> = {};
-  let error: string | undefined;
-
+async function fetchProviderModelConfig(
+  workspaceId: string,
+  providerName: string,
+): Promise<ProviderModelConfig | null> {
   try {
-    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
-      { role: "system", content: params.systemPrompt },
-      { role: "user", content: params.userMessage },
-    ];
+    const row = await prisma.modelProvider.findUnique({
+      where: { workspaceId_provider: { workspaceId, provider: providerName } },
+      select: {
+        adapter: true,
+        keyCipher: true,
+        enabled: true,
+        baseUrl: true,
+        config: true,
+      },
+    });
 
-    let continueLoop = true;
-    let attempts = 0;
+    if (row?.enabled && row.keyCipher) {
+      return {
+        adapter: row.adapter,
+        key: decryptKey(row.keyCipher),
+        baseUrl: row.baseUrl,
+        config: row.config as Record<string, unknown> | null,
+      };
+    }
+  } catch (err) {
+    console.error(`[DetectorEval] Failed to load BYOK provider "${providerName}":`, err);
+  }
+  return null;
+}
 
-    while (continueLoop && attempts < 5) {
-      attempts++;
-      const response = await client.chat.completions.create({
-        model: params.model,
-        // newer OpenAI reasoning/codex models reject `max_tokens`
-        max_completion_tokens: 1024,
-        messages,
-        tools: [tool],
-        tool_choice: "required",
-      });
-
-      const choice = response.choices[0];
-      const toolCall = choice.message.tool_calls?.find(
-        (tc) => tc.function.name === "submit_result",
-      );
-
-      if (toolCall) {
-        const input = JSON.parse(toolCall.function.arguments) as {
-          identified: boolean;
-          summary: string;
-          data?: Record<string, unknown>;
-        };
-        identified = input.identified;
-        summary = input.summary;
-        data = input.data ?? {};
-        continueLoop = false;
-      } else if (choice.finish_reason === "stop") {
-        messages.push({ role: "assistant", content: choice.message.content ?? "" });
-        messages.push({
-          role: "user",
-          content: "You must call submit_result. Do not respond with text.",
-        });
-      } else {
-        continueLoop = false;
+async function fetchAnyByokKeyForPiProvider(
+  workspaceId: string,
+  piProvider: string,
+): Promise<string | null> {
+  try {
+    const rows = await prisma.modelProvider.findMany({
+      where: { workspaceId, enabled: true },
+      select: { adapter: true, keyCipher: true },
+    });
+    for (const row of rows) {
+      if (!row.keyCipher) continue;
+      const mapped = ADAPTER_TO_PI_AI[row.adapter];
+      if (mapped === piProvider) {
+        return decryptKey(row.keyCipher);
       }
     }
-  } catch (e) {
-    error = e instanceof Error ? e.message : String(e);
+  } catch (err) {
+    console.warn(`[DetectorEval] Failed to list BYOK keys for workspace ${workspaceId}:`, err);
+  }
+  return null;
+}
+
+async function resolveEvalApiKey(
+  workspaceId: string,
+  source: import("@traceroot/core").ModelSource | undefined,
+  providerConfig: ProviderModelConfig | null,
+  piProvider: string,
+): Promise<string> {
+  if (providerConfig && providerConfig.key !== BEDROCK_USE_DEFAULT_CREDENTIALS) {
+    const mapped = ADAPTER_TO_PI_AI[providerConfig.adapter];
+    if (mapped === piProvider) {
+      return providerConfig.key;
+    }
+  }
+  if (source !== ModelSource.BYOK) {
+    const envKey = getEnvApiKey(piProvider);
+    if (envKey) return envKey;
+  }
+  const fromWorkspace = await fetchAnyByokKeyForPiProvider(workspaceId, piProvider);
+  if (fromWorkspace) return fromWorkspace;
+  return getEnvApiKey(piProvider) || "";
+}
+
+function toolChoiceForModel(model: Model<Api>): string {
+  if (model.api === "anthropic-messages") return "any";
+  return "required";
+}
+
+function defaultDetectionModelId(adapter: string): string {
+  const preferred = DETECTION_DEFAULT_MODEL[adapter];
+  if (preferred) return preferred;
+  const catalog = ADAPTER_MODELS[adapter as LLMAdapter];
+  if (catalog?.[0]?.id) return catalog[0].id;
+  return "claude-haiku-4-5";
+}
+
+/**
+ * Non-streaming completion for simple detector prompts (no forced tool schema).
+ */
+export async function completeDetectorSandboxEval(
+  input: DetectorSandboxEvalInput,
+): Promise<AssistantMessage> {
+  let providerConfig: ProviderModelConfig | null = null;
+  if (input.source === ModelSource.BYOK && input.providerName) {
+    providerConfig = await fetchProviderModelConfig(input.workspaceId, input.providerName);
+    if (!providerConfig) {
+      throw new Error(
+        `BYOK provider "${input.providerName}" not found or disabled for workspace ${input.workspaceId}.`,
+      );
+    }
   }
 
-  return { identified, summary, data, error };
+  const model = resolvePiModel(input.model, providerConfig);
+  const apiKey = await resolveEvalApiKey(
+    input.workspaceId,
+    input.source,
+    providerConfig,
+    model.provider as string,
+  );
+
+  return complete(
+    model,
+    { systemPrompt: input.systemPrompt, messages: input.messages },
+    {
+      apiKey: apiKey || undefined,
+      signal: input.signal,
+      maxTokens: input.maxTokens,
+    },
+  );
 }
 
 /**
  * Run LLM detection for a single trace.
- * spansJsonl is the content of the trace's spans.jsonl file.
- * The LLM must call submit_result to complete — plain text responses are retried.
+ * `spansJsonl` is the content of the trace's spans.jsonl file.
+ * The model must call `submit_result` to complete — plain text responses are retried.
  */
 export async function runDetectionForTrace(params: {
   traceId: string;
@@ -181,16 +205,51 @@ export async function runDetectionForTrace(params: {
 }): Promise<EvalResult> {
   const { traceId, spansJsonl, detector, workspaceId } = params;
 
-  const adapter = detector.detectionAdapter || DEFAULT_ADAPTER;
-  const adapterDefaults = DETECTION_DEFAULTS[adapter] ?? DETECTION_DEFAULTS[DEFAULT_ADAPTER];
-  const model = detector.detectionModel || adapterDefaults.model;
-  const provider = detector.detectionProvider || adapterDefaults.provider;
+  const source = detector.detectionModelSource ?? ModelSource.SYSTEM;
+  let providerConfig: ProviderModelConfig | null = null;
 
-  // Resolve the API key for the chosen provider, falling back to env var
-  const envVarFallback = adapter === "openai" ? "OPENAI_API_KEY" : "ANTHROPIC_API_KEY";
-  const apiKey = await resolveWorkspaceApiKey(workspaceId, provider, envVarFallback);
-  const submitTool = buildSubmitResultTool(detector.outputSchema);
+  if (source === ModelSource.BYOK) {
+    if (!detector.detectionProvider) {
+      return {
+        identified: false,
+        summary: "Analysis failed",
+        data: {},
+        error:
+          "BYOK detector requires detectionProvider (workspace model provider name from settings).",
+      };
+    }
+    providerConfig = await fetchProviderModelConfig(workspaceId, detector.detectionProvider);
+    if (!providerConfig) {
+      return {
+        identified: false,
+        summary: "Analysis failed",
+        data: {},
+        error: `BYOK provider "${detector.detectionProvider}" not found or disabled.`,
+      };
+    }
+  }
 
+  const adapter = providerConfig?.adapter ?? detector.detectionAdapter ?? DEFAULT_ADAPTER;
+  const modelId = detector.detectionModel?.trim() || defaultDetectionModelId(adapter);
+
+  const model = resolvePiModel(modelId, providerConfig);
+  const apiKey = await resolveEvalApiKey(
+    workspaceId,
+    source,
+    providerConfig,
+    model.provider as string,
+  );
+
+  if (!apiKey) {
+    return {
+      identified: false,
+      summary: "Analysis failed",
+      data: {},
+      error: "No API key configured for this model provider.",
+    };
+  }
+
+  const tool = buildSubmitResultToolForPiAi(detector.outputSchema);
   const systemPrompt = `You are a production monitoring assistant analyzing AI agent traces.
 You are evaluating one trace to determine if it exhibits the problem described below.
 
@@ -209,25 +268,56 @@ ${detector.prompt}
 TRACE ID: ${traceId}
 
 SPANS (one JSON object per line):
-${spansJsonl.slice(0, 40000)}`; // safety truncation at ~10k tokens
+${spansJsonl.slice(0, 40000)}`;
 
-  if (adapter === "openai") {
-    return runDetectionWithOpenAI({
-      traceId,
-      userMessage,
-      systemPrompt,
-      model,
-      apiKey,
-      submitTool,
-    });
+  const messages: Message[] = [{ role: "user", content: userMessage, timestamp: Date.now() }];
+
+  const toolChoice = toolChoiceForModel(model);
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const assistant = await complete(
+        model,
+        { systemPrompt, messages, tools: [tool] },
+        {
+          apiKey,
+          maxTokens: 1024,
+          toolChoice,
+        },
+      );
+
+      const toolCall = assistant.content.find(
+        (c): c is ToolCall => c.type === "toolCall" && c.name === "submit_result",
+      );
+      if (toolCall) {
+        const input = toolCall.arguments as SubmitResultInput;
+        return {
+          identified: input.identified,
+          summary: input.summary,
+          data: input.data ?? {},
+        };
+      }
+
+      messages.push(assistant);
+      messages.push({
+        role: "user",
+        content: "You must call submit_result. Do not respond with text.",
+        timestamp: Date.now(),
+      });
+    } catch (e) {
+      return {
+        identified: false,
+        summary: "Analysis failed",
+        data: {},
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
   }
 
-  return runDetectionWithAnthropic({
-    traceId,
-    userMessage,
-    systemPrompt,
-    model,
-    apiKey,
-    submitTool,
-  });
+  return {
+    identified: false,
+    summary: "Analysis failed",
+    data: {},
+    error: "Model did not call submit_result after retries",
+  };
 }

--- a/frontend/worker/src/detection/submit-result-tool.ts
+++ b/frontend/worker/src/detection/submit-result-tool.ts
@@ -1,3 +1,6 @@
+import { Type, type TSchema } from "@mariozechner/pi-ai";
+import type { Tool } from "@mariozechner/pi-ai";
+
 export interface SubmitResultInput {
   identified: boolean;
   summary: string;
@@ -5,11 +8,8 @@ export interface SubmitResultInput {
 }
 
 /**
- * Build the submit_result tool definition for the detection LLM.
- * outputSchemaFields is the user-defined fields from detector.outputSchema,
- * e.g. [{name: "category", type: "string"}, {name: "severity", type: "string"}]
- *
- * The LLM MUST call this tool to complete. Plain text responses are forbidden.
+ * Build the submit_result tool definition for the detection LLM (JSON-schema shape).
+ * Used by tests and any Anthropic-shaped tooling; runtime eval uses {@link buildSubmitResultToolForPiAi}.
  */
 export function buildSubmitResultTool(outputSchemaFields: Array<{ name: string; type: string }>) {
   const dataProperties: Record<string, { type: string; description: string }> = {};
@@ -43,11 +43,49 @@ export function buildSubmitResultTool(outputSchemaFields: Array<{ name: string; 
           properties: dataProperties,
         },
       },
-      // `data` is only required when identified=true (per the description).
-      // The system prompt also tells the LLM this. Marking it required at the
-      // schema level forced models to fabricate empty objects on clean traces,
-      // adding noise without value.
       required: ["identified", "summary"],
     },
+  };
+}
+
+function fieldToSchema(field: { name: string; type: string }): TSchema {
+  const desc = `User-defined field: ${field.name}`;
+  if (field.type === "number") return Type.Number({ description: desc });
+  if (field.type === "boolean") return Type.Boolean({ description: desc });
+  return Type.String({ description: desc });
+}
+
+/** pi-ai / TypeBox tool definition for {@link complete} with tool calling. */
+export function buildSubmitResultToolForPiAi(
+  outputSchemaFields: Array<{ name: string; type: string }>,
+): Tool {
+  const dataProps: Record<string, TSchema> = {};
+  for (const f of outputSchemaFields) {
+    dataProps[f.name] = fieldToSchema(f);
+  }
+  const dataObject = Type.Object(dataProps, {
+    description: "User-defined extraction fields. Supply when identified=true.",
+    additionalProperties: false,
+  });
+  const parameters = Type.Object(
+    {
+      identified: Type.Boolean({
+        description:
+          "true if the problem described in the prompt was found in this trace, false otherwise",
+      }),
+      summary: Type.String({
+        description:
+          "One sentence describing what was found. Required even if identified=false (explain why it is clean).",
+      }),
+      data: Type.Optional(dataObject),
+    },
+    { additionalProperties: false, required: ["identified", "summary"] },
+  );
+
+  return {
+    name: "submit_result",
+    description:
+      "Submit your detection result. You MUST call this tool to complete. Do not respond with plain text.",
+    parameters,
   };
 }

--- a/frontend/worker/src/detection/submit-result-tool.ts
+++ b/frontend/worker/src/detection/submit-result-tool.ts
@@ -7,13 +7,23 @@ export interface SubmitResultInput {
   data: Record<string, unknown>;
 }
 
+const UNSAFE_SCHEMA_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+
+function isSafeOutputFieldName(name: string): boolean {
+  return name.length > 0 && !UNSAFE_SCHEMA_KEYS.has(name);
+}
+
 /**
  * Build the submit_result tool definition for the detection LLM (JSON-schema shape).
  * Used by tests and any Anthropic-shaped tooling; runtime eval uses {@link buildSubmitResultToolForPiAi}.
  */
 export function buildSubmitResultTool(outputSchemaFields: Array<{ name: string; type: string }>) {
-  const dataProperties: Record<string, { type: string; description: string }> = {};
+  const dataProperties = Object.create(null) as Record<
+    string,
+    { type: string; description: string }
+  >;
   for (const field of outputSchemaFields) {
+    if (!isSafeOutputFieldName(field.name)) continue;
     dataProperties[field.name] = {
       type: field.type,
       description: `User-defined field: ${field.name}`,
@@ -59,8 +69,9 @@ function fieldToSchema(field: { name: string; type: string }): TSchema {
 export function buildSubmitResultToolForPiAi(
   outputSchemaFields: Array<{ name: string; type: string }>,
 ): Tool {
-  const dataProps: Record<string, TSchema> = {};
+  const dataProps = Object.create(null) as Record<string, TSchema>;
   for (const f of outputSchemaFields) {
+    if (!isSafeOutputFieldName(f.name)) continue;
     dataProps[f.name] = fieldToSchema(f);
   }
   const dataObject = Type.Object(dataProps, {

--- a/frontend/worker/src/index.ts
+++ b/frontend/worker/src/index.ts
@@ -8,6 +8,7 @@
 import cron from "node-cron";
 import { prisma, syncStandardPrices } from "@traceroot/core";
 import { runBillingJob, closeClickHouseClient } from "./ee/billing";
+// Detector sandbox LLM eval: import { runDetectionForTrace, completeDetectorSandboxEval } from "./detection";
 
 // Graceful shutdown handling
 let isShuttingDown = false;


### PR DESCRIPTION
Fixes #805

## Summary

Detector sandbox eval no longer goes through separate Anthropic / OpenAI SDK paths. It uses the same pi-ai **`complete()`** path as the rest of the stack, with models built from **`@traceroot/core/pi-model`** so routing follows **`ADAPTER_API_PROTOCOL`** / **`ADAPTER_DEFAULT_BASE_URL`** (and per-model overrides where we already encode them), not vendor-specific branching. That unlocks the workspace BYOK providers you already expose in the UI (Gemini, DeepSeek, xAI, Moonshot, Zhipu, OpenRouter, etc.) and the **Responses API** shape for Codex-style models, without growing a second matrix of SDK adapters in the worker.

The agent now calls the same **`resolvePiModel`** helper so we are not maintaining two divergent “how do we build this model object?” implementations.

There is a small **pre-commit** change: **`fail_fast: true`** so a **`mixed-line-ending`** rewrite does not immediately hand off to **`lint-staged`** on a half-updated tree (that combination was what caused the restore conflict on Windows).

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [x] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [x] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- **`@traceroot/core/pi-model`**: shared **`resolvePiModel`** / **`buildFallbackModel`** (exported via subpath so the Next bundle does not pick up pi-ai unless something imports that entry).
- **Agent**: drops the duplicated resolver; logs include **`api=`** for quicker support when something mis-resolves.
- **Worker / detection**: **`runDetectionForTrace`** drives **`submit_result`** through pi-ai with **`toolChoice`** aligned to Anthropic vs OpenAI-style stacks; **`completeDetectorSandboxEval`** stays available for simpler completions; **`resolveWorkspaceApiKey`** lives in core for the same “BYOK row label + env fallback” pattern used elsewhere.
- **Tests**: core **`pi-model`** tests; worker detection tests (mock **`complete`** so CI stays hermetic).

**Not in this PR (on purpose):** BullMQ detector processor, Prisma **`Detector`** tables, and the rest of the epic branch wiring—those are a separate merge. This change is the **LLM / BYOK / protocol** slice of #805 so that layer is correct before more surface area lands.

**How I verified**

- `cd frontend/packages/core && pnpm test && pnpm exec tsc --noEmit`
- `cd frontend/worker && pnpm test && pnpm exec tsc --noEmit`
- `cd frontend/packages/agent && pnpm exec tsc --noEmit`

## Screenshots / Recordings (if applicable)

N/A (no UI in this PR.)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detector evaluation now runs through `@mariozechner/pi-ai` using a shared `resolvePiModel` from `@traceroot/core/pi-model` for consistent BYOK and API-protocol routing across agent and worker. Adds a sandbox eval with a required `submit_result` tool, stricter BYOK provider resolution, pins `pnpm` for CI/Docker, and removes an unused Prisma GitHub type export; aligns with #805.

- New Features
  - Worker: sandbox eval via `complete()` with required `submit_result`; retries when no tool call; truncates spans; resolves model and key from BYOK (`ModelProvider`), env, or adapter defaults; exports from `worker/src/detection`.
  - Core/Agent: shared `pi-model` resolver (adapter→provider map, per-model protocol, safe defaults); agent uses it and logs `api`; tests for `pi-model`, sandbox eval, and tool schema (guards prototype-polluting keys).

- Dependencies
  - Add `@mariozechner/pi-ai@0.57.1`; remove `@anthropic-ai/sdk` and `openai` from worker; bump `bullmq` and `nodemailer`; update `@types/nodemailer`.
  - Export `./pi-model` subpath in `@traceroot/core` (including Docker image build).
  - Pin `pnpm@9.15.9` in CI/Docker and set `"packageManager": "pnpm@9.15.9"` in the root.
  - `.pre-commit-config.yaml` sets `fail_fast: true`.

<sup>Written for commit 2fda455dbccc2a3da5e8e89e320a31a82c38492f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



