### PR TITLE
style(traces): improve resize handle cursor and hover feedback

### DIFF
--- a/frontend/ui/src/components/ui/resizable.tsx
+++ b/frontend/ui/src/components/ui/resizable.tsx
@@ -15,7 +15,7 @@ export function ResizableHandle({ className, ...props }: React.ComponentProps<ty
   return (
     <Separator
       className={cn(
-        "relative w-px flex-shrink-0 cursor-col-resize bg-border/20 transition-colors hover:bg-border focus-visible:outline-none",
+        "relative w-px flex-shrink-0 !cursor-col-resize bg-border/20 transition-colors hover:bg-border focus-visible:outline-none",
         className,
       )}
       {...props}

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -268,7 +268,7 @@ export function TraceViewerPanel({
         </div>
       ) : (
         <div className="relative flex flex-1 overflow-hidden">
-          <ResizablePanelGroup orientation="horizontal">
+          <ResizablePanelGroup orientation="horizontal" disableCursor>
             {/* LEFT: tree panel */}
             <ResizablePanel
               defaultSize="30%"
@@ -301,9 +301,15 @@ export function TraceViewerPanel({
             </ResizablePanel>
 
             {/* RIGHT BORDER / RESIZER HANDLE */}
-            <ResizableHandle className="group/handle relative z-50 flex w-px cursor-col-resize items-center justify-center bg-border transition-colors duration-150 ease-in-out">
-              <div className="absolute inset-y-0 z-10 w-[3px] bg-transparent transition-colors duration-150 group-hover/handle:bg-primary/30 group-active/handle:bg-primary/40 group-data-[resize-handle-state=drag]/handle:bg-primary/40" />
-              <div className="absolute z-20 h-4 w-[3px] rounded-full bg-muted-foreground/40 ring-2 ring-transparent transition-all duration-150 group-hover/handle:h-6 group-hover/handle:bg-primary group-hover/handle:ring-background group-active/handle:bg-primary group-active/handle:ring-background group-data-[resize-handle-state=drag]/handle:h-6 group-data-[resize-handle-state=drag]/handle:bg-primary group-data-[resize-handle-state=drag]/handle:ring-background" />
+            <ResizableHandle
+              className={cn(
+                "group/handle relative z-50 flex w-px items-center justify-center bg-border transition-colors duration-150 ease-in-out",
+                "cursor-col-resize [&_*]:cursor-col-resize",
+              )}
+            >
+              <div className="absolute inset-y-0 -left-2 -right-2 z-10 bg-transparent" />
+              <div className="absolute inset-y-0 z-20 w-[3px] bg-transparent transition-colors duration-150 group-hover/handle:bg-primary/30 group-active/handle:bg-primary/40 group-data-[resize-handle-state=drag]/handle:bg-primary/40" />
+              <div className="absolute z-30 h-4 w-[3px] rounded-full bg-muted-foreground/40 ring-2 ring-transparent transition-all duration-150 group-hover/handle:h-6 group-hover/handle:bg-primary group-hover/handle:ring-background group-active/handle:bg-primary group-active/handle:ring-background group-data-[resize-handle-state=drag]/handle:h-6 group-data-[resize-handle-state=drag]/handle:bg-primary group-data-[resize-handle-state=drag]/handle:ring-background" />
             </ResizableHandle>
 
             {/* RIGHT: details panel (tree mode) or Gantt bars (timeline mode) */}


### PR DESCRIPTION
Fixes #863 

## Summary

The resize handle in the trace viewer showed an `ew-resize` (`<->`) cursor and had a misalignment between the cursor change and the border highlight — hovering near the edges triggered the visual correctly but hovering directly over the handle center did not.

This PR fixes both issues by disabling the library's cursor injection and widening the invisible hover buffer.

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [x] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

`frontend/ui/src/features/traces/components/TraceViewerPanel.tsx`
- Added `disableCursor` to `ResizablePanelGroup` — prevents `react-resizable-panels` from injecting a global `*, *:hover { cursor: ew-resize !important }` adoptedStyleSheet in Chrome/Firefox that overrides CSS classes regardless of specificity
- Added an invisible `-left-2 -right-2` hit area div to widen the hover buffer so cursor and border highlight trigger simultaneously across the full handle width
- Applied `cursor-col-resize [&_*]:cursor-col-resize` directly on `ResizableHandle` for full cursor control

`frontend/ui/src/components/ui/resizable.tsx`
- Added `!cursor-col-resize` to the Separator className as a belt-and-suspenders guard

**Test Plan**
- [x] Hover near edges of resize handle — verify col-resize cursor and border highlight trigger together
- [x] Hover directly over center of resize handle — verify same behavior, no cursor revert
- [x] Drag the handle — verify resize still works correctly
- [x] Verify no regression on panel resize behavior

## Screenshots / Recordings (if applicable)

**Video of resizing interaction before**

https://github.com/user-attachments/assets/ec1e7430-e490-496e-bd42-6f81daf53405

**Video of resizing interaction after**

https://github.com/user-attachments/assets/ff037152-35aa-4818-a4dd-123d0ed53b49

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve the trace viewer’s resize handle so the cursor and border highlight stay consistent across the full handle. Fixes the center-hover gap and removes the incorrect global ew-resize cursor.

- **Bug Fixes**
  - Disabled `react-resizable-panels` cursor injection via `disableCursor` on `ResizablePanelGroup`.
  - Applied `cursor-col-resize` on `ResizableHandle` (and children) and `!cursor-col-resize` on the separator for consistent cursor control.
  - Added an invisible, wider hit area around the handle so cursor change and border highlight trigger together.

<sup>Written for commit c7d6e2b0d4f84c13a52a8830470c99491641d3ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

