### PR TITLE
Feat/861 vercel ai integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The fastest way to get started. Ample storages and LLM tokens for testing, no cr
 | [Claude Agent SDK](https://traceroot.ai/docs/integrations/claude-agent-sdk) | Python, JS/TS | Automated instrumentation of agent invocations, subagent delegations, tool calls, and token usage. |
 | [OpenAI Agents SDK](https://traceroot.ai/docs/integrations/openai-agents-sdk) | Python, JS/TS | Automated instrumentation of agent runs, tool executions, and handoff transitions. |
 | [Mastra](https://traceroot.ai/docs/integrations/mastra) | JS/TS | Automated instrumentation via the TraceRoot OTLP exporter. |
+| [Vercel AI SDK](https://traceroot.ai/docs/integrations/vercel-ai) | JS/TS | Native OpenTelemetry tracing via `experimental_telemetry` — no `instrumentModules` config required. |
 | [AutoGen](https://traceroot.ai/docs/integrations/autogen) | Python | Automated instrumentation of multi-agent conversations, agent loops, and tool calls. |
 | [LlamaIndex](https://traceroot.ai/docs/integrations/llamaindex) | Python | Automated instrumentation of RAG pipelines, document ingestion, retrieval, and LLM synthesis. |
 | [CrewAI](https://traceroot.ai/docs/integrations/crewai) | Python | Automated instrumentation of multi-agent collaborative workflows and task executions. |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -142,6 +142,7 @@
               "integrations/claude-agent-sdk",
               "integrations/openai-agents-sdk",
               "integrations/mastra",
+              "integrations/vercel-ai",
               "integrations/autogen",
               "integrations/llamaindex",
               "integrations/crewai",

--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -31,6 +31,9 @@ TraceRoot integrates with popular LLM providers and agent frameworks via auto-in
   <Card title="Mastra" icon="bolt" href="/integrations/mastra">
     Export traces from Mastra agents via the TraceRoot OTLP exporter.
   </Card>
+  <Card title="Vercel AI SDK" icon="cloud-bolt" href="/integrations/vercel-ai">
+    Native OpenTelemetry tracing — no `instrumentModules` config required.
+  </Card>
   <Card title="AutoGen (AG2)" icon="robot" href="/integrations/autogen">
     Auto-instrument AutoGen multi-agent conversations and tool calls.
   </Card>

--- a/docs/integrations/vercel-ai.mdx
+++ b/docs/integrations/vercel-ai.mdx
@@ -7,8 +7,6 @@ Trace [Vercel AI SDK](https://sdk.vercel.ai) agents in TraceRoot. Unlike LangCha
 
 ## Setup
 
-Install the SDK:
-
 ```bash
 npm install @traceroot-ai/traceroot ai @ai-sdk/openai zod
 ```
@@ -23,8 +21,6 @@ TraceRoot.initialize();
 ```
 
 ## Usage
-
-Enable `experimental_telemetry` on each `generateText` / `streamText` / `generateObject` call. That single line activates the Vercel AI SDK's built-in OpenTelemetry spans; TraceRoot enriches them with no further setup.
 
 ```typescript
 import { generateText, tool } from 'ai';

--- a/docs/integrations/vercel-ai.mdx
+++ b/docs/integrations/vercel-ai.mdx
@@ -1,0 +1,76 @@
+---
+title: Vercel AI SDK
+description: Trace Vercel AI SDK agents — no instrumentModules config required
+---
+
+Trace [Vercel AI SDK](https://sdk.vercel.ai) agents in TraceRoot. Unlike LangChain, OpenAI, or Anthropic, no `instrumentModules` configuration is needed — the Vercel AI SDK emits OpenTelemetry spans natively when `experimental_telemetry` is enabled, and TraceRoot enriches them via the OpenInference span processor automatically.
+
+## Setup
+
+Install the SDK:
+
+```bash
+npm install @traceroot-ai/traceroot ai @ai-sdk/openai
+```
+
+Initialize TraceRoot at your entry point — no `instrumentModules` config:
+
+```typescript
+import { TraceRoot } from '@traceroot-ai/traceroot';
+
+// No instrumentModules — Vercel AI SDK telemetry is handled automatically.
+TraceRoot.initialize();
+```
+
+## Usage
+
+Enable `experimental_telemetry` on each `generateText` / `streamText` / `generateObject` call. That single line activates the Vercel AI SDK's built-in OpenTelemetry spans; TraceRoot enriches them with no further setup.
+
+```typescript
+import { generateText, tool } from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { z } from 'zod';
+import { observe } from '@traceroot-ai/traceroot';
+
+const result = await observe({ name: 'my_agent', type: 'agent' }, async () => {
+  return await generateText({
+    model: openai('gpt-4o-mini'),
+    maxSteps: 5,
+    prompt: 'What is the weather in Tokyo?',
+    // This single line activates Vercel AI SDK's built-in OpenTelemetry spans.
+    // TraceRoot enriches them automatically.
+    experimental_telemetry: { isEnabled: true },
+    tools: {
+      getWeather: tool({
+        description: 'Get current weather for a city',
+        parameters: z.object({ city: z.string() }),
+        execute: async ({ city }) => ({ city, temp: 72, condition: 'sunny' }),
+      }),
+    },
+  });
+});
+
+console.log(result.text);
+```
+
+## What Gets Captured
+
+| Attribute | Description |
+|-----------|-------------|
+| Model | The model passed to `generateText` / `streamText` / `generateObject` |
+| Messages | Input prompt and message history |
+| Response | Generated text output |
+| Tool calls | Each tool invocation with input and output |
+| Tokens | Input and output token counts |
+| Cost | Calculated from token usage and model pricing |
+| Latency | Request duration per span |
+| Multi-step iterations | Each `maxSteps` iteration captured as a child span |
+
+
+## Run the example
+
+Clone the repo and run a complete agent end-to-end.
+
+  <Card title="TypeScript" icon="js" href="https://github.com/traceroot-ai/traceroot/tree/main/examples/typescript/vercel-ai">
+    Run the TypeScript example
+  </Card>

--- a/docs/integrations/vercel-ai.mdx
+++ b/docs/integrations/vercel-ai.mdx
@@ -10,7 +10,7 @@ Trace [Vercel AI SDK](https://sdk.vercel.ai) agents in TraceRoot. Unlike LangCha
 Install the SDK:
 
 ```bash
-npm install @traceroot-ai/traceroot ai @ai-sdk/openai
+npm install @traceroot-ai/traceroot ai @ai-sdk/openai zod
 ```
 
 Initialize TraceRoot at your entry point — no `instrumentModules` config:

--- a/examples/typescript/vercel-ai/README.md
+++ b/examples/typescript/vercel-ai/README.md
@@ -22,3 +22,9 @@ Runs two demo queries that exercise multi-step tool use:
 2. Stock price lookup + calculation (NVDA +10%)
 
 Tools: `getWeather`, `getStockPrice`, `calculate`
+
+## Why no `instrumentModules` config?
+
+Unlike LangChain / OpenAI / Anthropic, the Vercel AI SDK emits OpenTelemetry spans natively when `experimental_telemetry: { isEnabled: true }` is set on each call. TraceRoot enriches those spans through the OpenInference span processor registered inside `TraceRoot.initialize()` — no `instrumentModules` entry needed.
+
+See [docs/integrations/vercel-ai](https://traceroot.ai/docs/integrations/vercel-ai) for details.

--- a/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
@@ -61,6 +61,12 @@ My project uses [Python / TypeScript/Node.js] — adjust the instructions to mat
    import { TraceRootExporter } from '@traceroot-ai/mastra';
    const exporter = new TraceRootExporter({ apiKey: process.env.TRACEROOT_API_KEY });
    // Pass exporter to Mastra's Observability config (see docs/integrations/mastra)
+
+   For the Vercel AI SDK, no instrumentModules entry is needed:
+   TraceRoot.initialize();
+   // Then on each generateText / streamText / generateObject call, set:
+   //   experimental_telemetry: { isEnabled: true }
+   // (See docs/integrations/vercel-ai)
 3. Wrap agent entrypoints and tool functions with observe():
    import { observe } from '@traceroot-ai/traceroot';
    const result = await observe({ name: 'my_agent', type: 'agent' }, async () => {

--- a/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
@@ -23,7 +23,6 @@ const PYTHON_INSTALL_COMMAND = "pip install traceroot";
 const TYPESCRIPT_INSTALL_COMMAND = "npm install @traceroot-ai/traceroot";
 const MASTRA_INSTALL_COMMAND =
   "npm install @traceroot-ai/mastra @mastra/core @mastra/observability";
-const VERCEL_AI_INSTALL_COMMAND = "npm install @traceroot-ai/traceroot ai @ai-sdk/openai zod";
 
 export const INTEGRATIONS: IntegrationOption[] = [
   {
@@ -212,7 +211,7 @@ const mastra = new Mastra({
     ),
     languages: {
       typescript: {
-        installCommand: VERCEL_AI_INSTALL_COMMAND,
+        installCommand: TYPESCRIPT_INSTALL_COMMAND,
         initSnippet: `import { TraceRoot } from "@traceroot-ai/traceroot";
 
 // No instrumentModules — Vercel AI SDK telemetry is handled automatically.

--- a/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
@@ -23,8 +23,7 @@ const PYTHON_INSTALL_COMMAND = "pip install traceroot";
 const TYPESCRIPT_INSTALL_COMMAND = "npm install @traceroot-ai/traceroot";
 const MASTRA_INSTALL_COMMAND =
   "npm install @traceroot-ai/mastra @mastra/core @mastra/observability";
-const VERCEL_AI_INSTALL_COMMAND =
-  "npm install @traceroot-ai/traceroot ai @ai-sdk/openai";
+const VERCEL_AI_INSTALL_COMMAND = "npm install @traceroot-ai/traceroot ai @ai-sdk/openai";
 
 export const INTEGRATIONS: IntegrationOption[] = [
   {
@@ -204,7 +203,7 @@ const mastra = new Mastra({
         aria-hidden="true"
         width="24"
         height="24"
-        viewBox="0 0 24 24"
+        viewBox="-2 -2 28 28"
         fill="currentColor"
         className="text-foreground"
       >

--- a/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
@@ -23,7 +23,7 @@ const PYTHON_INSTALL_COMMAND = "pip install traceroot";
 const TYPESCRIPT_INSTALL_COMMAND = "npm install @traceroot-ai/traceroot";
 const MASTRA_INSTALL_COMMAND =
   "npm install @traceroot-ai/mastra @mastra/core @mastra/observability";
-const VERCEL_AI_INSTALL_COMMAND = "npm install @traceroot-ai/traceroot ai @ai-sdk/openai";
+const VERCEL_AI_INSTALL_COMMAND = "npm install @traceroot-ai/traceroot ai @ai-sdk/openai zod";
 
 export const INTEGRATIONS: IntegrationOption[] = [
   {

--- a/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/integrations.tsx
@@ -23,6 +23,8 @@ const PYTHON_INSTALL_COMMAND = "pip install traceroot";
 const TYPESCRIPT_INSTALL_COMMAND = "npm install @traceroot-ai/traceroot";
 const MASTRA_INSTALL_COMMAND =
   "npm install @traceroot-ai/mastra @mastra/core @mastra/observability";
+const VERCEL_AI_INSTALL_COMMAND =
+  "npm install @traceroot-ai/traceroot ai @ai-sdk/openai";
 
 export const INTEGRATIONS: IntegrationOption[] = [
   {
@@ -190,6 +192,35 @@ const mastra = new Mastra({
     },
   }),
 });`,
+      },
+    },
+  },
+  {
+    id: "vercel-ai",
+    name: "Vercel AI SDK",
+    href: "https://traceroot.ai/docs/integrations/vercel-ai",
+    icon: (
+      <svg
+        aria-hidden="true"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="text-foreground"
+      >
+        <path d="M24 22.525H0l12-21.05 12 21.05z" />
+      </svg>
+    ),
+    languages: {
+      typescript: {
+        installCommand: VERCEL_AI_INSTALL_COMMAND,
+        initSnippet: `import { TraceRoot } from "@traceroot-ai/traceroot";
+
+// No instrumentModules — Vercel AI SDK telemetry is handled automatically.
+TraceRoot.initialize();
+
+// Then on each generateText / streamText / generateObject call:
+//   experimental_telemetry: { isEnabled: true }`,
       },
     },
   },


### PR DESCRIPTION
Closes #861 

## Summary
Adds the Vercel AI SDK to TraceRoot’s docs, README, and in-app Getting Started picker, completing the integration after [[traceroot-ts#66](https://github.com/traceroot-ai/traceroot-ts/pull/66)](https://github.com/traceroot-ai/traceroot-ts/pull/66) shipped in [[v0.1.4](https://github.com/traceroot-ai/traceroot-ts/releases/tag/v0.1.4)](https://github.com/traceroot-ai/traceroot-ts/releases/tag/v0.1.4) and the example app landed in #653. 

Unlike LangChain / OpenAI / Anthropic, the [Vercel AI SDK](https://ai-sdk.dev/docs/ai-sdk-core/telemetry) emits OpenTelemetry spans natively when `experimental_telemetry: { isEnabled: true }` is set per call. TraceRoot enriches those spans automatically through the OpenInference span processor — **no `instrumentModules` config required**. [langfuse](https://langfuse.com/integrations/frameworks/vercel-ai-sdk)

## Type of Change

- [x] docs - Documentation only changes

## Details

## End to end tests
**1. Docs page local build 3010 (Mintlify)**
https://github.com/user-attachments/assets/9c85d93d-e2e7-4c0b-a3a1-2500b2a163cd
Full page with setup, usage, what gets captured table, and run example card.

**2. Overview card local build 3010 (Mintlify)**
<img width="1192" height="821" alt="截屏2026-05-09 上午12 41 59" src="https://github.com/user-attachments/assets/a719e49d-2aee-46df-8cb5-fcf79644df0f" />
Vercel AI SDK card sits in Overview card

**3. Spans landed in dashboard with OpenInference shape**
vercel_ai_agent           [AGENT] ← observe() wrapper from agent.ts  
  └─ ai.generateText        [AGENT] gpt-4o-mini, in=49, out=35  
     ├─ ai.generateText.doGenerate  [LLM]  in=159, out=16  
     ├─ ai.toolCall                 [TOOL] (getStockPrice)  
     ├─ ai.generateText.doGenerate  [LLM]  in=209, out=20  
     ├─ ai.toolCall                 [TOOL] (calculate)  
     └─ ai.generateText.doGenerate  [LLM]  in=254, out=36
<img width="1208" height="821" alt="截屏2026-05-09 上午12 53 45" src="https://github.com/user-attachments/assets/895876cb-4db8-4121-a2b4-4b9db9872bfb" />
<img width="1198" height="821" alt="截屏2026-05-09 上午12 54 48" src="https://github.com/user-attachments/assets/3a662af8-ecd3-429c-8d53-72d1fa4fe49c" />
<img width="1203" height="825" alt="截屏2026-05-09 上午12 55 12" src="https://github.com/user-attachments/assets/b7f9cdbb-be46-4b3d-935e-ecc554818347" />

## Notes:
- span_kind is AGENT / LLM / TOOL (not a generic SPAN)
- model_name shows LLM used
- input_tokens / output_tokens rendered correctly
- status = OK across all tested spans
- multi-step tool rendered correctly as parent-child tree

## Pre-flight checks

- tsc --noEmit clean on changed TS files
- eslint clean on changed TS files
- prettier clean on changed TS files (collapsed an unnecessary line wrap on VERCEL_AI_INSTALL_COMMAND)
- Mintlify renders both new pages (HTTP 200, MDX compiles, TOC extracts)
- Install snippets are unpinned — resolve to ^0.1.4 automatically
- Repo-wide grep for Mastra / LangChain enumerations confirmed README was the only missed surface
- v0.1.3 → v0.1.4 SDK changelog reviewed: no init signature changes, existing integration docs unaffected [github](https://github.com/microsoft/TypeScript/issues/43116)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Vercel AI SDK integration across docs and the in‑app Getting Started flow to enable native OpenTelemetry tracing with a simple per‑call toggle. No `instrumentModules` needed; `TraceRoot.initialize()` enriches spans automatically via OpenInference.

- New Features
  - New docs page at /docs/integrations/vercel-ai with setup, usage, capture details, and example link.
  - Added Vercel AI SDK card to the docs overview and in‑app Getting Started picker (TS snippet), with install: `npm install @traceroot-ai/traceroot ai @ai-sdk/openai zod`.
  - Updated README framework table and the TS example README with the `experimental_telemetry: { isEnabled: true }` requirement and why no `instrumentModules` is needed.

<sup>Written for commit 9cc362cc8d3d8f8c5a60f78d374f419d2c4978ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

