### PR TITLE
fix(examples): Update LangGraph code-agent deps

### DIFF
--- a/examples/python/langgraph-code-agent/agent.py
+++ b/examples/python/langgraph-code-agent/agent.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 from typing import Any, TypedDict
 
-from langchain.prompts import ChatPromptTemplate
+from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 from langgraph.graph import END, StateGraph
 from pydantic import BaseModel, Field

--- a/examples/python/langgraph-code-agent/requirements.txt
+++ b/examples/python/langgraph-code-agent/requirements.txt
@@ -1,5 +1,5 @@
 langchain==1.3.1
-langgraph==1.0.10rc1
+langgraph>=1.2.0,<1.3.0
 langchain-openai==1.1.14
 openai>=1.0.0
 python-dotenv>=1.0.0


### PR DESCRIPTION
Fixes #940

## Summary

Update the LangGraph code-agent example so its dependency set resolves with the documented `uv run --no-project --python 3.13 --with-requirements requirements.txt` command.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Relax `langgraph` from the incompatible `1.0.10rc1` pin to the `>=1.2.0,<1.3.0` range required by `langchain==1.3.1`.
- Update the prompt import to `langchain_core.prompts.ChatPromptTemplate`, which is available with the current LangChain package split.

## Screenshots / Recordings (if applicable)

N/A

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

Validation:

- Before the change, `uv run --no-project --python 3.13 --with-requirements requirements.txt python -c 'print("deps ok")'` failed with the dependency conflict from #940.
- After the change, `uv run --no-project --python 3.13 --with-requirements requirements.txt python - <<'PY' ... from agent import build_graph ... PY` resolves dependencies, imports the example, and compiles the graph.
- `uv run --no-project --python 3.13 --with-requirements requirements.txt python -m py_compile agent.py server.py`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dependency resolution for the LangGraph code-agent example when installing via `uv` on Python 3.13, so the example installs and runs cleanly.

- **Bug Fixes**
  - Updated `langgraph` from `1.0.10rc1` to `>=1.2.0,<1.3.0` to align with `langchain==1.3.1` and resolve conflicts.
  - Switched prompt import to `langchain_core.prompts.ChatPromptTemplate` to match the current `langchain` package split.

<sup>Written for commit abd0b261f3163677fe8fb52fa659c372f1d80fce. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/945?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

