### PR TITLE
feat(slack): workspace-level Slack integration for detector alerts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,18 @@ GITHUB_APP_CLIENT_ID=               # From GitHub App settings > General > Clien
 GITHUB_APP_CLIENT_SECRET=           # From GitHub App settings > General > Client secrets
 GITHUB_OAUTH_REDIRECT_URI=http://localhost:3000/api/github/callback
 
+# --- Slack App ---------------------------------------------------------------
+# Create at https://api.slack.com/apps → "Create New App" → "From scratch".
+# Configure:
+#   - OAuth & Permissions → Bot Token Scopes:
+#       chat:write, chat:write.public, channels:read, groups:read
+#   - OAuth & Permissions → Redirect URLs: paste SLACK_REDIRECT_URI below
+# Then read values from "Basic Information" → "App Credentials".
+SLACK_CLIENT_ID=                    # Basic Information > App Credentials > Client ID
+SLACK_CLIENT_SECRET=                # Basic Information > App Credentials > Client Secret
+SLACK_STATE_SECRET=                 # Generate locally: `openssl rand -hex 32`
+SLACK_REDIRECT_URI=http://localhost:3000/api/slack/oauth/callback
+
 # --- Encryption (BYOK) --------------------------------------------------------
 # 64-character hex string (256 bits) for AES-256-GCM encryption of BYOK keys.
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,6 +77,8 @@ jobs:
             dockerfile: docker/Dockerfile.worker
           - service: billing
             dockerfile: docker/Dockerfile.billing
+          - service: detector
+            dockerfile: docker/Dockerfile.detector
           - service: agent
             dockerfile: docker/Dockerfile.agent
           - service: migrate-clickhouse

--- a/docker/Dockerfile.billing
+++ b/docker/Dockerfile.billing
@@ -10,6 +10,7 @@ COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml 
 COPY frontend/.npmrc ./.npmrc
 COPY frontend/worker/package.json ./worker/package.json
 COPY frontend/packages/core/package.json ./packages/core/package.json
+COPY frontend/packages/slack/package.json ./packages/slack/package.json
 
 RUN pnpm install --frozen-lockfile
 
@@ -19,8 +20,10 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/worker/node_modules ./worker/node_modules
 COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
+COPY --from=deps /app/packages/slack/node_modules ./packages/slack/node_modules
 
 COPY frontend/packages/core ./packages/core
+COPY frontend/packages/slack ./packages/slack
 COPY frontend/worker ./worker
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./
 
@@ -32,6 +35,12 @@ RUN cd packages/core && npx prisma generate \
 # Build core for Node.js (patch tsconfig to produce CJS, patch package.json exports)
 RUN cd packages/core && \
     node -e "const t=JSON.parse(require('fs').readFileSync('tsconfig.json','utf8')); t.compilerOptions.module='CommonJS'; t.compilerOptions.moduleResolution='node'; require('fs').writeFileSync('tsconfig.json',JSON.stringify(t,null,2))" && \
+    pnpm build && \
+    node -e "const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{'types':'./dist/index.d.ts','default':'./dist/index.js'}}; require('fs').writeFileSync('package.json',JSON.stringify(p,null,2))"
+# Build slack package — keeps NodeNext moduleResolution so it can resolve
+# @traceroot/core via exports.types; patches package.json to point at dist/
+# so the worker's require() resolves to compiled JS at runtime.
+RUN cd packages/slack && \
     pnpm build && \
     node -e "const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{'types':'./dist/index.d.ts','default':'./dist/index.js'}}; require('fs').writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN cd worker && pnpm build
@@ -49,6 +58,10 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages/core/dist ./packages/core/dist
 COPY --from=builder /app/packages/core/package.json ./packages/core/package.json
 COPY --from=builder /app/packages/core/node_modules ./packages/core/node_modules
+# Copy compiled slack package
+COPY --from=builder /app/packages/slack/dist ./packages/slack/dist
+COPY --from=builder /app/packages/slack/package.json ./packages/slack/package.json
+COPY --from=builder /app/packages/slack/node_modules ./packages/slack/node_modules
 # Copy compiled worker
 COPY --from=builder /app/worker/dist ./worker/dist
 COPY --from=builder /app/worker/package.json ./worker/package.json

--- a/docker/Dockerfile.detector
+++ b/docker/Dockerfile.detector
@@ -10,6 +10,7 @@ COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml 
 COPY frontend/.npmrc ./.npmrc
 COPY frontend/worker/package.json ./worker/package.json
 COPY frontend/packages/core/package.json ./packages/core/package.json
+COPY frontend/packages/slack/package.json ./packages/slack/package.json
 
 RUN pnpm install --frozen-lockfile
 
@@ -19,8 +20,10 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/worker/node_modules ./worker/node_modules
 COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
+COPY --from=deps /app/packages/slack/node_modules ./packages/slack/node_modules
 
 COPY frontend/packages/core ./packages/core
+COPY frontend/packages/slack ./packages/slack
 COPY frontend/worker ./worker
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./
 
@@ -32,6 +35,12 @@ RUN cd packages/core && npx prisma generate \
 # Build core for Node.js (patch tsconfig to produce CJS, patch package.json exports)
 RUN cd packages/core && \
     node -e "const t=JSON.parse(require('fs').readFileSync('tsconfig.json','utf8')); t.compilerOptions.module='CommonJS'; t.compilerOptions.moduleResolution='node'; require('fs').writeFileSync('tsconfig.json',JSON.stringify(t,null,2))" && \
+    pnpm build && \
+    node -e "const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{'types':'./dist/index.d.ts','default':'./dist/index.js'}}; require('fs').writeFileSync('package.json',JSON.stringify(p,null,2))"
+# Build slack package — keeps NodeNext moduleResolution so it can resolve
+# @traceroot/core via exports.types; patches package.json to point at dist/
+# so the worker's require() resolves to compiled JS at runtime.
+RUN cd packages/slack && \
     pnpm build && \
     node -e "const p=JSON.parse(require('fs').readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{'types':'./dist/index.d.ts','default':'./dist/index.js'}}; require('fs').writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN cd worker && pnpm build
@@ -49,6 +58,10 @@ COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages/core/dist ./packages/core/dist
 COPY --from=builder /app/packages/core/package.json ./packages/core/package.json
 COPY --from=builder /app/packages/core/node_modules ./packages/core/node_modules
+# Copy compiled slack package
+COPY --from=builder /app/packages/slack/dist ./packages/slack/dist
+COPY --from=builder /app/packages/slack/package.json ./packages/slack/package.json
+COPY --from=builder /app/packages/slack/node_modules ./packages/slack/node_modules
 # Copy compiled worker
 COPY --from=builder /app/worker/dist ./worker/dist
 COPY --from=builder /app/worker/package.json ./worker/package.json

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -15,6 +15,7 @@ COPY frontend/.npmrc ./.npmrc
 COPY frontend/ui/package.json ./ui/package.json
 COPY frontend/packages/core/package.json ./packages/core/package.json
 COPY frontend/packages/github/package.json ./packages/github/package.json
+COPY frontend/packages/slack/package.json ./packages/slack/package.json
 
 # Install all dependencies
 RUN pnpm install --frozen-lockfile
@@ -28,21 +29,26 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/ui/node_modules ./ui/node_modules
 COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
 COPY --from=deps /app/packages/github/node_modules ./packages/github/node_modules
+COPY --from=deps /app/packages/slack/node_modules ./packages/slack/node_modules
 
 # Copy source code
 COPY frontend/packages/core ./packages/core
 COPY frontend/packages/github ./packages/github
+COPY frontend/packages/slack ./packages/slack
 COPY frontend/ui ./ui
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./
 
-# Build workspace packages that export compiled dist/
-RUN cd packages/github && pnpm build
-
-# Generate Prisma client and stash engine binary for the runner stage
-# (pnpm symlinks break Next.js standalone output file tracing)
+# Generate Prisma client first — slack imports from @traceroot/core, whose
+# types reference @prisma/client. Without the generated client, tsc on
+# slack would fail to resolve those types.
+# (pnpm symlinks break Next.js standalone output file tracing, hence the stash.)
 RUN cd packages/core && npx prisma generate \
     && mkdir -p /tmp/prisma-engines/.prisma \
     && cp -rL /app/node_modules/.pnpm/@prisma+client*/node_modules/.prisma/client /tmp/prisma-engines/.prisma/client
+
+# Build workspace packages that export compiled dist/
+RUN cd packages/github && pnpm build
+RUN cd packages/slack && pnpm build
 
 # Build the Next.js app
 # better-auth validates BETTER_AUTH_SECRET at startup; pass a placeholder at

--- a/frontend/packages/core/prisma/migrations/20260504201642_add_slack_integration/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260504201642_add_slack_integration/migration.sql
@@ -1,0 +1,26 @@
+-- AlterTable
+ALTER TABLE "detector_alert_configs" ADD COLUMN     "slack_channel_id" VARCHAR,
+ADD COLUMN     "slack_channel_name" VARCHAR;
+
+-- CreateTable
+CREATE TABLE "slack_integrations" (
+    "id" VARCHAR NOT NULL,
+    "workspace_id" VARCHAR NOT NULL,
+    "team_id" VARCHAR NOT NULL,
+    "team_name" VARCHAR NOT NULL,
+    "bot_user_id" VARCHAR NOT NULL,
+    "bot_token" TEXT NOT NULL,
+    "channel_id" VARCHAR,
+    "channel_name" VARCHAR,
+    "connected_by_user_id" VARCHAR,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "slack_integrations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "slack_integrations_workspace_id_key" ON "slack_integrations"("workspace_id");
+
+-- AddForeignKey
+ALTER TABLE "slack_integrations" ADD CONSTRAINT "slack_integrations_workspace_id_fkey" FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -85,6 +85,7 @@ model Workspace {
 
   modelProviders ModelProvider[]
   githubInstallations GitHubInstallation[]
+  slackIntegration SlackIntegration?
 
   @@index([billingCustomerId])
   @@index([billingSubscriptionId])
@@ -235,6 +236,30 @@ model GitHubInstallation {
   @@map("github_installations")
 }
 
+// Workspace-level Slack OAuth integration.
+// One row per workspace (UNIQUE on workspaceId). The chosen channel is
+// inlined here for v1; per-project overrides live on DetectorAlertConfig.
+model SlackIntegration {
+  id          String    @id @default(cuid()) @db.VarChar
+  workspaceId String    @unique @map("workspace_id") @db.VarChar
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  teamId    String @map("team_id")     @db.VarChar
+  teamName  String @map("team_name")   @db.VarChar
+  botUserId String @map("bot_user_id") @db.VarChar
+  botToken  String @map("bot_token")   @db.Text
+
+  channelId   String? @map("channel_id")   @db.VarChar
+  channelName String? @map("channel_name") @db.VarChar
+
+  connectedByUserId String? @map("connected_by_user_id") @db.VarChar
+
+  createTime DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime DateTime @updatedAt      @map("update_time") @db.Timestamp(6)
+
+  @@map("slack_integrations")
+}
+
 // AI Sessions - Conversation sessions for the AI debugging assistant
 model AISession {
   id          String      @id @default(cuid()) @db.VarChar
@@ -342,6 +367,11 @@ model DetectorAlertConfig {
   id             String   @id @default(cuid()) @db.VarChar
   projectId      String   @unique @map("project_id") @db.VarChar
   emailAddresses String[] @default([]) @map("email_addresses")
+
+  // Per-project Slack channel override (no UI in v1).
+  // When set, takes precedence over SlackIntegration.channelId.
+  slackChannelId   String? @map("slack_channel_id")   @db.VarChar
+  slackChannelName String? @map("slack_channel_name") @db.VarChar
 
   project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 

--- a/frontend/packages/slack/README.md
+++ b/frontend/packages/slack/README.md
@@ -1,0 +1,55 @@
+# @traceroot/slack
+
+Workspace-level Slack integration for TraceRoot — OAuth installer, encrypted bot-token store, Block Kit alert builder, and a `WebClient` factory shared between the web app (route handlers) and worker (alert delivery).
+
+## Local development setup
+
+Local dev runs over plain HTTP. Slack auto-installs into your currently-active Slack workspace; if you're signed into multiple workspaces and Slack picks the wrong one, see "Installing into the right workspace" below.
+
+### 1. Create your own dev Slack app
+
+You'll create a per-developer Slack app for local testing.
+
+1. Go to https://api.slack.com/apps → **Create New App** → **From scratch**
+2. App name: `traceroot dev` (or anything; just keep it distinct from anyone else's)
+3. Pick a Slack workspace where you're an admin
+4. **OAuth & Permissions** → **Scopes** → **Bot Token Scopes** → add all four:
+   - `chat:write`
+   - `chat:write.public`
+   - `channels:read`
+   - `groups:read`
+5. **OAuth & Permissions** → **Redirect URLs** → add:
+   - `http://localhost:3000/api/slack/oauth/callback`
+
+### 2. Populate `.env`
+
+In the repo root `.env`:
+
+```bash
+SLACK_CLIENT_ID=...               # Slack app → Basic Information → App Credentials → Client ID
+SLACK_CLIENT_SECRET=...           # Same place → Client Secret
+SLACK_STATE_SECRET=...            # Generate: `openssl rand -hex 32`
+SLACK_REDIRECT_URI=http://localhost:3000/api/slack/oauth/callback
+```
+
+### 3. Installing into the right workspace
+
+When you click **Connect** under Slack on the workspace integrations page, Slack auto-installs into your **currently-active** Slack workspace (whichever one your browser is on). To install into a specific workspace:
+
+1. Open https://app.slack.com in another tab (incognito works well to isolate sessions)
+2. Click the workspace icon in the left rail for the workspace you want to install into
+3. Once that workspace is your active one, return to the integrations page and click **Connect**
+
+If you accidentally land on the wrong workspace's OAuth page (e.g., one where you're not admin and Slack returns "You are not authorized to install"), repeat with the correct active workspace.
+
+### Private channels: invite the bot
+
+The `groups:read` scope only returns **private channels the bot is a member of**. Public channels are visible regardless of membership; private ones must explicitly add the bot.
+
+To make a private channel selectable, open it in Slack and run:
+
+```
+/invite @traceroot dev
+```
+
+Close + reopen the Configure popover to pick up the new channel (or wait ~5 min for the cache to expire).

--- a/frontend/packages/slack/package.json
+++ b/frontend/packages/slack/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@traceroot/slack",
+  "version": "0.0.1",
+  "private": true,
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@slack/oauth": "^3.0.1",
+    "@slack/web-api": "^7.8.0",
+    "@traceroot/core": "workspace:*",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.9",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/frontend/packages/slack/src/__tests__/block-kit.test.ts
+++ b/frontend/packages/slack/src/__tests__/block-kit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { buildCombinedAlertBlocks } from "../block-kit";
+
+const base = {
+  detectorName: "Hallucination",
+  projectName: "billing-agent",
+  summary: "Agent invented a refund policy.",
+  traceId: "abcdef1234567890",
+  projectId: "proj_1",
+  appBaseUrl: "https://app.traceroot.ai",
+  rcaResult: "The agent did not have policy context.",
+};
+
+describe("buildCombinedAlertBlocks", () => {
+  it("includes header, summary, RCA, and View trace button", () => {
+    const blocks = buildCombinedAlertBlocks(base);
+    const header = blocks.find((b: any) => b.type === "header");
+    expect(header?.text.text).toContain("Hallucination");
+    const text = JSON.stringify(blocks);
+    expect(text).toContain("billing-agent");
+    expect(text).toContain("Agent invented a refund policy.");
+    expect(text).toContain("The agent did not have policy context.");
+    expect(text).toContain(
+      "https://app.traceroot.ai/projects/proj_1/traces?traceId=abcdef1234567890",
+    );
+  });
+
+  it("falls back to a placeholder when rcaResult is null", () => {
+    const blocks = buildCombinedAlertBlocks({ ...base, rcaResult: null });
+    expect(JSON.stringify(blocks)).toContain("Root cause analysis did not complete");
+  });
+
+  it("escapes mrkdwn injection in summary", () => {
+    const blocks = buildCombinedAlertBlocks({ ...base, summary: "Pinged <!channel> & friends" });
+    const text = JSON.stringify(blocks);
+    expect(text).toContain("&lt;!channel&gt;");
+    expect(text).toContain("&amp;");
+    expect(text).not.toContain("<!channel>");
+  });
+
+  it("rewrites markdown links to Slack syntax", () => {
+    const blocks = buildCombinedAlertBlocks({
+      ...base,
+      summary: "See [the docs](https://docs.example.com/x) for context",
+    });
+    expect(JSON.stringify(blocks)).toContain("<https://docs.example.com/x|the docs>");
+  });
+
+  it("truncates section text longer than 3000 chars", () => {
+    const long = "x".repeat(3500);
+    const blocks = buildCombinedAlertBlocks({ ...base, summary: long });
+    const sections = blocks.filter((b: any) => b.type === "section");
+    for (const s of sections) {
+      expect(s.text.text.length).toBeLessThanOrEqual(3000);
+    }
+  });
+});

--- a/frontend/packages/slack/src/__tests__/installer.test.ts
+++ b/frontend/packages/slack/src/__tests__/installer.test.ts
@@ -1,0 +1,73 @@
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted to the top of the file; using vi.hoisted ensures the
+// mock fns are initialized before the factory closure runs.
+const { upsert, findFirst, deleteMany } = vi.hoisted(() => ({
+  upsert: vi.fn(),
+  findFirst: vi.fn(),
+  deleteMany: vi.fn(),
+}));
+
+// @traceroot/core uses a single barrel export — prisma, encryptKey, decryptKey all come from "@traceroot/core".
+vi.mock("@traceroot/core", () => ({
+  prisma: { slackIntegration: { upsert, findFirst, deleteMany } },
+  encryptKey: (s: string) => `enc(${s})`,
+  decryptKey: (s: string) => s.replace(/^enc\(/, "").replace(/\)$/, ""),
+}));
+
+process.env.SLACK_CLIENT_ID = "test";
+process.env.SLACK_CLIENT_SECRET = "test";
+process.env.SLACK_STATE_SECRET = "test";
+
+describe("installationStore", () => {
+  beforeEach(() => {
+    upsert.mockReset();
+    findFirst.mockReset();
+    deleteMany.mockReset();
+  });
+
+  afterAll(() => {
+    delete process.env.SLACK_CLIENT_ID;
+    delete process.env.SLACK_CLIENT_SECRET;
+    delete process.env.SLACK_STATE_SECRET;
+  });
+
+  it("storeInstallation encrypts the bot token and upserts the row", async () => {
+    const { installationStore } = await import("../installer");
+    upsert.mockResolvedValue({});
+    await installationStore.storeInstallation({
+      team: { id: "T1", name: "Acme" },
+      bot: { token: "xoxb-secret", userId: "U1" },
+      metadata: JSON.stringify({ workspaceId: "ws_1", connectedByUserId: "u_1" }),
+    } as any);
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const arg = upsert.mock.calls[0][0];
+    expect(arg.where).toEqual({ workspaceId: "ws_1" });
+    expect(arg.create.botToken).toBe("enc(xoxb-secret)");
+    expect(arg.create.connectedByUserId).toBe("u_1");
+    expect(arg.create.teamId).toBe("T1");
+    expect(arg.create.teamName).toBe("Acme");
+    expect(arg.update.botToken).toBe("enc(xoxb-secret)");
+  });
+
+  it("fetchInstallation decrypts the token and returns Installation shape", async () => {
+    const { installationStore } = await import("../installer");
+    findFirst.mockResolvedValue({
+      teamId: "T1",
+      teamName: "Acme",
+      botUserId: "U1",
+      botToken: "enc(xoxb-secret)",
+    });
+    const inst = await installationStore.fetchInstallation({ teamId: "T1" } as any);
+    expect((inst as any).team.id).toBe("T1");
+    expect((inst as any).bot.token).toBe("xoxb-secret");
+  });
+
+  it("deleteInstallation removes rows for the team", async () => {
+    const { installationStore } = await import("../installer");
+    deleteMany.mockResolvedValue({ count: 1 });
+    await installationStore.deleteInstallation!({ teamId: "T1" } as any);
+    expect(deleteMany).toHaveBeenCalledWith({ where: { teamId: "T1" } });
+  });
+});

--- a/frontend/packages/slack/src/__tests__/oauth-response.test.ts
+++ b/frontend/packages/slack/src/__tests__/oauth-response.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { SlackOAuthResponseSchema } from "../oauth-response";
+
+describe("SlackOAuthResponseSchema", () => {
+  it("parses a successful oauth.v2.access response", () => {
+    const result = SlackOAuthResponseSchema.parse({
+      ok: true,
+      access_token: "xoxb-1234",
+      token_type: "bot",
+      bot_user_id: "U123",
+      team: { id: "T123", name: "Acme" },
+    });
+    expect(result.access_token).toBe("xoxb-1234");
+    expect(result.team.name).toBe("Acme");
+  });
+
+  it("rejects responses with ok:false", () => {
+    expect(() => SlackOAuthResponseSchema.parse({ ok: false, error: "invalid_code" })).toThrow();
+  });
+
+  it("rejects token_type other than bot", () => {
+    expect(() =>
+      SlackOAuthResponseSchema.parse({
+        ok: true,
+        access_token: "xoxb-1",
+        token_type: "user",
+        bot_user_id: "U1",
+        team: { id: "T1", name: "x" },
+      }),
+    ).toThrow();
+  });
+});

--- a/frontend/packages/slack/src/block-kit.ts
+++ b/frontend/packages/slack/src/block-kit.ts
@@ -1,0 +1,62 @@
+const SECTION_LIMIT = 3000;
+
+function escapeMrkdwn(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function mdLinksToSlack(text: string): string {
+  return text.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "<$2|$1>");
+}
+
+function truncate(text: string, max = SECTION_LIMIT): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + "…";
+}
+
+function mrkdwnSection(raw: string) {
+  const formatted = truncate(mdLinksToSlack(escapeMrkdwn(raw)));
+  return { type: "section", text: { type: "mrkdwn", text: formatted } };
+}
+
+export interface CombinedAlertParams {
+  detectorName: string;
+  projectName: string;
+  summary: string;
+  traceId: string;
+  projectId: string;
+  appBaseUrl: string;
+  rcaResult: string | null;
+}
+
+export function buildCombinedAlertBlocks(params: CombinedAlertParams): unknown[] {
+  const traceUrl = `${params.appBaseUrl}/projects/${encodeURIComponent(params.projectId)}/traces?traceId=${encodeURIComponent(params.traceId)}`;
+  const shortTrace = params.traceId.slice(0, 8);
+
+  const headerText = truncate(`${params.detectorName} fired`, 150);
+  const projectLine = `*Project:* \`${params.projectName}\`  ·  *Trace:* \`${shortTrace}\``;
+
+  const rcaSection = params.rcaResult
+    ? mrkdwnSection(`*Root cause analysis*\n${params.rcaResult}`)
+    : {
+        type: "section",
+        text: { type: "mrkdwn", text: "_Root cause analysis did not complete._" },
+      };
+
+  return [
+    { type: "header", text: { type: "plain_text", text: headerText, emoji: true } },
+    mrkdwnSection(projectLine),
+    mrkdwnSection(`*Finding*\n${params.summary}`),
+    { type: "divider" },
+    rcaSection,
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "View trace" },
+          url: traceUrl,
+        },
+      ],
+    },
+  ];
+}

--- a/frontend/packages/slack/src/client.ts
+++ b/frontend/packages/slack/src/client.ts
@@ -1,0 +1,20 @@
+import { WebClient } from "@slack/web-api";
+import { installer } from "./installer";
+
+const RETRY = { retries: 3, maxRetryTime: 90_000 };
+
+export function createSlackClient(decryptedBotToken: string): WebClient {
+  return new WebClient(decryptedBotToken, { retryConfig: RETRY });
+}
+
+export async function getClientForTeam(teamId: string): Promise<WebClient> {
+  const auth = await installer.authorize({
+    teamId,
+    enterpriseId: undefined,
+    isEnterpriseInstall: false,
+  });
+  if (!auth.botToken) throw new Error(`No bot token for team ${teamId}`);
+  return new WebClient(auth.botToken, { retryConfig: RETRY });
+}
+
+export type { WebClient };

--- a/frontend/packages/slack/src/constants.ts
+++ b/frontend/packages/slack/src/constants.ts
@@ -1,0 +1,6 @@
+export const SLACK_BOT_SCOPES = [
+  "chat:write",
+  "chat:write.public",
+  "channels:read",
+  "groups:read",
+] as const;

--- a/frontend/packages/slack/src/index.ts
+++ b/frontend/packages/slack/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./constants";
+export * from "./oauth-response";
+export * from "./block-kit";
+export * from "./installer";
+export * from "./client";

--- a/frontend/packages/slack/src/installer.ts
+++ b/frontend/packages/slack/src/installer.ts
@@ -1,0 +1,65 @@
+import { InstallProvider, type Installation, type InstallationStore } from "@slack/oauth";
+import { decryptKey, encryptKey, prisma } from "@traceroot/core";
+
+interface InstallMetadata {
+  workspaceId: string;
+  connectedByUserId?: string;
+  returnTo?: string;
+}
+
+function parseMetadata(raw: string | undefined): InstallMetadata {
+  if (!raw) throw new Error("Slack install metadata missing");
+  return JSON.parse(raw) as InstallMetadata;
+}
+
+export const installationStore: InstallationStore = {
+  storeInstallation: async (installation: Installation) => {
+    const meta = parseMetadata(installation.metadata);
+    const teamId = installation.team!.id;
+    const teamName = installation.team!.name ?? teamId;
+    const botUserId = installation.bot!.userId;
+    const botToken = encryptKey(installation.bot!.token);
+
+    await prisma.slackIntegration.upsert({
+      where: { workspaceId: meta.workspaceId },
+      create: {
+        workspaceId: meta.workspaceId,
+        teamId,
+        teamName,
+        botUserId,
+        botToken,
+        connectedByUserId: meta.connectedByUserId ?? null,
+      },
+      update: { teamId, teamName, botUserId, botToken },
+    });
+  },
+
+  fetchInstallation: async (query) => {
+    const row = await prisma.slackIntegration.findFirst({
+      where: { teamId: query.teamId! },
+    });
+    if (!row) throw new Error("Slack integration not found");
+    return {
+      team: { id: row.teamId, name: row.teamName },
+      bot: {
+        token: decryptKey(row.botToken),
+        userId: row.botUserId,
+        scopes: [],
+        id: "",
+      },
+      enterprise: undefined,
+      user: { token: undefined, id: "", scopes: undefined },
+    } as unknown as Installation;
+  },
+
+  deleteInstallation: async (query) => {
+    await prisma.slackIntegration.deleteMany({ where: { teamId: query.teamId! } });
+  },
+};
+
+export const installer = new InstallProvider({
+  clientId: process.env.SLACK_CLIENT_ID ?? "",
+  clientSecret: process.env.SLACK_CLIENT_SECRET ?? "",
+  stateSecret: process.env.SLACK_STATE_SECRET ?? "",
+  installationStore,
+});

--- a/frontend/packages/slack/src/oauth-response.ts
+++ b/frontend/packages/slack/src/oauth-response.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const SlackOAuthResponseSchema = z.object({
+  ok: z.literal(true),
+  access_token: z.string().startsWith("xoxb-"),
+  token_type: z.literal("bot"),
+  bot_user_id: z.string(),
+  team: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+  // Optional fields read by the callback for storeInstallation:
+  app_id: z.string().optional(),
+  scope: z.string().optional(),
+  authed_user: z.object({ id: z.string() }).optional(),
+});
+
+export type SlackOAuthResponse = z.infer<typeof SlackOAuthResponseSchema>;

--- a/frontend/packages/slack/tsconfig.json
+++ b/frontend/packages/slack/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -128,6 +128,31 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/slack:
+    dependencies:
+      '@slack/oauth':
+        specifier: ^3.0.1
+        version: 3.0.5
+      '@slack/web-api':
+        specifier: ^7.8.0
+        version: 7.15.1
+      '@traceroot/core':
+        specifier: workspace:*
+        version: link:../core
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.19.9
+        version: 22.19.15
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+
   ui:
     dependencies:
       '@hookform/resolvers':
@@ -157,6 +182,9 @@ importers:
       '@traceroot/github':
         specifier: workspace:*
         version: link:../packages/github
+      '@traceroot/slack':
+        specifier: workspace:*
+        version: link:../packages/slack
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -247,10 +275,13 @@ importers:
     dependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.87.0
-        version: 0.87.0(zod@4.3.6)
+        version: 0.87.0(zod@3.25.76)
       '@traceroot/core':
         specifier: workspace:*
         version: link:../packages/core
+      '@traceroot/slack':
+        specifier: workspace:*
+        version: link:../packages/slack
       bullmq:
         specifier: ^5.73.3
         version: 5.73.3
@@ -265,7 +296,7 @@ importers:
         version: 6.10.1
       openai:
         specifier: ^4.98.0
-        version: 4.104.0(ws@8.19.0)(zod@4.3.6)
+        version: 4.104.0(ws@8.19.0)(zod@3.25.76)
       stripe:
         specifier: 14.25.0
         version: 14.25.0
@@ -2049,6 +2080,22 @@ packages:
   '@sinclair/typebox@0.34.48':
     resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
 
+  '@slack/logger@4.0.1':
+    resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
+  '@slack/oauth@3.0.5':
+    resolution: {integrity: sha512-exqFQySKhNDptWYSWhvRUJ4/+ndu2gayIy7vg/JfmJq3wGtGdHk531P96fAZyBm5c1Le3yaPYqv92rL4COlU3A==}
+    engines: {node: '>=18', npm: '>=8.6.0'}
+
+  '@slack/types@2.20.1':
+    resolution: {integrity: sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==}
+    engines: {node: '>= 12.13.0', npm: '>= 6.12.0'}
+
+  '@slack/web-api@7.15.1':
+    resolution: {integrity: sha512-y+TAF7TszcmFzbVtBkFqAdBwKSoD+8shkNxhp4WIfFwXmCKdFje9WD6evROApPa2FTy1v1uc9yBaJs3609PPgg==}
+    engines: {node: '>= 18', npm: '>= 8.6.0'}
+
   '@smithy/abort-controller@4.2.12':
     resolution: {integrity: sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==}
     engines: {node: '>=18.0.0'}
@@ -3072,6 +3119,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -3364,6 +3414,9 @@ packages:
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3390,6 +3443,10 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -3993,6 +4050,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -4001,8 +4062,16 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
   pac-proxy-agent@7.2.0:
@@ -4965,6 +5034,9 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -4981,11 +5053,11 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
-  '@anthropic-ai/sdk@0.87.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.87.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 3.25.76
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -7009,6 +7081,39 @@ snapshots:
 
   '@sinclair/typebox@0.34.48': {}
 
+  '@slack/logger@4.0.1':
+    dependencies:
+      '@types/node': 22.19.15
+
+  '@slack/oauth@3.0.5':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/web-api': 7.15.1
+      '@types/jsonwebtoken': 9.0.10
+      '@types/node': 22.19.15
+      jsonwebtoken: 9.0.3
+    transitivePeerDependencies:
+      - debug
+
+  '@slack/types@2.20.1': {}
+
+  '@slack/web-api@7.15.1':
+    dependencies:
+      '@slack/logger': 4.0.1
+      '@slack/types': 2.20.1
+      '@types/node': 22.19.15
+      '@types/retry': 0.12.0
+      axios: 1.15.2
+      eventemitter3: 5.0.4
+      form-data: 4.0.5
+      is-electron: 2.2.2
+      is-stream: 2.0.1
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      retry: 0.13.1
+    transitivePeerDependencies:
+      - debug
+
   '@smithy/abort-controller@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
@@ -8170,6 +8275,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
@@ -8493,6 +8600,8 @@ snapshots:
 
   is-decimal@2.0.1: {}
 
+  is-electron@2.2.2: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -8510,6 +8619,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
 
@@ -9227,7 +9338,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@4.104.0(ws@8.19.0)(zod@4.3.6):
+  openai@4.104.0(ws@8.19.0)(zod@3.25.76):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -9238,7 +9349,7 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.19.0
-      zod: 4.3.6
+      zod: 3.25.76
     transitivePeerDependencies:
       - encoding
 
@@ -9256,6 +9367,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  p-finally@1.0.0: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -9264,10 +9377,19 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
   p-retry@4.6.2:
     dependencies:
       '@types/retry': 0.12.0
       retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
 
   pac-proxy-agent@7.2.0:
     dependencies:
@@ -10354,6 +10476,9 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76:
+    optional: true
 
   zod@4.3.6: {}
 

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -21,6 +21,7 @@
     "@tanstack/react-query": "^5.62.0",
     "@traceroot/core": "workspace:*",
     "@traceroot/github": "workspace:*",
+    "@traceroot/slack": "workspace:*",
     "bcryptjs": "^3.0.3",
     "better-auth": "^1.5.5",
     "class-variance-authority": "^0.7.0",

--- a/frontend/ui/src/app/api/slack/oauth/callback/route.test.ts
+++ b/frontend/ui/src/app/api/slack/oauth/callback/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const verifyStateParam = vi.fn();
+const storeInstallation = vi.fn();
+const fetchMock = vi.fn();
+
+vi.mock("@traceroot/slack", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/slack")>();
+  return {
+    ...actual,
+    installer: {
+      stateStore: { verifyStateParam: (...a: unknown[]) => verifyStateParam(...a) },
+      installationStore: { storeInstallation: (...a: unknown[]) => storeInstallation(...a) },
+    },
+  };
+});
+vi.mock("@/env", () => ({
+  env: { SLACK_CLIENT_ID: "cid", SLACK_CLIENT_SECRET: "csec", SLACK_REDIRECT_URI: "http://x/cb" },
+}));
+
+global.fetch = fetchMock as any;
+
+describe("GET /api/slack/oauth/callback", () => {
+  beforeEach(() => {
+    verifyStateParam.mockReset();
+    storeInstallation.mockReset();
+    fetchMock.mockReset();
+  });
+
+  it("redirects with error on missing code/state", async () => {
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x/api/slack/oauth/callback") as any);
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("slack=error&reason=missing_params");
+  });
+
+  it("redirects with error on invalid state", async () => {
+    verifyStateParam.mockRejectedValue(new Error("bad state"));
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x/api/slack/oauth/callback?code=c&state=s") as any);
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("slack=error&reason=invalid_state");
+  });
+
+  it("happy path: exchanges code, calls storeInstallation, redirects to slack=connected", async () => {
+    verifyStateParam.mockResolvedValue({
+      metadata: JSON.stringify({ workspaceId: "ws_1", connectedByUserId: "u_1" }),
+    });
+    fetchMock.mockResolvedValue({
+      json: async () => ({
+        ok: true,
+        access_token: "xoxb-tok",
+        token_type: "bot",
+        bot_user_id: "U1",
+        app_id: "A1",
+        scope: "chat:write,channels:read",
+        team: { id: "T1", name: "Acme" },
+        authed_user: { id: "U_user" },
+      }),
+    });
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x/api/slack/oauth/callback?code=c&state=s") as any);
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain(
+      "/workspaces/ws_1/settings/integrations?slack=connected",
+    );
+    expect(storeInstallation).toHaveBeenCalledTimes(1);
+    const inst = storeInstallation.mock.calls[0][0];
+    expect(inst.team).toEqual({ id: "T1", name: "Acme" });
+    expect(inst.bot.token).toBe("xoxb-tok");
+    expect(JSON.parse(inst.metadata).workspaceId).toBe("ws_1");
+  });
+
+  it("redirects with reason from slack on oauth.v2.access failure", async () => {
+    verifyStateParam.mockResolvedValue({
+      metadata: JSON.stringify({ workspaceId: "ws_1" }),
+    });
+    fetchMock.mockResolvedValue({
+      json: async () => ({ ok: false, error: "invalid_code" }),
+    });
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x/api/slack/oauth/callback?code=c&state=s") as any);
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("slack=error&reason=exchange_failed");
+  });
+});

--- a/frontend/ui/src/app/api/slack/oauth/callback/route.ts
+++ b/frontend/ui/src/app/api/slack/oauth/callback/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { installer, SlackOAuthResponseSchema } from "@traceroot/slack";
+import { env } from "@/env";
+
+interface InstallMetadata {
+  workspaceId?: string;
+  connectedByUserId?: string;
+  returnTo?: string;
+}
+
+function parseMeta(raw: string | undefined | null): InstallMetadata {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as InstallMetadata;
+  } catch {
+    return {};
+  }
+}
+
+function destination(workspaceId: string | undefined, params: string, requestUrl: string): URL {
+  const path = workspaceId
+    ? `/workspaces/${workspaceId}/settings/integrations?${params}`
+    : `/?${params}`;
+  return new URL(path, requestUrl);
+}
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+
+  if (!code || !state) {
+    return NextResponse.redirect(
+      destination(undefined, "slack=error&reason=missing_params", request.url),
+    );
+  }
+
+  // 1. Verify the state param (signed via SLACK_STATE_SECRET) and recover metadata.
+  let meta: InstallMetadata;
+  try {
+    // stateStore is a public property on InstallProvider (StateStore | undefined)
+    const verified = await installer.stateStore!.verifyStateParam(new Date(), state);
+    meta = parseMeta(verified.metadata);
+  } catch {
+    return NextResponse.redirect(
+      destination(undefined, "slack=error&reason=invalid_state", request.url),
+    );
+  }
+
+  // 2. Exchange the code for a bot token.
+  const basic = Buffer.from(`${env.SLACK_CLIENT_ID}:${env.SLACK_CLIENT_SECRET}`).toString("base64");
+  const tokenRes = await fetch("https://slack.com/api/oauth.v2.access", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${basic}`,
+    },
+    body: new URLSearchParams({ code, redirect_uri: env.SLACK_REDIRECT_URI }),
+  });
+  const parsed = SlackOAuthResponseSchema.safeParse(await tokenRes.json());
+  if (!parsed.success) {
+    return NextResponse.redirect(
+      destination(meta.workspaceId, "slack=error&reason=exchange_failed", request.url),
+    );
+  }
+  const data = parsed.data;
+
+  // 3. Persist via installationStore (encrypts the bot token).
+  // Wrapped in try/catch — Prisma upserts and AES encryption can both throw,
+  // and we want a clean redirect rather than a raw 500 mid-OAuth flow.
+  try {
+    await installer.installationStore.storeInstallation({
+      team: { id: data.team.id, name: data.team.name },
+      bot: {
+        token: data.access_token,
+        userId: data.bot_user_id ?? "",
+        scopes: (data.scope ?? "").split(",").filter(Boolean),
+        id: data.app_id ?? "",
+      },
+      enterprise: undefined,
+      user: { token: undefined, id: data.authed_user?.id ?? "", scopes: undefined },
+      tokenType: "bot",
+      metadata: JSON.stringify(meta),
+      appId: data.app_id,
+    } as never);
+  } catch {
+    return NextResponse.redirect(
+      destination(meta.workspaceId, "slack=error&reason=store_failed", request.url),
+    );
+  }
+
+  return NextResponse.redirect(destination(meta.workspaceId, "slack=connected", request.url));
+}

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/channel/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/channel/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+
+const requireAuth = vi.fn();
+const requireWorkspaceMembership = vi.fn();
+const update = vi.fn();
+const info = vi.fn();
+const findUnique = vi.fn();
+const getClientForTeam = vi.fn(async () => ({ conversations: { info } }));
+
+vi.mock("@/lib/auth-helpers", () => ({ requireAuth, requireWorkspaceMembership }));
+vi.mock("@traceroot/core", () => ({
+  prisma: { slackIntegration: { update, findUnique } },
+}));
+vi.mock("@traceroot/slack", () => ({ getClientForTeam }));
+
+describe("POST /api/workspaces/[workspaceId]/slack/channel", () => {
+  it("403s for non-ADMIN", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: "..." }), { status: 403 }),
+    });
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://x", {
+        method: "POST",
+        body: JSON.stringify({ channelId: "C1", channelName: "ops" }),
+      }) as any,
+      { params: Promise.resolve({ workspaceId: "ws_1" }) },
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("saves channelId/channelName for ADMIN", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({ teamId: "T1" });
+    update.mockResolvedValue({});
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://x", {
+        method: "POST",
+        body: JSON.stringify({ channelId: "C1", channelName: "ops" }),
+      }) as any,
+      { params: Promise.resolve({ workspaceId: "ws_1" }) },
+    );
+    expect(res.status).toBe(200);
+    expect(update).toHaveBeenCalledWith({
+      where: { workspaceId: "ws_1" },
+      data: { channelId: "C1", channelName: "ops" },
+    });
+  });
+
+  it("resolves manual #name entry via conversations.info", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({ teamId: "T1" });
+    info.mockResolvedValue({ ok: true, channel: { id: "C42", name: "ops" } });
+    update.mockResolvedValue({});
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://x", {
+        method: "POST",
+        body: JSON.stringify({ channelId: "#ops", channelName: "ops" }),
+      }) as any,
+      { params: Promise.resolve({ workspaceId: "ws_1" }) },
+    );
+    expect(res.status).toBe(200);
+    expect(info).toHaveBeenCalledWith({ channel: "#ops" });
+    expect(update).toHaveBeenCalledWith({
+      where: { workspaceId: "ws_1" },
+      data: { channelId: "C42", channelName: "ops" },
+    });
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/channel/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/channel/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import { prisma } from "@traceroot/core";
+import { getClientForTeam } from "@traceroot/slack";
+import { z } from "zod";
+
+const Body = z.object({
+  channelId: z.string().min(1),
+  channelName: z.string().min(1),
+});
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> },
+) {
+  const auth = await requireAuth();
+  if (auth.error) return auth.error;
+  const { workspaceId } = await params;
+  const member = await requireWorkspaceMembership(auth.user.id, workspaceId, "ADMIN");
+  if (member.error) return member.error;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+  const parsed = Body.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "invalid_body" }, { status: 400 });
+  }
+  let { channelId, channelName } = parsed.data;
+
+  // Guard both branches: plain-id update would throw P2025 if row is missing.
+  const exists = await prisma.slackIntegration.findUnique({
+    where: { workspaceId },
+    select: { teamId: true },
+  });
+  if (!exists) return NextResponse.json({ error: "not_connected" }, { status: 404 });
+
+  // Manual `#name` entry — resolve to a real channel id via conversations.info.
+  if (channelId.startsWith("#")) {
+    const client = await getClientForTeam(exists.teamId);
+    const info = await client.conversations.info({ channel: channelId });
+    if (!info.ok || !info.channel) {
+      return NextResponse.json({ error: "channel_not_found" }, { status: 404 });
+    }
+    channelId = info.channel.id!;
+    channelName = info.channel.name ?? channelName;
+  }
+
+  await prisma.slackIntegration.update({
+    where: { workspaceId },
+    data: { channelId, channelName },
+  });
+  return NextResponse.json({ ok: true, channel: { id: channelId, name: channelName } });
+}

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/channels/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/channels/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requireAuth = vi.fn();
+const requireWorkspaceMembership = vi.fn();
+const findUnique = vi.fn();
+const list = vi.fn();
+const getClientForTeam = vi.fn(async () => ({ conversations: { list } }));
+
+vi.mock("@/lib/auth-helpers", () => ({ requireAuth, requireWorkspaceMembership }));
+vi.mock("@traceroot/core", () => ({
+  prisma: { slackIntegration: { findUnique } },
+}));
+vi.mock("@traceroot/slack", () => ({ getClientForTeam }));
+
+describe("GET /api/workspaces/[workspaceId]/slack/channels", () => {
+  beforeEach(() => {
+    list.mockReset();
+    findUnique.mockReset();
+  });
+
+  it("returns 404 when no integration", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue(null);
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x") as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("paginates conversations.list and returns id/name/isPrivate", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({ teamId: "T1" });
+    list
+      .mockResolvedValueOnce({
+        ok: true,
+        channels: [{ id: "C1", name: "ops", is_private: false }],
+        response_metadata: { next_cursor: "x" },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        channels: [{ id: "C2", name: "secret", is_private: true }],
+        response_metadata: { next_cursor: "" },
+      });
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x") as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+    expect(await res.json()).toEqual({
+      channels: [
+        { id: "C1", name: "ops", isPrivate: false },
+        { id: "C2", name: "secret", isPrivate: true },
+      ],
+      hasPrivateChannelAccess: true,
+    });
+  });
+
+  it("falls back to public-only on missing_scope and surfaces hint", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({ teamId: "T1" });
+    const err: any = new Error("missing_scope");
+    err.data = { error: "missing_scope" };
+    list.mockRejectedValueOnce(err).mockResolvedValueOnce({
+      ok: true,
+      channels: [{ id: "C1", name: "ops", is_private: false }],
+      response_metadata: { next_cursor: "" },
+    });
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x") as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+    const body = await res.json();
+    expect(body.hasPrivateChannelAccess).toBe(false);
+    expect(body.channels.map((c: any) => c.id)).toEqual(["C1"]);
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/channels/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/channels/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import { prisma } from "@traceroot/core";
+import { getClientForTeam, WebClient } from "@traceroot/slack";
+
+const FETCH_LIMIT = 5000;
+const PAGE_SIZE = 1000;
+
+interface ChannelDTO {
+  id: string;
+  name: string;
+  isPrivate: boolean;
+}
+
+async function listChannels(
+  client: WebClient,
+  types: string,
+  limit: number,
+): Promise<ChannelDTO[]> {
+  const out: ChannelDTO[] = [];
+  let cursor: string | undefined;
+  while (out.length < limit) {
+    const page = await client.conversations.list({
+      exclude_archived: true,
+      types,
+      limit: PAGE_SIZE,
+      cursor,
+    });
+    for (const ch of page.channels ?? []) {
+      out.push({ id: ch.id ?? "", name: ch.name ?? "", isPrivate: !!ch.is_private });
+      if (out.length >= limit) break;
+    }
+    cursor = page.response_metadata?.next_cursor;
+    if (!cursor) break;
+  }
+  return out;
+}
+
+function isMissingScope(err: unknown): boolean {
+  return (err as { data?: { error?: string } } | undefined)?.data?.error === "missing_scope";
+}
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> },
+) {
+  const auth = await requireAuth();
+  if (auth.error) return auth.error;
+  const { workspaceId } = await params;
+  const member = await requireWorkspaceMembership(auth.user.id, workspaceId, "ADMIN");
+  if (member.error) return member.error;
+
+  const integration = await prisma.slackIntegration.findUnique({
+    where: { workspaceId },
+    select: { teamId: true },
+  });
+  if (!integration) return NextResponse.json({ error: "not_connected" }, { status: 404 });
+
+  const client = await getClientForTeam(integration.teamId);
+  let channels: ChannelDTO[];
+  let hasPrivateChannelAccess = true;
+  try {
+    channels = await listChannels(client, "public_channel,private_channel", FETCH_LIMIT);
+  } catch (err) {
+    if (!isMissingScope(err)) throw err;
+    hasPrivateChannelAccess = false;
+    channels = await listChannels(client, "public_channel", FETCH_LIMIT);
+  }
+  return NextResponse.json({ channels, hasPrivateChannelAccess });
+}

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/install/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/install/route.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+
+const requireAuth = vi.fn();
+const requireWorkspaceMembership = vi.fn();
+const generateInstallUrl = vi.fn();
+
+vi.mock("@/lib/auth-helpers", () => ({ requireAuth, requireWorkspaceMembership }));
+vi.mock("@traceroot/slack", () => ({
+  installer: { generateInstallUrl: (...args: unknown[]) => generateInstallUrl(...args) },
+  SLACK_BOT_SCOPES: ["chat:write"],
+}));
+vi.mock("@/env", () => ({ env: { SLACK_REDIRECT_URI: "http://x/api/slack/oauth/callback" } }));
+
+describe("GET /api/workspaces/[workspaceId]/slack/install", () => {
+  it("403s for non-ADMIN", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: "Requires ADMIN role or higher" }), {
+        status: 403,
+      }),
+    });
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x/api?returnTo=/foo") as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+    expect(res.status).toBe(403);
+    expect(requireWorkspaceMembership).toHaveBeenCalledWith("u_1", "ws_1", "ADMIN");
+  });
+
+  it("redirects to the SDK-generated install URL", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    generateInstallUrl.mockResolvedValue(
+      "https://slack.com/oauth/v2/authorize?client_id=…&state=…",
+    );
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x/api?returnTo=/back") as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+
+    expect(res.status).toBe(307); // NextResponse.redirect default
+    expect(res.headers.get("location")).toContain("slack.com/oauth/v2/authorize");
+    expect(generateInstallUrl).toHaveBeenCalledTimes(1);
+    const opts = generateInstallUrl.mock.calls[0][0];
+    expect(opts.scopes).toEqual(["chat:write"]);
+    expect(opts.redirectUri).toBe("http://x/api/slack/oauth/callback");
+    const meta = JSON.parse(opts.metadata);
+    expect(meta.workspaceId).toBe("ws_1");
+    expect(meta.connectedByUserId).toBe("u_1");
+    expect(meta.returnTo).toBe("/back");
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/install/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/install/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import { installer, SLACK_BOT_SCOPES } from "@traceroot/slack";
+import { env } from "@/env";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> },
+) {
+  const auth = await requireAuth();
+  if (auth.error) return auth.error;
+
+  const { workspaceId } = await params;
+  const memberCheck = await requireWorkspaceMembership(auth.user.id, workspaceId, "ADMIN");
+  if (memberCheck.error) return memberCheck.error;
+
+  const url = new URL(request.url);
+  const returnTo = url.searchParams.get("returnTo") || "/";
+
+  // Use the SDK's URL builder (which signs state via SLACK_STATE_SECRET)
+  // and redirect with NextResponse — bypassing the SDK's HTTP plumbing,
+  // which is incompatible with Next.js App Router.
+  const installUrl = await installer.generateInstallUrl(
+    {
+      scopes: [...SLACK_BOT_SCOPES],
+      redirectUri: env.SLACK_REDIRECT_URI,
+      metadata: JSON.stringify({
+        workspaceId,
+        connectedByUserId: auth.user.id,
+        returnTo,
+      }),
+    },
+    true, // stateVerification
+  );
+
+  return NextResponse.redirect(installUrl);
+}

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/route.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+
+const requireAuth = vi.fn();
+const requireWorkspaceMembership = vi.fn();
+const findUnique = vi.fn();
+const deleteMany = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({ requireAuth, requireWorkspaceMembership }));
+vi.mock("@traceroot/core", () => ({
+  prisma: { slackIntegration: { findUnique, deleteMany } },
+}));
+
+describe("GET /api/workspaces/[workspaceId]/slack", () => {
+  it("returns connected:false when no integration row", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue(null);
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x") as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+    expect(await res.json()).toEqual({ connected: false });
+  });
+
+  it("returns connected status without exposing botToken", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({
+      teamName: "Acme",
+      botUserId: "U1",
+      channelId: "C1",
+      channelName: "ops",
+      botToken: "SHOULD_NEVER_LEAK",
+    });
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x") as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+    const body = await res.json();
+    expect(body).toEqual({
+      connected: true,
+      teamName: "Acme",
+      botUserId: "U1",
+      channel: { id: "C1", name: "ops" },
+    });
+    expect(JSON.stringify(body)).not.toContain("SHOULD_NEVER_LEAK");
+  });
+});
+
+describe("DELETE /api/workspaces/[workspaceId]/slack", () => {
+  it("403s for non-ADMIN", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: "Requires ADMIN role or higher" }), {
+        status: 403,
+      }),
+    });
+    const { DELETE } = await import("./route");
+    const res = await DELETE(new Request("http://x", { method: "DELETE" }) as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("deletes the integration row when ADMIN", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    deleteMany.mockResolvedValue({ count: 1 });
+    const { DELETE } = await import("./route");
+    const res = await DELETE(new Request("http://x", { method: "DELETE" }) as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+    expect(res.status).toBe(200);
+    expect(deleteMany).toHaveBeenCalledWith({ where: { workspaceId: "ws_1" } });
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, requireWorkspaceMembership, type Role } from "@/lib/auth-helpers";
+import { prisma } from "@traceroot/core";
+
+type RouteParams = { params: Promise<{ workspaceId: string }> };
+
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const auth = await requireAuth();
+  if (auth.error) return auth.error;
+
+  const { workspaceId } = await params;
+  const member = await requireWorkspaceMembership(auth.user.id, workspaceId, "MEMBER" as Role);
+  if (member.error) return member.error;
+
+  const row = await prisma.slackIntegration.findUnique({
+    where: { workspaceId },
+    select: { teamName: true, botUserId: true, channelId: true, channelName: true },
+  });
+  if (!row) return NextResponse.json({ connected: false });
+
+  return NextResponse.json({
+    connected: true,
+    teamName: row.teamName,
+    botUserId: row.botUserId,
+    channel: row.channelId ? { id: row.channelId, name: row.channelName ?? row.channelId } : null,
+  });
+}
+
+export async function DELETE(_request: NextRequest, { params }: RouteParams) {
+  const auth = await requireAuth();
+  if (auth.error) return auth.error;
+
+  const { workspaceId } = await params;
+  const member = await requireWorkspaceMembership(auth.user.id, workspaceId, "ADMIN" as Role);
+  if (member.error) return member.error;
+
+  // deleteMany is a no-op when no matching row exists (idempotent disconnect)
+  // and lets real DB errors propagate as 500 instead of being silently swallowed.
+  await prisma.slackIntegration.deleteMany({ where: { workspaceId } });
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/test-message/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/test-message/route.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+const requireAuth = vi.fn();
+const requireWorkspaceMembership = vi.fn();
+const findUnique = vi.fn();
+const postMessage = vi.fn();
+const getClientForTeam = vi.fn(async () => ({ chat: { postMessage } }));
+
+vi.mock("@/lib/auth-helpers", () => ({ requireAuth, requireWorkspaceMembership }));
+vi.mock("@/env", () => ({ env: { NEXT_PUBLIC_APP_URL: "http://localhost:3000" } }));
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    slackIntegration: { findUnique },
+  },
+}));
+vi.mock("@traceroot/slack", () => ({ getClientForTeam }));
+
+async function callPOST(workspaceId = "ws_1") {
+  const { POST } = await import("./route");
+  return POST(new Request("http://x", { method: "POST" }) as any, {
+    params: Promise.resolve({ workspaceId }),
+  });
+}
+
+describe("POST /api/workspaces/[workspaceId]/slack/test-message", () => {
+  it("403 for non-ADMIN", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1", email: "u@example.com" } });
+    requireWorkspaceMembership.mockResolvedValue({
+      error: new Response(JSON.stringify({ error: "Requires ADMIN role or higher" }), {
+        status: 403,
+      }),
+    });
+    const res = await callPOST();
+    expect(res.status).toBe(403);
+  });
+
+  it("404 not_connected when no SlackIntegration row exists", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1", email: "u@example.com" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue(null);
+    const res = await callPOST();
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("not_connected");
+  });
+
+  it("400 no_channel_set when channelId is null", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1", email: "u@example.com" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({
+      teamId: "T1",
+      teamName: "Acme",
+      channelId: null,
+      channelName: null,
+      botToken: "SHOULD_NEVER_LEAK",
+    });
+    const res = await callPOST();
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("no_channel_set");
+  });
+
+  it("happy path — sends Block Kit message and returns ok:true with ts and channel", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1", email: "admin@example.com" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({
+      teamId: "T1",
+      teamName: "Acme",
+      channelId: "C1",
+      channelName: "general",
+      botToken: "SHOULD_NEVER_LEAK",
+    });
+    postMessage.mockResolvedValue({ ok: true, ts: "1234.5678", channel: "C1" });
+    const res = await callPOST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.ts).toBe("1234.5678");
+    expect(body.channel).toEqual({ id: "C1", name: "general" });
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: "C1", text: "Test message from TraceRoot" }),
+    );
+  });
+
+  it("502 not_in_channel — returns user-readable message", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1", email: "admin@example.com" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({
+      teamId: "T1",
+      teamName: "Acme",
+      channelId: "C1",
+      channelName: "general",
+      botToken: "SHOULD_NEVER_LEAK",
+    });
+    const slackErr = Object.assign(new Error("not_in_channel"), {
+      data: { error: "not_in_channel" },
+    });
+    postMessage.mockRejectedValue(slackErr);
+    const res = await callPOST();
+    expect(res.status).toBe(502);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("not_in_channel");
+    expect(body.message).toBe(
+      "TraceRoot is not in this channel. Invite the app with `/invite @TraceRoot` in the channel and try again.",
+    );
+  });
+
+  it("bot token is never leaked in the response body", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1", email: "admin@example.com" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({
+      teamId: "T1",
+      teamName: "Acme",
+      channelId: "C1",
+      channelName: "general",
+      botToken: "SHOULD_NEVER_LEAK",
+    });
+    postMessage.mockResolvedValue({ ok: true, ts: "9999.0001", channel: "C1" });
+    const res = await callPOST();
+    const body = await res.json();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain("xoxb-");
+    expect(serialized).not.toContain("SHOULD_NEVER_LEAK");
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/test-message/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/test-message/route.ts
@@ -1,0 +1,109 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import { prisma } from "@traceroot/core";
+import { getClientForTeam } from "@traceroot/slack";
+import { env } from "@/env";
+
+const APP_BASE_URL = env.NEXT_PUBLIC_APP_URL;
+
+function mapSlackError(code: string): string {
+  switch (code) {
+    case "channel_not_found":
+      return "Channel not found. Make sure the channel ID is correct.";
+    case "not_in_channel":
+      return "TraceRoot is not in this channel. Invite the app with `/invite @TraceRoot` in the channel and try again.";
+    case "is_archived":
+      return "This channel is archived. Pick an active channel.";
+    case "invalid_auth":
+    case "token_revoked":
+    case "account_inactive":
+      return "Slack authorization is invalid. Please disconnect and reconnect Slack.";
+    default:
+      return `Slack API error: ${code}`;
+  }
+}
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ workspaceId: string }> },
+) {
+  const auth = await requireAuth();
+  if (auth.error) return auth.error;
+  const { workspaceId } = await params;
+  const member = await requireWorkspaceMembership(auth.user.id, workspaceId, "ADMIN");
+  if (member.error) return member.error;
+
+  const integration = await prisma.slackIntegration.findUnique({
+    where: { workspaceId },
+    select: { teamId: true, teamName: true, channelId: true, channelName: true },
+  });
+  if (!integration) {
+    return NextResponse.json({ error: "not_connected" }, { status: 404 });
+  }
+
+  const channelId = integration.channelId;
+  if (!channelId) {
+    return NextResponse.json({ error: "no_channel_set" }, { status: 400 });
+  }
+
+  const channelName = integration.channelName ?? channelId;
+  const teamName = integration.teamName;
+  const userEmail = auth.user.email ?? auth.user.id;
+
+  const blocks = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "🎉 Test Message from TraceRoot", emoji: true },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: "Hello from TraceRoot! This is a test message to verify your Slack integration is working properly.",
+      },
+    },
+    {
+      type: "section",
+      fields: [
+        { type: "mrkdwn", text: `*Workspace:*\n${teamName}` },
+        { type: "mrkdwn", text: `*Channel:*\n#${channelName}` },
+        { type: "mrkdwn", text: `*Sent by:*\n${userEmail}` },
+        { type: "mrkdwn", text: `*Time:*\n${new Date().toISOString()}` },
+      ],
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Open TraceRoot" },
+          url: `${APP_BASE_URL}/workspaces/${workspaceId}/settings/integrations`,
+          style: "primary",
+        },
+      ],
+    },
+  ];
+
+  let result: { ts?: string; channel?: string };
+  try {
+    const client = await getClientForTeam(integration.teamId);
+    const res = await client.chat.postMessage({
+      channel: channelId,
+      blocks: blocks as any,
+      text: "Test message from TraceRoot",
+      unfurl_links: false,
+      unfurl_media: false,
+    });
+    result = { ts: res.ts, channel: res.channel };
+  } catch (err: any) {
+    const code: string = err?.data?.error ?? err?.message ?? "unknown_error";
+    const message = mapSlackError(code);
+    return NextResponse.json({ ok: false, error: code, message }, { status: 502 });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    ts: result.ts,
+    channel: { id: channelId, name: channelName },
+  });
+}

--- a/frontend/ui/src/components/github/GitHubConnectButton.tsx
+++ b/frontend/ui/src/components/github/GitHubConnectButton.tsx
@@ -92,20 +92,20 @@ export function GitHubConnectButton({ workspaceId }: GitHubConnectButtonProps) {
                 <ChevronDown className="h-4 w-4" />
               </Button>
             </PopoverTrigger>
-            <PopoverContent align="end" className="w-48 p-1">
+            <PopoverContent align="end" className="w-40 p-1">
               <a
                 href={buildHref("/api/github/install")}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-[12px] transition-colors hover:bg-accent"
               >
-                <ExternalLink className="h-4 w-4" />
+                <ExternalLink className="h-3.5 w-3.5" />
                 Configure
               </a>
               <button
                 onClick={handleDisconnect}
                 disabled={isDisconnecting}
-                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-destructive transition-colors hover:bg-accent disabled:opacity-50"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1 text-[12px] text-destructive transition-colors hover:bg-accent disabled:opacity-50"
               >
-                <Unlink className="h-4 w-4" />
+                <Unlink className="h-3.5 w-3.5" />
                 {isDisconnecting ? "Disconnecting..." : "Disconnect"}
               </button>
             </PopoverContent>

--- a/frontend/ui/src/components/slack/SlackConnectButton.tsx
+++ b/frontend/ui/src/components/slack/SlackConnectButton.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
+import { Check, ChevronDown, ExternalLink, Hash, Lock, Send, Settings, Unlink } from "lucide-react";
+import { FaSlack } from "react-icons/fa";
+import { useWorkspace } from "@/features/workspaces/hooks";
+import {
+  useSlackStatus,
+  useSlackChannels,
+  useSaveSlackChannel,
+  useDisconnectSlack,
+  useSendSlackTest,
+} from "@/features/integrations/hooks/useSlackIntegration";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  workspaceId: string;
+}
+
+export function SlackConnectButton({ workspaceId }: Props) {
+  const queryClient = useQueryClient();
+  const { data: workspace } = useWorkspace(workspaceId);
+  const canManage = workspace?.role === "ADMIN";
+  const pathname = usePathname();
+  const [open, setOpen] = useState(false);
+  const [channelOpen, setChannelOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const [testFeedback, setTestFeedback] = useState<{ kind: "ok" | "err"; text: string } | null>(
+    null,
+  );
+  const testFeedbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function flashTestFeedback(kind: "ok" | "err", text: string) {
+    if (testFeedbackTimer.current) clearTimeout(testFeedbackTimer.current);
+    setTestFeedback({ kind, text });
+    testFeedbackTimer.current = setTimeout(() => setTestFeedback(null), 2500);
+  }
+
+  const { data, isLoading } = useSlackStatus(workspaceId);
+  // Fetch channels when the channel picker is open
+  const { data: channelData, isLoading: channelsLoading } = useSlackChannels(
+    workspaceId,
+    channelOpen,
+  );
+  const saveChannel = useSaveSlackChannel(workspaceId);
+  const disconnect = useDisconnectSlack(workspaceId);
+  const testMessage = useSendSlackTest(workspaceId);
+
+  const installHref = `/api/workspaces/${encodeURIComponent(workspaceId)}/slack/install?returnTo=${encodeURIComponent(pathname || "/")}`;
+
+  const sorted = useMemo(() => {
+    if (!channelData?.channels) return [];
+    return [...channelData.channels].sort((a, b) => {
+      if (a.isPrivate !== b.isPrivate) return a.isPrivate ? 1 : -1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [channelData]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().replace(/^#/, "").toLowerCase();
+    if (!q) return sorted;
+    return sorted.filter((c) => c.name.toLowerCase().includes(q));
+  }, [sorted, search]);
+
+  const showManualEntry =
+    search.startsWith("#") && search.length > 1 && !sorted.some((c) => `#${c.name}` === search);
+
+  const showPrivateScopeHint = channelData?.hasPrivateChannelAccess === false;
+
+  const selectedChannelId = data?.channel?.id;
+
+  function handleSelectChannel(ch: { id: string; name: string }) {
+    saveChannel.mutate(
+      { channelId: ch.id, channelName: ch.name },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ["slack", workspaceId, "status"] });
+          setChannelOpen(false);
+          setOpen(false);
+          setSearch("");
+        },
+      },
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-between">
+        <Row>
+          <span className="text-[12px] text-muted-foreground">Loading…</span>
+        </Row>
+      </div>
+    );
+  }
+
+  if (data?.connected) {
+    const channelLabel = data.channel ? `#${data.channel.name}` : null;
+    return (
+      <div className="flex items-center justify-between">
+        <Row>
+          <div>
+            <div className="text-sm font-medium">Slack</div>
+            <div className="text-sm text-muted-foreground">Post detector alerts to a channel.</div>
+            <div className="mt-1 flex items-center gap-1.5 text-sm text-muted-foreground">
+              <span>
+                Connected to <span className="font-medium text-foreground">{data.teamName}</span>
+                {channelLabel && (
+                  <>
+                    {" · "}
+                    {channelLabel}
+                  </>
+                )}
+              </span>
+              {canManage && data.channel && (
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    testMessage.mutate(undefined, {
+                      onSuccess: () => flashTestFeedback("ok", "Sent ✓"),
+                      onError: (err) =>
+                        flashTestFeedback(
+                          "err",
+                          err instanceof Error ? err.message : "Failed to send test message",
+                        ),
+                    })
+                  }
+                  disabled={testMessage.isPending}
+                  className="ml-1 gap-1.5 px-2.5"
+                  title="Send a test message to this channel"
+                >
+                  {testMessage.isPending ? (
+                    <span className="h-3.5 w-3.5 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                  ) : (
+                    <Send className="h-3.5 w-3.5 shrink-0" />
+                  )}
+                  {testMessage.isPending ? "Testing…" : "Test Connection"}
+                </Button>
+              )}
+              {testFeedback && (
+                <span
+                  className={
+                    testFeedback.kind === "ok"
+                      ? "ml-1 text-[12px] text-green-600 dark:text-green-500"
+                      : "ml-1 text-[12px] text-destructive"
+                  }
+                >
+                  {testFeedback.text}
+                </span>
+              )}
+            </div>
+          </div>
+        </Row>
+        {canManage && (
+          <Popover
+            open={open}
+            onOpenChange={(next) => {
+              setOpen(next);
+              if (!next) {
+                setChannelOpen(false);
+                setSearch("");
+              }
+            }}
+          >
+            <PopoverTrigger asChild>
+              <Button variant="outline" size="sm" className="gap-1">
+                Manage
+                <ChevronDown className="h-4 w-4" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-44 p-1">
+              {/* Channel item — opens nested channel picker to the right */}
+              <Popover
+                open={channelOpen}
+                onOpenChange={(next) => {
+                  setChannelOpen(next);
+                  if (!next) setSearch("");
+                }}
+              >
+                <PopoverTrigger asChild>
+                  <button
+                    type="button"
+                    className="flex w-full select-none items-center gap-2 rounded-sm px-2 py-1 text-[12px] transition-colors hover:bg-accent"
+                  >
+                    <Settings className="h-3.5 w-3.5 shrink-0" />
+                    Configure
+                  </button>
+                </PopoverTrigger>
+                <PopoverContent side="right" align="start" sideOffset={4} className="w-72 p-2">
+                  {/* Selected channel summary */}
+                  <div className="px-2 pb-2 text-[11px] text-muted-foreground">
+                    {channelLabel ? `Posting alerts to ${channelLabel}` : "No channel selected"}
+                  </div>
+
+                  {/* Search input */}
+                  <input
+                    type="text"
+                    placeholder="Search or enter #channel-name"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    className="mb-1 w-full rounded-md border bg-transparent px-2 py-1 text-[12px] outline-none focus:ring-1 focus:ring-ring"
+                    autoFocus
+                  />
+
+                  {/* Channel list */}
+                  <div className="max-h-72 overflow-y-auto rounded-md py-0.5">
+                    {channelsLoading && (
+                      <div className="px-2 py-1 text-[12px] text-muted-foreground">
+                        Loading channels…
+                      </div>
+                    )}
+                    {!channelsLoading && filtered.length === 0 && !showManualEntry && (
+                      <div className="px-2 py-1 text-[12px] text-muted-foreground">
+                        No channels found.
+                      </div>
+                    )}
+                    {filtered.map((ch) => (
+                      <button
+                        key={ch.id}
+                        type="button"
+                        onClick={() => handleSelectChannel({ id: ch.id, name: ch.name })}
+                        className="flex w-full select-none items-center rounded-sm px-2 py-1 text-left text-[12px] transition-colors hover:bg-accent"
+                      >
+                        {ch.isPrivate ? (
+                          <Lock className="mr-2 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                        ) : (
+                          <Hash className="mr-2 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                        )}
+                        <span className="flex-1 truncate">{ch.name}</span>
+                        {selectedChannelId === ch.id && (
+                          <Check className="ml-2 h-3.5 w-3.5 shrink-0" />
+                        )}
+                      </button>
+                    ))}
+                    {showManualEntry && (
+                      <button
+                        type="button"
+                        onClick={() => handleSelectChannel({ id: search, name: search.slice(1) })}
+                        className="flex w-full select-none items-center rounded-sm px-2 py-1 text-left text-[12px] transition-colors hover:bg-accent"
+                      >
+                        Use <span className="ml-1 font-mono">{search}</span>
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Private channel re-auth hint */}
+                  {showPrivateScopeHint && (
+                    <p className="mt-1 px-2 text-[11px] italic text-muted-foreground">
+                      Re-authenticate to grant private-channel access.
+                    </p>
+                  )}
+                </PopoverContent>
+              </Popover>
+
+              {/* Disconnect */}
+              <button
+                type="button"
+                onClick={() => {
+                  disconnect.mutate();
+                  setOpen(false);
+                }}
+                disabled={disconnect.isPending}
+                className="flex w-full select-none items-center gap-2 rounded-sm px-2 py-1 text-[12px] text-destructive transition-colors hover:bg-accent disabled:opacity-50"
+              >
+                <Unlink className="h-3.5 w-3.5" />
+                {disconnect.isPending ? "Disconnecting…" : "Disconnect"}
+              </button>
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center justify-between">
+      <Row>
+        <div>
+          <div className="text-sm font-medium">Slack</div>
+          <div className="text-sm text-muted-foreground">
+            {canManage
+              ? "Post detector alerts to a Slack channel."
+              : "Slack is not connected. Ask a workspace admin to set it up."}
+          </div>
+        </div>
+      </Row>
+      {canManage && (
+        <a
+          href={installHref}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Connect
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      )}
+    </div>
+  );
+}
+
+function Row({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-3">
+      <FaSlack className="h-6 w-6 text-muted-foreground" />
+      {children}
+    </div>
+  );
+}

--- a/frontend/ui/src/env.ts
+++ b/frontend/ui/src/env.ts
@@ -27,6 +27,11 @@ const serverSchema = z.object({
   GITHUB_APP_CLIENT_ID: z.string().default(""),
   GITHUB_APP_CLIENT_SECRET: z.string().default(""),
   GITHUB_OAUTH_REDIRECT_URI: z.string().default("http://localhost:3000/api/github/callback"),
+  // Slack App
+  SLACK_CLIENT_ID: z.string().default(""),
+  SLACK_CLIENT_SECRET: z.string().default(""),
+  SLACK_STATE_SECRET: z.string().default(""),
+  SLACK_REDIRECT_URI: z.string().default("http://localhost:3000/api/slack/oauth/callback"),
 });
 
 export const env = serverSchema.parse(process.env);

--- a/frontend/ui/src/features/integrations/hooks/useSlackIntegration.ts
+++ b/frontend/ui/src/features/integrations/hooks/useSlackIntegration.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  fetchSlackConnection,
+  fetchSlackChannels,
+  saveSlackChannel,
+  disconnectSlack,
+  sendSlackTestMessage,
+  SlackStatus,
+} from "@/lib/slack";
+
+const STATUS_KEY = (workspaceId: string) => ["slack", workspaceId, "status"];
+const CHANNELS_KEY = (workspaceId: string) => ["slack", workspaceId, "channels"];
+
+export function useSlackStatus(workspaceId: string | undefined) {
+  return useQuery<SlackStatus>({
+    queryKey: STATUS_KEY(workspaceId ?? ""),
+    queryFn: () => fetchSlackConnection(workspaceId!),
+    enabled: !!workspaceId,
+    staleTime: 30_000,
+  });
+}
+
+export function useSlackChannels(workspaceId: string | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: CHANNELS_KEY(workspaceId ?? ""),
+    queryFn: () => fetchSlackChannels(workspaceId!),
+    enabled: !!workspaceId && enabled,
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useSaveSlackChannel(workspaceId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { channelId: string; channelName: string }) =>
+      saveSlackChannel(workspaceId, input.channelId, input.channelName),
+    onSuccess: () => qc.invalidateQueries({ queryKey: STATUS_KEY(workspaceId) }),
+  });
+}
+
+export function useDisconnectSlack(workspaceId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => disconnectSlack(workspaceId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: STATUS_KEY(workspaceId) }),
+  });
+}
+
+export function useSendSlackTest(workspaceId: string) {
+  return useMutation({
+    mutationFn: () => sendSlackTestMessage(workspaceId),
+  });
+}

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
@@ -2,10 +2,13 @@
 
 import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Mail, Slack, ArrowUpRight } from "lucide-react";
+import Link from "next/link";
+import { ArrowUpRight, Mail } from "lucide-react";
+import { FaSlack } from "react-icons/fa";
 import { Button } from "@/components/ui/button";
 import { updateProject } from "@/lib/api";
 import { useProject } from "@/features/projects/hooks";
+import { useSlackStatus } from "@/features/integrations/hooks/useSlackIntegration";
 import {
   ModelSelector,
   type ModelSelection,
@@ -19,6 +22,7 @@ interface DetectorsTabProps {
 export function DetectorsTab({ projectId }: DetectorsTabProps) {
   const queryClient = useQueryClient();
   const { data: project, isLoading } = useProject(projectId);
+  const { data: slack } = useSlackStatus(project?.workspace_id);
 
   const [agentModelSelection, setAgentModelSelection] = useState<ModelSelection>({
     model: "",
@@ -129,26 +133,31 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
           </Button>
         </div>
 
-        {/* Slack subsection — config will live in Project → Settings → Integrations */}
+        {/* Slack subsection — read-only mirror, configured at workspace settings */}
         <div className="border-t border-border px-4 py-3">
           <div className="flex items-center gap-1.5">
-            <Slack className="h-3.5 w-3.5 text-muted-foreground" />
+            <FaSlack className="h-3.5 w-3.5 text-muted-foreground" />
             <h4 className="text-[12px] font-medium">Slack</h4>
-            <span className="rounded-sm border border-border bg-muted/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">
-              Coming soon
-            </span>
           </div>
-          <button
-            type="button"
-            disabled
-            aria-disabled="true"
-            className="mt-2 inline-flex h-7 cursor-not-allowed items-center gap-1 rounded-sm border border-border bg-muted/40 px-2.5 text-[12px] text-muted-foreground opacity-70"
-            title="Slack integration is not yet available"
-          >
-            Connect
-            <ArrowUpRight className="h-3 w-3" />
-          </button>
-          <p className="mt-2 text-[12px] text-muted-foreground">Post alerts to a channel.</p>
+          <p className="mt-2 text-[12px] text-muted-foreground">
+            {slack?.connected ? (
+              <>
+                Connected to <span className="font-medium text-foreground">{slack.teamName}</span>
+                {slack.channel ? <> · #{slack.channel.name}</> : <> · No channel selected</>}
+              </>
+            ) : (
+              <>Not connected.</>
+            )}
+          </p>
+          {project?.workspace_id && (
+            <Link
+              href={`/workspaces/${project.workspace_id}/settings/integrations`}
+              className="mt-3 inline-flex h-7 items-center gap-1 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+            >
+              {slack?.connected ? "Manage" : "Connect"}
+              <ArrowUpRight className="h-3 w-3" />
+            </Link>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/ui/src/features/settings/workspace/components/IntegrationsTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/IntegrationsTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { GitHubConnectButton } from "@/components/github/GitHubConnectButton";
+import { SlackConnectButton } from "@/components/slack/SlackConnectButton";
 
 interface IntegrationsTabProps {
   workspaceId: string;
@@ -20,8 +21,13 @@ export function IntegrationsTab({ workspaceId }: IntegrationsTabProps) {
         <div className="border-b bg-muted/30 px-4 py-3">
           <h3 className="text-sm font-medium">Connected Services</h3>
         </div>
-        <div className="px-4 py-3">
-          <GitHubConnectButton workspaceId={workspaceId} />
+        <div className="divide-y">
+          <div className="px-4 py-3">
+            <GitHubConnectButton workspaceId={workspaceId} />
+          </div>
+          <div className="px-4 py-3">
+            <SlackConnectButton workspaceId={workspaceId} />
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/ui/src/lib/slack.ts
+++ b/frontend/ui/src/lib/slack.ts
@@ -1,0 +1,74 @@
+export interface SlackStatus {
+  connected: boolean;
+  teamName?: string;
+  botUserId?: string;
+  channel?: { id: string; name: string } | null;
+}
+
+export interface SlackChannel {
+  id: string;
+  name: string;
+  isPrivate: boolean;
+}
+
+export interface SlackChannelsResponse {
+  channels: SlackChannel[];
+  hasPrivateChannelAccess: boolean;
+}
+
+export async function fetchSlackConnection(workspaceId: string): Promise<SlackStatus> {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(workspaceId)}/slack`);
+  if (!res.ok) throw new Error("failed to fetch slack status");
+  return res.json();
+}
+
+export async function fetchSlackChannels(workspaceId: string): Promise<SlackChannelsResponse> {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(workspaceId)}/slack/channels`);
+  if (!res.ok) throw new Error("failed to fetch slack channels");
+  return res.json();
+}
+
+export async function saveSlackChannel(
+  workspaceId: string,
+  channelId: string,
+  channelName: string,
+): Promise<void> {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(workspaceId)}/slack/channel`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ channelId, channelName }),
+  });
+  if (!res.ok) throw new Error("failed to save slack channel");
+}
+
+export async function disconnectSlack(workspaceId: string): Promise<void> {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(workspaceId)}/slack`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw new Error("failed to disconnect slack");
+}
+
+export interface SlackTestMessageResponse {
+  ok: boolean;
+  ts?: string;
+  channel?: { id: string; name: string };
+  error?: string;
+  message?: string;
+}
+
+export async function sendSlackTestMessage(workspaceId: string): Promise<SlackTestMessageResponse> {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(workspaceId)}/slack/test-message`, {
+    method: "POST",
+  });
+  // Always parse the body — both success and error responses are JSON
+  const body: SlackTestMessageResponse = await res.json();
+  if (!res.ok) {
+    // Throw a typed error so onError handler can show the user-readable `message`
+    const err = new Error(body.message ?? "Failed to send test message") as Error & {
+      code?: string;
+    };
+    err.code = body.error;
+    throw err;
+  }
+  return body;
+}

--- a/frontend/worker/package.json
+++ b/frontend/worker/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.87.0",
     "@traceroot/core": "workspace:*",
+    "@traceroot/slack": "workspace:*",
     "bullmq": "^5.73.3",
     "ioredis": "^5.10.1",
     "nodemailer": "^6.10.0",

--- a/frontend/worker/src/__tests__/slack-fanout.test.ts
+++ b/frontend/worker/src/__tests__/slack-fanout.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendCombinedAlertEmail = vi.fn();
+const sendCombinedAlertSlack = vi.fn();
+
+vi.mock("../notifications/email.js", () => ({
+  sendCombinedAlertEmail: (...a: unknown[]) => sendCombinedAlertEmail(...a),
+}));
+vi.mock("../notifications/slack.js", () => ({
+  sendCombinedAlertSlack: (...a: unknown[]) => sendCombinedAlertSlack(...a),
+}));
+
+const baseCommon = {
+  detectorName: "x",
+  projectName: "p",
+  summary: "s",
+  rcaResult: null,
+  traceId: "t",
+  projectId: "pid",
+};
+
+describe("runFanOut", () => {
+  beforeEach(() => {
+    sendCombinedAlertEmail.mockReset().mockResolvedValue(undefined);
+    sendCombinedAlertSlack.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("sends email only when slack is not configured", async () => {
+    const { runFanOut } = await import("../processors/detector-rca-processor.js");
+    await runFanOut({
+      emailAddresses: ["a@b.c"],
+      slackChannelId: null,
+      slackBotTokenEnc: null,
+      common: baseCommon,
+    });
+    expect(sendCombinedAlertEmail).toHaveBeenCalledTimes(1);
+    expect(sendCombinedAlertSlack).not.toHaveBeenCalled();
+  });
+
+  it("sends slack only when email is not configured", async () => {
+    const { runFanOut } = await import("../processors/detector-rca-processor.js");
+    await runFanOut({
+      emailAddresses: [],
+      slackChannelId: "C1",
+      slackBotTokenEnc: "enc",
+      common: baseCommon,
+    });
+    expect(sendCombinedAlertEmail).not.toHaveBeenCalled();
+    expect(sendCombinedAlertSlack).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends to both when both are configured", async () => {
+    const { runFanOut } = await import("../processors/detector-rca-processor.js");
+    await runFanOut({
+      emailAddresses: ["a@b.c"],
+      slackChannelId: "C1",
+      slackBotTokenEnc: "enc",
+      common: baseCommon,
+    });
+    expect(sendCombinedAlertEmail).toHaveBeenCalledTimes(1);
+    expect(sendCombinedAlertSlack).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when neither configured", async () => {
+    const { runFanOut } = await import("../processors/detector-rca-processor.js");
+    await runFanOut({
+      emailAddresses: [],
+      slackChannelId: null,
+      slackBotTokenEnc: null,
+      common: baseCommon,
+    });
+    expect(sendCombinedAlertEmail).not.toHaveBeenCalled();
+    expect(sendCombinedAlertSlack).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/worker/src/__tests__/slack-send.test.ts
+++ b/frontend/worker/src/__tests__/slack-send.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const postMessage = vi.fn();
+const createSlackClient = vi.fn((_token: string) => ({ chat: { postMessage } }));
+
+vi.mock("@traceroot/slack", () => ({
+  createSlackClient: (token: string) => createSlackClient(token),
+  buildCombinedAlertBlocks: () => [{ type: "section", text: { type: "mrkdwn", text: "block" } }],
+}));
+vi.mock("@traceroot/core", () => ({
+  decryptKey: (s: string) => `decrypted(${s})`,
+}));
+
+describe("sendCombinedAlertSlack", () => {
+  beforeEach(() => {
+    postMessage.mockReset();
+    createSlackClient.mockClear();
+  });
+
+  it("decrypts the token, builds blocks, and posts to the channel", async () => {
+    postMessage.mockResolvedValue({ ok: true, ts: "1234.5678" });
+    const { sendCombinedAlertSlack } = await import("../notifications/slack.js");
+    await sendCombinedAlertSlack({
+      encryptedBotToken: "enc-tok",
+      channelId: "C1",
+      detectorName: "Hallucination",
+      projectName: "billing",
+      summary: "x",
+      traceId: "abcd",
+      projectId: "p1",
+      rcaResult: null,
+    });
+    expect(createSlackClient).toHaveBeenCalledWith("decrypted(enc-tok)");
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    const arg = postMessage.mock.calls[0][0];
+    expect(arg.channel).toBe("C1");
+    expect(arg.unfurl_links).toBe(false);
+    expect(Array.isArray(arg.blocks)).toBe(true);
+  });
+
+  it("throws on a Slack API failure", async () => {
+    const err: any = new Error("not_in_channel");
+    err.data = { error: "not_in_channel" };
+    postMessage.mockRejectedValue(err);
+    const { sendCombinedAlertSlack } = await import("../notifications/slack.js");
+    await expect(
+      sendCombinedAlertSlack({
+        encryptedBotToken: "enc-tok",
+        channelId: "C1",
+        detectorName: "x",
+        projectName: "x",
+        summary: "x",
+        traceId: "x",
+        projectId: "x",
+        rcaResult: null,
+      }),
+    ).rejects.toThrow(/not_in_channel/);
+  });
+});

--- a/frontend/worker/src/notifications/slack.ts
+++ b/frontend/worker/src/notifications/slack.ts
@@ -1,0 +1,35 @@
+import { createSlackClient, buildCombinedAlertBlocks } from "@traceroot/slack";
+import { decryptKey } from "@traceroot/core";
+
+const APP_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+export interface SendCombinedAlertSlackParams {
+  encryptedBotToken: string;
+  channelId: string;
+  detectorName: string;
+  projectName: string;
+  summary: string;
+  traceId: string;
+  projectId: string;
+  rcaResult: string | null;
+}
+
+export async function sendCombinedAlertSlack(params: SendCombinedAlertSlackParams): Promise<void> {
+  const client = createSlackClient(decryptKey(params.encryptedBotToken));
+  const blocks = buildCombinedAlertBlocks({
+    detectorName: params.detectorName,
+    projectName: params.projectName,
+    summary: params.summary,
+    traceId: params.traceId,
+    projectId: params.projectId,
+    appBaseUrl: APP_BASE_URL,
+    rcaResult: params.rcaResult,
+  });
+  await client.chat.postMessage({
+    channel: params.channelId,
+    blocks: blocks as any,
+    text: `Alert: ${params.detectorName} fired on ${params.projectName}`,
+    unfurl_links: false,
+    unfurl_media: false,
+  });
+}

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -3,6 +3,7 @@ import { prisma, SYSTEM_MODELS } from "@traceroot/core";
 import type { DetectorRcaJob } from "../queues/detector-run-queue.js";
 import { DETECTOR_RCA_QUEUE, createRedisConnection } from "../queues/detector-run-queue.js";
 import { sendCombinedAlertEmail } from "../notifications/email.js";
+import { sendCombinedAlertSlack } from "../notifications/slack.js";
 
 const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:8100";
 
@@ -153,6 +154,55 @@ Output your findings in this format:
   return { result: rcaResult, sessionId: session.id };
 }
 
+// ---------------------------------------------------------------------------
+// Fan-out helper — exported for unit testing
+// ---------------------------------------------------------------------------
+
+export interface FanOutCommon {
+  detectorName: string;
+  projectName: string;
+  summary: string;
+  rcaResult: string | null;
+  traceId: string;
+  projectId: string;
+}
+
+export interface RunFanOutParams {
+  emailAddresses: string[];
+  slackChannelId: string | null;
+  slackBotTokenEnc: string | null;
+  common: FanOutCommon;
+}
+
+export async function runFanOut({
+  emailAddresses,
+  slackChannelId,
+  slackBotTokenEnc,
+  common,
+}: RunFanOutParams): Promise<void> {
+  const tasks: Promise<unknown>[] = [];
+
+  if (emailAddresses.length > 0) {
+    tasks.push(
+      sendCombinedAlertEmail({ to: emailAddresses, ...common }).catch((e) =>
+        console.error(`[RCA] Alert email failed for trace ${common.traceId}:`, e),
+      ),
+    );
+  }
+
+  if (slackChannelId && slackBotTokenEnc) {
+    tasks.push(
+      sendCombinedAlertSlack({
+        encryptedBotToken: slackBotTokenEnc,
+        channelId: slackChannelId,
+        ...common,
+      }).catch((e) => console.error(`[RCA] Slack send failed for trace ${common.traceId}:`, e)),
+    );
+  }
+
+  await Promise.allSettled(tasks);
+}
+
 export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
   const connection = createRedisConnection();
 
@@ -171,20 +221,17 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
       // outer catch's fallback alert can still use it (defaults to []).
       let emailAddresses: string[] = [];
 
+      let slackChannelId: string | null = null;
+
+      let slackBotTokenEnc: string | null = null;
+
       // Always send a combined alert (success: with RCA result; failure: null).
       // Detector findings should never fail silently on configured channels.
-      const sendAlert = (rcaResult: string | null) => {
-        if (emailAddresses.length === 0) return Promise.resolve();
+      const sendAlert = async (rcaResult: string | null) => {
         const summary = findings.map((f) => `[${f.detectorName}] ${f.summary}`).join("\n");
-        return sendCombinedAlertEmail({
-          to: emailAddresses,
-          detectorName: findings.map((f) => f.detectorName).join(", "),
-          projectName,
-          summary,
-          rcaResult,
-          traceId,
-          projectId,
-        }).catch((e) => console.error(`[RCA] Alert email failed for trace ${traceId}:`, e));
+        const detectorName = findings.map((f) => f.detectorName).join(", ");
+        const common = { detectorName, projectName, summary, rcaResult, traceId, projectId };
+        await runFanOut({ emailAddresses, slackChannelId, slackBotTokenEnc, common });
       };
 
       try {
@@ -193,9 +240,25 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
         // failure-state + fallback-alert handling.
         const project = await prisma.project.findUnique({
           where: { id: projectId },
-          select: { rcaModel: true, alertConfig: { select: { emailAddresses: true } } },
+          select: {
+            rcaModel: true,
+            alertConfig: {
+              select: { emailAddresses: true, slackChannelId: true, slackChannelName: true },
+            },
+            workspace: {
+              select: {
+                slackIntegration: {
+                  select: { channelId: true, channelName: true, botToken: true },
+                },
+              },
+            },
+          },
         });
         emailAddresses = project?.alertConfig?.emailAddresses ?? [];
+
+        const slack = project?.workspace?.slackIntegration ?? null;
+        slackChannelId = project?.alertConfig?.slackChannelId ?? slack?.channelId ?? null;
+        slackBotTokenEnc = slack?.botToken ?? null;
 
         // Workspace-level GitHub installations now drive the GitHub tool.
         // Any installation in this workspace is enough to flip the tool on.


### PR DESCRIPTION
## Summary
- Workspace-level Slack OAuth integration with encrypted bot-token storage at rest
- Detector RCA worker now fans alerts out to a configured Slack channel alongside email
- Workspace settings → Integrations gets a Slack row that mirrors the existing GitHub one (Connect / Configure / Test Connection / Disconnect)
- Project Detectors → Notifications gets a read-only "Connected to ..." status section that links back to workspace settings

Fixes https://github.com/traceroot-ai/traceroot/issues/807

## What's covered
- **Schema:** new `SlackIntegration` table (UNIQUE on `workspace_id`, FK CASCADE), encrypted `bot_token` via the existing AES-256-GCM helper. Per-project override columns added on `DetectorAlertConfig` for future use (no v1 UI).
- **OAuth:** `@slack/oauth` `InstallProvider` with a Prisma-backed installation store; `oauth.v2.access` response is Zod-validated.
- **API routes (all ADMIN-gated via `requireWorkspaceMembership`):**
  - `GET /api/workspaces/:id/slack/install` — start OAuth
  - `GET /api/slack/oauth/callback` — finish OAuth
  - `GET /api/workspaces/:id/slack` — status (no token in response)
  - `DELETE /api/workspaces/:id/slack` — disconnect
  - `GET /api/workspaces/:id/slack/channels` — paginated `conversations.list` with `missing_scope` fallback
  - `POST /api/workspaces/:id/slack/channel` — save channel; resolves manual `#name` via `conversations.info`
  - `POST /api/workspaces/:id/slack/test-message` — sends a Block Kit test message; maps Slack errors to user-friendly messages
- **UI:** `SlackConnectButton` (4 render states, density-matched to `GitHubConnectButton`), nested channel picker that opens to the right of the Manage popover, inline `Test Connection` button next to the channel reference. Read-only Slack mirror on the project Detectors tab links to workspace settings.
- **Worker:** new `sendCombinedAlertSlack` module + extracted `runFanOut` helper in `detector-rca-processor.ts`. `Promise.allSettled` so one channel failing doesn't block the other. Channel resolution: `alertConfig.slackChannelId ?? slackIntegration.channelId ?? null` (silent skip when null — RCA still runs).
- **Tests:** 11 in `@traceroot/slack`, 64 in `traceroot-ui` (incl. 6 new for the test-message route + 4 callback tests + others), 30 in `traceroot-worker` (incl. 4 fan-out branch tests). All `tsc --noEmit` clean.

## Out of scope (deferred)
- Per-project channel override UI (column exists)
- Threading via `thread_ts` (no `slackThreadTs` column)
- Slack interactivity (no slash commands, no events API)


## Screenshots

<img width="1135" height="1059" alt="Screenshot 2026-05-06 at 11 46 37 AM" src="https://github.com/user-attachments/assets/5336944f-16c0-4c42-99b8-eca53e85f033" />

<img width="1390" height="975" alt="Screenshot 2026-05-06 at 11 46 53 AM" src="https://github.com/user-attachments/assets/d2c631f3-9a45-4edc-9449-ebc65e00ce9b" />

<img width="1134" height="1054" alt="Screenshot 2026-05-06 at 11 46 29 AM" src="https://github.com/user-attachments/assets/545a8d43-b5d3-4d5f-b728-4120b18c7463" />



## Test plan
- [x] Unit tests: 105/105 passing
- [x] `tsc --noEmit` clean across `@traceroot/slack`, `traceroot-ui`, `traceroot-worker`
- [x] Manual e2e: Connect → channel pick → Test Connection (sends Block Kit) → real detector finding → Slack alert → Disconnect → Re-connect to a private channel (after `/invite @bot`) → private channel send works
- [x] Email + Slack fan-out both fire when both configured

## Local dev setup
See `frontend/packages/slack/README.md` for the OAuth app creation, env-var setup, and the `/invite @bot` note for private channels. Local dev runs on plain HTTP — Slack auto-installs into the active browser workspace; use an incognito window with only the target Slack workspace signed in to avoid landing on the wrong workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workspace-level Slack OAuth integration so detector alerts fan out to a configured Slack channel alongside email. Includes a settings UI to connect, pick a channel, send a test message, and disconnect.

- **New Features**
  - Schema: new `SlackIntegration` table (unique per workspace) with AES-encrypted bot token; per-project Slack override columns on `DetectorAlertConfig` (no v1 UI).
  - OAuth + Package: `@slack/oauth` installer with a Prisma-backed installation store; Slack `oauth.v2.access` validated with Zod; new `@traceroot/slack` package with a Block Kit builder and shared `WebClient` factory.
  - API: admin-gated routes for install, callback, status, list channels (public/private with `missing_scope` fallback), save channel, test message (friendly Slack error mapping), and disconnect.
  - UI: `SlackConnectButton` with Manage → Configure channel picker and inline Test Connection; read-only Slack status on the project Detectors tab linking to workspace settings.
  - Worker: Slack delivery via `sendCombinedAlertSlack` and shared `runFanOut` using `Promise.allSettled`; channel resolves via `alertConfig.slackChannelId ?? slackIntegration.channelId`.
  - Tests: coverage for installer, OAuth parsing, API routes, and worker fan-out.

- **Migration**
  - Create a Slack app with scopes: `chat:write`, `chat:write.public`, `channels:read`, `groups:read`.
  - Set env vars: `SLACK_CLIENT_ID`, `SLACK_CLIENT_SECRET`, `SLACK_STATE_SECRET`, `SLACK_REDIRECT_URI`.
  - Run Prisma migrate; then connect Slack in Workspace → Settings → Integrations. For private channels, invite the bot before selecting.

<sup>Written for commit 9c20326cf0b9a5b92015411c2b257bc17a016e62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

