### PR TITLE
ci: add detector image to custom build matrix

### DIFF
--- a/.github/workflows/_docker-images-custom.yml
+++ b/.github/workflows/_docker-images-custom.yml
@@ -42,6 +42,8 @@ jobs:
             dockerfile: docker/Dockerfile.billing
           - service: agent
             dockerfile: docker/Dockerfile.agent
+          - service: detector
+            dockerfile: docker/Dockerfile.detector
           - service: migrate-clickhouse
             dockerfile: docker/Dockerfile.migrate-clickhouse
           - service: migrate-postgres


### PR DESCRIPTION
## Summary

Mirrors the regular \`docker-images.yml\` service matrix in \`_docker-images-custom.yml\` so that custom-branch / staging-targeted builds also emit a \`detector\` image to ECR.

The detector service was added in #900 (detectors epic v1). The regular \`docker-images.yml\` workflow already had detector in its matrix, but \`_docker-images-custom.yml\` — which is what the staging deploy path triggers via \`gh workflow run\` to build images for a specific SHA — did not. Result: staging Deployments that pull \`detector:sha-<commit>\` hit \`ImagePullBackOff\` because the tag was never built or pushed.

## Test plan

- [x] Trigger \`_docker-images-custom.yml\` for a known SHA; verify a \`detector\` job appears in the matrix and produces \`<ecr-uri>/detector:sha-<short>\`
- [x] Re-run the staging deploy of #900 with the new image set; detector pod reaches Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `detector` image to the custom Docker build matrix so staging builds publish it to ECR. Fixes ImagePullBackOff in staging when deployments reference `detector:sha-<commit>`.

- **Bug Fixes**
  - Added `detector` to `_docker-images-custom.yml` matrix using `docker/Dockerfile.detector`, matching `docker-images.yml`.

<sup>Written for commit b358b651a0ed2c5ed2eb2ad2402e107b53b90868. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/902?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

