### PR TITLE
fix: add BACKEND_INTERNAL_URL to web services for SSE live tracing

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -136,6 +136,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
       AGENT_SERVICE_URL: http://agent:8100
       TRACEROOT_UI_URL: http://web:3000
+      BACKEND_INTERNAL_URL: http://rest:8000
       # --- Auth ---
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-local-dev-secret-change-in-production}


### PR DESCRIPTION
Fixes #836

## Summary

Fixes live tracing SSE connection failures when running the full Docker Compose stack. The `web` container was attempting to reach Uvicorn via `localhost:8000`, which resolves to the container's own loopback interface rather than the `rest` service. 

Adding `BACKEND_INTERNAL_URL: http://rest:8000` gives Next.js API routes an internal Docker network path to the backend, matching the pattern already used by `agent` and `billing` services.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

```diff
@@ -136,6 +136,7 @@ services:
       DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
       AGENT_SERVICE_URL: http://agent:8100
       TRACEROOT_UI_URL: http://web:3000
+      BACKEND_INTERNAL_URL: http://rest:8000
       # --- Auth ---
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-local-dev-secret-change-in-production}
```

`docker-compose.prod.yml` — added `BACKEND_INTERNAL_URL: http://rest:8000` to the `web` service environment block. Next.js API routes that proxy SSE connections now use this internal URL instead of falling back to `NEXT_PUBLIC_API_URL` which points to `localhost:8000` — unreachable from inside the container.

**Root cause:** `make dev` runs Next.js natively on the host where `localhost:8000` resolves correctly. In Docker Compose, `localhost` inside `web-1` refers to the container itself, causing `ECONNREFUSED` on every SSE proxy attempt and leaving spans stuck in pending state until a hard refresh.

**Test Plan**
- [x] Run `docker compose -f docker-compose.prod.yml up --build`
- [x] Start a long-running agent trace
- [x] Verify spans stream in real time without requiring a hard refresh
- [x] Verify `ECONNREFUSED` errors no longer appear in `web-1` logs

## Screenshots / Recordings (if applicable)

**Using the base of #799 , video of working live trace with equalizing fix matching both environments**

https://github.com/user-attachments/assets/0e0ceae6-7c08-484c-90fe-c01349bf0e61

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSE live tracing in Docker Compose by routing the web app to the backend over the internal network. Adds BACKEND_INTERNAL_URL=http://rest:8000 so Next.js API routes avoid localhost and keep spans streaming in real time.

<sup>Written for commit 5e94d8de1dbac83d1111e926742e1a626503d087. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

