### PR TITLE
feat(frontend): standardize token display as x → y (z)

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -13,7 +13,7 @@ import {
   formatDuration,
   formatDate,
   formatCost,
-  formatTokens,
+  formatTokenFlow,
   cn,
   buildUrlWithFilters,
 } from "@/lib/utils";
@@ -308,10 +308,9 @@ export default function TracesPage() {
                           {(trace.total_input_tokens ?? 0) + (trace.total_output_tokens ?? 0) >
                           0 ? (
                             <span
-                              title={`${(trace.total_input_tokens ?? 0).toLocaleString()} / ${(trace.total_output_tokens ?? 0).toLocaleString()}`}
+                              title={`${(trace.total_input_tokens ?? 0).toLocaleString()} → ${(trace.total_output_tokens ?? 0).toLocaleString()} (${((trace.total_input_tokens ?? 0) + (trace.total_output_tokens ?? 0)).toLocaleString()})`}
                             >
-                              {formatTokens(trace.total_input_tokens ?? 0)} /{" "}
-                              {formatTokens(trace.total_output_tokens ?? 0)}
+                              {formatTokenFlow(trace.total_input_tokens, trace.total_output_tokens)}
                             </span>
                           ) : (
                             "-"

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -14,7 +14,7 @@ import {
   FileCode,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
-import { formatDuration, formatDate, formatTokens, buildUrlWithFilters } from "@/lib/utils";
+import { formatDuration, formatDate, formatTokenFlow, buildUrlWithFilters } from "@/lib/utils";
 import { SpanStatus } from "@traceroot/core";
 import type { TraceDetail } from "@/types/api";
 import type { TraceSelection } from "../types";
@@ -123,10 +123,12 @@ export function SpanInfoPanel({
           {isTrace && traceTokenUsage && (
             <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
               <CircleStop className="h-3 w-3 text-muted-foreground" />
-              <span className="font-medium">{formatTokens(traceTokenUsage.totalTokens)}</span>
-              <span className="text-muted-foreground">
-                ({formatTokens(traceTokenUsage.inputTokens)} in /{" "}
-                {formatTokens(traceTokenUsage.outputTokens)} out)
+              <span className="font-medium">
+                {formatTokenFlow(
+                  traceTokenUsage.inputTokens,
+                  traceTokenUsage.outputTokens,
+                  traceTokenUsage.totalTokens,
+                )}
               </span>
             </div>
           )}
@@ -144,10 +146,12 @@ export function SpanInfoPanel({
           {!isTrace && selection.span.total_tokens != null && (
             <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
               <CircleStop className="h-3 w-3 text-muted-foreground" />
-              <span className="font-medium">{formatTokens(selection.span.total_tokens)}</span>
-              <span className="text-muted-foreground">
-                ({formatTokens(selection.span.input_tokens)} in /{" "}
-                {formatTokens(selection.span.output_tokens)} out)
+              <span className="font-medium">
+                {formatTokenFlow(
+                  selection.span.input_tokens,
+                  selection.span.output_tokens,
+                  selection.span.total_tokens,
+                )}
               </span>
             </div>
           )}

--- a/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useRef, useEffect, type RefObject } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { CircleStop, CircleDollarSign } from "lucide-react";
-import { cn, formatDuration, formatTokens } from "@/lib/utils";
+import { cn, formatDuration, formatTokenFlow } from "@/lib/utils";
 import { SpanStatus, SpanKind } from "@traceroot/core";
 import { flattenTreeWithMetrics } from "../utils/timeline";
 import { TREE_LAYOUT, enrichSpansWithPending, getTraceDuration } from "../utils";
@@ -105,9 +105,11 @@ export function SpanTimelineView({
   }, [traceDurationMs, timelineWidth]);
 
   const traceAggregates = useMemo(() => {
+    const inputTokens = trace.spans.reduce((sum, s) => sum + (s.input_tokens || 0), 0);
+    const outputTokens = trace.spans.reduce((sum, s) => sum + (s.output_tokens || 0), 0);
     const totalTokens = trace.spans.reduce((sum, s) => sum + (s.total_tokens || 0), 0);
     const totalCost = trace.spans.reduce((sum, s) => sum + (s.cost || 0), 0);
-    return { totalTokens, totalCost };
+    return { inputTokens, outputTokens, totalTokens, totalCost };
   }, [trace.spans]);
 
   const traceIsCollapsed = collapsedIds.has("trace");
@@ -223,7 +225,11 @@ export function SpanTimelineView({
                       {traceAggregates.totalTokens > 0 && (
                         <span className="inline-flex items-center gap-0.5">
                           <CircleStop className="h-2.5 w-2.5" />
-                          {formatTokens(traceAggregates.totalTokens)}
+                          {formatTokenFlow(
+                            traceAggregates.inputTokens,
+                            traceAggregates.outputTokens,
+                            traceAggregates.totalTokens,
+                          )}
                         </span>
                       )}
                       {traceAggregates.totalCost > 0 && (
@@ -291,7 +297,7 @@ export function SpanTimelineView({
                     {showTokens && (
                       <span className="inline-flex items-center gap-0.5">
                         <CircleStop className="h-2.5 w-2.5" />
-                        {formatTokens(span.total_tokens!)}
+                        {formatTokenFlow(span.input_tokens, span.output_tokens, span.total_tokens)}
                       </span>
                     )}
                     {showCost && (

--- a/frontend/ui/src/lib/utils.ts
+++ b/frontend/ui/src/lib/utils.ts
@@ -81,6 +81,11 @@ export function formatTokenFlow(
   total?: number | null | undefined,
 ): string {
   const resolvedTotal = total ?? (input ?? 0) + (output ?? 0);
+  // When the input/output breakdown is unknown, show only the total rather
+  // than a misleading "0 → 0 (z)".
+  if (input == null && output == null) {
+    return formatTokens(resolvedTotal);
+  }
   return `${formatTokens(input ?? 0)} → ${formatTokens(output ?? 0)} (${formatTokens(resolvedTotal)})`;
 }
 

--- a/frontend/ui/src/lib/utils.ts
+++ b/frontend/ui/src/lib/utils.ts
@@ -75,6 +75,15 @@ export function formatTokens(count: number | null | undefined): string {
   return _compactTokenFormatter.format(count);
 }
 
+export function formatTokenFlow(
+  input: number | null | undefined,
+  output: number | null | undefined,
+  total?: number | null | undefined,
+): string {
+  const resolvedTotal = total ?? (input ?? 0) + (output ?? 0);
+  return `${formatTokens(input ?? 0)} → ${formatTokens(output ?? 0)} (${formatTokens(resolvedTotal)})`;
+}
+
 /**
  * Parse a date string as UTC.
  * Backend sends timestamps without timezone marker, but they are UTC.


### PR DESCRIPTION
Closes #957

## Summary

Unify token counts across the trace UI on the `x → y (z)` format (input → output (total)) via a shared formatTokenFlow helper, replacing the previous mixed formats. Applies to the trace list, the SpanInfoPanel trace-header and per-span badges, and the SpanTimelineView trace/span bars. Preserves the existing formatTokens thousands-formatting.

## Type of Change

- [x] feat - A new feature

## Screenshots 

Trace list:

<img width="1723" height="159" alt="image" src="https://github.com/user-attachments/assets/a8e62205-077d-4ce3-b275-6b9fadf8d438" />

Trace detail header:

<img width="1316" height="451" alt="image" src="https://github.com/user-attachments/assets/01283e03-a1df-432a-b93a-ea2fd2b70550" />

Timeline view:

<img width="1316" height="275" alt="image" src="https://github.com/user-attachments/assets/3bf9732c-8838-4005-9183-dfe7ea9358fe" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes token display across the trace UI to the x → y (z) format and avoids misleading flows when breakdowns are unknown. Addresses #957 by unifying counts in lists, headers, badges, and timeline bars.

- **New Features**
  - Added `formatTokenFlow`; keeps `formatTokens` thousands-formatting.
  - Applied to trace list, SpanInfoPanel, and SpanTimelineView; tooltips/titles use the new format.

- **Bug Fixes**
  - When only total tokens are known, show just the total instead of "0 → 0 (z)"; implemented in the shared utility so all views inherit the fix.

<sup>Written for commit 852fb3a1d1d18ede661401cf55b07d74798194b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

