### PR TITLE
fix(pricing): match Bedrock and Vertex AI model IDs for Claude families

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -2,7 +2,7 @@
   {
     "id": "tr-claude-opus-4-6",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-6)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-6(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-6-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000015,
@@ -14,7 +14,7 @@
   {
     "id": "tr-claude-sonnet-4-6",
     "modelName": "claude-sonnet-4-6",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-6-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -26,7 +26,7 @@
   {
     "id": "tr-claude-opus-4-5",
     "modelName": "claude-opus-4-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-5)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000015,
@@ -38,7 +38,7 @@
   {
     "id": "tr-claude-sonnet-4-5",
     "modelName": "claude-sonnet-4-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-5)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -50,7 +50,7 @@
   {
     "id": "tr-claude-haiku-4-5",
     "modelName": "claude-haiku-4-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-haiku-4-5)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-haiku-4-5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-haiku(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.0000008,
@@ -254,7 +254,7 @@
   {
     "id": "tr-claude-3-5-sonnet",
     "modelName": "claude-3-5-sonnet",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-5-sonnet)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-5-sonnet(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-sonnet(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-5-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -266,7 +266,7 @@
   {
     "id": "tr-claude-3-5-haiku",
     "modelName": "claude-3-5-haiku",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-5-haiku)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-5-haiku(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-haiku(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-5-haiku(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.0000008,
@@ -278,7 +278,7 @@
   {
     "id": "tr-claude-3-opus",
     "modelName": "claude-3-opus",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-opus)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-opus(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-opus(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000015,
@@ -290,7 +290,7 @@
   {
     "id": "tr-claude-3-sonnet",
     "modelName": "claude-3-sonnet",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-sonnet)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-sonnet(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-sonnet(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -302,7 +302,7 @@
   {
     "id": "tr-claude-3-haiku",
     "modelName": "claude-3-haiku",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-haiku)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-haiku(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-haiku(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-haiku(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.00000025,
@@ -314,7 +314,7 @@
   {
     "id": "tr-claude-sonnet-4",
     "modelName": "claude-sonnet-4",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4)(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -1,8 +1,21 @@
 """Unit tests for model pricing and cost calculation."""
 
+import json
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from worker.tokens.pricing import calculate_cost, get_model_price
+
+PRICES_JSON = (
+    Path(__file__).resolve().parents[3]
+    / "frontend"
+    / "packages"
+    / "core"
+    / "src"
+    / "standard-model-prices.json"
+)
 
 # Mock data matching the standard-model-prices.json (prices in USD per token)
 MOCK_CACHE = [
@@ -89,3 +102,74 @@ class TestCalculateCost:
         # Cost should be a reasonable float, not have floating-point artifacts
         cost_str = f"{result['cost']:.10f}"
         assert "999999" not in cost_str  # No floating-point weirdness
+
+
+# ---------------------------------------------------------------------------
+# Real-JSON tests — guard against pricing patterns drifting from real model IDs
+# emitted by AWS Bedrock and Google Vertex AI (issue #877).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def real_cache() -> list[dict]:
+    """Build a pricing cache from the production standard-model-prices.json."""
+    entries = json.loads(PRICES_JSON.read_text())
+    return [
+        {
+            "model_name": e["modelName"],
+            "match_pattern": e["matchPattern"],
+            "prices": e["prices"],
+        }
+        for e in entries
+    ]
+
+
+# (model_id, expected modelName) for IDs the worker must price correctly.
+CLAUDE_BEDROCK_VERTEX_CASES = [
+    # Bedrock — with cross-region inference profile prefixes
+    ("us.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5"),
+    ("eu.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5"),
+    ("apac.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5"),
+    ("global.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5"),
+    # Bedrock — no CRIS prefix
+    ("anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5"),
+    ("us.anthropic.claude-sonnet-4-5-20250929-v1:0", "claude-sonnet-4-5"),
+    ("us.anthropic.claude-opus-4-5-20251101-v1:0", "claude-opus-4-5"),
+    ("us.anthropic.claude-sonnet-4-6-20251015-v1:0", "claude-sonnet-4-6"),
+    ("us.anthropic.claude-opus-4-6-20251015-v1:0", "claude-opus-4-6"),
+    ("us.anthropic.claude-sonnet-4-20250514-v1:0", "claude-sonnet-4"),
+    ("us.anthropic.claude-3-5-sonnet-20241022-v2:0", "claude-3-5-sonnet"),
+    ("anthropic.claude-3-5-sonnet-20241022-v2:0", "claude-3-5-sonnet"),
+    ("us.anthropic.claude-3-5-haiku-20241022-v1:0", "claude-3-5-haiku"),
+    ("anthropic.claude-3-opus-20240229-v1:0", "claude-3-opus"),
+    ("anthropic.claude-3-sonnet-20240229-v1:0", "claude-3-sonnet"),
+    ("anthropic.claude-3-haiku-20240307-v1:0", "claude-3-haiku"),
+    # Vertex AI — number-first ordering for 4.x families, @date separator
+    ("claude-4-5-haiku@20251001", "claude-haiku-4-5"),
+    ("claude-4-5-sonnet@20250929", "claude-sonnet-4-5"),
+    ("claude-4-5-opus@20251101", "claude-opus-4-5"),
+    ("claude-4-6-sonnet@20251015", "claude-sonnet-4-6"),
+    ("claude-4-6-opus@20251015", "claude-opus-4-6"),
+    ("claude-4-sonnet@20250514", "claude-sonnet-4"),
+    # Vertex AI — 3.x families keep number-first ordering, @date separator
+    ("claude-3-5-sonnet@20241022", "claude-3-5-sonnet"),
+    ("claude-3-5-haiku@20241022", "claude-3-5-haiku"),
+]
+
+
+class TestClaudeBedrockAndVertexIds:
+    @pytest.mark.parametrize("model_id,expected_name", CLAUDE_BEDROCK_VERTEX_CASES)
+    def test_matches_expected_family(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert "input" in price and "output" in price
+
+        expected = next(e for e in real_cache if e["model_name"] == expected_name)
+        assert price["input"] == expected["prices"]["input"], (
+            f"{model_id} matched a different family than {expected_name}"
+        )
+
+    def test_unrelated_model_still_none(self, real_cache):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            assert get_model_price("totally-not-a-real-model-2099") is None


### PR DESCRIPTION
Fixes #877

## Summary

LLM spans whose model name came from AWS Bedrock or Google Vertex AI landed with `cost = $0` because the `matchPattern` regexes in `standard-model-prices.json` only covered the Anthropic-API ID form (e.g. `claude-haiku-4-5-20251001`). Bedrock IDs (`us.anthropic.claude-haiku-4-5-20251001-v1:0`) and Vertex IDs (`claude-4-5-haiku@20251001`) fell through `get_model_price()` and were stored with null cost in ClickHouse, even though token counts were captured correctly.

Data-only fix: extend each Claude family's pattern with a Bedrock branch (optional `us./eu./apac./global.` CRIS prefix + `anthropic.` + name + `-vN:N`) and a Vertex branch (`@YYYYMMDD` separator, number-first ordering for 4.x). Eleven Claude entries updated. New spans get cost computed after the TS sync upserts the patterns into Postgres; historical spans stay at $0 (no backfill, per the issue).

## Type of Change

- [x] fix - A bug fix

## Details

Added `TestClaudeBedrockAndVertexIds` to `tests/worker/tokens/test_pricing.py` that loads the production JSON and runs 25 parametrized cases across every affected family (Bedrock with all four CRIS prefixes + no-prefix, Vertex 4.x and 3.x), plus a negative case.

## Screenshots:

Before:

<img width="979" height="192" alt="image" src="https://github.com/user-attachments/assets/84a5d25e-9a35-4ce4-a2fb-2c502efd8892" />

After:

<img width="979" height="192" alt="image" src="https://github.com/user-attachments/assets/f8b78670-6282-4011-b5ab-a7eb5963a3a9" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zero-cost pricing for Claude spans when model IDs come from AWS Bedrock or Google Vertex AI. New spans from these providers now compute cost correctly.

- **Bug Fixes**
  - Extended `standard-model-prices.json` regexes for 11 Claude families to match Bedrock IDs (optional `us./eu./apac./global.` prefix + `anthropic.` + name + optional `-vN:N`) and Vertex IDs (`@YYYYMMDD`, number-first for 4.x).
  - Added tests that load the real pricing JSON and cover Bedrock prefixes and Vertex IDs, plus a negative case. Fixes #877.

- **Migration**
  - No backfill; historical spans remain $0. Patterns are upserted by the TS sync and picked up on worker restart.

<sup>Written for commit 7d955829469dbf7eda87fbb8fa4f260ffb71ec54. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/920?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

