### PR TITLE
fix(detectors):add FINAL to dedupe pre-merge rows . closes #937

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -394,7 +394,7 @@ async def get_spans_jsonl(trace_id: str, project_id: str):
 
     ch = get_clickhouse_client()
     result = ch.query(
-        """SELECT * FROM spans
+        """SELECT * FROM spans FINAL
            WHERE trace_id = {trace_id:String} AND project_id = {project_id:String}
            ORDER BY span_start_time""",
         parameters={"trace_id": trace_id, "project_id": project_id},


### PR DESCRIPTION
Fixes #937 

## Summary
Added `FINAL` to the ClickHouse query


 The `spans` table uses `ReplacingMergeTree(ch_update_time)`, which means  before background merges run, multiple versions of the same span can exist.
  The rest of the codebase handles this  `trace_reader.py` and `live.py`  both use `FROM spans FINAL`  but this endpoint was missed.

  Detector workers call this endpoint to build the evaluator prompt. Without  `FINAL`, they can read stale duplicate rows alongside the current ones.
  I hit this locally with a streaming trace the UI showed 16 spans but the  JSONL endpoint returned 17. One span appeared twice: once with nul `span_end_time` (the old in-progress version) and once with the real value.

  Since `sandbox-eval.ts` caps the prompt at 150,000 characters and doesn't  dedupe by `span_id`, those duplicates eat into the token budget and could  push useful spans past the truncation point on larger traces.


## Type of Change

- [ ] feat - A new feature
- [X] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

<img width="1043" height="296" alt="Screenshot from 2026-05-23 22-14-40" src="https://github.com/user-attachments/assets/a5547e84-5df0-40e4-83eb-a2e18026a23a" />




## Checklist

- [X ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] I have added/updated tests where applicable
- [X] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
