### PR TITLE
fix(logo): use resolvedTheme instead of theme for consistent dark mode

### DIFF
--- a/frontend/ui/src/components/Logo.tsx
+++ b/frontend/ui/src/components/Logo.tsx
@@ -16,14 +16,14 @@ interface LogoProps {
  * TraceRoot Logo React component with theme support
  */
 export function Logo({ className, size = "sm" }: LogoProps) {
-  const { theme } = useTheme();
+  const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
   }, []);
 
-  const isDark = mounted && theme === "dark";
+  const isDark = mounted && resolvedTheme === "dark";
 
   const sizeClasses = {
     sm: "h-5 w-5",


### PR DESCRIPTION
Fixes #934 

## Summary

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #934 by using resolvedTheme instead of theme in the Logo. The logo now matches the effective dark mode on initial load and when the system theme changes.

<sup>Written for commit f6e3319cf9eb9f8511df22f9dea86b018973748b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/966?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

