### PR TITLE
feat: show detector findings in trace detail view

### DIFF
--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -18,10 +18,17 @@ import { formatDuration, formatDate, formatTokens, buildUrlWithFilters } from "@
 import { SpanStatus } from "@traceroot/core";
 import type { TraceDetail } from "@/types/api";
 import type { TraceSelection } from "../types";
+import type { BackendFinding } from "@/features/detectors/hooks/use-findings";
 import { getSpanDuration, getTraceDuration, getTraceTotalCost, getTraceTokenUsage } from "../utils";
 import { SpanKindIcon } from "./SpanKindIcon";
 import { ContentRenderer } from "./ContentRenderer";
 import { ExpandableSection } from "@/components/ui/expandable-section";
+
+interface DetectorFindingEntry {
+  detectorId: string;
+  detectorName: string;
+  summary: string;
+}
 
 interface SpanInfoPanelProps {
   projectId: string;
@@ -31,6 +38,7 @@ interface SpanInfoPanelProps {
   dateFilter?: { id: string; isCustom?: boolean };
   customStartDate?: Date | null;
   customEndDate?: Date | null;
+  finding?: BackendFinding;
 }
 
 /**
@@ -44,6 +52,7 @@ export function SpanInfoPanel({
   dateFilter,
   customStartDate,
   customEndDate,
+  finding,
 }: SpanInfoPanelProps) {
   const router = useRouter();
 
@@ -78,6 +87,23 @@ export function SpanInfoPanel({
   // Error status
   const hasError = isTrace ? false : selection.span.status === SpanStatus.ERROR;
   const statusMessage = !isTrace ? selection.span.status_message : null;
+
+  const findingEntries: DetectorFindingEntry[] | null = (() => {
+    if (!isTrace || !finding) return null;
+    try {
+      const parsed = JSON.parse(finding.payload);
+      if (!Array.isArray(parsed)) return null;
+      return parsed
+        .filter((e): e is DetectorFindingEntry => !!e && typeof e === "object")
+        .map((e) => ({
+          detectorId: String(e.detectorId ?? ""),
+          detectorName: String(e.detectorName ?? "Detector"),
+          summary: String(e.summary ?? ""),
+        }));
+    } catch {
+      return null;
+    }
+  })();
 
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
@@ -284,6 +310,51 @@ export function SpanInfoPanel({
               {statusMessage}
             </p>
           </div>
+        )}
+
+        {/* Detector Findings — trace-level only */}
+        {isTrace && finding && (
+          <ExpandableSection title="Detector Findings" defaultOpen={true}>
+            <div className="space-y-2">
+              <div className="text-[11px] text-muted-foreground">
+                Detected {formatDate(finding.timestamp)}
+              </div>
+              {findingEntries && findingEntries.length > 0 ? (
+                findingEntries.map((entry, idx) => (
+                  <button
+                    key={`${entry.detectorId}-${idx}`}
+                    type="button"
+                    onClick={() => {
+                      if (!entry.detectorId) return;
+                      onClose?.();
+                      router.push(`/projects/${projectId}/detectors/${entry.detectorId}`);
+                    }}
+                    disabled={!entry.detectorId}
+                    className="block w-full rounded-md border border-red-200 bg-red-50 p-3 text-left transition-colors hover:bg-red-100 disabled:cursor-default disabled:hover:bg-red-50 dark:border-red-900 dark:bg-red-950/50 dark:hover:bg-red-950/70 dark:disabled:hover:bg-red-950/50"
+                  >
+                    <div className="mb-1 flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-1.5 text-xs font-medium text-red-700 dark:text-red-400">
+                        <AlertCircle className="h-3 w-3" />
+                        <span>{entry.detectorName}</span>
+                      </div>
+                      {entry.detectorId && (
+                        <ChevronRight className="h-3 w-3 text-red-700 dark:text-red-400" />
+                      )}
+                    </div>
+                    <p className="whitespace-pre-wrap break-words text-xs text-red-600 dark:text-red-400">
+                      {entry.summary}
+                    </p>
+                  </button>
+                ))
+              ) : (
+                <div className="rounded-md border border-red-200 bg-red-50 p-3 dark:border-red-900 dark:bg-red-950/50">
+                  <p className="whitespace-pre-wrap break-words text-xs text-red-600 dark:text-red-400">
+                    {finding.summary}
+                  </p>
+                </div>
+              )}
+            </div>
+          </ExpandableSection>
         )}
 
         {/* Input */}

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -366,6 +366,7 @@ export function TraceViewerPanel({
                     dateFilter={dateFilter}
                     customStartDate={customStartDate}
                     customEndDate={customEndDate}
+                    finding={traceFinding}
                   />
                 ) : (
                   <SpanTimelineView


### PR DESCRIPTION
Fixes #930

## Summary

Surface detector findings directly inside TraceViewerPanel so users no longer have to navigate to the Detectors page to see what fired on a trace. Reuses the existing /traces/{id}/findings query (already fetched for the header Alert button), parses the per-detector payload, and renders each detector's summary as a card linking back to its detector configuration.

## Type of Change

- [x] feat - A new feature

## Screenshots 

<img width="1314" height="850" alt="image" src="https://github.com/user-attachments/assets/b5c8b953-39f7-409f-aa39-978613592fdb" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show detector findings directly in the trace detail view so users can see what triggered without leaving the page. Addresses #930 by linking each finding to its detector config.

- **New Features**
  - Adds a “Detector Findings” section to the trace-level panel (default open) with detection timestamp.
  - Reuses the existing /traces/{id}/findings data already fetched for the header.
  - Parses per-detector payload when it’s a JSON array and renders cards with name + summary; each card links to the detector. Falls back to the raw summary if parsing fails.

<sup>Written for commit 134c1c408d3b6553d5278956d6ca99427608bfae. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/931?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

