### PR TITLE
fix: render live timeline bars with UTC timestamp parsing

### DIFF
--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -7,11 +7,7 @@ import type { SpanTreeRow } from "../types";
 import { parseAsUTC } from "@/lib/utils";
 
 export function parseTimestamp(ts: string): number {
-  let normalizedTs = ts.trim();
-  if (!/(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalizedTs)) {
-    normalizedTs += "Z";
-  }
-  return parseAsUTC(normalizedTs).getTime();
+  return parseAsUTC(ts.trim()).getTime();
 }
 
 function parseMetadata(metadata: string | null): Record<string, unknown> {

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -6,8 +6,12 @@ import type { Span, TraceDetail } from "@/types/api";
 import type { SpanTreeRow } from "../types";
 import { parseAsUTC } from "@/lib/utils";
 
-function parseTimestamp(ts: string): number {
-  return parseAsUTC(ts).getTime();
+export function parseTimestamp(ts: string): number {
+  let normalizedTs = ts.trim();
+  if (!/(?:Z|[+-]\d{2}:?\d{2})$/i.test(normalizedTs)) {
+    normalizedTs += "Z";
+  }
+  return parseAsUTC(normalizedTs).getTime();
 }
 
 function parseMetadata(metadata: string | null): Record<string, unknown> {

--- a/frontend/ui/src/features/traces/utils/timeline.ts
+++ b/frontend/ui/src/features/traces/utils/timeline.ts
@@ -1,5 +1,5 @@
 import type { Span } from "@/types/api";
-import { buildChildrenMap, getSpanDuration } from "../utils";
+import { buildChildrenMap, getSpanDuration, parseTimestamp } from "../utils";
 
 export interface TimelineMetrics {
   startOffsetPx: number;
@@ -29,7 +29,7 @@ export function flattenTreeWithMetrics(
   // Cache parsed timestamps to avoid re-parsing during traversal
   const startTimes = new Map<string, number>();
   for (const span of spans) {
-    startTimes.set(span.span_id, new Date(span.span_start_time).getTime());
+    startTimes.set(span.span_id, parseTimestamp(span.span_start_time));
   }
 
   const traceStartMs = spans.reduce(


### PR DESCRIPTION
Fixes #873 

## Summary

This PR fixes live trace timeline bars not rendering correctly in non-UTC browser timezones.

The issue was caused by timeline metric generation parsing `span_start_time` with native `new Date(...)`. Production trace timestamps are UTC timestamps, but they may arrive without a timezone suffix, such as:

```json
"span_start_time": "2026-05-10T11:54:18.050811"
```

Browsers parse this format as local time unless it includes `Z` or an explicit offset. In non-UTC timezones, this shifted parsed span start times and corrupted timeline coordinate calculations.

The existing `parseAsUTC(` helper already handles timezone-naive backend timestamps as UTC. This PR routes timeline start-time parsing through the shared `parseTimestamp` helper so timeline offsets and durations use the same UTC-aware parsing path.

## Type of Change

- [x] fix - A bug fix

## Details

### Root cause

Live span data was arriving correctly and rendering in the trace tree, so this was not an SSE delivery issue.

The issue was further isolated to timeline rendering. `flattenTreeWithMetrics` was using native browser parsing for span start times:

```ts
new Date(span.span_start_time).getTime()
```

Production timestamps are UTC timestamps, but they may arrive without a timezone suffix. Browsers parse timezone-naive ISO strings as local time, which shifts the parsed span start time in non-UTC browser timezones.

Example in MDT:
```ts
new Date("2026-05-10T11:54:18.050811").toISOString()
// "2026-05-10T17:54:18.050Z"

new Date("2026-05-10T11:54:18.050811Z").toISOString()
// "2026-05-10T11:54:18.050Z"
```

This corrupted the computed timeline coordinates, especially `startOffsetPx`. Completed child spans could still show the correct duration because `end - start` cancels out the timezone offset, but the bar placement could still be wrong because timeline offsets were calculated from incorrectly parsed start times.

### What changed
- Exported the shared `parseTimestamp` helper from `frontend/ui/src/features/traces/utils/index.ts`.
- Updated timeline metric generation to use `parseTimestamp(span.span_start_time)` instead of native new `Date(span.span_start_time).getTime()`.
- Ensured trace duration calculations use the same normalized timestamp parsing path.

###  Test plan
- [x] Reproduced the issue in production with live traces.
 Confirmed live spans were arriving by verifying they appeared in the trace tree.
- [x] Confirmed the corresponding timeline bars were missing before the fix.
- [x] Verified the browser timezone behavior manually:
```js
new Date("2026-05-10T11:54:18.050811").toISOString()
// Local-time interpretation

new Date("2026-05-10T11:54:18.050811Z").toISOString()
// Correct UTC interpretation
```
- [x] Verified that switching the local machine timezone to UTC made the production issue disappear, confirming that browser-local timestamp parsing was involved.
- [ ] Verify live timeline bars render correctly in a non-UTC timezone after this fix (this cannot be verified since unproduceable locally)
- [x] Verify completed trace timeline bars still render correctly.

## Screenshots / Recordings (if applicable)

https://github.com/user-attachments/assets/3febc4fa-e3e5-4fb4-9a9b-6b31c8c407d7

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #873 by parsing span timestamps as UTC so live timeline bars render correctly in non-UTC browsers. Prevents negative durations that hid in‑progress bars.

- **Bug Fixes**
  - Updated and exported `parseTimestamp` to normalize timezone‑naive inputs via `parseAsUTC`, trimming whitespace and appending `Z` when missing.
  - Replaced native `Date(...)` parsing in timeline metrics and offsets with `parseTimestamp` for consistent start times and durations.

<sup>Written for commit 745d2707d1c9d2552b4438edb5088654eb03d82f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

