### PR TITLE
Validate Content-Type for trace ingest endpoint

### DIFF
--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -172,6 +172,22 @@ async def ingest_traces(
 
     project_id = auth.project_id
 
+    # Validate Content-Type before reading body
+    # Accept exactly 'application/x-protobuf' and variants with parameters
+    content_type = request.headers.get("content-type")
+    if not content_type:
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="Content-Type must be application/x-protobuf",
+        )
+    # handle parameters like 'application/x-protobuf; charset=utf-8'
+    mime = content_type.split(";", 1)[0].strip().lower()
+    if mime != "application/x-protobuf":
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="Content-Type must be application/x-protobuf",
+        )
+
     # 1. Read body
     body = await request.body()
 

--- a/tests/rest/test_free_plan_blocker.py
+++ b/tests/rest/test_free_plan_blocker.py
@@ -38,7 +38,11 @@ class TestFreePlanBlocker:
         )
 
         test_client = TestClient(app)
-        response = test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
 
         assert response.status_code == 402
         assert "Free plan limit exceeded" in response.json()["detail"]
@@ -61,7 +65,11 @@ class TestFreePlanBlocker:
         monkeypatch.setattr("rest.routers.public.traces.process_s3_traces", MagicMock())
 
         test_client = TestClient(app)
-        response = test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
 
         assert response.status_code == 200
 
@@ -83,7 +91,11 @@ class TestFreePlanBlocker:
         monkeypatch.setattr("rest.routers.public.traces.process_s3_traces", MagicMock())
 
         test_client = TestClient(app)
-        response = test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
 
         assert response.status_code == 200
 
@@ -104,6 +116,10 @@ class TestFreePlanBlocker:
         monkeypatch.setattr("rest.routers.public.traces.process_s3_traces", MagicMock())
 
         test_client = TestClient(app)
-        response = test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
 
         assert response.status_code == 200

--- a/tests/rest/test_public_traces.py
+++ b/tests/rest/test_public_traces.py
@@ -49,6 +49,7 @@ class TestIngestTraces:
         response = test_client.post(
             "/api/v1/public/traces",
             content=b"fake-protobuf-bytes",
+            headers={"Content-Type": "application/x-protobuf"},
         )
         assert response.status_code == 200
         data = response.json()
@@ -69,7 +70,7 @@ class TestIngestTraces:
         response = test_client.post(
             "/api/v1/public/traces",
             content=compressed,
-            headers={"Content-Encoding": "gzip"},
+            headers={"Content-Encoding": "gzip", "Content-Type": "application/x-protobuf"},
         )
         assert response.status_code == 200
         mock_decode.assert_called_once_with(raw_bytes)
@@ -77,7 +78,11 @@ class TestIngestTraces:
     def test_empty_body_returns_400(self):
         app.dependency_overrides[authenticate_api_key] = lambda: make_auth_result()
         test_client = TestClient(app)
-        response = test_client.post("/api/v1/public/traces", content=b"")
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
         assert response.status_code == 400
 
     def test_invalid_protobuf_returns_400(self, monkeypatch):
@@ -87,7 +92,11 @@ class TestIngestTraces:
             MagicMock(side_effect=Exception("Invalid protobuf")),
         )
         test_client = TestClient(app)
-        response = test_client.post("/api/v1/public/traces", content=b"garbage-data")
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"garbage-data",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
         assert response.status_code == 400
 
     def test_invalid_gzip_returns_400(self):
@@ -96,26 +105,38 @@ class TestIngestTraces:
         response = test_client.post(
             "/api/v1/public/traces",
             content=b"not-gzip-data",
-            headers={"Content-Encoding": "gzip"},
+            headers={"Content-Encoding": "gzip", "Content-Type": "application/x-protobuf"},
         )
         assert response.status_code == 400
 
     def test_s3_failure_returns_500(self, client):
         test_client, mock_s3, _ = client
         mock_s3.upload_json.side_effect = Exception("S3 connection refused")
-        response = test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
         assert response.status_code == 500
 
     def test_celery_failure_still_returns_200(self, client):
         """Celery enqueue failure is logged but response is still 200 (S3 has the data)."""
         test_client, _mock_s3, mock_task = client
         mock_task.delay.side_effect = Exception("Redis down")
-        response = test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
         assert response.status_code == 200
 
     def test_s3_key_time_partitioned_format(self, client):
         test_client, mock_s3, _ = client
-        test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
+        test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
         s3_key = mock_s3.upload_json.call_args[0][0]
         assert s3_key.startswith("events/otel/test-project/")
         assert s3_key.endswith(".json")
@@ -125,7 +146,11 @@ class TestIngestTraces:
 
     def test_celery_task_receives_correct_args(self, client):
         test_client, _mock_s3, mock_task = client
-        test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
+        test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
         kw = mock_task.delay.call_args.kwargs
         assert kw["project_id"] == "test-project"
         assert kw["s3_key"].startswith("events/otel/test-project/")
@@ -134,9 +159,40 @@ class TestIngestTraces:
         test_client, mock_s3, _ = client
         decoded = {"resourceSpans": [{"custom": "data"}]}
         monkeypatch.setattr("rest.routers.public.traces.decode_otlp_protobuf", lambda _: decoded)
-        test_client.post("/api/v1/public/traces", content=b"protobuf-bytes")
+        test_client.post(
+            "/api/v1/public/traces",
+            content=b"protobuf-bytes",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
         uploaded_data = mock_s3.upload_json.call_args[0][1]
         assert uploaded_data == decoded
+
+
+class TestContentTypeValidation:
+    def test_missing_content_type_returns_415(self, client):
+        test_client, _mock_s3, _ = client
+        response = test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
+        assert response.status_code == 415
+        assert response.json().get("detail") == "Content-Type must be application/x-protobuf"
+
+    def test_invalid_content_type_returns_415(self, client):
+        test_client, _mock_s3, _ = client
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 415
+        assert response.json().get("detail") == "Content-Type must be application/x-protobuf"
+
+    def test_content_type_with_parameters_accepted(self, client):
+        test_client, _mock_s3, _ = client
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf; charset=utf-8"},
+        )
+        assert response.status_code == 200
 
 
 class TestIngestNoAuth:


### PR DESCRIPTION
## Summary

Adds Content-Type validation to the public trace ingest endpoint so unsupported media types fail early with a clear 415 response.

Fixes: N/A

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to our CI configuration files and scripts
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

The public trace ingest endpoint documents `Content-Type: application/x-protobuf`, but the request body was previously processed before validating the media type.

This change:
- Checks the `Content-Type` header before reading/parsing the request body
- Accepts `application/x-protobuf`
- Accepts `application/x-protobuf` with parameters, such as `application/x-protobuf; charset=utf-8`
- Returns `415 Unsupported Media Type` for missing or unsupported content types

## Screenshots / Recordings (if applicable)

N/A

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Content-Type validation to the public trace ingest endpoint to accept only `application/x-protobuf` (parameters allowed). Unsupported or missing types now return 415 before reading the body; tests updated to require the header and cover missing/invalid/parameterized cases.

<sup>Written for commit 4c989f83d64e183b9597c617ba13277c560a3a6d. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/943?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

