### PR TITLE
docs(env): show stripe listen command for local webhook testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,7 @@ ENABLE_BILLING=false
 
 # --- Stripe Billing -----------------------------------------------------------
 STRIPE_SECRET_KEY=sk_test_xxx  # CHANGEME - from Stripe Dashboard > Developers > API keys
+# For local dev: run `stripe listen --forward-to localhost:3000/api/billing/webhook` and copy the printed whsec_ value here
 STRIPE_WEBHOOK_SIGNING_SECRET=whsec_xxx  # CHANGEME - from Stripe CLI or Dashboard > Webhooks
 STRIPE_PRICE_ID_STARTER=price_xxx  # CHANGEME - from Stripe Dashboard > Products > Prices
 STRIPE_PRICE_ID_PRO=price_xxx  # CHANGEME


### PR DESCRIPTION
## Summary
- Adds a one-line comment above `STRIPE_WEBHOOK_SIGNING_SECRET` in `.env.example` with the exact `stripe listen --forward-to localhost:3000/api/billing/webhook` command, so new devs setting up billing locally know how to obtain the signing secret without leaving the file.
- Webhook path verified against `frontend/ui/src/app/api/billing/webhook/route.ts`.

Closes #832

## Test plan
- [ ] Open `.env.example` and confirm the comment is correctly placed above `STRIPE_WEBHOOK_SIGNING_SECRET`.
- [ ] Run `stripe listen --forward-to localhost:3000/api/billing/webhook` locally and confirm a `whsec_` value is printed (sanity check that the documented command works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a comment to `.env.example` showing the exact Stripe CLI command to obtain a local webhook signing secret, so devs can copy the `whsec_` value without leaving the file. Uses `stripe listen --forward-to localhost:3000/api/billing/webhook` (path matches our API route) and addresses #832.

<sup>Written for commit 07e89d0f9ed43afb264ee30005d0b77860a05189. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

