### PR TITLE
chore: update Claude model pricing

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -1,14 +1,26 @@
 [
   {
+    "id": "tr-claude-opus-4-7",
+    "modelName": "claude-opus-4-7",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-7(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-7-opus(@[\\d-]+)?)$",
+    "provider": "anthropic",
+    "prices": {
+      "input": 0.000005,
+      "output": 0.000025,
+      "cacheRead": 0.0000005,
+      "cacheWrite": 0.00000625
+    }
+  },
+  {
     "id": "tr-claude-opus-4-6",
     "modelName": "claude-opus-4-6",
     "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-6(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-6-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
-      "input": 0.000015,
-      "output": 0.000075,
-      "cacheRead": 0.0000015,
-      "cacheWrite": 0.00001875
+      "input": 0.000005,
+      "output": 0.000025,
+      "cacheRead": 0.0000005,
+      "cacheWrite": 0.00000625
     }
   },
   {
@@ -29,10 +41,10 @@
     "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
-      "input": 0.000015,
-      "output": 0.000075,
-      "cacheRead": 0.0000015,
-      "cacheWrite": 0.00001875
+      "input": 0.000005,
+      "output": 0.000025,
+      "cacheRead": 0.0000005,
+      "cacheWrite": 0.00000625
     }
   },
   {
@@ -53,10 +65,10 @@
     "matchPattern": "(?i)^(anthropic\\/)?(claude-haiku-4-5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-haiku(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
-      "input": 0.0000008,
-      "output": 0.000004,
-      "cacheRead": 0.00000008,
-      "cacheWrite": 0.000001
+      "input": 0.000001,
+      "output": 0.000005,
+      "cacheRead": 0.0000001,
+      "cacheWrite": 0.00000125
     }
   },
   {
@@ -593,10 +605,10 @@
     "matchPattern": "(?i)^(anthropic\\/)?(claude-3-opus(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-opus(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
-      "input": 0.000015,
-      "output": 0.000075,
-      "cacheRead": 0.0000015,
-      "cacheWrite": 0.00001875
+      "input": 0.000005,
+      "output": 0.000025,
+      "cacheRead": 0.0000005,
+      "cacheWrite": 0.00000625
     }
   },
   {

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -241,6 +241,10 @@ class TestCalculateCost:
 
 # (model_id, expected modelName) for IDs the worker must price correctly.
 CLAUDE_BEDROCK_VERTEX_CASES = [
+    ("claude-opus-4-7", "claude-opus-4-7"),
+    ("claude-opus-4-7[1m]", "claude-opus-4-7"),
+    ("us.anthropic.claude-opus-4-7-20260514-v1:0", "claude-opus-4-7"),
+    ("claude-4-7-opus@20260514", "claude-opus-4-7"),
     # Bedrock — with cross-region inference profile prefixes
     ("us.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5"),
     ("eu.anthropic.claude-haiku-4-5-20251001-v1:0", "claude-haiku-4-5"),


### PR DESCRIPTION
## Summary
- add pricing and model matching for Claude Opus 4.7
- update current Claude Opus/Haiku pricing entries
- cover Opus 4.7 direct, cache-duration, Bedrock, and Vertex-style model IDs in pricing tests

## Testing
- uv run pytest tests/worker/tokens/test_pricing.py

## Notes
- This PR intentionally does not change cache-token accounting in otel_transform.py. Provider-aware cache pricing is deferred to a follow-up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Anthropic pricing and add support for `claude-opus-4-7`. Align Opus/Haiku prices with the latest rates and extend matching/tests for Bedrock and Vertex IDs.

- New Features
  - Add `claude-opus-4-7` to `standard-model-prices.json` with input 0.000005, output 0.000025, cacheRead 0.0000005, cacheWrite 0.00000625.
  - Update pricing for `claude-opus-4-6`, `claude-opus-4-5`, and `claude-3-opus` to the same Opus rates; set `claude-haiku-4-5` to input 0.000001, output 0.000005, cacheRead 0.0000001, cacheWrite 0.00000125.
  - Broaden match patterns and tests to cover direct IDs, `[1m]` cache-duration, Bedrock cross-region, and Vertex aliases for 4.7.

<sup>Written for commit 54d25ab760ebf09707c54f0fcf3f2ee52c89d176. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/942?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

