### PR TITLE
feat(detectors): wire search + time-range filters and total-count pagination (#806)

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -11,7 +11,21 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from db.clickhouse.client import get_clickhouse_client
+from rest.schemas.detectors import FindingListResponse, RunListResponse
+from rest.services.trace_reader import _to_utc_naive
 from shared.config import settings
+
+
+def _escape_ilike(value: str) -> str:
+    """Escape ClickHouse ILIKE wildcards (`%`, `_`) plus the escape char itself.
+
+    ClickHouse ILIKE uses backslash as the default escape character (no
+    explicit ESCAPE clause is supported in syntax), so wrapping user input
+    with backslash-escapes makes `%` and `_` match literally instead of
+    behaving as wildcards.
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
 
 router = APIRouter(prefix="/internal", tags=["internal"])
 
@@ -226,61 +240,128 @@ async def write_detector_finding(body: DetectorFindingPayload):
     return {"ok": True}
 
 
-@router.get("/detector-runs", dependencies=[Depends(verify_internal_secret)])
+@router.get(
+    "/detector-runs",
+    response_model=RunListResponse,
+    dependencies=[Depends(verify_internal_secret)],
+)
 async def list_detector_runs(
     project_id: str,
     detector_id: str,
-    limit: int = 50,
-    offset: int = 0,
+    page: int = Query(0, ge=0, description="Page number (0-indexed)"),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    start_after: datetime | None = Query(
+        None, description="Filter runs at/after this timestamp (inclusive)"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Filter runs strictly before this timestamp"
+    ),
+    search_query: str | None = Query(
+        None, description="Substring match against trace_id OR the per-detector summary"
+    ),
 ):
     """List runs for a detector, newest first.
+
+    Param naming and pagination shape mirror the trace listing endpoints
+    (`page`/`limit`/`start_after`/`end_before`/`search_query`) so the same
+    `useListPageState` queryOptions can flow through unchanged.
 
     For triggered runs, JOIN with detector_findings to surface this detector's
     per-detector summary string (the finding's `payload` is the combined
     array of all triggered detectors for the trace; we filter to the entry
     matching this run's detector_id).
+
+    Returns {data: [...], meta: {page, limit, total}}. Total is computed by a
+    second COUNT query against the same WHERE clause.
     """
     ch = get_clickhouse_client()
-    result = ch.query(
-        """SELECT
-             r.run_id      AS run_id,
-             r.detector_id AS detector_id,
-             r.project_id  AS project_id,
-             r.trace_id    AS trace_id,
-             r.finding_id  AS finding_id,
-             r.status      AS status,
-             r.timestamp   AS timestamp,
-             if(
-               r.finding_id IS NOT NULL,
-               JSONExtractString(
-                 arrayFirst(
-                   x -> JSONExtractString(x, 'detectorId') = r.detector_id,
-                   JSONExtractArrayRaw(f.payload)
-                 ),
-                 'summary'
-               ),
-               ''
-             ) AS summary
-           FROM detector_runs r
-           LEFT JOIN detector_findings f
-             ON r.finding_id = f.finding_id AND r.project_id = f.project_id
-           WHERE r.project_id = {project_id:String} AND r.detector_id = {detector_id:String}
-           ORDER BY r.timestamp DESC
-           LIMIT {limit:Int32} OFFSET {offset:Int32}""",
-        parameters={
-            "project_id": project_id,
-            "detector_id": detector_id,
-            "limit": limit,
-            "offset": offset,
-        },
+    offset = page * limit
+
+    conditions: list[str] = [
+        "r.project_id = {project_id:String}",
+        "r.detector_id = {detector_id:String}",
+    ]
+    params: dict = {
+        "project_id": project_id,
+        "detector_id": detector_id,
+    }
+
+    if start_after is not None:
+        conditions.append("r.timestamp >= {start_after:DateTime64(3)}")
+        params["start_after"] = _to_utc_naive(start_after)
+
+    if end_before is not None:
+        conditions.append("r.timestamp < {end_before:DateTime64(3)}")
+        params["end_before"] = _to_utc_naive(end_before)
+
+    # Per-detector summary expression; reused in WHERE search and SELECT to keep
+    # one source of truth for what "the summary for this detector" means.
+    summary_expr = (
+        "if("
+        "  r.finding_id IS NOT NULL,"
+        "  JSONExtractString("
+        "    arrayFirst("
+        "      x -> JSONExtractString(x, 'detectorId') = r.detector_id,"
+        "      JSONExtractArrayRaw(f.payload)"
+        "    ),"
+        "    'summary'"
+        "  ),"
+        "  ''"
+        ")"
     )
+
+    if search_query:
+        # ClickHouse ILIKE uses backslash as the default escape character; no
+        # ESCAPE clause is supported in the syntax, so we pre-escape `%`/`_`
+        # in user input via `_escape_ilike`.
+        conditions.append(
+            f"(r.trace_id ILIKE {{search_kw:String}} OR {summary_expr} ILIKE {{search_kw:String}})"
+        )
+        params["search_kw"] = f"%{_escape_ilike(search_query)}%"
+
+    where_clause = " AND ".join(conditions)
+
+    data_query = f"""
+        SELECT
+            r.run_id      AS run_id,
+            r.detector_id AS detector_id,
+            r.project_id  AS project_id,
+            r.trace_id    AS trace_id,
+            r.finding_id  AS finding_id,
+            r.status      AS status,
+            r.timestamp   AS timestamp,
+            {summary_expr} AS summary
+        FROM detector_runs r
+        LEFT JOIN detector_findings f
+          ON r.finding_id = f.finding_id AND r.project_id = f.project_id
+        WHERE {where_clause}
+        ORDER BY r.timestamp DESC
+        LIMIT {{limit:Int32}} OFFSET {{offset:Int32}}
+    """
+    data_params = {**params, "limit": limit, "offset": offset}
+    result = ch.query(data_query, parameters=data_params)
+
+    count_query = f"""
+        SELECT count()
+        FROM detector_runs r
+        LEFT JOIN detector_findings f
+          ON r.finding_id = f.finding_id AND r.project_id = f.project_id
+        WHERE {where_clause}
+    """
+    count_result = ch.query(count_query, parameters=params)
+    total = count_result.result_rows[0][0] if count_result.result_rows else 0
+
     runs = []
     for row in result.result_rows:
         row_dict = dict(zip(result.column_names, row))
         if hasattr(row_dict.get("timestamp"), "isoformat"):
             row_dict["timestamp"] = row_dict["timestamp"].isoformat()
         runs.append(row_dict)
-    return {"runs": runs}
+
+    return {
+        "data": runs,
+        "meta": {"page": page, "limit": limit, "total": total},
+    }
 
 
 @router.get(
@@ -317,43 +398,93 @@ async def get_spans_jsonl(trace_id: str, project_id: str):
     return PlainTextResponse("\n".join(lines))
 
 
-@router.get("/detector-findings", dependencies=[Depends(verify_internal_secret)])
+@router.get(
+    "/detector-findings",
+    response_model=FindingListResponse,
+    dependencies=[Depends(verify_internal_secret)],
+)
 async def list_detector_findings(
     project_id: str,
     detector_id: str,
-    limit: int = 50,
-    offset: int = 0,
-    since: str | None = None,
+    page: int = Query(0, ge=0, description="Page number (0-indexed)"),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    start_after: datetime | None = Query(
+        None, description="Filter findings at/after this timestamp (inclusive)"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Filter findings strictly before this timestamp"
+    ),
+    search_query: str | None = Query(
+        None, description="Substring match against trace_id OR summary"
+    ),
 ):
-    """List findings for a detector (joined through runs), newest first."""
+    """List findings for a detector (joined through runs), newest first.
+
+    Param naming and pagination shape mirror the trace listing endpoints
+    (`page`/`limit`/`start_after`/`end_before`/`search_query`) so the same
+    `useListPageState` queryOptions can flow through unchanged.
+
+    Returns {data: [...], meta: {page, limit, total}}.
+    """
     ch = get_clickhouse_client()
-    since_clause = "AND f.timestamp >= {since:String}" if since else ""
+    offset = page * limit
+
+    conditions: list[str] = [
+        "r.project_id = {project_id:String}",
+        "r.detector_id = {detector_id:String}",
+    ]
     params: dict = {
         "project_id": project_id,
         "detector_id": detector_id,
-        "limit": limit,
-        "offset": offset,
     }
-    if since:
-        params["since"] = since
-    result = ch.query(
-        f"""SELECT f.finding_id, f.project_id, f.trace_id, f.summary, f.payload, f.timestamp
-            FROM detector_findings f
-            INNER JOIN detector_runs r ON f.finding_id = r.finding_id
-            WHERE r.project_id = {{project_id:String}}
-              AND r.detector_id = {{detector_id:String}}
-            {since_clause}
-            ORDER BY f.timestamp DESC
-            LIMIT {{limit:Int32}} OFFSET {{offset:Int32}}""",
-        parameters=params,
-    )
+
+    if start_after is not None:
+        conditions.append("f.timestamp >= {start_after:DateTime64(3)}")
+        params["start_after"] = _to_utc_naive(start_after)
+
+    if end_before is not None:
+        conditions.append("f.timestamp < {end_before:DateTime64(3)}")
+        params["end_before"] = _to_utc_naive(end_before)
+
+    if search_query:
+        conditions.append(
+            "(f.trace_id ILIKE {search_kw:String} OR f.summary ILIKE {search_kw:String})"
+        )
+        params["search_kw"] = f"%{_escape_ilike(search_query)}%"
+
+    where_clause = " AND ".join(conditions)
+
+    data_query = f"""
+        SELECT f.finding_id, f.project_id, f.trace_id, f.summary, f.payload, f.timestamp
+        FROM detector_findings f
+        INNER JOIN detector_runs r ON f.finding_id = r.finding_id
+        WHERE {where_clause}
+        ORDER BY f.timestamp DESC
+        LIMIT {{limit:Int32}} OFFSET {{offset:Int32}}
+    """
+    data_params = {**params, "limit": limit, "offset": offset}
+    result = ch.query(data_query, parameters=data_params)
+
+    count_query = f"""
+        SELECT count()
+        FROM detector_findings f
+        INNER JOIN detector_runs r ON f.finding_id = r.finding_id
+        WHERE {where_clause}
+    """
+    count_result = ch.query(count_query, parameters=params)
+    total = count_result.result_rows[0][0] if count_result.result_rows else 0
+
     findings = []
     for row in result.result_rows:
         row_dict = dict(zip(result.column_names, row))
         if hasattr(row_dict.get("timestamp"), "isoformat"):
             row_dict["timestamp"] = row_dict["timestamp"].isoformat()
         findings.append(row_dict)
-    return {"findings": findings}
+
+    return {
+        "data": findings,
+        "meta": {"page": page, "limit": limit, "total": total},
+    }
 
 
 @router.get(

--- a/backend/rest/schemas/detectors.py
+++ b/backend/rest/schemas/detectors.py
@@ -1,0 +1,45 @@
+"""Detector finding/run response schemas."""
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from rest.schemas.common import PaginationMeta
+
+
+class FindingItem(BaseModel):
+    """Single detector finding row."""
+
+    finding_id: str
+    project_id: str
+    trace_id: str
+    summary: str
+    payload: str
+    timestamp: datetime
+
+
+class FindingListResponse(BaseModel):
+    """Paginated list of findings."""
+
+    data: list[FindingItem]
+    meta: PaginationMeta
+
+
+class RunItem(BaseModel):
+    """Single detector run row, optionally joined with its finding's per-detector summary."""
+
+    run_id: str
+    detector_id: str
+    project_id: str
+    trace_id: str
+    finding_id: str | None
+    status: str
+    timestamp: datetime
+    summary: str
+
+
+class RunListResponse(BaseModel):
+    """Paginated list of runs."""
+
+    data: list[RunItem]
+    meta: PaginationMeta

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/findings/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/findings/route.ts
@@ -20,18 +20,22 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
 
   const { searchParams } = req.nextUrl;
   const rawLimit = parseInt(searchParams.get("limit") ?? "50", 10);
-  const rawOffset = parseInt(searchParams.get("offset") ?? "0", 10);
+  const rawPage = parseInt(searchParams.get("page") ?? "0", 10);
   const limit = isNaN(rawLimit) ? 50 : Math.min(Math.max(rawLimit, 1), 200);
-  const offset = isNaN(rawOffset) ? 0 : Math.max(rawOffset, 0);
-  const since = searchParams.get("since");
+  const page = isNaN(rawPage) ? 0 : Math.max(rawPage, 0);
+  const startAfter = searchParams.get("start_after");
+  const endBefore = searchParams.get("end_before");
+  const searchQuery = searchParams.get("search_query");
 
   const backendParams = new URLSearchParams({
     project_id: projectId,
     detector_id: detectorId,
     limit: limit.toString(),
-    offset: offset.toString(),
+    page: page.toString(),
   });
-  if (since) backendParams.set("since", since);
+  if (startAfter) backendParams.set("start_after", startAfter);
+  if (endBefore) backendParams.set("end_before", endBefore);
+  if (searchQuery) backendParams.set("search_query", searchQuery);
 
   let response: Response;
   try {

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/runs/route.ts
@@ -20,16 +20,22 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
 
   const { searchParams } = req.nextUrl;
   const rawLimit = parseInt(searchParams.get("limit") ?? "50", 10);
-  const rawOffset = parseInt(searchParams.get("offset") ?? "0", 10);
+  const rawPage = parseInt(searchParams.get("page") ?? "0", 10);
   const limit = isNaN(rawLimit) ? 50 : Math.min(Math.max(rawLimit, 1), 200);
-  const offset = isNaN(rawOffset) ? 0 : Math.max(rawOffset, 0);
+  const page = isNaN(rawPage) ? 0 : Math.max(rawPage, 0);
+  const startAfter = searchParams.get("start_after");
+  const endBefore = searchParams.get("end_before");
+  const searchQuery = searchParams.get("search_query");
 
   const backendParams = new URLSearchParams({
     project_id: projectId,
     detector_id: detectorId,
     limit: limit.toString(),
-    offset: offset.toString(),
+    page: page.toString(),
   });
+  if (startAfter) backendParams.set("start_after", startAfter);
+  if (endBefore) backendParams.set("end_before", endBefore);
+  if (searchQuery) backendParams.set("search_query", searchQuery);
 
   let response: Response;
   try {

--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
@@ -26,49 +26,48 @@ export default function DetectorDetailPage() {
 
   const [activeTab, setActiveTab] = useState("findings");
   const [itemsPerPageOpen, setItemsPerPageOpen] = useState(false);
-  const [runsItemsPerPageOpen, setRunsItemsPerPageOpen] = useState(false);
   const [selectedFinding, setSelectedFinding] = useState<BackendFinding | null>(null);
 
-  const { state, updateDateFilter, updateCustomRange, updateKeyword, updateLimit, goToPage } =
-    useListPageState();
-
-  const [runsPage, setRunsPage] = useState(0);
-  const [runsLimit, setRunsLimit] = useState(50);
+  // Single shared state across both tabs — same pattern as traces/sessions/users.
+  // Pagination, search, and date filter live in the URL so a tab switch keeps
+  // them; `defaultDateFilter` is the only detector-specific deviation (#806).
+  const {
+    state,
+    queryOptions,
+    updateDateFilter,
+    updateCustomRange,
+    updateKeyword,
+    updateLimit,
+    goToPage,
+  } = useListPageState();
 
   const { data: detectorsData } = useDetectors(projectId);
   const detector = detectorsData?.find((d) => d.id === detectorId);
 
-  const limit = state.limit;
-  const offset = state.page * limit;
-
-  const {
-    data: findingsData,
-    isLoading,
-    error,
-  } = useFindings(projectId, detectorId, {
-    limit,
-    offset,
-  });
-
-  const findings = findingsData?.findings ?? [];
-  const hasMore = findings.length === limit;
+  const { data: findingsData, isLoading, error } = useFindings(projectId, detectorId, queryOptions);
 
   const {
     data: runsData,
     isLoading: runsLoading,
     error: runsError,
-  } = useRuns(projectId, detectorId, {
-    limit: runsLimit,
-    offset: runsPage * runsLimit,
-  });
+  } = useRuns(projectId, detectorId, queryOptions);
 
-  const runs = runsData?.runs ?? [];
-  const runsHasMore = runs.length === runsLimit;
+  const findings = findingsData?.data ?? [];
+  const runs = runsData?.data ?? [];
+
+  // Active tab's meta drives pagination. Both tabs share the same page/limit
+  // since `useListPageState` is one shared instance — switching tabs keeps you
+  // on the same page index. The other tab's data may show empty if it has
+  // fewer pages; clicking "first" recovers.
+  const meta = (activeTab === "runs" ? runsData?.meta : findingsData?.meta) || {
+    page: 0,
+    limit: 50,
+    total: 0,
+  };
+  const totalPages = Math.ceil(meta.total / meta.limit);
 
   // Clear `selectedFinding` if the row it points to is no longer in the
   // current findings list (e.g. user paginated, refetched, or filtered).
-  // Without this the trace panel stays open showing a finding that's no
-  // longer visible in the table, and `handleNavigate` silently no-ops.
   useEffect(() => {
     if (selectedFinding && !findings.some((f) => f.finding_id === selectedFinding.finding_id)) {
       setSelectedFinding(null);
@@ -131,7 +130,7 @@ export default function DetectorDetailPage() {
           </div>
         </div>
 
-        {/* Filter bar */}
+        {/* Filter bar — identical instantiation to traces/sessions/users. */}
         <SearchFilterBar
           searchValue={state.keyword}
           onSearchChange={updateKeyword}
@@ -143,7 +142,7 @@ export default function DetectorDetailPage() {
           onCustomRangeChange={updateCustomRange}
         />
 
-        {/* Content area */}
+        {/* Content */}
         <div className="flex-1 overflow-auto bg-background">
           {activeTab === "runs" ? (
             runsLoading ? (
@@ -155,145 +154,78 @@ export default function DetectorDetailPage() {
                 <p className="text-[13px] text-destructive">Error loading runs</p>
               </div>
             ) : runs.length === 0 ? (
-              <div className="flex h-64 flex-col items-center justify-center gap-2">
-                <History className="h-8 w-8 text-muted-foreground/40" />
-                <p className="text-[13px] text-muted-foreground">No runs yet</p>
+              <div className="flex h-64 flex-col items-center justify-center gap-3">
+                <p className="text-[13px] text-muted-foreground">No runs found</p>
                 <p className="text-[12px] text-muted-foreground">
-                  Per-trace evaluation run history will appear here.
+                  Try adjusting your filters or date range.
                 </p>
               </div>
             ) : (
-              <div className="flex h-full flex-col">
-                <div className="flex-1 overflow-auto">
-                  <table className="w-full">
-                    <thead className="sticky top-0 bg-background">
-                      <tr className="border-b border-border bg-muted/50">
-                        <th className="w-[160px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                          Timestamp
-                        </th>
-                        <th className="w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                          Run ID
-                        </th>
-                        <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                          Trace ID
-                        </th>
-                        <th className="w-[80px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                          Identified
-                        </th>
-                        <th className="w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                          Finding ID
-                        </th>
-                        <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                          Summary
-                        </th>
-                        <th className="w-[90px] px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                          Status
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {runs.map((e) => (
-                        <tr
-                          key={e.run_id}
-                          className="border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
-                        >
-                          <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
-                            {formatDate(e.timestamp)}
-                          </td>
-                          <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                            {e.run_id}
-                          </td>
-                          <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                            {e.trace_id}
-                          </td>
-                          <td className="border-r border-border/50 px-3 py-1.5 text-[12px]">
-                            {e.finding_id != null ? (
-                              <span className="text-destructive">Yes</span>
-                            ) : (
-                              <span className="text-muted-foreground">No</span>
-                            )}
-                          </td>
-                          <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                            {e.finding_id ?? "—"}
-                          </td>
-                          <td className="max-w-[400px] border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
-                            {e.summary ? (
-                              <span className="block truncate" title={e.summary}>
-                                {e.summary.length > 100 ? e.summary.slice(0, 100) + "…" : e.summary}
-                              </span>
-                            ) : (
-                              <span className="font-mono text-[11px] text-muted-foreground">—</span>
-                            )}
-                          </td>
-                          <td className="px-3 py-1.5 text-[12px] text-muted-foreground">
-                            {e.status}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-
-                {/* Runs pagination */}
-                <div className="flex items-center justify-end gap-6 border-t border-border bg-background px-4 py-2.5">
-                  <div className="flex items-center gap-2">
-                    <span className="text-[12px] text-muted-foreground">Items per page</span>
-                    <Popover open={runsItemsPerPageOpen} onOpenChange={setRunsItemsPerPageOpen}>
-                      <PopoverTrigger asChild>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          className="h-7 min-w-[60px] justify-between px-2 text-[12px]"
-                        >
-                          <span>{runsLimit}</span>
-                          <ChevronDown className="ml-1 h-3 w-3 text-muted-foreground" />
-                        </Button>
-                      </PopoverTrigger>
-                      <PopoverContent side="top" align="start" className="w-[80px] p-1">
-                        {[50, 100, 200].map((value) => (
-                          <button
-                            key={value}
-                            className={cn(
-                              "w-full rounded-md px-2.5 py-1.5 text-left text-[12px] transition-colors",
-                              runsLimit === value ? "bg-muted" : "hover:bg-muted/50",
-                            )}
-                            onClick={() => {
-                              setRunsLimit(value);
-                              setRunsPage(0);
-                              setRunsItemsPerPageOpen(false);
-                            }}
-                          >
-                            {value}
-                          </button>
-                        ))}
-                      </PopoverContent>
-                    </Popover>
-                  </div>
-                  <div className="flex items-center gap-0.5">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setRunsPage(Math.max(0, runsPage - 1))}
-                      disabled={runsPage === 0}
-                      className="h-7 w-7 p-0"
+              <table className="w-full">
+                <thead className="sticky top-0 bg-background">
+                  <tr className="border-b border-border bg-muted/50">
+                    <th className="w-[160px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      Timestamp
+                    </th>
+                    <th className="w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      Run ID
+                    </th>
+                    <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      Trace ID
+                    </th>
+                    <th className="w-[80px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      Identified
+                    </th>
+                    <th className="w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      Finding ID
+                    </th>
+                    <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      Summary
+                    </th>
+                    <th className="w-[90px] px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      Status
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {runs.map((e) => (
+                    <tr
+                      key={e.run_id}
+                      className="border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
                     >
-                      <ChevronLeft className="h-3.5 w-3.5" />
-                    </Button>
-                    <span className="px-2 text-[12px] text-muted-foreground">
-                      Page {runsPage + 1}
-                    </span>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setRunsPage(runsPage + 1)}
-                      disabled={!runsHasMore}
-                      className="h-7 w-7 p-0"
-                    >
-                      <ChevronRight className="h-3.5 w-3.5" />
-                    </Button>
-                  </div>
-                </div>
-              </div>
+                      <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                        {formatDate(e.timestamp)}
+                      </td>
+                      <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
+                        {e.run_id}
+                      </td>
+                      <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
+                        {e.trace_id}
+                      </td>
+                      <td className="border-r border-border/50 px-3 py-1.5 text-[12px]">
+                        {e.finding_id != null ? (
+                          <span className="text-destructive">Yes</span>
+                        ) : (
+                          <span className="text-muted-foreground">No</span>
+                        )}
+                      </td>
+                      <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
+                        {e.finding_id ?? "—"}
+                      </td>
+                      <td className="max-w-[400px] border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
+                        {e.summary ? (
+                          <span className="block truncate" title={e.summary}>
+                            {e.summary.length > 100 ? e.summary.slice(0, 100) + "…" : e.summary}
+                          </span>
+                        ) : (
+                          <span className="font-mono text-[11px] text-muted-foreground">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-1.5 text-[12px] text-muted-foreground">{e.status}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             )
           ) : isLoading ? (
             <div className="flex h-64 items-center justify-center">
@@ -304,132 +236,166 @@ export default function DetectorDetailPage() {
               <p className="text-[13px] text-destructive">Error loading findings</p>
             </div>
           ) : findings.length === 0 ? (
-            <div className="flex h-64 flex-col items-center justify-center gap-2">
-              <Flag className="h-8 w-8 text-muted-foreground/40" />
-              <p className="text-[13px] text-muted-foreground">No findings yet</p>
+            <div className="flex h-64 flex-col items-center justify-center gap-3">
+              <p className="text-[13px] text-muted-foreground">No findings found</p>
               <p className="text-[12px] text-muted-foreground">
-                Findings appear when this detector flags a trace.
+                Try adjusting your filters or date range.
               </p>
             </div>
           ) : (
-            <div className="flex h-full flex-col">
-              <div className="flex-1 overflow-auto">
-                <table className="w-full">
-                  <thead className="sticky top-0 bg-background">
-                    <tr className="border-b border-border bg-muted/50">
-                      <th className="w-[140px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Timestamp
-                      </th>
-                      <th className="w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Finding ID
-                      </th>
-                      <th className="w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Trace ID
-                      </th>
-                      <th className="px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Summary
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {findings.map((f) => (
-                      <tr
-                        key={f.finding_id}
-                        onClick={() =>
-                          setSelectedFinding(
-                            selectedFinding?.finding_id === f.finding_id ? null : f,
-                          )
-                        }
-                        className={cn(
-                          "cursor-pointer border-b border-border/50 transition-colors last:border-0",
-                          selectedFinding?.finding_id === f.finding_id
-                            ? "bg-muted"
-                            : "hover:bg-muted/50",
-                        )}
-                      >
-                        <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
-                          {formatDate(f.timestamp)}
-                        </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                          {f.finding_id}
-                        </td>
-                        <td className="w-[280px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
-                          <span className="block truncate" title={f.trace_id}>
-                            {f.trace_id}
-                          </span>
-                        </td>
-                        <td className="max-w-[400px] px-3 py-1.5 text-[12px] text-foreground">
-                          <span className="block truncate" title={f.summary}>
-                            {f.summary.length > 100 ? f.summary.slice(0, 100) + "…" : f.summary}
-                          </span>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-
-              {/* Pagination */}
-              <div className="flex items-center justify-end gap-6 border-t border-border bg-background px-4 py-2.5">
-                <div className="flex items-center gap-2">
-                  <span className="text-[12px] text-muted-foreground">Items per page</span>
-                  <Popover open={itemsPerPageOpen} onOpenChange={setItemsPerPageOpen}>
-                    <PopoverTrigger asChild>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="h-7 min-w-[60px] justify-between px-2 text-[12px]"
-                      >
-                        <span>{limit}</span>
-                        <ChevronDown className="ml-1 h-3 w-3 text-muted-foreground" />
-                      </Button>
-                    </PopoverTrigger>
-                    <PopoverContent side="top" align="start" className="w-[80px] p-1">
-                      {[50, 100, 200].map((value) => (
-                        <button
-                          key={value}
-                          className={cn(
-                            "w-full rounded-md px-2.5 py-1.5 text-left text-[12px] transition-colors",
-                            limit === value ? "bg-muted" : "hover:bg-muted/50",
-                          )}
-                          onClick={() => {
-                            updateLimit(value);
-                            setItemsPerPageOpen(false);
-                          }}
-                        >
-                          {value}
-                        </button>
-                      ))}
-                    </PopoverContent>
-                  </Popover>
-                </div>
-                <div className="flex items-center gap-0.5">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => goToPage(Math.max(0, state.page - 1))}
-                    disabled={state.page === 0}
-                    className="h-7 w-7 p-0"
+            <table className="w-full">
+              <thead className="sticky top-0 bg-background">
+                <tr className="border-b border-border bg-muted/50">
+                  <th className="w-[140px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                    Timestamp
+                  </th>
+                  <th className="w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                    Finding ID
+                  </th>
+                  <th className="w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                    Trace ID
+                  </th>
+                  <th className="px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                    Summary
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {findings.map((f) => (
+                  <tr
+                    key={f.finding_id}
+                    onClick={() =>
+                      setSelectedFinding(selectedFinding?.finding_id === f.finding_id ? null : f)
+                    }
+                    className={cn(
+                      "cursor-pointer border-b border-border/50 transition-colors last:border-0",
+                      selectedFinding?.finding_id === f.finding_id
+                        ? "bg-muted"
+                        : "hover:bg-muted/50",
+                    )}
                   >
-                    <ChevronLeft className="h-3.5 w-3.5" />
-                  </Button>
-                  <span className="px-2 text-[12px] text-muted-foreground">
-                    Page {state.page + 1}
-                  </span>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => goToPage(state.page + 1)}
-                    disabled={!hasMore}
-                    className="h-7 w-7 p-0"
-                  >
-                    <ChevronRight className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-              </div>
-            </div>
+                    <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                      {formatDate(f.timestamp)}
+                    </td>
+                    <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
+                      {f.finding_id}
+                    </td>
+                    <td className="w-[280px] border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
+                      <span className="block truncate" title={f.trace_id}>
+                        {f.trace_id}
+                      </span>
+                    </td>
+                    <td className="max-w-[400px] px-3 py-1.5 text-[12px] text-foreground">
+                      <span className="block truncate" title={f.summary}>
+                        {f.summary.length > 100 ? f.summary.slice(0, 100) + "…" : f.summary}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           )}
         </div>
+
+        {/* Pagination — copied from traces/page.tsx so the detector page
+            renders an identical control: items-per-page popover, typeable
+            page input, and first/prev/next/last navigation buttons. */}
+        {((activeTab === "findings" && findings.length > 0) ||
+          (activeTab === "runs" && runs.length > 0)) && (
+          <div className="flex items-center justify-end gap-6 border-t border-border bg-background px-4 py-2.5">
+            <div className="flex items-center gap-2">
+              <span className="text-[12px] text-muted-foreground">Items per page</span>
+              <Popover open={itemsPerPageOpen} onOpenChange={setItemsPerPageOpen}>
+                <PopoverTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 min-w-[60px] justify-between px-2 text-[12px]"
+                  >
+                    <span>{state.limit}</span>
+                    <ChevronDown className="ml-1 h-3 w-3 text-muted-foreground" />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent side="top" align="start" className="w-[80px] p-1">
+                  {[50, 100, 200].map((value) => (
+                    <button
+                      key={value}
+                      className={cn(
+                        "w-full rounded-md px-2.5 py-1.5 text-left text-[12px] transition-colors",
+                        state.limit === value ? "bg-muted" : "hover:bg-muted/50",
+                      )}
+                      onClick={() => {
+                        updateLimit(value);
+                        setItemsPerPageOpen(false);
+                      }}
+                    >
+                      {value}
+                    </button>
+                  ))}
+                </PopoverContent>
+              </Popover>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[12px] text-muted-foreground">Page</span>
+              <input
+                type="number"
+                min={1}
+                max={Math.max(1, totalPages)}
+                value={state.page + 1}
+                onChange={(e) => {
+                  const val = parseInt(e.target.value, 10);
+                  if (!isNaN(val) && val >= 1 && val <= totalPages) {
+                    goToPage(val - 1);
+                  }
+                }}
+                className="h-7 w-12 rounded border border-border bg-background px-2 py-1 text-center text-[12px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              />
+              <span className="text-[12px] text-muted-foreground">
+                of {Math.max(1, totalPages)}
+              </span>
+            </div>
+            <div className="flex items-center gap-0.5">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => goToPage(0)}
+                disabled={state.page === 0}
+                className="h-7 w-7 p-0"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+                <ChevronLeft className="-ml-2 h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => goToPage(Math.max(0, state.page - 1))}
+                disabled={state.page === 0}
+                className="h-7 w-7 p-0"
+              >
+                <ChevronLeft className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => goToPage(state.page + 1)}
+                disabled={state.page >= totalPages - 1}
+                className="h-7 w-7 p-0"
+              >
+                <ChevronRight className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => goToPage(totalPages - 1)}
+                disabled={state.page >= totalPages - 1}
+                className="h-7 w-7 p-0"
+              >
+                <ChevronRight className="h-3.5 w-3.5" />
+                <ChevronRight className="-ml-2 h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Detail panel — fixed overlay sliding in from right, same pattern as traces page */}

--- a/frontend/ui/src/features/detectors/hooks/use-findings.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-findings.ts
@@ -10,27 +10,50 @@ export interface BackendFinding {
   payload: string;
 }
 
+/** Pagination metadata returned alongside data arrays. */
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+}
+
+/**
+ * Query options shape mirrors `TraceQueryOptions` so a `useListPageState`
+ * `queryOptions` object can be spread directly into either hook.
+ */
 export interface FindingsQuery {
+  page?: number;
   limit?: number;
-  offset?: number;
-  since?: string;
+  /** ISO-8601 lower bound on `timestamp` (inclusive). */
+  start_after?: string;
+  /** ISO-8601 upper bound on `timestamp` (exclusive). */
+  end_before?: string;
+  /** Substring match against trace_id OR summary. */
+  search_query?: string;
+}
+
+export interface FindingsResponse {
+  data: BackendFinding[];
+  meta: PaginationMeta;
 }
 
 async function fetchFindings(
   projectId: string,
   detectorId: string,
   query: FindingsQuery = {},
-): Promise<{ findings: BackendFinding[] }> {
+): Promise<FindingsResponse> {
   const params = new URLSearchParams();
+  if (query.page !== undefined) params.set("page", String(query.page));
   if (query.limit !== undefined) params.set("limit", String(query.limit));
-  if (query.offset !== undefined) params.set("offset", String(query.offset));
-  if (query.since) params.set("since", query.since);
+  if (query.start_after) params.set("start_after", query.start_after);
+  if (query.end_before) params.set("end_before", query.end_before);
+  if (query.search_query) params.set("search_query", query.search_query);
 
   const qs = params.toString();
   const url = `/api/projects/${projectId}/detectors/${detectorId}/findings${qs ? `?${qs}` : ""}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to fetch findings: ${res.status}`);
-  return res.json() as Promise<{ findings: BackendFinding[] }>;
+  return res.json() as Promise<FindingsResponse>;
 }
 
 async function fetchTraceFindings(
@@ -49,9 +72,11 @@ export function useFindings(projectId: string, detectorId: string, query: Findin
       "findings",
       projectId,
       detectorId,
+      query.page ?? 0,
       query.limit ?? 50,
-      query.offset ?? 0,
-      query.since ?? null,
+      query.search_query ?? null,
+      query.start_after ?? null,
+      query.end_before ?? null,
     ],
     queryFn: () => fetchFindings(projectId, detectorId, query),
     enabled: !!projectId && !!detectorId,
@@ -105,29 +130,49 @@ export interface BackendRun {
 }
 
 export interface RunsQuery {
+  page?: number;
   limit?: number;
-  offset?: number;
+  start_after?: string;
+  end_before?: string;
+  search_query?: string;
+}
+
+export interface RunsResponse {
+  data: BackendRun[];
+  meta: PaginationMeta;
 }
 
 async function fetchRuns(
   projectId: string,
   detectorId: string,
   query: RunsQuery = {},
-): Promise<{ runs: BackendRun[] }> {
+): Promise<RunsResponse> {
   const params = new URLSearchParams();
+  if (query.page !== undefined) params.set("page", String(query.page));
   if (query.limit !== undefined) params.set("limit", String(query.limit));
-  if (query.offset !== undefined) params.set("offset", String(query.offset));
+  if (query.start_after) params.set("start_after", query.start_after);
+  if (query.end_before) params.set("end_before", query.end_before);
+  if (query.search_query) params.set("search_query", query.search_query);
 
   const qs = params.toString();
   const url = `/api/projects/${projectId}/detectors/${detectorId}/runs${qs ? `?${qs}` : ""}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to fetch runs: ${res.status}`);
-  return res.json() as Promise<{ runs: BackendRun[] }>;
+  return res.json() as Promise<RunsResponse>;
 }
 
 export function useRuns(projectId: string, detectorId: string, query: RunsQuery = {}) {
   return useQuery({
-    queryKey: ["detector-runs", projectId, detectorId, query.limit ?? 50, query.offset ?? 0],
+    queryKey: [
+      "detector-runs",
+      projectId,
+      detectorId,
+      query.page ?? 0,
+      query.limit ?? 50,
+      query.search_query ?? null,
+      query.start_after ?? null,
+      query.end_before ?? null,
+    ],
     queryFn: () => fetchRuns(projectId, detectorId, query),
     enabled: !!projectId && !!detectorId,
   });

--- a/frontend/ui/src/features/traces/hooks/use-list-page-state.ts
+++ b/frontend/ui/src/features/traces/hooks/use-list-page-state.ts
@@ -3,7 +3,7 @@
  * Combines pagination, URL-based date filtering, and search with coordinated page resets.
  *
  * URL params: page_index, page_limit, date_filter, start, end
- * Use this for pages that need shared filter state (traces, users, sessions).
+ * Use this for pages that need shared filter state (traces, users, sessions, detector page).
  */
 import { useMemo } from "react";
 import { useUrlPagination } from "./use-url-pagination";

--- a/frontend/ui/src/lib/date-filter.ts
+++ b/frontend/ui/src/lib/date-filter.ts
@@ -11,7 +11,8 @@ export interface DateFilterOption {
 }
 
 /**
- * Available date filter presets for trace listing.
+ * Available date filter presets for trace listing. Shared by all list pages
+ * (traces, sessions, users, detector findings/runs) — no per-page overrides.
  */
 export const DATE_FILTER_OPTIONS: DateFilterOption[] = [
   { id: "30m", label: "Last 30 minutes", durationMinutes: 30 },

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -1,0 +1,282 @@
+"""Unit tests for the internal detector findings/runs endpoints (#806).
+
+Covers the server-side filters (start_after/end_before/search_query — same
+names trace/sessions/users use), the COUNT-driven pagination metadata, and
+the {data, meta} response envelope.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from shared.config import settings
+
+
+@pytest.fixture()
+def secret(monkeypatch):
+    """Configure a known internal-secret so the auth dep accepts our header."""
+    monkeypatch.setattr(settings, "internal_api_secret", "test-secret")
+    return "test-secret"
+
+
+@pytest.fixture()
+def mock_ch(monkeypatch):
+    """Mock the ClickHouse client used by the internal router."""
+    mock = MagicMock()
+    monkeypatch.setattr(
+        "rest.routers.internal.get_clickhouse_client",
+        lambda: mock,
+    )
+    return mock
+
+
+@pytest.fixture()
+def client(secret, mock_ch):
+    return TestClient(app)
+
+
+def _make_query_result(rows: list[tuple], column_names: list[str]) -> MagicMock:
+    """Helper: shape ClickHouse-client-style result object."""
+    r = MagicMock()
+    r.result_rows = rows
+    r.column_names = column_names
+    return r
+
+
+# =============================================================================
+# /detector-findings
+# =============================================================================
+
+
+class TestListDetectorFindings:
+    def _fake_data(self):
+        ts = datetime(2026, 5, 1, 12, 0, 0)
+        return _make_query_result(
+            rows=[("f1", "p1", "trace-aaa", "summary text", "{}", ts)],
+            column_names=[
+                "finding_id",
+                "project_id",
+                "trace_id",
+                "summary",
+                "payload",
+                "timestamp",
+            ],
+        )
+
+    def _fake_count(self, total: int):
+        return _make_query_result(rows=[(total,)], column_names=["count()"])
+
+    def test_returns_data_meta_envelope(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(1)]
+        resp = client.get(
+            "/api/v1/internal/detector-findings",
+            params={"project_id": "p1", "detector_id": "d1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "data" in body and "meta" in body
+        assert body["meta"] == {"page": 0, "limit": 50, "total": 1}
+        assert body["data"][0]["finding_id"] == "f1"
+
+    def test_search_query_adds_ilike_clause(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(0)]
+        resp = client.get(
+            "/api/v1/internal/detector-findings",
+            params={"project_id": "p1", "detector_id": "d1", "search_query": "foo"},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        # First call is the data query — assert SQL contains both ILIKE branches
+        # so we know substring search hits trace_id AND summary.
+        data_sql = mock_ch.query.call_args_list[0].args[0]
+        assert "f.trace_id ILIKE" in data_sql
+        assert "f.summary ILIKE" in data_sql
+        params = mock_ch.query.call_args_list[0].kwargs["parameters"]
+        assert params["search_kw"] == "%foo%"
+
+    def test_search_escapes_ilike_wildcards(self, client, mock_ch, secret):
+        """% and _ in user input must be escaped so they're matched literally."""
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(0)]
+        client.get(
+            "/api/v1/internal/detector-findings",
+            params={"project_id": "p1", "detector_id": "d1", "search_query": "100%_x"},
+            headers={"X-Internal-Secret": secret},
+        )
+        params = mock_ch.query.call_args_list[0].kwargs["parameters"]
+        # Wildcards inside the user input are escaped; outer % wrappers stay.
+        assert params["search_kw"] == r"%100\%\_x%"
+
+    def test_start_after_end_before_become_datetime_params(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(0)]
+        resp = client.get(
+            "/api/v1/internal/detector-findings",
+            params={
+                "project_id": "p1",
+                "detector_id": "d1",
+                "start_after": "2026-04-01T00:00:00Z",
+                "end_before": "2026-05-01T00:00:00Z",
+            },
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        data_sql = mock_ch.query.call_args_list[0].args[0]
+        assert "f.timestamp >= {start_after:DateTime64(3)}" in data_sql
+        assert "f.timestamp < {end_before:DateTime64(3)}" in data_sql
+        params = mock_ch.query.call_args_list[0].kwargs["parameters"]
+        # FastAPI auto-parses ISO; we then convert to UTC-naive for ClickHouse.
+        assert isinstance(params["start_after"], datetime)
+        assert params["start_after"].tzinfo is None
+        assert isinstance(params["end_before"], datetime)
+
+    def test_invalid_start_after_returns_422(self, client, mock_ch, secret):
+        """FastAPI's auto-parser rejects malformed datetime input with 422 (project standard)."""
+        resp = client.get(
+            "/api/v1/internal/detector-findings",
+            params={"project_id": "p1", "detector_id": "d1", "start_after": "not-a-date"},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 422
+        # ClickHouse should never be called with a malformed timestamp.
+        mock_ch.query.assert_not_called()
+
+    def test_count_query_omits_pagination_params(self, client, mock_ch, secret):
+        """COUNT must run against the same WHERE clause but without LIMIT/OFFSET."""
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(123)]
+        client.get(
+            "/api/v1/internal/detector-findings",
+            params={"project_id": "p1", "detector_id": "d1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        count_call = mock_ch.query.call_args_list[1]
+        count_sql = count_call.args[0]
+        assert "SELECT count()" in count_sql
+        assert "LIMIT" not in count_sql
+        assert "OFFSET" not in count_sql
+
+    def test_meta_echoes_requested_page(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(500)]
+        resp = client.get(
+            "/api/v1/internal/detector-findings",
+            params={"project_id": "p1", "detector_id": "d1", "limit": 50, "page": 2},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.json()["meta"] == {"page": 2, "limit": 50, "total": 500}
+
+    def test_limit_capped_at_200(self, client, mock_ch, secret):
+        # Limit > 200 should be rejected by the FastAPI Query validator.
+        resp = client.get(
+            "/api/v1/internal/detector-findings",
+            params={"project_id": "p1", "detector_id": "d1", "limit": 999},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 422
+
+
+# =============================================================================
+# /detector-runs
+# =============================================================================
+
+
+class TestListDetectorRuns:
+    def _fake_data(self):
+        ts = datetime(2026, 5, 1, 12, 0, 0)
+        return _make_query_result(
+            rows=[
+                ("r1", "d1", "p1", "trace-bbb", "f1", "completed", ts, "summary text"),
+            ],
+            column_names=[
+                "run_id",
+                "detector_id",
+                "project_id",
+                "trace_id",
+                "finding_id",
+                "status",
+                "timestamp",
+                "summary",
+            ],
+        )
+
+    def _fake_count(self, total: int):
+        return _make_query_result(rows=[(total,)], column_names=["count()"])
+
+    def test_returns_data_meta_envelope(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(1)]
+        resp = client.get(
+            "/api/v1/internal/detector-runs",
+            params={"project_id": "p1", "detector_id": "d1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["meta"] == {"page": 0, "limit": 50, "total": 1}
+        assert body["data"][0]["run_id"] == "r1"
+
+    def test_search_query_hits_trace_id_and_joined_summary(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(0)]
+        resp = client.get(
+            "/api/v1/internal/detector-runs",
+            params={"project_id": "p1", "detector_id": "d1", "search_query": "foo"},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        data_sql = mock_ch.query.call_args_list[0].args[0]
+        # Runs search must hit trace_id directly and the joined finding's
+        # per-detector summary expression — confirm both are wired.
+        assert "r.trace_id ILIKE" in data_sql
+        assert "JSONExtractString" in data_sql  # the joined-summary expression
+        assert "ILIKE {search_kw:String}" in data_sql
+
+    def test_start_after_end_before_apply_to_run_timestamp(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(0)]
+        client.get(
+            "/api/v1/internal/detector-runs",
+            params={
+                "project_id": "p1",
+                "detector_id": "d1",
+                "start_after": "2026-04-01T00:00:00Z",
+                "end_before": "2026-05-01T00:00:00Z",
+            },
+            headers={"X-Internal-Secret": secret},
+        )
+        data_sql = mock_ch.query.call_args_list[0].args[0]
+        assert "r.timestamp >= {start_after:DateTime64(3)}" in data_sql
+        assert "r.timestamp < {end_before:DateTime64(3)}" in data_sql
+
+    def test_no_filters_means_no_extra_where(self, client, mock_ch, secret):
+        """Bare query should have only project_id + detector_id conditions."""
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(1)]
+        client.get(
+            "/api/v1/internal/detector-runs",
+            params={"project_id": "p1", "detector_id": "d1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        data_sql = mock_ch.query.call_args_list[0].args[0]
+        assert "ILIKE" not in data_sql  # no search → no ILIKE
+        assert "start_after" not in data_sql
+        assert "end_before" not in data_sql
+
+
+# =============================================================================
+# Auth — both endpoints
+# =============================================================================
+
+
+class TestInternalAuth:
+    def test_missing_secret_rejected(self, client, mock_ch):
+        resp = client.get(
+            "/api/v1/internal/detector-findings",
+            params={"project_id": "p1", "detector_id": "d1"},
+        )
+        assert resp.status_code == 403
+
+    def test_wrong_secret_rejected(self, client, mock_ch, secret):
+        resp = client.get(
+            "/api/v1/internal/detector-findings",
+            params={"project_id": "p1", "detector_id": "d1"},
+            headers={"X-Internal-Secret": "wrong"},
+        )
+        assert resp.status_code == 403


### PR DESCRIPTION
Closes #806.

## Problem

The detector detail page rendered a `SearchFilterBar` and pagination controls that weren't wired to the data hooks — typing in search did nothing, the date filter triggered refetches without including filter params, and "has-more" was guessed from `length === limit` instead of a real total.

## Approach

Align with the existing trace listing pattern. The detector page now uses the same `useListPageState()` hook (no per-page args), the same `SearchFilterBar`, the same pagination markup, the same backend param naming, the same empty-state copy, and the same date filter dropdown as `traces` / `sessions` / `users`. **Zero functional shared-file customization** — the only diffs in shared files are docstring updates.

### Note on issue spec deviation

Acceptance criterion #2 of #806 calls for presets `1h / 24h / 7d / 14d / 30d` with default `14d`. **This PR deliberately violates AC2** in favor of full UI consistency with the trace listing — same dropdown, same default `1d`. This was a conscious call after weighing the maintainer's "reference existing code to keep the product consistent" guidance against the literal spec. Happy to revert to the AC2 preset list if you prefer; it's a small change isolated to one component prop and one constant.

## Backend (`/detector-findings`, `/detector-runs`)

- Query params named to project convention: `start_after`, `end_before`, `search_query` (matches `traces.py` / `sessions.py` / `users.py` exactly)
- Time bounds typed as `datetime | None = Query(None)` so FastAPI auto-parses ISO; bad input returns 422 (project standard)
- Search is a single ILIKE OR across `trace_id` and (for runs) the joined finding's per-detector summary; user input has \`%\` and \`_\` escaped so they match literally
- Separate COUNT query against the same WHERE clause backs a real \`total\`
- Response shape \`{data: [...], meta: {page, limit, total}}\` enforced via Pydantic \`response_model\` on each endpoint

## Frontend

- \`useFindings\` / \`useRuns\` consume \`{page, limit, search_query, start_after, end_before}\` so \`useListPageState\`'s \`queryOptions\` spreads in directly
- Detector page uses \`useListPageState()\` — same one-liner trace, users, sessions use. No options.
- Pagination markup copied verbatim from \`traces/page.tsx\`: items-per-page popover, typeable page input, first/prev/next/last buttons
- Empty-state copy matches trace pattern: single static "No findings/runs found" + "Try adjusting your filters or date range." (no branching)
- One shared pagination across both Findings/Runs tabs (acceptable scope reduction — trace doesn't have tabs so the question doesn't arise; switching tabs keeps your filter state)
- \`SearchFilterBar\` no longer touched; uses default \`DATE_FILTER_OPTIONS\`

## Test plan

- [ ] Backend: \`pytest tests/rest/test_detector_endpoints.py\` — 14 unit tests cover renamed params, COUNT correctness, response envelope, ILIKE escaping, datetime parsing, limit cap, and auth
- [ ] Backend: full \`pytest tests/\` — 156 tests green
- [ ] Frontend: \`npx tsc --noEmit\` — clean (excluding pre-existing Prisma-generation errors in unrelated files on this branch)
- [ ] Manual: open \`/projects/<id>/detectors/<detectorId>\` — type in search, change date filter, paginate. Confirm Network tab shows requests gain \`&search_query=...&start_after=...&end_before=...&page=...\`. Switch tabs; filter/page state persists.
- [ ] Manual side-by-side: open \`/projects/<id>/traces\` in another tab. Confirm filter bar and pagination markup are visually identical.

## Things noticed in trace listing during this work (separate issues, not addressed here)

While researching the trace pattern I noticed a few small things worth tracking — happy to file separately:

1. \`useKeywordSearch\` doesn't trim whitespace before treating input as truthy (\`"   "\` becomes a query that ILIKE-matches every row containing whitespace)
2. \`useUrlDateFilter.timestamps\` doesn't slide on a wall-clock interval — "Last 1 hour" lower bound is locked at first render, so a long-open page silently widens the window
3. Pagination renders "Page 1 of 1" when totally empty (cosmetic)
4. \`useUrlDateFilter\` keeps stale \`customStartDate\`/\`customEndDate\` in local state after switching from custom → preset
5. With autoRefresh on, the trace page refetches every 5s but the \`timestamps\` (frozen at first render per #2) don't slide — so "Last 1 hour" + auto-refresh = same window over time, not a rolling one

Let me know which of these (if any) are intentional UX vs bugs to fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired search, time-range filters, and total-count pagination on the detector detail page. Matches the trace listing pattern for consistent UX and accurate pagination for both findings and runs.

- **New Features**
  - Frontend
    - Uses `useListPageState()` for shared search, date, page, and limit across Findings/Runs tabs; state persists when switching tabs.
    - `SearchFilterBar` uses default `DATE_FILTER_OPTIONS`; empty states align with traces (“No findings/runs found. Try adjusting your filters or date range.”).
    - Pagination control matches traces: items-per-page popover, typeable page input, first/prev/next/last buttons.
    - Findings and runs hooks accept `{page, limit, search_query, start_after, end_before}` and consume `{data, meta: {page, limit, total}}`.
  - Backend
    - `GET /internal/detector-findings` and `GET /internal/detector-runs` accept `page`, `limit`, `start_after`, `end_before`, `search_query`.
    - Search hits `trace_id` and summary; `%` and `_` are escaped for literal ILIKE matches.
    - Returns `{data, meta: {page, limit, total}}`; `total` from a COUNT query using the same WHERE clause.
    - ISO datetimes auto-parsed by FastAPI; invalid input returns 422. Response models enforced via Pydantic.
  - Tests
    - Adds unit tests for filters, COUNT-driven totals, response envelope, ILIKE escaping, and auth.

Addresses Linear #806. Note: uses the existing date presets and default (`1d`) for consistency with traces instead of the specified `1h/24h/7d/14d/30d` with `14d` default.

<sup>Written for commit d98a5dfe3f2954b77874c3c49de08ba30eb00e4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

