### PR TITLE
Fix theme inconsistencies across logo and 404 page, and fix Windows pre-commit hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Auto detect text files and force LF line endings
+* text=auto eol=lf
+
+# Specific overrides (optional, but good to have)
+*.ts text eol=lf
+*.tsx text eol=lf
+*.js text eol=lf
+*.jsx text eol=lf
+*.json text eol=lf
+*.css text eol=lf
+*.md text eol=lf

--- a/frontend/ui/src/app/not-found.tsx
+++ b/frontend/ui/src/app/not-found.tsx
@@ -1,0 +1,26 @@
+// app/not-found.tsx
+
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="text-center">
+        <h1 className="mb-4 text-6xl font-bold text-foreground">404</h1>
+        <h2 className="mb-4 text-2xl text-foreground">Page Not Found</h2>
+
+        <p className="mb-8 text-muted-foreground">The page you are looking for does not exist.</p>
+        <Link
+          href="/"
+          className={cn(
+            "inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground",
+            "transition-colors hover:bg-primary/90",
+          )}
+        >
+          Go Home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/components/Logo.tsx
+++ b/frontend/ui/src/components/Logo.tsx
@@ -16,14 +16,14 @@ interface LogoProps {
  * TraceRoot Logo React component with theme support
  */
 export function Logo({ className, size = "sm" }: LogoProps) {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  const isDark = mounted && theme === "dark";
+  const isDark = mounted && resolvedTheme === "dark";
 
   const sizeClasses = {
     sm: "h-5 w-5",


### PR DESCRIPTION
Fixes #953 , #939 , #934

## Summary
This PR resolves theme inconsistencies and fixes Windows pre‑commit hook failures:
- Logo component – switched from theme to resolvedTheme so explicit dark mode and system dark mode produce the same icon color.

- 404 page – added custom not-found.tsx with theme‑aware styling using CSS variables (bg-background, text-foreground) and a “Go Home” button.

- Pre‑commit (Windows) – added .gitattributes forcing LF line endings, preventing conflicts between mixed-line-ending and lint-staged on Windows.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
Logo fix
- frontend/ui/src/components/Logo.tsx
- Changed const { theme } = useTheme() → const { resolvedTheme } = useTheme(
- Added hydration guard (mounted state)
- Now isDark correctly detects dark mode for both explicit "dark" and "system" (when OS is dark).

404 page
- Added app/not-found.tsx (was previously using Next.js default).
- Uses Tailwind CSS with design tokens (bg-background, text-foreground, text-muted-foreground, bg-primary).
- Includes a “Go Home” link styled as a primary button.
- No client‑side hooks → no hydration mismatch.

Pre‑commit Windows fix
- Added .gitattributes at repo root with:
- * text=auto eol=lf
- After git add --renormalize ., all text files use LF line endings.
- The mixed-line-ending hook no longer modifies staged files, eliminating merge conflicts with lint-staged.

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes theme inconsistencies in the logo and 404 page, and stabilizes pre-commit hooks on Windows by enforcing LF line endings. Dark mode now renders correctly across the app, and Windows commits no longer fail.

- **Bug Fixes**
  - Logo: use `resolvedTheme` with a hydration guard for consistent dark mode (explicit and system).
  - 404: add custom `app/not-found.tsx` with theme-aware styles and a “Go Home” button.
  - Windows pre-commit: add `.gitattributes` to force LF line endings; prevents conflicts with `lint-staged`.

- **Migration**
  - After pulling, run: git add --renormalize . (once) to update local line endings.

<sup>Written for commit ff718ac7cf14fa0e4dafcbe3f19a8680e3aaa12f. Summary will update on new commits. <a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/954?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

