### PR TITLE
feat(github): scope GitHub integration to workspace level

### DIFF
--- a/frontend/packages/agent/src/index.ts
+++ b/frontend/packages/agent/src/index.ts
@@ -142,7 +142,7 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
     sessionExecutors.set(sessionId, executor);
   }
 
-  const tools = createTools({ projectId, userId, executor });
+  const tools = createTools({ projectId, userId, workspaceId, executor });
 
   console.log(
     `[Agent] POST message: session=${sessionId}, model=${body.model}, provider=${body.providerName}, source=${body.source}`,

--- a/frontend/packages/agent/src/index.ts
+++ b/frontend/packages/agent/src/index.ts
@@ -158,7 +158,7 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
   const { agent, sessionManager } = await getOrCreateAgent({
     sessionId,
     projectId,
-    workspaceId,
+    workspaceId: ownedSession.workspaceId,
     userId,
     systemPrompt,
     tools,

--- a/frontend/packages/agent/src/index.ts
+++ b/frontend/packages/agent/src/index.ts
@@ -142,7 +142,14 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
     sessionExecutors.set(sessionId, executor);
   }
 
-  const tools = createTools({ projectId, userId, workspaceId, executor });
+  // Use the session's workspaceId (authorized by getSession above) rather than
+  // the raw header value, so tools can't be coerced into another workspace.
+  const tools = createTools({
+    projectId,
+    userId,
+    workspaceId: ownedSession.workspaceId,
+    executor,
+  });
 
   console.log(
     `[Agent] POST message: session=${sessionId}, model=${body.model}, provider=${body.providerName}, source=${body.source}`,

--- a/frontend/packages/agent/src/tools/git-clone.ts
+++ b/frontend/packages/agent/src/tools/git-clone.ts
@@ -13,7 +13,7 @@ const schema = Type.Object({
 });
 
 export function createGitCloneTool(
-  userId: string,
+  workspaceId: string,
   uiBaseUrl: string,
   executor: Executor,
 ): AgentTool<typeof schema> {
@@ -34,7 +34,7 @@ export function createGitCloneTool(
         `${uiBaseUrl}/api/github/token?repo=${encodeURIComponent(params.repo)}`,
         {
           headers: {
-            "x-user-id": userId,
+            "x-workspace-id": workspaceId,
             "X-Internal-Secret": process.env.INTERNAL_API_SECRET || "",
           },
         },

--- a/frontend/packages/agent/src/tools/github-access.ts
+++ b/frontend/packages/agent/src/tools/github-access.ts
@@ -6,7 +6,7 @@ const schema = Type.Object({
 });
 
 export function createCheckGitHubAccessTool(
-  userId: string,
+  workspaceId: string,
   uiBaseUrl: string,
 ): AgentTool<typeof schema> {
   return {
@@ -21,7 +21,7 @@ export function createCheckGitHubAccessTool(
         `${uiBaseUrl}/api/github/token?repo=${encodeURIComponent(params.repo)}`,
         {
           headers: {
-            "x-user-id": userId,
+            "x-workspace-id": workspaceId,
             "X-Internal-Secret": process.env.INTERNAL_API_SECRET || "",
           },
         },

--- a/frontend/packages/agent/src/tools/index.ts
+++ b/frontend/packages/agent/src/tools/index.ts
@@ -20,6 +20,7 @@ const UI_BASE_URL = process.env.TRACEROOT_UI_URL || "http://localhost:3000";
 export function createTools(params: {
   projectId: string;
   userId: string;
+  workspaceId: string;
   executor: Executor;
 }): AgentTool<any>[] {
   const tools: AgentTool<any>[] = [];
@@ -30,9 +31,9 @@ export function createTools(params: {
   tools.push(createDownloadTracesTool(params.projectId, params.userId, params.executor));
   tools.push(createDownloadSessionTool(params.projectId, params.userId, params.executor));
 
-  // GitHub tools (host-side, need auth tokens)
-  tools.push(createCheckGitHubAccessTool(params.userId, UI_BASE_URL));
-  tools.push(createGitCloneTool(params.userId, UI_BASE_URL, params.executor));
+  // GitHub tools (host-side, workspace-scoped — installation lives at workspace level)
+  tools.push(createCheckGitHubAccessTool(params.workspaceId, UI_BASE_URL));
+  tools.push(createGitCloneTool(params.workspaceId, UI_BASE_URL, params.executor));
 
   // Sandbox-side tools (run inside Docker container via executor)
   tools.push(createBashTool(params.executor));

--- a/frontend/packages/core/prisma/migrations/20260503000000_github_installations/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260503000000_github_installations/migration.sql
@@ -1,0 +1,34 @@
+-- Move GitHub App connections from user level to workspace level.
+--
+-- Breaking change: drops github_connections entirely. Existing users will see
+-- an unconnected state and reconnect via the normal Connect flow. The GitHub
+-- App installations on github.com are unaffected — re-OAuth discovers them
+-- and writes a row into the new table.
+
+-- DropForeignKey
+ALTER TABLE "github_connections" DROP CONSTRAINT IF EXISTS "github_connections_user_id_fkey";
+
+-- DropTable
+DROP TABLE IF EXISTS "github_connections";
+
+-- CreateTable
+CREATE TABLE "github_installations" (
+    "id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "installation_id" VARCHAR NOT NULL,
+    "account_login" VARCHAR NOT NULL,
+    "installed_by_user_id" VARCHAR,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "github_installations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_github_installation" ON "github_installations"("workspace_id", "installation_id");
+
+-- CreateIndex
+CREATE INDEX "ix_github_installation_workspace_id" ON "github_installations"("workspace_id");
+
+-- AddForeignKey
+ALTER TABLE "github_installations" ADD CONSTRAINT "github_installations_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -84,6 +84,7 @@ model Workspace {
   currentUsage           Json?     @map("current_usage") // { traces, spans, tokens, updatedAt, ai }
 
   modelProviders ModelProvider[]
+  githubInstallations GitHubInstallation[]
 
   @@index([billingCustomerId])
   @@index([billingSubscriptionId])
@@ -153,7 +154,6 @@ model User {
   memberships   WorkspaceMember[]
   accounts      Account[]
   sessions      Session[]
-  githubConnection GitHubConnection?
 
   @@map("users")
 }
@@ -212,21 +212,27 @@ model Verification {
   @@map("verifications")
 }
 
-// GitHub App Connections - Links GitHub accounts and app installations to users
-model GitHubConnection {
-  id              String   @id @default(cuid()) @db.VarChar
-  userId          String   @unique @map("user_id") @db.VarChar
-  user            User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+// Workspace-level GitHub App installations.
+// One row per (workspace, GitHub installation). Multiple rows per workspace
+// supports the multi-org case (e.g. workspace has projects under github.com/acme
+// and github.com/acme-labs — each is a separate App installation on GitHub's side).
+// No accessToken stored: getInstallationToken signs a JWT with the App private
+// key and exchanges it for a short-lived installation token at request time.
+model GitHubInstallation {
+  id                String   @id @default(cuid()) @db.VarChar
+  workspaceId       String   @map("workspace_id") @db.VarChar
+  workspace         Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
-  githubUserId    String   @map("github_user_id") @db.VarChar
-  githubUsername  String   @map("github_username") @db.VarChar
-  accessToken     String   @map("access_token") @db.Text
-  installationId  String?  @map("installation_id") @db.VarChar
+  installationId    String   @map("installation_id") @db.VarChar
+  accountLogin      String   @map("account_login") @db.VarChar  // GitHub org/user that owns the install
+  installedByUserId String?  @map("installed_by_user_id") @db.VarChar  // who clicked Connect
 
-  createTime      DateTime @default(now()) @map("create_time") @db.Timestamp(6)
-  updateTime      DateTime @updatedAt @map("update_time") @db.Timestamp(6)
+  createTime        DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime        DateTime @updatedAt @map("update_time") @db.Timestamp(6)
 
-  @@map("github_connections")
+  @@unique([workspaceId, installationId], map: "uq_github_installation")
+  @@index([workspaceId], map: "ix_github_installation_workspace_id")
+  @@map("github_installations")
 }
 
 // AI Sessions - Conversation sessions for the AI debugging assistant

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -18,7 +18,7 @@ export type {
   AccessKey,
   Invite,
   Account,
-  GitHubConnection,
+  GitHubInstallation,
   ModelProvider,
 } from "@prisma/client";
 

--- a/frontend/packages/github/src/auth.ts
+++ b/frontend/packages/github/src/auth.ts
@@ -1,14 +1,23 @@
 import { generateJWT } from "./jwt";
 
+function normalizeInstallationId(installationId: string): string {
+  const normalized = installationId.trim();
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error("Invalid GitHub installation id");
+  }
+  return normalized;
+}
+
 export async function getInstallationToken(
   installationId: string,
   appId: string,
   privateKey: string,
 ): Promise<{ token: string; expires_at: string }> {
+  const safeInstallationId = normalizeInstallationId(installationId);
   const jwtToken = generateJWT(appId, privateKey.replace(/\\n/g, "\n"));
 
   const res = await fetch(
-    `https://api.github.com/app/installations/${installationId}/access_tokens`,
+    `https://api.github.com/app/installations/${safeInstallationId}/access_tokens`,
     {
       method: "POST",
       headers: {
@@ -37,9 +46,10 @@ export async function getInstallation(
   appId: string,
   privateKey: string,
 ): Promise<GitHubInstallation> {
+  const safeInstallationId = normalizeInstallationId(installationId);
   const jwtToken = generateJWT(appId, privateKey.replace(/\\n/g, "\n"));
 
-  const res = await fetch(`https://api.github.com/app/installations/${installationId}`, {
+  const res = await fetch(`https://api.github.com/app/installations/${safeInstallationId}`, {
     headers: {
       Authorization: `Bearer ${jwtToken}`,
       Accept: "application/vnd.github.v3+json",

--- a/frontend/packages/github/src/auth.ts
+++ b/frontend/packages/github/src/auth.ts
@@ -25,3 +25,31 @@ export async function getInstallationToken(
   }
   return res.json();
 }
+
+export interface GitHubInstallation {
+  id: number;
+  account: { login: string; id: number; type: string };
+  app_id: number;
+}
+
+export async function getInstallation(
+  installationId: string,
+  appId: string,
+  privateKey: string,
+): Promise<GitHubInstallation> {
+  const jwtToken = generateJWT(appId, privateKey.replace(/\\n/g, "\n"));
+
+  const res = await fetch(`https://api.github.com/app/installations/${installationId}`, {
+    headers: {
+      Authorization: `Bearer ${jwtToken}`,
+      Accept: "application/vnd.github.v3+json",
+      "User-Agent": "TraceRoot",
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub API error: ${res.status} ${body}`);
+  }
+  return res.json();
+}

--- a/frontend/packages/github/src/constants.ts
+++ b/frontend/packages/github/src/constants.ts
@@ -4,3 +4,7 @@ export const GITHUB_INSTALLATION_ID_COOKIE = "x-github-installation-id";
 export const GITHUB_AUTH_STATE_COOKIE = "github_auth_state";
 export const GITHUB_INSTALL_STATE_COOKIE = "github_install_state";
 export const GITHUB_RETURN_TO_COOKIE = "github_return_to";
+// Workspace the user is connecting GitHub to. Captured at /api/github/login or
+// /api/github/install kickoff and read by the install-callback to attach the
+// resulting installation to the right workspace.
+export const GITHUB_WORKSPACE_ID_COOKIE = "github_workspace_id";

--- a/frontend/packages/github/src/index.ts
+++ b/frontend/packages/github/src/index.ts
@@ -1,11 +1,12 @@
 export { generateJWT } from "./jwt";
-export { getInstallationToken } from "./auth";
+export { getInstallationToken, getInstallation, type GitHubInstallation } from "./auth";
 export {
   GITHUB_ACCESS_TOKEN_COOKIE,
   GITHUB_INSTALLATION_ID_COOKIE,
   GITHUB_AUTH_STATE_COOKIE,
   GITHUB_INSTALL_STATE_COOKIE,
   GITHUB_RETURN_TO_COOKIE,
+  GITHUB_WORKSPACE_ID_COOKIE,
 } from "./constants";
 export {
   validateCallbackParams,

--- a/frontend/ui/src/app/api/github/callback/route.test.ts
+++ b/frontend/ui/src/app/api/github/callback/route.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/env", () => ({
     GITHUB_APP_ID: "123456",
     GITHUB_APP_CLIENT_ID: "client_id",
     GITHUB_APP_CLIENT_SECRET: "client_secret",
+    GITHUB_APP_PRIVATE_KEY: "fake-key",
   },
 }));
 
@@ -28,7 +29,8 @@ vi.mock("next/server", () => ({
 
 vi.mock("@traceroot/core", () => ({
   prisma: {
-    gitHubConnection: { upsert: vi.fn() },
+    workspaceMember: { findFirst: vi.fn(async () => ({ workspaceId: "ws_1" })) },
+    gitHubInstallation: { upsert: vi.fn(async () => ({})) },
   },
 }));
 
@@ -37,9 +39,16 @@ vi.mock("@/lib/auth-helpers", () => ({
 }));
 
 vi.mock("@traceroot/github", async (importOriginal) => {
-  // Keep real validateCallbackParams / verifyInstallationId
+  // Keep real validateCallbackParams / verifyInstallationId; stub network helpers.
   const original = await importOriginal<typeof import("@traceroot/github")>();
-  return { ...original };
+  return {
+    ...original,
+    getInstallation: vi.fn(async () => ({
+      id: 789,
+      account: { login: "octocat", id: 42, type: "User" },
+      app_id: 123456,
+    })),
+  };
 });
 
 import { POST } from "./route";
@@ -65,16 +74,11 @@ function makeRequest(
 
 // Sequence-aware fetch stub.
 //  - Call #1: GitHub token exchange → { access_token }
-//  - Call #2: GitHub /user            → { id, login }
-//  - Call #3: GitHub /user/installations → { installations }
-
+//  - Call #2: GitHub /user/installations → { installations }
 function stubFetch({
   accessToken = "ghp_mock",
-  userId = 42,
-  login = "octocat",
-  installations = [{ id: 789, app_id: 123456 }],
+  installations = [{ id: 789, app_id: 123456, account: { login: "octocat" } }],
   tokenOk = true,
-  userOk = true,
   installOk = true,
 } = {}) {
   let callCount = 0;
@@ -84,7 +88,6 @@ function stubFetch({
       callCount++;
       if (callCount === 1)
         return { ok: tokenOk, json: async () => ({ access_token: accessToken }) };
-      if (callCount === 2) return { ok: userOk, json: async () => ({ id: userId, login }) };
       return { ok: installOk, json: async () => ({ installations }) };
     }),
   );
@@ -96,7 +99,6 @@ describe("POST /api/github/callback (direct install confirmation)", () => {
     vi.clearAllMocks();
   });
 
-  //Origin header validation
   describe("Origin header validation", () => {
     it("returns 403 when Origin header is absent", async () => {
       const req = makeRequest(null);
@@ -134,7 +136,6 @@ describe("POST /api/github/callback (direct install confirmation)", () => {
     });
   });
 
-  // Request body validation
   describe("Request body validation", () => {
     it("returns 400 when code is missing from body", async () => {
       stubFetch();
@@ -145,7 +146,6 @@ describe("POST /api/github/callback (direct install confirmation)", () => {
     });
   });
 
-  // Successful flow
   describe("Successful flow", () => {
     it("returns 200 with redirectUrl when Origin, code, and auth are valid", async () => {
       stubFetch();

--- a/frontend/ui/src/app/api/github/callback/route.test.ts
+++ b/frontend/ui/src/app/api/github/callback/route.test.ts
@@ -36,6 +36,7 @@ vi.mock("@traceroot/core", () => ({
 
 vi.mock("@/lib/auth-helpers", () => ({
   requireAuth: vi.fn(async () => ({ user: { id: "user_abc" } })),
+  requireWorkspaceMembership: vi.fn(async () => ({ membership: { workspaceId: "ws_1" } })),
 }));
 
 vi.mock("@traceroot/github", async (importOriginal) => {

--- a/frontend/ui/src/app/api/github/callback/route.ts
+++ b/frontend/ui/src/app/api/github/callback/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 import { prisma } from "@traceroot/core";
-import { requireAuth } from "@/lib/auth-helpers";
+import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
 import {
   GITHUB_AUTH_STATE_COOKIE,
   GITHUB_INSTALL_STATE_COOKIE,
@@ -133,8 +133,11 @@ async function processGitHubCallback(
 
   // 6. Persist the install if both pieces are known. If we have no install yet,
   //    we'll bounce through /api/github/install — that flow ends in install-callback,
-  //    which writes the row.
+  //    which writes the row. ADMIN-gated: writing a workspace integration is admin-only.
   if (chosen && workspaceId) {
+    const memberCheck = await requireWorkspaceMembership(user.id, workspaceId, "ADMIN");
+    if (memberCheck.error) return memberCheck.error;
+
     const installationId = String(chosen.id);
     await prisma.gitHubInstallation.upsert({
       where: { workspaceId_installationId: { workspaceId, installationId } },

--- a/frontend/ui/src/app/api/github/callback/route.ts
+++ b/frontend/ui/src/app/api/github/callback/route.ts
@@ -158,9 +158,15 @@ async function processGitHubCallback(
   const returnTo = rawReturnTo.startsWith("/") && !rawReturnTo.startsWith("//") ? rawReturnTo : "/";
   // Use BETTER_AUTH_URL as base — request.url inside Docker resolves to 0.0.0.0
   // which loses the session cookie (set on localhost).
-  const redirectUrl = chosen
-    ? new URL(returnTo, env.BETTER_AUTH_URL)
-    : new URL(`/api/github/install?returnTo=${encodeURIComponent(returnTo)}`, env.BETTER_AUTH_URL);
+  // Mirror the persistence condition (chosen && workspaceId): if either is
+  // missing we didn't write a row, so we shouldn't redirect "as connected".
+  const redirectUrl =
+    chosen && workspaceId
+      ? new URL(returnTo, env.BETTER_AUTH_URL)
+      : new URL(
+          `/api/github/install?returnTo=${encodeURIComponent(returnTo)}`,
+          env.BETTER_AUTH_URL,
+        );
 
   const response =
     request.method === "POST"
@@ -173,7 +179,7 @@ async function processGitHubCallback(
   const clearCookie = (name: string) =>
     response.cookies.set(name, "", { httpOnly: true, sameSite: "lax", maxAge: 0, path: "/" });
   clearCookie(GITHUB_AUTH_STATE_COOKIE);
-  if (chosen) {
+  if (chosen && workspaceId) {
     clearCookie(GITHUB_RETURN_TO_COOKIE);
     clearCookie(GITHUB_INSTALL_STATE_COOKIE);
     clearCookie(GITHUB_WORKSPACE_ID_COOKIE);

--- a/frontend/ui/src/app/api/github/callback/route.ts
+++ b/frontend/ui/src/app/api/github/callback/route.ts
@@ -6,9 +6,15 @@ import {
   GITHUB_AUTH_STATE_COOKIE,
   GITHUB_INSTALL_STATE_COOKIE,
   GITHUB_RETURN_TO_COOKIE,
+  GITHUB_WORKSPACE_ID_COOKIE,
   validateCallbackParams,
-  verifyInstallationId,
 } from "@traceroot/github";
+
+interface UserInstallation {
+  id: number | string;
+  app_id: number | string;
+  account: { login: string };
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -23,7 +29,6 @@ export async function GET(request: NextRequest) {
     const storedState =
       state === authState ? authState : state === installState ? installState : null;
 
-    // Validate callback parameters (handles both normal OAuth and direct GitHub install flows)
     const validation = validateCallbackParams({
       code,
       state,
@@ -36,19 +41,14 @@ export async function GET(request: NextRequest) {
       const status = validation.error === "Missing code or state parameter" ? 400 : 403;
       return NextResponse.json({ error: validation.error }, { status });
     }
-    // Direct Github install flow, do not process yet
+    // Direct GitHub install flow — defer to the confirm page (re-POSTs here).
     if (validation.isDirectGitHubInstall && code) {
       const confirmUrl = new URL("/auth/github/confirm", env.BETTER_AUTH_URL);
       confirmUrl.searchParams.set("code", code);
-      if (installationId) {
-        confirmUrl.searchParams.set("installation_id", installationId);
-      }
-      if (setupAction) {
-        confirmUrl.searchParams.set("setup_action", setupAction);
-      }
+      if (installationId) confirmUrl.searchParams.set("installation_id", installationId);
+      if (setupAction) confirmUrl.searchParams.set("setup_action", setupAction);
       return NextResponse.redirect(confirmUrl);
     }
-    // Normal Oauth Flow
     if (!code) {
       return NextResponse.json({ error: "Missing code parameter" }, { status: 400 });
     }
@@ -63,165 +63,130 @@ export async function GET(request: NextRequest) {
   }
 }
 
-//helper function to validate callback parameters
-
 async function processGitHubCallback(
   request: NextRequest,
   code: string,
-  installationId: string | null,
+  installationIdParam: string | null,
 ) {
-  // Exchange code for access token
+  // 1. Exchange OAuth code for access token (used once to query user installations; not stored).
   const tokenResponse = await fetch("https://github.com/login/oauth/access_token", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
     body: JSON.stringify({
       client_id: env.GITHUB_APP_CLIENT_ID,
       client_secret: env.GITHUB_APP_CLIENT_SECRET,
       code,
     }),
   });
-
-  const tokenData = await tokenResponse.json();
-  const accessToken = tokenData.access_token;
-
+  const { access_token: accessToken } = await tokenResponse.json();
   if (!accessToken) {
-    console.error("GitHub OAuth token exchange failed:", tokenData);
     return NextResponse.json({ error: "Failed to exchange code for token" }, { status: 500 });
   }
 
-  // Fetch GitHub user info
-  const userResponse = await fetch("https://api.github.com/user", {
+  // 2. Require Traceroot session.
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  // 3. List the user's installations of our App. The /user/installations response
+  //    already contains account.login, so we don't need a separate getInstallation call.
+  const installRes = await fetch("https://api.github.com/user/installations", {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       Accept: "application/vnd.github.v3+json",
       "User-Agent": "TraceRoot",
     },
   });
+  const installData = installRes.ok ? await installRes.json() : { installations: [] };
+  const myInstalls: UserInstallation[] = (installData.installations || []).filter(
+    (i: UserInstallation) => String(i.app_id) === env.GITHUB_APP_ID,
+  );
 
-  if (!userResponse.ok) {
-    return NextResponse.json({ error: "Failed to fetch GitHub user info" }, { status: 500 });
-  }
-
-  const ghUser = await userResponse.json();
-
-  // Require authenticated session
-  const authResult = await requireAuth();
-  if (authResult.error) return authResult.error;
-  const { user } = authResult;
-
-  // Look up GitHub App installations for this user and verify/resolve installation_id.
-  // If installation_id was passed in URL (direct GitHub install), we verify it belongs
-  // to this user. Otherwise, we look up an existing installation.
-  let resolvedInstallationId: string | undefined;
-  try {
-    const installRes = await fetch("https://api.github.com/user/installations", {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        Accept: "application/vnd.github.v3+json",
-        "User-Agent": "TraceRoot",
-      },
-    });
-    if (installRes.ok) {
-      const data = await installRes.json();
-      const installationCheck = verifyInstallationId(
-        installationId,
-        data.installations || [],
-        env.GITHUB_APP_ID,
+  // 4. Pick which install to attach. If installation_id was passed in the URL,
+  //    it must be one of the user's installs of our App (security check).
+  //    Otherwise, take the first install they have for our App (if any).
+  let chosen: UserInstallation | undefined;
+  if (installationIdParam) {
+    chosen = myInstalls.find((i) => String(i.id) === installationIdParam);
+    if (!chosen) {
+      return NextResponse.json(
+        { error: "Installation ID does not belong to authenticated user" },
+        { status: 403 },
       );
-
-      if (!installationCheck.verified) {
-        console.error(installationCheck.error);
-        return NextResponse.json(
-          { error: "Installation ID does not belong to authenticated user" },
-          { status: 403 },
-        );
-      }
-      resolvedInstallationId = installationCheck.installationId;
     }
-  } catch (e) {
-    // Non-fatal — installationId will be filled later via install-callback
-    console.warn("Failed to look up existing GitHub App installations:", e);
+  } else {
+    chosen = myInstalls[0];
   }
 
-  // Upsert GitHubConnection
-  await prisma.gitHubConnection.upsert({
-    where: { userId: user.id },
-    create: {
-      userId: user.id,
-      githubUserId: String(ghUser.id),
-      githubUsername: ghUser.login,
-      accessToken,
-      ...(resolvedInstallationId && { installationId: resolvedInstallationId }),
-    },
-    update: {
-      githubUserId: String(ghUser.id),
-      githubUsername: ghUser.login,
-      accessToken,
-      ...(resolvedInstallationId && { installationId: resolvedInstallationId }),
-    },
-  });
+  // 5. Resolve target workspace: cookie set at /api/github/login kickoff, or
+  //    the user's first membership for the direct-install flow (where the user
+  //    started at github.com and we never set the cookie).
+  let workspaceId = request.cookies.get(GITHUB_WORKSPACE_ID_COOKIE)?.value;
+  if (!workspaceId) {
+    const membership = await prisma.workspaceMember.findFirst({
+      where: { userId: user.id },
+      orderBy: { createTime: "asc" },
+      select: { workspaceId: true },
+    });
+    workspaceId = membership?.workspaceId;
+  }
 
-  // Get the return URL from cookie (will be used after installation completes).
+  // 6. Persist the install if both pieces are known. If we have no install yet,
+  //    we'll bounce through /api/github/install — that flow ends in install-callback,
+  //    which writes the row.
+  if (chosen && workspaceId) {
+    const installationId = String(chosen.id);
+    await prisma.gitHubInstallation.upsert({
+      where: { workspaceId_installationId: { workspaceId, installationId } },
+      create: {
+        workspaceId,
+        installationId,
+        accountLogin: chosen.account.login,
+        installedByUserId: user.id,
+      },
+      update: { accountLogin: chosen.account.login },
+    });
+  }
+
+  // 7. Build the redirect.
+  const rawReturnTo = request.cookies.get(GITHUB_RETURN_TO_COOKIE)?.value || "/";
   // Guard against open redirect: only accept relative paths. new URL(absolute, base)
   // ignores the base entirely, so an absolute URL in the cookie would escape the origin.
-  const rawReturnTo = request.cookies.get(GITHUB_RETURN_TO_COOKIE)?.value || "/";
   const returnTo = rawReturnTo.startsWith("/") && !rawReturnTo.startsWith("//") ? rawReturnTo : "/";
-
-  // If we already have installation_id (from direct GitHub install), redirect to returnTo.
-  // Otherwise, redirect to the installation flow.
-  const redirectUrl = resolvedInstallationId
+  // Use BETTER_AUTH_URL as base — request.url inside Docker resolves to 0.0.0.0
+  // which loses the session cookie (set on localhost).
+  const redirectUrl = chosen
     ? new URL(returnTo, env.BETTER_AUTH_URL)
     : new URL(`/api/github/install?returnTo=${encodeURIComponent(returnTo)}`, env.BETTER_AUTH_URL);
 
-  // Use BETTER_AUTH_URL as base — request.url inside Docker resolves to 0.0.0.0
-  // which loses the session cookie (set on localhost).
-
-  // Returns JSON for POST requests, Redirect for GET requests.
   const response =
     request.method === "POST"
       ? NextResponse.json({ success: true, redirectUrl: redirectUrl.toString() })
       : NextResponse.redirect(redirectUrl);
 
-  // Clear OAuth state cookie
-  response.cookies.set(GITHUB_AUTH_STATE_COOKIE, "", {
-    httpOnly: true,
-    sameSite: "lax",
-    maxAge: 0,
-    path: "/",
-  });
-
-  // Clear return-to cookie
-  response.cookies.set(GITHUB_RETURN_TO_COOKIE, "", {
-    httpOnly: true,
-    sameSite: "lax",
-    maxAge: 0,
-    path: "/",
-  });
-
-  // Clear install state cookie
-  response.cookies.set(GITHUB_INSTALL_STATE_COOKIE, "", {
-    httpOnly: true,
-    sameSite: "lax",
-    maxAge: 0,
-    path: "/",
-  });
+  // Clear OAuth state cookie regardless. Clear return-to / install-state /
+  // workspace cookies only after we've persisted the row (so install-callback
+  // can still read return-to and workspace if we redirect to install instead).
+  const clearCookie = (name: string) =>
+    response.cookies.set(name, "", { httpOnly: true, sameSite: "lax", maxAge: 0, path: "/" });
+  clearCookie(GITHUB_AUTH_STATE_COOKIE);
+  if (chosen) {
+    clearCookie(GITHUB_RETURN_TO_COOKIE);
+    clearCookie(GITHUB_INSTALL_STATE_COOKIE);
+    clearCookie(GITHUB_WORKSPACE_ID_COOKIE);
+  }
 
   return response;
 }
 
 export async function POST(request: NextRequest) {
   try {
-    // This endpoint is exclusively used by the direct GitHub install flow (confirm/page.tsx).
-    // In that flow, the user arrived from GitHub's UI directly and no state cookie was ever set by us,
-    // so validateCallbackParams is intentionally NOT called here (the state check would always fail
-    // because storedState is null by design). Security is enforced by:
-    //   1. Origin header check (same-origin enforcement below)
-    //   2. GitHub validating the OAuth code on exchange (one-time use, short TTL)
-    //   3. requireAuth() — user must have an active TraceRoot session
-    //   4. verifyInstallationId() — installation_id must belong to the authenticated GitHub user
+    // Used exclusively by the direct GitHub install confirm page. State check
+    // is intentionally skipped (no cookie set in that flow); security is enforced by:
+    //   1. Origin header check (same-origin)
+    //   2. GitHub validating the OAuth code on exchange
+    //   3. requireAuth() — user must have an active Traceroot session
+    //   4. installation_id must appear in the user's /user/installations
     const origin = request.headers.get("origin");
     let parsedOrigin: string;
     try {

--- a/frontend/ui/src/app/api/github/disconnect/route.test.ts
+++ b/frontend/ui/src/app/api/github/disconnect/route.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn((data, init) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+      cookies: { set: vi.fn() },
+    })),
+  },
+}));
+
+const deleteManyMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    gitHubInstallation: {
+      deleteMany: (...args: unknown[]) => deleteManyMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireMembershipMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireWorkspaceMembership: (...args: unknown[]) => requireMembershipMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(workspaceId: string | null, installationId: string | null = null) {
+  const params = new URLSearchParams();
+  if (workspaceId) params.set("workspaceId", workspaceId);
+  if (installationId) params.set("installationId", installationId);
+  return {
+    nextUrl: { searchParams: params },
+  } as unknown as Parameters<typeof POST>[0];
+}
+
+beforeEach(() => {
+  deleteManyMock.mockReset();
+  requireAuthMock.mockReset();
+  requireMembershipMock.mockReset();
+});
+
+describe("POST /api/github/disconnect", () => {
+  it("returns 401 when not authenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = await POST(makeRequest("ws_1"));
+    expect(res.status).toBe(401);
+    expect(deleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when workspaceId is missing", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    const res = await POST(makeRequest(null));
+    expect(res.status).toBe(400);
+    expect(deleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 for non-ADMIN members", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    requireMembershipMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Requires ADMIN role or higher" }) },
+    });
+    const res = await POST(makeRequest("ws_1"));
+    expect(res.status).toBe(403);
+    expect(requireMembershipMock).toHaveBeenCalledWith("u_1", "ws_1", "ADMIN");
+    expect(deleteManyMock).not.toHaveBeenCalled();
+  });
+
+  it("deletes all installations for the workspace when no installationId", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    requireMembershipMock.mockResolvedValue({ membership: { workspaceId: "ws_1" } });
+    deleteManyMock.mockResolvedValue({ count: 2 });
+    const res = await POST(makeRequest("ws_1"));
+    expect(res.status).toBe(200);
+    expect(deleteManyMock).toHaveBeenCalledWith({ where: { workspaceId: "ws_1" } });
+  });
+
+  it("deletes a single installation when installationId is provided", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    requireMembershipMock.mockResolvedValue({ membership: { workspaceId: "ws_1" } });
+    deleteManyMock.mockResolvedValue({ count: 1 });
+    const res = await POST(makeRequest("ws_1", "inst_42"));
+    expect(res.status).toBe(200);
+    expect(deleteManyMock).toHaveBeenCalledWith({
+      where: { workspaceId: "ws_1", installationId: "inst_42" },
+    });
+  });
+
+  it("never deletes installs from other workspaces", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    requireMembershipMock.mockResolvedValue({ membership: { workspaceId: "ws_1" } });
+    deleteManyMock.mockResolvedValue({ count: 0 });
+    await POST(makeRequest("ws_1"));
+    const call = deleteManyMock.mock.calls[0][0];
+    expect(call.where.workspaceId).toBe("ws_1");
+  });
+});

--- a/frontend/ui/src/app/api/github/disconnect/route.ts
+++ b/frontend/ui/src/app/api/github/disconnect/route.ts
@@ -1,32 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@traceroot/core";
-import { requireAuth, successResponse } from "@/lib/auth-helpers";
+import { errorResponse, requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
 import { GITHUB_INSTALLATION_ID_COOKIE } from "@traceroot/github";
-import { NextResponse } from "next/server";
 
-// POST /api/github/disconnect - Disconnect GitHub integration
-export async function POST() {
+// POST /api/github/disconnect?workspaceId=...&installationId=...
+// Removes a single installation if installationId is given, otherwise removes
+// all installations for the workspace. Requires workspace membership.
+export async function POST(request: NextRequest) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
   const { user } = authResult;
 
-  try {
-    // Delete the GitHub connection
-    await prisma.gitHubConnection.delete({
-      where: { userId: user.id },
-    });
-
-    // Clear the installation ID cookie
-    const response = NextResponse.json({ success: true });
-    response.cookies.set(GITHUB_INSTALLATION_ID_COOKIE, "", {
-      httpOnly: false,
-      sameSite: "lax",
-      maxAge: 0,
-      path: "/",
-    });
-
-    return response;
-  } catch (error) {
-    // If no connection exists, that's fine
-    return successResponse({ success: true });
+  const workspaceId = request.nextUrl.searchParams.get("workspaceId");
+  if (!workspaceId) {
+    return errorResponse("workspaceId required", 400);
   }
+
+  const memberCheck = await requireWorkspaceMembership(user.id, workspaceId, "ADMIN");
+  if (memberCheck.error) return memberCheck.error;
+
+  const installationId = request.nextUrl.searchParams.get("installationId");
+  await prisma.gitHubInstallation.deleteMany({
+    where: {
+      workspaceId,
+      ...(installationId ? { installationId } : {}),
+    },
+  });
+
+  const response = NextResponse.json({ success: true });
+  response.cookies.set(GITHUB_INSTALLATION_ID_COOKIE, "", {
+    httpOnly: false,
+    sameSite: "lax",
+    maxAge: 0,
+    path: "/",
+  });
+  return response;
 }

--- a/frontend/ui/src/app/api/github/disconnect/route.ts
+++ b/frontend/ui/src/app/api/github/disconnect/route.ts
@@ -19,11 +19,15 @@ export async function POST(request: NextRequest) {
   const memberCheck = await requireWorkspaceMembership(user.id, workspaceId, "ADMIN");
   if (memberCheck.error) return memberCheck.error;
 
+  // Distinguish "param absent" (delete all) from "param present but empty"
+  // (delete nothing — pass the empty string through as a no-match filter).
+  // Truthy check would conflate the two and turn ?installationId= into a
+  // workspace-wide wipe, which is not what the URL implies.
   const installationId = request.nextUrl.searchParams.get("installationId");
   await prisma.gitHubInstallation.deleteMany({
     where: {
       workspaceId,
-      ...(installationId ? { installationId } : {}),
+      ...(installationId !== null ? { installationId } : {}),
     },
   });
 

--- a/frontend/ui/src/app/api/github/install-callback/route.ts
+++ b/frontend/ui/src/app/api/github/install-callback/route.ts
@@ -6,6 +6,8 @@ import {
   GITHUB_INSTALL_STATE_COOKIE,
   GITHUB_INSTALLATION_ID_COOKIE,
   GITHUB_RETURN_TO_COOKIE,
+  GITHUB_WORKSPACE_ID_COOKIE,
+  getInstallation,
 } from "@traceroot/github";
 
 export async function GET(request: NextRequest) {
@@ -31,19 +33,58 @@ export async function GET(request: NextRequest) {
     if (authResult.error) return authResult.error;
     const { user } = authResult;
 
-    // Only update installationId on an existing connection (OAuth must complete first)
-    const updated = await prisma.gitHubConnection.updateMany({
-      where: { userId: user.id },
-      data: { installationId },
-    });
+    // Resolve target workspace from cookie, falling back to user's first
+    // membership (covers direct-from-GitHub install flow).
+    const cookieWorkspaceId = request.cookies.get(GITHUB_WORKSPACE_ID_COOKIE)?.value;
+    let workspaceId = cookieWorkspaceId;
+    if (!workspaceId) {
+      const membership = await prisma.workspaceMember.findFirst({
+        where: { userId: user.id },
+        orderBy: { createTime: "asc" },
+        select: { workspaceId: true },
+      });
+      workspaceId = membership?.workspaceId;
+    }
 
-    if (updated.count === 0) {
-      // No OAuth connection exists yet — redirect to OAuth flow first
-      const returnTo = request.cookies.get(GITHUB_RETURN_TO_COOKIE)?.value || "/";
-      return NextResponse.redirect(
-        new URL(`/api/github/login?returnTo=${encodeURIComponent(returnTo)}`, env.BETTER_AUTH_URL),
+    if (!workspaceId) {
+      return NextResponse.json(
+        { error: "User has no workspace to attach this installation to" },
+        { status: 400 },
       );
     }
+
+    // Fetch installation details (account.login) using the App's JWT — no user
+    // OAuth token required. This is the source of truth for which org/user the
+    // App is installed on.
+    let accountLogin: string;
+    try {
+      const installation = await getInstallation(
+        installationId,
+        env.GITHUB_APP_ID,
+        env.GITHUB_APP_PRIVATE_KEY,
+      );
+      accountLogin = installation.account.login;
+    } catch (e) {
+      console.error("Failed to fetch installation details:", e);
+      return NextResponse.json(
+        { error: "Failed to fetch installation details from GitHub" },
+        { status: 502 },
+      );
+    }
+
+    // Upsert workspace-level installation row.
+    await prisma.gitHubInstallation.upsert({
+      where: {
+        workspaceId_installationId: { workspaceId, installationId },
+      },
+      create: {
+        workspaceId,
+        installationId,
+        accountLogin,
+        installedByUserId: user.id,
+      },
+      update: { accountLogin },
+    });
 
     // Redirect to return URL
     const returnTo = request.cookies.get(GITHUB_RETURN_TO_COOKIE)?.value || "/";
@@ -58,6 +99,13 @@ export async function GET(request: NextRequest) {
     });
 
     response.cookies.set(GITHUB_RETURN_TO_COOKIE, "", {
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 0,
+      path: "/",
+    });
+
+    response.cookies.set(GITHUB_WORKSPACE_ID_COOKIE, "", {
       httpOnly: true,
       sameSite: "lax",
       maxAge: 0,

--- a/frontend/ui/src/app/api/github/install-callback/route.ts
+++ b/frontend/ui/src/app/api/github/install-callback/route.ts
@@ -33,22 +33,17 @@ export async function GET(request: NextRequest) {
     if (authResult.error) return authResult.error;
     const { user } = authResult;
 
-    // Resolve target workspace from cookie, falling back to user's first
-    // membership (covers direct-from-GitHub install flow).
-    const cookieWorkspaceId = request.cookies.get(GITHUB_WORKSPACE_ID_COOKIE)?.value;
-    let workspaceId = cookieWorkspaceId;
-    if (!workspaceId) {
-      const membership = await prisma.workspaceMember.findFirst({
-        where: { userId: user.id },
-        orderBy: { createTime: "asc" },
-        select: { workspaceId: true },
-      });
-      workspaceId = membership?.workspaceId;
-    }
-
+    // Workspace must come from the cookie set by /api/github/install. Falling
+    // back to "user's first workspace" can attach the install to the wrong
+    // workspace for users in multiple workspaces — force them to start the
+    // install from a workspace settings page so the cookie is set correctly.
+    const workspaceId = request.cookies.get(GITHUB_WORKSPACE_ID_COOKIE)?.value;
     if (!workspaceId) {
       return NextResponse.json(
-        { error: "User has no workspace to attach this installation to" },
+        {
+          error:
+            "Missing workspace context for installation. Start installation from a workspace settings page.",
+        },
         { status: 400 },
       );
     }

--- a/frontend/ui/src/app/api/github/install-callback/route.ts
+++ b/frontend/ui/src/app/api/github/install-callback/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 import { prisma } from "@traceroot/core";
-import { requireAuth } from "@/lib/auth-helpers";
+import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
 import {
   GITHUB_INSTALL_STATE_COOKIE,
   GITHUB_INSTALLATION_ID_COOKIE,
@@ -52,6 +52,12 @@ export async function GET(request: NextRequest) {
         { status: 400 },
       );
     }
+
+    // ADMIN-only: writing the workspace's GitHub installation mutates a shared
+    // resource. The state cookie alone is not enough — a non-admin member could
+    // still complete this flow if they obtained a state cookie somehow.
+    const memberCheck = await requireWorkspaceMembership(user.id, workspaceId, "ADMIN");
+    if (memberCheck.error) return memberCheck.error;
 
     // Fetch installation details (account.login) using the App's JWT — no user
     // OAuth token required. This is the source of truth for which org/user the

--- a/frontend/ui/src/app/api/github/install/route.ts
+++ b/frontend/ui/src/app/api/github/install/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
-import { requireAuth } from "@/lib/auth-helpers";
-import { GITHUB_INSTALL_STATE_COOKIE, GITHUB_RETURN_TO_COOKIE } from "@traceroot/github";
+import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import {
+  GITHUB_INSTALL_STATE_COOKIE,
+  GITHUB_RETURN_TO_COOKIE,
+  GITHUB_WORKSPACE_ID_COOKIE,
+} from "@traceroot/github";
 
 export async function GET(request: NextRequest) {
   try {
@@ -10,6 +14,17 @@ export async function GET(request: NextRequest) {
 
     const state = crypto.randomUUID();
     const returnTo = request.nextUrl.searchParams.get("returnTo") || "/";
+    const workspaceId = request.nextUrl.searchParams.get("workspaceId") || "";
+
+    // Adding/configuring an installation mutates a workspace-shared resource — admin only.
+    if (workspaceId) {
+      const memberCheck = await requireWorkspaceMembership(
+        authResult.user.id,
+        workspaceId,
+        "ADMIN",
+      );
+      if (memberCheck.error) return memberCheck.error;
+    }
 
     const params = new URLSearchParams({ state });
     const redirectUrl = `https://github.com/apps/${env.GITHUB_APP_NAME}/installations/new?${params.toString()}`;
@@ -28,6 +43,15 @@ export async function GET(request: NextRequest) {
       maxAge: 600,
       path: "/",
     });
+
+    if (workspaceId) {
+      response.cookies.set(GITHUB_WORKSPACE_ID_COOKIE, workspaceId, {
+        httpOnly: true,
+        sameSite: "lax",
+        maxAge: 600,
+        path: "/",
+      });
+    }
 
     return response;
   } catch (error) {

--- a/frontend/ui/src/app/api/github/install/route.ts
+++ b/frontend/ui/src/app/api/github/install/route.ts
@@ -14,17 +14,14 @@ export async function GET(request: NextRequest) {
 
     const state = crypto.randomUUID();
     const returnTo = request.nextUrl.searchParams.get("returnTo") || "/";
-    const workspaceId = request.nextUrl.searchParams.get("workspaceId") || "";
+    const workspaceId = request.nextUrl.searchParams.get("workspaceId");
 
     // Adding/configuring an installation mutates a workspace-shared resource — admin only.
-    if (workspaceId) {
-      const memberCheck = await requireWorkspaceMembership(
-        authResult.user.id,
-        workspaceId,
-        "ADMIN",
-      );
-      if (memberCheck.error) return memberCheck.error;
+    if (!workspaceId) {
+      return NextResponse.json({ error: "workspaceId required" }, { status: 400 });
     }
+    const memberCheck = await requireWorkspaceMembership(authResult.user.id, workspaceId, "ADMIN");
+    if (memberCheck.error) return memberCheck.error;
 
     const params = new URLSearchParams({ state });
     const redirectUrl = `https://github.com/apps/${env.GITHUB_APP_NAME}/installations/new?${params.toString()}`;
@@ -44,14 +41,12 @@ export async function GET(request: NextRequest) {
       path: "/",
     });
 
-    if (workspaceId) {
-      response.cookies.set(GITHUB_WORKSPACE_ID_COOKIE, workspaceId, {
-        httpOnly: true,
-        sameSite: "lax",
-        maxAge: 600,
-        path: "/",
-      });
-    }
+    response.cookies.set(GITHUB_WORKSPACE_ID_COOKIE, workspaceId, {
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 600,
+      path: "/",
+    });
 
     return response;
   } catch (error) {

--- a/frontend/ui/src/app/api/github/install/route.ts
+++ b/frontend/ui/src/app/api/github/install/route.ts
@@ -14,7 +14,12 @@ export async function GET(request: NextRequest) {
 
     const state = crypto.randomUUID();
     const returnTo = request.nextUrl.searchParams.get("returnTo") || "/";
-    const workspaceId = request.nextUrl.searchParams.get("workspaceId");
+    // Allow workspaceId to come from either the query (button click) or the
+    // cookie set by /api/github/login earlier in the flow — callback redirects
+    // here without re-passing the param when no install exists yet.
+    const workspaceId =
+      request.nextUrl.searchParams.get("workspaceId") ||
+      request.cookies.get(GITHUB_WORKSPACE_ID_COOKIE)?.value;
 
     // Adding/configuring an installation mutates a workspace-shared resource — admin only.
     if (!workspaceId) {

--- a/frontend/ui/src/app/api/github/login/route.ts
+++ b/frontend/ui/src/app/api/github/login/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
-import { requireAuth } from "@/lib/auth-helpers";
-import { GITHUB_AUTH_STATE_COOKIE, GITHUB_RETURN_TO_COOKIE } from "@traceroot/github";
+import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import {
+  GITHUB_AUTH_STATE_COOKIE,
+  GITHUB_RETURN_TO_COOKIE,
+  GITHUB_WORKSPACE_ID_COOKIE,
+} from "@traceroot/github";
 
 export async function GET(request: NextRequest) {
   try {
@@ -10,6 +14,17 @@ export async function GET(request: NextRequest) {
 
     const state = crypto.randomUUID();
     const returnTo = request.nextUrl.searchParams.get("returnTo") || "/";
+    const workspaceId = request.nextUrl.searchParams.get("workspaceId") || "";
+
+    // Connecting GitHub mutates a workspace-shared resource — admin only.
+    if (workspaceId) {
+      const memberCheck = await requireWorkspaceMembership(
+        authResult.user.id,
+        workspaceId,
+        "ADMIN",
+      );
+      if (memberCheck.error) return memberCheck.error;
+    }
 
     const params = new URLSearchParams({
       client_id: env.GITHUB_APP_CLIENT_ID,
@@ -34,6 +49,15 @@ export async function GET(request: NextRequest) {
       maxAge: 600,
       path: "/",
     });
+
+    if (workspaceId) {
+      response.cookies.set(GITHUB_WORKSPACE_ID_COOKIE, workspaceId, {
+        httpOnly: true,
+        sameSite: "lax",
+        maxAge: 600,
+        path: "/",
+      });
+    }
 
     return response;
   } catch (error) {

--- a/frontend/ui/src/app/api/github/login/route.ts
+++ b/frontend/ui/src/app/api/github/login/route.ts
@@ -14,17 +14,14 @@ export async function GET(request: NextRequest) {
 
     const state = crypto.randomUUID();
     const returnTo = request.nextUrl.searchParams.get("returnTo") || "/";
-    const workspaceId = request.nextUrl.searchParams.get("workspaceId") || "";
+    const workspaceId = request.nextUrl.searchParams.get("workspaceId");
 
     // Connecting GitHub mutates a workspace-shared resource — admin only.
-    if (workspaceId) {
-      const memberCheck = await requireWorkspaceMembership(
-        authResult.user.id,
-        workspaceId,
-        "ADMIN",
-      );
-      if (memberCheck.error) return memberCheck.error;
+    if (!workspaceId) {
+      return NextResponse.json({ error: "workspaceId required" }, { status: 400 });
     }
+    const memberCheck = await requireWorkspaceMembership(authResult.user.id, workspaceId, "ADMIN");
+    if (memberCheck.error) return memberCheck.error;
 
     const params = new URLSearchParams({
       client_id: env.GITHUB_APP_CLIENT_ID,
@@ -50,14 +47,12 @@ export async function GET(request: NextRequest) {
       path: "/",
     });
 
-    if (workspaceId) {
-      response.cookies.set(GITHUB_WORKSPACE_ID_COOKIE, workspaceId, {
-        httpOnly: true,
-        sameSite: "lax",
-        maxAge: 600,
-        path: "/",
-      });
-    }
+    response.cookies.set(GITHUB_WORKSPACE_ID_COOKIE, workspaceId, {
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 600,
+      path: "/",
+    });
 
     return response;
   } catch (error) {

--- a/frontend/ui/src/app/api/github/status/route.test.ts
+++ b/frontend/ui/src/app/api/github/status/route.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn((data, init) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    })),
+  },
+}));
+
+const findManyMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    gitHubInstallation: {
+      findMany: (...args: unknown[]) => findManyMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireMembershipMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireWorkspaceMembership: (...args: unknown[]) => requireMembershipMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+  successResponse: <T>(data: T, status = 200) => ({
+    status,
+    json: async () => data,
+  }),
+}));
+
+import { GET } from "./route";
+
+function makeRequest(workspaceId: string | null) {
+  const params = new URLSearchParams();
+  if (workspaceId) params.set("workspaceId", workspaceId);
+  return {
+    nextUrl: { searchParams: params },
+  } as unknown as Parameters<typeof GET>[0];
+}
+
+beforeEach(() => {
+  findManyMock.mockReset();
+  requireAuthMock.mockReset();
+  requireMembershipMock.mockReset();
+});
+
+describe("GET /api/github/status", () => {
+  it("returns 401 when not authenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = await GET(makeRequest("ws_1"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when workspaceId is missing", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    const res = await GET(makeRequest(null));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "workspaceId required" });
+  });
+
+  it("returns 403 when user is not a member of the workspace", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    requireMembershipMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Not a member of this workspace" }) },
+    });
+    const res = await GET(makeRequest("ws_1"));
+    expect(res.status).toBe(403);
+    expect(findManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns connected:false with empty list when no installs", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    requireMembershipMock.mockResolvedValue({ membership: { workspaceId: "ws_1" } });
+    findManyMock.mockResolvedValue([]);
+    const res = await GET(makeRequest("ws_1"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ connected: false, installations: [] });
+  });
+
+  it("returns connected:true with installations", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    requireMembershipMock.mockResolvedValue({ membership: { workspaceId: "ws_1" } });
+    findManyMock.mockResolvedValue([
+      { installationId: "1", accountLogin: "acme", createTime: new Date() },
+      { installationId: "2", accountLogin: "acme-labs", createTime: new Date() },
+    ]);
+    const res = await GET(makeRequest("ws_1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.connected).toBe(true);
+    expect(body.installations).toEqual([
+      { installationId: "1", accountLogin: "acme" },
+      { installationId: "2", accountLogin: "acme-labs" },
+    ]);
+  });
+
+  it("scopes findMany to the requested workspace", async () => {
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    requireMembershipMock.mockResolvedValue({ membership: { workspaceId: "ws_42" } });
+    findManyMock.mockResolvedValue([]);
+    await GET(makeRequest("ws_42"));
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { workspaceId: "ws_42" } }),
+    );
+  });
+});

--- a/frontend/ui/src/app/api/github/status/route.ts
+++ b/frontend/ui/src/app/api/github/status/route.ts
@@ -1,25 +1,38 @@
+import { NextRequest } from "next/server";
 import { prisma } from "@traceroot/core";
-import { requireAuth, successResponse } from "@/lib/auth-helpers";
+import {
+  errorResponse,
+  requireAuth,
+  requireWorkspaceMembership,
+  successResponse,
+} from "@/lib/auth-helpers";
 
-// GET /api/github/status - Check GitHub connection status for current user
-// Only returns connected:true if both OAuth AND app installation are complete
-export async function GET() {
+// GET /api/github/status?workspaceId=...
+// Returns the workspace's GitHub App installations.
+export async function GET(request: NextRequest) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
   const { user } = authResult;
 
-  const connection = await prisma.gitHubConnection.findUnique({
-    where: { userId: user.id },
-    select: { githubUsername: true, installationId: true },
-  });
-
-  if (!connection) {
-    return successResponse({ connected: false });
+  const workspaceId = request.nextUrl.searchParams.get("workspaceId");
+  if (!workspaceId) {
+    return errorResponse("workspaceId required", 400);
   }
 
+  const memberCheck = await requireWorkspaceMembership(user.id, workspaceId);
+  if (memberCheck.error) return memberCheck.error;
+
+  const installations = await prisma.gitHubInstallation.findMany({
+    where: { workspaceId },
+    orderBy: { createTime: "asc" },
+    select: { installationId: true, accountLogin: true, createTime: true },
+  });
+
   return successResponse({
-    connected: true,
-    username: connection.githubUsername,
-    installationId: connection.installationId,
+    connected: installations.length > 0,
+    installations: installations.map((i) => ({
+      installationId: i.installationId,
+      accountLogin: i.accountLogin,
+    })),
   });
 }

--- a/frontend/ui/src/app/api/github/token/route.test.ts
+++ b/frontend/ui/src/app/api/github/token/route.test.ts
@@ -176,7 +176,7 @@ describe("GET /api/github/token", () => {
       expect((await res.json()).installation_id).toBe("1");
     });
 
-    it("falls back to the first install when repo owner doesn't match any", async () => {
+    it("returns 404 when repo owner doesn't match any installation", async () => {
       findManyMock.mockResolvedValue([
         { installationId: "1", accountLogin: "acme" },
         { installationId: "2", accountLogin: "other" },
@@ -188,8 +188,7 @@ describe("GET /api/github/token", () => {
           repo: "stranger/api",
         }),
       );
-      expect(res.status).toBe(200);
-      expect((await res.json()).installation_id).toBe("1");
+      expect(res.status).toBe(404);
     });
   });
 

--- a/frontend/ui/src/app/api/github/token/route.test.ts
+++ b/frontend/ui/src/app/api/github/token/route.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/env", () => ({
+  env: {
+    GITHUB_APP_ID: "123456",
+    GITHUB_APP_PRIVATE_KEY: "fake-key",
+    INTERNAL_API_SECRET: "test-secret",
+  },
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn((data, init) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    })),
+  },
+}));
+
+const findManyMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    gitHubInstallation: {
+      findMany: (...args: unknown[]) => findManyMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireMembershipMock = vi.fn();
+const verifyInternalSecretMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireWorkspaceMembership: (...args: unknown[]) => requireMembershipMock(...args),
+  verifyInternalSecret: (...args: unknown[]) => verifyInternalSecretMock(...args),
+}));
+
+const getInstallationTokenMock = vi.fn();
+vi.mock("@traceroot/github", () => ({
+  getInstallationToken: (...args: unknown[]) => getInstallationTokenMock(...args),
+}));
+
+import { GET } from "./route";
+
+interface RequestInit {
+  workspaceIdHeader?: string | null;
+  internalSecret?: boolean;
+  workspaceIdQuery?: string | null;
+  repo?: string | null;
+}
+
+function makeRequest({
+  workspaceIdHeader = null,
+  internalSecret = false,
+  workspaceIdQuery = null,
+  repo = null,
+}: RequestInit = {}) {
+  const headers: Record<string, string> = {};
+  if (workspaceIdHeader) headers["x-workspace-id"] = workspaceIdHeader;
+  if (internalSecret) headers["X-Internal-Secret"] = "test-secret";
+
+  const params = new URLSearchParams();
+  if (workspaceIdQuery) params.set("workspaceId", workspaceIdQuery);
+  if (repo) params.set("repo", repo);
+
+  return {
+    headers: { get: (k: string) => headers[k] ?? null },
+    nextUrl: { searchParams: params },
+  } as unknown as Parameters<typeof GET>[0];
+}
+
+beforeEach(() => {
+  findManyMock.mockReset();
+  requireAuthMock.mockReset();
+  requireMembershipMock.mockReset();
+  verifyInternalSecretMock.mockReset();
+  getInstallationTokenMock.mockReset();
+  getInstallationTokenMock.mockResolvedValue({
+    token: "ghs_x",
+    expires_at: "2030-01-01T00:00:00Z",
+  });
+});
+
+describe("GET /api/github/token", () => {
+  describe("auth", () => {
+    it("uses internal path when x-workspace-id header + valid secret", async () => {
+      verifyInternalSecretMock.mockReturnValue(true);
+      findManyMock.mockResolvedValue([{ installationId: "1", accountLogin: "acme" }]);
+      const res = await GET(makeRequest({ workspaceIdHeader: "ws_1", internalSecret: true }));
+      expect(res.status).toBe(200);
+      expect(requireAuthMock).not.toHaveBeenCalled();
+      expect(findManyMock).toHaveBeenCalledWith({ where: { workspaceId: "ws_1" } });
+    });
+
+    it("falls through to session auth when internal secret is missing/invalid", async () => {
+      verifyInternalSecretMock.mockReturnValue(false);
+      requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+      requireMembershipMock.mockResolvedValue({ membership: { workspaceId: "ws_1" } });
+      findManyMock.mockResolvedValue([{ installationId: "1", accountLogin: "acme" }]);
+      const res = await GET(makeRequest({ workspaceIdHeader: "ws_1", workspaceIdQuery: "ws_1" }));
+      expect(res.status).toBe(200);
+      expect(requireAuthMock).toHaveBeenCalled();
+    });
+
+    it("session path returns 401 when not authenticated", async () => {
+      requireAuthMock.mockResolvedValue({
+        error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+      });
+      const res = await GET(makeRequest({ workspaceIdQuery: "ws_1" }));
+      expect(res.status).toBe(401);
+    });
+
+    it("session path returns 400 without workspaceId query", async () => {
+      requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+      const res = await GET(makeRequest({}));
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: "workspaceId required" });
+    });
+
+    it("session path returns 403 when user is not a member", async () => {
+      requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+      requireMembershipMock.mockResolvedValue({
+        error: { status: 403, json: async () => ({ error: "Not a member of this workspace" }) },
+      });
+      const res = await GET(makeRequest({ workspaceIdQuery: "ws_1" }));
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("installation lookup", () => {
+    beforeEach(() => {
+      verifyInternalSecretMock.mockReturnValue(true);
+    });
+
+    it("returns 404 when workspace has no installations", async () => {
+      findManyMock.mockResolvedValue([]);
+      const res = await GET(makeRequest({ workspaceIdHeader: "ws_1", internalSecret: true }));
+      expect(res.status).toBe(404);
+    });
+
+    it("returns the only installation when no repo is specified", async () => {
+      findManyMock.mockResolvedValue([{ installationId: "1", accountLogin: "acme" }]);
+      const res = await GET(makeRequest({ workspaceIdHeader: "ws_1", internalSecret: true }));
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.installation_id).toBe("1");
+      expect(body.github_username).toBe("acme");
+      expect(body.token).toBe("ghs_x");
+    });
+
+    it("matches installation by repo owner when multiple installs exist", async () => {
+      findManyMock.mockResolvedValue([
+        { installationId: "1", accountLogin: "acme" },
+        { installationId: "2", accountLogin: "acme-labs" },
+        { installationId: "3", accountLogin: "personal" },
+      ]);
+      const res = await GET(
+        makeRequest({
+          workspaceIdHeader: "ws_1",
+          internalSecret: true,
+          repo: "acme-labs/api",
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.installation_id).toBe("2");
+      expect(body.github_username).toBe("acme-labs");
+    });
+
+    it("matches case-insensitively on owner", async () => {
+      findManyMock.mockResolvedValue([{ installationId: "1", accountLogin: "Acme" }]);
+      const res = await GET(
+        makeRequest({ workspaceIdHeader: "ws_1", internalSecret: true, repo: "ACME/api" }),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).installation_id).toBe("1");
+    });
+
+    it("falls back to the first install when repo owner doesn't match any", async () => {
+      findManyMock.mockResolvedValue([
+        { installationId: "1", accountLogin: "acme" },
+        { installationId: "2", accountLogin: "other" },
+      ]);
+      const res = await GET(
+        makeRequest({
+          workspaceIdHeader: "ws_1",
+          internalSecret: true,
+          repo: "stranger/api",
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect((await res.json()).installation_id).toBe("1");
+    });
+  });
+
+  it("returns 500 when installation token minting fails", async () => {
+    verifyInternalSecretMock.mockReturnValue(true);
+    findManyMock.mockResolvedValue([{ installationId: "1", accountLogin: "acme" }]);
+    getInstallationTokenMock.mockRejectedValue(new Error("github 500"));
+    const res = await GET(makeRequest({ workspaceIdHeader: "ws_1", internalSecret: true }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/frontend/ui/src/app/api/github/token/route.ts
+++ b/frontend/ui/src/app/api/github/token/route.ts
@@ -40,13 +40,24 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: "No GitHub App installation found" }, { status: 404 });
     }
 
-    // If a repo is provided, prefer the installation whose accountLogin matches
-    // the repo owner. Otherwise fall back to the first installation.
+    // If a repo is provided, the install whose accountLogin matches the repo
+    // owner is the only valid one — silently falling back to the first install
+    // would mint a token for the wrong org in multi-installation workspaces.
+    // No repo provided → caller doesn't care which install (e.g. status check),
+    // so we hand back the first one.
     let chosen = installations[0];
     if (repo) {
       const repoOwner = repo.split("/")[0]?.toLowerCase();
-      const match = installations.find((i) => i.accountLogin.toLowerCase() === repoOwner);
-      if (match) chosen = match;
+      const match = repoOwner
+        ? installations.find((i) => i.accountLogin.toLowerCase() === repoOwner)
+        : undefined;
+      if (!match) {
+        return NextResponse.json(
+          { error: "No GitHub App installation found for repo owner" },
+          { status: 404 },
+        );
+      }
+      chosen = match;
     }
 
     const { token, expires_at } = await getInstallationToken(

--- a/frontend/ui/src/app/api/github/token/route.ts
+++ b/frontend/ui/src/app/api/github/token/route.ts
@@ -1,92 +1,64 @@
 import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 import { prisma } from "@traceroot/core";
-import { requireAuth, verifyInternalSecret } from "@/lib/auth-helpers";
+import { requireAuth, requireWorkspaceMembership, verifyInternalSecret } from "@/lib/auth-helpers";
 import { getInstallationToken } from "@traceroot/github";
 
 /**
- * Look up the correct GitHub App installation for a given repo owner.
- * Uses the user's OAuth token to query GET /user/installations and match
- * by account login. This handles personal, org, and multi-org installations.
+ * Issue a short-lived GitHub App installation access token for a workspace's
+ * GitHub install. Repo-scoped: ?repo=owner/name selects the matching installation
+ * (multi-org workspaces have multiple installations, one per org).
+ *
+ * Two auth paths:
+ *   - Internal (agent tools): X-Internal-Secret + x-workspace-id header.
+ *   - Browser/session: workspaceId query param + workspace membership.
  */
-async function findInstallationForRepo(
-  accessToken: string,
-  appId: string,
-  repoOwner: string,
-): Promise<string | null> {
-  const res = await fetch("https://api.github.com/user/installations", {
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      Accept: "application/vnd.github.v3+json",
-      "User-Agent": "TraceRoot",
-    },
-  });
-
-  if (!res.ok) return null;
-
-  const data = await res.json();
-  const installation = data.installations?.find(
-    (inst: { app_id: number; account: { login: string } }) =>
-      String(inst.app_id) === appId && inst.account.login.toLowerCase() === repoOwner.toLowerCase(),
-  );
-
-  return installation ? String(installation.id) : null;
-}
-
 export async function GET(request: NextRequest) {
   try {
-    // Support both session auth (browser) and internal x-user-id (agent service)
-    let userId: string;
-    const internalUserId = request.headers.get("x-user-id");
+    let workspaceId: string | undefined;
 
-    if (internalUserId && verifyInternalSecret(request)) {
-      userId = internalUserId;
+    const internalWorkspaceId = request.headers.get("x-workspace-id");
+    if (internalWorkspaceId && verifyInternalSecret(request)) {
+      workspaceId = internalWorkspaceId;
     } else {
       const authResult = await requireAuth();
       if (authResult.error) return authResult.error;
-      userId = authResult.user.id;
+      workspaceId = request.nextUrl.searchParams.get("workspaceId") || undefined;
+      if (!workspaceId) {
+        return NextResponse.json({ error: "workspaceId required" }, { status: 400 });
+      }
+      const memberCheck = await requireWorkspaceMembership(authResult.user.id, workspaceId);
+      if (memberCheck.error) return memberCheck.error;
     }
 
-    const connection = await prisma.gitHubConnection.findUnique({
-      where: { userId },
+    const repo = request.nextUrl.searchParams.get("repo");
+    const installations = await prisma.gitHubInstallation.findMany({
+      where: { workspaceId },
     });
 
-    if (!connection) {
-      return NextResponse.json({ error: "No GitHub connection found" }, { status: 404 });
-    }
-
-    // If a repo is specified, dynamically find the right installation
-    const repo = request.nextUrl.searchParams.get("repo");
-    let installationId = connection.installationId;
-
-    if (repo) {
-      const repoOwner = repo.split("/")[0];
-      if (repoOwner && connection.accessToken) {
-        const resolved = await findInstallationForRepo(
-          connection.accessToken,
-          env.GITHUB_APP_ID,
-          repoOwner,
-        );
-        if (resolved) {
-          installationId = resolved;
-        }
-      }
-    }
-
-    if (!installationId) {
+    if (installations.length === 0) {
       return NextResponse.json({ error: "No GitHub App installation found" }, { status: 404 });
     }
 
+    // If a repo is provided, prefer the installation whose accountLogin matches
+    // the repo owner. Otherwise fall back to the first installation.
+    let chosen = installations[0];
+    if (repo) {
+      const repoOwner = repo.split("/")[0]?.toLowerCase();
+      const match = installations.find((i) => i.accountLogin.toLowerCase() === repoOwner);
+      if (match) chosen = match;
+    }
+
     const { token, expires_at } = await getInstallationToken(
-      installationId,
+      chosen.installationId,
       env.GITHUB_APP_ID,
       env.GITHUB_APP_PRIVATE_KEY,
     );
 
     return NextResponse.json({
       token,
-      installation_id: installationId,
-      github_username: connection.githubUsername,
+      installation_id: chosen.installationId,
+      github_username: chosen.accountLogin,
       expires_at,
     });
   } catch (error) {

--- a/frontend/ui/src/components/github/GitHubConnectButton.tsx
+++ b/frontend/ui/src/components/github/GitHubConnectButton.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
 import { FaGithub } from "react-icons/fa";
 import { ChevronDown, ExternalLink, Unlink } from "lucide-react";
 import { fetchGitHubConnection } from "@/lib/github";
@@ -20,6 +21,7 @@ export function GitHubConnectButton({ workspaceId }: GitHubConnectButtonProps) {
 
   const { data: workspace } = useWorkspace(workspaceId);
   const canManage = workspace?.role === "ADMIN";
+  const pathname = usePathname();
 
   const { data, isLoading } = useQuery({
     queryKey: ["github-connection", workspaceId],
@@ -43,8 +45,10 @@ export function GitHubConnectButton({ workspaceId }: GitHubConnectButtonProps) {
     }
   };
 
+  // usePathname is consistent on server and client — using window.location here
+  // would create an SSR/CSR hydration mismatch in this client component.
   const buildHref = (path: string) =>
-    `${path}?workspaceId=${encodeURIComponent(workspaceId)}&returnTo=${encodeURIComponent(typeof window !== "undefined" ? window.location.pathname : "/")}`;
+    `${path}?workspaceId=${encodeURIComponent(workspaceId)}&returnTo=${encodeURIComponent(pathname || "/")}`;
 
   if (isLoading) {
     return (

--- a/frontend/ui/src/components/github/GitHubConnectButton.tsx
+++ b/frontend/ui/src/components/github/GitHubConnectButton.tsx
@@ -5,31 +5,46 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { FaGithub } from "react-icons/fa";
 import { ChevronDown, ExternalLink, Unlink } from "lucide-react";
 import { fetchGitHubConnection } from "@/lib/github";
+import { useWorkspace } from "@/features/workspaces/hooks";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
 
-export function GitHubConnectButton() {
+interface GitHubConnectButtonProps {
+  workspaceId: string;
+}
+
+export function GitHubConnectButton({ workspaceId }: GitHubConnectButtonProps) {
   const queryClient = useQueryClient();
   const [isDisconnecting, setIsDisconnecting] = useState(false);
   const [open, setOpen] = useState(false);
 
+  const { data: workspace } = useWorkspace(workspaceId);
+  const canManage = workspace?.role === "ADMIN";
+
   const { data, isLoading } = useQuery({
-    queryKey: ["github-connection"],
-    queryFn: fetchGitHubConnection,
+    queryKey: ["github-connection", workspaceId],
+    queryFn: () => fetchGitHubConnection(workspaceId),
+    enabled: !!workspaceId,
   });
 
   const handleDisconnect = async () => {
     setIsDisconnecting(true);
     try {
-      const res = await fetch("/api/github/disconnect", { method: "POST" });
+      const res = await fetch(
+        `/api/github/disconnect?workspaceId=${encodeURIComponent(workspaceId)}`,
+        { method: "POST" },
+      );
       if (res.ok) {
-        queryClient.invalidateQueries({ queryKey: ["github-connection"] });
+        queryClient.invalidateQueries({ queryKey: ["github-connection", workspaceId] });
         setOpen(false);
       }
     } finally {
       setIsDisconnecting(false);
     }
   };
+
+  const buildHref = (path: string) =>
+    `${path}?workspaceId=${encodeURIComponent(workspaceId)}&returnTo=${encodeURIComponent(typeof window !== "undefined" ? window.location.pathname : "/")}`;
 
   if (isLoading) {
     return (
@@ -46,6 +61,10 @@ export function GitHubConnectButton() {
   }
 
   if (data?.connected) {
+    const summary =
+      data.installations.length === 1
+        ? data.installations[0].accountLogin
+        : `${data.installations.length} installations`;
     return (
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -56,36 +75,38 @@ export function GitHubConnectButton() {
               Connect GitHub for repository linking and code-level tracing.
             </div>
             <div className="mt-1 text-sm text-muted-foreground">
-              Connected as <span className="font-medium text-foreground">{data.username}</span>
+              Connected to <span className="font-medium text-foreground">{summary}</span>
             </div>
           </div>
         </div>
 
-        <Popover open={open} onOpenChange={setOpen}>
-          <PopoverTrigger asChild>
-            <Button variant="outline" size="sm" className="gap-1">
-              Manage
-              <ChevronDown className="h-4 w-4" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent align="end" className="w-48 p-1">
-            <a
-              href={`/api/github/install?returnTo=${encodeURIComponent(window.location.pathname)}`}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent"
-            >
-              <ExternalLink className="h-4 w-4" />
-              Configure
-            </a>
-            <button
-              onClick={handleDisconnect}
-              disabled={isDisconnecting}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-destructive transition-colors hover:bg-accent disabled:opacity-50"
-            >
-              <Unlink className="h-4 w-4" />
-              {isDisconnecting ? "Disconnecting..." : "Disconnect"}
-            </button>
-          </PopoverContent>
-        </Popover>
+        {canManage && (
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm" className="gap-1">
+                Manage
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-48 p-1">
+              <a
+                href={buildHref("/api/github/install")}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent"
+              >
+                <ExternalLink className="h-4 w-4" />
+                Configure
+              </a>
+              <button
+                onClick={handleDisconnect}
+                disabled={isDisconnecting}
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-destructive transition-colors hover:bg-accent disabled:opacity-50"
+              >
+                <Unlink className="h-4 w-4" />
+                {isDisconnecting ? "Disconnecting..." : "Disconnect"}
+              </button>
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
     );
   }
@@ -97,18 +118,22 @@ export function GitHubConnectButton() {
         <div>
           <div className="text-sm font-medium">GitHub</div>
           <div className="text-sm text-muted-foreground">
-            Connect GitHub for repository linking and code-level tracing.
+            {canManage
+              ? "Connect GitHub for repository linking and code-level tracing."
+              : "GitHub is not connected. Ask a workspace admin to set it up."}
           </div>
         </div>
       </div>
 
-      <a
-        href={`/api/github/login?returnTo=${encodeURIComponent(window.location.pathname)}`}
-        className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-      >
-        Connect
-        <ExternalLink className="h-3 w-3" />
-      </a>
+      {canManage && (
+        <a
+          href={buildHref("/api/github/login")}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Connect
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      )}
     </div>
   );
 }

--- a/frontend/ui/src/components/github/GitHubStatus.tsx
+++ b/frontend/ui/src/components/github/GitHubStatus.tsx
@@ -4,20 +4,29 @@ import { useQuery } from "@tanstack/react-query";
 import { FaGithub } from "react-icons/fa";
 import { fetchGitHubConnection } from "@/lib/github";
 
-export function GitHubStatus() {
+interface GitHubStatusProps {
+  workspaceId: string;
+}
+
+export function GitHubStatus({ workspaceId }: GitHubStatusProps) {
   const { data, isLoading } = useQuery({
-    queryKey: ["github-connection"],
-    queryFn: fetchGitHubConnection,
+    queryKey: ["github-connection", workspaceId],
+    queryFn: () => fetchGitHubConnection(workspaceId),
+    enabled: !!workspaceId,
   });
 
   if (isLoading) return null;
   if (!data?.connected) return null;
 
+  const summary =
+    data.installations.length === 1
+      ? `@${data.installations[0].accountLogin}`
+      : `${data.installations.length} installations`;
+
   return (
     <div className="flex items-center gap-2 text-sm text-muted-foreground">
       <FaGithub className="h-4 w-4" />
-      <span>Connected as @{data.username}</span>
-      {data.installationId && <span className="text-green-600">&#8226; App installed</span>}
+      <span>Connected to {summary}</span>
     </div>
   );
 }

--- a/frontend/ui/src/features/settings/workspace/components/IntegrationsTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/IntegrationsTab.tsx
@@ -6,7 +6,7 @@ interface IntegrationsTabProps {
   workspaceId: string;
 }
 
-export function IntegrationsTab({ workspaceId: _workspaceId }: IntegrationsTabProps) {
+export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
   return (
     <div className="space-y-6">
       <div>
@@ -21,7 +21,7 @@ export function IntegrationsTab({ workspaceId: _workspaceId }: IntegrationsTabPr
           <h3 className="text-sm font-medium">Connected Services</h3>
         </div>
         <div className="px-4 py-3">
-          <GitHubConnectButton />
+          <GitHubConnectButton workspaceId={workspaceId} />
         </div>
       </div>
     </div>

--- a/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
@@ -5,6 +5,7 @@ import { Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { GitHubConnectButton } from "@/components/github/GitHubConnectButton";
+import { useProject } from "@/features/projects/hooks";
 import { ApiKeyBlock } from "./ApiKeyBlock";
 
 const INSTRUMENT_PROMPT = `I want to add observability to my project using TraceRoot.
@@ -117,6 +118,8 @@ interface AITabProps {
 }
 
 export function AITab({ projectId }: AITabProps) {
+  const { data: project } = useProject(projectId);
+  const workspaceId = project?.workspace_id ?? "";
   return (
     <div className="space-y-6">
       <div className="space-y-2">
@@ -165,7 +168,7 @@ export function AITab({ projectId }: AITabProps) {
             analysis.
           </p>
           <div className="mt-3">
-            <GitHubConnectButton />
+            <GitHubConnectButton workspaceId={workspaceId} />
           </div>
         </div>
       </div>

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { CopyButton } from "@/components/ui/copy-button";
 import { GitHubConnectButton } from "@/components/github/GitHubConnectButton";
+import { useProject } from "@/features/projects/hooks";
 import { ApiKeyBlock } from "./ApiKeyBlock";
 import { ALL_LANGS, INTEGRATIONS, type Lang } from "./integrations";
 
@@ -48,6 +49,8 @@ interface ManualTabProps {
 }
 
 export function ManualTab({ projectId }: ManualTabProps) {
+  const { data: project } = useProject(projectId);
+  const workspaceId = project?.workspace_id ?? "";
   const [selectedIntegrationId, setSelectedIntegrationId] = useState("openai");
   const [lang, setLang] = useState<Lang>("python");
 
@@ -147,7 +150,7 @@ export function ManualTab({ projectId }: ManualTabProps) {
             analysis.
           </p>
           <div className="mt-3">
-            <GitHubConnectButton />
+            <GitHubConnectButton workspaceId={workspaceId} />
           </div>
         </div>
       </div>

--- a/frontend/ui/src/lib/github.ts
+++ b/frontend/ui/src/lib/github.ts
@@ -1,13 +1,18 @@
 "use client";
 
-export interface GitHubConnectionStatus {
-  connected: boolean;
-  username?: string;
-  installationId?: string; // Present when connected is true
+export interface GitHubInstallation {
+  installationId: string;
+  accountLogin: string;
 }
 
-export async function fetchGitHubConnection(): Promise<GitHubConnectionStatus> {
-  const res = await fetch("/api/github/status");
-  if (!res.ok) return { connected: false };
+export interface GitHubConnectionStatus {
+  connected: boolean;
+  installations: GitHubInstallation[];
+}
+
+export async function fetchGitHubConnection(workspaceId: string): Promise<GitHubConnectionStatus> {
+  if (!workspaceId) return { connected: false, installations: [] };
+  const res = await fetch(`/api/github/status?workspaceId=${encodeURIComponent(workspaceId)}`);
+  if (!res.ok) return { connected: false, installations: [] };
   return res.json();
 }

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -28,7 +28,6 @@ async function runRcaSession(params: {
   traceId: string;
   findings: DetectorRcaJob["findings"];
   hasGitHub: boolean;
-  githubUserId?: string;
   rcaModel?: string | null;
 }): Promise<{ result: string; sessionId: string }> {
   const sessionRes = await fetch(
@@ -92,9 +91,6 @@ Output your findings in this format:
     "Content-Type": "application/json",
     "x-workspace-id": params.workspaceId,
   };
-  if (params.githubUserId) {
-    msgHeaders["x-user-id"] = params.githubUserId;
-  }
 
   const resolved = resolveSystemModel(params.rcaModel);
   const msgBody: {
@@ -201,14 +197,12 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
         });
         emailAddresses = project?.alertConfig?.emailAddresses ?? [];
 
-        // Find any workspace member with a GitHub connection for the GitHub tool.
-        // TODO (PR 2): replace with project-level GitHubConnection lookup.
-        const members = await prisma.workspaceMember.findMany({
+        // Workspace-level GitHub installations now drive the GitHub tool.
+        // Any installation in this workspace is enough to flip the tool on.
+        const ghCount = await prisma.gitHubInstallation.count({
           where: { workspaceId },
-          include: { user: { include: { githubConnection: true } } },
         });
-        const hasGitHub = members.some((m) => !!m.user.githubConnection);
-        const githubUserId = members.find((m) => !!m.user.githubConnection)?.userId;
+        const hasGitHub = ghCount > 0;
 
         const { result: rcaResult } = await runRcaSession({
           findingId,
@@ -217,7 +211,6 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
           traceId,
           findings,
           hasGitHub,
-          githubUserId,
           rcaModel: project?.rcaModel,
         });
 


### PR DESCRIPTION
Closes #828.

## Summary

Moves the GitHub App connection record from per-user (`GitHubConnection`, keyed by `userId`) to per-workspace (`GitHubInstallation`, keyed by `workspaceId`). Any member of a workspace can now use the GitHub-backed AI features as long as someone has connected the App — no per-teammate OAuth/install required.

## Migration

Drops `github_connections` and creates `github_installations` (`20260503000000_github_installations`). **Breaking**: existing users see "Connect" again and reconnect. The GitHub App installations on github.com are unaffected — re-OAuth discovers them and writes the new row. `accessToken` is no longer stored; installation tokens are minted on demand from the App private key.

## Auth model

| Action | VIEWER | MEMBER | ADMIN |
|---|---|---|---|
| See status (`/api/github/status`) | ✓ | ✓ | ✓ |
| Use via agent (`/api/github/token`) | ✓ | ✓ | ✓ |
| Connect / Configure / Disconnect | ✗ | ✗ | ✓ |

UI mirrors this — Manage popover and Connect button hidden from non-admins.

## Multi-org

Multiple installations per workspace allowed (`@@unique([workspaceId, installationId])`). Token route matches install by repo owner against `accountLogin`. Single-org workspaces work without any matching — there's only one row.

## Test plan

- [x] Single user reconnect flow
- [x] User B (different login, no GitHub presence) uses agent in workspace where User A connected — works
- [x] Detector RCA path uses the workspace install correctly
- [x] Non-ADMIN sees status only, no Manage/Connect buttons
- [x] 32 unit tests pass (`callback`, `status`, `disconnect`, `token` routes)

## Deploy

Helm pre-upgrade hook runs `prisma migrate deploy` automatically. `pg_dump` first as cheap insurance. Existing GitHub-connected users will see "Connect" once and reconnect — no app data lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the GitHub App integration to the workspace. Admins connect once per workspace; any member can use GitHub-backed features. Agent/worker tools now scope tokens to the session’s workspace.

- **New Features**
  - Workspace-scoped `github_installations` replaces per-user connections; multi‑org supported; no stored user tokens (installation tokens minted from the App key).
  - API updates: `/api/github/login` and `/api/github/install` require ADMIN; `install` reads `workspaceId` from query or `github_workspace_id` cookie; `install-callback` requires the `github_workspace_id` cookie and ADMIN before upserting; `callback` enforces ADMIN when persisting and only redirects “connected” after upsert; `status` lists all installs by workspace; `token` supports internal `X-Internal-Secret` + `x-workspace-id` or session + `workspaceId`, matches by repo owner when provided, returns 404 if no match; `disconnect` removes all installs when `installationId` is omitted, or just one when provided; `?installationId=` (empty) is a no‑op.
  - Agent/worker: agent uses the session’s `workspaceId` for tools and `getOrCreateAgent`; tools send `x-workspace-id`; RCA checks workspace installs, not user connections.
  - UI: `GitHubConnectButton`/`GitHubStatus` take `workspaceId`; Connect/Manage hidden for non-admins; fixed hydration mismatch by using `usePathname` for `returnTo`.

- **Migration**
  - Drops `github_connections`; adds `github_installations`. Existing users will see “Connect” once; GitHub-side installs are reused.
  - Run Prisma migrate. Ensure `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` are set.

<sup>Written for commit 1180302e1f471df316d141fca6860b1d126d1d50. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

