### PR TITLE
fix(docs): integration overview logos broken in production

### DIFF
--- a/docs/integrations/overview.mdx
+++ b/docs/integrations/overview.mdx
@@ -49,8 +49,8 @@ Don't see your integration? [Request one on GitHub](https://github.com/traceroot
 Auto-instrument with TraceRoot's official SDKs.
 
 <IntegrationGrid cols={2}>
-  <IntegrationCard logo="/logo/integrations/python.svg" logoDark="/logo/integrations/python-dark.svg" title="Python SDK" href="/tracing/python-sdk" />
-  <IntegrationCard logo="/logo/integrations/typescript.svg" logoDark="/logo/integrations/typescript-dark.svg" title="TypeScript SDK" href="/tracing/typescript-sdk" />
+  <IntegrationCard logo="../logo/integrations/python.svg" logoDark="../logo/integrations/python-dark.svg" title="Python SDK" href="/tracing/python-sdk" />
+  <IntegrationCard logo="../logo/integrations/typescript.svg" logoDark="../logo/integrations/typescript-dark.svg" title="TypeScript SDK" href="/tracing/typescript-sdk" />
 </IntegrationGrid>
 
 ## Frameworks
@@ -58,18 +58,18 @@ Auto-instrument with TraceRoot's official SDKs.
 Trace popular agent frameworks and orchestration libraries.
 
 <IntegrationGrid cols={3}>
-  <IntegrationCard logo="/logo/integrations/agno.png" title="Agno" href="/integrations/agno" />
-  <IntegrationCard logo="/logo/integrations/autogen.svg" title="AutoGen" href="/integrations/autogen" />
-  <IntegrationCard logo="/logo/integrations/claude-agent-sdk.svg" title="Claude Agent SDK" href="/integrations/claude-agent-sdk" />
-  <IntegrationCard logo="/logo/integrations/crewai.svg" title="CrewAI" href="/integrations/crewai" />
-  <IntegrationCard logo="/logo/integrations/dspy.png" title="DSPy" href="/integrations/dspy" />
-  <IntegrationCard logo="/logo/integrations/google-adk.png" title="Google ADK" href="/integrations/google-adk" />
-  <IntegrationCard logo="/logo/integrations/langchain.png" title="LangChain & LangGraph" href="/integrations/langchain" />
-  <IntegrationCard logo="/logo/integrations/langchain.png" title="LangChain DeepAgents" href="/integrations/langchain-deepagents" />
-  <IntegrationCard logo="/logo/integrations/llamaindex.png" title="LlamaIndex" href="/integrations/llamaindex" />
-  <IntegrationCard logo="/logo/integrations/mastra.svg" logoDark="/logo/integrations/mastra-dark.svg" title="Mastra" href="/integrations/mastra" />
-  <IntegrationCard logo="/logo/integrations/openai-agents-sdk.svg" logoDark="/logo/integrations/openai-agents-sdk-dark.svg" title="OpenAI Agents SDK" href="/integrations/openai-agents-sdk" />
-  <IntegrationCard logo="/logo/integrations/vercel-ai.svg" logoDark="/logo/integrations/vercel-ai-dark.svg" title="Vercel AI SDK" href="/integrations/vercel-ai" />
+  <IntegrationCard logo="../logo/integrations/agno.png" title="Agno" href="/integrations/agno" />
+  <IntegrationCard logo="../logo/integrations/autogen.svg" title="AutoGen" href="/integrations/autogen" />
+  <IntegrationCard logo="../logo/integrations/claude-agent-sdk.svg" title="Claude Agent SDK" href="/integrations/claude-agent-sdk" />
+  <IntegrationCard logo="../logo/integrations/crewai.svg" title="CrewAI" href="/integrations/crewai" />
+  <IntegrationCard logo="../logo/integrations/dspy.png" title="DSPy" href="/integrations/dspy" />
+  <IntegrationCard logo="../logo/integrations/google-adk.png" title="Google ADK" href="/integrations/google-adk" />
+  <IntegrationCard logo="../logo/integrations/langchain.png" title="LangChain & LangGraph" href="/integrations/langchain" />
+  <IntegrationCard logo="../logo/integrations/langchain.png" title="LangChain DeepAgents" href="/integrations/langchain-deepagents" />
+  <IntegrationCard logo="../logo/integrations/llamaindex.png" title="LlamaIndex" href="/integrations/llamaindex" />
+  <IntegrationCard logo="../logo/integrations/mastra.svg" logoDark="../logo/integrations/mastra-dark.svg" title="Mastra" href="/integrations/mastra" />
+  <IntegrationCard logo="../logo/integrations/openai-agents-sdk.svg" logoDark="../logo/integrations/openai-agents-sdk-dark.svg" title="OpenAI Agents SDK" href="/integrations/openai-agents-sdk" />
+  <IntegrationCard logo="../logo/integrations/vercel-ai.svg" logoDark="../logo/integrations/vercel-ai-dark.svg" title="Vercel AI SDK" href="/integrations/vercel-ai" />
 </IntegrationGrid>
 
 ## Model Providers
@@ -77,10 +77,10 @@ Trace popular agent frameworks and orchestration libraries.
 Trace direct calls to LLM providers.
 
 <IntegrationGrid cols={3}>
-  <IntegrationCard logo="/logo/integrations/anthropic.svg" logoDark="/logo/integrations/anthropic-dark.svg" title="Anthropic" href="/integrations/anthropic" />
-  <IntegrationCard logo="/logo/integrations/gemini.svg" title="Google Gemini" href="/integrations/gemini" />
-  <IntegrationCard logo="/logo/integrations/mistral.svg" title="Mistral" href="/integrations/mistral" />
-  <IntegrationCard logo="/logo/integrations/openai.svg" logoDark="/logo/integrations/openai-dark.svg" title="OpenAI" href="/integrations/openai" />
+  <IntegrationCard logo="../logo/integrations/anthropic.svg" logoDark="../logo/integrations/anthropic-dark.svg" title="Anthropic" href="/integrations/anthropic" />
+  <IntegrationCard logo="../logo/integrations/gemini.svg" title="Google Gemini" href="/integrations/gemini" />
+  <IntegrationCard logo="../logo/integrations/mistral.svg" title="Mistral" href="/integrations/mistral" />
+  <IntegrationCard logo="../logo/integrations/openai.svg" logoDark="../logo/integrations/openai-dark.svg" title="OpenAI" href="/integrations/openai" />
 </IntegrationGrid>
 
 ## Internal Model Providers


### PR DESCRIPTION
Follow-up to PR875 (https://github.com/traceroot-ai/traceroot/pull/875)

## Issue
On `traceroot.ai/docs/integrations/overview` (Production code), every logo renders as a broken image after PR867 was merged.

<img width="1208" height="818" alt="Screenshot 2026-05-14 at 8 13 39 PM" src="https://github.com/user-attachments/assets/fa118be2-432b-4546-9888-f44feb2cfa27" />


Root cause: the `IntegrationCard` JSX component (introduced in #875) uses raw `<img src="/logo/integrations/...">`. Mintlify only rewrites image paths for built-in components and markdown `![]()`, not raw `<img>`. So the browser requests `traceroot.ai/logo/integrations/python.svg` (no `/docs/` prefix), which falls through to the SPA HTML fallback and returns `text/html`, and the browser refuses to render that as an image.

This patch prefixes every logo path with `/docs/` so requests resolve to `traceroot.ai/docs/logo/integrations/...`, where the assets already live.

## Verification
- `curl` against prod confirmed `/docs/logo/integrations/python.svg` returns `image/svg+xml` (200), while `/logo/integrations/python.svg` returns `text/html` (the SPA fallback).
- Ran `pnpm dlx mint dev` locally and confirmed the overview page renders all 18 logos.

## Scope
- Only `docs/integrations/overview.mdx`. 18 lines changed (path prefixes only).
- No content, layout, or component changes.
- Other integration pages (`/integrations/<name>`) are untouched and were never broken; they use plain markdown which Mintlify rewrites.

## E2e test
<img width="1147" height="848" alt="Screenshot 2026-05-14 at 8 15 45 PM" src="https://github.com/user-attachments/assets/ab4ddfb9-4f36-483b-b264-90fd463d6bdd" />
Normal and Dark mode
<img width="1242" height="857" alt="Screenshot 2026-05-14 at 8 16 01 PM" src="https://github.com/user-attachments/assets/e61fc1c8-9135-4706-a56c-fcee9fd844af" />
