### PR TITLE
docs: add Live Tracing coverage

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -90,7 +90,8 @@
                   "tracing/metadata",
                   "tracing/cost-tracking",
                   "tracing/git-context",
-                  "tracing/timeline"
+                  "tracing/timeline",
+                  "tracing/live-streaming"
                 ]
               }
             ]

--- a/docs/tracing/live-streaming.mdx
+++ b/docs/tracing/live-streaming.mdx
@@ -1,0 +1,20 @@
+---
+title: Live Tracing
+description: Watch spans stream into the trace viewer in real time while your agent is still running
+---
+
+When you open a trace whose root span hasn't ended yet, TraceRoot streams new spans into the viewer as they arrive. There is no toggle and no SDK flag — live tracing is on by default for every in-flight trace.
+
+<Frame>
+  <img src="/images/trace_live_v1.png" alt="TraceRoot trace viewer streaming new spans live while an agent runs" />
+</Frame>
+
+## How spans arrive
+
+Spans are merged into the existing tree by span ID, so they can arrive in any order:
+
+- Newly started spans appear as **pending** rows (greyed out, no duration yet).
+- When a pending span finishes, its end time fills in and the row renders normally.
+- The [Timeline View](/tracing/timeline) updates in step — bars extend and new bars appear.
+
+Once the root span completes, the viewer makes a final consistency pass and stops streaming.


### PR DESCRIPTION
## Summary

Adds `tracing/live-streaming.mdx` under **Tracing → Features** in `docs.json`, documenting the SSE-based real-time span streaming in the trace viewer.

Covers:
- What live tracing is and when it kicks in (open the trace viewer on an in-flight trace)
- How spans stream in as the agent runs (pending placeholders that fill in)
- No setup required — automatic for any in-flight trace
- One screenshot using the existing `trace_live_v1.png`

## Test plan

- [x] `python3 -m json.tool docs/docs.json` — JSON valid
- [x] `mint dev` — left nav shows "Live Tracing" under Tracing → Features, page renders, screenshot loads, cross-links resolve
- [x] Pre-commit hooks pass

Closes #906

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Live Tracing doc under Tracing → Features and updates `docs.json` nav (closes #906). Explains SSE-based streaming for in‑flight traces, merge‑by‑ID and pending→resolved spans, timeline updates, final consistency pass, and zero setup; includes a screenshot.

<sup>Written for commit 2066b1cd7c8cc84b8ee1ccac882cbdac8955cec8. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/917?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

