### PR TITLE
fix: align getTraceDuration with getSpanDuration for live traces

### DIFF
--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -122,17 +122,18 @@ export function getSpanDuration(span: Span): number | null {
  * traces grow.
  */
 export function getTraceDuration(trace: TraceDetail): number | null {
-  const realSpans = trace.spans.filter((s) => !s.pending && s.span_start_time);
-  if (!realSpans.length) return null;
+  const allSpans = enrichSpansWithPending(trace.spans);
+  if (!allSpans.length) return null;
 
-  const root = realSpans.find((s) => s.parent_span_id === null);
-  if (root?.span_end_time) {
-    return parseTimestamp(root.span_end_time) - parseTimestamp(root.span_start_time);
+  const root = allSpans.find((s) => !s.parent_span_id);
+  if (root) {
+    return getSpanDuration(root);
   }
 
-  const minStart = Math.min(...realSpans.map((s) => parseTimestamp(s.span_start_time)));
+  const now = Date.now();
+  const minStart = Math.min(...allSpans.map((s) => parseTimestamp(s.span_start_time)));
   const maxEnd = Math.max(
-    ...realSpans.map((s) => (s.span_end_time ? parseTimestamp(s.span_end_time) : Date.now())),
+    ...allSpans.map((s) => (s.span_end_time ? parseTimestamp(s.span_end_time) : now)),
   );
   return Math.max(0, maxEnd - minStart);
 }


### PR DESCRIPTION
Fixes #857 

## Summary

`getTraceDuration` was computing the trace root duration independently from `getSpanDuration`, using separate `Date.now()` calls and filtering out pending spans. This caused drift on live/streaming traces where the root duration could appear shorter than a child span's duration.

The fix routes `getTraceDuration` through `getSpanDuration` when a root span exists, ensuring both functions use the same calculation path. When no root span is found, a single `Date.now()` snapshot is taken once and reused across all span comparisons, eliminating per-span timestamp drift.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

`frontend/ui/src/features/traces/utils/index.ts`
- `getTraceDuration` now calls `enrichSpansWithPending` to include all spans including pending placeholders
- When a root span exists (`parent_span_id === null`), delegates directly to `getSpanDuration(root)` — same formula, same `Date.now()` reference
- When no root span exists, captures `Date.now()` once before the min/max reduce instead of calling it per-span

**Test Plan**
- [x] Open a long-running live trace and verify root duration greater than all child span durations
- [x] Verify timeline ruler intervals contain all span bars correctly
- [x] Verify completed traces display correct durations unchanged
- [x] Verify no regression on short traces or traces with pending spans

## Screenshots / Recordings (if applicable)

**Video of applied fixes**

https://github.com/user-attachments/assets/ea0d13b5-a622-4ee5-ab62-0b4e414e2bf9

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns trace duration calculation with span duration to remove timestamp drift in live traces. Root durations no longer appear shorter than child spans. Fixes #857.

- **Bug Fixes**
  - `getTraceDuration` now includes pending spans via `enrichSpansWithPending` and delegates to `getSpanDuration` when a root span exists.
  - When no root span is found, takes a single `Date.now()` snapshot and reuses it to avoid per-span drift.

<sup>Written for commit ef94ee4c9065a3482ebe97feb62017f7282c3fdb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

