### PR TITLE
fix(docker): add DATABASE_URL to worker service in prod compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -220,6 +220,7 @@ services:
     environment:
       TZ: UTC
       # --- Internal Docker networking (fixed) ---
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
       CLICKHOUSE_HOST: clickhouse
       CLICKHOUSE_PORT: "8123"
       CLICKHOUSE_NATIVE_PORT: "9000"


### PR DESCRIPTION
Fixes #835

## Summary

Adds missing `DATABASE_URL` environment variable to the `worker` service in `docker-compose.prod.yml`. Without it, the worker cannot connect to PostgreSQL for model pricing lookups, causing all trace costs to display as "-".

## Type of Change

- [x] fix - A bug fix

## Details

The worker service uses `DATABASE_URL` to query the `standard_models` and `standard_model_prices` tables in PostgreSQL for LLM cost calculation. This variable was already present in `rest`, `web`, `billing`, and `agent` services but missing from `worker`.

## Screenshots / Recordings (if applicable)

N/A — config-only change.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `DATABASE_URL` to the `worker` service in `docker-compose.prod.yml` so the worker can connect to PostgreSQL and calculate model pricing. This fixes trace costs showing "-" when the worker couldn’t fetch prices.

<sup>Written for commit ecdacad85c9aa5278a8fb2e222a1d0b3ebb9ece0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

