### PR TITLE
feat: add GPT-5.5 and GPT-5.5-pro to BYOK model catalog

### DIFF
--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -135,6 +135,8 @@ export const PROVIDER_PRIORITY: LLMAdapter[] = [
 // Adapters NOT listed here (azure, amazon-bedrock, openrouter) use free-text input.
 export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
   openai: [
+    { id: "gpt-5.5", label: "gpt-5.5" },
+    { id: "gpt-5.5-pro", label: "gpt-5.5-pro" },
     { id: "gpt-5.4", label: "gpt-5.4" },
     { id: "gpt-5.4-pro", label: "gpt-5.4-pro" },
     { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },


### PR DESCRIPTION
Closes #841 

## Summary
OpenAi shipped GPT-5.5 and Pro to limited release and recently opened to API platform. Traceroot's current OpenAI model dropdown (ADAPTER_MODELS.openai) tops at previous flagship model GPT 5.4. This commit will bring latest OpenAI flagship models to Traceroot BYOK users to tracing and detector pages. 
## Type of Change

- [x] feat - A new feature

## Details

frontend/packages/core/src/llm-providers.ts
  - Two entries prepended to ADAPTER_MODELS.openai (lines 138–139): { id: "gpt-5.5", label: "gpt-5.5" } and { id: "gpt-5.5-pro", label: "gpt-5.5-pro" }.                                  
  - Newest-first ordering matches the convention used for the gpt-5.4 family, Opus 4.7 in #691, and Kimi K2.6 in #703 — gpt-5.5 is now the default-selected model on "Add Provider → OpenAI". 
  - label equals id per the #627 convention.                                                    
  - No apiProtocol override — both inherit openai-completions from ADAPTER_API_PROTOCOL["openai"] (line 52). Unlike gpt-5.3-codex (line 142), GPT-5.5 supports both Chat Completions and Responses, so the adapter default is fine.                          
                                                                      
  No changes to SYSTEM_MODELS, PROVIDER_PRIORITY, docs/integrations/internal-models.mdx, or the provider-test route. BYOK-only, single-file, +2/-0 — same shape as #703.  

## Screenshots / Recordings (if applicable)
Verified locally against prod web container (docker compose -f docker-compose.prod.yml up -d --build web;
<img width="1052" height="816" alt="841-1" src="https://github.com/user-attachments/assets/1bfdb65b-6aa3-4562-bc2a-4705355a0971" />
Chat completions tested against real openai api key.
<img width="1054" height="823" alt="841-2" src="https://github.com/user-attachments/assets/cc265782-5079-46d4-ae09-d64e98f03759" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAI `gpt-5.5` and `gpt-5.5-pro` to the BYOK model catalog so users can select the latest models on Tracing and Detector pages. The OpenAI dropdown now defaults to `gpt-5.5` (addresses #841).

- **New Features**
  - Prepends `gpt-5.5` and `gpt-5.5-pro` to `ADAPTER_MODELS.openai` in `frontend/packages/core/src/llm-providers.ts` with newest-first ordering (label = id).
  - Uses existing `openai-completions` adapter; no other provider, priority, or docs changes.

<sup>Written for commit a38f3e6b99e1c919f77f4e01f55aafbdba596d91. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

