### PR TITLE
Avoid exposing gzip decompression errors

### DIFF
--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -190,7 +190,7 @@ async def ingest_traces(
             logger.warning(f"Failed to decompress gzip: {e}")
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Failed to decompress gzip: {e}",
+                detail="Invalid gzip payload",
             ) from e
 
     # 3. Decode protobuf to camelCase JSON (OTLP standard format)

--- a/tests/rest/test_public_traces.py
+++ b/tests/rest/test_public_traces.py
@@ -99,6 +99,7 @@ class TestIngestTraces:
             headers={"Content-Encoding": "gzip"},
         )
         assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid gzip payload"
 
     def test_s3_failure_returns_500(self, client):
         test_client, mock_s3, _ = client


### PR DESCRIPTION
Fixes N/A

## Summary

Avoid exposing raw gzip decompression exception details in the public trace ingest endpoint.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

When gzip decompression fails, the endpoint now returns a stable client-facing error message:

`Invalid gzip payload`

The detailed exception is still kept in server logs for debugging.

This keeps the API response cleaner and avoids exposing internal exception details to clients.

## Screenshots / Recordings (if applicable)

N/A

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid exposing raw gzip decompression exceptions in the public trace ingest endpoint. Now returns 400 with "Invalid gzip payload" while logging full details; added a test to assert the response message.

<sup>Written for commit 0b1f658ae6b382856bf958b3537d5d43bb440d31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/968?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

