### PR TITLE
feat(billing): three-meter pricing for chat / RCA / detector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,6 +74,8 @@ STRIPE_WEBHOOK_SIGNING_SECRET=whsec_xxx  # CHANGEME - from Stripe CLI or Dashboa
 STRIPE_PRICE_ID_STARTER=price_xxx  # CHANGEME - from Stripe Dashboard > Products > Prices
 STRIPE_PRICE_ID_PRO=price_xxx  # CHANGEME
 STRIPE_PRICE_ID_AI_USAGE=price_xxx  # CHANGEME
+STRIPE_PRICE_ID_RCA_USAGE=price_xxx  # CHANGEME - separate metered product for RCA runs
+STRIPE_PRICE_ID_DETECTOR_USAGE=price_xxx  # CHANGEME - meter for managed detector inference (1.05x pass-through)
 
 # --- GitHub App ---------------------------------------------------------------
 GITHUB_APP_ID=                      # From GitHub App settings > General > App ID

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -55,6 +55,7 @@ class UsageTotalResponse(BaseModel):
 class UsageDetailsResponse(BaseModel):
     traces: int
     spans: int
+    detector_runs: int = 0
 
 
 @router.get(
@@ -79,20 +80,20 @@ async def get_usage_total(
     start_str = start.strftime("%Y-%m-%d %H:%M:%S")
     end_str = end.strftime("%Y-%m-%d %H:%M:%S")
 
+    # ReplacingMergeTree dedup via uniqExact — same trace/span id can have
+    # multiple pre-merge rows in ClickHouse.
     result = ch.query(
         """
-        SELECT count(*) as total
-        FROM (
-            SELECT 1 FROM traces
-            WHERE project_id IN {project_ids:Array(String)}
-              AND ch_create_time >= {start:String}
-              AND ch_create_time < {end:String}
-            UNION ALL
-            SELECT 1 FROM spans
-            WHERE project_id IN {project_ids:Array(String)}
-              AND ch_create_time >= {start:String}
-              AND ch_create_time < {end:String}
-        )
+        SELECT (
+            (SELECT uniqExact(trace_id) FROM traces
+             WHERE project_id IN {project_ids:Array(String)}
+               AND ch_create_time >= {start:String}
+               AND ch_create_time < {end:String})
+          + (SELECT uniqExact(span_id) FROM spans
+             WHERE project_id IN {project_ids:Array(String)}
+               AND ch_create_time >= {start:String}
+               AND ch_create_time < {end:String})
+        ) as total
         """,
         parameters={
             "project_ids": project_id_list,
@@ -119,7 +120,7 @@ async def get_usage_details(
     project_id_list = [p.strip() for p in project_ids.split(",") if p.strip()]
 
     if not project_id_list:
-        return UsageDetailsResponse(traces=0, spans=0)
+        return UsageDetailsResponse(traces=0, spans=0, detector_runs=0)
 
     ch = get_clickhouse_client()
 
@@ -127,10 +128,13 @@ async def get_usage_details(
     start_str = start.strftime("%Y-%m-%d %H:%M:%S")
     end_str = end.strftime("%Y-%m-%d %H:%M:%S")
 
-    # Query traces count
+    # Query traces count — uniqExact dedups across pre-merge ReplacingMergeTree
+    # rows (a single trace can have multiple rows until background merge runs,
+    # e.g. on status update). uniqExact is faster than count(DISTINCT trace_id)
+    # in ClickHouse and produces identical results.
     traces_result = ch.query(
         """
-        SELECT count(*) as total
+        SELECT uniqExact(trace_id) as total
         FROM traces
         WHERE project_id IN {project_ids:Array(String)}
           AND ch_create_time >= {start:String}
@@ -143,10 +147,10 @@ async def get_usage_details(
         },
     )
 
-    # Query spans count
+    # Query spans count — same uniqExact pattern for ReplacingMergeTree dedup
     spans_result = ch.query(
         """
-        SELECT count(*) as total
+        SELECT uniqExact(span_id) as total
         FROM spans
         WHERE project_id IN {project_ids:Array(String)}
           AND ch_create_time >= {start:String}
@@ -162,7 +166,27 @@ async def get_usage_details(
     traces = int(traces_result.result_rows[0][0]) if traces_result.result_rows else 0
     spans = int(spans_result.result_rows[0][0]) if spans_result.result_rows else 0
 
-    return UsageDetailsResponse(traces=traces, spans=spans)
+    # Detector runs: count every scan attempt recorded by the detector worker
+    # (BYOK + system source both count toward Free-plan hard cap).
+    detector_runs_result = ch.query(
+        """
+        SELECT count(*) as total
+        FROM detector_runs
+        WHERE project_id IN {project_ids:Array(String)}
+          AND timestamp >= {start:String}
+          AND timestamp < {end:String}
+        """,
+        parameters={
+            "project_ids": project_id_list,
+            "start": start_str,
+            "end": end_str,
+        },
+    )
+    detector_runs = (
+        int(detector_runs_result.result_rows[0][0]) if detector_runs_result.result_rows else 0
+    )
+
+    return UsageDetailsResponse(traces=traces, spans=spans, detector_runs=detector_runs)
 
 
 # =============================================================================

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -168,9 +168,11 @@ async def get_usage_details(
 
     # Detector runs: count every scan attempt recorded by the detector worker
     # (BYOK + system source both count toward Free-plan hard cap).
+    # uniqExact on run_id dedups pre-merge duplicates in the ReplacingMergeTree —
+    # same pattern as the traces / spans queries above.
     detector_runs_result = ch.query(
         """
-        SELECT count(*) as total
+        SELECT uniqExact(run_id) as total
         FROM detector_runs
         WHERE project_id IN {project_ids:Array(String)}
           AND timestamp >= {start:String}

--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,7 +1,7 @@
 # docker/Dockerfile.agent
 FROM node:20-alpine AS base
 RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+    corepack enable && corepack prepare pnpm@10 --activate
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.billing
+++ b/docker/Dockerfile.billing
@@ -1,7 +1,7 @@
 # docker/Dockerfile.billing
 FROM node:20-alpine AS base
 RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+    corepack enable && corepack prepare pnpm@10 --activate
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.detector
+++ b/docker/Dockerfile.detector
@@ -1,7 +1,7 @@
 # docker/Dockerfile.detector
 FROM node:20-alpine AS base
 RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+    corepack enable && corepack prepare pnpm@10 --activate
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.migrate-postgres
+++ b/docker/Dockerfile.migrate-postgres
@@ -3,7 +3,7 @@
 # Build with: docker build --platform linux/amd64 -f docker/Dockerfile.migrate-postgres .
 FROM node:20-alpine AS base
 RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+    corepack enable && corepack prepare pnpm@10 --activate
 
 FROM base AS deps
 WORKDIR /app

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,7 +1,7 @@
 # docker/Dockerfile.web
 FROM node:20-alpine AS base
 RUN apk add --no-cache openssl && \
-    corepack enable && corepack prepare pnpm@latest --activate
+    corepack enable && corepack prepare pnpm@10 --activate
 
 # --- Dependencies stage ---
 FROM base AS deps

--- a/frontend/packages/agent/package.json
+++ b/frontend/packages/agent/package.json
@@ -19,9 +19,9 @@
   },
   "dependencies": {
     "@daytonaio/sdk": "0.148.0",
+    "@earendil-works/pi-agent-core": "0.74.0",
+    "@earendil-works/pi-ai": "0.74.0",
     "@hono/node-server": "^1.19.13",
-    "@mariozechner/pi-agent-core": "0.57.1",
-    "@mariozechner/pi-ai": "0.57.1",
     "@traceroot/core": "workspace:*",
     "hono": "^4.12.14"
   },

--- a/frontend/packages/agent/src/agent.ts
+++ b/frontend/packages/agent/src/agent.ts
@@ -3,8 +3,8 @@ import {
   type AgentEvent,
   type AgentTool,
   type AgentMessage,
-} from "@mariozechner/pi-agent-core";
-import { getEnvApiKey, type Message } from "@mariozechner/pi-ai";
+} from "@earendil-works/pi-agent-core";
+import { getEnvApiKey, type Message } from "@earendil-works/pi-ai";
 import { ADAPTER_TO_PI_AI, BEDROCK_USE_DEFAULT_CREDENTIALS, ModelSource } from "@traceroot/core";
 import {
   resolvePiModel,
@@ -126,7 +126,9 @@ export async function getOrCreateAgent(config: AgentRunnerConfig): Promise<{
   // Load existing conversation history
   const agentMessages = await sessionManager.buildContext();
   if (agentMessages.length > 0) {
-    agent.replaceMessages(agentMessages);
+    // pi-agent-core 0.74.0 dropped `replaceMessages` in favor of direct state
+    // assignment. Semantically equivalent — sets the agent's message history.
+    agent.state.messages = agentMessages;
   }
 
   sessionAgents.set(config.sessionId, agent);

--- a/frontend/packages/agent/src/session.ts
+++ b/frontend/packages/agent/src/session.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@traceroot/core";
-import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { UserMessage, Message } from "@mariozechner/pi-ai";
+import type { AgentMessage } from "@earendil-works/pi-agent-core";
+import type { UserMessage, Message } from "@earendil-works/pi-ai";
 
 // ============================================================
 // SessionManager — follows Mom's SessionManager pattern
@@ -55,6 +55,11 @@ export class SessionManager {
   /**
    * Append a message to the session.
    * Like Mom's sessionManager.appendMessage() — persists to DB.
+   *
+   * `workspaceId` and `kind` are required on every AIMessage row (see schema).
+   * We derive both from the parent AISession: `kind = "chat"` for user sessions
+   * (userId set), `kind = "rca"` for system sessions (userId null). This
+   * mirrors the existing convention in createSession.
    */
   async appendMessage(
     role: string,
@@ -62,9 +67,20 @@ export class SessionManager {
     metadata?: Record<string, unknown>,
     tokenUsage?: TokenUsageData,
   ): Promise<void> {
+    const session = await prisma.aISession.findUnique({
+      where: { id: this.sessionId },
+      select: { workspaceId: true, userId: true },
+    });
+    if (!session) {
+      throw new Error(`AISession not found: ${this.sessionId}`);
+    }
+    const kind = session.userId === null ? "rca" : "chat";
+
     await prisma.aIMessage.create({
       data: {
         sessionId: this.sessionId,
+        workspaceId: session.workspaceId,
+        kind,
         role,
         content,
         metadata: metadata as any,

--- a/frontend/packages/agent/src/tools/download-session.ts
+++ b/frontend/packages/agent/src/tools/download-session.ts
@@ -1,5 +1,5 @@
-import { Type, type Static } from "@mariozechner/pi-ai";
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type, type Static } from "@earendil-works/pi-ai";
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Executor } from "../executors/interface.js";
 import { downloadOneTrace } from "./download-traces.js";
 
@@ -27,9 +27,10 @@ export function createDownloadSessionTool(
     parameters: downloadSessionSchema,
     execute: async (
       _toolCallId: string,
-      params: DownloadSessionParams,
+      rawParams: unknown,
       signal?: AbortSignal,
     ): Promise<AgentToolResult<undefined>> => {
+      const params = rawParams as DownloadSessionParams;
       if (!executor.isReady()) {
         await executor.init();
       }

--- a/frontend/packages/agent/src/tools/download-traces.ts
+++ b/frontend/packages/agent/src/tools/download-traces.ts
@@ -1,5 +1,5 @@
-import { Type, type Static } from "@mariozechner/pi-ai";
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type, type Static } from "@earendil-works/pi-ai";
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Executor } from "../executors/interface.js";
 
 const FASTAPI_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
@@ -110,9 +110,10 @@ export function createDownloadTracesTool(
     parameters: downloadTracesSchema,
     execute: async (
       _toolCallId: string,
-      params: DownloadTracesParams,
+      rawParams: unknown,
       signal?: AbortSignal,
     ): Promise<AgentToolResult<undefined>> => {
+      const params = rawParams as DownloadTracesParams;
       if (!executor.isReady()) {
         await executor.init();
       }

--- a/frontend/packages/agent/src/tools/git-clone.ts
+++ b/frontend/packages/agent/src/tools/git-clone.ts
@@ -1,5 +1,5 @@
-import { Type } from "@mariozechner/pi-ai";
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type } from "@earendil-works/pi-ai";
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Executor } from "../executors/interface.js";
 import { setupGhCli } from "../executors/docker.js";
 import { setupGhCliDaytona } from "../executors/daytona.js";

--- a/frontend/packages/agent/src/tools/github-access.ts
+++ b/frontend/packages/agent/src/tools/github-access.ts
@@ -1,5 +1,5 @@
-import { Type } from "@mariozechner/pi-ai";
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type } from "@earendil-works/pi-ai";
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 
 const schema = Type.Object({
   repo: Type.String({ description: "Repository in 'owner/repo' format" }),

--- a/frontend/packages/agent/src/tools/index.ts
+++ b/frontend/packages/agent/src/tools/index.ts
@@ -1,4 +1,4 @@
-import type { AgentTool } from "@mariozechner/pi-agent-core";
+import type { AgentTool } from "@earendil-works/pi-agent-core";
 import type { Executor } from "../executors/interface.js";
 import { createQueryTracesTool } from "./query-traces.js";
 import { createQuerySessionsTool } from "./query-sessions.js";

--- a/frontend/packages/agent/src/tools/query-sessions.ts
+++ b/frontend/packages/agent/src/tools/query-sessions.ts
@@ -1,5 +1,5 @@
-import { Type, type Static } from "@mariozechner/pi-ai";
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type, type Static } from "@earendil-works/pi-ai";
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 
 const FASTAPI_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
 
@@ -31,9 +31,10 @@ export function createQuerySessionsTool(projectId: string, userId: string): Agen
     parameters: querySessionsSchema,
     execute: async (
       _toolCallId: string,
-      params: QuerySessionsParams,
+      rawParams: unknown,
       signal?: AbortSignal,
     ): Promise<AgentToolResult<undefined>> => {
+      const params = rawParams as QuerySessionsParams;
       const headers: Record<string, string> = {
         "Content-Type": "application/json",
         "x-user-id": userId,

--- a/frontend/packages/agent/src/tools/query-traces.ts
+++ b/frontend/packages/agent/src/tools/query-traces.ts
@@ -1,5 +1,5 @@
-import { Type, type Static } from "@mariozechner/pi-ai";
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type, type Static } from "@earendil-works/pi-ai";
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 
 const FASTAPI_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
 
@@ -32,9 +32,10 @@ export function createQueryTracesTool(projectId: string, userId: string): AgentT
     parameters: queryTracesSchema,
     execute: async (
       _toolCallId: string,
-      params: QueryTracesParams,
+      rawParams: unknown,
       signal?: AbortSignal,
     ): Promise<AgentToolResult<undefined>> => {
+      const params = rawParams as QueryTracesParams;
       const queryParams = new URLSearchParams();
       queryParams.set("limit", String(params.limit || 20));
       if (params.userId) queryParams.set("user_id", params.userId);

--- a/frontend/packages/agent/src/tools/sandbox.ts
+++ b/frontend/packages/agent/src/tools/sandbox.ts
@@ -1,5 +1,5 @@
-import { Type } from "@mariozechner/pi-ai";
-import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type } from "@earendil-works/pi-ai";
+import type { AgentTool, AgentToolResult } from "@earendil-works/pi-agent-core";
 import type { Executor } from "../executors/interface.js";
 import {
   DEFAULT_MAX_BYTES,
@@ -43,9 +43,10 @@ export function createBashTool(executor: Executor): AgentTool<any> {
     parameters: bashSchema,
     execute: async (
       _toolCallId: string,
-      { command, timeout }: { label: string; command: string; timeout?: number },
+      params: unknown,
       signal?: AbortSignal,
     ): Promise<AgentToolResult<BashToolDetails | undefined>> => {
+      const { command, timeout } = params as { label: string; command: string; timeout?: number };
       if (!executor.isReady()) {
         await executor.init();
       }
@@ -122,9 +123,15 @@ export function createReadTool(executor: Executor): AgentTool<any> {
     parameters: readSchema,
     execute: async (
       _toolCallId: string,
-      { path, offset, limit }: { label: string; path: string; offset?: number; limit?: number },
+      params: unknown,
       signal?: AbortSignal,
     ): Promise<AgentToolResult<ReadToolDetails | undefined>> => {
+      const { path, offset, limit } = params as {
+        label: string;
+        path: string;
+        offset?: number;
+        limit?: number;
+      };
       if (!executor.isReady()) {
         await executor.init();
       }
@@ -230,9 +237,10 @@ export function createWriteTool(executor: Executor): AgentTool<any> {
     parameters: writeSchema,
     execute: async (
       _toolCallId: string,
-      { path, content }: { label: string; path: string; content: string },
+      params: unknown,
       signal?: AbortSignal,
     ): Promise<AgentToolResult<undefined>> => {
+      const { path, content } = params as { label: string; path: string; content: string };
       if (!executor.isReady()) {
         await executor.init();
       }

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -25,7 +25,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@mariozechner/pi-ai": "0.57.1",
+    "@earendil-works/pi-ai": "0.74.0",
     "@prisma/client": "^5.22.0",
     "zod": "^4.3.6"
   },

--- a/frontend/packages/core/prisma/migrations/20260414000000_add_detectors/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260414000000_add_detectors/migration.sql
@@ -1,9 +1,19 @@
 -- Detectors feature: detectors, triggers, alert configs, RCA
--- Also includes: ai_sessions.user_id nullable (system sessions for RCA worker)
--- Also includes: projects.rca_model (project-scoped agent model for RCA)
+-- Also includes:
+--   * ai_sessions.user_id nullable (system sessions for RCA worker)
+--   * projects.rca_model (project-scoped agent model for RCA)
+--   * workspaces.detector_blocked / rca_blocked (Free-plan hard-cap flags
+--     set by the hourly billing cron; mirrors existing ai_blocked)
+--   * ai_messages.kind / workspace_id / nullable session_id (so chat,
+--     RCA, and detector-scan rows share one table with categorical
+--     billing aggregation by kind)
 
 -- AlterTable: project-scoped RCA agent model
 ALTER TABLE "projects" ADD COLUMN "rca_model" VARCHAR;
+
+-- AlterTable: Free-plan hard-cap flags (set by hourly billing cron)
+ALTER TABLE "workspaces" ADD COLUMN "detector_blocked" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "workspaces" ADD COLUMN "rca_blocked" BOOLEAN NOT NULL DEFAULT false;
 
 -- CreateTable
 CREATE TABLE "detectors" (
@@ -85,3 +95,29 @@ ALTER TABLE "detector_rcas" ADD CONSTRAINT "detector_rcas_project_id_fkey" FOREI
 
 -- Make ai_sessions.user_id nullable (system/RCA sessions have no user)
 ALTER TABLE "ai_sessions" ALTER COLUMN "user_id" DROP NOT NULL;
+
+-- AlterTable ai_messages: categorical kind tag, direct workspace pointer,
+-- and nullable session_id so detector-scan rows (no chat session) can live
+-- alongside chat + RCA agent turns. Backfill workspace_id from the
+-- existing session -> project -> workspace chain, then enforce NOT NULL.
+ALTER TABLE "ai_messages" ADD COLUMN "kind" VARCHAR NOT NULL DEFAULT 'chat';
+
+ALTER TABLE "ai_messages" ALTER COLUMN "session_id" DROP NOT NULL;
+
+ALTER TABLE "ai_messages" ADD COLUMN "workspace_id" VARCHAR;
+
+UPDATE "ai_messages" m
+SET workspace_id = p.workspace_id
+FROM ai_sessions s
+JOIN projects p ON p.id = s.project_id
+WHERE s.id = m.session_id;
+
+ALTER TABLE "ai_messages" ALTER COLUMN "workspace_id" SET NOT NULL;
+
+ALTER TABLE "ai_messages"
+  ADD CONSTRAINT "ai_messages_workspace_id_fkey"
+  FOREIGN KEY ("workspace_id") REFERENCES "workspaces"("id")
+  ON DELETE CASCADE ON UPDATE NO ACTION;
+
+CREATE INDEX "ix_ai_message_workspace_kind_time"
+  ON "ai_messages"("workspace_id", "kind", "create_time");

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -78,13 +78,25 @@ model Workspace {
   billingStatus          String?   @map("billing_status") // active, canceled, past_due, trialing
   billingPeriodStart     DateTime? @map("billing_period_start")
   billingPeriodEnd       DateTime? @map("billing_period_end")
-  billingPlan            String    @default("free") @map("billing_plan") // free, starter, pro, startups
+  billingPlan            String    @default("free") @map("billing_plan") // free, starter, pro, enterprise
   ingestionBlocked       Boolean   @default(false) @map("ingestion_blocked") // true when free plan exceeds usage limit
   aiBlocked              Boolean   @default(false) @map("ai_blocked") // true when free plan exceeds AI token allowance
-  currentUsage           Json?     @map("current_usage") // { traces, spans, tokens, updatedAt, ai }
+  rcaBlocked             Boolean   @default(false) @map("rca_blocked") // true when free plan exceeds 30 RCA runs (mirrors aiBlocked)
+  detectorBlocked        Boolean   @default(false) @map("detector_blocked") // true when free plan exceeds 100 detector runs (any source)
+  // currentUsage shape:
+  //   { traces, spans, tokens, updatedAt,
+  //     ai:       { runsUsed, systemUsage, byokUsage, byModel, lastReportedUnits, lastReportedPeriodStart },
+  //     rca:      { runsUsed, systemTokenCost, systemInputTokens, systemOutputTokens, lastReportedUnits, lastReportedPeriodStart },
+  //     detector: { scansRun, systemTokenCost, systemInputTokens, systemOutputTokens, lastReportedUnits, lastReportedPeriodStart } }
+  // rca.systemTokenCost and detector.systemTokenCost are raw USD inference costs on
+  // system-source agent/scan calls (BYOK skipped). The hourly billing job bills each
+  // at 1.05× pass-through via STRIPE_PRICE_ID_RCA_USAGE / STRIPE_PRICE_ID_DETECTOR_USAGE.
+  // detector.scansRun is informational only (BYOK + system; no quota).
+  currentUsage           Json?     @map("current_usage")
 
   modelProviders ModelProvider[]
   githubInstallations GitHubInstallation[]
+  aiMessages          AIMessage[]
   slackIntegration SlackIntegration?
 
   @@index([billingCustomerId])
@@ -282,21 +294,25 @@ model AISession {
 
 // AI Messages - Individual messages within an AI session
 model AIMessage {
-  id           String    @id @default(cuid()) @db.VarChar
-  sessionId    String    @map("session_id") @db.VarChar
-  role         String    @db.VarChar  // user, assistant, tool
-  content      String    @db.Text
-  metadata     Json?     @db.JsonB    // tool name, tool result, etc.
-  model        String?   @db.VarChar
-  provider     String?   @db.VarChar
-  isByok       Boolean?  @map("is_byok")
-  inputTokens  Int?      @map("input_tokens")
-  outputTokens Int?      @map("output_tokens")
-  cost         Decimal?  @map("cost_usd") @db.Decimal(10, 6)
-  createTime   DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
-  session      AISession @relation(fields: [sessionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  id           String     @id @default(cuid()) @db.VarChar
+  workspaceId  String     @map("workspace_id") @db.VarChar // direct workspace pointer for per-kind aggregation (detector scans have no session)
+  sessionId    String?    @map("session_id") @db.VarChar // nullable: detector scans have no chat session
+  kind         String     @default("chat") @db.VarChar // "chat" | "rca" | "detector" — categorical tag for usage aggregation
+  role         String     @db.VarChar // user, assistant, tool
+  content      String     @db.Text
+  metadata     Json?      @db.JsonB // tool name, tool result, etc.
+  model        String?    @db.VarChar
+  provider     String?    @db.VarChar
+  isByok       Boolean?   @map("is_byok")
+  inputTokens  Int?       @map("input_tokens")
+  outputTokens Int?       @map("output_tokens")
+  cost         Decimal?   @map("cost_usd") @db.Decimal(10, 6)
+  createTime   DateTime   @default(now()) @map("create_time") @db.Timestamp(6)
+  workspace    Workspace  @relation(fields: [workspaceId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  session      AISession? @relation(fields: [sessionId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([sessionId], map: "ix_ai_message_session_id")
+  @@index([workspaceId, kind, createTime], map: "ix_ai_message_workspace_kind_time")
   @@map("ai_messages")
 }
 
@@ -379,14 +395,14 @@ model DetectorAlertConfig {
 }
 
 model DetectorRca {
-  id          String    @id @default(cuid()) @db.VarChar
-  findingId   String    @unique @map("finding_id") @db.VarChar  // trace-level finding UUID (one per trace)
-  projectId   String    @map("project_id") @db.VarChar
-  sessionId   String?   @map("session_id") @db.VarChar  // AISession id for the system RCA session
-  status      String    @db.VarChar  // "pending"|"running"|"done"|"failed"
-  result      String?   @db.Text
-  completedAt DateTime? @map("completed_at") @db.Timestamp(6)
-  createTime  DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
+  id              String    @id @default(cuid()) @db.VarChar
+  findingId       String    @unique @map("finding_id") @db.VarChar  // trace-level finding UUID (one per trace)
+  projectId       String    @map("project_id") @db.VarChar
+  sessionId       String?   @map("session_id") @db.VarChar  // AISession id for the system RCA session
+  status          String    @db.VarChar  // "pending"|"running"|"done"|"failed"
+  result          String?   @db.Text
+  completedAt     DateTime? @map("completed_at") @db.Timestamp(6)
+  createTime      DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
 
   // Cascade with Project — keeps RCA rows consistent with Detector /
   // DetectorAlertConfig when a project is deleted.

--- a/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
+++ b/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  AI_RUN_QUOTAS,
+  RCA_RUN_QUOTAS,
+  DETECTOR_RUN_QUOTAS,
+  PlanType,
+  isAiRunBlocked,
+  isRcaRunBlocked,
+  isDetectorRunBlocked,
+} from "../plans.js";
+
+describe("RCA_RUN_QUOTAS", () => {
+  it("mirrors AI_RUN_QUOTAS shape and values per resolved decision", () => {
+    expect(RCA_RUN_QUOTAS[PlanType.FREE].included).toBe(30);
+    expect(RCA_RUN_QUOTAS[PlanType.STARTER].included).toBe(100);
+    expect(RCA_RUN_QUOTAS[PlanType.PRO].included).toBe(100);
+    expect(RCA_RUN_QUOTAS[PlanType.ENTERPRISE].included).toBe(Infinity);
+  });
+
+  it("Starter and Pro share quota (parity rule)", () => {
+    expect(RCA_RUN_QUOTAS[PlanType.STARTER].included).toBe(RCA_RUN_QUOTAS[PlanType.PRO].included);
+    expect(RCA_RUN_QUOTAS[PlanType.STARTER].overageLabel).toBe(
+      RCA_RUN_QUOTAS[PlanType.PRO].overageLabel,
+    );
+  });
+});
+
+describe("RCA vs AI quota separation", () => {
+  beforeEach(() => {
+    vi.stubEnv("ENABLE_BILLING", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("free plan: RCA usage does not count against AI run quota", () => {
+    expect(isAiRunBlocked(PlanType.FREE, 0)).toBe(false);
+    expect(isRcaRunBlocked(PlanType.FREE, 30)).toBe(true);
+  });
+
+  it("free plan: AI usage does not count against RCA quota", () => {
+    expect(isRcaRunBlocked(PlanType.FREE, 0)).toBe(false);
+    expect(isAiRunBlocked(PlanType.FREE, 30)).toBe(true);
+  });
+
+  it("paid plans: never hard-block on either meter", () => {
+    expect(isAiRunBlocked(PlanType.STARTER, 9999)).toBe(false);
+    expect(isRcaRunBlocked(PlanType.STARTER, 9999)).toBe(false);
+    expect(isAiRunBlocked(PlanType.PRO, 9999)).toBe(false);
+    expect(isRcaRunBlocked(PlanType.PRO, 9999)).toBe(false);
+    expect(isAiRunBlocked(PlanType.ENTERPRISE, 99999)).toBe(false);
+    expect(isRcaRunBlocked(PlanType.ENTERPRISE, 99999)).toBe(false);
+  });
+});
+
+describe("DETECTOR_RUN_QUOTAS", () => {
+  it("Free has a 100-scan hard cap; paid plans are unlimited", () => {
+    expect(DETECTOR_RUN_QUOTAS[PlanType.FREE].included).toBe(100);
+    expect(DETECTOR_RUN_QUOTAS[PlanType.STARTER].included).toBe(Infinity);
+    expect(DETECTOR_RUN_QUOTAS[PlanType.PRO].included).toBe(Infinity);
+    expect(DETECTOR_RUN_QUOTAS[PlanType.ENTERPRISE].included).toBe(Infinity);
+  });
+});
+
+describe("isDetectorRunBlocked", () => {
+  beforeEach(() => {
+    vi.stubEnv("ENABLE_BILLING", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("Free: blocked at exactly 100 scans (hard cap)", () => {
+    expect(isDetectorRunBlocked(PlanType.FREE, 0)).toBe(false);
+    expect(isDetectorRunBlocked(PlanType.FREE, 99)).toBe(false);
+    expect(isDetectorRunBlocked(PlanType.FREE, 100)).toBe(true);
+    expect(isDetectorRunBlocked(PlanType.FREE, 5000)).toBe(true);
+  });
+
+  it("Paid plans: never blocked", () => {
+    expect(isDetectorRunBlocked(PlanType.STARTER, 100_000)).toBe(false);
+    expect(isDetectorRunBlocked(PlanType.PRO, 100_000)).toBe(false);
+    expect(isDetectorRunBlocked(PlanType.ENTERPRISE, 100_000)).toBe(false);
+  });
+
+  it("respects ENABLE_BILLING=false (unblocks all)", () => {
+    vi.stubEnv("ENABLE_BILLING", "false");
+    expect(isDetectorRunBlocked(PlanType.FREE, 9999)).toBe(false);
+  });
+});

--- a/frontend/packages/core/src/ee/billing/index.ts
+++ b/frontend/packages/core/src/ee/billing/index.ts
@@ -10,6 +10,9 @@ export {
   USAGE_CONFIG,
   EVENT_QUOTAS,
   AI_RUN_QUOTAS,
+  RCA_RUN_QUOTAS,
+  DETECTOR_RUN_QUOTAS,
+  DETECTOR_HOSTED_LLM_FREE_THRESHOLD,
   PlanType,
   // Types
   type PlanConfig,
@@ -33,4 +36,6 @@ export {
   // Free plan blocking
   isFreePlanBlocked,
   isAiRunBlocked,
+  isRcaRunBlocked,
+  isDetectorRunBlocked,
 } from "./plans.js";

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -18,8 +18,8 @@ export type PlanType = (typeof PlanType)[keyof typeof PlanType];
 // Spans (observability)
 export const EVENT_QUOTAS: Record<PlanType, { included: number; overageLabel: string }> = {
   [PlanType.FREE]: { included: 50_000, overageLabel: "Hard cap (upgrade to continue)" },
-  [PlanType.STARTER]: { included: 150_000, overageLabel: "$3 per 50k events" },
-  [PlanType.PRO]: { included: 150_000, overageLabel: "$3 per 50k events" },
+  [PlanType.STARTER]: { included: 150_000, overageLabel: "$4 per 50k events" },
+  [PlanType.PRO]: { included: 150_000, overageLabel: "$4 per 50k events" },
   [PlanType.ENTERPRISE]: { included: Infinity, overageLabel: "Custom" },
 };
 
@@ -30,6 +30,33 @@ export const AI_RUN_QUOTAS: Record<PlanType, { included: number; overageLabel: s
   [PlanType.PRO]: { included: 100, overageLabel: "$10 per 100 runs" },
   [PlanType.ENTERPRISE]: { included: Infinity, overageLabel: "Unlimited" },
 };
+
+// RCA runs (auto-triggered by detector findings) — separate meter, same shape as AI runs
+export const RCA_RUN_QUOTAS: Record<PlanType, { included: number; overageLabel: string }> = {
+  [PlanType.FREE]: { included: 30, overageLabel: "Hard cap (upgrade to continue)" },
+  [PlanType.STARTER]: { included: 100, overageLabel: "$10 per 100 runs" },
+  [PlanType.PRO]: { included: 100, overageLabel: "$10 per 100 runs" },
+  [PlanType.ENTERPRISE]: { included: Infinity, overageLabel: "Unlimited" },
+};
+
+// Detector runs (BYOK + hosted combined). Free has a hard cap so the
+// "Free is truly free" promise holds — we absorb hosted-LLM cost up to the
+// cap as customer-acquisition spend. Paid plans are unlimited; hosted
+// inference is billed via STRIPE_PRICE_ID_DETECTOR_USAGE at 1.05× passthrough.
+export const DETECTOR_RUN_QUOTAS: Record<PlanType, { included: number; overageLabel: string }> = {
+  [PlanType.FREE]: { included: 100, overageLabel: "Hard cap (upgrade to continue)" },
+  [PlanType.STARTER]: { included: Infinity, overageLabel: "Unlimited" },
+  [PlanType.PRO]: { included: Infinity, overageLabel: "Unlimited" },
+  [PlanType.ENTERPRISE]: { included: Infinity, overageLabel: "Unlimited" },
+};
+
+// First N detector scans per billing period are billed at $0 even on paid
+// plans — we absorb the hosted-LLM cost. This matches Free's 100-scan grant
+// so upgrading from Free to Starter never *removes* a feature the customer
+// already had. Beyond this threshold, hosted-LLM tokens are billed at 1.05×
+// passthrough (proportional to the overage portion of the period total).
+// BYOK scans bypass billing entirely regardless of this threshold.
+export const DETECTOR_HOSTED_LLM_FREE_THRESHOLD = 100;
 
 // Legacy compat — used by usageMetering and free-plan blocking
 export const USAGE_CONFIG = {
@@ -52,6 +79,37 @@ export function isAiRunBlocked(plan: PlanType, runsUsed: number): boolean {
     return runsUsed >= AI_RUN_QUOTAS[plan].included;
   }
   return false; // paid plans: overage is billed via Stripe, never hard-blocked
+}
+
+/**
+ * Check if RCA runs should be blocked for a given plan and usage.
+ * Free plan: hard cap at included runs (30).
+ * Paid plans: never blocked (overage is billed via Stripe).
+ *
+ * Mirrors isAiRunBlocked. The Free RCA cap (30) is lower than the Free
+ * detector-scan cap (100), so detectorBlocked alone does NOT implicitly
+ * cap RCA — a workspace can produce 30+ findings before hitting the
+ * detector cap, each of which would otherwise trigger an RCA.
+ */
+export function isRcaRunBlocked(plan: PlanType, runsUsed: number): boolean {
+  if (!isBillingEnabled()) return false;
+  if (plan === PlanType.FREE) {
+    return runsUsed >= RCA_RUN_QUOTAS[plan].included;
+  }
+  return false;
+}
+
+/**
+ * Check if detector runs should be blocked for a given plan and usage.
+ * Free plan: hard cap at 100 total scans (BYOK + hosted combined).
+ * Paid plans: never blocked (hosted inference is billed at 1.05× passthrough; BYOK is free).
+ */
+export function isDetectorRunBlocked(plan: PlanType, scansRun: number): boolean {
+  if (!isBillingEnabled()) return false;
+  if (plan === PlanType.FREE) {
+    return scansRun >= DETECTOR_RUN_QUOTAS[plan].included;
+  }
+  return false;
 }
 
 // =============================================================================
@@ -123,8 +181,10 @@ export const PLANS: Record<
       "2 seats",
       "50k events/month included",
       "15-day retention",
-      "30 AI runs/month",
-      "BYOK supported",
+      "30 chat runs/month",
+      "30 RCA runs/month",
+      "100 detector runs/month",
+      "BYOK or hosted LLM",
     ],
     support: "Discord",
     entitlements: getEntitlementsForPlan(PlanType.FREE),
@@ -140,10 +200,14 @@ export const PLANS: Record<
       "Everything in Free",
       "Unlimited seats",
       "150k events/month included",
-      "$3 per 50k overage events",
+      "$4 per 50k overage events",
       "30-day retention",
-      "100 AI runs/month",
-      "$10 per 100 overage runs",
+      "100 chat runs/month",
+      "$10 per 100 overage chat runs",
+      "100 RCA runs/month",
+      "$10 per 100 overage RCA runs",
+      "Unlimited detector runs",
+      "Hosted LLM: token cost × 1.05 on overage",
     ],
     support: "Discord",
     entitlements: getEntitlementsForPlan(PlanType.STARTER),
@@ -158,6 +222,7 @@ export const PLANS: Record<
     features: [
       "Everything in Starter",
       "90-day retention",
+      "Slack integration for detector alerts",
       "Higher rate limits",
       "SOC2 compliance",
     ],

--- a/frontend/packages/core/src/model-resolver.ts
+++ b/frontend/packages/core/src/model-resolver.ts
@@ -13,8 +13,8 @@
  *      live together because resolvePiModel takes the BYOK config that
  *      fetchProviderConfig produces; splitting them would just create churn.
  */
-import { getModel } from "@mariozechner/pi-ai";
-import type { Api, Model } from "@mariozechner/pi-ai";
+import { getModel } from "@earendil-works/pi-ai";
+import type { Api, Model } from "@earendil-works/pi-ai";
 import { prisma } from "./lib/prisma.js";
 import { decryptKey } from "./lib/encryption.js";
 import {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -49,15 +49,15 @@ importers:
       '@daytonaio/sdk':
         specifier: 0.148.0
         version: 0.148.0(ws@8.19.0)
+      '@earendil-works/pi-agent-core':
+        specifier: 0.74.0
+        version: 0.74.0(ws@8.19.0)(zod@4.3.6)
+      '@earendil-works/pi-ai':
+        specifier: 0.74.0
+        version: 0.74.0(ws@8.19.0)(zod@4.3.6)
       '@hono/node-server':
         specifier: ^1.19.13
         version: 1.19.13(hono@4.12.14)
-      '@mariozechner/pi-agent-core':
-        specifier: 0.57.1
-        version: 0.57.1(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai':
-        specifier: 0.57.1
-        version: 0.57.1(ws@8.19.0)(zod@4.3.6)
       '@traceroot/core':
         specifier: workspace:*
         version: link:../core
@@ -86,9 +86,9 @@ importers:
 
   packages/core:
     dependencies:
-      '@mariozechner/pi-ai':
-        specifier: 0.57.1
-        version: 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@earendil-works/pi-ai':
+        specifier: 0.74.0
+        version: 0.74.0(ws@8.19.0)(zod@4.3.6)
       '@prisma/client':
         specifier: ^5.22.0
         version: 5.22.0(prisma@5.22.0)
@@ -276,9 +276,9 @@ importers:
 
   worker:
     dependencies:
-      '@mariozechner/pi-ai':
-        specifier: 0.57.1
-        version: 0.57.1(ws@8.19.0)(zod@4.3.6)
+      '@earendil-works/pi-ai':
+        specifier: 0.74.0
+        version: 0.74.0(ws@8.19.0)(zod@4.3.6)
       '@traceroot/core':
         specifier: workspace:*
         version: link:../packages/core
@@ -326,8 +326,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/sdk@0.73.0':
-    resolution: {integrity: sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==}
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -358,8 +358,8 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-bedrock-runtime@3.1009.0':
-    resolution: {integrity: sha512-0k9d0oO6nw3Y6jtgs1cmMPNuwAVPQahIoshKK3NDfhVQR1wNC90/gSpdfa9GKswe8XRq/ZZlq7ny0qM1rd/Hkg==}
+  '@aws-sdk/client-bedrock-runtime@3.1045.0':
+    resolution: {integrity: sha512-aPC6gAz9uKRiwfnKB7peTs6yD0FpSzmVnSkx0f2QtJfosFM6J6KtBvR1lMKby050K4C4PAyEScwA5YTsGfTcGA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-s3@3.1009.0':
@@ -370,6 +370,10 @@ packages:
     resolution: {integrity: sha512-i3GuX+lowD892F3IuJf8o6AbyDupMTdyTxQrCJGcn71ni5hTZ82L4nQhcdumxZ7XPJRJJVHS/CR3uYOIIs0PVA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.8':
+    resolution: {integrity: sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/crc64-nvme@3.972.5':
     resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
     engines: {node: '>=20.0.0'}
@@ -378,36 +382,68 @@ packages:
     resolution: {integrity: sha512-X0B8AlQY507i5DwjLByeU2Af4ARsl9Vr84koDcXCbAkplmU+1xBFWxEPrWRAoh56waBne/yJqEloSwvRf4x6XA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.34':
+    resolution: {integrity: sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.20':
     resolution: {integrity: sha512-ey9Lelj001+oOfrbKmS6R2CJAiXX7QKY4Vj9VJv6L2eE6/VjD8DocHIoYqztTm70xDLR4E1jYPTKfIui+eRNDA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    resolution: {integrity: sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.20':
     resolution: {integrity: sha512-5flXSnKHMloObNF+9N0cupKegnH1Z37cdVlpETVgx8/rAhCe+VNlkcZH3HDg2SDn9bI765S+rhNPXGDJJPfbtA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    resolution: {integrity: sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.20':
     resolution: {integrity: sha512-gEWo54nfqp2jABMu6HNsjVC4hDLpg9HC8IKSJnp0kqWtxIJYHTmiLSsIfI4ScQjxEwpB+jOOH8dOLax1+hy/Hw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    resolution: {integrity: sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.21':
     resolution: {integrity: sha512-hah8if3/B/Q+LBYN5FukyQ1Mym6PLPDsBOBsIgNEYD6wLyZg0UmUF/OKIVC3nX9XH8TfTPuITK+7N/jenVACWA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.39':
+    resolution: {integrity: sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.18':
     resolution: {integrity: sha512-Tpl7SRaPoOLT32jbTWchPsn52hYYgJ0kpiFgnwk8pxTANQdUymVSZkzFvv1+oOgZm1CrbQUP9MBeoMZ9IzLZjA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    resolution: {integrity: sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.20':
     resolution: {integrity: sha512-p+R+PYR5Z7Gjqf/6pvbCnzEHcqPCpLzR7Yf127HjJ6EAb4hUcD+qsNRnuww1sB/RmSeCLxyay8FMyqREw4p1RA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    resolution: {integrity: sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.20':
     resolution: {integrity: sha512-rWCmh8o7QY4CsUj63qopzMzkDq/yPpkrpb+CnjBEFSOg/02T/we7sSTVg4QsDiVS9uwZ8VyONhq98qt+pIh3KA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/eventstream-handler-node@3.972.11':
-    resolution: {integrity: sha512-2IrLrOruRr1NhTK0vguBL1gCWv1pu4bf4KaqpsA+/vCJpFEbvXFawn71GvCzk1wyjnDUsemtKypqoKGv4cSGbA==}
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
+    resolution: {integrity: sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.14':
+    resolution: {integrity: sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/lib-storage@3.1009.0':
@@ -420,8 +456,8 @@ packages:
     resolution: {integrity: sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-eventstream@3.972.8':
-    resolution: {integrity: sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==}
+  '@aws-sdk/middleware-eventstream@3.972.10':
+    resolution: {integrity: sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-expect-continue@3.972.8':
@@ -432,6 +468,10 @@ packages:
     resolution: {integrity: sha512-0nYEgkJH7Yt9k+nZJyllTghnkKaz17TWFcr5Mi0XMVMzYlF4ytDZADQpF2/iJo36cKL5AYSzRsvlykE4M/ErTA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-host-header@3.972.8':
     resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
     engines: {node: '>=20.0.0'}
@@ -440,8 +480,16 @@ packages:
     resolution: {integrity: sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-logger@3.972.8':
     resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-recursion-detection@3.972.8':
@@ -452,6 +500,10 @@ packages:
     resolution: {integrity: sha512-yhva/xL5H4tWQgsBjwV+RRD0ByCzg0TcByDCLp3GXdn/wlyRNfy8zsswDtCvr1WSKQkSQYlyEzPuWkJG0f5HvQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    resolution: {integrity: sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-ssec@3.972.8':
     resolution: {integrity: sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==}
     engines: {node: '>=20.0.0'}
@@ -460,16 +512,32 @@ packages:
     resolution: {integrity: sha512-62XRl1GDYPpkt7cx1AX1SPy9wgNE9Iw/NPuurJu4lmhCWS7sGKO+kS53TQ8eRmIxy3skmvNInnk0ZbWrU5Dpyg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-websocket@3.972.13':
-    resolution: {integrity: sha512-Gp6EWIqHX5wmsOR5ZxWyyzEU8P0xBdSxkm6VHEwXwBqScKZ7QWRoj6ZmHpr+S44EYb5tuzGya4ottsogSu2W3A==}
+  '@aws-sdk/middleware-user-agent@3.972.38':
+    resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.16':
+    resolution: {integrity: sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==}
     engines: {node: '>= 14.0.0'}
 
   '@aws-sdk/nested-clients@3.996.10':
     resolution: {integrity: sha512-SlDol5Z+C7Ivnc2rKGqiqfSUmUZzY1qHfVs9myt/nxVwswgfpjdKahyTzLTx802Zfq0NFRs7AejwKzzzl5Co2w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.6':
+    resolution: {integrity: sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.972.8':
     resolution: {integrity: sha512-1eD4uhTDeambO/PNIDVG19A6+v4NdD7xzwLHDutHsUqz0B+i661MwQB2eYO4/crcCvCiQG4SRm1k81k54FEIvw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    resolution: {integrity: sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.8':
@@ -480,8 +548,20 @@ packages:
     resolution: {integrity: sha512-KCPLuTqN9u0Rr38Arln78fRG9KXpzsPWmof+PZzfAHMMQq2QED6YjQrkrfiH7PDefLWEposY1o4/eGwrmKA4JA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1041.0':
+    resolution: {integrity: sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1045.0':
+    resolution: {integrity: sha512-/o4qcty0DmQola0DBniRVeBakYY6ALOvKEFo1AtJpTmMn/cJ+Fk3RWGe5ieT/f/eYbHG9k5E7poKge/E+WGv4Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.6':
     resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -492,16 +572,32 @@ packages:
     resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-format-url@3.972.8':
-    resolution: {integrity: sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==}
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.10':
+    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.5':
     resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
   '@aws-sdk/util-user-agent-browser@3.972.8':
     resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    resolution: {integrity: sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
 
   '@aws-sdk/util-user-agent-node@3.973.7':
     resolution: {integrity: sha512-Hz6EZMUAEzqUd7e+vZ9LE7mn+5gMbxltXy18v+YSFY+9LBJz15wkNZvw5JqfX3z0FS9n3bgUtz3L5rAsfh4YlA==}
@@ -514,6 +610,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.11':
     resolution: {integrity: sha512-iitV/gZKQMvY9d7ovmyFnFuTHbBAtrmLnvaSb/3X8vOKyevwtpmEtyc8AdhVWZe0pI/1GsHxlEvQeOePFzy7KQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -575,8 +675,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.28.6':
@@ -667,6 +767,15 @@ packages:
 
   '@daytonaio/toolbox-api-client@0.148.0':
     resolution: {integrity: sha512-lLhl6XHCLYWTtI7/uH57+AEp8nS6q/Y1tgZg686qFrDW6lIdhTF7vVViGd4Z9XfmdoVSlMpV/2I2UnyNryWDtQ==}
+
+  '@earendil-works/pi-agent-core@0.74.0':
+    resolution: {integrity: sha512-6GMR7/wwjEJ1EsXLWEz03QOWin4AMrJ/AZoMpgm5DJ6GHsF6q6GOhQbj5Zip4dow3vo/TmBAVqM+vmGfrjGAFQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@earendil-works/pi-ai@0.74.0':
+    resolution: {integrity: sha512-7M7qcrZY/KEkH4wFkX3eqzvmKru4O88wezNKoN0KD2m4aAOmp9tdW2xCmUgSTSWlKB7b2Xw9QtAgrzHtg6t6iw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -886,8 +995,8 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@google/genai@1.45.0':
-    resolution: {integrity: sha512-+sNRWhKiRibVgc4OKi7aBJJ0A7RcoVD8tGG+eFkqxAWRjASDW+ktS9lLwTDnAxZICzCVoeAdu8dYLJVTX60N9w==}
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -1074,10 +1183,6 @@ packages:
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
-
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -1101,17 +1206,8 @@ packages:
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
 
-  '@mariozechner/pi-agent-core@0.57.1':
-    resolution: {integrity: sha512-WXsBbkNWOObFGHkhixaT8GXJpHDd3+fn8QntYF+4R8Sa9WB90ENXWidO6b7vcKX+JX0jjO5dIsQxmzosARJKlg==}
-    engines: {node: '>=20.0.0'}
-
-  '@mariozechner/pi-ai@0.57.1':
-    resolution: {integrity: sha512-Bd/J4a3YpdzJVyHLih0vDSdB0QPL4ti0XsAwtHOK/8eVhB0fHM1CpcgIrcBFJ23TMcKXMi0qamz18ERfp8tmgg==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@mistralai/mistralai@1.14.1':
-    resolution: {integrity: sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==}
+  '@mistralai/mistralai@2.2.1':
+    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
 
   '@mongodb-js/saslprep@1.4.9':
     resolution: {integrity: sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA==}
@@ -1443,10 +1539,6 @@ packages:
 
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
-
-  '@pkgjs/parseargs@0.11.0':
-    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
-    engines: {node: '>=14'}
 
   '@posthog/core@1.24.0':
     resolution: {integrity: sha512-Wkp9mgNfgdf6+G4C1VMKakm2RXKQFf4bb5/CPQRAjpqv9l6BY36zZrD1+X5Y2XIAzZqbMKRxsDu3V1r6uKu7/A==}
@@ -2068,9 +2160,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sinclair/typebox@0.34.48':
-    resolution: {integrity: sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==}
-
   '@slack/logger@4.0.1':
     resolution: {integrity: sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
@@ -2103,36 +2192,72 @@ packages:
     resolution: {integrity: sha512-YxFiiG4YDAtX7WMN7RuhHZLeTmRRAOyCbr+zB8e3AQzHPnUhS8zXjB1+cniPVQI3xbWsQPM0X2aaIkO/ME0ymw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/core@3.23.11':
     resolution: {integrity: sha512-952rGf7hBRnhUIaeLp6q4MptKW8sPFe5VvkoZ5qIzFAtx6c/QZ/54FS3yootsyUSf9gJX/NBqEBNdNR7jMIlpQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.2.12':
     resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/eventstream-codec@4.2.12':
     resolution: {integrity: sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-serde-browser@4.2.12':
     resolution: {integrity: sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/eventstream-serde-browser@4.2.14':
+    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/eventstream-serde-config-resolver@4.3.12':
     resolution: {integrity: sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-serde-node@4.2.12':
     resolution: {integrity: sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/eventstream-serde-node@4.2.14':
+    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/eventstream-serde-universal@4.2.12':
     resolution: {integrity: sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/eventstream-serde-universal@4.2.14':
+    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/fetch-http-handler@5.3.15':
     resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-blob-browser@4.2.13':
@@ -2143,12 +2268,20 @@ packages:
     resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/hash-stream-node@4.2.12':
     resolution: {integrity: sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/invalid-dependency@4.2.12':
     resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -2167,56 +2300,116 @@ packages:
     resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-endpoint@4.4.25':
     resolution: {integrity: sha512-dqjLwZs2eBxIUG6Qtw8/YZ4DvzHGIf0DA18wrgtfP6a50UIO7e2nY0FPdcbv5tVJKqWCCU5BmGMOUwT7Puan+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-retry@4.4.42':
     resolution: {integrity: sha512-vbwyqHRIpIZutNXZpLAozakzamcINaRCpEy1MYmK6xBeW3xN+TyPRA123GjXnuxZIjc9848MRRCugVMTXxC4Eg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-serde@4.2.14':
     resolution: {integrity: sha512-+CcaLoLa5apzSRtloOyG7lQvkUw2ZDml3hRh4QiG9WyEPfW5Ke/3tPOPiPjUneuT59Tpn8+c3RVaUvvkkwqZwg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-stack@4.2.12':
     resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-config-provider@4.3.12':
     resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.4.16':
     resolution: {integrity: sha512-ULC8UCS/HivdCB3jhi+kLFYe4B5gxH2gi9vHBfEIiRrT2jfKiZNiETJSlzRtE6B26XbBHjPtc8iZKSNqMol9bw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.12':
     resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/protocol-http@5.3.12':
     resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/querystring-builder@4.2.12':
     resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-parser@4.2.12':
     resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/service-error-classification@4.2.12':
     resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.3.1':
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/shared-ini-file-loader@4.4.7':
     resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.3.12':
     resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.5':
@@ -2227,8 +2420,16 @@ packages:
     resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/url-parser@4.2.12':
     resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-base64@4.3.2':
@@ -2259,12 +2460,24 @@ packages:
     resolution: {integrity: sha512-M1w1Ux0rSVvBOxIIiqbxvZvhnjQ+VUjJrugtORE90BbadSTH+jsQL279KRL3Hv0w69rE7EuYkV/4Lepz/NBW9g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-defaults-mode-node@4.2.44':
     resolution: {integrity: sha512-YPze3/lD1KmWuZsl9JlfhcgGLX7AXhSoaCDtiPntUjNW5/YY0lOHjkcgxyE9x/h5vvS1fzDifMGjzqnNlNiqOQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-endpoints@3.3.3':
     resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-hex-encoding@4.2.2':
@@ -2275,12 +2488,24 @@ packages:
     resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-retry@4.2.12':
     resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-retry@4.3.8':
+    resolution: {integrity: sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-stream@4.5.19':
     resolution: {integrity: sha512-v4sa+3xTweL1CLO2UP0p7tvIMH/Rq1X4KKOxd568mpe6LSLMQCnDHs4uv7m3ukpl3HvcN2JH6jiCS0SNRXKP/w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.2':
@@ -2513,19 +2738,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
-
-  ajv@8.18.0:
-    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
@@ -2603,8 +2817,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.3.0:
-    resolution: {integrity: sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==}
+  basic-ftp@6.0.1:
+    resolution: {integrity: sha512-3ilxa3n4276wGQp/ImRAuz4ALdsj/2Wd3FqoZBZlajDYnByCZ0JMb4+26Rde0wGXIbM0G2HWSfr/Fi8b21KX8g==}
     engines: {node: '>=10.0.0'}
 
   bcryptjs@3.0.3:
@@ -2693,9 +2907,6 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
@@ -2963,9 +3174,6 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
@@ -2977,9 +3185,6 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -3126,9 +3331,6 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
 
@@ -3183,10 +3385,6 @@ packages:
       debug:
         optional: true
 
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
@@ -3209,8 +3407,8 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
-  gaxios@7.1.3:
-    resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
     engines: {node: '>=18'}
 
   gcp-metadata@8.1.2:
@@ -3256,17 +3454,12 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob@10.5.0:
-    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-    hasBin: true
-
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  google-auth-library@10.6.1:
-    resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
     engines: {node: '>=18'}
 
   google-logging-utils@1.1.3:
@@ -3419,9 +3612,6 @@ packages:
     peerDependencies:
       ws: '*'
 
-  jackspeak@3.4.3:
-    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
-
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -3460,9 +3650,6 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -3628,9 +3815,6 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
-
-  lru-cache@10.4.3:
-    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -3817,10 +4001,6 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -3891,8 +4071,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  netmask@2.0.2:
-    resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
     engines: {node: '>= 0.4.0'}
 
   next-themes@0.4.6:
@@ -4024,9 +4204,6 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4055,10 +4232,6 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
-
-  path-scurry@1.11.1:
-    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
-    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -4339,10 +4512,6 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
-    engines: {node: '>=0.10.0'}
-
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
@@ -4373,10 +4542,6 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
-
-  rimraf@5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
-    hasBin: true
 
   rolldown@1.0.0-rc.9:
     resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
@@ -4508,10 +4673,6 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
 
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
@@ -4664,6 +4825,9 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+
   typescript-eslint@8.57.0:
     resolution: {integrity: sha512-W8GcigEMEeB07xEZol8oJ26rigm3+bfPHxHvwbYUlu1fUDsGuQ7Hiskx5xGW/xM4USc9Ephe3jtv7ZYPQntHeA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4679,8 +4843,8 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  undici@7.24.3:
-    resolution: {integrity: sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==}
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -4739,6 +4903,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vfile-message@4.0.3:
@@ -4901,10 +5066,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
-
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -4949,10 +5110,10 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
-  zod-to-json-schema@3.25.1:
-    resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25 || ^4
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -4970,7 +5131,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/sdk@0.73.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -5023,53 +5184,53 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-bedrock-runtime@3.1009.0':
+  '@aws-sdk/client-bedrock-runtime@3.1045.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.20
-      '@aws-sdk/credential-provider-node': 3.972.21
-      '@aws-sdk/eventstream-handler-node': 3.972.11
-      '@aws-sdk/middleware-eventstream': 3.972.8
-      '@aws-sdk/middleware-host-header': 3.972.8
-      '@aws-sdk/middleware-logger': 3.972.8
-      '@aws-sdk/middleware-recursion-detection': 3.972.8
-      '@aws-sdk/middleware-user-agent': 3.972.21
-      '@aws-sdk/middleware-websocket': 3.972.13
-      '@aws-sdk/region-config-resolver': 3.972.8
-      '@aws-sdk/token-providers': 3.1009.0
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-endpoints': 3.996.5
-      '@aws-sdk/util-user-agent-browser': 3.972.8
-      '@aws-sdk/util-user-agent-node': 3.973.7
-      '@smithy/config-resolver': 4.4.11
-      '@smithy/core': 3.23.11
-      '@smithy/eventstream-serde-browser': 4.2.12
-      '@smithy/eventstream-serde-config-resolver': 4.3.12
-      '@smithy/eventstream-serde-node': 4.2.12
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/hash-node': 4.2.12
-      '@smithy/invalid-dependency': 4.2.12
-      '@smithy/middleware-content-length': 4.2.12
-      '@smithy/middleware-endpoint': 4.4.25
-      '@smithy/middleware-retry': 4.4.42
-      '@smithy/middleware-serde': 4.2.14
-      '@smithy/middleware-stack': 4.2.12
-      '@smithy/node-config-provider': 4.3.12
-      '@smithy/node-http-handler': 4.4.16
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/smithy-client': 4.12.5
-      '@smithy/types': 4.13.1
-      '@smithy/url-parser': 4.2.12
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-node': 3.972.39
+      '@aws-sdk/eventstream-handler-node': 3.972.14
+      '@aws-sdk/middleware-eventstream': 3.972.10
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/middleware-websocket': 3.972.16
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/token-providers': 3.1045.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/eventstream-serde-browser': 4.2.14
+      '@smithy/eventstream-serde-config-resolver': 4.3.14
+      '@smithy/eventstream-serde-node': 4.2.14
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.41
-      '@smithy/util-defaults-mode-node': 4.2.44
-      '@smithy/util-endpoints': 3.3.3
-      '@smithy/util-middleware': 4.2.12
-      '@smithy/util-retry': 4.2.12
-      '@smithy/util-stream': 4.5.19
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-stream': 4.5.25
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -5151,6 +5312,23 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/crc64-nvme@3.972.5':
     dependencies:
       '@smithy/types': 4.13.1
@@ -5164,6 +5342,14 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.20':
     dependencies:
       '@aws-sdk/core': 3.973.20
@@ -5175,6 +5361,19 @@ snapshots:
       '@smithy/smithy-client': 4.12.5
       '@smithy/types': 4.13.1
       '@smithy/util-stream': 4.5.19
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.20':
@@ -5196,6 +5395,25 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-login': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-login@3.972.20':
     dependencies:
       '@aws-sdk/core': 3.973.20
@@ -5205,6 +5423,19 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -5226,6 +5457,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.39':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.34
+      '@aws-sdk/credential-provider-http': 3.972.36
+      '@aws-sdk/credential-provider-ini': 3.972.38
+      '@aws-sdk/credential-provider-process': 3.972.34
+      '@aws-sdk/credential-provider-sso': 3.972.38
+      '@aws-sdk/credential-provider-web-identity': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-process@3.972.18':
     dependencies:
       '@aws-sdk/core': 3.973.20
@@ -5233,6 +5481,15 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.20':
@@ -5244,6 +5501,19 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-sso@3.972.38':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/token-providers': 3.1041.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -5260,11 +5530,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/eventstream-handler-node@3.972.11':
+  '@aws-sdk/credential-provider-web-identity@3.972.38':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/eventstream-codec': 4.2.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/eventstream-handler-node@3.972.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/lib-storage@3.1009.0(@aws-sdk/client-s3@3.1009.0)':
@@ -5288,11 +5570,11 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-eventstream@3.972.8':
+  '@aws-sdk/middleware-eventstream@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-expect-continue@3.972.8':
@@ -5319,6 +5601,13 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-host-header@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -5332,10 +5621,24 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-logger@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.8':
@@ -5363,6 +5666,23 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-s3@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-ssec@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -5380,16 +5700,27 @@ snapshots:
       '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-websocket@3.972.13':
+  '@aws-sdk/middleware-user-agent@3.972.38':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@aws-sdk/util-format-url': 3.972.8
-      '@smithy/eventstream-codec': 4.2.12
-      '@smithy/eventstream-serde-browser': 4.2.12
-      '@smithy/fetch-http-handler': 5.3.15
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/signature-v4': 5.3.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.8
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.16':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-format-url': 3.972.10
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/eventstream-serde-browser': 4.2.14
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-hex-encoding': 4.2.2
       '@smithy/util-utf8': 4.2.2
@@ -5438,12 +5769,73 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.6':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.25
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.24
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
       '@smithy/config-resolver': 4.4.11
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.25':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.8':
@@ -5467,9 +5859,38 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.1041.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.1045.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.8
+      '@aws-sdk/nested-clients': 3.997.6
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/types@3.973.6':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.972.3':
@@ -5484,15 +5905,30 @@ snapshots:
       '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
 
-  '@aws-sdk/util-format-url@3.972.8':
+  '@aws-sdk/util-endpoints@3.996.8':
     dependencies:
-      '@aws-sdk/types': 3.973.6
-      '@smithy/querystring-builder': 4.2.12
-      '@smithy/types': 4.13.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.5':
     dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-browser@3.972.8':
@@ -5500,6 +5936,15 @@ snapshots:
       '@aws-sdk/types': 3.973.6
       '@smithy/types': 4.13.1
       bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.24':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.38
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.973.7':
@@ -5514,6 +5959,13 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.11':
     dependencies:
       '@smithy/types': 4.13.1
+      fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.22':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
       fast-xml-parser: 5.7.2
       tslib: 2.8.1
 
@@ -5596,7 +6048,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/runtime@7.28.6': {}
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5714,6 +6166,41 @@ snapshots:
       axios: 1.15.2
     transitivePeerDependencies:
       - debug
+
+  '@earendil-works/pi-agent-core@0.74.0(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.74.0(ws@8.19.0)(zod@4.3.6)
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.74.0(ws@8.19.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1045.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.1
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.19.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      typebox: 1.1.38
+      undici: 7.25.0
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -5872,9 +6359,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@google/genai@1.45.0':
+  '@google/genai@1.52.0':
     dependencies:
-      google-auth-library: 10.6.1
+      google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 8.0.1
       ws: 8.19.0
@@ -6016,15 +6503,6 @@ snapshots:
 
   '@ioredis/commands@1.5.1': {}
 
-  '@isaacs/cliui@8.0.2':
-    dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
-
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.3
@@ -6050,47 +6528,11 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@mariozechner/pi-agent-core@0.57.1(ws@8.19.0)(zod@4.3.6)':
-    dependencies:
-      '@mariozechner/pi-ai': 0.57.1(ws@8.19.0)(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mariozechner/pi-ai@0.57.1(ws@8.19.0)(zod@4.3.6)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
-      '@aws-sdk/client-bedrock-runtime': 3.1009.0
-      '@google/genai': 1.45.0
-      '@mistralai/mistralai': 1.14.1
-      '@sinclair/typebox': 0.34.48
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
-      chalk: 5.6.2
-      openai: 6.26.0(ws@8.19.0)(zod@4.3.6)
-      partial-json: 0.1.7
-      proxy-agent: 6.5.0
-      undici: 7.24.3
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - aws-crt
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@mistralai/mistralai@1.14.1':
+  '@mistralai/mistralai@2.2.1':
     dependencies:
       ws: 8.19.0
       zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@4.3.6)
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6463,9 +6905,6 @@ snapshots:
   '@oxc-project/runtime@0.115.0': {}
 
   '@oxc-project/types@0.115.0': {}
-
-  '@pkgjs/parseargs@0.11.0':
-    optional: true
 
   '@posthog/core@1.24.0':
     dependencies:
@@ -6996,8 +7435,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
-  '@sinclair/typebox@0.34.48': {}
-
   '@slack/logger@4.0.1':
     dependencies:
       '@types/node': 22.19.15
@@ -7054,6 +7491,15 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
+  '@smithy/config-resolver@4.4.17':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
   '@smithy/core@3.23.11':
     dependencies:
       '@smithy/protocol-http': 5.3.12
@@ -7067,12 +7513,33 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/core@3.23.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.12':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/property-provider': 4.2.12
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.12':
@@ -7082,15 +7549,33 @@ snapshots:
       '@smithy/util-hex-encoding': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/eventstream-codec@4.2.14':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
   '@smithy/eventstream-serde-browser@4.2.12':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.12
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/eventstream-serde-browser@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/eventstream-serde-config-resolver@4.3.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-node@4.2.12':
@@ -7099,10 +7584,22 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/eventstream-serde-node@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/eventstream-serde-universal@4.2.12':
     dependencies:
       '@smithy/eventstream-codec': 4.2.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.3.15':
@@ -7110,6 +7607,14 @@ snapshots:
       '@smithy/protocol-http': 5.3.12
       '@smithy/querystring-builder': 4.2.12
       '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
@@ -7127,6 +7632,13 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@smithy/hash-stream-node@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
@@ -7136,6 +7648,11 @@ snapshots:
   '@smithy/invalid-dependency@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -7158,6 +7675,12 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/middleware-endpoint@4.4.25':
     dependencies:
       '@smithy/core': 3.23.11
@@ -7167,6 +7690,17 @@ snapshots:
       '@smithy/types': 4.13.1
       '@smithy/url-parser': 4.2.12
       '@smithy/util-middleware': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.32':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
   '@smithy/middleware-retry@4.4.42':
@@ -7181,6 +7715,19 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
+  '@smithy/middleware-retry@4.5.7':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.8
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
   '@smithy/middleware-serde@4.2.14':
     dependencies:
       '@smithy/core': 3.23.11
@@ -7188,9 +7735,21 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/middleware-serde@4.2.20':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/middleware-stack@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.12':
@@ -7198,6 +7757,13 @@ snapshots:
       '@smithy/property-provider': 4.2.12
       '@smithy/shared-ini-file-loader': 4.4.7
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.16':
@@ -7208,14 +7774,31 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.6.1':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/protocol-http@5.3.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.12':
@@ -7224,18 +7807,38 @@ snapshots:
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
   '@smithy/querystring-parser@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.2.12':
     dependencies:
       '@smithy/types': 4.13.1
 
+  '@smithy/service-error-classification@4.3.1':
+    dependencies:
+      '@smithy/types': 4.14.1
+
   '@smithy/shared-ini-file-loader@4.4.7':
     dependencies:
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.12':
@@ -7247,6 +7850,27 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       '@smithy/util-uri-escape': 4.2.2
       '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.13':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
 
   '@smithy/smithy-client@4.12.5':
@@ -7263,10 +7887,20 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/url-parser@4.2.12':
     dependencies:
       '@smithy/querystring-parser': 4.2.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.2':
@@ -7304,6 +7938,13 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-defaults-mode-node@4.2.44':
     dependencies:
       '@smithy/config-resolver': 4.4.11
@@ -7314,10 +7955,26 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/util-defaults-mode-node@4.2.54':
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-endpoints@3.3.3':
     dependencies:
       '@smithy/node-config-provider': 4.3.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-hex-encoding@4.2.2':
@@ -7329,10 +7986,21 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@smithy/util-retry@4.2.12':
     dependencies:
       '@smithy/service-error-classification': 4.2.12
       '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.19':
@@ -7340,6 +8008,17 @@ snapshots:
       '@smithy/fetch-http-handler': 5.3.15
       '@smithy/node-http-handler': 4.4.16
       '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.25':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-hex-encoding': 4.2.2
@@ -7628,23 +8307,12 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ajv-formats@3.0.1(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
-
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.18.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   ansi-escapes@7.3.0:
     dependencies:
@@ -7710,7 +8378,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.8: {}
 
-  basic-ftp@5.3.0: {}
+  basic-ftp@6.0.1: {}
 
   bcryptjs@3.0.3: {}
 
@@ -7763,10 +8431,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.4:
     dependencies:
@@ -8006,8 +8670,6 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  eastasianwidth@0.2.0: {}
-
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
@@ -8017,8 +8679,6 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
-
-  emoji-regex@9.2.2: {}
 
   environment@1.1.0: {}
 
@@ -8201,8 +8861,6 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
-
   fast-xml-builder@1.1.5:
     dependencies:
       path-expression-matcher: 1.5.0
@@ -8251,11 +8909,6 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
@@ -8277,18 +8930,17 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  gaxios@7.1.3:
+  gaxios@7.1.4:
     dependencies:
       extend: 3.0.2
       https-proxy-agent: 7.0.6
       node-fetch: 3.3.2
-      rimraf: 5.0.10
     transitivePeerDependencies:
       - supports-color
 
   gcp-metadata@8.1.2:
     dependencies:
-      gaxios: 7.1.3
+      gaxios: 7.1.4
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -8326,7 +8978,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.3.0
+      basic-ftp: 6.0.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
@@ -8340,22 +8992,13 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
-  glob@10.5.0:
-    dependencies:
-      foreground-child: 3.3.1
-      jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
-      package-json-from-dist: 1.0.1
-      path-scurry: 1.11.1
-
   globals@14.0.0: {}
 
-  google-auth-library@10.6.1:
+  google-auth-library@10.6.2:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.3
+      gaxios: 7.1.4
       gcp-metadata: 8.1.2
       google-logging-utils: 1.1.3
       jws: 4.0.1
@@ -8515,12 +9158,6 @@ snapshots:
     dependencies:
       ws: 8.19.0
 
-  jackspeak@3.4.3:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
-    optionalDependencies:
-      '@pkgjs/parseargs': 0.11.0
-
   jiti@1.21.7: {}
 
   jiti@2.6.1:
@@ -8546,12 +9183,10 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
-
-  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -8702,8 +9337,6 @@ snapshots:
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
-
-  lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -9094,10 +9727,6 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.0.2
-
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -9151,7 +9780,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  netmask@2.0.2: {}
+  netmask@2.1.1: {}
 
   next-themes@0.4.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -9275,9 +9904,7 @@ snapshots:
   pac-resolver@7.0.1:
     dependencies:
       degenerator: 5.0.1
-      netmask: 2.0.2
-
-  package-json-from-dist@1.0.1: {}
+      netmask: 2.1.1
 
   parent-module@1.0.1:
     dependencies:
@@ -9304,11 +9931,6 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
-
-  path-scurry@1.11.1:
-    dependencies:
-      lru-cache: 10.4.3
-      minipass: 7.1.3
 
   pathe@2.0.3: {}
 
@@ -9566,8 +10188,6 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  require-from-string@2.0.2: {}
-
   require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3
@@ -9595,10 +10215,6 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
-
-  rimraf@5.0.10:
-    dependencies:
-      glob: 10.5.0
 
   rolldown@1.0.0-rc.9:
     dependencies:
@@ -9797,12 +10413,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
-
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
@@ -9971,6 +10581,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  typebox@1.1.38: {}
+
   typescript-eslint@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
@@ -9986,7 +10598,7 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  undici@7.24.3: {}
+  undici@7.25.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -10288,12 +10900,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 5.1.2
-      strip-ansi: 7.2.0
-
   wrap-ansi@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -10324,7 +10930,7 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zod-to-json-schema@3.25.1(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
 

--- a/frontend/ui/src/app/api/billing/change-plan/route.ts
+++ b/frontend/ui/src/app/api/billing/change-plan/route.ts
@@ -82,15 +82,29 @@ export async function POST(req: NextRequest) {
     // Case 3: Has subscription, changing to another paid plan
     const subscription = await stripe.subscriptions.retrieve(workspace.billingSubscriptionId);
 
-    // Find the plan item (non-metered) vs AI usage item (metered)
-    const aiUsagePriceId = process.env.STRIPE_PRICE_ID_AI_USAGE;
-    const planItem = subscription.items.data.find((item) => item.price.id !== aiUsagePriceId);
+    // All metered usage price IDs — must be excluded when finding the plan item,
+    // and preserved across plan changes / downgrade schedules so meter events
+    // continue to bill correctly.
+    const meteredPriceIds = new Set(
+      [
+        process.env.STRIPE_PRICE_ID_AI_USAGE,
+        process.env.STRIPE_PRICE_ID_RCA_USAGE,
+        process.env.STRIPE_PRICE_ID_DETECTOR_USAGE,
+      ].filter((p): p is string => Boolean(p)),
+    );
+    const planItem = subscription.items.data.find((item) => !meteredPriceIds.has(item.price.id));
 
     if (!planItem) {
       return NextResponse.json({ error: "Plan subscription item not found" }, { status: 500 });
     }
 
     const subscriptionItemId = planItem.id;
+    // Existing metered items on the subscription — used to preserve them
+    // across downgrade schedules (Stripe replaces phase.items, so we must
+    // re-include the metered prices in each phase or they get dropped).
+    const existingMeteredPriceIds = subscription.items.data
+      .map((item) => item.price.id)
+      .filter((priceId) => meteredPriceIds.has(priceId));
 
     // If subscription is set to cancel, remove that first
     if (subscription.cancel_at_period_end) {
@@ -125,6 +139,11 @@ export async function POST(req: NextRequest) {
           },
         ],
         proration_behavior: "always_invoice",
+        // Reset billing cycle to upgrade moment so usage quotas start fresh on
+        // the new plan. Matches Free→Paid behavior. Stripe handles money
+        // symmetrically via proration — customer pays full new-plan price
+        // minus refund for unused old-plan time.
+        billing_cycle_anchor: "now",
       });
 
       console.log("Stripe subscription updated:", {
@@ -160,15 +179,22 @@ export async function POST(req: NextRequest) {
         from_subscription: workspace.billingSubscriptionId!,
       });
 
+      // Preserve metered items on both phases — Stripe replaces `phase.items`
+      // wholesale, so anything we don't include here gets dropped at the
+      // phase boundary, breaking downstream billing for those meters.
+      const meteredPhaseItems = existingMeteredPriceIds.map((priceId) => ({ price: priceId }));
       await stripe.subscriptionSchedules.update(schedule.id, {
         phases: [
           {
-            items: [{ price: planItem.price.id, quantity: planItem.quantity ?? 1 }],
+            items: [
+              { price: planItem.price.id, quantity: planItem.quantity ?? 1 },
+              ...meteredPhaseItems,
+            ],
             start_date: schedule.phases[0].start_date,
             end_date: subscription.current_period_end,
           },
           {
-            items: [{ price: newPlanConfig.billingPriceId, quantity: 1 }],
+            items: [{ price: newPlanConfig.billingPriceId, quantity: 1 }, ...meteredPhaseItems],
             start_date: subscription.current_period_end,
           },
         ],

--- a/frontend/ui/src/app/api/billing/change-plan/route.ts
+++ b/frontend/ui/src/app/api/billing/change-plan/route.ts
@@ -85,12 +85,25 @@ export async function POST(req: NextRequest) {
     // All metered usage price IDs — must be excluded when finding the plan item,
     // and preserved across plan changes / downgrade schedules so meter events
     // continue to bill correctly.
+    const meteredPriceEnvVars: Array<[string, string | undefined]> = [
+      ["STRIPE_PRICE_ID_AI_USAGE", process.env.STRIPE_PRICE_ID_AI_USAGE],
+      ["STRIPE_PRICE_ID_RCA_USAGE", process.env.STRIPE_PRICE_ID_RCA_USAGE],
+      ["STRIPE_PRICE_ID_DETECTOR_USAGE", process.env.STRIPE_PRICE_ID_DETECTOR_USAGE],
+    ];
+    for (const [envName, priceId] of meteredPriceEnvVars) {
+      if (!priceId) {
+        // Loud warning so prod misconfig surfaces. If the existing subscription
+        // has a real metered item with this missing-from-env ID, plan-item
+        // detection below will treat it as the plan item — wrong, and likely
+        // surfaces as a 500 ("Plan subscription item not found").
+        console.warn(
+          `[Billing] ${envName} is not set — plan-item detection and downgrade ` +
+            `schedule preservation will treat this meter as missing.`,
+        );
+      }
+    }
     const meteredPriceIds = new Set(
-      [
-        process.env.STRIPE_PRICE_ID_AI_USAGE,
-        process.env.STRIPE_PRICE_ID_RCA_USAGE,
-        process.env.STRIPE_PRICE_ID_DETECTOR_USAGE,
-      ].filter((p): p is string => Boolean(p)),
+      meteredPriceEnvVars.map(([, p]) => p).filter((p): p is string => Boolean(p)),
     );
     const planItem = subscription.items.data.find((item) => !meteredPriceIds.has(item.price.id));
 

--- a/frontend/ui/src/app/api/billing/checkout/route.ts
+++ b/frontend/ui/src/app/api/billing/checkout/route.ts
@@ -50,13 +50,23 @@ export async function POST(req: NextRequest) {
       });
     }
 
-    // Create checkout session with plan price + AI usage metered price
+    // Create checkout session with plan price + all three metered products.
+    // Metered items have no quantity — usage flows from Stripe meter events.
+    // All three are required so paid plans can be billed for chat, RCA, and
+    // detector hosted-LLM usage. Missing any one means that meter's events
+    // will fire successfully but no charge will appear on the customer's bill.
     const lineItems: { price: string; quantity?: number }[] = [
       { price: planConfig.billingPriceId, quantity: 1 },
     ];
-    const aiUsagePriceId = process.env.STRIPE_PRICE_ID_AI_USAGE;
-    if (aiUsagePriceId) {
-      lineItems.push({ price: aiUsagePriceId });
+    const meteredPriceIds = [
+      process.env.STRIPE_PRICE_ID_AI_USAGE,
+      process.env.STRIPE_PRICE_ID_RCA_USAGE,
+      process.env.STRIPE_PRICE_ID_DETECTOR_USAGE,
+    ];
+    for (const priceId of meteredPriceIds) {
+      if (priceId) {
+        lineItems.push({ price: priceId });
+      }
     }
 
     const checkoutSession = await stripe.checkout.sessions.create({

--- a/frontend/ui/src/app/api/billing/checkout/route.ts
+++ b/frontend/ui/src/app/api/billing/checkout/route.ts
@@ -58,14 +58,22 @@ export async function POST(req: NextRequest) {
     const lineItems: { price: string; quantity?: number }[] = [
       { price: planConfig.billingPriceId, quantity: 1 },
     ];
-    const meteredPriceIds = [
-      process.env.STRIPE_PRICE_ID_AI_USAGE,
-      process.env.STRIPE_PRICE_ID_RCA_USAGE,
-      process.env.STRIPE_PRICE_ID_DETECTOR_USAGE,
+    const meteredPriceIds: Array<[string, string | undefined]> = [
+      ["STRIPE_PRICE_ID_AI_USAGE", process.env.STRIPE_PRICE_ID_AI_USAGE],
+      ["STRIPE_PRICE_ID_RCA_USAGE", process.env.STRIPE_PRICE_ID_RCA_USAGE],
+      ["STRIPE_PRICE_ID_DETECTOR_USAGE", process.env.STRIPE_PRICE_ID_DETECTOR_USAGE],
     ];
-    for (const priceId of meteredPriceIds) {
+    for (const [envName, priceId] of meteredPriceIds) {
       if (priceId) {
         lineItems.push({ price: priceId });
+      } else {
+        // Loud warning so prod misconfig surfaces in logs instead of silently
+        // dropping a metered line item (which means meter events fire but no
+        // revenue accrues for that usage type).
+        console.warn(
+          `[Billing] ${envName} is not set — checkout will skip this metered price. ` +
+            `Meter events for this usage type will fire but no charge will appear on the bill.`,
+        );
       }
     }
 

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/install/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/install/route.test.ts
@@ -1,17 +1,31 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const requireAuth = vi.fn();
 const requireWorkspaceMembership = vi.fn();
 const generateInstallUrl = vi.fn();
+const findUnique = vi.fn();
+const hasEntitlement = vi.fn();
 
 vi.mock("@/lib/auth-helpers", () => ({ requireAuth, requireWorkspaceMembership }));
 vi.mock("@traceroot/slack", () => ({
   installer: { generateInstallUrl: (...args: unknown[]) => generateInstallUrl(...args) },
   SLACK_BOT_SCOPES: ["chat:write"],
 }));
+vi.mock("@traceroot/core", () => ({
+  prisma: { workspace: { findUnique: (...a: unknown[]) => findUnique(...a) } },
+  hasEntitlement: (...a: unknown[]) => hasEntitlement(...a),
+}));
 vi.mock("@/env", () => ({ env: { SLACK_REDIRECT_URI: "http://x/api/slack/oauth/callback" } }));
 
 describe("GET /api/workspaces/[workspaceId]/slack/install", () => {
+  beforeEach(() => {
+    requireAuth.mockReset();
+    requireWorkspaceMembership.mockReset();
+    generateInstallUrl.mockReset();
+    findUnique.mockReset();
+    hasEntitlement.mockReset();
+  });
+
   it("403s for non-ADMIN", async () => {
     requireAuth.mockResolvedValue({ user: { id: "u_1" } });
     requireWorkspaceMembership.mockResolvedValue({
@@ -27,18 +41,38 @@ describe("GET /api/workspaces/[workspaceId]/slack/install", () => {
     expect(requireWorkspaceMembership).toHaveBeenCalledWith("u_1", "ws_1", "ADMIN");
   });
 
-  it("redirects to the SDK-generated install URL", async () => {
+  it("redirects to the upgrade page when plan lacks slack-integration", async () => {
     requireAuth.mockResolvedValue({ user: { id: "u_1" } });
     requireWorkspaceMembership.mockResolvedValue({ membership: {} });
-    generateInstallUrl.mockResolvedValue(
-      "https://slack.com/oauth/v2/authorize?client_id=…&state=…",
-    );
+    findUnique.mockResolvedValue({ billingPlan: "starter" });
+    hasEntitlement.mockReturnValue(false);
 
     const { GET } = await import("./route");
     const res = await GET(new Request("http://x/api?returnTo=/back") as any, {
       params: Promise.resolve({ workspaceId: "ws_1" }),
     });
 
+    expect(hasEntitlement).toHaveBeenCalledWith("starter", "slack-integration");
+    expect(generateInstallUrl).not.toHaveBeenCalled();
+    expect(res.status).toBe(307);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/workspaces/ws_1/settings/billing");
+    expect(location).toContain("upgrade=slack-integration");
+  });
+
+  it("redirects to the SDK-generated install URL when entitled", async () => {
+    requireAuth.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembership.mockResolvedValue({ membership: {} });
+    findUnique.mockResolvedValue({ billingPlan: "pro" });
+    hasEntitlement.mockReturnValue(true);
+    generateInstallUrl.mockResolvedValue("https://slack.com/oauth/v2/authorize?client_id=&state=");
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://x/api?returnTo=/back") as any, {
+      params: Promise.resolve({ workspaceId: "ws_1" }),
+    });
+
+    expect(hasEntitlement).toHaveBeenCalledWith("pro", "slack-integration");
     expect(res.status).toBe(307); // NextResponse.redirect default
     expect(res.headers.get("location")).toContain("slack.com/oauth/v2/authorize");
     expect(generateInstallUrl).toHaveBeenCalledTimes(1);

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/install/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/slack/install/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
 import { installer, SLACK_BOT_SCOPES } from "@traceroot/slack";
+import { hasEntitlement, prisma, type PlanType } from "@traceroot/core";
 import { env } from "@/env";
+
+const APP_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
 export async function GET(
   request: NextRequest,
@@ -13,6 +16,17 @@ export async function GET(
   const { workspaceId } = await params;
   const memberCheck = await requireWorkspaceMembership(auth.user.id, workspaceId, "ADMIN");
   if (memberCheck.error) return memberCheck.error;
+
+  const workspace = await prisma.workspace.findUnique({
+    where: { id: workspaceId },
+    select: { billingPlan: true },
+  });
+  const plan = (workspace?.billingPlan ?? "free") as PlanType;
+  if (!hasEntitlement(plan, "slack-integration")) {
+    const upgradeUrl = new URL(`/workspaces/${workspaceId}/settings/billing`, APP_BASE_URL);
+    upgradeUrl.searchParams.set("upgrade", "slack-integration");
+    return NextResponse.redirect(upgradeUrl);
+  }
 
   const url = new URL(request.url);
   const returnTo = url.searchParams.get("returnTo") || "/";

--- a/frontend/ui/src/components/slack/SlackConnectButton.tsx
+++ b/frontend/ui/src/components/slack/SlackConnectButton.tsx
@@ -2,9 +2,21 @@
 
 import { useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Check, ChevronDown, ExternalLink, Hash, Lock, Send, Settings, Unlink } from "lucide-react";
+import {
+  ArrowUpRight,
+  Check,
+  ChevronDown,
+  ExternalLink,
+  Hash,
+  Lock,
+  Send,
+  Settings,
+  Unlink,
+} from "lucide-react";
 import { FaSlack } from "react-icons/fa";
+import { hasEntitlement, type PlanType } from "@traceroot/core";
 import { useWorkspace } from "@/features/workspaces/hooks";
 import {
   useSlackStatus,
@@ -14,7 +26,7 @@ import {
   useSendSlackTest,
 } from "@/features/integrations/hooks/useSlackIntegration";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 
 interface Props {
   workspaceId: string;
@@ -24,6 +36,9 @@ export function SlackConnectButton({ workspaceId }: Props) {
   const queryClient = useQueryClient();
   const { data: workspace } = useWorkspace(workspaceId);
   const canManage = workspace?.role === "ADMIN";
+  const isEntitled = workspace?.billingPlan
+    ? hasEntitlement(workspace.billingPlan as PlanType, "slack-integration")
+    : false;
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [channelOpen, setChannelOpen] = useState(false);
@@ -271,6 +286,31 @@ export function SlackConnectButton({ workspaceId }: Props) {
               </button>
             </PopoverContent>
           </Popover>
+        )}
+      </div>
+    );
+  }
+
+  if (!isEntitled) {
+    const upgradeHref = `/workspaces/${encodeURIComponent(workspaceId)}/settings/billing?upgrade=slack-integration`;
+    return (
+      <div className="flex items-center justify-between">
+        <Row>
+          <div>
+            <div className="text-sm font-medium">Slack</div>
+            <div className="text-sm text-muted-foreground">
+              Upgrade to Pro to unlock Slack Integration for alerts.
+            </div>
+          </div>
+        </Row>
+        {canManage && (
+          <Link
+            href={upgradeHref}
+            className={buttonVariants({ variant: "outline", size: "sm", className: "gap-1" })}
+          >
+            Upgrade
+            <ArrowUpRight className="h-3.5 w-3.5" />
+          </Link>
         )}
       </div>
     );

--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import { ArrowRight, ExternalLink, AlertCircle, CalendarClock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -11,8 +12,101 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import { PLANS, PlanType, isUpgrade, EVENT_QUOTAS, AI_RUN_QUOTAS } from "@traceroot/core";
-import type { UsageStats } from "@/types/api";
+import {
+  PLANS,
+  PlanType,
+  isUpgrade,
+  EVENT_QUOTAS,
+  AI_RUN_QUOTAS,
+  RCA_RUN_QUOTAS,
+  DETECTOR_RUN_QUOTAS,
+} from "@traceroot/core";
+import type { UsageStats, AIUsageByModel } from "@/types/api";
+import { formatRcaQuotaLabel, formatDetectorScanLabel } from "./usage-labels";
+
+function formatCost(cost: number): string {
+  if (cost < 0.01) return cost > 0 ? "< $0.01" : "$0.00";
+  return `$${cost.toFixed(2)}`;
+}
+
+function formatTokens(input: number, output: number): string {
+  return `${(input + output).toLocaleString()} tokens`;
+}
+
+interface UsageSectionProps {
+  title: string;
+  runsLabel: string;
+  runsValue: string;
+  runsHelper: string;
+  systemCost: number;
+  systemHelper: string;
+  systemInputTokens: number;
+  systemOutputTokens: number;
+  byModel: AIUsageByModel[] | undefined;
+}
+
+function UsageSection({
+  title,
+  runsLabel,
+  runsValue,
+  runsHelper,
+  systemCost,
+  systemHelper,
+  systemInputTokens,
+  systemOutputTokens,
+  byModel,
+}: UsageSectionProps) {
+  return (
+    <div className="border">
+      <div className="border-b bg-muted/30 px-4 py-3">
+        <h3 className="text-sm font-medium">{title}</h3>
+      </div>
+      <div className="space-y-4 px-4 py-3">
+        <div>
+          <div className="flex items-baseline justify-between">
+            <p className="text-sm font-medium">{runsLabel}</p>
+            <span className="text-sm font-medium">{runsValue}</span>
+          </div>
+          <p className="text-xs text-muted-foreground">{runsHelper}</p>
+        </div>
+
+        <div>
+          <div className="flex items-baseline justify-between">
+            <p className="text-sm font-medium">Internal Models</p>
+            <span className="text-sm font-medium">{formatCost(systemCost)}</span>
+          </div>
+          <p className="text-xs text-muted-foreground">{systemHelper}</p>
+          <div className="mt-2 flex justify-between text-sm text-muted-foreground">
+            <span>Input / Output</span>
+            <span>
+              {systemInputTokens.toLocaleString()} / {systemOutputTokens.toLocaleString()}
+            </span>
+          </div>
+        </div>
+
+        {byModel && byModel.length > 0 && (
+          <div className="-mx-4 border-t px-4 pt-3">
+            <p className="text-xs font-medium uppercase text-muted-foreground">By model</p>
+            <div className="mt-2 space-y-1.5 text-sm">
+              {byModel.map((row) => (
+                <div key={`${row.model}-${row.isByok}`} className="flex justify-between">
+                  <span className="text-muted-foreground">
+                    {row.model}
+                    {row.isByok && <span className="ml-1 text-xs opacity-60">BYOK</span>}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {formatTokens(row.inputTokens, row.outputTokens)}
+                    {!row.isByok && ` · ${formatCost(row.cost)}`}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 import {
   createCheckoutSession,
   changePlan,
@@ -34,15 +128,21 @@ export function BillingTab({
   hasSubscription = false,
   currentUsage,
 }: BillingTabProps) {
-  const [showPricingDialog, setShowPricingDialog] = useState(false);
+  const searchParams = useSearchParams();
+  const upgradeIntent = searchParams.get("upgrade");
+  const [showPricingDialog, setShowPricingDialog] = useState(Boolean(upgradeIntent));
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
 
   const currentPlanConfig = PLANS[currentPlan];
   const aiUsage = currentUsage?.ai;
+  const rcaUsage = currentUsage?.rca;
+  const detectorUsage = currentUsage?.detector;
   const eventQuota = EVENT_QUOTAS[currentPlan];
   const aiRunQuota = AI_RUN_QUOTAS[currentPlan];
+  const rcaRunQuota = RCA_RUN_QUOTAS[currentPlan];
+  const detectorRunQuota = DETECTOR_RUN_QUOTAS[currentPlan];
 
   // Fetch live subscription info from Stripe
   useEffect(() => {
@@ -106,15 +206,6 @@ export function BillingTab({
     if (planId === PlanType.FREE) return "Downgrade";
     if (isUpgrade(currentPlan, planId)) return "Upgrade";
     return "Downgrade";
-  }
-
-  function formatCost(cost: number): string {
-    if (cost < 0.01) return cost > 0 ? "< $0.01" : "$0.00";
-    return `$${cost.toFixed(2)}`;
-  }
-
-  function formatTokens(input: number, output: number): string {
-    return `${(input + output).toLocaleString()} tokens`;
   }
 
   return (
@@ -244,96 +335,67 @@ export function BillingTab({
         </div>
       </div>
 
-      {/* AI Usage Section */}
-      <div className="border">
-        <div className="border-b bg-muted/30 px-4 py-3">
-          <h3 className="text-sm font-medium">AI Usage</h3>
-        </div>
-        <div className="space-y-4 px-4 py-3">
-          {/* AI Runs */}
-          <div>
-            <div className="flex items-baseline justify-between">
-              <p className="text-sm font-medium">AI Runs</p>
-              <span className="text-sm font-medium">
-                {aiRunQuota.included === Infinity
-                  ? `${aiUsage?.runsUsed ?? 0} (Unlimited)`
-                  : `${aiUsage?.runsUsed ?? 0} / ${aiRunQuota.included}`}
-              </span>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              1 run = 1 chat message, 1 agent turn, 1 auto-triage, or 1 issue creation.
-              {currentPlan !== PlanType.FREE &&
-                currentPlan !== PlanType.ENTERPRISE &&
-                ` Overage: ${aiRunQuota.overageLabel}.`}
-            </p>
-          </div>
+      <UsageSection
+        title="Chat Usage"
+        runsLabel="Chat Runs"
+        runsValue={
+          aiRunQuota.included === Infinity
+            ? `${aiUsage?.runsUsed ?? 0} (Unlimited)`
+            : `${aiUsage?.runsUsed ?? 0} / ${aiRunQuota.included}`
+        }
+        runsHelper={
+          "Each chat request." +
+          (currentPlan !== PlanType.FREE && currentPlan !== PlanType.ENTERPRISE
+            ? ` Overage: ${aiRunQuota.overageLabel}.`
+            : "")
+        }
+        systemCost={aiUsage?.systemUsage.cost ?? 0}
+        systemHelper={
+          currentPlan === PlanType.FREE
+            ? "Included in your plan (we pay)."
+            : "Included with runs; 1.05x markup on overage token cost."
+        }
+        systemInputTokens={aiUsage?.systemUsage.inputTokens ?? 0}
+        systemOutputTokens={aiUsage?.systemUsage.outputTokens ?? 0}
+        byModel={aiUsage?.byModel}
+      />
 
-          {/* System Models */}
-          <div>
-            <div className="flex items-baseline justify-between">
-              <p className="text-sm font-medium">Internal Models</p>
-              <span className="text-sm font-medium">
-                {formatCost(aiUsage?.systemUsage.cost ?? 0)}
-              </span>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              {currentPlan === PlanType.FREE
-                ? "Included in your plan (we pay)."
-                : "Included with runs; 1.05x markup on overage token cost."}
-            </p>
-            <div className="mt-2 flex justify-between text-sm text-muted-foreground">
-              <span>Input / Output</span>
-              <span>
-                {(aiUsage?.systemUsage.inputTokens ?? 0).toLocaleString()} /{" "}
-                {(aiUsage?.systemUsage.outputTokens ?? 0).toLocaleString()}
-              </span>
-            </div>
-          </div>
+      <UsageSection
+        title="Detector Usage"
+        runsLabel="Detector Runs"
+        runsValue={
+          detectorRunQuota.included === Infinity
+            ? formatDetectorScanLabel(detectorUsage?.scansRun ?? 0)
+            : `${detectorUsage?.scansRun ?? 0} / ${detectorRunQuota.included}`
+        }
+        runsHelper="Each detector scan."
+        systemCost={detectorUsage?.systemTokenCost ?? 0}
+        systemHelper="Usage based."
+        systemInputTokens={detectorUsage?.systemInputTokens ?? 0}
+        systemOutputTokens={detectorUsage?.systemOutputTokens ?? 0}
+        byModel={detectorUsage?.byModel}
+      />
 
-          {/* BYOK Models */}
-          {aiUsage && (aiUsage.byokUsage.messages > 0 || aiUsage.byModel.some((m) => m.isByok)) && (
-            <div>
-              <div className="flex items-baseline justify-between">
-                <p className="text-sm font-medium">BYOK Models</p>
-                <span className="text-sm text-muted-foreground">
-                  {formatTokens(aiUsage.byokUsage.inputTokens, aiUsage.byokUsage.outputTokens)}
-                </span>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                Your own API keys. Not billed by TraceRoot (runs still count).
-              </p>
-              <div className="mt-2 flex justify-between text-sm text-muted-foreground">
-                <span>Input / Output</span>
-                <span>
-                  {aiUsage.byokUsage.inputTokens.toLocaleString()} /{" "}
-                  {aiUsage.byokUsage.outputTokens.toLocaleString()}
-                </span>
-              </div>
-            </div>
-          )}
-
-          {/* By Model breakdown */}
-          {aiUsage && aiUsage.byModel.length > 0 && (
-            <div className="-mx-4 border-t px-4 pt-3">
-              <p className="text-xs font-medium uppercase text-muted-foreground">By model</p>
-              <div className="mt-2 space-y-1.5 text-sm">
-                {aiUsage.byModel.map((row) => (
-                  <div key={`${row.model}-${row.isByok}`} className="flex justify-between">
-                    <span className="text-muted-foreground">
-                      {row.model}
-                      {row.isByok && <span className="ml-1 text-xs opacity-60">BYOK</span>}
-                    </span>
-                    <span className="text-muted-foreground">
-                      {formatTokens(row.inputTokens, row.outputTokens)}
-                      {!row.isByok && ` \u00b7 ${formatCost(row.cost)}`}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
+      <UsageSection
+        title="Root Cause Analysis Usage"
+        runsLabel="Root Cause Analysis Runs"
+        runsValue={formatRcaQuotaLabel(rcaRunQuota, rcaUsage?.runsUsed ?? 0)}
+        runsHelper={
+          "Triggered by detector findings." +
+          (currentPlan !== PlanType.FREE && currentPlan !== PlanType.ENTERPRISE
+            ? ` Overage: ${rcaRunQuota.overageLabel}.`
+            : "")
+        }
+        systemCost={rcaUsage?.systemTokenCost ?? 0}
+        systemHelper={
+          currentPlan === PlanType.FREE
+            ? "Included in your plan (we pay)."
+            : "Included with runs; 1.05x markup on overage token cost."
+        }
+        systemInputTokens={rcaUsage?.systemInputTokens ?? 0}
+        systemOutputTokens={rcaUsage?.systemOutputTokens ?? 0}
+        byModel={rcaUsage?.byModel}
+      />
 
       {/* Pricing Dialog */}
       <Dialog open={showPricingDialog} onOpenChange={setShowPricingDialog}>

--- a/frontend/ui/src/ee/features/billing/usage-labels.test.ts
+++ b/frontend/ui/src/ee/features/billing/usage-labels.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { PlanType } from "@traceroot/core";
+import { RCA_RUN_QUOTAS, formatRcaQuotaLabel, formatDetectorScanLabel } from "./usage-labels";
+
+describe("RCA_RUN_QUOTAS", () => {
+  it("matches the Phase 2 spec — 30 / 100 / 100 / unlimited", () => {
+    expect(RCA_RUN_QUOTAS[PlanType.FREE].included).toBe(30);
+    expect(RCA_RUN_QUOTAS[PlanType.STARTER].included).toBe(100);
+    expect(RCA_RUN_QUOTAS[PlanType.PRO].included).toBe(100);
+    expect(RCA_RUN_QUOTAS[PlanType.ENTERPRISE].included).toBe(Infinity);
+  });
+
+  it("Starter and Pro share the same RCA pool (quota-parity rule)", () => {
+    expect(RCA_RUN_QUOTAS[PlanType.STARTER].included).toBe(RCA_RUN_QUOTAS[PlanType.PRO].included);
+    expect(RCA_RUN_QUOTAS[PlanType.STARTER].overageLabel).toBe(
+      RCA_RUN_QUOTAS[PlanType.PRO].overageLabel,
+    );
+  });
+});
+
+describe("formatRcaQuotaLabel", () => {
+  it("renders quota for finite plans", () => {
+    expect(formatRcaQuotaLabel({ included: 100, overageLabel: "x" }, 7)).toBe("7 / 100");
+    expect(formatRcaQuotaLabel({ included: 30, overageLabel: "x" }, 0)).toBe("0 / 30");
+  });
+
+  it("renders Unlimited for enterprise plans", () => {
+    expect(formatRcaQuotaLabel({ included: Infinity, overageLabel: "x" }, 42)).toBe(
+      "42 (Unlimited)",
+    );
+  });
+});
+
+describe("formatDetectorScanLabel", () => {
+  it("formats with locale-string commas", () => {
+    expect(formatDetectorScanLabel(0)).toBe("0");
+    expect(formatDetectorScanLabel(1234)).toBe("1,234");
+    expect(formatDetectorScanLabel(1_234_567)).toBe("1,234,567");
+  });
+});

--- a/frontend/ui/src/ee/features/billing/usage-labels.ts
+++ b/frontend/ui/src/ee/features/billing/usage-labels.ts
@@ -1,0 +1,22 @@
+// Pure helpers for rendering RCA / detector usage labels on the billing page.
+// Extracted from BillingTab so the logic is unit-testable without rendering React.
+
+import { RCA_RUN_QUOTAS } from "@traceroot/core";
+
+export interface QuotaConfig {
+  included: number;
+  overageLabel: string;
+}
+
+export { RCA_RUN_QUOTAS };
+
+export function formatRcaQuotaLabel(quota: QuotaConfig, runsUsed: number): string {
+  if (quota.included === Infinity) {
+    return `${runsUsed} (Unlimited)`;
+  }
+  return `${runsUsed} / ${quota.included}`;
+}
+
+export function formatDetectorScanLabel(scansRun: number): string {
+  return scansRun.toLocaleString();
+}

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
@@ -121,7 +121,7 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
             <AlertChannelsEditor emailAddresses={emailAddresses} onChange={setEmailAddresses} />
           </div>
           <p className="mt-2 text-[12px] text-muted-foreground">
-            Sent once per trace, after RCA completes.
+            Sent once per trace, after Root Cause Analysis completes.
           </p>
           <Button
             size="sm"

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -13,6 +13,8 @@ export interface UsageStats {
   tokens: number;
   updatedAt: string;
   ai?: AIUsageData;
+  rca?: RcaUsageData;
+  detector?: DetectorUsageData;
 }
 
 // Workspace types
@@ -241,6 +243,32 @@ export interface AIUsageData {
   systemUsage: AIUsageCategory;
   byokUsage: AIUsageCategory;
   byModel: AIUsageByModel[];
+}
+
+// RCA run usage stats (nested in UsageStats.rca). Separate meter from AI runs.
+// Mirrors the worker shape exactly. Optional on UsageStats — workspaces in
+// transition may not have the field populated yet.
+export interface RcaUsageData {
+  runsUsed: number;
+  systemTokenCost: number;
+  systemInputTokens: number;
+  systemOutputTokens: number;
+  byModel: AIUsageByModel[];
+  lastReportedUnits: number;
+  lastReportedPeriodStart: string | null;
+}
+
+// Detector scan usage (nested in UsageStats.detector). Informational + 1.05× pass-through
+// on system-source inference. scansRun counts BYOK + system; systemTokenCost / system*Tokens
+// track only system-source. Detector scans have no quota — this is just a counter.
+export interface DetectorUsageData {
+  scansRun: number;
+  systemTokenCost: number;
+  systemInputTokens: number;
+  systemOutputTokens: number;
+  byModel: AIUsageByModel[];
+  lastReportedUnits?: number;
+  lastReportedPeriodStart?: string | null;
 }
 
 // Legacy aliases for backward compatibility

--- a/frontend/worker/package.json
+++ b/frontend/worker/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "dotenv -e ../../.env -- tsx watch src/index.ts",
     "dev:billing": "dotenv -e ../../.env -- tsx watch src/index.ts",
+    "dev:billing:once": "dotenv -e ../../.env -- tsx src/billing-run-once.ts",
     "dev:detectors": "dotenv -e ../../.env -- tsx watch src/detector-main.ts",
     "build": "tsc",
     "start": "node dist/index.js",
@@ -22,13 +23,13 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@mariozechner/pi-ai": "0.57.1",
+    "@earendil-works/pi-ai": "0.74.0",
     "@traceroot/core": "workspace:*",
     "@traceroot/slack": "workspace:*",
     "bullmq": "^5.73.3",
     "ioredis": "^5.10.1",
-    "nodemailer": "^6.10.0",
     "node-cron": "^3.0.0",
+    "nodemailer": "^6.10.0",
     "stripe": "14.25.0"
   },
   "devDependencies": {

--- a/frontend/worker/package.json
+++ b/frontend/worker/package.json
@@ -8,7 +8,6 @@
   "scripts": {
     "dev": "dotenv -e ../../.env -- tsx watch src/index.ts",
     "dev:billing": "dotenv -e ../../.env -- tsx watch src/index.ts",
-    "dev:billing:once": "dotenv -e ../../.env -- tsx src/billing-run-once.ts",
     "dev:detectors": "dotenv -e ../../.env -- tsx watch src/detector-main.ts",
     "build": "tsc",
     "start": "node dist/index.js",

--- a/frontend/worker/src/__tests__/slack-fanout.test.ts
+++ b/frontend/worker/src/__tests__/slack-fanout.test.ts
@@ -28,6 +28,7 @@ describe("runFanOut", () => {
   it("sends email only when slack is not configured", async () => {
     const { runFanOut } = await import("../processors/detector-rca-processor.js");
     await runFanOut({
+      workspaceId: "ws_1",
       emailAddresses: ["a@b.c"],
       slackChannelId: null,
       slackBotTokenEnc: null,
@@ -40,6 +41,7 @@ describe("runFanOut", () => {
   it("sends slack only when email is not configured", async () => {
     const { runFanOut } = await import("../processors/detector-rca-processor.js");
     await runFanOut({
+      workspaceId: "ws_1",
       emailAddresses: [],
       slackChannelId: "C1",
       slackBotTokenEnc: "enc",
@@ -47,11 +49,13 @@ describe("runFanOut", () => {
     });
     expect(sendCombinedAlertEmail).not.toHaveBeenCalled();
     expect(sendCombinedAlertSlack).toHaveBeenCalledTimes(1);
+    expect(sendCombinedAlertSlack.mock.calls[0][0].workspaceId).toBe("ws_1");
   });
 
   it("sends to both when both are configured", async () => {
     const { runFanOut } = await import("../processors/detector-rca-processor.js");
     await runFanOut({
+      workspaceId: "ws_1",
       emailAddresses: ["a@b.c"],
       slackChannelId: "C1",
       slackBotTokenEnc: "enc",
@@ -64,6 +68,7 @@ describe("runFanOut", () => {
   it("does nothing when neither configured", async () => {
     const { runFanOut } = await import("../processors/detector-rca-processor.js");
     await runFanOut({
+      workspaceId: "ws_1",
       emailAddresses: [],
       slackChannelId: null,
       slackBotTokenEnc: null,

--- a/frontend/worker/src/__tests__/slack-send.test.ts
+++ b/frontend/worker/src/__tests__/slack-send.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const postMessage = vi.fn();
 const createSlackClient = vi.fn((_token: string) => ({ chat: { postMessage } }));
+const findUnique = vi.fn();
+const hasEntitlement = vi.fn();
 
 vi.mock("@traceroot/slack", () => ({
   createSlackClient: (token: string) => createSlackClient(token),
@@ -9,27 +11,39 @@ vi.mock("@traceroot/slack", () => ({
 }));
 vi.mock("@traceroot/core", () => ({
   decryptKey: (s: string) => `decrypted(${s})`,
+  hasEntitlement: (...a: unknown[]) => hasEntitlement(...a),
+  prisma: { workspace: { findUnique: (...a: unknown[]) => findUnique(...a) } },
 }));
+
+const baseParams = {
+  workspaceId: "ws_1",
+  encryptedBotToken: "enc-tok",
+  channelId: "C1",
+  detectorName: "Hallucination",
+  projectName: "billing",
+  summary: "x",
+  traceId: "abcd",
+  projectId: "p1",
+  rcaResult: null,
+};
 
 describe("sendCombinedAlertSlack", () => {
   beforeEach(() => {
     postMessage.mockReset();
     createSlackClient.mockClear();
+    findUnique.mockReset();
+    hasEntitlement.mockReset();
   });
 
-  it("decrypts the token, builds blocks, and posts to the channel", async () => {
+  it("posts to the channel when workspace plan has slack-integration entitlement", async () => {
+    findUnique.mockResolvedValue({ billingPlan: "pro" });
+    hasEntitlement.mockReturnValue(true);
     postMessage.mockResolvedValue({ ok: true, ts: "1234.5678" });
+
     const { sendCombinedAlertSlack } = await import("../notifications/slack.js");
-    await sendCombinedAlertSlack({
-      encryptedBotToken: "enc-tok",
-      channelId: "C1",
-      detectorName: "Hallucination",
-      projectName: "billing",
-      summary: "x",
-      traceId: "abcd",
-      projectId: "p1",
-      rcaResult: null,
-    });
+    await sendCombinedAlertSlack(baseParams);
+
+    expect(hasEntitlement).toHaveBeenCalledWith("pro", "slack-integration");
     expect(createSlackClient).toHaveBeenCalledWith("decrypted(enc-tok)");
     expect(postMessage).toHaveBeenCalledTimes(1);
     const arg = postMessage.mock.calls[0][0];
@@ -38,22 +52,37 @@ describe("sendCombinedAlertSlack", () => {
     expect(Array.isArray(arg.blocks)).toBe(true);
   });
 
-  it("throws on a Slack API failure", async () => {
+  it("silently skips when workspace plan lacks slack-integration entitlement", async () => {
+    findUnique.mockResolvedValue({ billingPlan: "starter" });
+    hasEntitlement.mockReturnValue(false);
+
+    const { sendCombinedAlertSlack } = await import("../notifications/slack.js");
+    await sendCombinedAlertSlack(baseParams);
+
+    expect(hasEntitlement).toHaveBeenCalledWith("starter", "slack-integration");
+    expect(createSlackClient).not.toHaveBeenCalled();
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it("treats a missing workspace row as free plan and skips", async () => {
+    findUnique.mockResolvedValue(null);
+    hasEntitlement.mockReturnValue(false);
+
+    const { sendCombinedAlertSlack } = await import("../notifications/slack.js");
+    await sendCombinedAlertSlack(baseParams);
+
+    expect(hasEntitlement).toHaveBeenCalledWith("free", "slack-integration");
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it("throws on a Slack API failure when entitled", async () => {
+    findUnique.mockResolvedValue({ billingPlan: "pro" });
+    hasEntitlement.mockReturnValue(true);
     const err: any = new Error("not_in_channel");
     err.data = { error: "not_in_channel" };
     postMessage.mockRejectedValue(err);
+
     const { sendCombinedAlertSlack } = await import("../notifications/slack.js");
-    await expect(
-      sendCombinedAlertSlack({
-        encryptedBotToken: "enc-tok",
-        channelId: "C1",
-        detectorName: "x",
-        projectName: "x",
-        summary: "x",
-        traceId: "x",
-        projectId: "x",
-        rcaResult: null,
-      }),
-    ).rejects.toThrow(/not_in_channel/);
+    await expect(sendCombinedAlertSlack(baseParams)).rejects.toThrow(/not_in_channel/);
   });
 });

--- a/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
+++ b/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
@@ -11,8 +11,8 @@ const { mockComplete, mockResolvePiModel, mockFetchProviderConfig, mockFindByokK
 
 // Forward unmocked exports (Type, getModel, etc.) so submit-result-tool.ts's
 // TypeBox imports still work; only `complete` is replaced with the mock.
-vi.mock("@mariozechner/pi-ai", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@mariozechner/pi-ai")>();
+vi.mock("@earendil-works/pi-ai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@earendil-works/pi-ai")>();
   return {
     ...actual,
     complete: mockComplete,
@@ -50,6 +50,17 @@ const ZERO_USAGE = {
   totalTokens: 0,
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
+
+function usageWithCost(total: number) {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total },
+  };
+}
 
 describe("runDetectionForTrace", () => {
   beforeEach(() => {
@@ -180,7 +191,7 @@ describe("runDetectionForTrace", () => {
     }
   });
 
-  it("truncates spansJsonl at 40000 chars", async () => {
+  it("truncates spansJsonl at 150000 chars", async () => {
     mockComplete.mockResolvedValueOnce({
       content: [
         {
@@ -193,7 +204,7 @@ describe("runDetectionForTrace", () => {
       stopReason: "toolUse",
     });
 
-    const longSpans = "x".repeat(50000);
+    const longSpans = "x".repeat(200_000);
     await runDetectionForTrace({
       traceId: "t",
       spansJsonl: longSpans,
@@ -204,7 +215,7 @@ describe("runDetectionForTrace", () => {
     const ctxArg = mockComplete.mock.calls[0][1] as { messages: { content: string }[] };
     const userMessage = ctxArg.messages[0].content;
     expect(typeof userMessage).toBe("string");
-    expect((userMessage as string).length).toBeLessThan(42000);
+    expect((userMessage as string).length).toBeLessThan(152_000);
   });
 
   it("returns error when complete() throws", async () => {
@@ -219,5 +230,155 @@ describe("runDetectionForTrace", () => {
 
     expect(result.identified).toBe(false);
     expect(result.error).toBe("API rate limit");
+  });
+
+  describe("inference cost + source attribution", () => {
+    it("captures system source cost on happy path", async () => {
+      mockComplete.mockResolvedValueOnce({
+        content: [
+          {
+            type: "toolCall",
+            name: "submit_result",
+            arguments: { identified: false, summary: "clean", data: {} },
+          },
+        ],
+        usage: usageWithCost(0.0042),
+        stopReason: "toolUse",
+      });
+
+      const result = await runDetectionForTrace({
+        traceId: "t",
+        spansJsonl: "{}",
+        detector: { ...DETECTOR, detectionSource: "system" },
+        workspaceId: "ws-1",
+      });
+
+      expect(result.inferenceCost).toBeCloseTo(0.0042, 6);
+      expect(result.inferenceSource).toBe("system");
+    });
+
+    it("sums cost across attempts on retry-then-success", async () => {
+      mockComplete
+        .mockResolvedValueOnce({
+          content: [{ type: "text", text: "ignoring instructions" }],
+          usage: usageWithCost(0.001),
+          stopReason: "stop",
+        })
+        .mockResolvedValueOnce({
+          content: [
+            {
+              type: "toolCall",
+              name: "submit_result",
+              arguments: { identified: true, summary: "found", data: {} },
+            },
+          ],
+          usage: usageWithCost(0.003),
+          stopReason: "toolUse",
+        });
+
+      const result = await runDetectionForTrace({
+        traceId: "t",
+        spansJsonl: "{}",
+        detector: { ...DETECTOR, detectionSource: "system" },
+        workspaceId: "ws-1",
+      });
+
+      expect(result.identified).toBe(true);
+      expect(result.inferenceCost).toBeCloseTo(0.004, 6);
+      expect(result.inferenceSource).toBe("system");
+    });
+
+    it("captures BYOK source attribution with positive cost", async () => {
+      mockFetchProviderConfig.mockResolvedValueOnce({
+        key: "byok-key",
+        provider: "anthropic",
+        model: "claude-haiku-4-5",
+      });
+      mockComplete.mockResolvedValueOnce({
+        content: [
+          {
+            type: "toolCall",
+            name: "submit_result",
+            arguments: { identified: false, summary: "ok", data: {} },
+          },
+        ],
+        usage: usageWithCost(0.005),
+        stopReason: "toolUse",
+      });
+
+      const result = await runDetectionForTrace({
+        traceId: "t",
+        spansJsonl: "{}",
+        detector: {
+          ...DETECTOR,
+          detectionSource: "byok",
+          detectionProvider: "byok-provider",
+        },
+        workspaceId: "ws-1",
+      });
+
+      expect(result.inferenceSource).toBe("byok");
+      expect(result.inferenceCost).toBeCloseTo(0.005, 6);
+    });
+
+    it("preserves source on error path with cost=0 (early-exit, BYOK provider missing)", async () => {
+      mockFetchProviderConfig.mockResolvedValueOnce(null);
+
+      const result = await runDetectionForTrace({
+        traceId: "t",
+        spansJsonl: "{}",
+        detector: {
+          ...DETECTOR,
+          detectionSource: "byok",
+          detectionProvider: "missing",
+        },
+        workspaceId: "ws-1",
+      });
+
+      expect(result.error).toMatch(/not found or disabled/i);
+      expect(result.inferenceCost).toBe(0);
+      expect(result.inferenceSource).toBe("byok");
+      expect(mockComplete).not.toHaveBeenCalled();
+    });
+
+    it("preserves source on error path with cost=0 (complete() throws)", async () => {
+      mockComplete.mockRejectedValueOnce(new Error("network down"));
+
+      const result = await runDetectionForTrace({
+        traceId: "t",
+        spansJsonl: "{}",
+        detector: { ...DETECTOR, detectionSource: "system" },
+        workspaceId: "ws-1",
+      });
+
+      expect(result.error).toBe("network down");
+      expect(result.inferenceCost).toBe(0);
+      expect(result.inferenceSource).toBe("system");
+    });
+
+    it("treats null source as null on the EvalResult (processor normalizes)", async () => {
+      mockComplete.mockResolvedValueOnce({
+        content: [
+          {
+            type: "toolCall",
+            name: "submit_result",
+            arguments: { identified: false, summary: "ok", data: {} },
+          },
+        ],
+        usage: usageWithCost(0.002),
+        stopReason: "toolUse",
+      });
+
+      const detectorWithoutSource = { ...DETECTOR };
+      const result = await runDetectionForTrace({
+        traceId: "t",
+        spansJsonl: "{}",
+        detector: detectorWithoutSource,
+        workspaceId: "ws-1",
+      });
+
+      expect(result.inferenceSource).toBeNull();
+      expect(result.inferenceCost).toBeCloseTo(0.002, 6);
+    });
   });
 });

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -1,5 +1,5 @@
-import { complete, getEnvApiKey } from "@mariozechner/pi-ai";
-import type { Message, ToolCall } from "@mariozechner/pi-ai";
+import { complete, getEnvApiKey } from "@earendil-works/pi-ai";
+import type { Message, ToolCall } from "@earendil-works/pi-ai";
 import {
   findByokKeyForPiProvider,
   fetchProviderConfig,
@@ -23,10 +23,30 @@ export interface EvalResult {
   summary: string;
   data: Record<string, unknown>;
   error?: string;
+  /** Sum of `response.usage.cost.total` (USD) across attempts; 0 on early-exit error paths. */
+  inferenceCost: number;
+  /** Sum of `response.usage.input` tokens across attempts. */
+  inferenceInputTokens: number;
+  /** Sum of `response.usage.output` tokens across attempts. */
+  inferenceOutputTokens: number;
+  /** Source attribution for billing — preserved on error paths so failures still attribute. */
+  inferenceSource: "system" | "byok" | null;
+  /** Model id reported by pi-ai (e.g. "claude-haiku-4-5"); null on early-exit error paths. */
+  inferenceModel: string | null;
+  /** Provider key reported by pi-ai (e.g. "anthropic"); null on early-exit error paths. */
+  inferenceProvider: string | null;
 }
 
 const MAX_ATTEMPTS = 2;
-const SAFETY_TRUNCATE_CHARS = 40000;
+/**
+ * Hard character cap on per-trace context sent to the judge.
+ * Set at ~19% of claude-haiku-4-5's 200k-token window (~37k tokens at 4 chars/token),
+ * leaving generous headroom for the system prompt + tool definitions + response budget.
+ * Smart compression (type-aware truncation + path-based dedup + base64
+ * stripping) is a future improvement when we see real customer complaints
+ * about traces being truncated. For now, rely on this hard cap.
+ */
+const SAFETY_TRUNCATE_CHARS = 150_000;
 /** Default screening model for system source — cheap-and-fast, not the agent default. */
 const SYSTEM_DEFAULT_MODEL = "claude-haiku-4-5";
 
@@ -44,8 +64,27 @@ const SYSTEM_DEFAULT_MODEL = "claude-haiku-4-5";
  */
 const TOOL_CHOICE = "auto";
 
-function errorResult(message: string): EvalResult {
-  return { identified: false, summary: "Analysis failed", data: {}, error: message };
+function errorResult(
+  message: string,
+  source: "system" | "byok" | null,
+  inferenceCost = 0,
+  inferenceInputTokens = 0,
+  inferenceOutputTokens = 0,
+  inferenceModel: string | null = null,
+  inferenceProvider: string | null = null,
+): EvalResult {
+  return {
+    identified: false,
+    summary: "Analysis failed",
+    data: {},
+    error: message,
+    inferenceCost,
+    inferenceInputTokens,
+    inferenceOutputTokens,
+    inferenceSource: source,
+    inferenceModel,
+    inferenceProvider,
+  };
 }
 
 /**
@@ -86,12 +125,13 @@ export async function runDetectionForTrace(params: {
   let providerConfig: ProviderModelConfig | null = null;
   if (source === "byok") {
     if (!detector.detectionProvider) {
-      return errorResult("BYOK detector has no detectionProvider");
+      return errorResult("BYOK detector has no detectionProvider", source);
     }
     providerConfig = await fetchProviderConfig(workspaceId, detector.detectionProvider);
     if (!providerConfig) {
       return errorResult(
         `BYOK provider "${detector.detectionProvider}" not found or disabled in workspace settings`,
+        source,
       );
     }
   }
@@ -104,7 +144,7 @@ export async function runDetectionForTrace(params: {
   // 3. Resolve API key (BYOK row → env var → workspace BYOK scan)
   const apiKey = await resolveDetectorApiKey(workspaceId, providerConfig, model.provider);
   if (!apiKey) {
-    return errorResult(`No API key configured for provider "${model.provider}"`);
+    return errorResult(`No API key configured for provider "${model.provider}"`, source);
   }
 
   // 4. Build prompt + tool
@@ -132,6 +172,11 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
   // 5. Single-shot complete() with retry-once-on-text-response
   const messages: Message[] = [{ role: "user", content: userText, timestamp: Date.now() }];
   let lastError: string | undefined;
+  let inferenceCost = 0;
+  let inferenceInputTokens = 0;
+  let inferenceOutputTokens = 0;
+  let inferenceModel: string | null = null;
+  let inferenceProvider: string | null = null;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
@@ -139,6 +184,12 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
         apiKey,
         toolChoice: TOOL_CHOICE,
       } as Record<string, unknown>);
+
+      inferenceCost += response.usage?.cost?.total ?? 0;
+      inferenceInputTokens += response.usage?.input ?? 0;
+      inferenceOutputTokens += response.usage?.output ?? 0;
+      inferenceModel = response.model ?? inferenceModel;
+      inferenceProvider = response.provider ?? inferenceProvider;
 
       const toolCall = response.content.find(
         (c): c is ToolCall => c.type === "toolCall" && c.name === "submit_result",
@@ -149,6 +200,12 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
           identified: Boolean(args.identified),
           summary: typeof args.summary === "string" ? args.summary : "",
           data: (args.data as Record<string, unknown>) ?? {},
+          inferenceCost,
+          inferenceInputTokens,
+          inferenceOutputTokens,
+          inferenceSource: source,
+          inferenceModel,
+          inferenceProvider,
         };
       }
 
@@ -182,5 +239,13 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
     }
   }
 
-  return errorResult(lastError ?? "LLM did not call submit_result after retry");
+  return errorResult(
+    lastError ?? "LLM did not call submit_result after retry",
+    source,
+    inferenceCost,
+    inferenceInputTokens,
+    inferenceOutputTokens,
+    inferenceModel,
+    inferenceProvider,
+  );
 }

--- a/frontend/worker/src/detection/submit-result-tool.ts
+++ b/frontend/worker/src/detection/submit-result-tool.ts
@@ -1,5 +1,5 @@
-import { Type, type TSchema } from "@mariozechner/pi-ai";
-import type { Tool } from "@mariozechner/pi-ai";
+import { Type, type TSchema } from "@earendil-works/pi-ai";
+import type { Tool } from "@earendil-works/pi-ai";
 
 export interface SubmitResultInput {
   identified: boolean;

--- a/frontend/worker/src/ee/billing/__tests__/usageMetering-detector.test.ts
+++ b/frontend/worker/src/ee/billing/__tests__/usageMetering-detector.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {},
+  USAGE_CONFIG: { includedUnits: 50_000 },
+  PlanType: { FREE: "free", STARTER: "starter", PRO: "pro", ENTERPRISE: "enterprise" },
+  isAiRunBlocked: () => false,
+  AI_RUN_QUOTAS: {
+    free: { included: 30 },
+    starter: { included: 100 },
+    pro: { included: 100 },
+    enterprise: { included: 0 },
+  },
+  EVENT_QUOTAS: {
+    free: { included: 50_000 },
+    starter: { included: 150_000 },
+    pro: { included: 150_000 },
+    enterprise: { included: 0 },
+  },
+}));
+
+vi.mock("./clickhouse.js", () => ({
+  getWorkspaceUsageDetails: vi.fn().mockResolvedValue({ traces: 0, spans: 0, detectorRuns: 0 }), // unused
+}));
+
+import { reportDetectorOverageToStripe } from "../usageMetering.js";
+
+function makeStripe() {
+  const create = vi.fn().mockResolvedValue({});
+  return {
+    client: {
+      billing: {
+        meterEvents: { create },
+      },
+    } as unknown as import("stripe").default,
+    create,
+  };
+}
+
+describe("reportDetectorOverageToStripe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("emits a detector_usage meter event with correct units", async () => {
+    const { client, create } = makeStripe();
+
+    const ok = await reportDetectorOverageToStripe("ws-1", "cus_x", 42, client);
+
+    expect(ok).toBe(true);
+    expect(create).toHaveBeenCalledTimes(1);
+    const args = create.mock.calls[0][0];
+    expect(args.event_name).toBe("detector_usage");
+    expect(args.payload.stripe_customer_id).toBe("cus_x");
+    expect(args.payload.value).toBe("42");
+  });
+
+  it("skips and returns false when units <= 0 (idempotency: nothing to report)", async () => {
+    const { client, create } = makeStripe();
+
+    const a = await reportDetectorOverageToStripe("ws-1", "cus_x", 0, client);
+    const b = await reportDetectorOverageToStripe("ws-1", "cus_x", -5, client);
+
+    expect(a).toBe(false);
+    expect(b).toBe(false);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns false when Stripe call throws (caller decides whether to advance lastReportedUnits)", async () => {
+    const { client, create } = makeStripe();
+    create.mockRejectedValueOnce(new Error("stripe down"));
+
+    const ok = await reportDetectorOverageToStripe("ws-1", "cus_x", 100, client);
+
+    expect(ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure-math sanity checks for the detector billing path.
+// These mirror the inline math in processWorkspace so a refactor of either
+// the rounding rule or the markup rate must touch this test.
+// ---------------------------------------------------------------------------
+describe("detector unit math (1.05× pass-through, $0.01/unit)", () => {
+  function detectorUnits(systemCost: number): number {
+    return Math.round(systemCost * 1.05 * 100);
+  }
+
+  it("$1.00 of system token cost → 105 units ($1.05 billed)", () => {
+    expect(detectorUnits(1.0)).toBe(105);
+  });
+
+  it("$0 → 0 units", () => {
+    expect(detectorUnits(0)).toBe(0);
+  });
+
+  it("very small cost rounds correctly ($0.001 → 0 units, $0.005 → 1 unit)", () => {
+    expect(detectorUnits(0.001)).toBe(0);
+    // 0.005 * 1.05 * 100 = 0.525 → rounds to 1
+    expect(detectorUnits(0.005)).toBe(1);
+  });
+});
+
+describe("detector delta tracking (idempotency contract)", () => {
+  // Replicates the delta-calc shape of processWorkspace for the detector path:
+  //   totalUnits = round(systemCost * 1.05 * 100)
+  //   delta      = totalUnits - lastReportedUnits   (when same period)
+  //   delta      = totalUnits                        (when period rolled over)
+  function computeDelta(
+    systemCost: number,
+    lastReportedUnits: number,
+    prevPeriodStart: string | null,
+    currentPeriodStart: string | null,
+  ): { totalUnits: number; deltaUnits: number } {
+    const totalUnits = Math.round(systemCost * 1.05 * 100);
+    const effectiveLast = prevPeriodStart === currentPeriodStart ? lastReportedUnits : 0;
+    return { totalUnits, deltaUnits: totalUnits - effectiveLast };
+  }
+
+  it("first hour of period: full units billed", () => {
+    const { deltaUnits } = computeDelta(1.0, 0, "2026-05-01T00:00:00Z", "2026-05-01T00:00:00Z");
+    expect(deltaUnits).toBe(105);
+  });
+
+  it("re-running same hour with no new cost: delta=0 (idempotent)", () => {
+    const { deltaUnits } = computeDelta(1.0, 105, "2026-05-01T00:00:00Z", "2026-05-01T00:00:00Z");
+    expect(deltaUnits).toBe(0);
+  });
+
+  it("incremental cost in next hour: only delta billed", () => {
+    // last hour: $1.00 → 105; new total: $1.50 → 158; delta = 53
+    const { totalUnits, deltaUnits } = computeDelta(
+      1.5,
+      105,
+      "2026-05-01T00:00:00Z",
+      "2026-05-01T00:00:00Z",
+    );
+    expect(totalUnits).toBe(158);
+    expect(deltaUnits).toBe(53);
+  });
+
+  it("billing period rollover resets the delta baseline", () => {
+    const { deltaUnits } = computeDelta(0.5, 105, "2026-04-01T00:00:00Z", "2026-05-01T00:00:00Z");
+    // 0.5 * 1.05 * 100 = 52.5 → 53. Period changed, baseline resets to 0.
+    expect(deltaUnits).toBe(53);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// First-100-free included threshold for paid plans. Mirrors the inline math in
+// the 5d block of processWorkspace.
+// ---------------------------------------------------------------------------
+describe("detector included-threshold math (first 100 free on paid plans)", () => {
+  const INCLUDED = 100;
+
+  function billableUnits(systemCost: number, scansRun: number): number {
+    const overageScans = Math.max(0, scansRun - INCLUDED);
+    const billable = scansRun > 0 ? systemCost * (overageScans / scansRun) : 0;
+    return Math.round(billable * 1.05 * 100);
+  }
+
+  it("50 scans (within 100 included): $0 billable, 0 units", () => {
+    expect(billableUnits(0.05, 50)).toBe(0);
+  });
+
+  it("100 scans (exactly at threshold): $0 billable, 0 units", () => {
+    expect(billableUnits(0.1, 100)).toBe(0);
+  });
+
+  it("200 scans, $0.20 total cost: half is overage → $0.10 × 1.05 = $0.105 → 11 units", () => {
+    // overage proportion = 100/200 = 0.5; billable = 0.20 * 0.5 = 0.10
+    // 0.10 * 1.05 * 100 = 10.5 → rounds to 11
+    expect(billableUnits(0.2, 200)).toBe(11);
+  });
+
+  it("1000 scans, $1.30 total cost: 90% overage → $1.17 × 1.05 → $1.2285 → 123 units", () => {
+    // overage = 900/1000 = 0.9; billable = 1.30 * 0.9 = 1.17
+    // 1.17 * 1.05 * 100 = 122.85 → rounds to 123
+    expect(billableUnits(1.3, 1000)).toBe(123);
+  });
+
+  it("upgrading from Free preserves the 100-free benefit: 99 scans on Starter bills $0", () => {
+    // Reflects the "Starter is never worse than Free" invariant.
+    expect(billableUnits(0.1, 99)).toBe(0);
+  });
+
+  it("0 scans guards against divide-by-zero", () => {
+    expect(billableUnits(0, 0)).toBe(0);
+  });
+});

--- a/frontend/worker/src/ee/billing/__tests__/usageMetering.test.ts
+++ b/frontend/worker/src/ee/billing/__tests__/usageMetering.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi } from "vitest";
+import type Stripe from "stripe";
+import { reportRcaRunOverageToStripe } from "../usageMetering.js";
+
+function makeStripeStub(): {
+  client: Stripe;
+  calls: Array<Parameters<Stripe["billing"]["meterEvents"]["create"]>[0]>;
+} {
+  const calls: Array<Parameters<Stripe["billing"]["meterEvents"]["create"]>[0]> = [];
+  const client = {
+    billing: {
+      meterEvents: {
+        create: vi.fn(async (params: any) => {
+          calls.push(params);
+          return {} as any;
+        }),
+      },
+    },
+  } as unknown as Stripe;
+  return { client, calls };
+}
+
+describe("reportRcaRunOverageToStripe", () => {
+  it("emits a stripe meter event on the rca_usage event_name", async () => {
+    const { client, calls } = makeStripeStub();
+    const ok = await reportRcaRunOverageToStripe("ws-1", "cus_123", 1500, client);
+    expect(ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].event_name).toBe("rca_usage");
+    expect(calls[0].payload.stripe_customer_id).toBe("cus_123");
+    expect(calls[0].payload.value).toBe("1500");
+  });
+
+  it("uses a different event_name than AI run overage (separate Stripe product)", async () => {
+    const { client, calls } = makeStripeStub();
+    await reportRcaRunOverageToStripe("ws-1", "cus_123", 100, client);
+    expect(calls[0].event_name).not.toBe("ai_usage");
+  });
+
+  it("returns false and emits no event when units <= 0", async () => {
+    const { client, calls } = makeStripeStub();
+    expect(await reportRcaRunOverageToStripe("ws-1", "cus_1", 0, client)).toBe(false);
+    expect(await reportRcaRunOverageToStripe("ws-1", "cus_1", -5, client)).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns false on stripe error and does not throw", async () => {
+    const client = {
+      billing: {
+        meterEvents: {
+          create: vi.fn().mockRejectedValue(new Error("stripe down")),
+        },
+      },
+    } as unknown as Stripe;
+    expect(await reportRcaRunOverageToStripe("ws-1", "cus_1", 100, client)).toBe(false);
+  });
+});
+
+// Mirror the delta-tracking math used in processWorkspace for RCA reporting.
+// This isolates the idempotency invariant from the prisma-bound flow:
+//  - lastReportedUnits resets on billing-period change.
+//  - Only the positive delta is reported per hourly run.
+function computeRcaDelta(args: {
+  totalRcaBillableUnits: number;
+  prevRcaPeriodStart: string | null;
+  currentPeriodStart: string | null;
+  prevLastReportedRcaUnits: number;
+}): { deltaUnits: number; lastReportedUnits: number } {
+  const lastReportedUnits =
+    args.prevRcaPeriodStart === args.currentPeriodStart ? args.prevLastReportedRcaUnits : 0;
+  const deltaUnits = args.totalRcaBillableUnits - lastReportedUnits;
+  return { deltaUnits, lastReportedUnits };
+}
+
+function rcaUnitsForOverage(overageRuns: number, systemTokenCost: number): number {
+  if (overageRuns <= 0) return 0;
+  const blocks = Math.ceil(overageRuns / 100);
+  const runOverage = blocks * 1000;
+  const tokenMarkup = Math.round(systemTokenCost * 1.05 * 100);
+  return runOverage + tokenMarkup;
+}
+
+describe("RCA delta-tracking idempotency", () => {
+  it("does not double-bill on re-run within the same billing period", () => {
+    const periodStart = "2026-05-01T00:00:00.000Z";
+    // First hourly run: 5 overage runs, $1.00 system cost
+    const totalT1 = rcaUnitsForOverage(5, 1.0);
+    const r1 = computeRcaDelta({
+      totalRcaBillableUnits: totalT1,
+      prevRcaPeriodStart: null,
+      currentPeriodStart: periodStart,
+      prevLastReportedRcaUnits: 0,
+    });
+    expect(r1.deltaUnits).toBe(totalT1);
+
+    // Second hourly run: same usage (no new RCAs)
+    const r2 = computeRcaDelta({
+      totalRcaBillableUnits: totalT1,
+      prevRcaPeriodStart: periodStart,
+      currentPeriodStart: periodStart,
+      prevLastReportedRcaUnits: totalT1,
+    });
+    expect(r2.deltaUnits).toBe(0);
+  });
+
+  it("only reports the increase since last successful report", () => {
+    const periodStart = "2026-05-01T00:00:00.000Z";
+    const totalT1 = rcaUnitsForOverage(5, 0);
+    const totalT2 = rcaUnitsForOverage(15, 0);
+    const r = computeRcaDelta({
+      totalRcaBillableUnits: totalT2,
+      prevRcaPeriodStart: periodStart,
+      currentPeriodStart: periodStart,
+      prevLastReportedRcaUnits: totalT1,
+    });
+    expect(r.deltaUnits).toBe(totalT2 - totalT1);
+  });
+
+  it("resets last-reported on billing-period rollover", () => {
+    const r = computeRcaDelta({
+      totalRcaBillableUnits: 5000,
+      prevRcaPeriodStart: "2026-04-01T00:00:00.000Z",
+      currentPeriodStart: "2026-05-01T00:00:00.000Z",
+      prevLastReportedRcaUnits: 9999,
+    });
+    expect(r.lastReportedUnits).toBe(0);
+    expect(r.deltaUnits).toBe(5000);
+  });
+});
+
+describe("RCA unit math", () => {
+  it("100 overage runs = 1 block = 1000 units (run overage portion)", () => {
+    expect(rcaUnitsForOverage(100, 0)).toBe(1000);
+  });
+
+  it("105 overage runs = 2 blocks = 2000 units", () => {
+    expect(rcaUnitsForOverage(105, 0)).toBe(2000);
+  });
+
+  it("token markup is 1.05x systemTokenCost in cent units", () => {
+    // $2.00 cost * 1.05 * 100 cents = 210 units
+    expect(rcaUnitsForOverage(0, 2.0)).toBe(0); // no overage runs => no markup either (gated by caller)
+    // Combined: 5 overage runs ($10 fee = 1000 units) + $2 token markup (210 units) = 1210
+    expect(rcaUnitsForOverage(5, 2.0)).toBe(1210);
+  });
+});

--- a/frontend/worker/src/ee/billing/clickhouse.ts
+++ b/frontend/worker/src/ee/billing/clickhouse.ts
@@ -34,27 +34,34 @@ async function internalApiRequest<T>(path: string, params?: Record<string, strin
 }
 
 /**
- * Get detailed usage (traces and spans separately) for a workspace.
+ * Get detailed usage (traces, spans, detector runs) for a workspace.
+ * Detector runs are counted from ClickHouse `detector_runs` so the billing
+ * cron is the single source of truth — matching how spans/AI runs work.
  */
 export async function getWorkspaceUsageDetails(params: {
   projectIds: string[];
   start: Date;
   end: Date;
-}): Promise<{ traces: number; spans: number }> {
+}): Promise<{ traces: number; spans: number; detectorRuns: number }> {
   if (params.projectIds.length === 0) {
-    return { traces: 0, spans: 0 };
+    return { traces: 0, spans: 0, detectorRuns: 0 };
   }
 
   const result = await internalApiRequest<{
     traces: number;
     spans: number;
+    detector_runs: number;
   }>("/api/v1/internal/usage/details", {
     project_ids: params.projectIds.join(","),
     start: params.start.toISOString(),
     end: params.end.toISOString(),
   });
 
-  return result;
+  return {
+    traces: result.traces,
+    spans: result.spans,
+    detectorRuns: result.detector_runs ?? 0,
+  };
 }
 
 /**

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -21,7 +21,12 @@ import {
   USAGE_CONFIG,
   PlanType,
   isAiRunBlocked,
+  isRcaRunBlocked,
+  isDetectorRunBlocked,
+  DETECTOR_HOSTED_LLM_FREE_THRESHOLD,
   AI_RUN_QUOTAS,
+  RCA_RUN_QUOTAS,
+  DETECTOR_RUN_QUOTAS,
   EVENT_QUOTAS,
 } from "@traceroot/core";
 import { getWorkspaceUsageDetails } from "./clickhouse.js";
@@ -96,6 +101,8 @@ async function processWorkspace(
     billingPeriodEnd: Date | null;
     ingestionBlocked: boolean;
     aiBlocked: boolean;
+    rcaBlocked: boolean;
+    detectorBlocked: boolean;
     currentUsage: any;
     projects: { id: string }[];
   },
@@ -110,11 +117,11 @@ async function processWorkspace(
   const isFreePlan = plan === PlanType.FREE;
 
   // =========================================================================
-  // 1. Query event usage (traces + spans) from ClickHouse
+  // 1. Query event usage (traces + spans + detector runs) from ClickHouse
   // =========================================================================
-  let usage: { traces: number; spans: number };
+  let usage: { traces: number; spans: number; detectorRuns: number };
   if (projectIds.length === 0) {
-    usage = { traces: 0, spans: 0 };
+    usage = { traces: 0, spans: 0, detectorRuns: 0 };
   } else {
     // Free plan: total usage (all time)
     // Paid plans: usage within current billing period (from Stripe webhook)
@@ -153,68 +160,67 @@ async function processWorkspace(
     ? ctx.now
     : (workspace.billingPeriodEnd ?? new Date(ctx.now.getFullYear(), ctx.now.getMonth() + 1, 1));
 
-  // 2a. Count total AI runs in period (both BYOK and system model)
-  const runsUsed = await prisma.aIMessage.count({
-    where: {
-      role: "assistant",
-      session: { workspaceId: workspace.id },
-      createTime: { gte: aiPeriodStart, lt: aiPeriodEnd },
-    },
-  });
+  // =========================================================================
+  // 2a-2d. Aggregate aIMessage rows by kind for billing + usage display.
+  //
+  // Three categorical sources flow into the same table:
+  //   kind = "chat"     — user-initiated chat (and manual triage / issue-gen)
+  //   kind = "rca"      — auto-RCA agent turns (system-initiated)
+  //   kind = "detector" — single-shot detector LLM scans
+  //
+  // `aggregateMessagesForKind` does the per-kind heavy lifting; only the
+  // chat block reads `runsUsedCount` + byokAgg (the others don't need them).
+  // =========================================================================
 
-  // 2b. Aggregate system model token usage (for cost display + Stripe metering)
-  const systemWhere = {
-    role: "assistant" as const,
-    inputTokens: { not: null as null },
-    isByok: false as const,
-    session: { workspaceId: workspace.id },
-    createTime: { gte: aiPeriodStart, lt: aiPeriodEnd },
-  };
+  const periodWindow = { createTime: { gte: aiPeriodStart, lt: aiPeriodEnd } };
 
-  // BYOK models: same billing period as system models (runs count toward quota)
-  const byokWhere = {
-    role: "assistant" as const,
-    inputTokens: { not: null as null },
-    isByok: true as const,
-    session: { workspaceId: workspace.id },
-    createTime: { gte: aiPeriodStart, lt: aiPeriodEnd },
-  };
-
-  const [systemAgg, byokAgg, systemByModel, byokByModel] = await Promise.all([
-    prisma.aIMessage.aggregate({
-      where: systemWhere,
-      _count: { id: true },
-      _sum: { inputTokens: true, outputTokens: true, cost: true },
-    }),
-    prisma.aIMessage.aggregate({
-      where: byokWhere,
-      _count: { id: true },
-      _sum: { inputTokens: true, outputTokens: true, cost: true },
-    }),
-    prisma.aIMessage.groupBy({
-      by: ["model", "provider", "isByok"],
-      where: systemWhere,
-      _count: { id: true },
-      _sum: { inputTokens: true, outputTokens: true, cost: true },
-    }),
-    prisma.aIMessage.groupBy({
-      by: ["model", "provider", "isByok"],
-      where: byokWhere,
-      _count: { id: true },
-      _sum: { inputTokens: true, outputTokens: true, cost: true },
+  const [chatAgg, rcaAgg, detectorAgg, rcaRunsUsed] = await Promise.all([
+    aggregateMessagesForKind(workspace.id, "chat", periodWindow),
+    aggregateMessagesForKind(workspace.id, "rca", periodWindow),
+    aggregateMessagesForKind(workspace.id, "detector", periodWindow),
+    prisma.detectorRca.count({
+      where: { project: { workspaceId: workspace.id }, ...periodWindow },
     }),
   ]);
 
-  const byModel = [...systemByModel, ...byokByModel];
+  const runsUsed = chatAgg.runsUsedCount;
+  const systemAgg = chatAgg.systemAgg;
+  const byokAgg = chatAgg.byokAgg;
+  const byModel = [...chatAgg.systemByModel, ...chatAgg.byokByModel];
   const systemCost = Number(systemAgg._sum.cost ?? 0);
+
+  const rcaSystemTokenCost = Number(rcaAgg.systemAgg._sum.cost ?? 0);
+  const rcaSystemInputTokens = Number(rcaAgg.systemAgg._sum.inputTokens ?? 0);
+  const rcaSystemOutputTokens = Number(rcaAgg.systemAgg._sum.outputTokens ?? 0);
+  const rcaByModel = [...rcaAgg.systemByModel, ...rcaAgg.byokByModel];
+
+  const detectorSystemTokenCost = Number(detectorAgg.systemAgg._sum.cost ?? 0);
+  const detectorSystemInputTokens = Number(detectorAgg.systemAgg._sum.inputTokens ?? 0);
+  const detectorSystemOutputTokens = Number(detectorAgg.systemAgg._sum.outputTokens ?? 0);
+  const detectorByModel = [...detectorAgg.systemByModel, ...detectorAgg.byokByModel];
 
   // =========================================================================
   // 3. Build update data
   // =========================================================================
+  // Preserve detector cost fields written per-scan by the detector worker.
+  // (scansRun comes from ClickHouse on every cron run — no need to preserve.)
+  const previousDetector =
+    ((workspace.currentUsage as any)?.detector as
+      | {
+          systemTokenCost?: number;
+          systemInputTokens?: number;
+          systemOutputTokens?: number;
+          lastReportedUnits?: number;
+          lastReportedPeriodStart?: string | null;
+        }
+      | undefined) ?? {};
+
   const updateData: {
     currentUsage: object;
     ingestionBlocked?: boolean;
     aiBlocked?: boolean;
+    rcaBlocked?: boolean;
+    detectorBlocked?: boolean;
   } = {
     currentUsage: {
       traces: usage.traces,
@@ -244,6 +250,42 @@ async function processWorkspace(
           outputTokens: row._sum.outputTokens ?? 0,
           cost: Number(row._sum.cost ?? 0),
         })),
+      },
+      rca: {
+        runsUsed: rcaRunsUsed,
+        systemTokenCost: rcaSystemTokenCost,
+        systemInputTokens: rcaSystemInputTokens,
+        systemOutputTokens: rcaSystemOutputTokens,
+        byModel: rcaByModel.map((row) => ({
+          model: row.model ?? "unknown",
+          provider: row.provider ?? "unknown",
+          isByok: row.isByok ?? false,
+          messages: row._count.id,
+          inputTokens: row._sum.inputTokens ?? 0,
+          outputTokens: row._sum.outputTokens ?? 0,
+          cost: Number(row._sum.cost ?? 0),
+        })),
+        lastReportedUnits: 0,
+        lastReportedPeriodStart: null as string | null,
+      },
+      detector: {
+        // scansRun = canonical count from ClickHouse `detector_runs`.
+        // Cost + tokens = aIMessage rows tagged kind="detector" (system source).
+        scansRun: usage.detectorRuns,
+        systemTokenCost: detectorSystemTokenCost,
+        systemInputTokens: detectorSystemInputTokens,
+        systemOutputTokens: detectorSystemOutputTokens,
+        byModel: detectorByModel.map((row) => ({
+          model: row.model ?? "unknown",
+          provider: row.provider ?? "unknown",
+          isByok: row.isByok ?? false,
+          messages: row._count.id,
+          inputTokens: row._sum.inputTokens ?? 0,
+          outputTokens: row._sum.outputTokens ?? 0,
+          cost: Number(row._sum.cost ?? 0),
+        })),
+        lastReportedUnits: previousDetector.lastReportedUnits ?? 0,
+        lastReportedPeriodStart: previousDetector.lastReportedPeriodStart ?? null,
       },
     },
   };
@@ -281,6 +323,45 @@ async function processWorkspace(
     console.log(`[Billing] Workspace ${workspace.id}: unblocking AI (paid plan)`);
   }
 
+  // 4c-bis. RCA blocking — Free plan only, 30-run hard cap. Mirrors AI at 4b.
+  // detectorBlocked alone does NOT cap RCA: the Free RCA quota (30) is lower
+  // than the Free detector-scan cap (100), so a workspace can produce 30+
+  // findings before hitting the detector cap, each triggering an RCA.
+  if (isFreePlan) {
+    const shouldBlockRca = isRcaRunBlocked(plan, rcaRunsUsed);
+    if (workspace.rcaBlocked !== shouldBlockRca) {
+      updateData.rcaBlocked = shouldBlockRca;
+      console.log(
+        `[Billing] Workspace ${workspace.id}: ${rcaRunsUsed}/${RCA_RUN_QUOTAS[plan].included} RCA runs, rca_blocked: ${shouldBlockRca}`,
+      );
+    }
+  }
+
+  // 4c-ter. Paid plans: always unblock RCA (overage is billed, not blocked)
+  if (!isFreePlan && workspace.rcaBlocked) {
+    updateData.rcaBlocked = false;
+    console.log(`[Billing] Workspace ${workspace.id}: unblocking RCA (paid plan)`);
+  }
+
+  // 4d. Detector blocking — Free plan only, 100-scan hard cap (any source).
+  // Count comes from the ClickHouse `detector_runs` aggregate we just fetched
+  // (same source as traces/spans). Mirrors the AI-runs hard-cap pattern at 4b.
+  if (isFreePlan) {
+    const shouldBlockDetector = isDetectorRunBlocked(plan, usage.detectorRuns);
+    if (workspace.detectorBlocked !== shouldBlockDetector) {
+      updateData.detectorBlocked = shouldBlockDetector;
+      console.log(
+        `[Billing] Workspace ${workspace.id}: ${usage.detectorRuns}/${DETECTOR_RUN_QUOTAS[plan].included} detector scans, detector_blocked: ${shouldBlockDetector}`,
+      );
+    }
+  }
+
+  // 4e. Paid plans: always unblock detector
+  if (!isFreePlan && workspace.detectorBlocked) {
+    updateData.detectorBlocked = false;
+    console.log(`[Billing] Workspace ${workspace.id}: unblocking detector (paid plan)`);
+  }
+
   // =========================================================================
   // 5. Stripe metering (paid plans only)
   // =========================================================================
@@ -298,7 +379,7 @@ async function processWorkspace(
     // Reports total 50k blocks, minimum = included blocks (e.g. 3 for starter = 150k).
     // Stripe tiered graduated price handles the math:
     //   Tier 1: 0-3 blocks → $30 flat fee (base plan cost)
-    //   Tier 2: 4+ blocks  → $3/unit     (overage at $3 per 50k block)
+    //   Tier 2: 4+ blocks  → $4/unit     (overage at $4 per 50k block)
     if (plan !== PlanType.ENTERPRISE) {
       const includedEvents = EVENT_QUOTAS[plan].included;
       const includedBlocks = includedEvents / 50_000;
@@ -369,6 +450,100 @@ async function processWorkspace(
       (updateData.currentUsage as any).ai.lastReportedUnits = lastReportedUnits;
       (updateData.currentUsage as any).ai.lastReportedPeriodStart = currentPeriodStart;
     }
+
+    // 5c. Report RCA run overage to Stripe (separate meter / Stripe product)
+    const includedRcaRuns = RCA_RUN_QUOTAS[plan].included;
+    const overageRcaRuns = Math.max(0, rcaRunsUsed - includedRcaRuns);
+
+    let totalRcaBillableUnits = 0;
+    if (overageRcaRuns > 0) {
+      const rcaOverageBlocks = Math.ceil(overageRcaRuns / 100);
+      const rcaRunOverageUnits = rcaOverageBlocks * 1000;
+      // 1.05x markup over the period's system-source RCA inference cost.
+      // BYOK turns are excluded by the kind="rca" aggregation's isByok=false filter.
+      const rcaTokenMarkupUnits = Math.round(rcaSystemTokenCost * 1.05 * 100);
+      totalRcaBillableUnits = rcaRunOverageUnits + rcaTokenMarkupUnits;
+    }
+
+    const prevRcaPeriodStart = previousUsage?.rca?.lastReportedPeriodStart ?? null;
+    const lastReportedRcaUnits =
+      prevRcaPeriodStart === currentPeriodStart ? (previousUsage?.rca?.lastReportedUnits ?? 0) : 0;
+    const deltaRcaUnits = totalRcaBillableUnits - lastReportedRcaUnits;
+
+    console.log(
+      `[Billing] RCA run metering: runsUsed=${rcaRunsUsed}, included=${includedRcaRuns}, overage=${overageRcaRuns}, ` +
+        `systemTokenCost=$${rcaSystemTokenCost.toFixed(4)}, totalUnits=${totalRcaBillableUnits}, ` +
+        `lastReported=${lastReportedRcaUnits}, delta=${deltaRcaUnits}`,
+    );
+
+    if (deltaRcaUnits > 0) {
+      const reported = await reportRcaRunOverageToStripe(
+        workspace.id,
+        workspace.billingCustomerId!,
+        deltaRcaUnits,
+        ctx.stripeClient,
+      );
+      if (reported) {
+        (updateData.currentUsage as any).rca.lastReportedUnits = totalRcaBillableUnits;
+        (updateData.currentUsage as any).rca.lastReportedPeriodStart = currentPeriodStart;
+      } else {
+        (updateData.currentUsage as any).rca.lastReportedUnits = lastReportedRcaUnits;
+        (updateData.currentUsage as any).rca.lastReportedPeriodStart = currentPeriodStart;
+      }
+    } else {
+      (updateData.currentUsage as any).rca.lastReportedUnits = lastReportedRcaUnits;
+      (updateData.currentUsage as any).rca.lastReportedPeriodStart = currentPeriodStart;
+    }
+
+    // 5d. Report managed detector inference token usage (1.05× pass-through).
+    //
+    // Paid plans inherit Free's "first 100 detector scans/month at $0" — we
+    // absorb that hosted-LLM cost so upgrading from Free never *removes* the
+    // 100-free benefit. Beyond the threshold, the OVERAGE portion of the
+    // hosted-LLM cost is billed at 1.05× passthrough.
+    //
+    // Proportional split: we don't have per-scan cost in ClickHouse today, so
+    // we apportion the period's total cost by scan count (overage / total).
+    // Approximation is fine — scans within a single detector have similar cost.
+    // BYOK detectors contribute 0 to systemTokenCost (we filter by isByok=false above).
+    const detectorSystemCost = detectorSystemTokenCost;
+    const detectorOverageScans = Math.max(
+      0,
+      usage.detectorRuns - DETECTOR_HOSTED_LLM_FREE_THRESHOLD,
+    );
+    const detectorBillableCost =
+      usage.detectorRuns > 0 ? detectorSystemCost * (detectorOverageScans / usage.detectorRuns) : 0;
+    const detectorTotalUnits = Math.round(detectorBillableCost * 1.05 * 100);
+
+    const prevDetectorPeriodStart = previousDetector.lastReportedPeriodStart ?? null;
+    const detectorLastReportedUnits =
+      prevDetectorPeriodStart === currentPeriodStart
+        ? (previousDetector.lastReportedUnits ?? 0)
+        : 0;
+    const detectorDeltaUnits = detectorTotalUnits - detectorLastReportedUnits;
+
+    console.log(
+      `[Billing] Detector token metering: scansRun=${usage.detectorRuns}, ` +
+        `included=${DETECTOR_HOSTED_LLM_FREE_THRESHOLD}, overageScans=${detectorOverageScans}, ` +
+        `totalCost=$${detectorSystemCost.toFixed(4)}, billableCost=$${detectorBillableCost.toFixed(4)}, ` +
+        `totalUnits=${detectorTotalUnits}, lastReported=${detectorLastReportedUnits}, delta=${detectorDeltaUnits}`,
+    );
+
+    if (detectorDeltaUnits > 0) {
+      const reported = await reportDetectorOverageToStripe(
+        workspace.id,
+        workspace.billingCustomerId!,
+        detectorDeltaUnits,
+        ctx.stripeClient,
+      );
+      if (reported) {
+        (updateData.currentUsage as any).detector.lastReportedUnits = detectorTotalUnits;
+        (updateData.currentUsage as any).detector.lastReportedPeriodStart = currentPeriodStart;
+      }
+    } else {
+      (updateData.currentUsage as any).detector.lastReportedUnits = detectorLastReportedUnits;
+      (updateData.currentUsage as any).detector.lastReportedPeriodStart = currentPeriodStart;
+    }
   }
 
   // =========================================================================
@@ -388,6 +563,56 @@ async function processWorkspace(
   );
 }
 
+type MessageKind = "chat" | "rca" | "detector";
+
+/**
+ * Aggregate `aIMessage` rows for one `kind` over a billing window. Returns:
+ *   - runsUsedCount: total assistant rows (chat uses this for run-count meter;
+ *     rca/detector get their canonical counts from elsewhere)
+ *   - systemAgg / byokAgg: cost + token sums split by inference source
+ *   - systemByModel / byokByModel: per-(model, provider) breakdowns for UI
+ *
+ * `inputTokens: { not: null }` filters out incomplete writes; rows with null
+ * tokens have null cost too, so this is a no-op for cost sums.
+ */
+async function aggregateMessagesForKind(
+  workspaceId: string,
+  kind: MessageKind,
+  periodWindow: { createTime: { gte: Date; lt: Date } },
+) {
+  const baseWhere = { workspaceId, kind, role: "assistant", ...periodWindow };
+  const systemWhere = { ...baseWhere, isByok: false, inputTokens: { not: null } };
+  const byokWhere = { ...baseWhere, isByok: true, inputTokens: { not: null } };
+
+  const [runsUsedCount, systemAgg, byokAgg, systemByModel, byokByModel] = await Promise.all([
+    prisma.aIMessage.count({ where: baseWhere }),
+    prisma.aIMessage.aggregate({
+      where: systemWhere,
+      _count: { id: true },
+      _sum: { inputTokens: true, outputTokens: true, cost: true },
+    }),
+    prisma.aIMessage.aggregate({
+      where: byokWhere,
+      _count: { id: true },
+      _sum: { inputTokens: true, outputTokens: true, cost: true },
+    }),
+    prisma.aIMessage.groupBy({
+      by: ["model", "provider", "isByok"],
+      where: systemWhere,
+      _count: { id: true },
+      _sum: { inputTokens: true, outputTokens: true, cost: true },
+    }),
+    prisma.aIMessage.groupBy({
+      by: ["model", "provider", "isByok"],
+      where: byokWhere,
+      _count: { id: true },
+      _sum: { inputTokens: true, outputTokens: true, cost: true },
+    }),
+  ]);
+
+  return { runsUsedCount, systemAgg, byokAgg, systemByModel, byokByModel };
+}
+
 /**
  * Get the total system model token cost for AI runs beyond the included quota.
  *
@@ -401,12 +626,15 @@ async function getOverageSystemModelCost(
   start: Date,
   end: Date,
 ): Promise<number> {
-  // Step 1: Find the cutoff timestamp — the createTime of the first message
-  // after the included quota (e.g., the 101st message for Starter/Pro)
+  // Step 1: Find the cutoff timestamp — the createTime of the first chat
+  // message after the included quota (e.g., the 101st message for Starter/Pro).
+  // kind="chat" so RCA/detector turns living in the same table don't shift
+  // the cutoff or inflate the cost sum.
   const cutoff = await prisma.aIMessage.findMany({
     where: {
+      workspaceId,
+      kind: "chat",
       role: "assistant",
-      session: { workspaceId },
       createTime: { gte: start, lt: end },
     },
     orderBy: { createTime: "asc" },
@@ -420,9 +648,10 @@ async function getOverageSystemModelCost(
   // Step 2: Aggregate system model cost from the cutoff onward (DB-side sum)
   const agg = await prisma.aIMessage.aggregate({
     where: {
+      workspaceId,
+      kind: "chat",
       role: "assistant",
       isByok: false,
-      session: { workspaceId },
       createTime: { gte: cutoff[0].createTime, lt: end },
     },
     _sum: { cost: true },
@@ -438,9 +667,16 @@ async function updateStripeQuantity(
 ): Promise<void> {
   try {
     const subscription = await stripeClient.subscriptions.retrieve(subscriptionId);
-    // Find the plan item (not the AI usage metered item)
+    // Find the plan item (not the metered usage items — AI runs, RCA runs, detector usage)
     const aiUsagePriceId = process.env.STRIPE_PRICE_ID_AI_USAGE;
-    const planItem = subscription.items.data.find((item) => item.price.id !== aiUsagePriceId);
+    const rcaUsagePriceId = process.env.STRIPE_PRICE_ID_RCA_USAGE;
+    const detectorUsagePriceId = process.env.STRIPE_PRICE_ID_DETECTOR_USAGE;
+    const meteredPriceIds = new Set(
+      [aiUsagePriceId, rcaUsagePriceId, detectorUsagePriceId].filter((p): p is string =>
+        Boolean(p),
+      ),
+    );
+    const planItem = subscription.items.data.find((item) => !meteredPriceIds.has(item.price.id));
 
     if (!planItem) {
       console.warn(`[Billing] No plan subscription item found for ${subscriptionId}`);
@@ -466,6 +702,45 @@ async function updateStripeQuantity(
  * - System model token markup: 1.05x of token cost on overage runs (granular)
  * Returns true if successfully reported.
  */
+/**
+ * Report managed (system-source) detector inference token cost to Stripe.
+ * Pricing: 1.05× pass-through, billed at $0.01/unit. No quota, no cap —
+ * informational meter; every system-source dollar is billed.
+ *
+ * Idempotent across hourly runs via lastReportedUnits delta tracking. The
+ * underlying system-token cost is aggregated from `aIMessage` rows with
+ * kind="detector" and isByok=false; this function just pushes the delta.
+ */
+export async function reportDetectorOverageToStripe(
+  workspaceId: string,
+  customerId: string,
+  units: number,
+  stripeClient: Stripe,
+): Promise<boolean> {
+  if (units <= 0) return false;
+
+  try {
+    await stripeClient.billing.meterEvents.create({
+      event_name: "detector_usage",
+      payload: {
+        stripe_customer_id: customerId,
+        value: String(units),
+      },
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+    console.log(
+      `[Billing] Reported detector usage to Stripe: workspace=${workspaceId}, delta=${units} units ($${(units * 0.01).toFixed(2)})`,
+    );
+    return true;
+  } catch (error) {
+    console.error(
+      `[Billing] Failed to report detector usage to Stripe for workspace ${workspaceId}:`,
+      error,
+    );
+    return false;
+  }
+}
+
 async function reportAiRunOverageToStripe(
   workspaceId: string,
   customerId: string,
@@ -490,6 +765,44 @@ async function reportAiRunOverageToStripe(
   } catch (error) {
     console.error(
       `[Billing] Failed to report AI run overage to Stripe for workspace ${workspaceId}:`,
+      error,
+    );
+    return false;
+  }
+}
+
+/**
+ * Report RCA run overage to Stripe via meter events on a separate Stripe
+ * product (`STRIPE_PRICE_ID_RCA_USAGE`). Same shape as AI run overage:
+ * units at $0.01 each, including:
+ *  - Run overage fee: $10 per 100-run block (rounded up), 1 block = 1000 units
+ *  - System token markup: 1.05x of system-source RCA inference cost (granular)
+ * Returns true if successfully reported.
+ */
+export async function reportRcaRunOverageToStripe(
+  workspaceId: string,
+  customerId: string,
+  units: number,
+  stripeClient: Stripe,
+): Promise<boolean> {
+  if (units <= 0) return false;
+
+  try {
+    await stripeClient.billing.meterEvents.create({
+      event_name: "rca_usage",
+      payload: {
+        stripe_customer_id: customerId,
+        value: String(units),
+      },
+      timestamp: Math.floor(Date.now() / 1000),
+    });
+    console.log(
+      `[Billing] Reported RCA run overage to Stripe: workspace=${workspaceId}, delta=${units} units ($${(units * 0.01).toFixed(2)})`,
+    );
+    return true;
+  } catch (error) {
+    console.error(
+      `[Billing] Failed to report RCA run overage to Stripe for workspace ${workspaceId}:`,
       error,
     );
     return false;

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -459,9 +459,15 @@ async function processWorkspace(
     if (overageRcaRuns > 0) {
       const rcaOverageBlocks = Math.ceil(overageRcaRuns / 100);
       const rcaRunOverageUnits = rcaOverageBlocks * 1000;
-      // 1.05x markup over the period's system-source RCA inference cost.
-      // BYOK turns are excluded by the kind="rca" aggregation's isByok=false filter.
-      const rcaTokenMarkupUnits = Math.round(rcaSystemTokenCost * 1.05 * 100);
+      // 1.05x markup applied ONLY to the overage portion of token cost.
+      // Proportional allocation by run count: same shape as detector's
+      // (overageScans / scansRun), and matches chat's getOverageSystemModelCost()
+      // behavior. Avoids overbilling customers whose included runs already
+      // accrued most of the period's inference cost.
+      // BYOK turns are excluded upstream by the kind="rca" isByok=false filter.
+      const rcaOverageTokenCost =
+        rcaRunsUsed > 0 ? rcaSystemTokenCost * (overageRcaRuns / rcaRunsUsed) : 0;
+      const rcaTokenMarkupUnits = Math.round(rcaOverageTokenCost * 1.05 * 100);
       totalRcaBillableUnits = rcaRunOverageUnits + rcaTokenMarkupUnits;
     }
 

--- a/frontend/worker/src/notifications/slack.ts
+++ b/frontend/worker/src/notifications/slack.ts
@@ -1,9 +1,10 @@
 import { createSlackClient, buildCombinedAlertBlocks } from "@traceroot/slack";
-import { decryptKey } from "@traceroot/core";
+import { decryptKey, hasEntitlement, prisma, type PlanType } from "@traceroot/core";
 
 const APP_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
 
 export interface SendCombinedAlertSlackParams {
+  workspaceId: string;
   encryptedBotToken: string;
   channelId: string;
   detectorName: string;
@@ -15,6 +16,18 @@ export interface SendCombinedAlertSlackParams {
 }
 
 export async function sendCombinedAlertSlack(params: SendCombinedAlertSlackParams): Promise<void> {
+  const workspace = await prisma.workspace.findUnique({
+    where: { id: params.workspaceId },
+    select: { billingPlan: true },
+  });
+  const plan = (workspace?.billingPlan ?? "free") as PlanType;
+  if (!hasEntitlement(plan, "slack-integration")) {
+    console.log(
+      `[slack] Skipping Slack alert for workspace ${params.workspaceId}: plan "${plan}" lacks slack-integration entitlement`,
+    );
+    return;
+  }
+
   const client = createSlackClient(decryptKey(params.encryptedBotToken));
   const blocks = buildCombinedAlertBlocks({
     detectorName: params.detectorName,

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -216,13 +216,26 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
 
       // Free-plan RCA cap enforcement — read the cached `rcaBlocked` flag
       // set by the hourly billing job (same pattern as `detectorBlocked` in
-      // detector-run-processor). Skip cleanly: no DetectorRca row, no alert.
-      // Worst-case overshoot: ~1h of RCA runs between cron passes.
+      // detector-run-processor). Worst-case overshoot: ~1h of RCA runs
+      // between cron passes.
       const ws = await prisma.workspace.findUnique({
         where: { id: workspaceId },
         select: { billingPlan: true, rcaBlocked: true },
       });
       if (ws?.rcaBlocked && (ws.billingPlan as PlanType) === PlanType.FREE) {
+        // detector-run-processor pre-seeds a DetectorRca row with
+        // status="pending" before enqueuing; mark it terminal so the UI
+        // doesn't show a permanently-stuck "in progress" RCA.
+        await prisma.detectorRca
+          .update({
+            where: { findingId },
+            data: {
+              status: "failed",
+              result: "Skipped — Free plan RCA quota exceeded. Upgrade to continue.",
+              completedAt: new Date(),
+            },
+          })
+          .catch(() => {}); // best-effort; row may not exist if pre-seed failed
         console.log(
           `[RCA] Workspace ${workspaceId} is rca-blocked (Free plan cap exceeded); ` +
             `skipping RCA for finding ${findingId}`,

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -1,5 +1,5 @@
 import { Worker, type Job } from "bullmq";
-import { prisma, SYSTEM_MODELS } from "@traceroot/core";
+import { prisma, SYSTEM_MODELS, PlanType } from "@traceroot/core";
 import type { DetectorRcaJob } from "../queues/detector-run-queue.js";
 import { DETECTOR_RCA_QUEUE, createRedisConnection } from "../queues/detector-run-queue.js";
 import { sendCombinedAlertEmail } from "../notifications/email.js";
@@ -168,6 +168,7 @@ export interface FanOutCommon {
 }
 
 export interface RunFanOutParams {
+  workspaceId: string;
   emailAddresses: string[];
   slackChannelId: string | null;
   slackBotTokenEnc: string | null;
@@ -175,6 +176,7 @@ export interface RunFanOutParams {
 }
 
 export async function runFanOut({
+  workspaceId,
   emailAddresses,
   slackChannelId,
   slackBotTokenEnc,
@@ -193,6 +195,7 @@ export async function runFanOut({
   if (slackChannelId && slackBotTokenEnc) {
     tasks.push(
       sendCombinedAlertSlack({
+        workspaceId,
         encryptedBotToken: slackBotTokenEnc,
         channelId: slackChannelId,
         ...common,
@@ -210,6 +213,22 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
     DETECTOR_RCA_QUEUE,
     async (job: Job<DetectorRcaJob>) => {
       const { findingId, projectId, traceId, workspaceId, projectName, findings } = job.data;
+
+      // Free-plan RCA cap enforcement — read the cached `rcaBlocked` flag
+      // set by the hourly billing job (same pattern as `detectorBlocked` in
+      // detector-run-processor). Skip cleanly: no DetectorRca row, no alert.
+      // Worst-case overshoot: ~1h of RCA runs between cron passes.
+      const ws = await prisma.workspace.findUnique({
+        where: { id: workspaceId },
+        select: { billingPlan: true, rcaBlocked: true },
+      });
+      if (ws?.rcaBlocked && (ws.billingPlan as PlanType) === PlanType.FREE) {
+        console.log(
+          `[RCA] Workspace ${workspaceId} is rca-blocked (Free plan cap exceeded); ` +
+            `skipping RCA for finding ${findingId}`,
+        );
+        return;
+      }
 
       await prisma.detectorRca.upsert({
         where: { findingId },
@@ -231,7 +250,13 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
         const summary = findings.map((f) => `[${f.detectorName}] ${f.summary}`).join("\n");
         const detectorName = findings.map((f) => f.detectorName).join(", ");
         const common = { detectorName, projectName, summary, rcaResult, traceId, projectId };
-        await runFanOut({ emailAddresses, slackChannelId, slackBotTokenEnc, common });
+        await runFanOut({
+          workspaceId,
+          emailAddresses,
+          slackChannelId,
+          slackBotTokenEnc,
+          common,
+        });
       };
 
       try {
@@ -279,7 +304,11 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
 
         await prisma.detectorRca.update({
           where: { findingId },
-          data: { status: "done", result: rcaResult, completedAt: new Date() },
+          data: {
+            status: "done",
+            result: rcaResult,
+            completedAt: new Date(),
+          },
         });
 
         await sendAlert(rcaResult);

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -1,6 +1,6 @@
 import { Worker, Queue, type Job } from "bullmq";
 import { createHash } from "crypto";
-import { prisma } from "@traceroot/core";
+import { prisma, PlanType } from "@traceroot/core";
 import type {
   DetectorRunJob,
   DetectorRcaJob,
@@ -51,6 +51,21 @@ interface TriggeredResult {
   data: unknown;
 }
 
+export interface ScanUsage {
+  inferenceCost: number;
+  inferenceInputTokens: number;
+  inferenceOutputTokens: number;
+  inferenceSource: "system" | "byok" | null;
+  inferenceModel: string | null;
+  inferenceProvider: string | null;
+}
+
+interface SingleDetectorOutcome {
+  triggered: TriggeredResult | null;
+  /** null when the eval threw before pi-ai was called (cost/source unknown). */
+  usage: ScanUsage | null;
+}
+
 /**
  * Run one detector against a trace. Writes the run record immediately for
  * non-triggered and failed cases (finding_id = null). For triggered cases,
@@ -72,7 +87,7 @@ async function runSingleDetector(params: {
   projectId: string;
   spansJsonl: string;
   workspaceId: string;
-}): Promise<TriggeredResult | null> {
+}): Promise<SingleDetectorOutcome> {
   const { detector, traceId, projectId, spansJsonl, workspaceId } = params;
   const runId = deterministicRunId(projectId, traceId, detector.id);
 
@@ -102,8 +117,17 @@ async function runSingleDetector(params: {
       findingId: null,
       status: "failed",
     }).catch((err) => console.error("[Detector] Failed to write run:", err));
-    return null;
+    return { triggered: null, usage: null };
   }
+
+  const usage: ScanUsage = {
+    inferenceCost: result.inferenceCost,
+    inferenceInputTokens: result.inferenceInputTokens,
+    inferenceOutputTokens: result.inferenceOutputTokens,
+    inferenceSource: result.inferenceSource,
+    inferenceModel: result.inferenceModel,
+    inferenceProvider: result.inferenceProvider,
+  };
 
   if (!result.identified) {
     if (result.error) {
@@ -120,7 +144,7 @@ async function runSingleDetector(params: {
       findingId: null,
       status: result.error ? "failed" : "completed",
     }).catch((err) => console.error("[Detector] Failed to write run:", err));
-    return null;
+    return { triggered: null, usage };
   }
 
   // Triggered — return result without writing anything.
@@ -129,10 +153,13 @@ async function runSingleDetector(params: {
     `[Detector] Detector ${detector.name} triggered on trace ${traceId}: ${result.summary.slice(0, 80)}`,
   );
   return {
-    detectorId: detector.id,
-    detectorName: detector.name,
-    summary: result.summary,
-    data: result.data,
+    triggered: {
+      detectorId: detector.id,
+      detectorName: detector.name,
+      summary: result.summary,
+      data: result.data,
+    },
+    usage,
   };
 }
 
@@ -169,12 +196,30 @@ async function processTrace(
     }),
     prisma.project.findUnique({
       where: { id: projectId },
-      select: { name: true, workspaceId: true },
+      select: {
+        name: true,
+        workspaceId: true,
+        workspace: { select: { billingPlan: true, detectorBlocked: true } },
+      },
     }),
   ]);
 
   const projectName = project?.name ?? "";
   const workspaceId = project?.workspaceId ?? "";
+
+  // Free-plan detector cap enforcement — read the cached `detectorBlocked`
+  // flag set by the hourly billing job (same pattern as `aiBlocked` and
+  // `ingestionBlocked`). Worst-case overshoot: ~1h of scans between cron
+  // runs, which costs us a few cents of haiku tokens — acceptable as
+  // customer-acquisition spend per the pricing rule "Free is truly free."
+  const billingPlan = (project?.workspace?.billingPlan ?? "free") as PlanType;
+  if (project?.workspace?.detectorBlocked && billingPlan === PlanType.FREE) {
+    console.log(
+      `[Detector] Workspace ${workspaceId} is detector-blocked (Free plan cap exceeded); ` +
+        `skipping ${detectors.length} scan(s) for trace ${traceId}`,
+    );
+    return;
+  }
 
   // Run all detectors in parallel; collect triggered results
   const settled = await Promise.allSettled(
@@ -201,12 +246,38 @@ async function processTrace(
     }),
   );
 
-  const triggered = settled
-    .filter(
-      (r): r is PromiseFulfilledResult<TriggeredResult> =>
-        r.status === "fulfilled" && r.value !== null,
-    )
+  const fulfilled = settled
+    .filter((r): r is PromiseFulfilledResult<SingleDetectorOutcome> => r.status === "fulfilled")
     .map((r) => r.value);
+
+  // Persist one AIMessage row per scan with kind="detector". This is the
+  // source of truth for detector by-model + cost aggregations in the hourly
+  // billing cron — same role aIMessage plays for chat + RCA.
+  const usages = fulfilled.map((o) => o.usage).filter((u): u is ScanUsage => u !== null);
+  if (usages.length > 0 && workspaceId) {
+    const aiMessageRows = usages.map((u) => ({
+      workspaceId,
+      sessionId: null,
+      kind: "detector",
+      role: "assistant",
+      content: "", // detector scans don't have a chat-like content payload
+      model: u.inferenceModel,
+      provider: u.inferenceProvider,
+      isByok: u.inferenceSource === "byok",
+      inputTokens: u.inferenceInputTokens,
+      outputTokens: u.inferenceOutputTokens,
+      cost: u.inferenceCost,
+    }));
+    try {
+      await prisma.aIMessage.createMany({ data: aiMessageRows });
+    } catch (err) {
+      console.error(`[Detector] Failed to write aIMessage rows for trace ${traceId}:`, err);
+    }
+  }
+
+  const triggered = fulfilled
+    .map((o) => o.triggered)
+    .filter((t): t is TriggeredResult => t !== null);
 
   if (triggered.length === 0) return;
 


### PR DESCRIPTION
## Summary
Adds detector scans and auto-RCA as their own Stripe-metered products, alongside the existing chat AI runs. Each meter has its own quota, overage logic, and Free-plan hard cap. Internal architecture: one `ai_messages` table discriminated by `kind ∈ {chat, rca, detector}`, aggregated per-kind by the hourly billing cron.

## What changed

**Billing**
- Three Stripe metered products: `2026_ai_token_usage`, `2026_rca_usage`, `2026_detector_usage`. All attached to Starter and Pro at checkout and on plan changes.
- Plan changes now set `billing_cycle_anchor: "now"` so quotas reset cleanly on upgrade.
- Hourly cron rewritten around `aggregateMessagesForKind(workspaceId, kind, period)` — one helper, three call sites.
- Three Free-plan hard-cap flags: `aiBlocked` / `rcaBlocked` / `detectorBlocked`. Set by the cron, honored by the chat / RCA / detector workers respectively.

**Schema** (folded into the existing `20260414000000_add_detectors` migration since detectors haven't shipped to prod):
- `workspaces.detector_blocked`, `workspaces.rca_blocked`
- `ai_messages.kind` (default `"chat"`), `ai_messages.workspace_id` (FK + index, backfilled from sessions), `ai_messages.session_id` made nullable so detector-scan rows can live without a chat session

**UI**
- `BillingTab` now has three usage sections (Chat / Detector / RCA) extracted into one `<UsageSection>` component; ~150 lines of copy-paste deduped.
- Live Stripe subscription info, cancellation + scheduled-change banners (carry-forward, not new).

**Dependencies**
- `@mariozechner/pi-ai@0.57.1` → `@earendil-works/pi-ai@0.74.0` (deprecation rename; new `params: unknown` tool signature requires per-tool typed cast)
- Detector eval `SAFETY_TRUNCATE_CHARS` bumped 40k → 150k (~19% of haiku 200k window)
**Backend**
- New `/api/v1/internal/usage/details` returns `{ traces, spans, detector_runs }` from ClickHouse with `uniqExact` for `ReplacingMergeTree` dedup.

## Screenshots
<img width="1706" height="964" alt="Screenshot 2026-05-10 at 7 20 53 PM" src="https://github.com/user-attachments/assets/c91aa56c-98af-4912-ac00-795feeb16fba" />
<img width="1715" height="970" alt="Screenshot 2026-05-10 at 6 49 19 PM" src="https://github.com/user-attachments/assets/dc4f7e75-a631-4b6e-a760-69eb8e8d5419" />

## Test plan
- [x] Unit tests: 170 passing (66 worker + 34 core + 70 ui)
- [x] Free → Pro upgrade: 3 metered items attached at checkout
- [x] Chat / RCA / detector all metered independently with correct `kind` attribution
- [x] Cost attribution: system vs BYOK separation works
- [x] Under-quota: 0 units pushed to Stripe (no spurious billing)
- [x] Billing cron manually triggered multiple times, deltas correct
- [x] Validated in prior sessions: downgrade Pro → Starter / Free, overage past quota, rcaBlocked flip

## Deployment notes
- Run `make dev-reset` locally before testing — the `add_detectors` migration was modified to absorb three follow-up migrations.
- Prod hasn't run any of `feat/detector-epic-v1`'s migrations yet (only `init` is on `main`), so the consolidation is operationally a no-op for prod.
- Stripe Dashboard PROD: create the three metered products with matching event names + per-unit pricing before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds separate Stripe meters for chat, RCA, and detector usage with independent quotas and Free caps. Also fixes RCA overage markup, deduplicates detector run counts, surfaces missing meter config, and marks blocked RCA rows as terminal to avoid stuck “pending” states.

- **New Features**
  - Stripe: three metered products (`2026_ai_token_usage`, `2026_rca_usage`, `2026_detector_usage`) attached at checkout and on plan changes (`billing_cycle_anchor: "now"`).
  - Billing/Schema/UI: hourly cron aggregates by `ai_messages.kind ∈ {chat, rca, detector}`; adds `aiBlocked`/`rcaBlocked`/`detectorBlocked`; `/api/v1/internal/usage/details` returns `{ traces, spans, detector_runs }` with `uniqExact`; Billing tab shows Chat/Detector/RCA with clearer labels.
  - Slack: install flow and alert fanout gated by plan entitlement with upgrade prompts.
  - Dependencies: migrate to `@earendil-works/pi-ai@0.74.0` and `@earendil-works/pi-agent-core@0.74.0` (tools take `params: unknown`); pin `pnpm@10` in Node-based Dockerfiles.

- **Bug Fixes**
  - RCA overage: apply 1.05× system-inference markup only to the overage portion via proportional allocation.
  - RCA UI: mark `rcaBlocked` skips as `failed` with a “Skipped — quota exceeded” message so rows don’t remain “pending”.
  - Usage accuracy: count `detector_runs` with `uniqExact(run_id)` to avoid ReplacingMergeTree pre-merge dupes.
  - Stripe config: log warnings when `STRIPE_PRICE_ID_*` env vars are missing in checkout and plan-change flows.
  - Cleanup: remove orphaned dev script that referenced a non-existent billing runner.

<sup>Written for commit f2b44ed66e29498e04472967322a27c5a062d731. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

