### PR TITLE
fix(docker): pin pnpm via packageManager to unbreak Docker builds

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,7 +1,6 @@
 # docker/Dockerfile.agent
 FROM node:20-alpine AS base
-RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+RUN apk add --no-cache openssl && corepack enable
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.billing
+++ b/docker/Dockerfile.billing
@@ -1,7 +1,6 @@
 # docker/Dockerfile.billing
 FROM node:20-alpine AS base
-RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+RUN apk add --no-cache openssl && corepack enable
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.migrate-postgres
+++ b/docker/Dockerfile.migrate-postgres
@@ -2,8 +2,7 @@
 # Prisma migration image — reuses the migrate stage from Dockerfile.web.
 # Build with: docker build --platform linux/amd64 -f docker/Dockerfile.migrate-postgres .
 FROM node:20-alpine AS base
-RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+RUN apk add --no-cache openssl && corepack enable
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,7 +1,6 @@
 # docker/Dockerfile.web
 FROM node:20-alpine AS base
-RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+RUN apk add --no-cache openssl && corepack enable
 
 # --- Dependencies stage ---
 FROM base AS deps

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "traceroot-frontend",
   "private": true,
+  "packageManager": "pnpm@10.33.4",
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## Summary

- Pin pnpm to `10.33.4` via `packageManager` field in `frontend/package.json` (corepack reads it automatically)
- Drop `corepack prepare pnpm@latest --activate` from the four Node-based Dockerfiles (`agent`, `web`, `billing`, `migrate-postgres`)
- Single source of truth for the pnpm version across CI and Docker

## Why

pnpm `v11.0.0` (published 2026-04-28) bumped the minimum Node requirement to Node 22 — it imports `node:sqlite`, which only exists as a stable builtin in Node 22.5+ / Node 24. Our Dockerfiles pin `node:20-alpine` but resolved `pnpm@latest` at layer-build time. Once the gha layer cache missed, every fresh build started failing with:

```
Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:sqlite
```

This started landing on `main` between 2026-05-05 and 2026-05-07 — the GPT-5.5 PR #842 was incidentally the first push to hit the broken state, but did not cause it.

The CI TypeScript build job did **not** break because `pnpm/action-setup@v4` was already pinned with `version: 10`.

Fixes #851

## Test plan

- [ ] Build Validation workflow passes on this PR (all 7 docker matrix jobs green)
- [ ] Confirm `frontend/pnpm-lock.yaml` has not changed (lockfileVersion 9.0 is compatible with pnpm 10.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `pnpm` to `10.33.4` and remove `pnpm@latest` installs in Dockerfiles to restore Node 20 Docker builds. This avoids `pnpm` 11’s Node 22 requirement and fixes recent image build failures.

- **Bug Fixes**
  - Set `"packageManager": "pnpm@10.33.4"` in `frontend/package.json` so `corepack` uses that version.
  - Removed `corepack prepare pnpm@latest --activate` from `docker/Dockerfile.agent`, `docker/Dockerfile.web`, `docker/Dockerfile.billing`, and `docker/Dockerfile.migrate-postgres`.

<sup>Written for commit 8b5636584d7ac946e5d1d32b6d5d6a9bdab09ea4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

