### PR TITLE
fix(worker): Include cache tokens in span cost

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -84,6 +84,11 @@ def first_present(attrs: dict[str, Any], keys: list[str]) -> Any:
     return None
 
 
+def int_or_zero(value: Any) -> int:
+    """Convert a present OTEL numeric attribute to int, defaulting missing values to zero."""
+    return int(value) if value is not None else 0
+
+
 def decode_otel_id(b64_value: str | None) -> str | None:
     """Decode base64-encoded OTEL trace/span ID to hex string.
 
@@ -393,31 +398,53 @@ def transform_otel_to_clickhouse(
                     # Try API-provided token counts first (from instrumentors)
                     # OpenInference: llm.token_count.*
                     # GenAI semconv: gen_ai.usage.*
-                    api_input_tokens = (
-                        span_attrs.get("llm.token_count.prompt")
-                        or span_attrs.get("gen_ai.usage.input_tokens")
-                        or span_attrs.get("gen_ai.usage.prompt_tokens")
+                    api_input_tokens = first_present(
+                        span_attrs,
+                        [
+                            "llm.token_count.prompt",
+                            "gen_ai.usage.input_tokens",
+                            "gen_ai.usage.prompt_tokens",
+                        ],
                     )
-                    api_output_tokens = (
-                        span_attrs.get("llm.token_count.completion")
-                        or span_attrs.get("gen_ai.usage.output_tokens")
-                        or span_attrs.get("gen_ai.usage.completion_tokens")
+                    api_output_tokens = first_present(
+                        span_attrs,
+                        [
+                            "llm.token_count.completion",
+                            "gen_ai.usage.output_tokens",
+                            "gen_ai.usage.completion_tokens",
+                        ],
                     )
-                    api_total_tokens = span_attrs.get("llm.token_count.total") or span_attrs.get(
-                        "gen_ai.usage.total_tokens"
+                    api_total_tokens = first_present(
+                        span_attrs,
+                        ["llm.token_count.total", "gen_ai.usage.total_tokens"],
+                    )
+                    api_cache_read_tokens = first_present(
+                        span_attrs,
+                        [
+                            "gen_ai.usage.cache_read_input_tokens",
+                            "gen_ai.usage.input_cached_tokens",
+                            "gen_ai.usage.details.cache_read_tokens",
+                        ],
+                    )
+                    api_cache_write_tokens = first_present(
+                        span_attrs,
+                        [
+                            "gen_ai.usage.cache_creation_input_tokens",
+                            "gen_ai.usage.details.cache_write_tokens",
+                        ],
                     )
 
                     if api_input_tokens is not None or api_output_tokens is not None:
                         # Use API-provided counts (accurate)
-                        input_tokens = int(api_input_tokens) if api_input_tokens is not None else 0
-                        output_tokens = (
-                            int(api_output_tokens) if api_output_tokens is not None else 0
-                        )
+                        input_tokens = int_or_zero(api_input_tokens)
+                        output_tokens = int_or_zero(api_output_tokens)
                         total_tokens = (
-                            int(api_total_tokens)
+                            int_or_zero(api_total_tokens)
                             if api_total_tokens is not None
                             else input_tokens + output_tokens
                         )
+                        cache_read_tokens = int_or_zero(api_cache_read_tokens)
+                        cache_write_tokens = int_or_zero(api_cache_write_tokens)
                         span_record["input_tokens"] = input_tokens
                         span_record["output_tokens"] = output_tokens
                         span_record["total_tokens"] = total_tokens
@@ -436,7 +463,15 @@ def transform_otel_to_clickhouse(
                             output_cost = Decimal(output_tokens) * Decimal(
                                 str(prices.get("output", 0))
                             )
-                            span_record["cost"] = float(input_cost + output_cost)
+                            cache_read_cost = Decimal(cache_read_tokens) * Decimal(
+                                str(prices.get("cacheRead") or 0)
+                            )
+                            cache_write_cost = Decimal(cache_write_tokens) * Decimal(
+                                str(prices.get("cacheWrite") or 0)
+                            )
+                            span_record["cost"] = float(
+                                input_cost + output_cost + cache_read_cost + cache_write_cost
+                            )
                     else:
                         # Fall back to text-based estimation
                         from worker.tokens import calculate_cost

--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -108,6 +108,8 @@ def calculate_cost(
     model: str,
     input_text: str | None,
     output_text: str | None,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
 ) -> dict[str, int | float | None]:
     """Calculate token usage and cost.
 
@@ -138,6 +140,8 @@ def calculate_cost(
         # Prices are in USD per token — multiply directly
         input_cost = Decimal(input_tokens) * Decimal(str(prices.get("input", 0)))
         output_cost = Decimal(output_tokens) * Decimal(str(prices.get("output", 0)))
-        result["cost"] = float(input_cost + output_cost)
+        cache_read_cost = Decimal(cache_read_tokens) * Decimal(str(prices.get("cacheRead") or 0))
+        cache_write_cost = Decimal(cache_write_tokens) * Decimal(str(prices.get("cacheWrite") or 0))
+        result["cost"] = float(input_cost + output_cost + cache_read_cost + cache_write_cost)
 
     return result

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -3,6 +3,8 @@
 import base64
 from datetime import datetime
 
+import pytest
+
 from tests.fixtures.otel_payloads import make_attr, make_otel_payload, make_span
 from worker.otel_transform import (
     attributes_to_dict,
@@ -382,6 +384,66 @@ class TestTransformOtelToClickhouse:
         assert spans[0]["output_tokens"] == 50
         assert spans[0]["total_tokens"] == 150
         assert spans[0]["cost"] is not None
+
+    @pytest.mark.parametrize(
+        ("model_name", "cache_attrs", "prices"),
+        [
+            (
+                "claude-3-5-sonnet",
+                [
+                    make_attr("gen_ai.usage.cache_read_input_tokens", 900),
+                    make_attr("gen_ai.usage.cache_creation_input_tokens", 100),
+                ],
+                {
+                    "input": 0.000003,
+                    "output": 0.000015,
+                    "cacheRead": 0.0000003,
+                    "cacheWrite": 0.00000375,
+                },
+            ),
+            (
+                "gpt-4o",
+                [
+                    make_attr("gen_ai.usage.input_cached_tokens", 900),
+                    make_attr("gen_ai.usage.details.cache_write_tokens", 100),
+                ],
+                {
+                    "input": 0.0000025,
+                    "output": 0.00001,
+                    "cacheRead": 0.0000005,
+                    "cacheWrite": 0.00000375,
+                },
+            ),
+        ],
+    )
+    def test_api_token_cost_includes_cache_usage(self, model_name, cache_attrs, prices):
+        from unittest.mock import patch
+
+        trace_hex = "aa" * 16
+        span_hex = "bb" * 8
+        payload = make_otel_payload(
+            [
+                make_span(
+                    trace_hex,
+                    span_hex,
+                    attributes=[
+                        make_attr("gen_ai.request.model", model_name),
+                        make_attr("gen_ai.usage.input_tokens", 100),
+                        make_attr("gen_ai.usage.output_tokens", 50),
+                        *cache_attrs,
+                    ],
+                )
+            ]
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert spans[0]["cost"] == pytest.approx(
+            100 * prices["input"]
+            + 50 * prices["output"]
+            + 900 * prices["cacheRead"]
+            + 100 * prices["cacheWrite"]
+        )
 
     def test_text_estimation_fallback(self):
         """Falls back to text-based token estimation when no API counts."""

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -24,12 +24,22 @@ MOCK_CACHE = [
     {
         "model_name": "gpt-4o",
         "match_pattern": "(?i)^(openai\\/)?(gpt-4o)(-[\\d-]+)?$",
-        "prices": {"input": 0.0000025, "output": 0.00001},
+        "prices": {
+            "input": 0.0000025,
+            "output": 0.00001,
+            "cacheRead": 0.0000005,
+            "cacheWrite": 0.00000375,
+        },
     },
     {
         "model_name": "claude-3-5-sonnet",
         "match_pattern": "(?i)^(anthropic\\/)?(claude-3-5-sonnet)(-[\\d-]+)?$",
-        "prices": {"input": 0.000003, "output": 0.000015},
+        "prices": {
+            "input": 0.000003,
+            "output": 0.000015,
+            "cacheRead": 0.0000003,
+            "cacheWrite": 0.00000375,
+        },
     },
 ]
 
@@ -231,6 +241,24 @@ class TestCalculateCost:
         # Cost should be a reasonable float, not have floating-point artifacts
         cost_str = f"{result['cost']:.10f}"
         assert "999999" not in cost_str  # No floating-point weirdness
+
+    def test_cache_tokens_are_included_in_cost(self):
+        result = calculate_cost(
+            "gpt-4o",
+            "Hello",
+            "World",
+            cache_read_tokens=100,
+            cache_write_tokens=20,
+        )
+
+        assert result["cost"] is not None
+        input_cost = result["input_tokens"] * MOCK_CACHE[0]["prices"]["input"]
+        output_cost = result["output_tokens"] * MOCK_CACHE[0]["prices"]["output"]
+        cache_read_cost = 100 * MOCK_CACHE[0]["prices"]["cacheRead"]
+        cache_write_cost = 20 * MOCK_CACHE[0]["prices"]["cacheWrite"]
+        assert result["cost"] == pytest.approx(
+            input_cost + output_cost + cache_read_cost + cache_write_cost
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #956

## Summary

Include cache-read and cache-write token charges in the Python ingest cost path so prompt-cached spans are no longer undercounted.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Extend `calculate_cost` with optional `cache_read_tokens` and `cache_write_tokens` inputs.
- Read Anthropic, OpenAI, and fallback OTel cache token attributes before computing ingest cost.
- Treat missing or null cache prices as zero, matching the existing TypeScript cost calculator behavior.
- Add regression coverage for direct pricing calls and OTEL API-token spans with cache-heavy usage.

## Screenshots / Recordings (if applicable)

Not applicable.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

Validation:

- `UV_HTTP_TIMEOUT=120 uv run pytest tests/worker/tokens/test_pricing.py tests/worker/test_otel_transform.py -q`
- `uv run ruff format --check backend/worker/tokens/pricing.py backend/worker/otel_transform.py tests/worker/tokens/test_pricing.py tests/worker/test_otel_transform.py`
- `uv run ruff check backend/worker/tokens/pricing.py backend/worker/otel_transform.py tests/worker/tokens/test_pricing.py tests/worker/test_otel_transform.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include cache-read and cache-write token charges in the Python ingest cost path so prompt-cached spans are counted correctly. Fixes #956.

- **Bug Fixes**
  - Add `cache_read_tokens` and `cache_write_tokens` to `calculate_cost` and include them in span cost.
  - Parse cache token OTEL attributes (Anthropic/OpenAI variants) and default missing cache prices to zero.
  - Add regression tests for pricing and OTEL transform with cache-heavy spans.

<sup>Written for commit 2a1f787c001c72b90e962326333e6b2fe6ec6ab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/961?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

