### PR TITLE
Security: Open Redirect Vulnerability in GitHub OAuth returnTo Parameter

### DIFF
--- a/frontend/ui/src/app/api/github/login/route.ts
+++ b/frontend/ui/src/app/api/github/login/route.ts
@@ -9,7 +9,13 @@ export async function GET(request: NextRequest) {
     if (authResult.error) return authResult.error;
 
     const state = crypto.randomUUID();
-    const returnTo = request.nextUrl.searchParams.get("returnTo") || "/";
+    const returnToParam = request.nextUrl.searchParams.get("returnTo");
+    let returnTo = "/";
+
+    // Validate returnTo is a relative path to prevent open redirect vulnerability
+    if (returnToParam && returnToParam.startsWith("/")) {
+      returnTo = returnToParam;
+    }
 
     const params = new URLSearchParams({
       client_id: env.GITHUB_APP_CLIENT_ID,


### PR DESCRIPTION
## Summary

Security: Open Redirect Vulnerability in GitHub OAuth returnTo Parameter

## Problem

**Severity**: `High` | **File**: `frontend/ui/src/app/api/github/login/route.ts:L14`

The returnTo parameter in /api/github/login and /api/github/install is used directly without validation. An attacker could craft a URL like /api/github/login?returnTo=https://evil.com to redirect users to a malicious site after GitHub OAuth flow completes.

## Solution

Validate returnTo is a relative path (starts with /) or matches an allowed domain. Reject absolute URLs with different origins. Use URL constructor to parse and verify the origin/hostname.

## Changes

- `frontend/ui/src/app/api/github/login/route.ts` (modified)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix open redirect in GitHub OAuth login by validating the `returnTo` query param. Only relative paths are allowed; external URLs are ignored and we fall back to `/`.

- **Bug Fixes**
  - Validate `returnTo` starts with `/`; block absolute/external URLs to prevent off-site redirects.
  - Fallback to `/` when invalid or missing in `frontend/ui/src/app/api/github/login/route.ts`.

<sup>Written for commit 09e1d536366ca0e62df7d41a0cf73ef70bb3dc78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

