### PR TITLE
Avoid exposing protobuf parser errors

### DIFF
--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -201,7 +201,7 @@ async def ingest_traces(
         logger.warning(f"Failed to parse OTLP protobuf: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Failed to parse OTLP protobuf: {e}",
+            detail="Malformed OTLP protobuf payload",
         ) from e
 
     # 4. Generate S3 key (time-partitioned)

--- a/tests/rest/test_public_traces.py
+++ b/tests/rest/test_public_traces.py
@@ -89,6 +89,7 @@ class TestIngestTraces:
         test_client = TestClient(app)
         response = test_client.post("/api/v1/public/traces", content=b"garbage-data")
         assert response.status_code == 400
+        assert response.json()["detail"] == "Malformed OTLP protobuf payload"
 
     def test_invalid_gzip_returns_400(self):
         app.dependency_overrides[authenticate_api_key] = lambda: make_auth_result()


### PR DESCRIPTION
Fixes N/A

## Summary

Avoid exposing raw protobuf parser exception details in the public trace ingest endpoint.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to our CI configuration files and scripts
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit
- [x] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

When OTLP protobuf parsing fails, the endpoint now returns a stable client-facing error message:

`Malformed OTLP protobuf payload`

The detailed parser exception is still kept in server logs for debugging.

This keeps API responses cleaner and avoids exposing internal parser details to clients.

## Screenshots / Recordings (if applicable)

N/A

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide raw protobuf parser errors in the public trace ingest endpoint. Return a stable 400 with "Malformed OTLP protobuf payload" while keeping full details in server logs.

- **Bug Fixes**
  - Replace parser exception text in the 400 response with "Malformed OTLP protobuf payload".
  - Keep the original exception in server logs for debugging.

<sup>Written for commit 2dec0c532e909c0f2e510842d20f6ae3426a73c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/970?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

