### PR TITLE
docs: add Timeline view coverage

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -89,7 +89,8 @@
                   "tracing/tags",
                   "tracing/metadata",
                   "tracing/cost-tracking",
-                  "tracing/git-context"
+                  "tracing/git-context",
+                  "tracing/timeline"
                 ]
               }
             ]

--- a/docs/tracing/timeline.mdx
+++ b/docs/tracing/timeline.mdx
@@ -1,0 +1,40 @@
+---
+title: Timeline View
+description: Visualize spans as Gantt-style bars over time to spot long operations, parallelism, and gaps
+---
+
+The trace viewer renders every trace in two complementary views: **Trace** (a hierarchical tree of spans) and **Timeline** (a Gantt-style view where each span is a bar laid out over time).
+
+<Frame>
+  <img src="/images/trace_timeline_v1.png" alt="TraceRoot trace viewer showing the Timeline view with span bars" />
+</Frame>
+
+## Trace view vs Timeline view
+
+Both views show the same spans — they just emphasize different things.
+
+| Use the **Trace** view when… | Use the **Timeline** view when… |
+|---|---|
+| You want to understand the call hierarchy — which span is a child of which | You want to see how long each span took relative to the others |
+| You're inspecting attributes, inputs, and outputs of a specific span | You're looking for the critical path, the longest span, or unexpected gaps |
+| You're navigating nested agent or tool calls | You're checking whether work happened in parallel or serially |
+
+The two views share the same selection and collapse state, so collapsing a subtree or selecting a span in one is reflected in the other.
+
+## Toggling between views
+
+In the trace viewer's sub-header, two buttons sit side by side:
+
+- **Trace** — the hierarchical tree view (default).
+- **Timeline** — the Gantt-style view with span bars.
+
+Click either button to switch. Your selection persists across the switch, so you can jump back and forth without losing context.
+
+## Selecting a span from the timeline
+
+Clicking a span bar in the Timeline view does two things at once:
+
+1. Selects that span (so its details appear in the side panel).
+2. Switches back to the **Trace** view and scrolls the tree so the selected span is centered and visible — expanding any collapsed ancestors as needed.
+
+This makes the Timeline a fast jump-to: scan visually for the longest bar or the bar that looks out of place, click it, and you land on the span in the tree ready to inspect its attributes.

--- a/docs/tracing/timeline.mdx
+++ b/docs/tracing/timeline.mdx
@@ -3,38 +3,24 @@ title: Timeline View
 description: Visualize spans as Gantt-style bars over time to spot long operations, parallelism, and gaps
 ---
 
-The trace viewer renders every trace in two complementary views: **Trace** (a hierarchical tree of spans) and **Timeline** (a Gantt-style view where each span is a bar laid out over time).
+The trace viewer renders every trace as either a **Trace** view (hierarchical tree) or a **Timeline** view (Gantt-style bars). Both views share selection and collapse state.
 
 <Frame>
   <img src="/images/trace_timeline_v1.png" alt="TraceRoot trace viewer showing the Timeline view with span bars" />
 </Frame>
 
-## Trace view vs Timeline view
+## Trace vs Timeline
 
-Both views show the same spans — they just emphasize different things.
-
-| Use the **Trace** view when… | Use the **Timeline** view when… |
+| Trace view | Timeline view |
 |---|---|
-| You want to understand the call hierarchy — which span is a child of which | You want to see how long each span took relative to the others |
-| You're inspecting attributes, inputs, and outputs of a specific span | You're looking for the critical path, the longest span, or unexpected gaps |
-| You're navigating nested agent or tool calls | You're checking whether work happened in parallel or serially |
+| Call hierarchy and parent/child relationships | Span duration relative to siblings |
+| Inspecting span attributes, inputs, outputs | Finding the critical path or longest span |
+| Navigating nested agent or tool calls | Checking parallel vs serial execution |
 
-The two views share the same selection and collapse state, so collapsing a subtree or selecting a span in one is reflected in the other.
+## Toggling
 
-## Toggling between views
+Use the **Trace** / **Timeline** buttons in the trace viewer's sub-header. Selection persists across the switch.
 
-In the trace viewer's sub-header, two buttons sit side by side:
+## Click-to-select
 
-- **Trace** — the hierarchical tree view (default).
-- **Timeline** — the Gantt-style view with span bars.
-
-Click either button to switch. Your selection persists across the switch, so you can jump back and forth without losing context.
-
-## Selecting a span from the timeline
-
-Clicking a span bar in the Timeline view does two things at once:
-
-1. Selects that span (so its details appear in the side panel).
-2. Switches back to the **Trace** view and scrolls the tree so the selected span is centered and visible — expanding any collapsed ancestors as needed.
-
-This makes the Timeline a fast jump-to: scan visually for the longest bar or the bar that looks out of place, click it, and you land on the span in the tree ready to inspect its attributes.
+Clicking a bar in the Timeline view selects the span and switches back to the Trace view, scrolling and expanding ancestors so the span is visible.


### PR DESCRIPTION
## Summary

Adds `tracing/timeline.mdx` under **Tracing → Features** in `docs.json`, documenting the trace viewer's Timeline view.

Covers:
- Tree view vs Timeline view — when to use each (comparison table)
- The Trace / Timeline toggle in the trace viewer sub-header
- Click-to-select: clicking a timeline bar selects the span and scrolls the Tree view to it
- One screenshot using the existing `trace_timeline_v1.png`

## Test plan

- [x] `python3 -m json.tool docs/docs.json` — JSON valid
- [x] `mint dev` — left nav shows "Timeline View" under Tracing → Features, page renders, screenshot loads, comparison table renders
- [x] Pre-commit hooks pass

Closes #907

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new “Timeline View” page under Tracing → Features that explains when to use Timeline vs the Trace (tree) view, how the Trace/Timeline toggle works, and the click-to-select behavior, with a screenshot. Updates `docs.json` navigation and tightens the page content to match sibling docs style, addressing #907.

<sup>Written for commit 8b6554ac670c36a18257877bb09596a4a0a93344. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/918?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

