### PR TITLE
feat(detectors): time range, finding/run counts, search/pagination on list page (#810)

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -11,7 +11,11 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from db.clickhouse.client import get_clickhouse_client
-from rest.schemas.detectors import FindingListResponse, RunListResponse
+from rest.schemas.detectors import (
+    DetectorCountsResponse,
+    FindingListResponse,
+    RunListResponse,
+)
 from rest.sql_utils import escape_ilike, to_utc_naive
 from shared.config import settings
 
@@ -496,3 +500,62 @@ async def get_trace_findings(trace_id: str, project_id: str):
             row_dict["timestamp"] = row_dict["timestamp"].isoformat()
         findings.append(row_dict)
     return {"findings": findings}
+
+
+@router.get(
+    "/detector-counts",
+    response_model=DetectorCountsResponse,
+    dependencies=[Depends(verify_internal_secret)],
+)
+async def list_detector_counts(
+    project_id: str,
+    start_after: datetime = Query(
+        ..., description="Lower bound on detector_runs.timestamp (inclusive)"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Upper bound on detector_runs.timestamp (exclusive)"
+    ),
+):
+    """Aggregate finding and run counts per detector for a project, in one query.
+
+    `detector_runs.finding_id` is set when a run produced a finding; counting
+    `finding_id IS NOT NULL` avoids a JOIN with `detector_findings`.
+
+    Detectors with zero runs in the window are absent from the result map; the
+    frontend defaults absent entries to {findingCount: 0, runCount: 0}.
+    """
+    ch = get_clickhouse_client()
+
+    conditions = [
+        "project_id = {project_id:String}",
+        "timestamp >= {start_after:DateTime64(3)}",
+    ]
+    params: dict = {
+        "project_id": project_id,
+        "start_after": to_utc_naive(start_after),
+    }
+    if end_before is not None:
+        conditions.append("timestamp < {end_before:DateTime64(3)}")
+        params["end_before"] = to_utc_naive(end_before)
+
+    where_clause = " AND ".join(conditions)
+    query = f"""
+        SELECT
+            detector_id,
+            count()                          AS run_count,
+            countIf(finding_id IS NOT NULL)  AS finding_count
+        FROM detector_runs
+        WHERE {where_clause}
+        GROUP BY detector_id
+    """
+
+    result = ch.query(query, parameters=params)
+    data: dict[str, dict[str, int]] = {}
+    for row in result.result_rows:
+        row_dict = dict(zip(result.column_names, row))
+        data[row_dict["detector_id"]] = {
+            "finding_count": int(row_dict["finding_count"]),
+            "run_count": int(row_dict["run_count"]),
+        }
+
+    return {"data": data}

--- a/backend/rest/schemas/detectors.py
+++ b/backend/rest/schemas/detectors.py
@@ -43,3 +43,17 @@ class RunListResponse(BaseModel):
 
     data: list[RunItem]
     meta: PaginationMeta
+
+
+class DetectorCountsItem(BaseModel):
+    """Aggregated counts for a single detector over a time window."""
+
+    finding_count: int
+    run_count: int
+
+
+class DetectorCountsResponse(BaseModel):
+    """Map of detector_id -> counts. Detectors with zero runs in the window
+    are omitted; the frontend defaults absent entries to {0, 0}."""
+
+    data: dict[str, DetectorCountsItem]

--- a/frontend/ui/src/app/api/projects/[projectId]/detector-counts/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detector-counts/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest } from "next/server";
+import { requireAuth, requireProjectAccess, errorResponse } from "@/lib/auth-helpers";
+import { env } from "@/env";
+
+const BACKEND_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
+const INTERNAL_API_SECRET = env.INTERNAL_API_SECRET || "";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+// GET /api/projects/[projectId]/detector-counts
+// Proxies to Python backend: GET /api/v1/internal/detector-counts
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const { searchParams } = req.nextUrl;
+  const startAfter = searchParams.get("start_after");
+  const endBefore = searchParams.get("end_before");
+
+  if (!startAfter) {
+    return errorResponse("start_after is required", 400);
+  }
+
+  const backendParams = new URLSearchParams({
+    project_id: projectId,
+    start_after: startAfter,
+  });
+  if (endBefore) backendParams.set("end_before", endBefore);
+
+  let response: Response;
+  try {
+    response = await fetch(
+      `${BACKEND_URL}/api/v1/internal/detector-counts?${backendParams.toString()}`,
+      {
+        headers: {
+          "X-Internal-Secret": INTERNAL_API_SECRET,
+          "Content-Type": "application/json",
+        },
+      },
+    );
+  } catch (err) {
+    console.error("[detector-counts proxy] fetch error:", err);
+    return errorResponse("Failed to reach backend", 502);
+  }
+
+  const data: unknown = await response.json();
+  return Response.json(data, { status: response.status });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -9,8 +9,10 @@ import {
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
-// GET /api/projects/[projectId]/detectors - List all detectors for the project
-export async function GET(_req: NextRequest, { params }: RouteParams) {
+// GET /api/projects/[projectId]/detectors - List detectors for the project.
+// Supports `search_query` (substring on name/template/prompt), `page`, `limit`.
+// Returns `{ data, meta }` to match the rest of the list endpoints.
+export async function GET(req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
   const { user } = authResult;
@@ -19,13 +21,36 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   const accessResult = await requireProjectAccess(user.id, projectId);
   if (accessResult.error) return accessResult.error;
 
-  const detectors = await prisma.detector.findMany({
-    where: { projectId },
-    include: { trigger: true },
-    orderBy: { createTime: "asc" },
-  });
+  const { searchParams } = req.nextUrl;
+  const rawLimit = parseInt(searchParams.get("limit") ?? "50", 10);
+  const rawPage = parseInt(searchParams.get("page") ?? "0", 10);
+  const limit = isNaN(rawLimit) ? 50 : Math.min(Math.max(rawLimit, 1), 200);
+  const page = isNaN(rawPage) ? 0 : Math.max(rawPage, 0);
+  const searchQuery = searchParams.get("search_query")?.trim() || null;
 
-  return successResponse({ detectors });
+  const where = searchQuery
+    ? {
+        projectId,
+        OR: [
+          { name: { contains: searchQuery, mode: "insensitive" as const } },
+          { template: { contains: searchQuery, mode: "insensitive" as const } },
+          { prompt: { contains: searchQuery, mode: "insensitive" as const } },
+        ],
+      }
+    : { projectId };
+
+  const [data, total] = await prisma.$transaction([
+    prisma.detector.findMany({
+      where,
+      include: { trigger: true },
+      orderBy: { createTime: "asc" },
+      skip: page * limit,
+      take: limit,
+    }),
+    prisma.detector.count({ where }),
+  ]);
+
+  return successResponse({ data, meta: { page, limit, total } });
 }
 
 // POST /api/projects/[projectId]/detectors - Create a new detector

--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
@@ -7,7 +7,7 @@ import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ListPagination } from "@/components/list-pagination";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { formatDate, cn } from "@/lib/utils";
-import { useDetectors } from "@/features/detectors/hooks/use-detectors";
+import { useDetector } from "@/features/detectors/hooks/use-detectors";
 import { useFindings, useRuns, type BackendFinding } from "@/features/detectors/hooks/use-findings";
 import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { TraceViewerPanel } from "@/features/traces/components/TraceViewerPanel";
@@ -27,8 +27,7 @@ export default function DetectorDetailPage() {
   const [selectedFinding, setSelectedFinding] = useState<BackendFinding | null>(null);
 
   // Single shared state across both tabs — same pattern as traces/sessions/users.
-  // Pagination, search, and date filter live in the URL so a tab switch keeps
-  // them; `defaultDateFilter` is the only detector-specific deviation (#806).
+  // Pagination, search, and date filter live in the URL so a tab switch keeps them.
   const {
     state,
     queryOptions,
@@ -39,8 +38,7 @@ export default function DetectorDetailPage() {
     goToPage,
   } = useListPageState();
 
-  const { data: detectorsData } = useDetectors(projectId);
-  const detector = detectorsData?.find((d) => d.id === detectorId);
+  const { data: detector } = useDetector(projectId, detectorId);
 
   const { data: findingsData, isLoading, error } = useFindings(projectId, detectorId, queryOptions);
 

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -5,9 +5,16 @@ import { useParams, useRouter } from "next/navigation";
 import { Eye, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { ListPagination } from "@/components/list-pagination";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { formatDate, cn } from "@/lib/utils";
-import { useDetectors, useDeleteDetector } from "@/features/detectors/hooks/use-detectors";
+import {
+  useDetectorList,
+  useDetectorCounts,
+  useDeleteDetector,
+} from "@/features/detectors/hooks/use-detectors";
+import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { useProject } from "@/features/projects/hooks";
 import { DeleteDetectorDialog } from "@/features/detectors/components/delete-detector-dialog";
 import { DetectorPanel } from "@/features/detectors/components/detector-panel";
@@ -22,11 +29,32 @@ export default function DetectorsPage() {
   const [actionsOpen, setActionsOpen] = useState<string | null>(null);
   const [selectedDetectorId, setSelectedDetectorId] = useState<string | null>(null);
 
-  const { data: project } = useProject(projectId);
-  const { data, isLoading, error } = useDetectors(projectId);
-  const deleteMutation = useDeleteDetector(projectId);
+  const {
+    state,
+    queryOptions,
+    updateDateFilter,
+    updateCustomRange,
+    updateKeyword,
+    updateLimit,
+    goToPage,
+  } = useListPageState({ defaultDateFilterId: "14d" });
 
-  const detectors = data ?? [];
+  const { data: project } = useProject(projectId);
+
+  const { data, isLoading, error } = useDetectorList(projectId, {
+    page: queryOptions.page,
+    limit: queryOptions.limit,
+    search_query: queryOptions.search_query,
+  });
+
+  const { data: counts, isLoading: countsLoading } = useDetectorCounts(projectId, {
+    start_after: queryOptions.start_after,
+    end_before: queryOptions.end_before,
+  });
+
+  const deleteMutation = useDeleteDetector(projectId);
+  const detectors = data?.data ?? [];
+  const meta = data?.meta;
 
   const handleDeleteConfirm = () => {
     if (!deleteTarget) return;
@@ -49,6 +77,9 @@ export default function DetectorsPage() {
     if (next >= 0 && next < detectors.length) setSelectedDetectorId(detectors[next].id);
   };
 
+  const isEmptyProject = !isLoading && !error && (meta?.total ?? 0) === 0 && !state.keyword;
+  const isEmptySearch = !isLoading && !error && detectors.length === 0 && !!state.keyword;
+
   return (
     <div className="relative flex h-full text-[13px]">
       <ProjectBreadcrumb projectId={projectId} />
@@ -66,6 +97,18 @@ export default function DetectorsPage() {
           </Button>
         </div>
 
+        {/* Search / time-range filter */}
+        <SearchFilterBar
+          searchValue={state.keyword}
+          onSearchChange={updateKeyword}
+          searchPlaceholder="Search..."
+          dateFilter={state.dateFilter}
+          customStartDate={state.customStartDate}
+          customEndDate={state.customEndDate}
+          onDateFilterChange={updateDateFilter}
+          onCustomRangeChange={updateCustomRange}
+        />
+
         {/* Table */}
         <div className="flex-1 overflow-auto bg-background">
           {isLoading ? (
@@ -76,7 +119,7 @@ export default function DetectorsPage() {
             <div className="flex h-64 flex-col items-center justify-center gap-3">
               <p className="text-[13px] text-destructive">Error loading detectors</p>
             </div>
-          ) : detectors.length === 0 ? (
+          ) : isEmptyProject ? (
             <div className="flex h-64 flex-col items-center justify-center gap-3">
               <Eye className="h-8 w-8 text-muted-foreground/40" />
               <p className="text-[13px] text-muted-foreground">No detectors yet</p>
@@ -89,6 +132,20 @@ export default function DetectorsPage() {
                 onClick={() => router.push(`/projects/${projectId}/detectors/new`)}
               >
                 New Detector
+              </Button>
+            </div>
+          ) : isEmptySearch ? (
+            <div className="flex h-64 flex-col items-center justify-center gap-3">
+              <p className="text-[13px] text-muted-foreground">
+                No detectors match &ldquo;{state.keyword}&rdquo;
+              </p>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-7 text-[12px]"
+                onClick={() => updateKeyword("")}
+              >
+                Clear search
               </Button>
             </div>
           ) : (
@@ -107,6 +164,12 @@ export default function DetectorsPage() {
                   <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                     Sampling
                   </th>
+                  <th className="border-r border-border/50 px-3 py-1.5 text-right text-[12px] font-medium text-muted-foreground">
+                    Findings
+                  </th>
+                  <th className="border-r border-border/50 px-3 py-1.5 text-right text-[12px] font-medium text-muted-foreground">
+                    Runs
+                  </th>
                   <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                     Created At
                   </th>
@@ -124,6 +187,11 @@ export default function DetectorsPage() {
               <tbody>
                 {detectors.map((detector) => {
                   const template = getTemplate(detector.template);
+                  const c = counts?.[detector.id];
+                  const findingCount = c?.finding_count ?? 0;
+                  const runCount = c?.run_count ?? 0;
+                  const countClass =
+                    "border-r border-border/50 px-3 py-1.5 text-right text-[12px] text-muted-foreground tabular-nums";
                   return (
                     <tr
                       key={detector.id}
@@ -145,6 +213,8 @@ export default function DetectorsPage() {
                       <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                         {detector.sampleRate}%
                       </td>
+                      <td className={countClass}>{countsLoading ? "—" : findingCount}</td>
+                      <td className={countClass}>{countsLoading ? "—" : runCount}</td>
                       <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                         {formatDate(detector.createTime)}
                       </td>
@@ -202,6 +272,16 @@ export default function DetectorsPage() {
             </table>
           )}
         </div>
+
+        {meta && (
+          <ListPagination
+            page={meta.page}
+            limit={meta.limit}
+            total={meta.total}
+            onPageChange={goToPage}
+            onLimitChange={updateLimit}
+          />
+        )}
       </div>
 
       {/* Edit panel — fixed overlay */}

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { Eye, X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
-import { useDetectors, useUpdateDetector } from "../hooks/use-detectors";
+import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
 import { useProject } from "@/features/projects/hooks";
 import { TriggerEditor } from "./trigger-editor";
 import type { TriggerCondition } from "./trigger-editor";
@@ -33,8 +33,7 @@ export function DetectorPanel({
   canNavigateUp,
   canNavigateDown,
 }: DetectorPanelProps) {
-  const { data: detectorsData } = useDetectors(projectId);
-  const detector = detectorsData?.find((d) => d.id === detectorId);
+  const { data: detector } = useDetector(projectId, detectorId);
   const { data: project } = useProject(projectId);
 
   const [editName, setEditName] = useState("");

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -61,12 +61,22 @@ export function DetectorPanel({
     setEditConditions((d.trigger?.conditions ?? []) as TriggerCondition[]);
   };
 
+  // When the loaded detector matches the requested id, populate edit state.
+  // Otherwise clear it: the panel's Next/Prev arrow can change `detectorId`
+  // before `useDetector` resolves the new fetch, and without this clear the
+  // form would briefly hold the previous detector's values — a Save during
+  // that gap would write them to the new detector.
   useEffect(() => {
-    populate(detector);
-  }, [detector]);
-  useEffect(() => {
-    populate(detector);
-  }, [detectorId]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (detector && detector.id === detectorId) {
+      populate(detector);
+    } else {
+      setEditName("");
+      setEditPrompt("");
+      setEditSampleRate(100);
+      setEditModelSelection({ model: "", provider: "", source: "system", adapter: "" });
+      setEditConditions([]);
+    }
+  }, [detectorId, detector]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [copied, setCopied] = useState(false);
   const copyId = useCallback(() => {
@@ -78,6 +88,12 @@ export function DetectorPanel({
   const updateMutation = useUpdateDetector(projectId, detectorId);
 
   const handleSave = () => {
+    // Guard against saving while the new detector's data is still loading.
+    // Edit state would be the previous detector's, but the mutation targets
+    // the current detectorId; without this guard, stale values would
+    // overwrite the new detector. The Save button is also disabled in this
+    // state — this is defense-in-depth.
+    if (!detector || detector.id !== detectorId) return;
     updateMutation.mutate(
       {
         name: editName,
@@ -240,7 +256,7 @@ export function DetectorPanel({
           <Button
             size="sm"
             onClick={handleSave}
-            disabled={updateMutation.isPending}
+            disabled={updateMutation.isPending || !detector || detector.id !== detectorId}
             className="h-7 text-[12px]"
           >
             {updateMutation.isPending ? "Saving..." : "Save"}

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.ts
@@ -16,6 +16,23 @@ export interface Detector {
   trigger?: { conditions: Array<{ field: string; op: string; value: unknown }> } | null;
 }
 
+interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+}
+
+interface DetectorListQuery {
+  page?: number;
+  limit?: number;
+  search_query?: string;
+}
+
+interface DetectorListResponse {
+  data: Detector[];
+  meta: PaginationMeta;
+}
+
 export interface CreateDetectorInput {
   name: string;
   template: string;
@@ -28,11 +45,27 @@ export interface CreateDetectorInput {
   detectionSource?: "system" | "byok";
 }
 
-async function fetchDetectors(projectId: string): Promise<Detector[]> {
-  const res = await fetch(`/api/projects/${projectId}/detectors`);
+async function fetchDetectorList(
+  projectId: string,
+  query: DetectorListQuery = {},
+): Promise<DetectorListResponse> {
+  const params = new URLSearchParams();
+  if (query.page !== undefined) params.set("page", String(query.page));
+  if (query.limit !== undefined) params.set("limit", String(query.limit));
+  if (query.search_query) params.set("search_query", query.search_query);
+
+  const qs = params.toString();
+  const url = `/api/projects/${projectId}/detectors${qs ? `?${qs}` : ""}`;
+  const res = await fetch(url);
   if (!res.ok) throw new Error(`Failed to fetch detectors: ${res.status}`);
-  const data = (await res.json()) as { detectors: Detector[] };
-  return data.detectors;
+  return res.json() as Promise<DetectorListResponse>;
+}
+
+async function fetchDetector(projectId: string, detectorId: string): Promise<Detector> {
+  const res = await fetch(`/api/projects/${projectId}/detectors/${detectorId}`);
+  if (!res.ok) throw new Error(`Failed to fetch detector: ${res.status}`);
+  const data = (await res.json()) as { detector: Detector };
+  return data.detector;
 }
 
 async function createDetector(projectId: string, input: CreateDetectorInput): Promise<Detector> {
@@ -78,11 +111,60 @@ async function deleteDetector(projectId: string, detectorId: string): Promise<vo
   if (!res.ok) throw new Error(`Failed to delete detector: ${res.status}`);
 }
 
-export function useDetectors(projectId: string) {
+/** List detectors for the list page (paginated, optional search). */
+export function useDetectorList(projectId: string, query: DetectorListQuery = {}) {
   return useQuery({
-    queryKey: ["detectors", projectId],
-    queryFn: () => fetchDetectors(projectId),
+    queryKey: [
+      "detectors",
+      "list",
+      projectId,
+      query.page ?? 0,
+      query.limit ?? 50,
+      query.search_query ?? null,
+    ],
+    queryFn: () => fetchDetectorList(projectId, query),
     enabled: !!projectId,
+    placeholderData: (prev) => prev,
+  });
+}
+
+/** Look up a single detector by ID (used by detail page + edit panel). */
+export function useDetector(projectId: string, detectorId: string) {
+  return useQuery({
+    queryKey: ["detectors", "byId", projectId, detectorId],
+    queryFn: () => fetchDetector(projectId, detectorId),
+    enabled: !!projectId && !!detectorId,
+  });
+}
+
+interface DetectorCountsItem {
+  finding_count: number;
+  run_count: number;
+}
+
+async function fetchDetectorCounts(
+  projectId: string,
+  startAfter: string,
+  endBefore?: string,
+): Promise<Record<string, DetectorCountsItem>> {
+  const params = new URLSearchParams({ start_after: startAfter });
+  if (endBefore) params.set("end_before", endBefore);
+  const res = await fetch(`/api/projects/${projectId}/detector-counts?${params.toString()}`);
+  if (!res.ok) throw new Error(`Failed to fetch detector counts: ${res.status}`);
+  const body = (await res.json()) as { data: Record<string, DetectorCountsItem> };
+  return body.data;
+}
+
+/** Aggregated finding/run counts per detector for a project + window. */
+export function useDetectorCounts(
+  projectId: string,
+  opts: { start_after?: string; end_before?: string },
+) {
+  return useQuery({
+    queryKey: ["detectors", "counts", projectId, opts.start_after ?? null, opts.end_before ?? null],
+    queryFn: () => fetchDetectorCounts(projectId, opts.start_after!, opts.end_before),
+    enabled: !!projectId && !!opts.start_after,
+    staleTime: 30_000,
   });
 }
 
@@ -91,7 +173,7 @@ export function useCreateDetector(projectId: string) {
   return useMutation({
     mutationFn: (input: CreateDetectorInput) => createDetector(projectId, input),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["detectors", projectId] });
+      void queryClient.invalidateQueries({ queryKey: ["detectors"] });
     },
   });
 }
@@ -101,7 +183,7 @@ export function useUpdateDetector(projectId: string, detectorId: string) {
   return useMutation({
     mutationFn: (input: UpdateDetectorInput) => updateDetector(projectId, detectorId, input),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["detectors", projectId] });
+      void queryClient.invalidateQueries({ queryKey: ["detectors"] });
     },
   });
 }
@@ -111,7 +193,7 @@ export function useDeleteDetector(projectId: string) {
   return useMutation({
     mutationFn: (detectorId: string) => deleteDetector(projectId, detectorId),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["detectors", projectId] });
+      void queryClient.invalidateQueries({ queryKey: ["detectors"] });
     },
   });
 }

--- a/frontend/ui/src/lib/date-filter.ts
+++ b/frontend/ui/src/lib/date-filter.ts
@@ -21,6 +21,7 @@ export const DATE_FILTER_OPTIONS: DateFilterOption[] = [
   { id: "6h", label: "Last 6 hours", durationMinutes: 360 },
   { id: "1d", label: "Last 24 hours", durationMinutes: 1440 },
   { id: "7d", label: "Last 7 days", durationMinutes: 10080 },
+  { id: "14d", label: "Last 14 days", durationMinutes: 20160 },
   { id: "30d", label: "Last 30 days", durationMinutes: 43200 },
   { id: "custom", label: "Custom", durationMinutes: null, isCustom: true },
 ];

--- a/frontend/ui/src/lib/hooks/use-list-page-state.ts
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.ts
@@ -46,13 +46,17 @@ interface UseListPageStateReturn {
   queryOptions: QueryOptions;
 }
 
-export function useListPageState(defaultLimit = 50): UseListPageStateReturn {
+export function useListPageState(
+  options: { defaultLimit?: number; defaultDateFilterId?: string } = {},
+): UseListPageStateReturn {
+  const { defaultLimit = 50, defaultDateFilterId } = options;
+
   // URL-synced pagination hook - persists page/limit in URL
   const pagination = useUrlPagination(defaultLimit);
 
   // URL-synced date filter hook - resets page on change
   const { dateFilter, customStartDate, customEndDate, setDateFilter, setCustomRange, timestamps } =
-    useUrlDateFilter(pagination.resetPage);
+    useUrlDateFilter(pagination.resetPage, defaultDateFilterId);
 
   // Search hook - resets page on change
   const { keyword, setKeyword, searchQuery } = useKeywordSearch(pagination.resetPage);

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.ts
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.ts
@@ -24,7 +24,10 @@ interface UseUrlDateFilterReturn {
   };
 }
 
-export function useUrlDateFilter(onFilterChange?: () => void): UseUrlDateFilterReturn {
+export function useUrlDateFilter(
+  onFilterChange?: () => void,
+  defaultId?: string,
+): UseUrlDateFilterReturn {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
@@ -37,7 +40,9 @@ export function useUrlDateFilter(onFilterChange?: () => void): UseUrlDateFilterR
   // Parse URL values into state
   const initialDateFilter = urlDateFilterId
     ? findDateFilterOption(urlDateFilterId)
-    : DEFAULT_DATE_FILTER;
+    : defaultId
+      ? findDateFilterOption(defaultId)
+      : DEFAULT_DATE_FILTER;
   const initialCustomStart = urlStartDate ? new Date(urlStartDate) : null;
   const initialCustomEnd = urlEndDate ? new Date(urlEndDate) : null;
 

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -280,3 +280,98 @@ class TestInternalAuth:
             headers={"X-Internal-Secret": "wrong"},
         )
         assert resp.status_code == 403
+
+
+# =============================================================================
+# /detector-counts (#810)
+# =============================================================================
+
+
+class TestListDetectorCounts:
+    def _fake_aggregate(self, rows: list[tuple]):
+        return _make_query_result(
+            rows=rows,
+            column_names=["detector_id", "run_count", "finding_count"],
+        )
+
+    def test_returns_per_detector_counts(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [
+            self._fake_aggregate([("d-a", 100, 7), ("d-b", 25, 0)]),
+        ]
+        resp = client.get(
+            "/api/v1/internal/detector-counts",
+            params={
+                "project_id": "p1",
+                "start_after": "2026-04-20T00:00:00Z",
+            },
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body == {
+            "data": {
+                "d-a": {"finding_count": 7, "run_count": 100},
+                "d-b": {"finding_count": 0, "run_count": 25},
+            }
+        }
+
+    def test_empty_when_no_runs_in_window(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_aggregate([])]
+        resp = client.get(
+            "/api/v1/internal/detector-counts",
+            params={
+                "project_id": "p1",
+                "start_after": "2026-04-20T00:00:00Z",
+            },
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"data": {}}
+
+    def test_passes_end_before_when_provided(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_aggregate([])]
+        client.get(
+            "/api/v1/internal/detector-counts",
+            params={
+                "project_id": "p1",
+                "start_after": "2026-04-20T00:00:00Z",
+                "end_before": "2026-05-01T00:00:00Z",
+            },
+            headers={"X-Internal-Secret": secret},
+        )
+        call_args = mock_ch.query.call_args
+        sql = call_args.args[0] if call_args.args else call_args.kwargs.get("query")
+        params = call_args.kwargs.get("parameters", {})
+        assert "timestamp <" in sql
+        assert "end_before" in params
+
+    def test_omits_end_before_when_absent(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_aggregate([])]
+        client.get(
+            "/api/v1/internal/detector-counts",
+            params={
+                "project_id": "p1",
+                "start_after": "2026-04-20T00:00:00Z",
+            },
+            headers={"X-Internal-Secret": secret},
+        )
+        call_args = mock_ch.query.call_args
+        sql = call_args.args[0] if call_args.args else call_args.kwargs.get("query")
+        params = call_args.kwargs.get("parameters", {})
+        assert "timestamp <" not in sql or "end_before" not in sql
+        assert "end_before" not in params
+
+    def test_requires_internal_secret(self, client, mock_ch):
+        resp = client.get(
+            "/api/v1/internal/detector-counts",
+            params={"project_id": "p1", "start_after": "2026-04-20T00:00:00Z"},
+        )
+        assert resp.status_code == 403
+
+    def test_requires_start_after(self, client, mock_ch, secret):
+        resp = client.get(
+            "/api/v1/internal/detector-counts",
+            params={"project_id": "p1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 422


### PR DESCRIPTION
## Summary

- Detector list now mirrors the SearchFilterBar + ListPagination + `useListPageState` trio used across `traces` / `sessions` / `users` / detector-detail (PR #826), with **search** (name/template/prompt), **time-range presets** (defaulting to 14d), and **pagination**.
- Two new right-aligned columns — **Findings** and **Runs** — driven by a new `/api/v1/internal/detector-counts` endpoint that aggregates per-detector counts from ClickHouse in a single query (no N+1).
- The date range only flows into the counts query; the detector list itself is window-independent, so silent detectors still appear (with `0 / 0`).
- Splits `useDetectors` into `useDetectorList` (paginated/searchable, list page) + `useDetector` (single-record lookup, detail page + edit panel) — the old "fetch full list, `.find()` by id" pattern wouldn't have survived pagination past page 0.

Fixes #810

## Test plan

- [ ] `uv run pytest tests/rest/test_detector_endpoints.py` — 20 pass (6 new for `/detector-counts`).
- [ ] `pnpm tsc --noEmit` from `frontend/ui` — clean.
- [ ] `pnpm lint` from `frontend/ui` — no new errors (warnings are pre-existing).
- [ ] Toggle time-range presets (1h / 24h / 7d / 14d / 30d): only counts refetch, list rows do not change.
- [ ] Search by name/template/prompt fragment narrows the list; clearing restores it.
- [ ] With ≥ 50 detectors, paginate to page 2; counts remain correct per row.
- [ ] Detector with 0 runs in the selected window still appears (counts read `0 / 0`).
- [ ] Edit-panel and detail-page detector lookup still work after the hook split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds search, pagination, and a 14d time range to the detector list, plus Findings/Runs columns so activity is visible at a glance. Implements a single backend counts endpoint and updates the list API for filtering at scale; also fixes an edit panel state bug. Fixes #810.

- **New Features**
  - Detector list supports search (name/template/prompt), pagination, and a time range (defaults to 14d).
  - New Findings and Runs columns powered by `/api/v1/internal/detector-counts`; the time range only affects counts, and missing entries default to 0/0.
  - `GET /api/projects/[projectId]/detectors` now accepts `search_query`, `page`, `limit` and returns `{ data, meta }`.

- **Bug Fixes**
  - Edit panel now clears fields and disables Save while the next detector loads, preventing stale values from being saved when navigating between detectors.

<sup>Written for commit 92adc12e92c7e84e4ccf8a57bef18f6713d05cc5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

