### PR TITLE
fix(rest): backfill session io from non-empty spans

### DIFF
--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -330,8 +330,8 @@ class TraceReaderService:
             span_io_query = """
                 SELECT
                     t.session_id,
-                    argMin(s.input, s.span_start_time) as first_input,
-                    argMax(s.output, s.span_end_time) as last_output
+                    argMinIf(s.input, s.span_start_time, s.input != '' AND s.input != '{}') as first_input,
+                    argMaxIf(s.output, s.span_end_time, s.output != '' AND s.output != '{}') as last_output
                 FROM traces AS t FINAL
                 JOIN spans AS s FINAL ON t.trace_id = s.trace_id AND t.project_id = s.project_id
                 WHERE t.project_id = {project_id:String}
@@ -452,8 +452,8 @@ class TraceReaderService:
             span_io_query = """
                 SELECT
                     trace_id,
-                    argMin(input, span_start_time) as first_input,
-                    argMax(output, span_end_time) as last_output
+                    argMinIf(input, span_start_time, input != '' AND input != '{}') as first_input,
+                    argMaxIf(output, span_end_time, output != '' AND output != '{}') as last_output
                 FROM spans FINAL
                 WHERE project_id = {project_id:String}
                   AND trace_id IN ({trace_ids:Array(String)})

--- a/tests/rest/test_trace_reader_service.py
+++ b/tests/rest/test_trace_reader_service.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+from rest.services.trace_reader import TraceReaderService
+
+
+class RecordingClient:
+    def __init__(self, handlers):
+        self.handlers = handlers
+        self.calls = []
+
+    def query(self, query, parameters=None):
+        self.calls.append((query, parameters))
+        return self.handlers[len(self.calls) - 1](query, parameters or {})
+
+
+def _rows(rows):
+    return SimpleNamespace(result_rows=rows)
+
+
+def test_list_sessions_backfills_input_output_with_conditional_aggregates():
+    service = TraceReaderService.__new__(TraceReaderService)
+
+    def main_query(query, _params):
+        assert "FROM (" in query
+        return _rows(
+            [["sess-1", 1, ["user-1"], "2026-04-30", "2026-04-30", 10, 1, 2, 0.1, "", "{}"]]
+        )
+
+    def count_query(_query, _params):
+        return _rows([[1]])
+
+    def span_query(query, params):
+        assert "argMinIf(s.input, s.span_start_time, s.input != '' AND s.input != '{}')" in query
+        assert "argMaxIf(s.output, s.span_end_time, s.output != '' AND s.output != '{}')" in query
+        assert params["session_ids"] == ["sess-1"]
+        return _rows([["sess-1", "real input", "real output"]])
+
+    service._client = RecordingClient([main_query, count_query, span_query])
+
+    result = service.list_sessions("proj-1")
+
+    assert result["data"][0]["input"] == "real input"
+    assert result["data"][0]["output"] == "real output"
+
+
+def test_get_session_backfills_trace_io_with_conditional_aggregates():
+    service = TraceReaderService.__new__(TraceReaderService)
+
+    def traces_query(query, _params):
+        assert "ORDER BY t.trace_start_time ASC" in query
+        return _rows([["trace-1", "Trace 1", "2026-04-30", "user-1", "", "{}", 12, "ok"]])
+
+    def span_query(query, params):
+        assert "argMinIf(input, span_start_time, input != '' AND input != '{}')" in query
+        assert "argMaxIf(output, span_end_time, output != '' AND output != '{}')" in query
+        assert params["trace_ids"] == ["trace-1"]
+        return _rows([["trace-1", "span input", "span output"]])
+
+    def tokens_query(_query, _params):
+        return _rows([[3, 4, 0.25]])
+
+    service._client = RecordingClient([traces_query, span_query, tokens_query])
+
+    result = service.get_session("proj-1", "sess-1")
+
+    assert result is not None
+    assert result["traces"][0]["input"] == "span input"
+    assert result["traces"][0]["output"] == "span output"


### PR DESCRIPTION
Fixes #801

## Summary

Fixes session input/output backfill when the earliest span with payload only has output, or the latest span with payload only has input.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Switch the session/span fallback queries to `argMinIf` / `argMaxIf` so input is chosen only from non-empty inputs and output is chosen only from non-empty outputs
- Apply the same fix to both `list_sessions()` and `get_session()`
- Add targeted tests covering the new conditional aggregate queries and the patched session/trace payloads

## Screenshots / Recordings (if applicable)

N/A (backend query fix)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes session input/output backfill by selecting only non-empty span payloads when reconstructing session and trace IO. Addresses #801 where empty input or output could appear if edge spans lacked one side.

- **Bug Fixes**
  - Use argMinIf/argMaxIf to choose the first non-empty input and last non-empty output from spans.
  - Apply to list_sessions() and get_session().
  - Add tests for the conditional aggregates and backfilled values.

<sup>Written for commit 6df7f775d778710a463ad0059e018233e5b6437d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

