### PR TITLE
fix(frontend): Stabilize trace detail loading

### DIFF
--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.ts
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const sourcePath = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "TraceViewerPanel.tsx",
+);
+const source = readFileSync(sourcePath, "utf8");
+
+describe("TraceViewerPanel trace loading", () => {
+  it("uses the auth-aware useTrace hook instead of fetching trace details directly", () => {
+    expect(source).toContain('import { useTrace } from "../hooks";');
+    expect(source).toContain("useTrace(projectId, traceId)");
+    expect(source).not.toContain('import { getTrace } from "@/lib/api"');
+    expect(source).not.toContain("queryFn: () => getTrace(projectId, traceId");
+  });
+
+  it("keeps loading visible while the auth-gated trace query is pending", () => {
+    expect(source).toContain("isPending");
+    expect(source).toContain("Loading trace...");
+    expect(source).not.toContain("isLoading ?");
+  });
+});

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.ts
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.ts
@@ -3,10 +3,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
 
-const sourcePath = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "TraceViewerPanel.tsx",
-);
+const sourcePath = path.join(path.dirname(fileURLToPath(import.meta.url)), "TraceViewerPanel.tsx");
 const source = readFileSync(sourcePath, "utf8");
 
 describe("TraceViewerPanel trace loading", () => {

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState, useEffect, useRef, useCallback } from "react";
-import { useQuery } from "@tanstack/react-query";
 import {
   Workflow,
   X,
@@ -14,13 +13,13 @@ import {
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
-import { getTrace } from "@/lib/api";
 import type { Span } from "@/types/api";
 import type { TraceSelection } from "../types";
 import { SpanTreeView } from "./SpanTreeView";
 import { SpanInfoPanel } from "./SpanInfoPanel";
 import { useLayout } from "@/components/layout/app-layout";
 import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
+import { useTrace } from "../hooks";
 import { useTraceStream } from "../hooks/use-trace-stream";
 import { SpanTimelineView } from "./SpanTimelineView";
 import { buildSpanTree, enrichSpansWithPending, TREE_LAYOUT } from "../utils";
@@ -105,14 +104,7 @@ export function TraceViewerPanel({
     setAiPanelOpen(true);
   }, [autoOpenRca, rcaSessionId, traceId, setAiContext, setAiInitialSessionId, setAiPanelOpen]);
 
-  const {
-    data: trace,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: ["trace", projectId, traceId],
-    queryFn: () => getTrace(projectId, traceId, ""),
-  });
+  const { data: trace, isPending, error } = useTrace(projectId, traceId);
 
   useTraceStream(projectId, traceId, true);
 
@@ -349,7 +341,7 @@ export function TraceViewerPanel({
                 minSize="320px"
                 className="min-w-0 overflow-hidden bg-background"
               >
-                {isLoading ? (
+                {isPending ? (
                   <div className="flex h-full items-center justify-center">
                     <p className="text-sm text-muted-foreground">Loading trace...</p>
                   </div>


### PR DESCRIPTION
Fixes #948

## Summary

TraceViewerPanel now loads trace details through the existing auth-aware `useTrace` hook instead of creating its own direct `useQuery(getTrace(...))` call.

This keeps the trace detail request aligned with the trace list and session detail paths: it waits for the auth session to be ready and passes the current user headers into the trace API call. The panel also uses the hook's pending state so it stays on the loading UI during that auth-gated window instead of falling through to the error state.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Reuses `useTrace(projectId, traceId)` in `TraceViewerPanel`.
- Removes the duplicate direct `getTrace` query from the panel.
- Adds a regression test that guards the trace viewer wiring and loading-state behavior.

## Screenshots / Recordings (if applicable)

N/A. This is a request/loading-state fix.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

## Validation

- `pnpm --dir frontend/ui exec vitest run src/features/traces/components/TraceViewerPanel.test.ts src/features/traces/utils/index.test.ts`
- `pnpm --dir frontend/ui exec tsc --noEmit`
- `pnpm --dir frontend/ui lint` (passes with existing warnings)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes trace detail loading in TraceViewerPanel by switching to the auth-aware `useTrace` hook and keeping the UI in a loading state until auth is ready. Prevents the false error state during the auth gating window.

- **Bug Fixes**
  - Replace direct `useQuery`/`getTrace` with `useTrace(projectId, traceId)`; remove `@tanstack/react-query` usage in the panel.
  - Use `isPending` to keep "Loading trace..." visible until headers are ready.
  - Add a regression test to enforce hook usage and pending-state behavior.

<sup>Written for commit 72897751b80d5a9793a14d05c0c70c36eb6d5c88. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/949?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

