### PR TITLE
chore: update Claude Agent SDK example

### DIFF
--- a/examples/typescript/claude-agent-sdk/agent.ts
+++ b/examples/typescript/claude-agent-sdk/agent.ts
@@ -72,6 +72,7 @@ async function runResearch(topic: string): Promise<string> {
         `Coordinate the agents and present the final report.`,
       ].join(''),
       options: {
+        model: 'claude-opus-4-6',
         allowedTools: ['Agent'],
         maxTurns: 15,
         // bypassPermissions auto-approves all tool calls. Demo-only — do NOT

--- a/examples/typescript/claude-agent-sdk/package.json
+++ b/examples/typescript/claude-agent-sdk/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
-    "@traceroot-ai/traceroot": "0.1.2",
+    "@traceroot-ai/traceroot": "0.1.5",
     "dotenv": "^16.4.5",
     "openai": "^6.34.0"
   },


### PR DESCRIPTION
## Summary
- update the TypeScript Claude Agent SDK example to use @traceroot-ai/traceroot 0.1.5
- set the top-level Claude Agent SDK query model explicitly to claude-opus-4-6 while keeping subagents on haiku

## Testing
- pre-commit hooks passed during commit

## Notes
- This PR intentionally excludes local e2e scratch files such as agent-v1.ts, agent-v2.ts, and pnpm-lock.yaml.

<!-- This is an auto-generated description by cubic. -->

## Screenshots
<img width="2556" height="1331" alt="claude-agent-sdk-trace-v2" src="https://github.com/user-attachments/assets/d8ec9d0d-37aa-41a5-89b6-25a3681b98e4" />
<img width="2555" height="1324" alt="claude-agent-sdk-timeline-v2" src="https://github.com/user-attachments/assets/67dea647-6fac-4855-a1a2-c0b76a396cf9" />


---
## Summary by cubic
Sets the top-level model in the TypeScript Claude Agent SDK example to `claude-opus-4-6` and updates `@traceroot-ai/traceroot` to `0.1.5` for compatibility and better orchestration.

- **New Features**
  - Explicitly sets `model: 'claude-opus-4-6'` for the coordinator agent. Subagents remain on Haiku.

- **Dependencies**
  - Bump `@traceroot-ai/traceroot` from `0.1.2` to `0.1.5`.

<sup>Written for commit 3c5a81907e6a429936c1f63c47b18c4cfe35326b. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/944?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

