### PR TITLE
fix(404): add not-found.tsx to replace default 404 page

### DIFF
--- a/frontend/ui/src/app/not-found.tsx
+++ b/frontend/ui/src/app/not-found.tsx
@@ -1,0 +1,26 @@
+// app/not-found.tsx
+
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="text-center">
+        <h1 className="mb-4 text-6xl font-bold text-foreground">404</h1>
+        <h2 className="mb-4 text-2xl text-foreground">Page Not Found</h2>
+
+        <p className="mb-8 text-muted-foreground">The page you are looking for does not exist.</p>
+        <Link
+          href="/"
+          className={cn(
+            "inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground",
+            "transition-colors hover:bg-primary/90",
+          )}
+        >
+          Go Home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #939 

## Summary

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a custom 404 page (`app/not-found.tsx`) that replaces the default and matches our design. Includes a "Go Home" button using `next/link`; fixes #939.

<sup>Written for commit a6a59eb3ad88c452a2cb78d482c9e6e705f1cc63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/965?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

