### PR TITLE
Fix/storage error message

### DIFF
--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -223,7 +223,7 @@ async def ingest_traces(
         logger.error(f"Failed to upload OTEL JSON to S3: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Storage error: {e}",
+            detail="Failed to store trace payload",
         ) from e
 
     # 6. Enqueue Celery task for async processing (S3 reference only, not full payload)

--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -201,7 +201,7 @@ async def ingest_traces(
         logger.warning(f"Failed to parse OTLP protobuf: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Failed to parse OTLP protobuf: {e}",
+            detail="Malformed OTLP protobuf payload",
         ) from e
 
     # 4. Generate S3 key (time-partitioned)

--- a/tests/rest/test_public_traces.py
+++ b/tests/rest/test_public_traces.py
@@ -106,6 +106,7 @@ class TestIngestTraces:
         mock_s3.upload_json.side_effect = Exception("S3 connection refused")
         response = test_client.post("/api/v1/public/traces", content=b"fake-protobuf")
         assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to store trace payload"
 
     def test_celery_failure_still_returns_200(self, client):
         """Celery enqueue failure is logged but response is still 200 (S3 has the data)."""

--- a/tests/rest/test_public_traces.py
+++ b/tests/rest/test_public_traces.py
@@ -89,6 +89,7 @@ class TestIngestTraces:
         test_client = TestClient(app)
         response = test_client.post("/api/v1/public/traces", content=b"garbage-data")
         assert response.status_code == 400
+        assert response.json()["detail"] == "Malformed OTLP protobuf payload"
 
     def test_invalid_gzip_returns_400(self):
         app.dependency_overrides[authenticate_api_key] = lambda: make_auth_result()


### PR DESCRIPTION
Fixes N/A

## Summary

Avoid exposing raw storage backend exception details in the public trace ingest endpoint.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to our CI configuration files and scripts
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit
- [x] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

When storing decoded trace payloads fails, the endpoint now returns a stable client-facing error message:

`Failed to store trace payload`

The detailed storage backend exception is still kept in server logs for debugging.

This keeps API responses cleaner and avoids exposing internal storage/provider details to clients.

## Screenshots / Recordings (if applicable)

N/A

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop exposing storage and parser error details in the public trace ingest endpoint. Return stable, client-safe messages and keep full exceptions in server logs.

- **Bug Fixes**
  - 400 now returns `Malformed OTLP protobuf payload` instead of raw parser errors.
  - 500 now returns `Failed to store trace payload` instead of storage backend exceptions (tests updated).

<sup>Written for commit 2b06772b9a433134b601f2c3523672ea68d025bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/971?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

