### PR TITLE
feat(examples): add OpenRouter examples (Python + TypeScript)

### DIFF
--- a/examples/python/openrouter-tool-agent/.env.example
+++ b/examples/python/openrouter-tool-agent/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenRouter (https://openrouter.ai/keys)
+OPENROUTER_API_KEY=your_openrouter_api_key_here

--- a/examples/python/openrouter-tool-agent/README.md
+++ b/examples/python/openrouter-tool-agent/README.md
@@ -2,7 +2,7 @@
 
 ReAct-style agent with [OpenRouter](https://openrouter.ai/) streaming and tool use, instrumented with [TraceRoot](https://traceroot.ai).
 
-OpenRouter provides a unified API to 200+ models (GPT-4o, Claude, Llama, Gemini, Mistral, etc.). Since it's OpenAI-compatible, TraceRoot's OpenAI integration captures all calls automatically — no extra configuration needed.
+OpenRouter provides a unified API to 200+ models (Claude, Llama, Gemini, Mistral, GPT-4o, etc.). Since it's OpenAI-compatible, TraceRoot's OpenAI integration captures all calls automatically — no extra configuration needed.
 
 ## Setup
 
@@ -13,14 +13,6 @@ cp .env.example .env  # fill in OPENROUTER_API_KEY and TRACEROOT_API_KEY
 With `uv` (recommended):
 ```bash
 uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
-```
-
-## Streaming pipeline
-
-Demonstrates `@observe` on async generators — spans stay open until the last token, capturing real end-to-end latency.
-
-```bash
-uv run --no-project --python 3.13 --with-requirements requirements.txt python streaming-pipeline.py
 ```
 
 ## What it does

--- a/examples/python/openrouter-tool-agent/README.md
+++ b/examples/python/openrouter-tool-agent/README.md
@@ -1,0 +1,44 @@
+# OpenRouter Tool Agent
+
+ReAct-style agent with [OpenRouter](https://openrouter.ai/) streaming and tool use, instrumented with [TraceRoot](https://traceroot.ai).
+
+OpenRouter provides a unified API to 200+ models (GPT-4o, Claude, Llama, Gemini, Mistral, etc.). Since it's OpenAI-compatible, TraceRoot's OpenAI integration captures all calls automatically — no extra configuration needed.
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in OPENROUTER_API_KEY and TRACEROOT_API_KEY
+```
+
+With `uv` (recommended):
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+## Streaming pipeline
+
+Demonstrates `@observe` on async generators — spans stay open until the last token, capturing real end-to-end latency.
+
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python streaming-pipeline.py
+```
+
+## What it does
+
+Runs two demo queries that exercise tool use:
+1. Weather comparison (San Francisco vs Tokyo)
+2. Stock price lookup + calculation (NVDA +10%)
+
+Tools: `get_weather`, `get_stock_price`, `calculate`, `get_current_time`
+
+## Model selection
+
+Change the model by passing a different OpenRouter model string to `ReActAgent()`:
+
+```python
+agent = ReActAgent(model="anthropic/claude-3-5-sonnet")
+agent = ReActAgent(model="google/gemini-2.0-flash")
+agent = ReActAgent(model="meta-llama/llama-3.3-70b-instruct")
+```
+
+See [openrouter.ai/models](https://openrouter.ai/models) for the full list.

--- a/examples/python/openrouter-tool-agent/main.py
+++ b/examples/python/openrouter-tool-agent/main.py
@@ -183,12 +183,13 @@ class ReActAgent:
 
     Uses OpenRouter as the model provider by setting base_url on the
     OpenAI client. Any OpenRouter model string works — examples include
-    'openai/gpt-4o-mini', 'anthropic/claude-3-5-sonnet', etc.
+    'anthropic/claude-3-5-sonnet', 'meta-llama/llama-3.3-70b-instruct',
+    etc.
     """
 
     OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
-    def __init__(self, model: str = "openai/gpt-4o-mini"):
+    def __init__(self, model: str = "anthropic/claude-3-5-sonnet"):
         self.client = openai.OpenAI(
             api_key=os.environ["OPENROUTER_API_KEY"],
             base_url=self.OPENROUTER_BASE_URL,
@@ -297,7 +298,20 @@ class ReActAgent:
 
             # Execute each tool call
             for tc in msg.tool_calls:
-                args = json.loads(tc.function.arguments)
+                try:
+                    args = json.loads(tc.function.arguments)
+                except json.JSONDecodeError as e:
+                    logger.warning("Invalid tool arguments for %s: %s", tc.function.name, e)
+                    self.messages.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tc.id,
+                            "content": json.dumps(
+                                {"error": "Invalid tool arguments JSON", "details": str(e)}
+                            ),
+                        }
+                    )
+                    continue
                 logger.info(f"Tool call: {tc.function.name}({args})")
                 result = self._execute_tool(tc.function.name, args)
                 logger.info(f"Tool result: {result}")

--- a/examples/python/openrouter-tool-agent/main.py
+++ b/examples/python/openrouter-tool-agent/main.py
@@ -1,0 +1,333 @@
+"""
+OpenRouter ReAct agent with tool use, streaming, and TraceRoot observability.
+
+OpenRouter provides a unified API to 200+ models from a single endpoint.
+Since OpenRouter is OpenAI-compatible, TraceRoot's OpenAI integration
+captures all calls automatically — no extra configuration needed.
+
+Usage:
+    cp .env.example .env
+    pip install -r requirements.txt
+    python main.py
+"""
+
+import json
+import logging
+import os
+from datetime import datetime
+from types import SimpleNamespace
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found (find_dotenv returned None).\nUsing process environment variables.")
+
+import openai
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.OPENAI])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+@observe(name="get_weather", type="tool")
+def get_weather(city: str) -> dict:
+    """Get current weather for a city."""
+    weather_db = {
+        "san francisco": {"temp": 68, "condition": "foggy", "humidity": 75},
+        "new york": {"temp": 45, "condition": "cloudy", "humidity": 60},
+        "london": {"temp": 52, "condition": "rainy", "humidity": 85},
+        "tokyo": {"temp": 72, "condition": "sunny", "humidity": 50},
+    }
+    data = weather_db.get(city.lower(), {"temp": 70, "condition": "unknown", "humidity": 50})
+    return {"city": city, **data}
+
+
+@observe(name="get_stock_price", type="tool")
+def get_stock_price(symbol: str) -> dict:
+    """Get stock price for a symbol."""
+    stocks = {
+        "AAPL": {"price": 178.50, "change": +2.30, "percent": "+1.3%"},
+        "GOOGL": {"price": 141.20, "change": -0.80, "percent": "-0.6%"},
+        "MSFT": {"price": 378.90, "change": +4.50, "percent": "+1.2%"},
+        "NVDA": {"price": 495.20, "change": +12.30, "percent": "+2.5%"},
+    }
+    data = stocks.get(symbol.upper(), {"price": 0, "change": 0, "percent": "N/A"})
+    return {"symbol": symbol.upper(), **data}
+
+
+@observe(name="calculate", type="tool")
+def calculate(expression: str) -> dict:
+    """Evaluate a math expression safely using AST parsing."""
+    import ast
+    import operator
+
+    ops = {
+        ast.Add: operator.add,
+        ast.Sub: operator.sub,
+        ast.Mult: operator.mul,
+        ast.Div: operator.truediv,
+    }
+
+    def _eval(node):
+        if isinstance(node, ast.Expression):
+            return _eval(node.body)
+        if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+            return node.value
+        if isinstance(node, ast.BinOp) and type(node.op) in ops:
+            return ops[type(node.op)](_eval(node.left), _eval(node.right))
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -_eval(node.operand)
+        raise ValueError(f"Unsupported expression: {ast.dump(node)}")
+
+    try:
+        tree = ast.parse(expression, mode="eval")
+        result = _eval(tree)
+        return {"expression": expression, "result": result}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+@observe(name="get_current_time", type="tool")
+def get_current_time(timezone: str = "UTC") -> dict:
+    """Get current time."""
+    return {"timezone": timezone, "time": datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+
+
+TOOLS = {
+    "get_weather": get_weather,
+    "get_stock_price": get_stock_price,
+    "calculate": calculate,
+    "get_current_time": get_current_time,
+}
+
+TOOL_SCHEMAS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string", "description": "City name"}},
+                "required": ["city"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_stock_price",
+            "description": "Get current stock price for a ticker symbol",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "symbol": {"type": "string", "description": "Stock ticker symbol (e.g., AAPL)"}
+                },
+                "required": ["symbol"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "calculate",
+            "description": "Evaluate a mathematical expression",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "expression": {
+                        "type": "string",
+                        "description": "Math expression (e.g., '2 + 2 * 3')",
+                    }
+                },
+                "required": ["expression"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_current_time",
+            "description": "Get the current date and time",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "timezone": {"type": "string", "description": "Timezone (default: UTC)"}
+                },
+                "required": [],
+            },
+        },
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class ReActAgent:
+    """ReAct-style agent that reasons and acts in a loop with streaming.
+
+    Uses OpenRouter as the model provider by setting base_url on the
+    OpenAI client. Any OpenRouter model string works — examples include
+    'openai/gpt-4o-mini', 'anthropic/claude-3-5-sonnet', etc.
+    """
+
+    OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+    def __init__(self, model: str = "openai/gpt-4o-mini"):
+        self.client = openai.OpenAI(
+            api_key=os.environ["OPENROUTER_API_KEY"],
+            base_url=self.OPENROUTER_BASE_URL,
+        )
+        self.model = model
+        self.messages: list[dict] = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a helpful AI assistant with access to tools. "
+                    "Use available tools to gather information, then provide "
+                    "a clear, comprehensive answer."
+                ),
+            }
+        ]
+
+    @observe(name="execute_tool", type="span")
+    def _execute_tool(self, name: str, arguments: dict) -> str:
+        if name not in TOOLS:
+            return json.dumps({"error": f"Unknown tool: {name}"})
+        try:
+            return json.dumps(TOOLS[name](**arguments))
+        except Exception as e:
+            return json.dumps({"error": str(e)})
+
+    @observe(name="llm_completion_stream", type="span")
+    def _stream_completion(self) -> SimpleNamespace:
+        """Stream a chat completion and return a message-like object."""
+        stream = self.client.chat.completions.create(
+            model=self.model,
+            messages=self.messages,
+            tools=TOOL_SCHEMAS,
+            tool_choice="auto",
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+
+        content = ""
+        tool_calls: dict[int, dict] = {}
+
+        for chunk in stream:
+            if not chunk.choices:
+                continue
+            delta = chunk.choices[0].delta
+
+            if delta.content:
+                content += delta.content
+
+            if delta.tool_calls:
+                for tc in delta.tool_calls:
+                    idx = tc.index
+                    if idx not in tool_calls:
+                        tool_calls[idx] = {"id": "", "function": {"name": "", "arguments": ""}}
+                    if tc.id:
+                        tool_calls[idx]["id"] = tc.id
+                    if tc.function:
+                        if tc.function.name:
+                            tool_calls[idx]["function"]["name"] = tc.function.name
+                        if tc.function.arguments:
+                            tool_calls[idx]["function"]["arguments"] += tc.function.arguments
+
+        return SimpleNamespace(
+            content=content,
+            tool_calls=[
+                SimpleNamespace(
+                    id=tc["id"],
+                    function=SimpleNamespace(
+                        name=tc["function"]["name"],
+                        arguments=tc["function"]["arguments"],
+                    ),
+                )
+                for tc in tool_calls.values()
+            ]
+            or None,
+        )
+
+    @observe(name="agent_turn", type="agent")
+    def run(self, query: str) -> str:
+        self.messages.append({"role": "user", "content": query})
+
+        for _ in range(5):
+            msg = self._stream_completion()
+
+            if not msg.tool_calls:
+                self.messages.append({"role": "assistant", "content": msg.content})
+                return msg.content
+
+            # Append assistant message with tool calls
+            self.messages.append(
+                {
+                    "role": "assistant",
+                    "content": msg.content,
+                    "tool_calls": [
+                        {
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {
+                                "name": tc.function.name,
+                                "arguments": tc.function.arguments,
+                            },
+                        }
+                        for tc in msg.tool_calls
+                    ],
+                }
+            )
+
+            # Execute each tool call
+            for tc in msg.tool_calls:
+                args = json.loads(tc.function.arguments)
+                logger.info(f"Tool call: {tc.function.name}({args})")
+                result = self._execute_tool(tc.function.name, args)
+                logger.info(f"Tool result: {result}")
+                self.messages.append({"role": "tool", "tool_call_id": tc.id, "content": result})
+
+        return "I wasn't able to complete this task within the allowed steps."
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+DEMO_QUERIES = [
+    "What's the weather in San Francisco and Tokyo? Compare them.",
+    "What's NVDA stock price? If it goes up 10%, what would the new price be?",
+]
+
+
+@observe(name="demo_session", type="agent")
+def run_demo():
+    for i, query in enumerate(DEMO_QUERIES, 1):
+        agent = ReActAgent()
+        print(f"\n{'=' * 60}")
+        print(f"Query {i}: {query}")
+        print("=" * 60)
+        result = agent.run(query)
+        print(f"\nAgent: {result}\n")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="openrouter-tool-agent-session"):
+        run_demo()
+    traceroot.flush()

--- a/examples/python/openrouter-tool-agent/requirements.txt
+++ b/examples/python/openrouter-tool-agent/requirements.txt
@@ -1,0 +1,4 @@
+openai>=1.0.0
+python-dotenv>=1.0.0
+
+traceroot==0.1.4

--- a/examples/typescript/openrouter/.env.example
+++ b/examples/typescript/openrouter/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenRouter (https://openrouter.ai/keys)
+OPENROUTER_API_KEY=your_openrouter_api_key_here

--- a/examples/typescript/openrouter/README.md
+++ b/examples/typescript/openrouter/README.md
@@ -1,0 +1,39 @@
+# OpenRouter Tool Agent
+
+ReAct-style agent with [OpenRouter](https://openrouter.ai/) tool calling, instrumented with [TraceRoot](https://traceroot.ai).
+
+OpenRouter provides a unified API to 200+ models (GPT-4o, Claude, Llama, Gemini, Mistral, etc.). Since it's OpenAI-compatible, TraceRoot's OpenAI instrumentation captures all calls automatically — no extra configuration needed.
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in OPENROUTER_API_KEY and TRACEROOT_API_KEY
+pnpm install
+```
+
+## Usage
+
+```bash
+pnpm demo        # tool-calling agent
+```
+
+## What it does
+
+Runs three demo queries that exercise tool use:
+1. Weather comparison (San Francisco vs Tokyo)
+2. Stock price lookup + calculation (NVDA +10%)
+3. Web search + summarization
+
+Tools: `get_weather`, `get_stock_price`, `calculate`, `search_web`, `get_current_time`
+
+## Model selection
+
+Change the model by editing the `model` property in `ReActAgent`:
+
+```ts
+private readonly model = 'anthropic/claude-3-5-sonnet';
+// or: 'google/gemini-2.0-flash'
+// or: 'meta-llama/llama-3.3-70b-instruct'
+```
+
+See [openrouter.ai/models](https://openrouter.ai/models) for the full list.

--- a/examples/typescript/openrouter/README.md
+++ b/examples/typescript/openrouter/README.md
@@ -2,7 +2,7 @@
 
 ReAct-style agent with [OpenRouter](https://openrouter.ai/) tool calling, instrumented with [TraceRoot](https://traceroot.ai).
 
-OpenRouter provides a unified API to 200+ models (GPT-4o, Claude, Llama, Gemini, Mistral, etc.). Since it's OpenAI-compatible, TraceRoot's OpenAI instrumentation captures all calls automatically — no extra configuration needed.
+OpenRouter provides a unified API to 200+ models (Claude, Llama, Gemini, Mistral, GPT-4o, etc.). Since it's OpenAI-compatible, TraceRoot's OpenAI instrumentation captures all calls automatically — no extra configuration needed.
 
 ## Setup
 

--- a/examples/typescript/openrouter/agent.ts
+++ b/examples/typescript/openrouter/agent.ts
@@ -1,0 +1,249 @@
+/**
+ * OpenRouter ReAct Agent — TraceRoot Observability
+ *
+ * Uses @traceroot/sdk with instrumentModules to auto-instrument all
+ * calls through OpenRouter's OpenAI-compatible API.
+ *
+ * OpenRouter baseURL: https://openrouter.ai/api/v1
+ *
+ * Env vars required: OPENROUTER_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm demo
+ */
+
+import 'dotenv/config';
+import OpenAI from 'openai';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
+
+// ── TraceRoot setup ───────────────────────────────────────────────────────────
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const openai = new OpenAI({
+  apiKey: process.env.OPENROUTER_API_KEY,
+  baseURL: 'https://openrouter.ai/api/v1',
+});
+console.log('[Observability: TraceRoot + OpenRouter]');
+
+// ── Tools ─────────────────────────────────────────────────────────────────────
+type ToolResult = Record<string, unknown>;
+
+function getWeather(city: string): ToolResult {
+  const db: Record<string, ToolResult> = {
+    'san francisco': { temp: 68, condition: 'foggy', humidity: 75 },
+    'new york': { temp: 45, condition: 'cloudy', humidity: 60 },
+    'london': { temp: 52, condition: 'rainy', humidity: 85 },
+    'tokyo': { temp: 72, condition: 'sunny', humidity: 50 },
+    'paris': { temp: 58, condition: 'partly cloudy', humidity: 65 },
+  };
+  return { city, ...(db[city.toLowerCase()] ?? { temp: 70, condition: 'unknown', humidity: 50 }) };
+}
+
+function searchWeb(query: string): ToolResult[] {
+  return [
+    { title: `Result 1 for '${query}'`, snippet: `This is information about ${query}...` },
+    { title: `Result 2 for '${query}'`, snippet: `More details on ${query} can be found...` },
+  ];
+}
+
+function getStockPrice(symbol: string): ToolResult {
+  const stocks: Record<string, ToolResult> = {
+    AAPL: { price: 178.5, change: +2.3, percent: '+1.3%' },
+    GOOGL: { price: 141.2, change: -0.8, percent: '-0.6%' },
+    MSFT: { price: 378.9, change: +4.5, percent: '+1.2%' },
+    NVDA: { price: 495.2, change: +12.3, percent: '+2.5%' },
+  };
+  return {
+    symbol: symbol.toUpperCase(),
+    ...(stocks[symbol.toUpperCase()] ?? { price: 0, change: 0, percent: 'N/A' }),
+  };
+}
+
+function calculate(expression: string): ToolResult {
+  try {
+    if (!/^[0-9+\-*/.() ]+$/.test(expression)) return { error: 'Invalid expression' };
+    // eslint-disable-next-line no-eval
+    return { expression, result: eval(expression) as number };
+  } catch (e) {
+    return { error: String(e) };
+  }
+}
+
+function getCurrentTime(timezone = 'UTC'): ToolResult {
+  return { timezone, time: new Date().toISOString() };
+}
+
+const TOOLS: Record<string, (a: Record<string, unknown>) => ToolResult | ToolResult[]> = {
+  get_weather: (a) => getWeather(a.city as string),
+  search_web: (a) => searchWeb(a.query as string),
+  get_stock_price: (a) => getStockPrice(a.symbol as string),
+  calculate: (a) => calculate(a.expression as string),
+  get_current_time: (a) => getCurrentTime(a.timezone as string | undefined),
+};
+
+const TOOL_SCHEMAS: OpenAI.Chat.ChatCompletionTool[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'get_weather',
+      description: 'Get current weather for a city',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string', description: 'City name' } },
+        required: ['city'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'search_web',
+      description: 'Search the web for information',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string', description: 'Search query' } },
+        required: ['query'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_stock_price',
+      description: 'Get current stock price for a ticker symbol',
+      parameters: {
+        type: 'object',
+        properties: {
+          symbol: { type: 'string', description: 'Stock ticker symbol (e.g., AAPL)' },
+        },
+        required: ['symbol'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'calculate',
+      description: 'Evaluate a mathematical expression',
+      parameters: {
+        type: 'object',
+        properties: { expression: { type: 'string', description: 'Math expression' } },
+        required: ['expression'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_current_time',
+      description: 'Get the current date and time',
+      parameters: {
+        type: 'object',
+        properties: { timezone: { type: 'string', description: 'Timezone (default: UTC)' } },
+      },
+    },
+  },
+];
+
+// ── Agent ─────────────────────────────────────────────────────────────────────
+const SYSTEM_PROMPT = `You are a helpful AI assistant with access to tools.
+When answering questions:
+1. Think about what information you need
+2. Use available tools to gather information
+3. Combine information from multiple sources when helpful
+4. Provide a clear, comprehensive answer
+Available tools: weather, web search, stock prices, calculator, current time.`;
+
+class ReActAgent {
+  private conversationHistory: OpenAI.Chat.ChatCompletionMessageParam[] = [];
+  private readonly model = 'openai/gpt-4o-mini';
+
+  constructor() {
+    this.conversationHistory.push({ role: 'system', content: SYSTEM_PROMPT });
+  }
+
+  private async executeTool(name: string, fnArgs: Record<string, unknown>): Promise<string> {
+    const result = await observe({ name: `tool:${name}`, type: 'tool' }, async () => {
+      if (name in TOOLS) return TOOLS[name](fnArgs);
+      return { error: `Unknown tool: ${name}` };
+    });
+    return JSON.stringify(result);
+  }
+
+  async runTurn(userInput: string): Promise<string> {
+    return observe({ name: 'agent_turn', type: 'agent' }, async () => {
+      this.conversationHistory.push({ role: 'user', content: userInput });
+
+      for (let i = 0; i < 5; i++) {
+        const completion = await openai.chat.completions.create({
+          model: this.model,
+          messages: this.conversationHistory,
+          tools: TOOL_SCHEMAS,
+          tool_choice: 'auto',
+        });
+
+        const msg = completion.choices[0].message;
+
+        if (msg.tool_calls && msg.tool_calls.length > 0) {
+          this.conversationHistory.push(msg);
+          for (const tc of msg.tool_calls) {
+            const fnArgs = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+            console.log(`\n  [Tool: ${tc.function.name}(${JSON.stringify(fnArgs)})]`);
+            const result = await this.executeTool(tc.function.name, fnArgs);
+            console.log(`  [Result: ${result}]`);
+            this.conversationHistory.push({ role: 'tool', tool_call_id: tc.id, content: result });
+          }
+        } else {
+          const response = msg.content ?? '';
+          this.conversationHistory.push({ role: 'assistant', content: response });
+          return response;
+        }
+      }
+      return "I wasn't able to complete this task within the allowed steps.";
+    });
+  }
+}
+
+// ── Demo ──────────────────────────────────────────────────────────────────────
+const DEMO_QUERIES = [
+  "What's the weather in San Francisco and Tokyo? Compare them.",
+  "What's NVDA stock price? If it goes up 10%, what would the new price be?",
+  'Search for information about AI observability and summarize what you find.',
+];
+
+async function main() {
+  try {
+    await usingAttributes(
+      {
+        sessionId: 'openrouter-demo-session',
+        userId: 'demo-user',
+        tags: ['demo', 'openrouter', 'react-agent'],
+        metadata: { example: 'openrouter-react-agent', sdkFeature: 'usingAttributes' },
+      },
+      () => observe({ name: 'demo_session' }, async () => {
+        console.log('='.repeat(60));
+        console.log('OpenRouter ReAct Agent — Demo (TraceRoot)');
+        console.log('='.repeat(60));
+
+        for (let i = 0; i < DEMO_QUERIES.length; i++) {
+          const query = DEMO_QUERIES[i];
+          const agent = new ReActAgent();
+          console.log(`\n${'='.repeat(60)}`);
+          console.log(`Query ${i + 1}: ${query}`);
+          console.log('='.repeat(60));
+          process.stdout.write('\nAgent: ');
+          const response = await agent.runTurn(query);
+          console.log(response);
+          console.log();
+        }
+      }),
+    );
+  } finally {
+    await TraceRoot.shutdown();
+    console.log('[Traces exported]');
+  }
+}
+
+main().catch(console.error);

--- a/examples/typescript/openrouter/agent.ts
+++ b/examples/typescript/openrouter/agent.ts
@@ -158,7 +158,7 @@ Available tools: weather, web search, stock prices, calculator, current time.`;
 
 class ReActAgent {
   private conversationHistory: OpenAI.Chat.ChatCompletionMessageParam[] = [];
-  private readonly model = 'openai/gpt-4o-mini';
+  private readonly model = 'anthropic/claude-3-5-sonnet';
 
   constructor() {
     this.conversationHistory.push({ role: 'system', content: SYSTEM_PROMPT });
@@ -189,7 +189,18 @@ class ReActAgent {
         if (msg.tool_calls && msg.tool_calls.length > 0) {
           this.conversationHistory.push(msg);
           for (const tc of msg.tool_calls) {
-            const fnArgs = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+            let fnArgs: Record<string, unknown>;
+            try {
+              fnArgs = JSON.parse(tc.function.arguments) as Record<string, unknown>;
+            } catch (error) {
+              const result = JSON.stringify({
+                error: 'Invalid tool arguments JSON',
+                details: error instanceof Error ? error.message : String(error),
+              });
+              console.warn(`\n  [Tool: ${tc.function.name}(invalid JSON)]`);
+              this.conversationHistory.push({ role: 'tool', tool_call_id: tc.id, content: result });
+              continue;
+            }
             console.log(`\n  [Tool: ${tc.function.name}(${JSON.stringify(fnArgs)})]`);
             const result = await this.executeTool(tc.function.name, fnArgs);
             console.log(`  [Result: ${result}]`);

--- a/examples/typescript/openrouter/package.json
+++ b/examples/typescript/openrouter/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@traceroot/example-openrouter",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "demo": "tsx agent.ts"
+  },
+  "dependencies": {
+    "@traceroot-ai/traceroot": "0.1.2",
+    "dotenv": "^16.4.5",
+    "openai": "^6.7.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/typescript/openrouter/tsconfig.json
+++ b/examples/typescript/openrouter/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["agent.ts"]
+}


### PR DESCRIPTION
## Summary
Fixes #742 by adding working OpenRouter examples in both Python and TypeScript.

OpenRouter is a popular unified API router for 200+ models. Since it's OpenAI-compatible, TraceRoot's existing OpenAI instrumentation captures all calls automatically — this PR just adds discoverable examples.

## Changes

### Python: `examples/python/openrouter-tool-agent/`
- `main.py` — ReAct agent with streaming + tool use, adapted from the OpenAI example with `base_url="https://openrouter.ai/api/v1"` and `OPENROUTER_API_KEY`
- `requirements.txt` — same dependencies as openai-tool-agent
- `README.md` — setup instructions with model selection examples
- `.env.example` — environment variable template

### TypeScript: `examples/typescript/openrouter/`
- `agent.ts` — ReAct agent with `instrumentModules`, adapted from the OpenAI example with `baseURL: "https://openrouter.ai/api/v1"` and `OPENROUTER_API_KEY`
- `package.json` — same dependencies as openai example, scoped as `@traceroot/example-openrouter`
- `tsconfig.json` — TypeScript config matching existing examples
- `README.md` — setup instructions with model selection examples
- `.env.example` — environment variable template

## Key implementation note
```python
# Python
client = OpenAI(api_key=os.environ["OPENROUTER_API_KEY"], base_url="https://openrouter.ai/api/v1")
```
```typescript
// TypeScript
const client = new OpenAI({ apiKey: process.env.OPENROUTER_API_KEY, baseURL: "https://openrouter.ai/api/v1" });
```

## Checklist
- [x] Follows existing example structure (naming, file layout, conventions)
- [x] No SDK code changes — examples only
- [x] Both Python and TypeScript examples included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenRouter examples in Python and TypeScript to show TraceRoot capturing OpenAI‑compatible calls without SDK changes. Closes #742.

- **New Features**
  - Python: `examples/python/openrouter-tool-agent/` — ReAct agent with streaming and tools; uses `openai` with `base_url` set to OpenRouter and `OPENROUTER_API_KEY`; includes README and `.env.example`.
  - TypeScript: `examples/typescript/openrouter/` — ReAct agent with tool calling; uses `@traceroot-ai/traceroot` with `instrumentModules` and the `openai` SDK pointed at OpenRouter; includes README and `.env.example`.

- **Bug Fixes**
  - Addressed example feedback to improve setup clarity and tool-call robustness (env vars, invalid JSON handling).

<sup>Written for commit d86b7171994dcee8d65b4a1b04e7ee16202ffb02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/897?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

