### PR TITLE
docs: add Ask DeepWiki badge to READMEs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -11,6 +11,7 @@
   [![Discord][discord-image]][discord-url]
   [![Documentation][docs-image]][docs-url]
   [![PyPI SDK Downloads][pypi-sdk-downloads-image]][pypi-sdk-downloads-url]
+  [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/traceroot-ai/traceroot)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   [![Discord][discord-image]][discord-url]
   [![Documentation][docs-image]][docs-url]
   [![PyPI SDK Downloads][pypi-sdk-downloads-image]][pypi-sdk-downloads-url]
+  [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/traceroot-ai/traceroot)
 
 </div>
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,6 +11,7 @@
   [![Discord][discord-image]][discord-url]
   [![Documentation][docs-image]][docs-url]
   [![PyPI SDK Downloads][pypi-sdk-downloads-image]][pypi-sdk-downloads-url]
+  [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/traceroot-ai/traceroot)
 
 </div>
 


### PR DESCRIPTION
## Summary
- Add the Ask DeepWiki badge to `README.md`, `README.zh.md`, and `README.ko.md`, placed alongside the existing badge row.

## Test plan
- [x] Verify the badge renders on the rendered README on the PR page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added the Ask DeepWiki badge to README.md, README.zh.md, and README.ko.md alongside the existing badges, linking to https://deepwiki.com/traceroot-ai/traceroot. This gives readers a quick, consistent entry point to DeepWiki from all README variants.

<sup>Written for commit 40ef52e19fed970a6434fe15290b6355ce335a43. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/946?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

