### PR TITLE
feat(detectors): Support trace tags in trigger filtering (#811)

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -559,3 +559,116 @@ async def list_detector_counts(
         }
 
     return {"data": data}
+
+
+# =============================================================================
+# Trace Tag Suggestion Endpoints (for detector trigger tag autocomplete)
+# =============================================================================
+
+
+class TraceTagKeysResponse(BaseModel):
+    keys: list[str]
+
+
+class TraceTagValuesResponse(BaseModel):
+    values: list[str]
+
+
+@router.get(
+    "/trace-tag-keys",
+    response_model=TraceTagKeysResponse,
+    dependencies=[Depends(verify_internal_secret)],
+)
+async def list_trace_tag_keys(
+    project_id: str = Query(..., description="Project ID"),
+    limit: int = Query(50, ge=1, le=200, description="Max number of keys to return"),
+):
+    """Return distinct metadata keys from recent root spans.
+
+    Scans root spans (parent_span_id IS NULL) from the last 7 days and
+    extracts top-level JSON keys from their `metadata` column. These keys
+    are used for tag autocomplete in the detector TriggerEditor.
+    """
+    import json as _json
+
+    ch = get_clickhouse_client()
+    result = ch.query(
+        """
+        SELECT DISTINCT metadata
+        FROM spans
+        WHERE project_id = {project_id:String}
+          AND parent_span_id IS NULL
+          AND metadata IS NOT NULL
+          AND metadata != ''
+          AND span_start_time >= now() - INTERVAL 7 DAY
+        LIMIT 500
+        """,
+        parameters={"project_id": project_id},
+    )
+
+    key_set: set[str] = set()
+    for row in result.result_rows:
+        raw = row[0]
+        if not raw:
+            continue
+        try:
+            meta = _json.loads(raw) if isinstance(raw, str) else raw
+            if isinstance(meta, dict):
+                key_set.update(meta.keys())
+        except (ValueError, TypeError):
+            continue
+
+    # Sort for deterministic ordering, limit result
+    keys = sorted(key_set)[:limit]
+    return TraceTagKeysResponse(keys=keys)
+
+
+@router.get(
+    "/trace-tag-values",
+    response_model=TraceTagValuesResponse,
+    dependencies=[Depends(verify_internal_secret)],
+)
+async def list_trace_tag_values(
+    project_id: str = Query(..., description="Project ID"),
+    key: str = Query(..., description="Metadata key to get values for"),
+    limit: int = Query(30, ge=1, le=100, description="Max number of values to return"),
+):
+    """Return distinct values for a given metadata key from recent root spans.
+
+    Scans root spans (parent_span_id IS NULL) from the last 7 days and
+    extracts the value for the specified key from their `metadata` column.
+    Used for tag value autocomplete in the detector TriggerEditor.
+    """
+    import json as _json
+
+    ch = get_clickhouse_client()
+    result = ch.query(
+        """
+        SELECT DISTINCT metadata
+        FROM spans
+        WHERE project_id = {project_id:String}
+          AND parent_span_id IS NULL
+          AND metadata IS NOT NULL
+          AND metadata != ''
+          AND span_start_time >= now() - INTERVAL 7 DAY
+        LIMIT 500
+        """,
+        parameters={"project_id": project_id},
+    )
+
+    value_set: set[str] = set()
+    for row in result.result_rows:
+        raw = row[0]
+        if not raw:
+            continue
+        try:
+            meta = _json.loads(raw) if isinstance(raw, str) else raw
+            if isinstance(meta, dict) and key in meta:
+                val = meta[key]
+                if isinstance(val, (str, int, float, bool)):
+                    value_set.add(str(val))
+        except (ValueError, TypeError):
+            continue
+
+    values = sorted(value_set)[:limit]
+    return TraceTagValuesResponse(values=values)

--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -5,6 +5,7 @@ Called from process_s3_traces after ClickHouse insert.
 Non-blocking: exceptions are caught and logged, never re-raised.
 """
 
+import fnmatch
 import json
 import logging
 import random
@@ -40,6 +41,8 @@ def _eval_condition(trace_summary: dict, condition: dict) -> bool:
         return actual == value
     elif op == "!=":
         return actual != value
+    elif op == "matches":
+        return fnmatch.fnmatchcase(str(actual), str(value))
     elif op == ">":
         return float(actual) > float(value)
     elif op == ">=":
@@ -59,7 +62,7 @@ def _passes_trigger(trace_summary: dict, conditions: list[dict]) -> bool:
 def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dict]:
     """
     Query ClickHouse for the fields needed for trigger evaluation.
-    Returns {trace_id: {root_span_finished, status, environment}}
+    Returns {trace_id: {root_span_finished, status, environment, tag:*...}}
     """
     from db.clickhouse.client import get_clickhouse_client
 
@@ -74,7 +77,8 @@ def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dic
             trace_id,
             max(CASE WHEN parent_span_id IS NULL THEN 1 ELSE 0 END) AS root_span_finished,
             max(CASE WHEN status = 'ERROR' THEN 1 ELSE 0 END)       AS has_error,
-            anyIf(environment, parent_span_id IS NULL)               AS environment
+            anyIf(environment, parent_span_id IS NULL)               AS environment,
+            anyIf(metadata, parent_span_id IS NULL)                  AS root_metadata
         FROM spans
         WHERE project_id = {project_id:String}
           AND trace_id IN {trace_ids:Array(String)}
@@ -85,12 +89,24 @@ def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dic
 
     summaries: dict[str, dict] = {}
     for row in result.result_rows:
-        summaries[row[0]] = {
+        summary: dict = {
             "root_span_finished": bool(row[1]),
             # Expose status as a string matching what users configure ("ERROR" or "OK")
             "status": "ERROR" if bool(row[2]) else "OK",
             "environment": row[3],  # Nullable — None if not set
         }
+        # Inject tag:* keys from root span metadata for trigger evaluation
+        raw_metadata = row[4]
+        if raw_metadata:
+            try:
+                meta = json.loads(raw_metadata) if isinstance(raw_metadata, str) else raw_metadata
+                if isinstance(meta, dict):
+                    for key, val in meta.items():
+                        if isinstance(val, (str, int, float, bool)):
+                            summary[f"tag:{key}"] = str(val)
+            except (json.JSONDecodeError, TypeError):
+                pass  # Malformed metadata — skip tags, don't break trigger eval
+        summaries[row[0]] = summary
     return summaries
 
 

--- a/backend/worker/tests/test_detector_tasks.py
+++ b/backend/worker/tests/test_detector_tasks.py
@@ -113,6 +113,30 @@ def test_eval_condition_numeric_strings_in_comparisons():
     assert _eval_condition(trace_summary, condition) is True
 
 
+def test_eval_condition_tag_equality():
+    """Test equality operator with a trace tag field."""
+    trace_summary = {"tag:model": "claude-haiku", "status": "OK"}
+    condition = {"field": "tag:model", "op": "=", "value": "claude-haiku"}
+    assert _eval_condition(trace_summary, condition) is True
+
+
+def test_eval_condition_matches_wildcard():
+    """Test 'matches' operator with wildcard pattern."""
+    trace_summary = {"tag:customer-tier": "enterprise-plus"}
+    condition = {"field": "tag:customer-tier", "op": "matches", "value": "enterprise*"}
+    assert _eval_condition(trace_summary, condition) is True
+
+    condition_fail = {"field": "tag:customer-tier", "op": "matches", "value": "free*"}
+    assert _eval_condition(trace_summary, condition_fail) is False
+
+
+def test_eval_condition_matches_none():
+    """Test 'matches' operator when the field is missing (None)."""
+    trace_summary = {"status": "OK"}
+    condition = {"field": "tag:customer-tier", "op": "matches", "value": "enterprise*"}
+    assert _eval_condition(trace_summary, condition) is False
+
+
 # ── Tests for _passes_trigger ──────────────────────────────────────
 
 
@@ -160,6 +184,30 @@ def test_passes_trigger_single_condition_passes():
     trace_summary = {"cost": 100.0}
     conditions = [{"field": "cost", "op": ">", "value": 50.0}]
     assert _passes_trigger(trace_summary, conditions) is True
+
+
+def test_passes_trigger_mixed_builtin_and_tags():
+    """Trigger passes with mixed built-in and tag conditions."""
+    trace_summary = {
+        "status": "ERROR",
+        "environment": "production",
+        "tag:model": "gpt-4",
+        "tag:severity": "high",
+    }
+    conditions = [
+        {"field": "status", "op": "=", "value": "ERROR"},
+        {"field": "tag:model", "op": "matches", "value": "gpt-*"},
+        {"field": "tag:severity", "op": "=", "value": "high"},
+    ]
+    assert _passes_trigger(trace_summary, conditions) is True
+
+    # One condition fails -> false
+    conditions_fail = [
+        {"field": "status", "op": "=", "value": "ERROR"},
+        {"field": "tag:model", "op": "matches", "value": "claude-*"},  # Fails here
+        {"field": "tag:severity", "op": "=", "value": "high"},
+    ]
+    assert _passes_trigger(trace_summary, conditions_fail) is False
 
 
 # ── Tests for _enqueue_to_bullmq ───────────────────────────────────

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
@@ -88,6 +88,24 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   if (triggerConditions !== undefined && !Array.isArray(triggerConditions)) {
     return errorResponse("triggerConditions must be an array", 400);
   }
+  if (triggerConditions !== undefined && Array.isArray(triggerConditions)) {
+    for (const cond of triggerConditions as Array<Record<string, unknown>>) {
+      if (typeof cond.field !== "string" || !cond.field) {
+        return errorResponse("Each condition must have a valid field string", 400);
+      }
+      if (typeof cond.op !== "string" || !cond.op) {
+        return errorResponse("Each condition must have a valid op string", 400);
+      }
+      if (cond.field.startsWith("tag:")) {
+        if (!["=", "!=", "matches"].includes(cond.op)) {
+          return errorResponse(`Invalid operator '${cond.op}' for tag field`, 400);
+        }
+        if (typeof cond.value !== "string") {
+          return errorResponse(`Value for tag field must be a string`, 400);
+        }
+      }
+    }
+  }
   if (outputSchema !== undefined && !Array.isArray(outputSchema)) {
     return errorResponse("outputSchema must be an array", 400);
   }

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
@@ -90,6 +90,9 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   }
   if (triggerConditions !== undefined && Array.isArray(triggerConditions)) {
     for (const cond of triggerConditions as Array<Record<string, unknown>>) {
+      if (!cond || typeof cond !== "object" || Array.isArray(cond)) {
+        return errorResponse("Each condition must be an object", 400);
+      }
       if (typeof cond.field !== "string" || !cond.field) {
         return errorResponse("Each condition must have a valid field string", 400);
       }
@@ -97,7 +100,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
         return errorResponse("Each condition must have a valid op string", 400);
       }
       if (cond.field.startsWith("tag:")) {
-        if (!["=", "!=", "matches"].includes(cond.op)) {
+        if (!["=", "!=", "matches"].includes(cond.op as string)) {
           return errorResponse(`Invalid operator '${cond.op}' for tag field`, 400);
         }
         if (typeof cond.value !== "string") {

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -118,6 +118,24 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   if (triggerConditions !== undefined && !Array.isArray(triggerConditions)) {
     return errorResponse("triggerConditions must be an array", 400);
   }
+  if (triggerConditions !== undefined && Array.isArray(triggerConditions)) {
+    for (const cond of triggerConditions as Array<Record<string, unknown>>) {
+      if (typeof cond.field !== "string" || !cond.field) {
+        return errorResponse("Each condition must have a valid field string", 400);
+      }
+      if (typeof cond.op !== "string" || !cond.op) {
+        return errorResponse("Each condition must have a valid op string", 400);
+      }
+      if (cond.field.startsWith("tag:")) {
+        if (!["=", "!=", "matches"].includes(cond.op)) {
+          return errorResponse(`Invalid operator '${cond.op}' for tag field`, 400);
+        }
+        if (typeof cond.value !== "string") {
+          return errorResponse(`Value for tag field must be a string`, 400);
+        }
+      }
+    }
+  }
   if (outputSchema !== undefined && !Array.isArray(outputSchema)) {
     return errorResponse("outputSchema must be an array", 400);
   }

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -120,6 +120,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   }
   if (triggerConditions !== undefined && Array.isArray(triggerConditions)) {
     for (const cond of triggerConditions as Array<Record<string, unknown>>) {
+      if (!cond || typeof cond !== "object" || Array.isArray(cond)) {
+        return errorResponse("Each condition must be an object", 400);
+      }
       if (typeof cond.field !== "string" || !cond.field) {
         return errorResponse("Each condition must have a valid field string", 400);
       }
@@ -127,7 +130,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
         return errorResponse("Each condition must have a valid op string", 400);
       }
       if (cond.field.startsWith("tag:")) {
-        if (!["=", "!=", "matches"].includes(cond.op)) {
+        if (!["=", "!=", "matches"].includes(cond.op as string)) {
           return errorResponse(`Invalid operator '${cond.op}' for tag field`, 400);
         }
         if (typeof cond.value !== "string") {

--- a/frontend/ui/src/app/api/projects/[projectId]/trace-tag-keys/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/trace-tag-keys/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+import { requireAuth, requireProjectAccess, errorResponse } from "@/lib/auth-helpers";
+
+const BACKEND_URL = process.env.PYTHON_BACKEND_URL ?? "http://localhost:8000";
+const INTERNAL_SECRET = process.env.INTERNAL_API_SECRET ?? "";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+// GET /api/projects/[projectId]/trace-tag-keys
+// Proxies to Python backend: GET /api/v1/internal/trace-tag-keys
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  try {
+    const backendParams = new URLSearchParams({ project_id: projectId });
+    const limitParam = req.nextUrl.searchParams.get("limit");
+    if (limitParam) backendParams.set("limit", limitParam);
+
+    const res = await fetch(
+      `${BACKEND_URL}/api/v1/internal/trace-tag-keys?${backendParams.toString()}`,
+      { headers: { "X-Internal-Secret": INTERNAL_SECRET } },
+    );
+    const body = await res.json();
+    return Response.json(body, { status: res.status });
+  } catch (err) {
+    console.error("[trace-tag-keys proxy] fetch error:", err);
+    return errorResponse("Failed to fetch tag keys", 502);
+  }
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/trace-tag-values/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/trace-tag-values/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest } from "next/server";
+import { requireAuth, requireProjectAccess, errorResponse } from "@/lib/auth-helpers";
+
+const BACKEND_URL = process.env.PYTHON_BACKEND_URL ?? "http://localhost:8000";
+const INTERNAL_SECRET = process.env.INTERNAL_API_SECRET ?? "";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+// GET /api/projects/[projectId]/trace-tag-values?key=model
+// Proxies to Python backend: GET /api/v1/internal/trace-tag-values
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const key = req.nextUrl.searchParams.get("key");
+  if (!key) {
+    return errorResponse("key query parameter is required", 400);
+  }
+
+  try {
+    const backendParams = new URLSearchParams({ project_id: projectId, key });
+    const limitParam = req.nextUrl.searchParams.get("limit");
+    if (limitParam) backendParams.set("limit", limitParam);
+
+    const res = await fetch(
+      `${BACKEND_URL}/api/v1/internal/trace-tag-values?${backendParams.toString()}`,
+      { headers: { "X-Internal-Secret": INTERNAL_SECRET } },
+    );
+    const body = await res.json();
+    return Response.json(body, { status: res.status });
+  } catch (err) {
+    console.error("[trace-tag-values proxy] fetch error:", err);
+    return errorResponse("Failed to fetch tag values", 502);
+  }
+}

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -193,6 +193,7 @@ export default function NewDetectorPage() {
                 conditions={triggerConditions}
                 onChange={setTriggerConditions}
                 asCard
+                projectId={projectId}
               />
             </div>
 

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -225,7 +225,12 @@ export function DetectorPanel({
 
         {/* Filter */}
         <div className="border border-border">
-          <TriggerEditor conditions={editConditions} onChange={setEditConditions} asCard />
+          <TriggerEditor
+            conditions={editConditions}
+            onChange={setEditConditions}
+            asCard
+            projectId={projectId}
+          />
         </div>
 
         {/* Sampling */}

--- a/frontend/ui/src/features/detectors/components/trigger-editor.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { X, Plus } from "lucide-react";
+import { useState, useEffect, useRef, useCallback } from "react";
+import { X, Plus, Tag } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -45,12 +45,135 @@ const FIELD_DEFS: FieldDef[] = [
   },
 ];
 
+/** Sentinel value used in the field selector to indicate a tag-type condition. */
+const TAG_FIELD_SENTINEL = "__tag__";
+
+const TAG_OPS = ["=", "!=", "matches"];
+
+const isTagField = (field: string): boolean => field.startsWith("tag:");
+
+const tagKeyFromField = (field: string): string => (isTagField(field) ? field.slice(4) : "");
+
 const defaultValueForField = (field: string): unknown => {
+  if (isTagField(field)) return "";
   const def = FIELD_DEFS.find((d) => d.field === field);
   if (!def) return "";
   if (def.valueType === "select") return def.options?.[0]?.value ?? "";
   return "";
 };
+
+// ── Tag suggestions hook ──────────────────────────────────────────
+
+function useTagKeys(projectId?: string) {
+  const [keys, setKeys] = useState<string[]>([]);
+  useEffect(() => {
+    if (!projectId) return;
+    let cancelled = false;
+    fetch(`/api/projects/${projectId}/trace-tag-keys`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled && data?.keys) setKeys(data.keys as string[]);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+  return keys;
+}
+
+function useTagValues(projectId?: string, tagKey?: string) {
+  const [values, setValues] = useState<string[]>([]);
+  useEffect(() => {
+    if (!projectId || !tagKey) {
+      setValues([]);
+      return;
+    }
+    let cancelled = false;
+    fetch(`/api/projects/${projectId}/trace-tag-values?key=${encodeURIComponent(tagKey)}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled && data?.values) setValues(data.values as string[]);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId, tagKey]);
+  return values;
+}
+
+// ── Autocomplete dropdown ─────────────────────────────────────────
+
+function AutocompleteInput({
+  value,
+  onChange,
+  suggestions,
+  placeholder,
+  className,
+}: {
+  value: string;
+  onChange: (val: string) => void;
+  suggestions: string[];
+  placeholder?: string;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState("");
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const filtered = suggestions.filter((s) =>
+    s.toLowerCase().includes((filter || value).toLowerCase()),
+  );
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+      setOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [handleClickOutside]);
+
+  return (
+    <div ref={wrapperRef} className="relative flex-1">
+      <Input
+        value={value}
+        onChange={(e) => {
+          onChange(e.target.value);
+          setFilter(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        placeholder={placeholder}
+        className={className}
+      />
+      {open && filtered.length > 0 && (
+        <div className="absolute left-0 top-full z-50 mt-0.5 max-h-36 w-full overflow-y-auto rounded border border-border bg-popover shadow-md">
+          {filtered.map((s) => (
+            <button
+              key={s}
+              type="button"
+              className="block w-full px-2 py-1 text-left text-[12px] hover:bg-accent"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onChange(s);
+                setFilter("");
+                setOpen(false);
+              }}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── TriggerEditor component ───────────────────────────────────────
 
 interface TriggerEditorProps {
   conditions: TriggerCondition[];
@@ -63,6 +186,8 @@ interface TriggerEditorProps {
   readOnly?: boolean;
   /** Card mode: renders as a bordered card section (header + body) for embedding inside a card container */
   asCard?: boolean;
+  /** When provided, enables tag-field autocomplete from recent traces in the project */
+  projectId?: string;
 }
 
 export function TriggerEditor({
@@ -72,6 +197,7 @@ export function TriggerEditor({
   isSaving,
   readOnly,
   asCard,
+  projectId,
 }: TriggerEditorProps) {
   const [conditions, setConditions] = useState<TriggerCondition[]>(initialConditions);
   const [dirty, setDirty] = useState(false);
@@ -80,6 +206,8 @@ export function TriggerEditor({
     setConditions(initialConditions);
     setDirty(false);
   }, [initialConditions]);
+
+  const tagKeys = useTagKeys(projectId);
 
   const update = (next: TriggerCondition[]) => {
     setConditions(next);
@@ -108,23 +236,49 @@ export function TriggerEditor({
         if (idx !== i) return c;
         const merged = { ...c, ...patch };
         if (patch.field && patch.field !== c.field) {
-          const def = FIELD_DEFS.find((d) => d.field === patch.field);
-          merged.op = def?.ops[0] ?? "=";
-          merged.value = defaultValueForField(patch.field);
+          if (isTagField(patch.field)) {
+            merged.op = TAG_OPS[0];
+            merged.value = "";
+          } else {
+            const def = FIELD_DEFS.find((d) => d.field === patch.field);
+            merged.op = def?.ops[0] ?? "=";
+            merged.value = defaultValueForField(patch.field);
+          }
         }
         return merged;
       }),
     );
   };
 
+  /** Called when user selects a tag key in the tag-key autocomplete. */
+  const handleTagKeyChange = (i: number, tagKey: string) => {
+    updateCondition(i, { field: `tag:${tagKey}` });
+  };
+
   const conditionRows = (
     <div className={`space-y-1.5 ${readOnly ? "pointer-events-none opacity-60" : ""}`}>
       {conditions.map((cond, i) => {
-        const fieldDef = FIELD_DEFS.find((d) => d.field === cond.field) ?? FIELD_DEFS[0];
+        const isTag = isTagField(cond.field);
+        const fieldDef = isTag
+          ? null
+          : (FIELD_DEFS.find((d) => d.field === cond.field) ?? FIELD_DEFS[0]);
+        // Determine which field selector value to show
+        const selectorValue = isTag ? TAG_FIELD_SENTINEL : cond.field;
+        const ops = isTag ? TAG_OPS : (fieldDef?.ops ?? ["="]);
+
         return (
           <div key={i} className="flex items-center gap-1.5">
             {/* Field */}
-            <Select value={cond.field} onValueChange={(val) => updateCondition(i, { field: val })}>
+            <Select
+              value={selectorValue}
+              onValueChange={(val) => {
+                if (val === TAG_FIELD_SENTINEL) {
+                  updateCondition(i, { field: "tag:", op: TAG_OPS[0], value: "" });
+                } else {
+                  updateCondition(i, { field: val });
+                }
+              }}
+            >
               <SelectTrigger className="h-7 w-[120px] shrink-0 text-[12px]">
                 <SelectValue />
               </SelectTrigger>
@@ -134,16 +288,30 @@ export function TriggerEditor({
                     {d.label}
                   </SelectItem>
                 ))}
+                <SelectItem value={TAG_FIELD_SENTINEL} className="text-[12px]">
+                  Trace Tag
+                </SelectItem>
               </SelectContent>
             </Select>
 
+            {/* Tag key input — shown only for tag fields */}
+            {isTag && (
+              <AutocompleteInput
+                value={tagKeyFromField(cond.field)}
+                onChange={(key) => handleTagKeyChange(i, key)}
+                suggestions={tagKeys}
+                placeholder="tag key…"
+                className="h-7 w-[110px] shrink-0 text-[12px]"
+              />
+            )}
+
             {/* Op */}
             <Select value={cond.op} onValueChange={(val) => updateCondition(i, { op: val })}>
-              <SelectTrigger className="h-7 w-14 shrink-0 text-[12px]">
+              <SelectTrigger className="h-7 w-[70px] shrink-0 text-[12px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {fieldDef.ops.map((op) => (
+                {ops.map((op) => (
                   <SelectItem key={op} value={op} className="text-[12px]">
                     {op}
                   </SelectItem>
@@ -152,7 +320,14 @@ export function TriggerEditor({
             </Select>
 
             {/* Value */}
-            {fieldDef.valueType === "select" ? (
+            {isTag ? (
+              <TagValueInput
+                projectId={projectId}
+                tagKey={tagKeyFromField(cond.field)}
+                value={cond.value as string}
+                onChange={(val) => updateCondition(i, { value: val })}
+              />
+            ) : fieldDef?.valueType === "select" ? (
               <Select
                 value={cond.value as string}
                 onValueChange={(val) => updateCondition(i, { value: val })}
@@ -265,5 +440,30 @@ export function TriggerEditor({
         </div>
       )}
     </div>
+  );
+}
+
+// ── Tag value input with autocomplete ─────────────────────────────
+
+function TagValueInput({
+  projectId,
+  tagKey,
+  value,
+  onChange,
+}: {
+  projectId?: string;
+  tagKey: string;
+  value: string;
+  onChange: (val: string) => void;
+}) {
+  const suggestions = useTagValues(projectId, tagKey);
+  return (
+    <AutocompleteInput
+      value={value}
+      onChange={onChange}
+      suggestions={suggestions}
+      placeholder="Enter value…"
+      className="h-7 flex-1 text-[12px]"
+    />
   );
 }


### PR DESCRIPTION
Fixes #811

## Summary
Adds support for trace-level tags (user-defined metadata) as queryable trigger conditions for detectors. This enables users to scope detectors to specific traces, for instance, traces tagged with `model:claude-haiku` or `customer-tier: enterprise`.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] GitHub - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
- **Backend Trigger Evaluation**: 
  - Updated `_get_trace_summaries` ClickHouse query to extract root span metadata and inject `tag:*` keys into the trace summary dict.
  - Added a new `matches` operator in `_eval_condition` using `fnmatch` for wildcard string pattern matching.
- **Tag Suggestion APIs**:
  - Created `GET /internal/trace-tag-keys` to fetch unique metadata keys from recent root spans.
  - Created `GET /internal/trace-tag-values` to fetch unique metadata values for a specific key.
  - Added Next.js proxy routes to securely expose these endpoints to the frontend.
- **Frontend Trigger Editor**:
  - Refactored `TriggerEditor` to support a dynamic "Trace Tag" option in the field picker.
  - Integrated custom autocomplete inputs for tag keys and values, populated automatically by the new suggestion APIs.
- **API Validation**: 
  - Added strict validation in the `POST` and `PATCH`/detectors routes to ensure `tag:*` conditions use valid operators (`=`, `!=`, `matches`) and string values.

## Screenshots / Recordings (if applicable)
<img width="1668" height="596" alt="image" src="https://github.com/user-attachments/assets/debf4000-993f-4dea-9050-b77ad1fcab9c" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds trace tag filtering to detectors so users can target traces by root-span metadata (e.g., `tag:model`, `tag:customer-tier`). Adds a case-sensitive wildcard `matches` operator and UI autocomplete for tag keys and values. Fixes #811.

- **New Features**
  - Backend: injects root-span metadata as `tag:*` fields in trace summaries; adds `matches` operator using `fnmatch.fnmatchcase`; safely stringifies simple metadata types.
  - Internal APIs: `GET /api/v1/internal/trace-tag-keys` and `GET /api/v1/internal/trace-tag-values` return distinct keys/values from the last 7 days of root spans; exposed via Next.js proxies at `/api/projects/[projectId]/trace-tag-keys` and `/api/projects/[projectId]/trace-tag-values` with optional `limit`.
  - Frontend: `TriggerEditor` adds a "Trace Tag" option with key/value autocomplete; integrated in new/edit detector flows and wired with `projectId`; tag fields restrict ops to `=`, `!=`, `matches`.
  - Validation: detector `POST`/`PATCH` routes validate tag fields and enforce allowed ops and string values.
  - Tests: unit tests for tag equality, wildcard matching (including missing fields), and mixed built-in/tag conditions.

<sup>Written for commit 358d58ce9efc00626519fe8ee35e02fbe504292a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

