### PR TITLE
feat(examples/typescript/mistral): add Mistral ReAct agent example

### DIFF
--- a/examples/typescript/mistral/.env.example
+++ b/examples/typescript/mistral/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# Mistral — get one at https://console.mistral.ai
+MISTRAL_API_KEY=your_mistral_api_key_here

--- a/examples/typescript/mistral/README.md
+++ b/examples/typescript/mistral/README.md
@@ -1,0 +1,64 @@
+# Mistral Tool Agent
+
+ReAct-style agent that calls [Mistral AI](https://mistral.ai) models using the official [`@mistralai/mistralai`](https://www.npmjs.com/package/@mistralai/mistralai) v2 SDK, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in MISTRAL_API_KEY and TRACEROOT_API_KEY
+pnpm install
+```
+
+## Usage
+
+```bash
+pnpm demo
+```
+
+## What it does
+
+Runs one demo query by default so it works reliably under Mistral free-tier rate limits. Use `pnpm demo:full` to run all three demo queries:
+
+1. Weather comparison (San Francisco vs Tokyo)
+2. Stock price lookup + calculation (NVDA +10%)
+3. Web search + summarization
+
+Tools: `get_weather`, `get_stock_price`, `calculate`, `search_web`, `get_current_time`
+
+> All tools except `calculate` and `get_current_time` return hardcoded mock data — they exist to exercise tool-call instrumentation, not to demo real services.
+
+## A note on instrumentation
+
+Auto-instrumentation for the Mistral SDK is tracked in `traceroot-ts` ([issue #739](https://github.com/traceroot-ai/traceroot/issues/739)) and isn't shipped yet. Until it is, this example wraps `mistral.chat.complete` with `observe()` via the small [`traced-mistral.ts`](./traced-mistral.ts) helper, which emits the same OpenInference span attributes a future auto-instrumentor would:
+
+| Attribute | Source |
+|---|---|
+| `openinference.span.kind` | `"LLM"` |
+| `llm.system` / `llm.provider` | `"mistralai"` |
+| `llm.model_name` | request `model` |
+| `llm.token_count.prompt` / `completion` / `total` | response `usage.*` |
+| `llm.invocation_parameters` | request body minus `messages` |
+| `input.value` / `input.mime_type` | request `messages` |
+| `output.value` / `output.mime_type` | response `choices[0].message` |
+| `llm.response.finish_reasons` | response `choices[0].finishReason` |
+
+**Why this matters:** trace shape stays correct *today* — no fake placeholders, no missing token counts. When the SDK ships native instrumentation, migration is two edits:
+
+1. Add `instrumentModules: { mistral: mistralSdk }` to `TraceRoot.initialize(...)`.
+2. Replace `tracedComplete(mistral, args)` with `mistral.chat.complete(args)` and delete `traced-mistral.ts`.
+
+The agent loop and tool plumbing don't change.
+
+## Models
+
+| Model | Notes |
+|---|---|
+| `mistral-large-latest` (default) | Mistral's flagship; supports tool calling. Used by this demo. |
+| `mistral-medium-latest` | Cheaper / faster, also supports tool calling. |
+| `mistral-small-latest` | Lightweight; tool calling supported on recent revisions. |
+
+Switch the default by changing the `model` field in `ReActAgent`.
+
+## Notes
+
+`@mistralai/mistralai` v2 is **ESM-only**, which is why `package.json` sets `"type": "module"` and the helper imports with the `.js` extension (`./traced-mistral.js`) — that's the standard NodeNext + ESM convention even when the source files are `.ts`.

--- a/examples/typescript/mistral/agent.ts
+++ b/examples/typescript/mistral/agent.ts
@@ -1,0 +1,363 @@
+/**
+ * Mistral ReAct Agent — TraceRoot Observability
+ *
+ * A ReAct-style tool-calling agent built on the official @mistralai/mistralai
+ * v2 SDK and instrumented with TraceRoot.
+ *
+ * Auto-instrumentation for the Mistral SDK is tracked in
+ * https://github.com/traceroot-ai/traceroot/issues/739 — until that lands in
+ * @traceroot-ai/traceroot, the `tracedComplete()` helper in ./traced-mistral.ts
+ * wraps `mistral.chat.complete` and emits the same OpenInference span attributes
+ * a future auto-instrumentor would emit (model, token counts, input/output,
+ * finish reasons), so the trace shape stays correct today and migration is a
+ * one-line swap later.
+ *
+ * Env vars required: MISTRAL_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm demo
+ */
+
+import 'dotenv/config';
+import { Mistral } from '@mistralai/mistralai';
+import type { ChatCompletionRequestMessage } from '@mistralai/mistralai/models/components/chatcompletionrequest.js';
+import {
+  TraceRoot,
+  observe,
+  usingAttributes,
+  getCurrentTraceId,
+} from '@traceroot-ai/traceroot';
+import { tracedComplete } from './traced-mistral.js';
+
+// ── TraceRoot setup ───────────────────────────────────────────────────────────
+// Pass an empty `instrumentModules` to explicitly opt out of RITM
+// auto-instrumentation — Mistral isn't a supported module yet (#739) and we
+// handle span emission manually in ./traced-mistral.ts. When auto-instrumentation
+// lands, replace this with `{ instrumentModules: { mistral: mistralSdk } }`.
+TraceRoot.initialize({ instrumentModules: {} });
+
+const mistral = new Mistral({ apiKey: process.env.MISTRAL_API_KEY ?? '' });
+console.log('[Observability: TraceRoot | Provider: Mistral]');
+
+// ── Tools ─────────────────────────────────────────────────────────────────────
+type ToolResult = Record<string, unknown>;
+
+function getWeather(city: string): ToolResult {
+  const db: Record<string, ToolResult> = {
+    'san francisco': { temp: 68, condition: 'foggy', humidity: 75 },
+    'new york': { temp: 45, condition: 'cloudy', humidity: 60 },
+    london: { temp: 52, condition: 'rainy', humidity: 85 },
+    tokyo: { temp: 72, condition: 'sunny', humidity: 50 },
+    paris: { temp: 58, condition: 'partly cloudy', humidity: 65 },
+  };
+  return { city, ...(db[city.toLowerCase()] ?? { temp: 70, condition: 'unknown', humidity: 50 }) };
+}
+
+function searchWeb(query: string): ToolResult[] {
+  return [
+    { title: `Result 1 for '${query}'`, snippet: `This is information about ${query}...` },
+    { title: `Result 2 for '${query}'`, snippet: `More details on ${query} can be found...` },
+  ];
+}
+
+function getStockPrice(symbol: string): ToolResult {
+  const stocks: Record<string, ToolResult> = {
+    AAPL: { price: 178.5, change: +2.3, percent: '+1.3%' },
+    GOOGL: { price: 141.2, change: -0.8, percent: '-0.6%' },
+    MSFT: { price: 378.9, change: +4.5, percent: '+1.2%' },
+    NVDA: { price: 495.2, change: +12.3, percent: '+2.5%' },
+  };
+  return {
+    symbol: symbol.toUpperCase(),
+    ...(stocks[symbol.toUpperCase()] ?? { price: 0, change: 0, percent: 'N/A' }),
+  };
+}
+
+// Recursive-descent parser for + - * / ( ) — no dynamic code execution.
+function calculate(expression: string): ToolResult {
+  try {
+    let pos = 0;
+    const src = expression.replace(/\s+/g, '');
+
+    const peek = () => src[pos];
+    const consume = (ch: string) => {
+      if (src[pos] !== ch) throw new Error(`Expected '${ch}' at ${pos}`);
+      pos++;
+    };
+
+    const parseNumber = (): number => {
+      const start = pos;
+      let hasDot = false;
+      while (pos < src.length && (/[0-9]/.test(src[pos]) || (src[pos] === '.' && !hasDot))) {
+        if (src[pos] === '.') hasDot = true;
+        pos++;
+      }
+      if (start === pos) throw new Error(`Expected number at ${pos}`);
+      return Number(src.slice(start, pos));
+    };
+
+    const parseFactor = (): number => {
+      if (peek() === '(') {
+        consume('(');
+        const v = parseAddSub();
+        consume(')');
+        return v;
+      }
+      if (peek() === '-') {
+        consume('-');
+        return -parseFactor();
+      }
+      return parseNumber();
+    };
+
+    const parseMulDiv = (): number => {
+      let v = parseFactor();
+      while (peek() === '*' || peek() === '/') {
+        const op = src[pos++];
+        const r = parseFactor();
+        v = op === '*' ? v * r : v / r;
+      }
+      return v;
+    };
+
+    function parseAddSub(): number {
+      let v = parseMulDiv();
+      while (peek() === '+' || peek() === '-') {
+        const op = src[pos++];
+        const r = parseMulDiv();
+        v = op === '+' ? v + r : v - r;
+      }
+      return v;
+    }
+
+    const result = parseAddSub();
+    if (pos !== src.length) throw new Error(`Unexpected '${src[pos]}' at ${pos}`);
+    return { expression, result };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+function getCurrentTime(timezone = 'UTC'): ToolResult {
+  try {
+    const time = new Date().toLocaleString('en-US', { timeZone: timezone, hour12: false });
+    return { timezone, time };
+  } catch {
+    return {
+      timezone: 'UTC',
+      time: new Date().toISOString(),
+      warning: `Unknown timezone '${timezone}'; fell back to UTC.`,
+    };
+  }
+}
+
+const TOOLS: Record<string, (a: Record<string, unknown>) => ToolResult | ToolResult[]> = {
+  get_weather: (a) => getWeather(a.city as string),
+  search_web: (a) => searchWeb(a.query as string),
+  get_stock_price: (a) => getStockPrice(a.symbol as string),
+  calculate: (a) => calculate(a.expression as string),
+  get_current_time: (a) => getCurrentTime(a.timezone as string | undefined),
+};
+
+const TOOL_SCHEMAS = [
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_weather',
+      description: 'Get current weather for a city',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string', description: 'City name' } },
+        required: ['city'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'search_web',
+      description: 'Search the web for information',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string', description: 'Search query' } },
+        required: ['query'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_stock_price',
+      description: 'Get current stock price for a ticker symbol',
+      parameters: {
+        type: 'object',
+        properties: {
+          symbol: { type: 'string', description: 'Stock ticker symbol (e.g., AAPL)' },
+        },
+        required: ['symbol'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'calculate',
+      description: 'Evaluate a mathematical expression',
+      parameters: {
+        type: 'object',
+        properties: { expression: { type: 'string', description: 'Math expression' } },
+        required: ['expression'],
+      },
+    },
+  },
+  {
+    type: 'function' as const,
+    function: {
+      name: 'get_current_time',
+      description: 'Get the current date and time',
+      parameters: {
+        type: 'object',
+        properties: { timezone: { type: 'string', description: 'Timezone (default: UTC)' } },
+      },
+    },
+  },
+];
+
+// ── Agent ─────────────────────────────────────────────────────────────────────
+const SYSTEM_PROMPT = `You are a helpful AI assistant with access to tools.
+When answering questions:
+1. Think about what information you need
+2. Use available tools to gather information
+3. Combine information from multiple sources when helpful
+4. Provide a clear, comprehensive answer
+Available tools: weather, web search, stock prices, calculator, current time.`;
+
+class ReActAgent {
+  private conversationHistory: ChatCompletionRequestMessage[] = [];
+  private readonly model = 'mistral-large-latest';
+
+  constructor() {
+    this.conversationHistory.push({ role: 'system', content: SYSTEM_PROMPT });
+  }
+
+  private async executeTool(name: string, fnArgs: Record<string, unknown>): Promise<string> {
+    const result = await observe({ name: `tool:${name}`, type: 'tool' }, async () => {
+      if (name in TOOLS) return TOOLS[name](fnArgs);
+      return { error: `Unknown tool: ${name}` };
+    });
+    return JSON.stringify(result);
+  }
+
+  async runTurn(userInput: string): Promise<string> {
+    return observe({ name: 'agent_turn', type: 'agent' }, async () => {
+      this.conversationHistory.push({ role: 'user', content: userInput });
+
+      for (let i = 0; i < 5; i++) {
+        const completion = await tracedComplete(mistral, {
+          model: this.model,
+          messages: this.conversationHistory,
+          tools: TOOL_SCHEMAS,
+          toolChoice: 'auto',
+          parallelToolCalls: false,
+        });
+
+        const msg = completion.choices?.[0]?.message;
+        if (!msg) {
+          return 'No response from model.';
+        }
+
+        const toolCalls = msg.toolCalls ?? [];
+        if (toolCalls.length > 0) {
+          this.conversationHistory.push({
+            role: 'assistant',
+            content: typeof msg.content === 'string' ? msg.content : '',
+            toolCalls,
+          });
+
+          for (const tc of toolCalls) {
+            const rawArgs = tc.function.arguments;
+            const fnArgs =
+              typeof rawArgs === 'string'
+                ? (JSON.parse(rawArgs) as Record<string, unknown>)
+                : (rawArgs as Record<string, unknown>);
+            console.log(`\n  [Tool: ${tc.function.name}(${JSON.stringify(fnArgs)})]`);
+            const result = await this.executeTool(tc.function.name, fnArgs);
+            console.log(`  [Result: ${result}]`);
+            this.conversationHistory.push({
+              role: 'tool',
+              name: tc.function.name,
+              toolCallId: tc.id,
+              content: result,
+            });
+          }
+        } else {
+          const response = typeof msg.content === 'string' ? msg.content : '';
+          this.conversationHistory.push({ role: 'assistant', content: response });
+          return response;
+        }
+      }
+      return "I wasn't able to complete this task within the allowed steps.";
+    });
+  }
+}
+
+// ── Demo ──────────────────────────────────────────────────────────────────────
+const DEMO_QUERIES = [
+  "What's the weather in San Francisco and Tokyo? Compare them.",
+  "What's NVDA stock price? If it goes up 10%, what would the new price be?",
+  'Search for information about AI observability and summarize what you find.',
+];
+
+async function main() {
+  const queries = process.argv.includes('--full') ? DEMO_QUERIES : DEMO_QUERIES.slice(0, 1);
+
+  let demoTraceId: string | undefined;
+
+  try {
+    await usingAttributes(
+      {
+        sessionId: 'mistral-demo-session',
+        userId: 'demo-user',
+        tags: ['demo', 'mistral', 'react-agent'],
+        metadata: { example: 'mistral-react-agent', sdkFeature: 'usingAttributes' },
+      },
+      () =>
+        observe({ name: 'demo_session' }, async () => {
+          demoTraceId = getCurrentTraceId();
+          console.log('='.repeat(60));
+          console.log('Mistral ReAct Agent — Demo (TraceRoot)');
+          console.log('='.repeat(60));
+          if (demoTraceId) console.log(`Trace ID: ${demoTraceId}`);
+
+          for (let i = 0; i < queries.length; i++) {
+            const query = queries[i];
+            const agent = new ReActAgent();
+            console.log(`\n${'='.repeat(60)}`);
+            console.log(`Query ${i + 1}: ${query}`);
+            console.log('='.repeat(60));
+            process.stdout.write('\nAgent: ');
+            const response = await agent.runTurn(query);
+            console.log(response);
+            console.log();
+          }
+        }),
+    );
+  } finally {
+    await TraceRoot.shutdown();
+    console.log('[Traces exported]');
+
+    if (demoTraceId) {
+      const host = (process.env.TRACEROOT_HOST_URL ?? 'https://app.traceroot.ai').replace(
+        /\/$/,
+        '',
+      );
+      console.log('\nView this trace in TraceRoot:');
+      console.log(`  ${host}/traces/${demoTraceId}`);
+      console.log(
+        '  (or filter by sessionId="mistral-demo-session" / tag="mistral" in the UI)',
+      );
+    }
+  }
+}
+
+main().catch(console.error);

--- a/examples/typescript/mistral/package.json
+++ b/examples/typescript/mistral/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@traceroot/example-mistral",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "demo": "tsx agent.ts",
+    "demo:full": "tsx agent.ts --full"
+  },
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.0",
+    "@mistralai/mistralai": "^2.2.1",
+    "@traceroot-ai/traceroot": "^0.1.4",
+    "dotenv": "^16.4.5",
+    "openai": "^6.34.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/typescript/mistral/traced-mistral.ts
+++ b/examples/typescript/mistral/traced-mistral.ts
@@ -1,0 +1,128 @@
+/**
+ * traced-mistral.ts — manual OpenInference-compatible tracing for @mistralai/mistralai
+ *
+ * Why this file exists
+ * --------------------
+ * @traceroot-ai/traceroot does not yet ship auto-instrumentation for the
+ * Mistral SDK (tracked in https://github.com/traceroot-ai/traceroot/issues/739).
+ * Until a dedicated MistralInstrumentation lands in the SDK, this module wraps
+ * `mistral.chat.complete` with `observe()` and emits the same OpenInference
+ * span attributes a future auto-instrumentor would emit:
+ *
+ *   openinference.span.kind   = "LLM"
+ *   llm.system                = "mistralai"
+ *   llm.provider              = "mistralai"
+ *   llm.model_name            = <model>
+ *   llm.token_count.prompt    = usage.promptTokens
+ *   llm.token_count.completion= usage.completionTokens
+ *   llm.token_count.total     = usage.totalTokens
+ *   llm.invocation_parameters = JSON of non-message params (model, tools, ...)
+ *   input.value               = JSON of messages
+ *   input.mime_type           = "application/json"
+ *   output.value              = JSON of completion message
+ *   output.mime_type          = "application/json"
+ *
+ * That means traces look correct *today*, and once the SDK ships
+ * `instrumentModules: { mistral }` the only diff in user code is:
+ *   - delete this file
+ *   - replace `tracedComplete(mistral, args)` with `mistral.chat.complete(args)`
+ *
+ * This module is also a useful starting point for the SDK-side
+ * MistralInstrumentation: the attribute mapping, finish-reason mapping, and
+ * tool-call serialisation are the same shape an InstrumentationBase
+ * monkey-patch would emit per OpenInference's chat-completion semantic
+ * conventions.
+ */
+
+import type { Mistral } from '@mistralai/mistralai';
+import { observe, updateCurrentSpan } from '@traceroot-ai/traceroot';
+
+type ChatCompleteArgs = Parameters<Mistral['chat']['complete']>[0];
+type ChatCompleteResult = Awaited<ReturnType<Mistral['chat']['complete']>>;
+
+const PROVIDER = 'mistralai';
+
+// Mirror of the OpenInference attribute names — kept as constants so the
+// future SDK instrumentor can import the exact same keys without drift.
+const ATTR = {
+  spanKind: 'openinference.span.kind',
+  system: 'llm.system',
+  provider: 'llm.provider',
+  modelName: 'llm.model_name',
+  tokenPrompt: 'llm.token_count.prompt',
+  tokenCompletion: 'llm.token_count.completion',
+  tokenTotal: 'llm.token_count.total',
+  invocationParams: 'llm.invocation_parameters',
+  inputValue: 'input.value',
+  inputMime: 'input.mime_type',
+  outputValue: 'output.value',
+  outputMime: 'output.mime_type',
+  finishReason: 'llm.response.finish_reasons',
+  toolName: 'llm.tools',
+} as const;
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Drop-in replacement for `mistral.chat.complete(args)` that opens an LLM span,
+ * captures inputs / outputs / tokens, and re-throws any error after recording it.
+ */
+export async function tracedComplete(
+  mistral: Mistral,
+  args: ChatCompleteArgs,
+): Promise<ChatCompleteResult> {
+  const model = args.model;
+  const spanName = `mistral.chat.complete ${model}`;
+
+  return observe(
+    {
+      name: spanName,
+      type: 'llm',
+      metadata: {
+        [ATTR.spanKind]: 'LLM',
+        [ATTR.system]: PROVIDER,
+        [ATTR.provider]: PROVIDER,
+        [ATTR.modelName]: model,
+      },
+    },
+    async () => {
+      const { messages, ...invocationParams } = args;
+
+      updateCurrentSpan({
+        input: { messages },
+        metadata: {
+          [ATTR.inputValue]: safeStringify(messages),
+          [ATTR.inputMime]: 'application/json',
+          [ATTR.invocationParams]: safeStringify(invocationParams),
+        },
+      });
+
+      const response = await mistral.chat.complete(args);
+
+      const choice = response.choices?.[0];
+      const message = choice?.message;
+      const finishReason = choice?.finishReason;
+      const usage = response.usage;
+
+      updateCurrentSpan({
+        output: { message },
+        metadata: {
+          [ATTR.outputValue]: safeStringify(message),
+          [ATTR.outputMime]: 'application/json',
+          [ATTR.tokenPrompt]: usage?.promptTokens ?? 0,
+          [ATTR.tokenCompletion]: usage?.completionTokens ?? 0,
+          [ATTR.tokenTotal]: usage?.totalTokens ?? 0,
+          [ATTR.finishReason]: finishReason ? [finishReason] : [],
+        },
+      });
+
+      return response;
+    },
+  );
+}

--- a/examples/typescript/mistral/tsconfig.json
+++ b/examples/typescript/mistral/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["."]
+}


### PR DESCRIPTION


**Fixes #739**

## Summary

Adds a working TypeScript example under `examples/typescript/mistral/` that uses the `@mistralai/mistralai` v2 SDK and sends OpenInference-compatible spans to TraceRoot. Mirrors the structure of the other TypeScript examples (`openai` and `deepseek`) and includes a temporary helper (`traced-mistral.ts`) so the demo works today until full auto-instrumentation is released.

## Type of Change

* [x] feat — New example feature
* [x] docs — README with setup, usage, and migration notes

## Details

**Included files:**

* `agent.ts` — ReAct agent exercising multiple tools, wrapped in TraceRoot observability.
* `traced-mistral.ts` — Temporary helper to wrap calls and emit attributes.
* `package.json` & `tsconfig.json` — ESM setup, dependencies, NodeNext + ES2022.
* `README.md` — Setup, usage, attributes, migration guide.
* `.env.example` — API keys for TraceRoot and Mistral.

**Notes:**

* Demo: `pnpm demo` runs a single query (free-tier friendly); `pnpm demo:full` runs all queries.
* On shutdown, prints trace ID and link for easy access.
* Migration to full auto-instrumentation is just two edits in README.

## Screenshots / Recordings

https://github.com/user-attachments/assets/ab10ec3c-34fc-4cc5-8dab-219af3a42d3f



## Checklist

* [x] Read [[CONTRIBUTING.md](https://chatgpt.com/CONTRIBUTING.md)](../CONTRIBUTING.md)
* [x] Example runs end-to-end as a smoke test
* [ ] Will add recording of demo + trace after PR is opened
* [x] Documentation updated



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TypeScript Mistral ReAct agent example that uses `@mistralai/mistralai` v2 and sends OpenInference-compatible spans to TraceRoot. Includes a small helper to trace `mistral.chat.complete` until native auto-instrumentation ships.

- **New Features**
  - Example at `examples/typescript/mistral/` mirroring the other TS samples.
  - ReAct agent with tools (weather, search, stocks, calculator, time).
  - Tracing via `@traceroot-ai/traceroot`, emitting model, tokens, input/output, and finish reasons through `traced-mistral.ts`.
  - Demo scripts: `pnpm demo` (single query) and `pnpm demo:full` (all queries); prints trace ID and link. README and `.env.example` included.

- **Migration**
  - Add `instrumentModules: { mistral: mistralSdk }` to `TraceRoot.initialize(...)`.
  - Replace `tracedComplete(mistral, args)` with `mistral.chat.complete(args)` and remove `traced-mistral.ts`.

<sup>Written for commit 19ff73f11a0acf83ae2eda1410cd729330f0ab4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

