### PR TITLE
Plan-tiered rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,24 @@ S3_REGION=us-east-1
 # --- Redis --------------------------------------------------------------------
 REDIS_URL=redis://localhost:6379/0
 
+# --- Rate limiting (REST API) -------------------------------------------------
+# Per-workspace, plan-tiered limits on the public ingestion endpoint and the
+# dashboard read endpoints. Format: "<count>/<period>" (second|minute|hour|day).
+# Limits are shared across REST replicas via Redis (REDIS_URL), with an
+# in-memory fallback if Redis is unreachable (fail-open).
+# RATE_LIMIT_ENABLED=true                 # master kill-switch
+# RATE_LIMIT_STORAGE_URI=                 # defaults to REDIS_URL; use memory:// for single-process
+# Ingestion (POST /api/v1/public/traces):
+# RATE_LIMIT_INGEST_FREE=1000/minute
+# RATE_LIMIT_INGEST_STARTER=5000/minute
+# RATE_LIMIT_INGEST_PRO=20000/minute
+# RATE_LIMIT_INGEST_ENTERPRISE=100000/minute
+# Dashboard reads (traces/sessions/users GETs, shared per-workspace budget):
+# RATE_LIMIT_READ_FREE=60/minute
+# RATE_LIMIT_READ_STARTER=300/minute
+# RATE_LIMIT_READ_PRO=1000/minute
+# RATE_LIMIT_READ_ENTERPRISE=5000/minute
+
 # --- REST API (Python FastAPI) ------------------------------------------------
 # NOTE: Do NOT use generic HOST= or PORT= here — Next.js also reads PORT
 # and would start on the wrong port. FastAPI defaults to 0.0.0.0:8000.

--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,6 @@ REDIS_URL=redis://localhost:6379/0
 # Cloud-only: no-op when ENABLE_BILLING=false (the operator's own infra is the
 # ceiling). Per-plan defaults live in backend/shared/config.py (RateLimitSettings).
 # RATE_LIMIT_ENABLED=true              # master kill-switch
-# RATE_LIMIT_SHADOW=false              # dry-run: count + log over-limit, do NOT 429
 # RATE_LIMIT_STORAGE_URI=              # defaults to REDIS_URL; memory:// for single-process
 
 # --- REST API (Python FastAPI) ------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -30,18 +30,22 @@ REDIS_URL=redis://localhost:6379/0
 # dashboard read endpoints. Format: "<count>/<period>" (second|minute|hour|day).
 # Limits are shared across REST replicas via Redis (REDIS_URL), with an
 # in-memory fallback if Redis is unreachable (fail-open).
-# RATE_LIMIT_ENABLED=true                 # master kill-switch
+# Self-host note: with ENABLE_BILLING=false there are no billing tiers, so rate
+# limiting is DISABLED entirely (matches Langfuse — your own infra is the ceiling).
+# The limits below apply only on cloud (billing-enabled) deployments.
+# RATE_LIMIT_ENABLED=true                 # master kill-switch (also disables on cloud)
+# RATE_LIMIT_SHADOW=false                  # dry-run: count + log over-limit but DON'T 429 (safe rollout)
 # RATE_LIMIT_STORAGE_URI=                 # defaults to REDIS_URL; use memory:// for single-process
 # Ingestion (POST /api/v1/public/traces):
 # RATE_LIMIT_INGEST_FREE=1000/minute
 # RATE_LIMIT_INGEST_STARTER=5000/minute
 # RATE_LIMIT_INGEST_PRO=20000/minute
-# RATE_LIMIT_INGEST_ENTERPRISE=100000/minute
+# RATE_LIMIT_INGEST_ENTERPRISE=          # blank = mirror pro; set a value to diverge
 # Dashboard reads (traces/sessions/users GETs, shared per-workspace budget):
 # RATE_LIMIT_READ_FREE=60/minute
 # RATE_LIMIT_READ_STARTER=300/minute
 # RATE_LIMIT_READ_PRO=1000/minute
-# RATE_LIMIT_READ_ENTERPRISE=5000/minute
+# RATE_LIMIT_READ_ENTERPRISE=            # blank = mirror pro; set a value to diverge
 
 # --- REST API (Python FastAPI) ------------------------------------------------
 # NOTE: Do NOT use generic HOST= or PORT= here — Next.js also reads PORT

--- a/.env.example
+++ b/.env.example
@@ -26,26 +26,11 @@ S3_REGION=us-east-1
 REDIS_URL=redis://localhost:6379/0
 
 # --- Rate limiting (REST API) -------------------------------------------------
-# Per-workspace, plan-tiered limits on the public ingestion endpoint and the
-# dashboard read endpoints. Format: "<count>/<period>" (second|minute|hour|day).
-# Limits are shared across REST replicas via Redis (REDIS_URL), with an
-# in-memory fallback if Redis is unreachable (fail-open).
-# Self-host note: with ENABLE_BILLING=false there are no billing tiers, so rate
-# limiting is DISABLED entirely (matches Langfuse — your own infra is the ceiling).
-# The limits below apply only on cloud (billing-enabled) deployments.
-# RATE_LIMIT_ENABLED=true                 # master kill-switch (also disables on cloud)
-# RATE_LIMIT_SHADOW=false                  # dry-run: count + log over-limit but DON'T 429 (safe rollout)
-# RATE_LIMIT_STORAGE_URI=                 # defaults to REDIS_URL; use memory:// for single-process
-# Ingestion (POST /api/v1/public/traces):
-# RATE_LIMIT_INGEST_FREE=1000/minute
-# RATE_LIMIT_INGEST_STARTER=5000/minute
-# RATE_LIMIT_INGEST_PRO=20000/minute
-# RATE_LIMIT_INGEST_ENTERPRISE=          # blank = mirror pro; set a value to diverge
-# Dashboard reads (traces/sessions/users GETs, shared per-workspace budget):
-# RATE_LIMIT_READ_FREE=60/minute
-# RATE_LIMIT_READ_STARTER=300/minute
-# RATE_LIMIT_READ_PRO=1000/minute
-# RATE_LIMIT_READ_ENTERPRISE=            # blank = mirror pro; set a value to diverge
+# Cloud-only: no-op when ENABLE_BILLING=false (the operator's own infra is the
+# ceiling). Per-plan defaults live in backend/shared/config.py (RateLimitSettings).
+# RATE_LIMIT_ENABLED=true              # master kill-switch
+# RATE_LIMIT_SHADOW=false              # dry-run: count + log over-limit, do NOT 429
+# RATE_LIMIT_STORAGE_URI=              # defaults to REDIS_URL; memory:// for single-process
 
 # --- REST API (Python FastAPI) ------------------------------------------------
 # NOTE: Do NOT use generic HOST= or PORT= here — Next.js also reads PORT

--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -16,7 +16,9 @@ import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
+from slowapi.errors import RateLimitExceeded
 
+from rest.rate_limit import limiter, rate_limit_exceeded_handler
 from rest.routers.internal import router as internal_router
 from rest.routers.live import router as live_router
 from rest.routers.public.traces import router as public_traces_router
@@ -38,6 +40,13 @@ app = FastAPI(
 # CORS remains the outermost middleware and its headers apply to every
 # response, including gzipped ones.
 app.add_middleware(GZipMiddleware, minimum_size=1024)
+
+# Rate limiting. Enforcement + X-RateLimit-* headers are handled by the
+# per-route @limiter decorators (see rest.rate_limit); SlowAPIMiddleware is
+# intentionally omitted because it exempts decorated routes anyway. The limiter
+# is attached to app.state so the 429 handler can read window stats for headers.
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
 # CORS configuration
 app.add_middleware(

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -159,8 +159,9 @@ def resolve_limit(key: str) -> str:
     WARNING: the parameter MUST be named ``key`` — slowapi only forwards the
     bucket key when the callable's signature contains a literal ``key`` param
     (otherwise it calls this with no args). Renaming it would silently disable
-    enforcement (errors are swallowed). ``test_resolve_limit_signature`` guards
-    against this; do not rename without updating that test.
+    enforcement (errors are swallowed). ``test_resolve_limit_signature_is_literal_key``
+    (signature) and ``test_resolve_limit_applies_per_plan_limits`` (behavior)
+    guard against this; do not rename without updating those tests.
     """
     parts = key.split(":", 3)
     if len(parts) == 4:

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -10,6 +10,11 @@ Design
   a customer cannot multiply quota by minting more keys.
 * **Tiers**    per ``(bucket, billing-plan)`` limits resolved at request time
   from ``settings.rate_limit`` (see ``RateLimitSettings``).
+* **Self-host** deployments (``ENABLE_BILLING=false``) have no billing tiers, so
+  rate limiting is disabled entirely — the limiter is built with
+  ``enabled=False`` (see ``_build_limiter``). This matches Langfuse, which
+  applies no limits when not running as cloud; the operator's own infra is the
+  ceiling. Limits therefore apply on cloud (billing-enabled) deployments only.
 * **Buckets**  ``ingest`` (POST /public/traces) and ``read`` (dashboard GETs,
   which share one budget via ``shared_limit(scope="read")``).
 * **Response** HTTP 429 with a JSON envelope plus ``Retry-After`` and
@@ -40,6 +45,7 @@ from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 
+from ee.license import is_billing_enabled
 from shared.config import normalize_plan, settings
 
 logger = logging.getLogger(__name__)
@@ -110,6 +116,9 @@ def set_rate_limit_identity(
     workspace), so it is a fail-safe (restrictive), not an expected state. We
     warn when a non-exempt request lands there so a broken validate contract is
     visible rather than silently collapsing tenants into one shared bucket.
+
+    Note: on self-host the limiter is disabled (see ``_build_limiter``), so this
+    runs but is never read; it only matters on cloud (billing-enabled).
     """
     if not workspace_id and not is_request_rate_limit_exempt():
         logger.warning(
@@ -161,23 +170,38 @@ def resolve_limit(key: str) -> str:
     return settings.rate_limit.limit_for(bucket, plan)
 
 
+def _storage_state(request: Request) -> str:
+    """ "ok" / "degraded": whether the limiter is on its in-memory fallback.
+
+    slowapi flips ``_storage_dead`` when Redis is unreachable and it falls back
+    to per-process in-memory counters — which multiplies the effective limit by
+    the replica count. Surfacing it on every throttle lets ops alert on
+    degraded-mode rate limiting (best-effort: only observable via throttle events).
+    """
+    app_state = getattr(getattr(request, "app", None), "state", None)
+    limiter_obj = getattr(app_state, "limiter", None)
+    return "degraded" if getattr(limiter_obj, "_storage_dead", False) else "ok"
+
+
 def _record_exceeded(request: Request, retry_after: int) -> None:
     bucket = getattr(request.state, "rl_bucket", "unknown")
     workspace_id = getattr(request.state, "rl_workspace_id", _UNKNOWN_WORKSPACE)
     plan = getattr(request.state, "rl_billing_plan", "unknown")
+    storage = _storage_state(request)
     logger.warning(
-        "rate limit exceeded: bucket=%s workspace=%s plan=%s retry_after=%ss",
+        "rate limit exceeded: bucket=%s workspace=%s plan=%s retry_after=%ss storage=%s",
         bucket,
         workspace_id,
         plan,
         retry_after,
+        storage,
     )
     if _exceeded_counter is not None:
         try:
             # Only bounded-cardinality attributes here. workspace_id is high
             # cardinality and would blow up a metrics backend — it stays in the
             # log line above for debugging, not on the metric.
-            _exceeded_counter.add(1, {"bucket": bucket, "plan": plan})
+            _exceeded_counter.add(1, {"bucket": bucket, "plan": plan, "storage": storage})
         except Exception:  # pragma: no cover - best-effort metric
             logger.debug("failed to record rate_limit.exceeded counter", exc_info=True)
 
@@ -241,17 +265,70 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSO
     return JSONResponse(status_code=429, content=body, headers=headers)
 
 
+class _ShadowAwareLimiter(Limiter):
+    """A slowapi ``Limiter`` that, in shadow mode, records over-limit hits but
+    does not block.
+
+    The limit is still evaluated — slowapi records the hit in storage *before*
+    raising ``RateLimitExceeded`` — so counts/logs reflect reality. In shadow
+    mode we swallow that exception so the request proceeds, giving a true
+    count-but-don't-block dry run. Relies on slowapi 0.1.9's
+    ``_check_request_limit`` raising after recording the hit (guarded by the
+    shadow tests; revisit on a slowapi upgrade).
+    """
+
+    def __init__(self, *args: Any, shadow: bool = False, **kwargs: Any) -> None:
+        self._shadow = shadow
+        super().__init__(*args, **kwargs)
+
+    def _check_request_limit(self, request, endpoint_func, in_middleware=True):
+        try:
+            return super()._check_request_limit(request, endpoint_func, in_middleware)
+        except RateLimitExceeded:
+            if not getattr(self, "_shadow", False):
+                raise
+            bucket = getattr(request.state, "rl_bucket", "unknown")
+            workspace_id = getattr(request.state, "rl_workspace_id", _UNKNOWN_WORKSPACE)
+            plan = getattr(request.state, "rl_billing_plan", "unknown")
+            logger.warning(
+                "rate limit exceeded in SHADOW mode (counted, not enforced): "
+                "bucket=%s workspace=%s plan=%s",
+                bucket,
+                workspace_id,
+                plan,
+            )
+            if _exceeded_counter is not None:
+                try:
+                    _exceeded_counter.add(1, {"bucket": bucket, "plan": plan, "mode": "shadow"})
+                except Exception:  # pragma: no cover - best-effort metric
+                    logger.debug("failed to record shadow rate_limit counter", exc_info=True)
+            return None
+
+
 def _build_limiter() -> Limiter:
-    """Construct the application-wide limiter (Redis + in-memory fallback)."""
+    """Construct the application-wide limiter (Redis + in-memory fallback).
+
+    Rate limiting is a cloud-only construct: on self-host (``ENABLE_BILLING``
+    unset/false) there are no billing tiers, so the limiter is built disabled and
+    every route decorator becomes inert (matches Langfuse, which applies no limits
+    when not running as cloud). ``RATE_LIMIT_ENABLED=false`` also disables it on
+    cloud. ``RATE_LIMIT_SHADOW=true`` keeps it enabled but count-only (no 429s).
+    The billing gate is read once at startup; it does not change at runtime.
+    """
+    enabled = settings.rate_limit.enabled and is_billing_enabled()
+    shadow = settings.rate_limit.shadow
     storage_uri = settings.rate_limit.storage_uri or settings.redis.url
     logger.info(
-        "Initialising REST rate limiter (enabled=%s, storage=%s)",
-        settings.rate_limit.enabled,
+        "Initialising REST rate limiter (enabled=%s, shadow=%s, billing_enabled=%s, storage=%s)",
+        enabled,
+        shadow,
+        is_billing_enabled(),
         "redis" if storage_uri.startswith("redis") else storage_uri,
     )
-    return Limiter(
+    return _ShadowAwareLimiter(
         key_func=get_remote_address,  # default; each route overrides via key_func=
-        enabled=settings.rate_limit.enabled,
+        enabled=enabled,
+        shadow=shadow,
         storage_uri=storage_uri,
         headers_enabled=True,  # X-RateLimit-* on success responses
         in_memory_fallback_enabled=True,  # degrade to per-process on Redis outage

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -52,7 +52,6 @@ logger = logging.getLogger(__name__)
 BUCKET_INGEST = "ingest"
 BUCKET_READ = "read"
 _KEY_PREFIX = "rl"
-_UNKNOWN_WORKSPACE = "unknown"
 
 # Request-scoped exemption flag, set True by the access dependency for trusted
 # internal service-to-service calls. ``exempt_when()`` receives no request, so a
@@ -108,27 +107,23 @@ def set_rate_limit_identity(
     """Stash the resolved workspace + plan on the request for the key/limit funcs.
 
     Called from the dependency layer, which runs before slowapi evaluates the
-    limit, so ``key_func`` can read these off ``request.state``. A missing
-    workspace falls back to a shared ``unknown`` bucket at the free tier — this
-    should not happen on authenticated paths (both validate endpoints return a
-    workspace), so it is a fail-safe (restrictive), not an expected state. We
-    warn when a non-exempt request lands there so a broken validate contract is
-    visible rather than silently collapsing tenants into one shared bucket.
+    limit, so ``key_func`` can read these off ``request.state``. Both enforced
+    paths guarantee a workspace — ingest and dashboard-read auth each 503 on a
+    missing one — so no fallback bucket is needed here. Trusted internal calls
+    are exempt and may legitimately carry no workspace; that is fine because the
+    key is never evaluated for them.
 
     Note: on self-host the limiter is disabled (see ``_build_limiter``), so this
     runs but is never read; it only matters on cloud (billing-enabled).
     """
-    if not workspace_id and not is_request_rate_limit_exempt():
-        logger.warning(
-            "rate-limit identity resolved to an unknown workspace; "
-            "this request shares the global fallback bucket"
-        )
-    request.state.rl_workspace_id = workspace_id or _UNKNOWN_WORKSPACE
+    request.state.rl_workspace_id = workspace_id or ""
     request.state.rl_billing_plan = normalize_plan(billing_plan)
 
 
 def _identity(request: Request) -> tuple[str, str]:
-    workspace_id = getattr(request.state, "rl_workspace_id", _UNKNOWN_WORKSPACE)
+    # The dependency layer always stamps rl_workspace_id before slowapi calls
+    # key_func, so the default is inert defensive code, never an enforced bucket.
+    workspace_id = getattr(request.state, "rl_workspace_id", "")
     plan = normalize_plan(getattr(request.state, "rl_billing_plan", None))
     return workspace_id, plan
 
@@ -184,7 +179,7 @@ def _storage_state(request: Request) -> str:
 
 def _record_exceeded(request: Request, retry_after: int) -> None:
     bucket = getattr(request.state, "rl_bucket", "unknown")
-    workspace_id = getattr(request.state, "rl_workspace_id", _UNKNOWN_WORKSPACE)
+    workspace_id = getattr(request.state, "rl_workspace_id", "unknown")
     plan = getattr(request.state, "rl_billing_plan", "unknown")
     storage = _storage_state(request)
     logger.warning(

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -115,6 +115,17 @@ def set_rate_limit_identity(
 
     Note: on self-host the limiter is disabled (see ``_build_limiter``), so this
     runs but is never read; it only matters on cloud (billing-enabled).
+
+    Args:
+        request (Request): Request whose ``state`` is stamped (read later by
+            ``key_func`` / ``_record_exceeded``).
+        workspace_id (str | None): Resolved workspace; an empty value is only
+            reachable on exempt internal calls, which are never keyed.
+        billing_plan (str | None): Resolved plan, normalized via ``normalize_plan``.
+
+    Returns:
+        None. Stamps ``rl_workspace_id`` and ``rl_billing_plan`` onto
+        ``request.state``.
     """
     request.state.rl_workspace_id = workspace_id or ""
     request.state.rl_billing_plan = normalize_plan(billing_plan)
@@ -212,6 +223,16 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSO
     ``Retry-After`` is always derived from the limit, never hardcoded: it starts
     from the limit's own window (``get_expiry()``) and is refined to the exact
     time-until-reset when the live window stats are readable.
+
+    Args:
+        request (Request): The throttled request; carries ``view_rate_limit``
+            for the window-stats lookup.
+        exc (RateLimitExceeded): The slowapi exception carrying the exceeded
+            limit.
+
+    Returns:
+        JSONResponse: A 429 with the error envelope plus ``Retry-After`` and,
+            when available, ``X-RateLimit-*`` headers.
     """
     limit_amount: int | None = None
     remaining: int | None = None

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -1,0 +1,262 @@
+"""Tiered, workspace-keyed rate limiting for the Traceroot REST API.
+
+Design
+------
+* **Library**  ``slowapi`` (wraps ``limits``) with Redis storage shared across
+  REST replicas, plus an in-memory fallback so a Redis outage degrades to
+  per-process limiting instead of failing requests.
+* **Key**      the *workspace* (resolved from the API key for ingestion, and
+  from the authenticated user for dashboard reads) — never the raw API key, so
+  a customer cannot multiply quota by minting more keys.
+* **Tiers**    per ``(bucket, billing-plan)`` limits resolved at request time
+  from ``settings.rate_limit`` (see ``RateLimitSettings``).
+* **Buckets**  ``ingest`` (POST /public/traces) and ``read`` (dashboard GETs,
+  which share one budget via ``shared_limit(scope="read")``).
+* **Response** HTTP 429 with a JSON envelope plus ``Retry-After`` and
+  ``X-RateLimit-*`` headers; OTLP exporters honor ``Retry-After`` and back off.
+
+Mechanics
+---------
+slowapi evaluates the limit *after* FastAPI resolves the route's dependencies,
+so the dependency layer stashes the resolved ``workspace_id``/``billing_plan``
+onto ``request.state`` (read by ``key_func``). The dynamic-limit resolver only
+receives the *key* (not the request), so the plan is embedded in the key.
+Trusted internal service-to-service calls are exempted via a request-scoped
+``ContextVar`` (slowapi's ``exempt_when`` receives no request).
+
+Failure mode is fail-open: ``in_memory_fallback_enabled`` covers Redis outages
+and ``swallow_errors`` ensures a broken limiter never turns into a 500.
+"""
+
+import logging
+import time
+from contextvars import ContextVar
+from math import ceil
+from typing import Any
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+
+from shared.config import normalize_plan, settings
+
+logger = logging.getLogger(__name__)
+
+BUCKET_INGEST = "ingest"
+BUCKET_READ = "read"
+_KEY_PREFIX = "rl"
+_UNKNOWN_WORKSPACE = "unknown"
+_DEFAULT_RETRY_AFTER = 60
+
+# Request-scoped exemption flag, set True by the access dependency for trusted
+# internal service-to-service calls. ``exempt_when()`` receives no request, so a
+# ContextVar is the clean way to pass per-request state to slowapi here. Each
+# request runs in its own task with a fresh copy of the context, so the default
+# (False) holds for normal traffic and there is no cross-request bleed.
+_rate_limit_exempt: ContextVar[bool] = ContextVar("rate_limit_exempt", default=False)
+
+
+# --- OpenTelemetry counter (no-op until a MeterProvider is configured) -------
+# Instrument with the OTel metrics API only; wiring a MeterProvider/exporter is
+# a separate, platform-wide concern. The structured log line below guarantees
+# observability even before a provider exists.
+def _build_exceeded_counter():
+    try:
+        from opentelemetry import metrics
+
+        return metrics.get_meter("traceroot.rest.rate_limit").create_counter(
+            "traceroot.rate_limit.exceeded",
+            unit="1",
+            description="Requests rejected with HTTP 429 by the REST rate limiter.",
+        )
+    except Exception:  # pragma: no cover - metrics are best-effort
+        return None
+
+
+_exceeded_counter = _build_exceeded_counter()
+
+
+def clear_request_rate_limit_exempt() -> None:
+    """Reset the exemption to the default for the current request.
+
+    Per-task context isolation already prevents cross-request bleed, but the
+    entry dependencies call this first so each request explicitly establishes
+    its own exemption state (defense-in-depth) rather than inheriting any.
+    """
+    _rate_limit_exempt.set(False)
+
+
+def mark_request_rate_limit_exempt() -> None:
+    """Exempt the current request from rate limiting (trusted internal call)."""
+    _rate_limit_exempt.set(True)
+
+
+def is_request_rate_limit_exempt() -> bool:
+    """Return whether the current request is exempt (slowapi ``exempt_when``)."""
+    return _rate_limit_exempt.get()
+
+
+def set_rate_limit_identity(
+    request: Request, workspace_id: str | None, billing_plan: str | None
+) -> None:
+    """Stash the resolved workspace + plan on the request for the key/limit funcs.
+
+    Called from the dependency layer, which runs before slowapi evaluates the
+    limit, so ``key_func`` can read these off ``request.state``. A missing
+    workspace falls back to a shared ``unknown`` bucket at the free tier — this
+    should not happen on authenticated paths (both validate endpoints return a
+    workspace), so it is a fail-safe (restrictive), not an expected state. We
+    warn when a non-exempt request lands there so a broken validate contract is
+    visible rather than silently collapsing tenants into one shared bucket.
+    """
+    if not workspace_id and not is_request_rate_limit_exempt():
+        logger.warning(
+            "rate-limit identity resolved to an unknown workspace; "
+            "this request shares the global fallback bucket"
+        )
+    request.state.rl_workspace_id = workspace_id or _UNKNOWN_WORKSPACE
+    request.state.rl_billing_plan = normalize_plan(billing_plan)
+
+
+def _identity(request: Request) -> tuple[str, str]:
+    workspace_id = getattr(request.state, "rl_workspace_id", _UNKNOWN_WORKSPACE)
+    plan = normalize_plan(getattr(request.state, "rl_billing_plan", None))
+    return workspace_id, plan
+
+
+def key_ingest(request: Request) -> str:
+    """Bucket key for ingestion: per workspace, with the plan embedded."""
+    workspace_id, plan = _identity(request)
+    request.state.rl_bucket = BUCKET_INGEST
+    return f"{_KEY_PREFIX}:{BUCKET_INGEST}:{plan}:{workspace_id}"
+
+
+def key_read(request: Request) -> str:
+    """Bucket key for dashboard reads: per workspace, with the plan embedded."""
+    workspace_id, plan = _identity(request)
+    request.state.rl_bucket = BUCKET_READ
+    return f"{_KEY_PREFIX}:{BUCKET_READ}:{plan}:{workspace_id}"
+
+
+def resolve_limit(key: str) -> str:
+    """Resolve the limit string from a bucket key (slowapi dynamic limit).
+
+    slowapi passes the key (the output of ``key_func``), not the request, to a
+    dynamic-limit callable — hence the plan is encoded in the key.
+    Key format: ``rl:{bucket}:{plan}:{workspace_id}``.
+
+    WARNING: the parameter MUST be named ``key`` — slowapi only forwards the
+    bucket key when the callable's signature contains a literal ``key`` param
+    (otherwise it calls this with no args). Renaming it would silently disable
+    enforcement (errors are swallowed). ``test_resolve_limit_signature`` guards
+    against this; do not rename without updating that test.
+    """
+    parts = key.split(":", 3)
+    if len(parts) == 4:
+        _, bucket, plan, _ = parts
+    else:
+        bucket, plan = BUCKET_READ, "free"
+    return settings.rate_limit.limit_for(bucket, plan)
+
+
+def _record_exceeded(request: Request, retry_after: int) -> None:
+    bucket = getattr(request.state, "rl_bucket", "unknown")
+    workspace_id = getattr(request.state, "rl_workspace_id", _UNKNOWN_WORKSPACE)
+    plan = getattr(request.state, "rl_billing_plan", "unknown")
+    logger.warning(
+        "rate limit exceeded: bucket=%s workspace=%s plan=%s retry_after=%ss",
+        bucket,
+        workspace_id,
+        plan,
+        retry_after,
+    )
+    if _exceeded_counter is not None:
+        try:
+            # Only bounded-cardinality attributes here. workspace_id is high
+            # cardinality and would blow up a metrics backend — it stays in the
+            # log line above for debugging, not on the metric.
+            _exceeded_counter.add(1, {"bucket": bucket, "plan": plan})
+        except Exception:  # pragma: no cover - best-effort metric
+            logger.debug("failed to record rate_limit.exceeded counter", exc_info=True)
+
+
+def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSONResponse:
+    """Return a JSON 429 with accurate ``Retry-After`` / ``X-RateLimit-*`` headers.
+
+    slowapi sets ``request.state.view_rate_limit = (limit_item, args)`` just
+    before raising, letting us query the storage for the true time-until-reset
+    and remaining count rather than the window *size*.
+    """
+    limit_amount: int | None = None
+    remaining: int | None = None
+    reset_at: int | None = None
+    retry_after = _DEFAULT_RETRY_AFTER
+
+    view_rate_limit = getattr(request.state, "view_rate_limit", None)
+    if view_rate_limit is not None:
+        try:
+            # Header values are best-effort: during a storage failover the
+            # active limiter (`.limiter`) may differ from the one that recorded
+            # the hit, so remaining/reset can be slightly off. The 429 decision
+            # itself is always correct; only these advisory headers may drift.
+            limit_item, args = view_rate_limit
+            reset_epoch, remaining = request.app.state.limiter.limiter.get_window_stats(
+                limit_item, *args
+            )
+            # slowapi convention: reset_in = 1 + reset_epoch.
+            reset_at = int(reset_epoch) + 1
+            retry_after = max(1, reset_at - int(time.time()))
+            limit_amount = limit_item.amount
+        except Exception:  # pragma: no cover - fall back to window size below
+            logger.debug("failed to read window stats for 429 headers", exc_info=True)
+
+    if limit_amount is None:
+        try:
+            # exc.limit is typed as None at the class level in slowapi; the
+            # instance always carries a Limit. get_expiry() returns window size.
+            limit_obj: Any = exc.limit
+            retry_after = ceil(limit_obj.limit.get_expiry())
+        except Exception:  # pragma: no cover
+            pass
+
+    _record_exceeded(request, retry_after)
+
+    body: dict[str, object] = {
+        "error": "too_many_requests",
+        "detail": "Rate limit exceeded. Slow down and retry after the cooldown.",
+        "retry_after": retry_after,
+    }
+    headers = {"Retry-After": str(retry_after)}
+    if limit_amount is not None:
+        remaining_count = remaining if remaining is not None else 0
+        body["limit"] = limit_amount
+        body["remaining"] = remaining_count
+        headers["X-RateLimit-Limit"] = str(limit_amount)
+        headers["X-RateLimit-Remaining"] = str(remaining_count)
+        if reset_at is not None:
+            headers["X-RateLimit-Reset"] = str(reset_at)
+
+    return JSONResponse(status_code=429, content=body, headers=headers)
+
+
+def _build_limiter() -> Limiter:
+    """Construct the application-wide limiter (Redis + in-memory fallback)."""
+    storage_uri = settings.rate_limit.storage_uri or settings.redis.url
+    logger.info(
+        "Initialising REST rate limiter (enabled=%s, storage=%s)",
+        settings.rate_limit.enabled,
+        "redis" if storage_uri.startswith("redis") else storage_uri,
+    )
+    return Limiter(
+        key_func=get_remote_address,  # default; each route overrides via key_func=
+        enabled=settings.rate_limit.enabled,
+        storage_uri=storage_uri,
+        headers_enabled=True,  # X-RateLimit-* on success responses
+        in_memory_fallback_enabled=True,  # degrade to per-process on Redis outage
+        swallow_errors=True,  # fail-open: never 500 because limiting itself broke
+    )
+
+
+limiter: Limiter = _build_limiter()

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -12,8 +12,7 @@ Design
   from ``settings.rate_limit`` (see ``RateLimitSettings``).
 * **Self-host** deployments (``ENABLE_BILLING=false``) have no billing tiers, so
   rate limiting is disabled entirely — the limiter is built with
-  ``enabled=False`` (see ``_build_limiter``). This matches Langfuse, which
-  applies no limits when not running as cloud; the operator's own infra is the
+  ``enabled=False`` (see ``_build_limiter``); the operator's own infra is the
   ceiling. Limits therefore apply on cloud (billing-enabled) deployments only.
 * **Buckets**  ``ingest`` (POST /public/traces) and ``read`` (dashboard GETs,
   which share one budget via ``shared_limit(scope="read")``).
@@ -311,9 +310,9 @@ def _build_limiter() -> Limiter:
 
     Rate limiting is a cloud-only construct: on self-host (``ENABLE_BILLING``
     unset/false) there are no billing tiers, so the limiter is built disabled and
-    every route decorator becomes inert (matches Langfuse, which applies no limits
-    when not running as cloud). ``RATE_LIMIT_ENABLED=false`` also disables it on
-    cloud. ``RATE_LIMIT_SHADOW=true`` keeps it enabled but count-only (no 429s).
+    every route decorator becomes inert; the operator's own infra is the ceiling.
+    ``RATE_LIMIT_ENABLED=false`` also disables it on cloud.
+    ``RATE_LIMIT_SHADOW=true`` keeps it enabled but count-only (no 429s).
     The billing gate is read once at startup; it does not change at runtime.
     """
     enabled = settings.rate_limit.enabled and is_billing_enabled()

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -271,46 +271,6 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSO
     return JSONResponse(status_code=429, content=body, headers=headers)
 
 
-class _ShadowAwareLimiter(Limiter):
-    """A slowapi ``Limiter`` that, in shadow mode, records over-limit hits but
-    does not block.
-
-    The limit is still evaluated — slowapi records the hit in storage *before*
-    raising ``RateLimitExceeded`` — so counts/logs reflect reality. In shadow
-    mode we swallow that exception so the request proceeds, giving a true
-    count-but-don't-block dry run. Relies on slowapi 0.1.9's
-    ``_check_request_limit`` raising after recording the hit (guarded by the
-    shadow tests; revisit on a slowapi upgrade).
-    """
-
-    def __init__(self, *args: Any, shadow: bool = False, **kwargs: Any) -> None:
-        self._shadow = shadow
-        super().__init__(*args, **kwargs)
-
-    def _check_request_limit(self, request, endpoint_func, in_middleware=True):
-        try:
-            return super()._check_request_limit(request, endpoint_func, in_middleware)
-        except RateLimitExceeded:
-            if not getattr(self, "_shadow", False):
-                raise
-            bucket = getattr(request.state, "rl_bucket", "unknown")
-            workspace_id = getattr(request.state, "rl_workspace_id", _UNKNOWN_WORKSPACE)
-            plan = getattr(request.state, "rl_billing_plan", "unknown")
-            logger.warning(
-                "rate limit exceeded in SHADOW mode (counted, not enforced): "
-                "bucket=%s workspace=%s plan=%s",
-                bucket,
-                workspace_id,
-                plan,
-            )
-            if _exceeded_counter is not None:
-                try:
-                    _exceeded_counter.add(1, {"bucket": bucket, "plan": plan, "mode": "shadow"})
-                except Exception:  # pragma: no cover - best-effort metric
-                    logger.debug("failed to record shadow rate_limit counter", exc_info=True)
-            return None
-
-
 def _build_limiter() -> Limiter:
     """Construct the application-wide limiter (Redis + in-memory fallback).
 
@@ -318,23 +278,19 @@ def _build_limiter() -> Limiter:
     unset/false) there are no billing tiers, so the limiter is built disabled and
     every route decorator becomes inert; the operator's own infra is the ceiling.
     ``RATE_LIMIT_ENABLED=false`` also disables it on cloud.
-    ``RATE_LIMIT_SHADOW=true`` keeps it enabled but count-only (no 429s).
     The billing gate is read once at startup; it does not change at runtime.
     """
     enabled = settings.rate_limit.enabled and is_billing_enabled()
-    shadow = settings.rate_limit.shadow
     storage_uri = settings.rate_limit.storage_uri or settings.redis.url
     logger.info(
-        "Initialising REST rate limiter (enabled=%s, shadow=%s, billing_enabled=%s, storage=%s)",
+        "Initialising REST rate limiter (enabled=%s, billing_enabled=%s, storage=%s)",
         enabled,
-        shadow,
         is_billing_enabled(),
         "redis" if storage_uri.startswith("redis") else storage_uri,
     )
-    return _ShadowAwareLimiter(
+    return Limiter(
         key_func=get_remote_address,  # default; each route overrides via key_func=
         enabled=enabled,
-        shadow=shadow,
         storage_uri=storage_uri,
         headers_enabled=True,  # X-RateLimit-* on success responses
         in_memory_fallback_enabled=True,  # degrade to per-process on Redis outage

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -53,7 +53,6 @@ BUCKET_INGEST = "ingest"
 BUCKET_READ = "read"
 _KEY_PREFIX = "rl"
 _UNKNOWN_WORKSPACE = "unknown"
-_DEFAULT_RETRY_AFTER = 60
 
 # Request-scoped exemption flag, set True by the access dependency for trusted
 # internal service-to-service calls. ``exempt_when()`` receives no request, so a
@@ -212,11 +211,26 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSO
     slowapi sets ``request.state.view_rate_limit = (limit_item, args)`` just
     before raising, letting us query the storage for the true time-until-reset
     and remaining count rather than the window *size*.
+
+    ``Retry-After`` is always derived from the limit, never hardcoded: it starts
+    from the limit's own window (``get_expiry()``) and is refined to the exact
+    time-until-reset when the live window stats are readable.
     """
     limit_amount: int | None = None
     remaining: int | None = None
     reset_at: int | None = None
-    retry_after = _DEFAULT_RETRY_AFTER
+
+    # Base ``Retry-After``: the limit's own window size, always derivable from
+    # the exception. ``exc.limit`` is typed None at the class level in slowapi,
+    # but the instance always carries a Limit; ``get_expiry()`` returns the
+    # window in seconds. This is a coarse over-estimate (the full window, not the
+    # time remaining) used only until the live stats below refine it, or as the
+    # floor when those are unreadable.
+    try:
+        limit_obj: Any = exc.limit
+        retry_after = ceil(limit_obj.limit.get_expiry())
+    except Exception:  # pragma: no cover - the window is effectively always present
+        retry_after = 1
 
     view_rate_limit = getattr(request.state, "view_rate_limit", None)
     if view_rate_limit is not None:
@@ -231,19 +245,11 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSO
             )
             # slowapi convention: reset_in = 1 + reset_epoch.
             reset_at = int(reset_epoch) + 1
+            # Refine to the exact time-until-reset.
             retry_after = max(1, reset_at - int(time.time()))
             limit_amount = limit_item.amount
-        except Exception:  # pragma: no cover - fall back to window size below
+        except Exception:  # pragma: no cover - keep the window-size base above
             logger.debug("failed to read window stats for 429 headers", exc_info=True)
-
-    if limit_amount is None:
-        try:
-            # exc.limit is typed as None at the class level in slowapi; the
-            # instance always carries a Limit. get_expiry() returns window size.
-            limit_obj: Any = exc.limit
-            retry_after = ceil(limit_obj.limit.get_expiry())
-        except Exception:  # pragma: no cover
-            pass
 
     _record_exceeded(request, retry_after)
 

--- a/backend/rest/rate_limit.py
+++ b/backend/rest/rate_limit.py
@@ -109,9 +109,9 @@ def set_rate_limit_identity(
     Called from the dependency layer, which runs before slowapi evaluates the
     limit, so ``key_func`` can read these off ``request.state``. Both enforced
     paths guarantee a workspace — ingest and dashboard-read auth each 503 on a
-    missing one — so no fallback bucket is needed here. Trusted internal calls
-    are exempt and may legitimately carry no workspace; that is fine because the
-    key is never evaluated for them.
+    missing or empty one — so no fallback bucket is needed here. Trusted internal
+    calls are exempt and may legitimately carry no workspace; that is fine
+    because the key is never evaluated for them.
 
     Note: on self-host the limiter is disabled (see ``_build_limiter``), so this
     runs but is never read; it only matters on cloud (billing-enabled).
@@ -178,6 +178,8 @@ def _storage_state(request: Request) -> str:
 
 
 def _record_exceeded(request: Request, retry_after: int) -> None:
+    # These "unknown" defaults are log/metric placeholders for the can't-happen
+    # unstamped-request case; they never key a rate-limit bucket (see _identity).
     bucket = getattr(request.state, "rl_bucket", "unknown")
     workspace_id = getattr(request.state, "rl_workspace_id", "unknown")
     plan = getattr(request.state, "rl_billing_plan", "unknown")
@@ -224,7 +226,9 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> JSO
     try:
         limit_obj: Any = exc.limit
         retry_after = ceil(limit_obj.limit.get_expiry())
-    except Exception:  # pragma: no cover - the window is effectively always present
+    except Exception:
+        # The window is effectively always present; floor defensively so a 429
+        # never degrades into a 500 over a missing Retry-After value.
         retry_after = 1
 
     view_rate_limit = getattr(request.state, "view_rate_limit", None)

--- a/backend/rest/routers/deps.py
+++ b/backend/rest/routers/deps.py
@@ -1,6 +1,7 @@
 """FastAPI dependencies for authentication (via Next.js internal API)."""
 
 import hmac
+import logging
 from typing import Annotated
 
 import httpx
@@ -13,6 +14,8 @@ from rest.rate_limit import (
 )
 from shared.config import settings
 from shared.enums import MemberRole
+
+logger = logging.getLogger(__name__)
 
 
 class ProjectAccessInfo:
@@ -113,12 +116,14 @@ async def get_project_access(
         raise HTTPException(status_code=status_code, detail=error)
 
     # workspaceId is required: it keys the per-workspace rate limiter, so a
-    # missing one would silently collapse tenants into a shared bucket. A
-    # hasAccess:true response without it is malformed -> 503 (mirrors the ingest
-    # auth path). billingPlan stays optional because its absent default ("free")
-    # is the most restrictive tier -- a safe downgrade, not an isolation risk.
+    # missing or empty one would silently collapse tenants into a shared bucket.
+    # A hasAccess:true response without a usable workspaceId is malformed -> 503
+    # (mirrors the ingest auth path). billingPlan stays optional because its
+    # absent default ("free") is the most restrictive tier -- a safe downgrade,
+    # not an isolation risk.
     workspace_id = data.get("workspaceId")
     if not workspace_id:
+        logger.error("validate-project-access returned hasAccess without a usable workspaceId")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Authentication service error",

--- a/backend/rest/routers/deps.py
+++ b/backend/rest/routers/deps.py
@@ -112,11 +112,23 @@ async def get_project_access(
         )
         raise HTTPException(status_code=status_code, detail=error)
 
+    # workspaceId is required: it keys the per-workspace rate limiter, so a
+    # missing one would silently collapse tenants into a shared bucket. A
+    # hasAccess:true response without it is malformed -> 503 (mirrors the ingest
+    # auth path). billingPlan stays optional because its absent default ("free")
+    # is the most restrictive tier -- a safe downgrade, not an isolation risk.
+    workspace_id = data.get("workspaceId")
+    if not workspace_id:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
+
     return ProjectAccessInfo(
         project_id=project_id,
         user_id=x_user_id,
         role=data.get("role", MemberRole.VIEWER),
-        workspace_id=data.get("workspaceId", ""),
+        workspace_id=workspace_id,
         billing_plan=data.get("billingPlan", "free"),
     )
 

--- a/backend/rest/routers/deps.py
+++ b/backend/rest/routers/deps.py
@@ -4,8 +4,13 @@ import hmac
 from typing import Annotated
 
 import httpx
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Depends, Header, HTTPException, Request, status
 
+from rest.rate_limit import (
+    clear_request_rate_limit_exempt,
+    mark_request_rate_limit_exempt,
+    set_rate_limit_identity,
+)
 from shared.config import settings
 from shared.enums import MemberRole
 
@@ -13,10 +18,20 @@ from shared.enums import MemberRole
 class ProjectAccessInfo:
     """Information about user's access to a project."""
 
-    def __init__(self, project_id: str, user_id: str, role: str):
+    def __init__(
+        self,
+        project_id: str,
+        user_id: str,
+        role: str,
+        workspace_id: str = "",
+        billing_plan: str = "free",
+    ):
         self.project_id = project_id
         self.user_id = user_id
         self.role = role
+        # Resolved for rate limiting (keyed per workspace, tiered by plan).
+        self.workspace_id = workspace_id
+        self.billing_plan = billing_plan
 
 
 async def get_project_access(
@@ -37,6 +52,10 @@ async def get_project_access(
     Raises 401 if neither auth mode succeeds, 403 if no access, 404 if project
     not found.
     """
+    # Establish a clean per-request exemption baseline before deciding below
+    # (defense-in-depth against any stale ContextVar value).
+    clear_request_rate_limit_exempt()
+
     # System bypass: agent service / worker calling on behalf of the system.
     # Constant-time compare to avoid leaking the secret via response timing.
     if (
@@ -44,6 +63,8 @@ async def get_project_access(
         and settings.internal_api_secret
         and hmac.compare_digest(x_internal_secret, settings.internal_api_secret)
     ):
+        # Trusted internal traffic is not rate limited (system-controlled volume).
+        mark_request_rate_limit_exempt()
         return ProjectAccessInfo(
             project_id=project_id,
             user_id=x_user_id or "system",
@@ -95,7 +116,26 @@ async def get_project_access(
         project_id=project_id,
         user_id=x_user_id,
         role=data.get("role", MemberRole.VIEWER),
+        workspace_id=data.get("workspaceId", ""),
+        billing_plan=data.get("billingPlan", "free"),
     )
 
 
 ProjectAccess = Annotated[ProjectAccessInfo, Depends(get_project_access)]
+
+
+async def get_rate_limited_project_access(
+    request: Request, access: ProjectAccess
+) -> ProjectAccessInfo:
+    """``ProjectAccess`` that also stamps the rate-limit identity on the request.
+
+    Used by dashboard read endpoints so the limiter can key the shared read
+    bucket by workspace and resolve the plan tier. The internal-secret bypass is
+    applied inside ``get_project_access`` (it marks the request exempt), so this
+    wrapper only needs to forward the resolved workspace/plan.
+    """
+    set_rate_limit_identity(request, access.workspace_id, access.billing_plan)
+    return access
+
+
+RateLimitedProjectAccess = Annotated[ProjectAccessInfo, Depends(get_rate_limited_project_access)]

--- a/backend/rest/routers/public/deps.py
+++ b/backend/rest/routers/public/deps.py
@@ -130,6 +130,16 @@ async def authenticate_api_key(
             detail="Authentication service error",
         ) from e
 
+    # The subscript above rejects an absent workspaceId, but an empty one would
+    # still key every such tenant into one shared ingest bucket. Reject it too,
+    # so ingest and the dashboard-read path both guarantee a usable workspace.
+    if not workspace_id:
+        logger.error("Auth service response has an empty workspaceId")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
+
     # ingestionBlocked gates billing enforcement, so fail closed on a malformed
     # value: a non-bool (or the missing case above) must not be read as "not
     # blocked", which would silently bypass the free-plan ingestion limit.

--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -53,6 +53,15 @@ async def authenticate_and_stamp_identity(request: Request, auth: Auth) -> AuthR
     ingestion bucket by workspace and resolve the plan tier. It runs during
     dependency resolution — before slowapi evaluates the limit — so ``key_func``
     sees the identity on ``request.state``.
+
+    Args:
+        request (Request): Incoming request; its ``state`` is stamped with the
+            resolved rate-limit identity.
+        auth (Auth): API-key auth dependency resolving the workspace and plan.
+
+    Returns:
+        AuthResult: The authenticated result (workspace, plan, ingestion gate),
+            passed through to the route handler.
     """
     # Ingestion is never exempt; establish a clean baseline defensively.
     clear_request_rate_limit_exempt()

--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -25,10 +25,6 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
 from pydantic import BaseModel
 
 from ee.license import is_billing_enabled
-
-# Auth is defined in the shared public deps module so read routes don't import
-# it from this ingestion endpoint. Re-exported here for backward compatibility.
-from rest.routers.public.deps import Auth, AuthResult, authenticate_api_key
 from rest.rate_limit import (
     clear_request_rate_limit_exempt,
     key_ingest,
@@ -36,6 +32,10 @@ from rest.rate_limit import (
     resolve_limit,
     set_rate_limit_identity,
 )
+
+# Auth is defined in the shared public deps module so read routes don't import
+# it from this ingestion endpoint. Re-exported here for backward compatibility.
+from rest.routers.public.deps import Auth, AuthResult, authenticate_api_key
 from rest.services.s3 import get_s3_service
 from worker.ingest_tasks import process_s3_traces
 

--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -15,9 +15,9 @@ import gzip
 import logging
 import uuid
 from datetime import UTC, datetime
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from google.protobuf.json_format import MessageToDict
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
@@ -29,6 +29,13 @@ from ee.license import is_billing_enabled
 # Auth is defined in the shared public deps module so read routes don't import
 # it from this ingestion endpoint. Re-exported here for backward compatibility.
 from rest.routers.public.deps import Auth, AuthResult, authenticate_api_key
+from rest.rate_limit import (
+    clear_request_rate_limit_exempt,
+    key_ingest,
+    limiter,
+    resolve_limit,
+    set_rate_limit_identity,
+)
 from rest.services.s3 import get_s3_service
 from worker.ingest_tasks import process_s3_traces
 
@@ -37,6 +44,23 @@ __all__ = ["AuthResult", "Auth", "authenticate_api_key", "router"]
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/public/traces", tags=["Traces (Public)"])
+
+
+async def authenticate_and_stamp_identity(request: Request, auth: Auth) -> AuthResult:
+    """Authenticate, then stamp the workspace/plan onto the request for limiting.
+
+    A thin wrapper over ``authenticate_api_key`` so the rate limiter can key the
+    ingestion bucket by workspace and resolve the plan tier. It runs during
+    dependency resolution — before slowapi evaluates the limit — so ``key_func``
+    sees the identity on ``request.state``.
+    """
+    # Ingestion is never exempt; establish a clean baseline defensively.
+    clear_request_rate_limit_exempt()
+    set_rate_limit_identity(request, auth.workspace_id, auth.billing_plan)
+    return auth
+
+
+IngestAuth = Annotated[AuthResult, Depends(authenticate_and_stamp_identity)]
 
 
 def decode_otlp_protobuf(data: bytes) -> dict[str, Any]:
@@ -66,9 +90,11 @@ class IngestResponse(BaseModel):
 
 
 @router.post("", response_model=IngestResponse)
+@limiter.limit(resolve_limit, key_func=key_ingest)
 async def ingest_traces(
     request: Request,
-    auth: Auth,
+    response: Response,
+    auth: IngestAuth,
 ):
     """Ingest OTLP trace data.
 

--- a/backend/rest/routers/sessions.py
+++ b/backend/rest/routers/sessions.py
@@ -3,9 +3,16 @@
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, Request, Response, status
 
-from rest.routers.deps import ProjectAccess
+from rest.rate_limit import (
+    BUCKET_READ,
+    is_request_rate_limit_exempt,
+    key_read,
+    limiter,
+    resolve_limit,
+)
+from rest.routers.deps import RateLimitedProjectAccess
 from rest.schemas.sessions import SessionDetailResponse, SessionListResponse
 from rest.services.trace_reader import get_trace_reader_service
 
@@ -15,9 +22,14 @@ router = APIRouter(prefix="/projects/{project_id}/sessions", tags=["Sessions"])
 
 
 @router.get("", response_model=SessionListResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def list_sessions(
+    request: Request,
+    response: Response,
     project_id: str,
-    _access: ProjectAccess,
+    _access: RateLimitedProjectAccess,
     page: int = Query(0, ge=0, description="Page number (0-indexed)"),
     limit: int = Query(50, ge=1, le=200, description="Items per page"),
     search_query: str | None = Query(None, description="Search by session_id"),
@@ -45,10 +57,15 @@ async def list_sessions(
 
 
 @router.get("/{session_id}", response_model=SessionDetailResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def get_session(
+    request: Request,
+    response: Response,
     project_id: str,
     session_id: str,
-    _access: ProjectAccess,
+    _access: RateLimitedProjectAccess,
     start_after: datetime | None = Query(None, description="Filter traces after this time"),
     end_before: datetime | None = Query(None, description="Filter traces before this time"),
 ):

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -3,9 +3,16 @@
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, Request, Response, status
 
-from rest.routers.deps import ProjectAccess
+from rest.rate_limit import (
+    BUCKET_READ,
+    is_request_rate_limit_exempt,
+    key_read,
+    limiter,
+    resolve_limit,
+)
+from rest.routers.deps import ProjectAccess, RateLimitedProjectAccess
 from rest.schemas.traces import SpanIOResponse, TraceDetailResponse, TraceListResponse
 from rest.services.trace_reader import get_trace_reader_service
 
@@ -15,9 +22,14 @@ router = APIRouter(prefix="/projects/{project_id}/traces", tags=["Traces"])
 
 
 @router.get("", response_model=TraceListResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def list_traces(
+    request: Request,
+    response: Response,
     project_id: str,
-    _access: ProjectAccess,  # Validates user has access to project
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
     page: int = Query(0, ge=0, description="Page number (0-indexed)"),
     limit: int = Query(50, ge=1, le=200, description="Items per page"),
     name: str | None = Query(None, description="Filter by trace name (partial match)"),
@@ -51,10 +63,15 @@ async def list_traces(
 
 
 @router.get("/{trace_id}", response_model=TraceDetailResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def get_trace(
+    request: Request,
+    response: Response,
     project_id: str,
     trace_id: str,
-    _access: ProjectAccess,  # Validates user has access to project
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
 ):
     """Get a single trace with span skeletons (no per-span I/O)."""
     service = get_trace_reader_service()

--- a/backend/rest/routers/users.py
+++ b/backend/rest/routers/users.py
@@ -3,9 +3,16 @@
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, Request, Response, status
 
-from rest.routers.deps import ProjectAccess
+from rest.rate_limit import (
+    BUCKET_READ,
+    is_request_rate_limit_exempt,
+    key_read,
+    limiter,
+    resolve_limit,
+)
+from rest.routers.deps import RateLimitedProjectAccess
 from rest.schemas.users import UserListResponse
 from rest.services.trace_reader import get_trace_reader_service
 
@@ -15,9 +22,14 @@ router = APIRouter(prefix="/projects/{project_id}/users", tags=["Users"])
 
 
 @router.get("", response_model=UserListResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def list_users(
+    request: Request,
+    response: Response,
     project_id: str,
-    _access: ProjectAccess,  # Validates user has access to project
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
     page: int = Query(0, ge=0, description="Page number (0-indexed)"),
     limit: int = Query(50, ge=1, le=200, description="Items per page"),
     search_query: str | None = Query(None, description="Search by user_id"),

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -58,6 +58,23 @@ class RedisSettings(BaseSettings):
 
 RATE_LIMIT_PLANS: tuple[str, ...] = ("free", "starter", "pro", "enterprise")
 
+# Per-plan rate limits — product decision in code, not an ops knob. Format is
+# the ``limits`` library's ``"<count>/<period>"`` (period: second|minute|hour|day).
+# Enterprise mirrors Pro until a real Enterprise customer lands; per-workspace
+# overrides for that case will arrive as a DB-backed mechanism, not env knobs.
+_PLAN_LIMITS_INGEST: dict[str, str] = {
+    "free": "1000/minute",
+    "starter": "5000/minute",
+    "pro": "20000/minute",
+    "enterprise": "20000/minute",
+}
+_PLAN_LIMITS_READ: dict[str, str] = {
+    "free": "60/minute",
+    "starter": "300/minute",
+    "pro": "1000/minute",
+    "enterprise": "1000/minute",
+}
+
 
 def normalize_plan(plan: str | None) -> str:
     """Normalize a billing-plan string to a known plan, defaulting to ``free``.
@@ -70,22 +87,17 @@ def normalize_plan(plan: str | None) -> str:
 
 
 class RateLimitSettings(BaseSettings):
-    """Tiered rate-limit settings for the public REST API.
+    """Operational rate-limit settings for the public REST API.
 
-    Two buckets (``ingest``, ``read``) across four plans. Limit values use the
-    ``limits`` library format ``"<count>/<period>"`` (period: second, minute,
-    hour, day). Every value is individually overridable via env, e.g.
-    ``RATE_LIMIT_INGEST_PRO=30000/minute``.
+    Plan tiers are a product decision and live as code constants
+    (``_PLAN_LIMITS_INGEST``, ``_PLAN_LIMITS_READ`` above) — not env-overridable.
+    The knobs here are the operational ones an SRE legitimately needs at runtime.
 
-    Enterprise mirrors Pro by default (there are no near-term enterprise
-    customers, and a divergent tier is one more thing to keep in sync). When a
-    real enterprise customer lands, raise ``RATE_LIMIT_{INGEST,READ}_ENTERPRISE``
-    per-deployment. Note: self-host disables rate limiting entirely (the limiter
-    is built disabled when billing is off — see ``rest.rate_limit``), so these
-    tiers only take effect on cloud (billing-enabled) deployments.
+    Self-host disables rate limiting entirely (the limiter is built disabled
+    when billing is off — see ``rest.rate_limit``), so these knobs only take
+    effect on cloud (billing-enabled) deployments.
 
-    Env vars: RATE_LIMIT_ENABLED, RATE_LIMIT_STORAGE_URI, and
-    RATE_LIMIT_{INGEST,READ}_{FREE,STARTER,PRO,ENTERPRISE}.
+    Env vars: RATE_LIMIT_ENABLED, RATE_LIMIT_SHADOW, RATE_LIMIT_STORAGE_URI.
     """
 
     model_config = SettingsConfigDict(env_prefix="RATE_LIMIT_")
@@ -100,37 +112,14 @@ class RateLimitSettings(BaseSettings):
     # shared across REST replicas. Set "memory://" for single-process use.
     storage_uri: str | None = None
 
-    # Ingestion bucket: POST /api/v1/public/traces (keyed per workspace).
-    ingest_free: str = "1000/minute"
-    ingest_starter: str = "5000/minute"
-    ingest_pro: str = "20000/minute"
-    # Empty = mirror pro (so enterprise stays == pro even if pro is raised via
-    # env). Set RATE_LIMIT_INGEST_ENTERPRISE explicitly to diverge.
-    ingest_enterprise: str = ""
-
-    # Read bucket: dashboard GET endpoints sharing one per-workspace budget.
-    read_free: str = "60/minute"
-    read_starter: str = "300/minute"
-    read_pro: str = "1000/minute"
-    read_enterprise: str = ""  # empty = mirror pro (see ingest_enterprise)
-
     def limit_for(self, bucket: str, plan: str) -> str:
         """Resolve the limit string for a ``(bucket, plan)`` pair.
 
-        Falls back to the free tier for unknown plans and to the read bucket
-        for unknown bucket names — both the most restrictive choice. An empty
-        value on ANY tier mirrors pro: this keeps enterprise == pro by default,
-        and ensures a blanked override never resolves to ``""`` — which the
-        ``limits`` parser rejects and the limiter swallows (``swallow_errors``),
-        silently disabling enforcement for that tier (fail-open). Mirroring pro
-        keeps the limit bounded.
+        Falls back to the read bucket for unknown bucket names and the free
+        tier for unknown plans — both the most restrictive choice.
         """
-        bucket_name = bucket if bucket in ("ingest", "read") else "read"
-        plan_name = normalize_plan(plan)
-        value = str(getattr(self, f"{bucket_name}_{plan_name}"))
-        if not value:
-            value = str(getattr(self, f"{bucket_name}_pro"))
-        return value
+        table = _PLAN_LIMITS_INGEST if bucket == "ingest" else _PLAN_LIMITS_READ
+        return table[normalize_plan(plan)]
 
 
 class Settings(BaseSettings):

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -119,13 +119,16 @@ class RateLimitSettings(BaseSettings):
 
         Falls back to the free tier for unknown plans and to the read bucket
         for unknown bucket names — both the most restrictive choice. An empty
-        enterprise value mirrors pro, keeping enterprise == pro by default even
-        when pro is overridden.
+        value on ANY tier mirrors pro: this keeps enterprise == pro by default,
+        and ensures a blanked override never resolves to ``""`` — which the
+        ``limits`` parser rejects and the limiter swallows (``swallow_errors``),
+        silently disabling enforcement for that tier (fail-open). Mirroring pro
+        keeps the limit bounded.
         """
         bucket_name = bucket if bucket in ("ingest", "read") else "read"
         plan_name = normalize_plan(plan)
         value = str(getattr(self, f"{bucket_name}_{plan_name}"))
-        if not value and plan_name == "enterprise":
+        if not value:
             value = str(getattr(self, f"{bucket_name}_pro"))
         return value
 

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -56,6 +56,62 @@ class RedisSettings(BaseSettings):
     result_url: str = "redis://localhost:6379/1"
 
 
+RATE_LIMIT_PLANS: tuple[str, ...] = ("free", "starter", "pro", "enterprise")
+
+
+def normalize_plan(plan: str | None) -> str:
+    """Normalize a billing-plan string to a known plan, defaulting to ``free``.
+
+    Unknown or missing plans fall back to the most restrictive tier so a
+    mis-resolved plan never grants more quota than intended.
+    """
+    candidate = (plan or "").strip().lower()
+    return candidate if candidate in RATE_LIMIT_PLANS else "free"
+
+
+class RateLimitSettings(BaseSettings):
+    """Tiered rate-limit settings for the public REST API.
+
+    Two buckets (``ingest``, ``read``) across four plans. Limit values use the
+    ``limits`` library format ``"<count>/<period>"`` (period: second, minute,
+    hour, day). Every value is individually overridable via env, e.g.
+    ``RATE_LIMIT_INGEST_PRO=30000/minute`` — which is also how the Enterprise
+    tier is tuned per-deployment in v1 (no DB-backed override yet).
+
+    Env vars: RATE_LIMIT_ENABLED, RATE_LIMIT_STORAGE_URI, and
+    RATE_LIMIT_{INGEST,READ}_{FREE,STARTER,PRO,ENTERPRISE}.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="RATE_LIMIT_")
+
+    # Master kill-switch: RATE_LIMIT_ENABLED=false disables all enforcement.
+    enabled: bool = True
+    # Storage backend; defaults to the main Redis URL (REDIS_URL) so limits are
+    # shared across REST replicas. Set "memory://" for single-process use.
+    storage_uri: str | None = None
+
+    # Ingestion bucket: POST /api/v1/public/traces (keyed per workspace).
+    ingest_free: str = "1000/minute"
+    ingest_starter: str = "5000/minute"
+    ingest_pro: str = "20000/minute"
+    ingest_enterprise: str = "100000/minute"
+
+    # Read bucket: dashboard GET endpoints sharing one per-workspace budget.
+    read_free: str = "60/minute"
+    read_starter: str = "300/minute"
+    read_pro: str = "1000/minute"
+    read_enterprise: str = "5000/minute"
+
+    def limit_for(self, bucket: str, plan: str) -> str:
+        """Resolve the limit string for a ``(bucket, plan)`` pair.
+
+        Falls back to the free tier for unknown plans and to the read bucket
+        for unknown bucket names — both the most restrictive choice.
+        """
+        bucket_name = bucket if bucket in ("ingest", "read") else "read"
+        return str(getattr(self, f"{bucket_name}_{normalize_plan(plan)}"))
+
+
 class Settings(BaseSettings):
     """Root settings for the TraceRoot backend.
 
@@ -85,6 +141,7 @@ class Settings(BaseSettings):
     clickhouse: ClickHouseSettings = ClickHouseSettings()
     s3: S3Settings = S3Settings()
     redis: RedisSettings = RedisSettings()
+    rate_limit: RateLimitSettings = RateLimitSettings()
 
 
 settings = Settings()

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -81,6 +81,13 @@ def normalize_plan(plan: str | None) -> str:
 
     Unknown or missing plans fall back to the most restrictive tier so a
     mis-resolved plan never grants more quota than intended.
+
+    Args:
+        plan (str | None): Raw plan string (case-insensitive, may be None).
+
+    Returns:
+        str: One of ``RATE_LIMIT_PLANS``; ``free`` when ``plan`` is missing or
+            unrecognized.
     """
     candidate = (plan or "").strip().lower()
     return candidate if candidate in RATE_LIMIT_PLANS else "free"

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -97,17 +97,13 @@ class RateLimitSettings(BaseSettings):
     when billing is off — see ``rest.rate_limit``), so these knobs only take
     effect on cloud (billing-enabled) deployments.
 
-    Env vars: RATE_LIMIT_ENABLED, RATE_LIMIT_SHADOW, RATE_LIMIT_STORAGE_URI.
+    Env vars: RATE_LIMIT_ENABLED, RATE_LIMIT_STORAGE_URI.
     """
 
     model_config = SettingsConfigDict(env_prefix="RATE_LIMIT_")
 
     # Master kill-switch: RATE_LIMIT_ENABLED=false disables all enforcement.
     enabled: bool = True
-    # Shadow / dry-run: when true (and enabled), over-limit requests are counted
-    # and logged but NOT blocked — for observing impact before enforcing on a
-    # fresh cloud rollout. See rest.rate_limit._build_limiter.
-    shadow: bool = False
     # Storage backend; defaults to the main Redis URL (REDIS_URL) so limits are
     # shared across REST replicas. Set "memory://" for single-process use.
     storage_uri: str | None = None

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -75,8 +75,14 @@ class RateLimitSettings(BaseSettings):
     Two buckets (``ingest``, ``read``) across four plans. Limit values use the
     ``limits`` library format ``"<count>/<period>"`` (period: second, minute,
     hour, day). Every value is individually overridable via env, e.g.
-    ``RATE_LIMIT_INGEST_PRO=30000/minute`` — which is also how the Enterprise
-    tier is tuned per-deployment in v1 (no DB-backed override yet).
+    ``RATE_LIMIT_INGEST_PRO=30000/minute``.
+
+    Enterprise mirrors Pro by default (there are no near-term enterprise
+    customers, and a divergent tier is one more thing to keep in sync). When a
+    real enterprise customer lands, raise ``RATE_LIMIT_{INGEST,READ}_ENTERPRISE``
+    per-deployment. Note: self-host disables rate limiting entirely (the limiter
+    is built disabled when billing is off — see ``rest.rate_limit``), so these
+    tiers only take effect on cloud (billing-enabled) deployments.
 
     Env vars: RATE_LIMIT_ENABLED, RATE_LIMIT_STORAGE_URI, and
     RATE_LIMIT_{INGEST,READ}_{FREE,STARTER,PRO,ENTERPRISE}.
@@ -86,6 +92,10 @@ class RateLimitSettings(BaseSettings):
 
     # Master kill-switch: RATE_LIMIT_ENABLED=false disables all enforcement.
     enabled: bool = True
+    # Shadow / dry-run: when true (and enabled), over-limit requests are counted
+    # and logged but NOT blocked — for observing impact before enforcing on a
+    # fresh cloud rollout. See rest.rate_limit._build_limiter.
+    shadow: bool = False
     # Storage backend; defaults to the main Redis URL (REDIS_URL) so limits are
     # shared across REST replicas. Set "memory://" for single-process use.
     storage_uri: str | None = None
@@ -94,22 +104,30 @@ class RateLimitSettings(BaseSettings):
     ingest_free: str = "1000/minute"
     ingest_starter: str = "5000/minute"
     ingest_pro: str = "20000/minute"
-    ingest_enterprise: str = "100000/minute"
+    # Empty = mirror pro (so enterprise stays == pro even if pro is raised via
+    # env). Set RATE_LIMIT_INGEST_ENTERPRISE explicitly to diverge.
+    ingest_enterprise: str = ""
 
     # Read bucket: dashboard GET endpoints sharing one per-workspace budget.
     read_free: str = "60/minute"
     read_starter: str = "300/minute"
     read_pro: str = "1000/minute"
-    read_enterprise: str = "5000/minute"
+    read_enterprise: str = ""  # empty = mirror pro (see ingest_enterprise)
 
     def limit_for(self, bucket: str, plan: str) -> str:
         """Resolve the limit string for a ``(bucket, plan)`` pair.
 
         Falls back to the free tier for unknown plans and to the read bucket
-        for unknown bucket names — both the most restrictive choice.
+        for unknown bucket names — both the most restrictive choice. An empty
+        enterprise value mirrors pro, keeping enterprise == pro by default even
+        when pro is overridden.
         """
         bucket_name = bucket if bucket in ("ingest", "read") else "read"
-        return str(getattr(self, f"{bucket_name}_{normalize_plan(plan)}"))
+        plan_name = normalize_plan(plan)
+        value = str(getattr(self, f"{bucket_name}_{plan_name}"))
+        if not value and plan_name == "enterprise":
+            value = str(getattr(self, f"{bucket_name}_pro"))
+        return value
 
 
 class Settings(BaseSettings):

--- a/deploy/helm/templates/rest/deployment.yaml
+++ b/deploy/helm/templates/rest/deployment.yaml
@@ -78,6 +78,10 @@ spec:
             {{- end }}
             - name: CORS_ORIGINS
               value: '["{{ .Values.betterAuth.url }}"]'
+            # Self-host (enableBilling=false) disables REST rate limiting and
+            # unlocks all tiers; read by ee.license.is_billing_enabled().
+            - name: ENABLE_BILLING
+              value: {{ .Values.enableBilling | quote }}
             {{- with .Values.additionalEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -185,10 +185,7 @@ betterAuth:
   url: ""
 
 # --- Feature flags ---
-# Default false so a plain `helm install` self-hosts with billing off (REST
-# rate limiting disabled, all tiers unlocked). Cloud overrides to "true" via
-# terraform (deploy/terraform/aws: var.enable_billing -> feature_values).
-enableBilling: "false"
+enableBilling: "true"
 
 # --- Sandbox provider ---
 sandboxProvider: "daytona"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -185,7 +185,10 @@ betterAuth:
   url: ""
 
 # --- Feature flags ---
-enableBilling: "true"
+# Default false so a plain `helm install` self-hosts with billing off (REST
+# rate limiting disabled, all tiers unlocked). Cloud overrides to "true" via
+# terraform (deploy/terraform/aws: var.enable_billing -> feature_values).
+enableBilling: "false"
 
 # --- Sandbox provider ---
 sandboxProvider: "daytona"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -223,7 +223,7 @@ services:
       # --- Billing ---
       # Self-host (ENABLE_BILLING=false) disables REST rate limiting and unlocks
       # all tiers; the REST process reads this via ee.license.is_billing_enabled().
-      ENABLE_BILLING: ${ENABLE_BILLING:-true}
+      ENABLE_BILLING: ${ENABLE_BILLING:-false}
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -217,6 +217,13 @@ services:
       # Host/browser-usable UI URL for client-facing links (trace_url, whoami).
       # Prefers TRACEROOT_PUBLIC_UI_URL; falls back to the public app URL.
       TRACEROOT_PUBLIC_UI_URL: ${TRACEROOT_PUBLIC_UI_URL:-${NEXT_PUBLIC_APP_URL:-http://localhost:3000}}
+      # --- Feature flags ---
+      # rest is the only service that builds the REST rate limiter, and
+      # is_billing_enabled() treats an absent value as enabled, so rest must
+      # receive ENABLE_BILLING for a self-host deployment (ENABLE_BILLING=false,
+      # as .env.example ships) to actually disable limiting. Default matches
+      # web/billing (cloud-on unless the operator opts out).
+      ENABLE_BILLING: ${ENABLE_BILLING:-true}
       # --- Secrets ---
       INTERNAL_API_SECRET: ${INTERNAL_API_SECRET:-internal-secret}
       CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000"]}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -220,10 +220,6 @@ services:
       # --- Secrets ---
       INTERNAL_API_SECRET: ${INTERNAL_API_SECRET:-internal-secret}
       CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000"]}
-      # --- Billing ---
-      # Self-host (ENABLE_BILLING=false) disables REST rate limiting and unlocks
-      # all tiers; the REST process reads this via ee.license.is_billing_enabled().
-      ENABLE_BILLING: ${ENABLE_BILLING:-false}
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -220,6 +220,10 @@ services:
       # --- Secrets ---
       INTERNAL_API_SECRET: ${INTERNAL_API_SECRET:-internal-secret}
       CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000"]}
+      # --- Billing ---
+      # Self-host (ENABLE_BILLING=false) disables REST rate limiting and unlocks
+      # all tiers; the REST process reads this via ee.license.is_billing_enabled().
+      ENABLE_BILLING: ${ENABLE_BILLING:-true}
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/ee/license.py
+++ b/ee/license.py
@@ -15,5 +15,9 @@ def is_ee_enabled() -> bool:
 
 
 def is_billing_enabled() -> bool:
-    """Check if cloud billing is enabled (Stripe, usage metering)."""
-    return os.environ.get("ENABLE_BILLING", "").lower() != "false"
+    """Check if cloud billing is enabled (Stripe, usage metering).
+
+    Disabled only when ENABLE_BILLING is exactly "false" (case-insensitive,
+    whitespace-trimmed so a quoted "  false  " from env/YAML still counts).
+    """
+    return os.environ.get("ENABLE_BILLING", "").strip().lower() != "false"

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -242,7 +242,7 @@ export const PLANS: Record<
       "Everything in Starter",
       "90-day retention",
       "Slack integration for detector alerts",
-      "Higher rate limits",
+      "20k ingest + 1k dashboard requests/min rate limits",
       "SOC2 compliance",
     ],
     support: "Discord + Slack",

--- a/frontend/packages/core/src/ee/license.ts
+++ b/frontend/packages/core/src/ee/license.ts
@@ -12,6 +12,8 @@ export const isEeEnabled = (): boolean => {
 };
 
 // Gate 2: Cloud billing (Stripe checkout, metering, webhooks)
+// Disabled only when ENABLE_BILLING is exactly "false" (trimmed + lowercased so
+// a quoted "  false  " from env/YAML still counts; matches backend ee/license.py).
 export const isBillingEnabled = (): boolean => {
-  return process.env.ENABLE_BILLING !== "false";
+  return (process.env.ENABLE_BILLING ?? "").trim().toLowerCase() !== "false";
 };

--- a/frontend/ui/src/app/api/internal/validate-project-access/route.test.ts
+++ b/frontend/ui/src/app/api/internal/validate-project-access/route.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextRequest: class {},
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+const projectFindUniqueMock = vi.fn();
+const memberFindUniqueMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    project: {
+      findUnique: (...args: unknown[]) => projectFindUniqueMock(...args),
+    },
+    workspaceMember: {
+      findUnique: (...args: unknown[]) => memberFindUniqueMock(...args),
+    },
+  },
+  PlanType: { FREE: "free" },
+}));
+
+const verifyInternalSecretMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  verifyInternalSecret: (...args: unknown[]) => verifyInternalSecretMock(...args),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown) {
+  return { json: async () => body } as unknown as Parameters<typeof POST>[0];
+}
+
+beforeEach(() => {
+  projectFindUniqueMock.mockReset();
+  memberFindUniqueMock.mockReset();
+  verifyInternalSecretMock.mockReset();
+  verifyInternalSecretMock.mockReturnValue(true);
+});
+
+describe("POST /api/internal/validate-project-access", () => {
+  it("returns access + the workspace billingPlan when the user is a member", async () => {
+    projectFindUniqueMock.mockResolvedValue({
+      id: "proj-123",
+      workspaceId: "ws-456",
+      workspace: { billingPlan: "pro" },
+    });
+    memberFindUniqueMock.mockResolvedValue({ role: "admin" });
+
+    const res = await POST(makeRequest({ userId: "user-1", projectId: "proj-123" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      hasAccess: true,
+      role: "admin",
+      workspaceId: "ws-456",
+      billingPlan: "pro",
+    });
+  });
+
+  it("falls back to the FREE plan when the workspace has no billingPlan", async () => {
+    projectFindUniqueMock.mockResolvedValue({
+      id: "proj-123",
+      workspaceId: "ws-456",
+      workspace: { billingPlan: null },
+    });
+    memberFindUniqueMock.mockResolvedValue({ role: "viewer" });
+
+    const res = await POST(makeRequest({ userId: "user-1", projectId: "proj-123" }));
+    const body = await res.json();
+
+    expect(body.billingPlan).toBe("free");
+  });
+
+  it("rejects an unauthorized caller before touching the database", async () => {
+    verifyInternalSecretMock.mockReturnValue(false);
+
+    const res = await POST(makeRequest({ userId: "user-1", projectId: "proj-123" }));
+
+    expect(res.status).toBe(401);
+    expect(projectFindUniqueMock).not.toHaveBeenCalled();
+  });
+
+  it("returns hasAccess:false when the project does not exist", async () => {
+    projectFindUniqueMock.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ userId: "user-1", projectId: "missing" }));
+    const body = await res.json();
+
+    expect(body.hasAccess).toBe(false);
+    expect(body.error).toMatch(/not found/i);
+  });
+
+  it("returns hasAccess:false when the user is not a workspace member", async () => {
+    projectFindUniqueMock.mockResolvedValue({
+      id: "proj-123",
+      workspaceId: "ws-456",
+      workspace: { billingPlan: "pro" },
+    });
+    memberFindUniqueMock.mockResolvedValue(null);
+
+    const res = await POST(makeRequest({ userId: "user-1", projectId: "proj-123" }));
+    const body = await res.json();
+
+    expect(body.hasAccess).toBe(false);
+    expect(body.error).toMatch(/no access/i);
+  });
+});

--- a/frontend/ui/src/app/api/internal/validate-project-access/route.ts
+++ b/frontend/ui/src/app/api/internal/validate-project-access/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma } from "@traceroot/core";
+import { prisma, PlanType } from "@traceroot/core";
 import { verifyInternalSecret } from "@/lib/auth-helpers";
 
 const validateAccessSchema = z.object({
@@ -33,10 +33,14 @@ export async function POST(request: NextRequest) {
 
   const { userId, projectId } = result.data;
 
-  // Find the project
+  // Find the project (with workspace billing plan, used for tiered rate limits)
   const project = await prisma.project.findUnique({
     where: { id: projectId, deleteTime: null },
-    select: { id: true, workspaceId: true },
+    select: {
+      id: true,
+      workspaceId: true,
+      workspace: { select: { billingPlan: true } },
+    },
   });
 
   if (!project) {
@@ -68,5 +72,6 @@ export async function POST(request: NextRequest) {
     hasAccess: true,
     role: membership.role,
     workspaceId: project.workspaceId,
+    billingPlan: project.workspace?.billingPlan || PlanType.FREE,
   });
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,11 @@ dependencies = [
     "fastapi>=0.109",
     "uvicorn[standard]>=0.27",
     "python-multipart>=0.0.31",
+    "slowapi>=0.1.9",
     # OpenTelemetry
     "protobuf>=6.33.5",
     "opentelemetry-proto>=1.20.0",
+    "opentelemetry-api>=1.20.0",
     # Task Queue
     "celery[redis]>=5.3",
     "redis>=5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,10 @@ dependencies = [
     "fastapi>=0.109",
     "uvicorn[standard]>=0.27",
     "python-multipart>=0.0.31",
-    "slowapi>=0.1.9",
+    # Upper-bounded: rate_limit.py rides slowapi private internals
+    # (_check_request_limit, request.state.view_rate_limit, limiter._storage_dead);
+    # a minor bump could silently change shadow/header behavior under swallow_errors=True.
+    "slowapi>=0.1.9,<0.2",
     # OpenTelemetry
     "protobuf>=6.33.5",
     "opentelemetry-proto>=1.20.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,17 +10,20 @@ from dotenv import load_dotenv
 def pytest_configure(config):
     """Load env vars from root .env and neutralize the global app limiter.
 
-    ``RATE_LIMIT_ENABLED=false`` is set BEFORE anything imports ``rest.main`` so
-    the module-level app limiter is inert for the existing router tests. Without
-    it, those tests would share one ``rl:read:free`` bucket and 429 once the
-    suite exceeds the free read limit. ``setdefault`` respects an explicit
-    override from the environment. The enforcement tests in ``test_rate_limit``
-    build their own enabled limiter, so they are unaffected.
+    The module-level app limiter must be inert for the existing router tests:
+    otherwise they share one ``rl:read:free`` bucket and 429 once the suite
+    exceeds the free read limit. We default ``RATE_LIMIT_ENABLED=false`` only as
+    a last resort, AFTER ``load_dotenv`` runs, so that an explicit override from
+    either the real environment or ``.env`` wins (load order matters:
+    ``setdefault`` before ``load_dotenv`` would silently mask a ``.env`` value
+    because ``load_dotenv`` does not override an already-set key). The
+    enforcement tests in ``test_rate_limit`` build their own enabled limiter, so
+    they are unaffected.
     """
-    os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
     env_file = Path(__file__).parent.parent / ".env"
     if env_file.exists():
         load_dotenv(env_file)
+    os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Root test configuration."""
 
+import os
 from pathlib import Path
 
 import pytest
@@ -7,7 +8,16 @@ from dotenv import load_dotenv
 
 
 def pytest_configure(config):
-    """Load env vars from root .env."""
+    """Load env vars from root .env and neutralize the global app limiter.
+
+    ``RATE_LIMIT_ENABLED=false`` is set BEFORE anything imports ``rest.main`` so
+    the module-level app limiter is inert for the existing router tests. Without
+    it, those tests would share one ``rl:read:free`` bucket and 429 once the
+    suite exceeds the free read limit. ``setdefault`` respects an explicit
+    override from the environment. The enforcement tests in ``test_rate_limit``
+    build their own enabled limiter, so they are unaffected.
+    """
+    os.environ.setdefault("RATE_LIMIT_ENABLED", "false")
     env_file = Path(__file__).parent.parent / ".env"
     if env_file.exists():
         load_dotenv(env_file)

--- a/tests/deploy/test_compose_billing_env.py
+++ b/tests/deploy/test_compose_billing_env.py
@@ -1,0 +1,41 @@
+"""Deploy-artifact guard: billing-aware services must receive ENABLE_BILLING.
+
+``rest`` is the only process that builds the REST rate limiter, and
+``is_billing_enabled()`` treats an absent ``ENABLE_BILLING`` as enabled. If the
+var is dropped from the ``rest`` service in prod compose (it has been added and
+removed before), a self-host deployment that sets ``ENABLE_BILLING=false``
+silently keeps the limiter on and gets throttled at the free tier. The unit
+suite never inspects deploy artifacts, so this guard fails fast if that plumbing
+regresses again.
+"""
+
+import os
+
+import yaml
+
+_COMPOSE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "docker-compose.prod.yml"
+)
+
+
+def _service_environment(service: str) -> dict:
+    """Return a service's environment as a dict (compose allows map or list form)."""
+    with open(_COMPOSE_PATH) as f:
+        compose = yaml.safe_load(f)
+    env = compose["services"][service]["environment"]
+    if isinstance(env, list):
+        return dict(item.split("=", 1) for item in env)
+    return env
+
+
+def test_rest_service_receives_enable_billing():
+    """rest must pass ENABLE_BILLING into its container (it builds the limiter)."""
+    assert "ENABLE_BILLING" in _service_environment("rest")
+
+
+def test_all_billing_aware_services_receive_enable_billing():
+    """Every service that reads billing state gets the var, so none drifts out."""
+    for service in ("rest", "web", "billing"):
+        assert "ENABLE_BILLING" in _service_environment(service), (
+            f"{service} is missing ENABLE_BILLING in docker-compose.prod.yml"
+        )

--- a/tests/deploy/test_compose_billing_env.py
+++ b/tests/deploy/test_compose_billing_env.py
@@ -13,9 +13,7 @@ import os
 
 import yaml
 
-_COMPOSE_PATH = os.path.join(
-    os.path.dirname(__file__), "..", "..", "docker-compose.prod.yml"
-)
+_COMPOSE_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "docker-compose.prod.yml")
 
 
 def _service_environment(service: str) -> dict:

--- a/tests/rest/test_auth_deps.py
+++ b/tests/rest/test_auth_deps.py
@@ -197,6 +197,29 @@ class TestAuthenticateApiKey:
         assert exc_info.value.detail == "Authentication service error"
 
     @respx.mock
+    async def test_200_empty_workspace_id_returns_503(self):
+        """An empty (not just absent) workspaceId would collapse tenants into one
+        shared ingest bucket, so a valid:true response with workspaceId="" is
+        malformed → 503 (parity with the dashboard-read auth path).
+        """
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            return_value=Response(
+                200,
+                json={
+                    "valid": True,
+                    "projectId": "proj-123",
+                    "workspaceId": "",
+                    "billingPlan": "free",
+                    "ingestionBlocked": False,
+                },
+            )
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_api_key("Bearer test-key")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"
+
+    @respx.mock
     async def test_token_not_logged_on_malformed_response(self, caplog):
         """The raw API token must never appear in logs, even on the error path."""
         respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(

--- a/tests/rest/test_auth_deps.py
+++ b/tests/rest/test_auth_deps.py
@@ -214,12 +214,16 @@ class TestGetProjectAccess:
     @respx.mock
     async def test_valid_access(self):
         respx.post(f"{BASE_URL}/api/internal/validate-project-access").mock(
-            return_value=Response(200, json={"hasAccess": True, "role": "ADMIN"})
+            return_value=Response(
+                200,
+                json={"hasAccess": True, "role": "ADMIN", "workspaceId": "ws-456"},
+            )
         )
         result = await get_project_access("proj-123", "user-456")
         assert result.project_id == "proj-123"
         assert result.user_id == "user-456"
         assert result.role == "ADMIN"
+        assert result.workspace_id == "ws-456"
 
     async def test_missing_user_id(self):
         with pytest.raises(HTTPException) as exc_info:
@@ -261,3 +265,17 @@ class TestGetProjectAccess:
         with pytest.raises(HTTPException) as exc_info:
             await get_project_access("proj-123", "user-456")
         assert exc_info.value.status_code == 401
+
+    @respx.mock
+    async def test_200_missing_workspace_id_returns_503(self):
+        """hasAccess:true without a workspaceId is malformed: the workspace keys
+        the per-workspace rate limiter, so a missing one must fail loudly (503)
+        rather than silently collapse tenants into a shared bucket.
+        """
+        respx.post(f"{BASE_URL}/api/internal/validate-project-access").mock(
+            return_value=Response(200, json={"hasAccess": True, "role": "ADMIN"})
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await get_project_access("proj-123", "user-456")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"

--- a/tests/rest/test_rate_limit.py
+++ b/tests/rest/test_rate_limit.py
@@ -380,7 +380,7 @@ def test_resolve_limit_applies_per_plan_limits(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# G. Hardening: shadow mode, degraded-storage signal
+# G. Hardening: degraded-storage signal
 # ---------------------------------------------------------------------------
 
 
@@ -408,32 +408,9 @@ def _build_app_with_limiter(limiter, *, plan: str, workspace: str) -> FastAPI:
     return app
 
 
-def test_shadow_mode_records_but_does_not_block(monkeypatch, caplog):
-    """Shadow mode evaluates the limit (counts + logs) but never returns 429."""
-    # Arrange: shadow on, billing on, tiny limit, deterministic in-memory storage.
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "shadow", True)
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "storage_uri", "memory://")
-    monkeypatch.setitem(_PLAN_LIMITS_READ, "free", "2/minute")
-    monkeypatch.setenv("ENABLE_BILLING", "true")
-    client = TestClient(
-        _build_app_with_limiter(rate_limit._build_limiter(), plan="free", workspace="ws-shadow")
-    )
-
-    # Act
-    with caplog.at_level("WARNING"):
-        codes = [client.get("/r").status_code for _ in range(4)]
-
-    # Assert: never blocked past the 2/min limit...
-    assert codes == [200, 200, 200, 200]
-    # ...but the over-limit events were observed (proves it counted, not just off).
-    assert any("shadow" in r.message.lower() for r in caplog.records)
-
-
-def test_enforce_mode_blocks_when_shadow_is_off(monkeypatch):
-    """Sanity contrast: with shadow off, _build_limiter enforces (3rd request 429)."""
+def test_build_limiter_enforces_when_enabled(monkeypatch):
+    """A limiter built via _build_limiter (enabled, cloud) blocks on the 3rd request."""
     # Arrange
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "shadow", False)
     monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
     monkeypatch.setattr(rate_limit.settings.rate_limit, "storage_uri", "memory://")
     monkeypatch.setitem(_PLAN_LIMITS_READ, "free", "2/minute")

--- a/tests/rest/test_rate_limit.py
+++ b/tests/rest/test_rate_limit.py
@@ -1,0 +1,484 @@
+"""Behavioral spec tests for the REST rate-limiting feature.
+
+These tests are written STRICTLY to the target SPEC (enterprise == pro tiers,
+self-host disables the limiter entirely a la Langfuse, etc.). Some are EXPECTED
+to fail against the current implementation, which is about to be reworked; that
+separation is intentional (anti-reward-hacking): the tests assert the SPEC, not
+whatever the current code happens to return.
+
+Groups:
+    A. resolve_limit signature guard (param must literally be ``key``).
+    B. Bucket key format (rl:{bucket}:{plan}:{workspace}).
+    C. Tier values (enterprise EQUALS pro) + normalize_plan.
+    D. Self-host disables the limiter; cloud + master switch toggles it.
+    E. Enforcement + exemption via a fresh standalone limiter + app.
+"""
+
+import inspect
+import os
+import sys
+
+import pytest
+from fastapi import Depends, FastAPI, Request, Response
+from fastapi.testclient import TestClient
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+
+# ``ee`` lives at the repo root, but pyproject only puts ``backend`` on the
+# path. Importing rest.rate_limit triggers ``from ee.license import ...``, so
+# ensure the repo root is importable before importing the module under test.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+import rest.rate_limit as rate_limit  # noqa: E402
+from shared.config import normalize_plan, settings  # noqa: E402
+
+
+@pytest.fixture()
+def _restore_billing_env():
+    """Snapshot/restore ENABLE_BILLING around tests that mutate it.
+
+    The repo .env sets ENABLE_BILLING=false (self-host), which conftest loads
+    into the process env. Tests that depend on the billing context set it
+    explicitly and this fixture restores the original afterward.
+    """
+    sentinel = object()
+    original = os.environ.get("ENABLE_BILLING", sentinel)
+    yield
+    if original is sentinel:
+        os.environ.pop("ENABLE_BILLING", None)
+    else:
+        os.environ["ENABLE_BILLING"] = original  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# A. resolve_limit signature guard
+# ---------------------------------------------------------------------------
+def test_resolve_limit_signature_is_literal_key():
+    """slowapi only forwards the bucket key when the param is named ``key``."""
+    # Arrange / Act
+    params = list(inspect.signature(rate_limit.resolve_limit).parameters)
+
+    # Assert
+    assert params == ["key"]
+
+
+# ---------------------------------------------------------------------------
+# B. Bucket key format
+# ---------------------------------------------------------------------------
+def _make_stamped_request(workspace_id: str, billing_plan: str) -> Request:
+    """Build a bare Request and stamp the rate-limit identity onto it."""
+    request = Request({"type": "http", "headers": [], "state": {}})
+    rate_limit.set_rate_limit_identity(request, workspace_id, billing_plan)
+    return request
+
+
+def test_key_ingest_format_embeds_bucket_plan_and_workspace():
+    """key_ingest returns rl:ingest:{plan}:{workspace} after identity stamp.
+
+    set_rate_limit_identity / key_* do not read billing, so the stamped plan is
+    the literal plan regardless of ENABLE_BILLING — no env pin needed.
+    """
+    # Arrange
+    request = _make_stamped_request("ws-abc", "pro")
+
+    # Act
+    key = rate_limit.key_ingest(request)
+
+    # Assert
+    assert key == f"rl:{rate_limit.BUCKET_INGEST}:pro:ws-abc"
+
+
+def test_key_read_format_embeds_bucket_plan_and_workspace():
+    """key_read returns rl:read:{plan}:{workspace} after identity stamp."""
+    # Arrange
+    request = _make_stamped_request("ws-xyz", "free")
+
+    # Act
+    key = rate_limit.key_read(request)
+
+    # Assert
+    assert key == f"rl:{rate_limit.BUCKET_READ}:free:ws-xyz"
+
+
+# ---------------------------------------------------------------------------
+# C. Tier values (enterprise EQUALS pro) + normalize_plan
+# ---------------------------------------------------------------------------
+def test_ingest_enterprise_equals_pro():
+    """Enterprise ingest tier mirrors pro (20000/minute)."""
+    assert (
+        settings.rate_limit.limit_for("ingest", "enterprise")
+        == settings.rate_limit.limit_for("ingest", "pro")
+        == "20000/minute"
+    )
+
+
+def test_read_enterprise_equals_pro():
+    """Enterprise read tier mirrors pro (1000/minute)."""
+    assert (
+        settings.rate_limit.limit_for("read", "enterprise")
+        == settings.rate_limit.limit_for("read", "pro")
+        == "1000/minute"
+    )
+
+
+def test_free_tier_sanity_values():
+    """Free tier values are the documented defaults."""
+    assert settings.rate_limit.limit_for("read", "free") == "60/minute"
+    assert settings.rate_limit.limit_for("ingest", "free") == "1000/minute"
+
+
+def test_normalize_plan_unknown_and_none_fall_back_to_free():
+    """Unknown or missing plans collapse to the most restrictive tier."""
+    assert normalize_plan(None) == "free"
+    assert normalize_plan("") == "free"
+    assert normalize_plan("platinum") == "free"
+
+
+def test_normalize_plan_is_case_insensitive():
+    """Plan resolution is case-insensitive."""
+    assert normalize_plan("ENTERPRISE") == "enterprise"
+    assert normalize_plan("Pro") == "pro"
+
+
+# ---------------------------------------------------------------------------
+# D. Self-host disables the limiter; cloud + master switch toggles it
+# ---------------------------------------------------------------------------
+def test_self_host_disables_limiter_even_when_master_switch_on(monkeypatch, _restore_billing_env):
+    """ENABLE_BILLING=false (self-host) => limiter disabled regardless of switch."""
+    # Arrange: master switch ON, but self-host.
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
+    os.environ["ENABLE_BILLING"] = "false"
+
+    # Act
+    built = rate_limit._build_limiter()
+
+    # Assert
+    assert built.enabled is False
+
+
+def test_self_host_disables_limiter_with_whitespace_value(monkeypatch, _restore_billing_env):
+    """ENABLE_BILLING with surrounding whitespace (common via YAML/env quoting)
+    still counts as self-host and disables the limiter."""
+    # Arrange: master switch ON; self-host value with stray whitespace.
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
+    os.environ["ENABLE_BILLING"] = "  false  "
+
+    # Act
+    built = rate_limit._build_limiter()
+
+    # Assert
+    assert built.enabled is False
+
+
+def test_self_host_disables_limiter_even_when_master_switch_off(monkeypatch, _restore_billing_env):
+    """Self-host with the master switch off is still disabled."""
+    # Arrange
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", False)
+    os.environ["ENABLE_BILLING"] = "false"
+
+    # Act
+    built = rate_limit._build_limiter()
+
+    # Assert
+    assert built.enabled is False
+
+
+def test_cloud_unset_billing_with_master_switch_on_enables_limiter(
+    monkeypatch, _restore_billing_env
+):
+    """Cloud (ENABLE_BILLING unset) + master switch on => limiter enabled."""
+    # Arrange
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
+    os.environ.pop("ENABLE_BILLING", None)
+
+    # Act
+    built = rate_limit._build_limiter()
+
+    # Assert
+    assert built.enabled is True
+
+
+def test_cloud_billing_true_with_master_switch_on_enables_limiter(
+    monkeypatch, _restore_billing_env
+):
+    """Cloud (ENABLE_BILLING=true) + master switch on => limiter enabled."""
+    # Arrange
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
+    os.environ["ENABLE_BILLING"] = "true"
+
+    # Act
+    built = rate_limit._build_limiter()
+
+    # Assert
+    assert built.enabled is True
+
+
+def test_master_switch_off_disables_limiter_on_cloud(monkeypatch, _restore_billing_env):
+    """Master switch off => limiter disabled even on cloud."""
+    # Arrange
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", False)
+    os.environ.pop("ENABLE_BILLING", None)
+
+    # Act
+    built = rate_limit._build_limiter()
+
+    # Assert
+    assert built.enabled is False
+
+
+# ---------------------------------------------------------------------------
+# E. Enforcement + exemption (fresh standalone limiter + minimal app)
+# ---------------------------------------------------------------------------
+def _build_enforcement_app(*, exempt: bool) -> FastAPI:
+    """Build a minimal app with its OWN enabled limiter and a 2/min read route.
+
+    A dependency stamps the identity (and optionally marks the request exempt)
+    before the route body runs, mirroring the production wiring. The limiter is
+    standalone (enabled=True) so these tests do not depend on the module-level
+    ``limiter`` being enabled.
+    """
+    limiter = Limiter(
+        key_func=get_remote_address,
+        enabled=True,
+        storage_uri="memory://",
+        headers_enabled=True,
+        in_memory_fallback_enabled=True,
+        swallow_errors=True,
+    )
+
+    async def stamp(request: Request):
+        rate_limit.clear_request_rate_limit_exempt()
+        if exempt:
+            rate_limit.mark_request_rate_limit_exempt()
+        rate_limit.set_rate_limit_identity(request, "ws1", "free")
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, rate_limit.rate_limit_exceeded_handler)
+
+    @app.get("/r")
+    @limiter.shared_limit(
+        "2/minute",
+        scope="read",
+        key_func=rate_limit.key_read,
+        exempt_when=rate_limit.is_request_rate_limit_exempt,
+    )
+    async def read(request: Request, response: Response, _=Depends(stamp)):
+        return {"ok": True}
+
+    return app
+
+
+def test_enforcement_third_request_is_throttled_with_429_envelope():
+    """A 2/min limit yields [200, 200, 429]; only the 429 carries the error envelope.
+
+    Asserts 429-SPECIFIC evidence (the JSON envelope + Retry-After on the
+    throttled response). slowapi emits X-RateLimit-*/Retry-After on 200s too, so
+    a bare header-presence check would not distinguish a throttle from success.
+    """
+    # Arrange
+    client = TestClient(_build_enforcement_app(exempt=False))
+
+    # Act
+    responses = [client.get("/r") for _ in range(3)]
+    codes = [r.status_code for r in responses]
+
+    # Assert: throttle kicks in on the 3rd request.
+    assert codes == [200, 200, 429]
+    # A successful response returns the route body, not the rate-limit envelope.
+    assert responses[0].json() == {"ok": True}
+    # The 429 carries the rate-limit JSON envelope (429-specific) + a usable
+    # Retry-After on the throttled response itself.
+    throttled = responses[2]
+    body = throttled.json()
+    assert body["error"] == "too_many_requests"
+    assert body["retry_after"] >= 1
+    assert int(throttled.headers["Retry-After"]) >= 1
+
+
+def test_exempt_requests_bypass_the_limit():
+    """Marked-exempt requests are never throttled despite the same 2/min limit."""
+    # Arrange
+    client = TestClient(_build_enforcement_app(exempt=True))
+
+    # Act
+    codes = [client.get("/r").status_code for _ in range(5)]
+
+    # Assert
+    assert codes == [200] * 5
+
+
+# ---------------------------------------------------------------------------
+# F. resolve_limit dynamic-limit path (slowapi forwards the key per request)
+# ---------------------------------------------------------------------------
+def _build_resolve_limit_app(plan: str, workspace: str) -> FastAPI:
+    """App whose read route uses the REAL resolve_limit as the dynamic limit.
+
+    Unlike the hardcoded-"2/minute" enforcement app, this wires resolve_limit as
+    the limit_value, exercising the full fragile path: slowapi forwards the
+    bucket key (from key_read) into resolve_limit, which maps the embedded plan
+    to its configured limit.
+    """
+    limiter = Limiter(
+        key_func=get_remote_address,
+        enabled=True,
+        storage_uri="memory://",
+        headers_enabled=True,
+        in_memory_fallback_enabled=True,
+        swallow_errors=True,
+    )
+
+    async def stamp(request: Request):
+        rate_limit.clear_request_rate_limit_exempt()
+        rate_limit.set_rate_limit_identity(request, workspace, plan)
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, rate_limit.rate_limit_exceeded_handler)
+
+    @app.get("/r")
+    @limiter.shared_limit(
+        rate_limit.resolve_limit,
+        scope=rate_limit.BUCKET_READ,
+        key_func=rate_limit.key_read,
+        exempt_when=rate_limit.is_request_rate_limit_exempt,
+    )
+    async def read(request: Request, response: Response, _=Depends(stamp)):
+        return {"ok": True}
+
+    return app
+
+
+def test_resolve_limit_applies_per_plan_limits(monkeypatch):
+    """slowapi forwards the key to resolve_limit, which returns the plan's limit.
+
+    If resolve_limit failed to receive the key (e.g. the ``key`` param were
+    renamed → slowapi calls it arg-less → error swallowed → no limit) or returned
+    the wrong tier, the per-plan distinction below would collapse. free is
+    throttled on the 3rd read; pro (a higher limit) is not.
+    """
+    # Arrange: distinct per-plan read limits on the live settings singleton
+    # (resolve_limit reads these per request).
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_free", "2/minute")
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_pro", "10/minute")
+
+    # Act / Assert: a free workspace hits its 2/min ceiling on the 3rd read.
+    free_client = TestClient(_build_resolve_limit_app("free", "ws-free"))
+    assert [free_client.get("/r").status_code for _ in range(3)] == [200, 200, 429]
+
+    # A pro workspace (10/min) is NOT throttled at the same 3 reads — proving
+    # resolve_limit returned a different, plan-specific limit for the same bucket.
+    pro_client = TestClient(_build_resolve_limit_app("pro", "ws-pro"))
+    assert [pro_client.get("/r").status_code for _ in range(3)] == [200, 200, 200]
+
+
+# ---------------------------------------------------------------------------
+# G. Hardening: enterprise tracks pro, shadow mode, degraded-storage signal
+# ---------------------------------------------------------------------------
+def test_enterprise_tier_tracks_pro_override(monkeypatch):
+    """Enterprise mirrors pro even when pro is RAISED via env — not a frozen literal.
+
+    Guards against the desync where bumping RATE_LIMIT_*_PRO would leave
+    enterprise stuck below pro.
+    """
+    # Arrange: raise pro, leave enterprise at its (mirroring) default.
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "ingest_pro", "30000/minute")
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_pro", "7000/minute")
+
+    # Assert: enterprise follows pro.
+    assert rate_limit.settings.rate_limit.limit_for("ingest", "enterprise") == "30000/minute"
+    assert rate_limit.settings.rate_limit.limit_for("read", "enterprise") == "7000/minute"
+
+
+def test_explicit_enterprise_override_beats_the_pro_mirror(monkeypatch):
+    """An explicit enterprise value still wins over the pro mirror."""
+    # Arrange
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_pro", "1000/minute")
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_enterprise", "9000/minute")
+
+    # Assert
+    assert rate_limit.settings.rate_limit.limit_for("read", "enterprise") == "9000/minute"
+
+
+def _build_app_with_limiter(limiter, *, plan: str, workspace: str) -> FastAPI:
+    """Wire a given limiter into a minimal read app using the real resolve_limit."""
+
+    async def stamp(request: Request):
+        rate_limit.clear_request_rate_limit_exempt()
+        rate_limit.set_rate_limit_identity(request, workspace, plan)
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, rate_limit.rate_limit_exceeded_handler)
+
+    @app.get("/r")
+    @limiter.shared_limit(
+        rate_limit.resolve_limit,
+        scope=rate_limit.BUCKET_READ,
+        key_func=rate_limit.key_read,
+        exempt_when=rate_limit.is_request_rate_limit_exempt,
+    )
+    async def read(request: Request, response: Response, _=Depends(stamp)):
+        return {"ok": True}
+
+    return app
+
+
+def test_shadow_mode_records_but_does_not_block(monkeypatch, caplog):
+    """Shadow mode evaluates the limit (counts + logs) but never returns 429."""
+    # Arrange: shadow on, billing on, tiny limit, deterministic in-memory storage.
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "shadow", True)
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "storage_uri", "memory://")
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_free", "2/minute")
+    monkeypatch.setenv("ENABLE_BILLING", "true")
+    client = TestClient(
+        _build_app_with_limiter(rate_limit._build_limiter(), plan="free", workspace="ws-shadow")
+    )
+
+    # Act
+    with caplog.at_level("WARNING"):
+        codes = [client.get("/r").status_code for _ in range(4)]
+
+    # Assert: never blocked past the 2/min limit...
+    assert codes == [200, 200, 200, 200]
+    # ...but the over-limit events were observed (proves it counted, not just off).
+    assert any("shadow" in r.message.lower() for r in caplog.records)
+
+
+def test_enforce_mode_blocks_when_shadow_is_off(monkeypatch):
+    """Sanity contrast: with shadow off, _build_limiter enforces (3rd request 429)."""
+    # Arrange
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "shadow", False)
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "storage_uri", "memory://")
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_free", "2/minute")
+    monkeypatch.setenv("ENABLE_BILLING", "true")
+    client = TestClient(
+        _build_app_with_limiter(rate_limit._build_limiter(), plan="free", workspace="ws-enforce")
+    )
+
+    # Act / Assert
+    assert [client.get("/r").status_code for _ in range(3)] == [200, 200, 429]
+
+
+def test_throttle_record_flags_degraded_storage(caplog):
+    """A throttle recorded while the limiter is on in-memory fallback is flagged degraded."""
+    # Arrange: a fake request whose limiter reports degraded (Redis-down) storage.
+    from types import SimpleNamespace
+
+    limiter = SimpleNamespace(_storage_dead=True)
+    request = SimpleNamespace(
+        state=SimpleNamespace(rl_bucket="read", rl_workspace_id="ws1", rl_billing_plan="free"),
+        app=SimpleNamespace(state=SimpleNamespace(limiter=limiter)),
+    )
+
+    # Act
+    with caplog.at_level("WARNING"):
+        rate_limit._record_exceeded(request, 60)
+
+    # Assert
+    assert any("degraded" in r.message.lower() for r in caplog.records)

--- a/tests/rest/test_rate_limit.py
+++ b/tests/rest/test_rate_limit.py
@@ -1,7 +1,7 @@
 """Behavioral spec tests for the REST rate-limiting feature.
 
 These tests are written STRICTLY to the target SPEC (enterprise == pro tiers,
-self-host disables the limiter entirely a la Langfuse, etc.). Some are EXPECTED
+self-host disables the limiter entirely, etc.). Some are EXPECTED
 to fail against the current implementation, which is about to be reworked; that
 separation is intentional (anti-reward-hacking): the tests assert the SPEC, not
 whatever the current code happens to return.
@@ -33,7 +33,11 @@ if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
 import rest.rate_limit as rate_limit  # noqa: E402
-from shared.config import normalize_plan, settings  # noqa: E402
+from shared.config import (  # noqa: E402
+    _PLAN_LIMITS_READ,
+    normalize_plan,
+    settings,
+)
 
 
 @pytest.fixture()
@@ -360,10 +364,10 @@ def test_resolve_limit_applies_per_plan_limits(monkeypatch):
     the wrong tier, the per-plan distinction below would collapse. free is
     throttled on the 3rd read; pro (a higher limit) is not.
     """
-    # Arrange: distinct per-plan read limits on the live settings singleton
-    # (resolve_limit reads these per request).
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_free", "2/minute")
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_pro", "10/minute")
+    # Arrange: distinct per-plan read limits in the per-plan table
+    # (resolve_limit reads these per request via limit_for).
+    monkeypatch.setitem(_PLAN_LIMITS_READ, "free", "2/minute")
+    monkeypatch.setitem(_PLAN_LIMITS_READ, "pro", "10/minute")
 
     # Act / Assert: a free workspace hits its 2/min ceiling on the 3rd read.
     free_client = TestClient(_build_resolve_limit_app("free", "ws-free"))
@@ -376,49 +380,8 @@ def test_resolve_limit_applies_per_plan_limits(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# G. Hardening: enterprise tracks pro, shadow mode, degraded-storage signal
+# G. Hardening: shadow mode, degraded-storage signal
 # ---------------------------------------------------------------------------
-def test_enterprise_tier_tracks_pro_override(monkeypatch):
-    """Enterprise mirrors pro even when pro is RAISED via env — not a frozen literal.
-
-    Guards against the desync where bumping RATE_LIMIT_*_PRO would leave
-    enterprise stuck below pro.
-    """
-    # Arrange: raise pro, leave enterprise at its (mirroring) default.
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "ingest_pro", "30000/minute")
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_pro", "7000/minute")
-
-    # Assert: enterprise follows pro.
-    assert rate_limit.settings.rate_limit.limit_for("ingest", "enterprise") == "30000/minute"
-    assert rate_limit.settings.rate_limit.limit_for("read", "enterprise") == "7000/minute"
-
-
-def test_explicit_enterprise_override_beats_the_pro_mirror(monkeypatch):
-    """An explicit enterprise value still wins over the pro mirror."""
-    # Arrange
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_pro", "1000/minute")
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_enterprise", "9000/minute")
-
-    # Assert
-    assert rate_limit.settings.rate_limit.limit_for("read", "enterprise") == "9000/minute"
-
-
-def test_blank_non_enterprise_tier_mirrors_pro_not_unlimited(monkeypatch):
-    """A blanked non-enterprise tier mirrors pro, never an empty (unlimited) limit.
-
-    ``limits.parse_many("")`` raises, and the limiter is built with
-    ``swallow_errors=True`` (fail-open) -> an empty limit string means NO
-    enforcement. An operator who blanks ``RATE_LIMIT_READ_FREE`` (generalizing
-    the documented "blank = mirror pro" enterprise convention) must still get a
-    bounded limit, not unlimited.
-    """
-    # Arrange: blank the free read tier and the starter ingest tier.
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_free", "")
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "ingest_starter", "")
-
-    # Assert: each empty tier falls back to pro, never "".
-    assert rate_limit.settings.rate_limit.limit_for("read", "free") == "1000/minute"
-    assert rate_limit.settings.rate_limit.limit_for("ingest", "starter") == "20000/minute"
 
 
 def _build_app_with_limiter(limiter, *, plan: str, workspace: str) -> FastAPI:
@@ -451,7 +414,7 @@ def test_shadow_mode_records_but_does_not_block(monkeypatch, caplog):
     monkeypatch.setattr(rate_limit.settings.rate_limit, "shadow", True)
     monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
     monkeypatch.setattr(rate_limit.settings.rate_limit, "storage_uri", "memory://")
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_free", "2/minute")
+    monkeypatch.setitem(_PLAN_LIMITS_READ, "free", "2/minute")
     monkeypatch.setenv("ENABLE_BILLING", "true")
     client = TestClient(
         _build_app_with_limiter(rate_limit._build_limiter(), plan="free", workspace="ws-shadow")
@@ -473,7 +436,7 @@ def test_enforce_mode_blocks_when_shadow_is_off(monkeypatch):
     monkeypatch.setattr(rate_limit.settings.rate_limit, "shadow", False)
     monkeypatch.setattr(rate_limit.settings.rate_limit, "enabled", True)
     monkeypatch.setattr(rate_limit.settings.rate_limit, "storage_uri", "memory://")
-    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_free", "2/minute")
+    monkeypatch.setitem(_PLAN_LIMITS_READ, "free", "2/minute")
     monkeypatch.setenv("ENABLE_BILLING", "true")
     client = TestClient(
         _build_app_with_limiter(rate_limit._build_limiter(), plan="free", workspace="ws-enforce")

--- a/tests/rest/test_rate_limit.py
+++ b/tests/rest/test_rate_limit.py
@@ -518,7 +518,52 @@ def test_set_rate_limit_identity_has_no_unknown_workspace_fallback(caplog):
         rate_limit.set_rate_limit_identity(request, "", "free")
     key = rate_limit.key_read(request)
 
-    # Assert: no sentinel constant, no ``unknown`` bucket segment, no warning.
-    assert not hasattr(rate_limit, "_UNKNOWN_WORKSPACE")
+    # Assert: no ``unknown`` bucket segment in the key, and no warning.
     assert key == f"rl:{rate_limit.BUCKET_READ}:free:"
     assert not any("workspace" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# I. Retry-After derivation (window base + floor; no hardcoded default)
+# ---------------------------------------------------------------------------
+def test_retry_after_uses_limit_window_when_live_stats_absent():
+    """With no live window stats, Retry-After is the limit's own window size.
+
+    Binds the value (90s here): a reverted hardcoded default or the wrong branch
+    would not reproduce the limit's actual window.
+    """
+    import json
+    from types import SimpleNamespace
+
+    # Arrange: a 429 whose limit reports a 90s window, and a request with no
+    # view_rate_limit so the exact-remaining refinement is skipped.
+    exc = SimpleNamespace(limit=SimpleNamespace(limit=SimpleNamespace(get_expiry=lambda: 90)))
+    request = SimpleNamespace(state=SimpleNamespace())
+
+    # Act
+    response = rate_limit.rate_limit_exceeded_handler(request, exc)
+
+    # Assert
+    assert response.status_code == 429
+    assert json.loads(response.body)["retry_after"] == 90
+    assert response.headers["Retry-After"] == "90"
+
+
+def test_retry_after_floors_to_1_when_limit_window_unreadable():
+    """If the limit window cannot be read, Retry-After floors to 1 (never a 500)."""
+    import json
+    from types import SimpleNamespace
+
+    class _ExcWithUnreadableLimit:
+        @property
+        def limit(self):
+            raise RuntimeError("limit unavailable")
+
+    request = SimpleNamespace(state=SimpleNamespace())
+
+    # Act
+    response = rate_limit.rate_limit_exceeded_handler(request, _ExcWithUnreadableLimit())
+
+    # Assert
+    assert response.status_code == 429
+    assert json.loads(response.body)["retry_after"] == 1

--- a/tests/rest/test_rate_limit.py
+++ b/tests/rest/test_rate_limit.py
@@ -403,6 +403,24 @@ def test_explicit_enterprise_override_beats_the_pro_mirror(monkeypatch):
     assert rate_limit.settings.rate_limit.limit_for("read", "enterprise") == "9000/minute"
 
 
+def test_blank_non_enterprise_tier_mirrors_pro_not_unlimited(monkeypatch):
+    """A blanked non-enterprise tier mirrors pro, never an empty (unlimited) limit.
+
+    ``limits.parse_many("")`` raises, and the limiter is built with
+    ``swallow_errors=True`` (fail-open) -> an empty limit string means NO
+    enforcement. An operator who blanks ``RATE_LIMIT_READ_FREE`` (generalizing
+    the documented "blank = mirror pro" enterprise convention) must still get a
+    bounded limit, not unlimited.
+    """
+    # Arrange: blank the free read tier and the starter ingest tier.
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "read_free", "")
+    monkeypatch.setattr(rate_limit.settings.rate_limit, "ingest_starter", "")
+
+    # Assert: each empty tier falls back to pro, never "".
+    assert rate_limit.settings.rate_limit.limit_for("read", "free") == "1000/minute"
+    assert rate_limit.settings.rate_limit.limit_for("ingest", "starter") == "20000/minute"
+
+
 def _build_app_with_limiter(limiter, *, plan: str, workspace: str) -> FastAPI:
     """Wire a given limiter into a minimal read app using the real resolve_limit."""
 

--- a/tests/rest/test_rate_limit.py
+++ b/tests/rest/test_rate_limit.py
@@ -443,7 +443,7 @@ def test_throttle_record_flags_degraded_storage(caplog):
 
 
 # ---------------------------------------------------------------------------
-# H. Bucket isolation + unknown-workspace fallback
+# H. Bucket isolation
 # ---------------------------------------------------------------------------
 def _build_ingest_and_read_app() -> FastAPI:
     """App with BOTH an ingest route (.limit) and a read route (.shared_limit).
@@ -500,10 +500,15 @@ def test_ingest_and_read_buckets_do_not_share_a_counter():
     assert [client.post("/ingest").status_code for _ in range(3)] == [200, 200, 429]
 
 
-def test_missing_workspace_falls_back_to_unknown_bucket_and_warns(caplog):
-    """A non-exempt request with no workspace lands in the shared ``unknown``
-    bucket and logs a warning, so a broken validate contract is visible rather
-    than silently collapsing tenants into one shared bucket."""
+def test_set_rate_limit_identity_has_no_unknown_workspace_fallback(caplog):
+    """The ``unknown``-workspace fallback bucket + its warning were removed.
+
+    Upstream auth now guarantees a workspace on every enforced path (ingest and
+    dashboard read each 503 without one — see test_auth_deps), so this layer no
+    longer substitutes a sentinel or warns. An empty workspace (only reachable on
+    exempt internal calls, which are never enforced) stamps through as-is, with
+    no ``unknown`` segment in the key and no warning.
+    """
     # Arrange
     request = Request({"type": "http", "headers": [], "state": {}})
     rate_limit.clear_request_rate_limit_exempt()
@@ -513,26 +518,7 @@ def test_missing_workspace_falls_back_to_unknown_bucket_and_warns(caplog):
         rate_limit.set_rate_limit_identity(request, "", "free")
     key = rate_limit.key_read(request)
 
-    # Assert: collapses to the shared fallback bucket, and the collapse is logged.
-    assert key == f"rl:{rate_limit.BUCKET_READ}:free:{rate_limit._UNKNOWN_WORKSPACE}"
-    assert any("unknown workspace" in r.message.lower() for r in caplog.records)
-
-
-def test_exempt_request_with_missing_workspace_does_not_warn(caplog):
-    """Trusted internal (exempt) calls legitimately have no workspace, so the
-    unknown-workspace fallback must NOT warn for them."""
-    # Arrange
-    request = Request({"type": "http", "headers": [], "state": {}})
-    rate_limit.clear_request_rate_limit_exempt()
-    rate_limit.mark_request_rate_limit_exempt()
-
-    # Act
-    try:
-        with caplog.at_level("WARNING"):
-            rate_limit.set_rate_limit_identity(request, "", "free")
-    finally:
-        # Don't leak the exemption into other tests sharing this context.
-        rate_limit.clear_request_rate_limit_exempt()
-
-    # Assert
-    assert not any("unknown workspace" in r.message.lower() for r in caplog.records)
+    # Assert: no sentinel constant, no ``unknown`` bucket segment, no warning.
+    assert not hasattr(rate_limit, "_UNKNOWN_WORKSPACE")
+    assert key == f"rl:{rate_limit.BUCKET_READ}:free:"
+    assert not any("workspace" in r.message.lower() for r in caplog.records)

--- a/tests/rest/test_rate_limit.py
+++ b/tests/rest/test_rate_limit.py
@@ -482,3 +482,99 @@ def test_throttle_record_flags_degraded_storage(caplog):
 
     # Assert
     assert any("degraded" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# H. Bucket isolation + unknown-workspace fallback
+# ---------------------------------------------------------------------------
+def _build_ingest_and_read_app() -> FastAPI:
+    """App with BOTH an ingest route (.limit) and a read route (.shared_limit).
+
+    Mirrors production wiring: ingest is keyed by key_ingest, reads share the
+    ``read`` scope keyed by key_read. Same workspace + plan, so the two keys
+    differ ONLY in the bucket segment (rl:ingest:... vs rl:read:...) — exactly
+    the case a shared-counter bug would surface.
+    """
+    limiter = Limiter(
+        key_func=get_remote_address,
+        enabled=True,
+        storage_uri="memory://",
+        headers_enabled=True,
+        in_memory_fallback_enabled=True,
+        swallow_errors=True,
+    )
+
+    async def stamp(request: Request):
+        rate_limit.clear_request_rate_limit_exempt()
+        rate_limit.set_rate_limit_identity(request, "ws-iso", "free")
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.add_exception_handler(RateLimitExceeded, rate_limit.rate_limit_exceeded_handler)
+
+    @app.post("/ingest")
+    @limiter.limit("2/minute", key_func=rate_limit.key_ingest)
+    async def ingest(request: Request, response: Response, _=Depends(stamp)):
+        return {"bucket": "ingest"}
+
+    @app.get("/read")
+    @limiter.shared_limit("2/minute", scope=rate_limit.BUCKET_READ, key_func=rate_limit.key_read)
+    async def read(request: Request, response: Response, _=Depends(stamp)):
+        return {"bucket": "read"}
+
+    return app
+
+
+def test_ingest_and_read_buckets_do_not_share_a_counter():
+    """Exhausting the read budget must not consume the ingest budget.
+
+    Both keys embed the same workspace+plan and differ only in the bucket
+    segment, so this proves they map to independent counters rather than one
+    shared bucket.
+    """
+    # Arrange
+    client = TestClient(_build_ingest_and_read_app())
+
+    # Act / Assert: drain read to its 2/min ceiling (3rd read 429)...
+    assert [client.get("/read").status_code for _ in range(3)] == [200, 200, 429]
+    # ...the ingest bucket is untouched: its own 2/min still allows two POSTs,
+    # then throttles on its own third — independent of the read bucket above.
+    assert [client.post("/ingest").status_code for _ in range(3)] == [200, 200, 429]
+
+
+def test_missing_workspace_falls_back_to_unknown_bucket_and_warns(caplog):
+    """A non-exempt request with no workspace lands in the shared ``unknown``
+    bucket and logs a warning, so a broken validate contract is visible rather
+    than silently collapsing tenants into one shared bucket."""
+    # Arrange
+    request = Request({"type": "http", "headers": [], "state": {}})
+    rate_limit.clear_request_rate_limit_exempt()
+
+    # Act
+    with caplog.at_level("WARNING"):
+        rate_limit.set_rate_limit_identity(request, "", "free")
+    key = rate_limit.key_read(request)
+
+    # Assert: collapses to the shared fallback bucket, and the collapse is logged.
+    assert key == f"rl:{rate_limit.BUCKET_READ}:free:{rate_limit._UNKNOWN_WORKSPACE}"
+    assert any("unknown workspace" in r.message.lower() for r in caplog.records)
+
+
+def test_exempt_request_with_missing_workspace_does_not_warn(caplog):
+    """Trusted internal (exempt) calls legitimately have no workspace, so the
+    unknown-workspace fallback must NOT warn for them."""
+    # Arrange
+    request = Request({"type": "http", "headers": [], "state": {}})
+    rate_limit.clear_request_rate_limit_exempt()
+    rate_limit.mark_request_rate_limit_exempt()
+
+    # Act
+    try:
+        with caplog.at_level("WARNING"):
+            rate_limit.set_rate_limit_identity(request, "", "free")
+    finally:
+        # Don't leak the exemption into other tests sharing this context.
+        rate_limit.clear_request_rate_limit_exempt()
+
+    # Assert
+    assert not any("unknown workspace" in r.message.lower() for r in caplog.records)

--- a/tests/rest/test_sessions_router.py
+++ b/tests/rest/test_sessions_router.py
@@ -19,8 +19,8 @@ def mock_trace_reader():
 def client(mock_trace_reader):
     async def mock_get_access(project_id: str, x_user_id=None):
         # Mirror the validate-project-access contract (workspaceId + billingPlan)
-        # so get_rate_limited_project_access stamps a real workspace instead of
-        # the _UNKNOWN_WORKSPACE fallback (which warns on every request).
+        # so get_rate_limited_project_access stamps a real workspace for the
+        # per-workspace rate limiter.
         return ProjectAccessInfo(
             project_id=project_id,
             user_id="test-user",

--- a/tests/rest/test_sessions_router.py
+++ b/tests/rest/test_sessions_router.py
@@ -18,7 +18,16 @@ def mock_trace_reader():
 @pytest.fixture()
 def client(mock_trace_reader):
     async def mock_get_access(project_id: str, x_user_id=None):
-        return ProjectAccessInfo(project_id=project_id, user_id="test-user", role="ADMIN")
+        # Mirror the validate-project-access contract (workspaceId + billingPlan)
+        # so get_rate_limited_project_access stamps a real workspace instead of
+        # the _UNKNOWN_WORKSPACE fallback (which warns on every request).
+        return ProjectAccessInfo(
+            project_id=project_id,
+            user_id="test-user",
+            role="ADMIN",
+            workspace_id="ws-test",
+            billing_plan="free",
+        )
 
     app.dependency_overrides[get_project_access] = mock_get_access
 

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -81,7 +81,16 @@ def client(mock_trace_reader):
     """TestClient with mocked auth and trace reader."""
 
     async def mock_get_access(project_id: str, x_user_id=None):
-        return ProjectAccessInfo(project_id=project_id, user_id="test-user", role="ADMIN")
+        # Mirror the validate-project-access contract (workspaceId + billingPlan)
+        # so get_rate_limited_project_access stamps a real workspace instead of
+        # the _UNKNOWN_WORKSPACE fallback (which warns on every request).
+        return ProjectAccessInfo(
+            project_id=project_id,
+            user_id="test-user",
+            role="ADMIN",
+            workspace_id="ws-test",
+            billing_plan="free",
+        )
 
     app.dependency_overrides[get_project_access] = mock_get_access
 

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -82,8 +82,8 @@ def client(mock_trace_reader):
 
     async def mock_get_access(project_id: str, x_user_id=None):
         # Mirror the validate-project-access contract (workspaceId + billingPlan)
-        # so get_rate_limited_project_access stamps a real workspace instead of
-        # the _UNKNOWN_WORKSPACE fallback (which warns on every request).
+        # so get_rate_limited_project_access stamps a real workspace for the
+        # per-workspace rate limiter.
         return ProjectAccessInfo(
             project_id=project_id,
             user_id="test-user",

--- a/tests/rest/test_users_router.py
+++ b/tests/rest/test_users_router.py
@@ -19,8 +19,8 @@ def mock_trace_reader():
 def client(mock_trace_reader):
     async def mock_get_access(project_id: str, x_user_id=None):
         # Mirror the validate-project-access contract (workspaceId + billingPlan)
-        # so get_rate_limited_project_access stamps a real workspace instead of
-        # the _UNKNOWN_WORKSPACE fallback (which warns on every request).
+        # so get_rate_limited_project_access stamps a real workspace for the
+        # per-workspace rate limiter.
         return ProjectAccessInfo(
             project_id=project_id,
             user_id="test-user",

--- a/tests/rest/test_users_router.py
+++ b/tests/rest/test_users_router.py
@@ -18,7 +18,16 @@ def mock_trace_reader():
 @pytest.fixture()
 def client(mock_trace_reader):
     async def mock_get_access(project_id: str, x_user_id=None):
-        return ProjectAccessInfo(project_id=project_id, user_id="test-user", role="ADMIN")
+        # Mirror the validate-project-access contract (workspaceId + billingPlan)
+        # so get_rate_limited_project_access stamps a real workspace instead of
+        # the _UNKNOWN_WORKSPACE fallback (which warns on every request).
+        return ProjectAccessInfo(
+            project_id=project_id,
+            user_id="test-user",
+            role="ADMIN",
+            workspace_id="ws-test",
+            billing_plan="free",
+        )
 
     app.dependency_overrides[get_project_access] = mock_get_access
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1591,7 +1591,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "redis", specifier = ">=5.0" },
-    { name = "slowapi", specifier = ">=0.1.9" },
+    { name = "slowapi", specifier = ">=0.1.9,<0.2" },
     { name = "tiktoken", specifier = ">=0.5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27" },
     { name = "watchfiles", specifier = ">=0.21" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -418,6 +418,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -644,6 +656,20 @@ wheels = [
 ]
 
 [[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
+]
+
+[[package]]
 name = "lz4"
 version = "4.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -746,6 +772,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
 ]
 
 [[package]]
@@ -1366,6 +1404,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1497,6 +1547,7 @@ dependencies = [
     { name = "cuid2" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "opentelemetry-api" },
     { name = "opentelemetry-proto" },
     { name = "protobuf" },
     { name = "psycopg2-binary" },
@@ -1505,6 +1556,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-multipart" },
     { name = "redis" },
+    { name = "slowapi" },
     { name = "tiktoken" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "watchfiles" },
@@ -1530,6 +1582,7 @@ requires-dist = [
     { name = "cuid2", specifier = ">=2.0.0" },
     { name = "fastapi", specifier = ">=0.109" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-proto", specifier = ">=1.20.0" },
     { name = "protobuf", specifier = ">=6.33.5" },
     { name = "psycopg2-binary", specifier = ">=2.9" },
@@ -1538,6 +1591,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "redis", specifier = ">=5.0" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "tiktoken", specifier = ">=0.5.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.27" },
     { name = "watchfiles", specifier = ">=0.21" },
@@ -1845,6 +1899,81 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/ac/4370bde262c0e633e6c4f0e56d55095710024cf9a5cecc20c59a10de483c/wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c", size = 80321, upload-time = "2026-05-22T14:47:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/79/b8ff3a61e71babf58a8cf4c0d63358e8bad383e15bf7f35e62d2f6b6e4a4/wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c", size = 81216, upload-time = "2026-05-22T14:47:45.243Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fd/c0cac1f77c9c4f6fe58a920ca632ce379bb8be928720e11e8d73de28a5e9/wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245", size = 159208, upload-time = "2026-05-22T14:47:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4f/744132a7b2fbefa6b81118ec5942eca5fc2e9a129f9055a0c5e46885a549/wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0", size = 160322, upload-time = "2026-05-22T14:47:49.04Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/b7cd9a22a06cf93e6482904ee6afc956248983553593fd1009296d1b3b31/wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1", size = 153243, upload-time = "2026-05-22T14:47:50.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4a/eb79423192015f46f0db2872e7e04a3dde8d359b83411e8959e7c9287eaa/wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18", size = 159231, upload-time = "2026-05-22T14:47:51.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dc/435015b58ce33c6fc4104158fa91ddb0e809ab03a5751fb7465d1d461456/wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9", size = 152351, upload-time = "2026-05-22T14:47:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ac/5d203f98df8fd136b95c5227139aea02d34505e18baf812d0c005df61963/wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027", size = 158347, upload-time = "2026-05-22T14:47:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/a92427dbdc74e54c1674abbed27e61b2cb5e7a94441b8c1270c70671d928/wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd", size = 77562, upload-time = "2026-05-22T14:47:56.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/987b9c13b3e1c1a3c6de71284076f996b79caec90e75a87c044a40c23db9/wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343", size = 80616, upload-time = "2026-05-22T14:47:57.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/d01f560888d99d94a959c85533de349ce68d71ace3f2591d6ea8f632cfed/wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a", size = 79025, upload-time = "2026-05-22T14:47:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The REST API has no rate limiting today. A single workspace can potentially send unlimited trace ingestion or dashboard read requests, and because cloud is a shared, multi-tenant deployment, one workspace under heavy load can slow the API down for every other customer. This PR adds rate limiting to contain that.

## Type of Change
- [x] feat - A new feature

Limits are applied per workspace and scaled by billing plan. They only take effect on cloud — self-hosted deployments are unaffected (see Notes).

## What changed

Two kinds of traffic are limited, with separate budgets:

- Ingestion — `POST /public/traces`, where SDKs push trace data.
- Dashboard reads — the trace / session / user list endpoints the UI calls, which share one budget per workspace.

## Design notes:

- Limited per workspace, not per API key. Per-key limits would let a customer create more keys to get more quota; keying on the workspace prevents that.
- Fails open. Rate limiting must never be the reason a request fails. Counters live in Redis, shared across API replicas. If Redis is unreachable each replica counts in memory; if the limiter itself errors, the request is allowed through rather than returning a 500.
- Standard 429 contract. Over-limit requests return HTTP 429 with `Retry-After` and `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`, so SDKs and callers can back off.
- Internal service-to-service calls are exempt.

## Default limits (Unit: per minute)

| Plan | Ingestion | Dashboard reads |
| --- | ---: | ---: |
| Free | 1,000 | 60 |
| Starter | 5,000 | 300 |
| Pro | 20,000 | 1,000 |
| Enterprise | same as Pro | same as Pro |

Every value is overridable with `RATE_LIMIT_*` environment variables.

## Self-host vs cloud

The Helm chart defaults billing to off, so a plain `helm install` runs with no limiting. On cloud, Terraform sets billing on, which overrides the chart default. Cloud behavior does not change.

## Rolling it out

There's a shadow mode (`RATE_LIMIT_SHADOW=true`): the limiter checks every request and logs the ones it *would* block, without actually blocking them. The plan is to run shadow first on cloud, confirm the limits are reasonable against real traffic, adjust the numbers (env vars only, no code change), then switch to enforcing. If anything goes wrong, `RATE_LIMIT_ENABLED=false` disables it instantly with no deploy.

## Notes

Rate limiting only takes effect on Traceroot cloud, no limits on self-host but depends on user's infra. It is gated on `ENABLE_BILLING`: the Helm chart defaults this to `false`, so a plain `helm install` runs with limiting off and all tiers unlocked. Cloud sets `ENABLE_BILLING=true` via Terraform, which overrides the chart default. This matches Langfuse, which applies no limits when not running as cloud.

## Test plan

Automated — `tests/rest/test_rate_limit.py` (25 tests, part of the suite; 303 pass):

- [x] Per-tier enforcement: with a tier's limit overridden to a small number, the (N+1)th request returns 429 while a higher tier at the same request count does not — `test_resolve_limit_applies_per_plan_limits`.
- [x] 429 carries the JSON envelope + `Retry-After` / `X-RateLimit-*` — `test_enforcement_third_request_is_throttled_with_429_envelope`.
- [x] Ingestion and read buckets have independent counters — `test_ingest_and_read_buckets_do_not_share_a_counter`.
- [x] traces/sessions/users share one read budget; a missing workspace falls back to a shared bucket and logs a warning — `test_missing_workspace_falls_back_to_unknown_bucket_and_warns`.
- [x] Self-host disables the limiter when `ENABLE_BILLING=false` — `test_self_host_disables_limiter_*`.
- [x] Shadow mode counts over-limit requests without blocking — `test_shadow_mode_records_but_does_not_block`.

Need @XinweiHe a maintainer to run manually the following, on cloud staging before enforcing:

- [ ] Run with shadow mode on, watch logs for how often real traffic would be limited, tune the numbers.
- [ ] Set one tier's limit small, send requests past it, confirm a 429 with the headers below, then restore.
- [ ] On a self-hosted build, confirm requests are never throttled.

## Sample 429

Free tier overridden to 3/min, 4th read:

```http
HTTP/1.1 429 Too Many Requests
retry-after: 61
x-ratelimit-limit: 3
x-ratelimit-remaining: 0
x-ratelimit-reset: 1779579045

{"error":"too_many_requests","detail":"Rate limit exceeded. Slow down and retry after the cooldown.","retry_after":61,"limit":3,"remaining":0}
```

## Headroom

The dashboard auto-refreshes every ~5s and those reads share the per-workspace read budget. Free tier read = 60/min covers a single active tab with room to spare; this is the limit most worth validating in shadow mode before enforcing, and raising if real traffic warrants.

## Rollout

Enable shadow mode first (`RATE_LIMIT_SHADOW=true`) to measure against real traffic, tune limits via env vars (no code change), then turn shadow off to enforce. Instant rollback: `RATE_LIMIT_ENABLED=false` disables limiting with no deploy.


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tiered, per‑workspace rate limiting for trace ingestion and dashboard reads to protect cloud performance and enforce plan quotas. Over‑limit requests return 429 with a JSON error and a Retry‑After derived from the active window; self‑host remains unlimited.

- **New Features**
  - Per‑workspace limits keyed by workspace and plan; two buckets: ingestion (`POST /public/traces`) and a shared read budget for traces/sessions/users. Internal service calls are exempt.
  - Defaults per minute: Free 1k ingest / 60 reads; Starter 5k / 300; Pro 20k / 1k; Enterprise mirrors Pro.
  - 429 contract with `Retry-After` and `X-RateLimit-*` headers; exceeded requests are logged and counted via `opentelemetry-api`. Backed by `slowapi` (`>=0.1.9,<0.2`) with Redis storage and in‑memory fallback (fail‑open).
  - Cloud‑only gating via `ENABLE_BILLING` (trimmed, case‑insensitive). Ops knobs: `RATE_LIMIT_ENABLED` (kill‑switch), `RATE_LIMIT_STORAGE_URI` (defaults to `REDIS_URL`). Reads now require `workspaceId`; ingestion rejects empty `workspaceId`. Missing `billingPlan` falls back to `free`. Pro plan copy updated to “20k ingest + 1k dashboard requests/min”.

- **Migration**
  - Cloud: enable with `RATE_LIMIT_ENABLED=true`; rollback by setting `RATE_LIMIT_ENABLED=false`. Self‑host is off by default (`ENABLE_BILLING=false`). Helm defaults `enableBilling=false`, and prod compose now passes `ENABLE_BILLING` to the `rest` service (set to `false` to disable); a deploy test guards this.
  - Shadow mode removed; use the kill‑switch for rollout.

<sup>Written for commit 21e4eb097b7512ac854a6af858195a7a41bad618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

