### PR TITLE
Render base64 images inline in trace viewer

### DIFF
--- a/examples/typescript/openai/agent-image.ts
+++ b/examples/typescript/openai/agent-image.ts
@@ -1,0 +1,114 @@
+/**
+ * OpenAI Image Agent — TraceRoot Observability
+ *
+ * A two-step multi-modal flow that tests how the platform tracks images as both
+ * output AND input:
+ *   step 1: text prompt              → image 1 (output)
+ *   step 2: image 1 + edit instruction → image 2 (output)
+ * In step 2 the generated image 1 is fed back in as an `input_image`, so the trace
+ * carries an image on the input side too.
+ *
+ * Uses the Responses API with the built-in `image_generation` tool. TraceRoot's
+ * instrumentModules auto-instruments the OpenAI call, and observe() adds an
+ * explicit span hierarchy.
+ *
+ * Env vars required: OPENAI_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm demo:images
+ */
+
+import 'dotenv/config';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import OpenAI from 'openai';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
+
+// ── TraceRoot setup ───────────────────────────────────────────────────────────
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const openai = new OpenAI();
+console.log('[Observability: TraceRoot]');
+
+const MODEL = 'gpt-4.1';
+const OUTPUT_DIR = join(process.cwd(), 'generated-images');
+
+// ── Agent ─────────────────────────────────────────────────────────────────────
+// Generates an image from a text instruction, optionally conditioned on a prior
+// image (passed as an input_image data URI). Returns the new image as a data URI
+// so it can be fed back in as the input to a subsequent step.
+async function generateImage(
+  instruction: string,
+  index: number,
+  inputImageDataUri?: string,
+): Promise<string> {
+  return observe({ name: 'generate_image', type: 'tool' }, async () => {
+    const content: OpenAI.Responses.ResponseInputContent[] = [
+      { type: 'input_text', text: instruction },
+    ];
+    if (inputImageDataUri) {
+      content.push({ type: 'input_image', image_url: inputImageDataUri, detail: 'auto' });
+    }
+
+    const response = await openai.responses.create({
+      model: MODEL,
+      input: [{ role: 'user', content }],
+      tools: [{ type: 'image_generation' }],
+    });
+
+    // The generated image comes back as raw base64 in the image_generation_call
+    // output item.
+    const b64 = response.output
+      ?.filter((o) => o.type === 'image_generation_call')
+      .map((o) => (o as { result: string | null }).result)[0];
+    if (!b64) throw new Error('No image data returned');
+
+    await mkdir(OUTPUT_DIR, { recursive: true });
+    const filePath = join(OUTPUT_DIR, `image-${index + 1}.png`);
+    await writeFile(filePath, Buffer.from(b64, 'base64'));
+    console.log(`  [Saved: ${filePath}]`);
+
+    return `data:image/png;base64,${b64}`;
+  });
+}
+
+// ── Demo ──────────────────────────────────────────────────────────────────────
+const BASE_PROMPT = 'A cute cartoon robot waving hello, simple line art on white background.';
+const EDIT_INSTRUCTION = 'Add a colorful party hat and some balloons to this robot.';
+
+async function main() {
+  try {
+    await usingAttributes(
+      {
+        sessionId: 'openai-image-session',
+        userId: 'demo-user',
+        tags: ['demo', 'openai', 'image-gen'],
+        metadata: { example: 'openai-image-agent', sdkFeature: 'usingAttributes' },
+      },
+      () => observe({ name: 'image_demo_session' }, async () => {
+        console.log('='.repeat(60));
+        console.log('OpenAI Image Agent — Demo (TraceRoot)');
+        console.log('='.repeat(60));
+
+        // Step 1: text → image 1
+        console.log(`\n${'='.repeat(60)}`);
+        console.log(`Step 1 (text → image): ${BASE_PROMPT}`);
+        console.log('='.repeat(60));
+        const image1 = await generateImage(BASE_PROMPT, 0);
+
+        // Step 2: image 1 (as input) + instruction → image 2
+        console.log(`\n${'='.repeat(60)}`);
+        console.log(`Step 2 (image → image): ${EDIT_INSTRUCTION}`);
+        console.log('='.repeat(60));
+        await generateImage(EDIT_INSTRUCTION, 1, image1);
+      }),
+    );
+  } finally {
+    await TraceRoot.shutdown();
+    console.log('[Traces exported]');
+  }
+}
+
+main().catch(console.error);

--- a/examples/typescript/openai/package.json
+++ b/examples/typescript/openai/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "demo": "tsx agent.ts",
+    "demo:images": "tsx agent-image.ts",
     "streaming": "tsx streaming-pipeline.ts"
   },
   "dependencies": {

--- a/frontend/ui/src/features/traces/components/ContentRenderer.tsx
+++ b/frontend/ui/src/features/traces/components/ContentRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { JsonRenderer } from "./JsonRenderer";
+import { InlineImage, JsonRenderer, imageSrc } from "./JsonRenderer";
 
 interface ContentRendererProps {
   content: string | null;
@@ -14,6 +14,13 @@ export function ContentRenderer({ content }: ContentRendererProps) {
     return <span className="text-[11px] text-muted-foreground">-</span>;
   }
 
+  // A bare image string (data URI or raw base64) won't reach JsonRenderer, so
+  // detect it here too.
+  const directImage = imageSrc(content);
+  if (directImage) {
+    return <InlineImage src={directImage} />;
+  }
+
   // Try to parse as JSON
   try {
     const parsed = JSON.parse(content);
@@ -25,6 +32,10 @@ export function ContentRenderer({ content }: ContentRendererProps) {
       );
     }
     // If it's a primitive after parsing, just show it
+    const parsedImage = typeof parsed === "string" ? imageSrc(parsed) : null;
+    if (parsedImage) {
+      return <InlineImage src={parsedImage} />;
+    }
     return (
       <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
         {content}

--- a/frontend/ui/src/features/traces/components/JsonRenderer.tsx
+++ b/frontend/ui/src/features/traces/components/JsonRenderer.tsx
@@ -5,6 +5,40 @@ interface JsonRendererProps {
   depth?: number;
 }
 
+// Raster image data URIs only — image/svg+xml is excluded because data-URI SVG
+// can execute embedded script (XSS).
+const IMAGE_DATA_URI = /^data:image\/(?:png|jpe?g|gif|webp);base64,[A-Za-z0-9+/=]+$/i;
+
+// Base64-encoded magic-byte prefixes for raster image formats. Used to detect
+// bare base64 (no data: prefix), e.g. OpenAI's image_generation_call.result.
+const BASE64_IMAGE_PREFIXES: ReadonlyArray<readonly [string, string]> = [
+  ["iVBORw0KGgo", "image/png"],
+  ["/9j/", "image/jpeg"],
+  ["R0lGOD", "image/gif"],
+  ["UklGR", "image/webp"],
+];
+
+// Returns a renderable <img> src for inline base64 images, or null.
+export function imageSrc(value: string): string | null {
+  if (IMAGE_DATA_URI.test(value)) return value;
+  if (value.length < 100) return null;
+  const match = BASE64_IMAGE_PREFIXES.find(([prefix]) => value.startsWith(prefix));
+  if (match && /^[A-Za-z0-9+/=]+$/.test(value)) {
+    return `data:${match[1]};base64,${value}`;
+  }
+  return null;
+}
+
+export function InlineImage({ src }: { src: string }) {
+  return (
+    <img
+      src={src}
+      alt="Inline image"
+      className="my-1 max-h-64 max-w-full rounded border border-border"
+    />
+  );
+}
+
 /**
  * Recursive JSON renderer with syntax highlighting
  */
@@ -22,6 +56,12 @@ export function JsonRenderer({ value, depth = 0 }: JsonRendererProps) {
   }
 
   if (typeof value === "string") {
+    // Render inline base64 images (data URIs and bare base64) as images.
+    const src = imageSrc(value);
+    if (src) {
+      return <InlineImage src={src} />;
+    }
+
     // Try to parse JSON strings and render them as structured objects
     if (value.startsWith("{") || value.startsWith("[")) {
       try {


### PR DESCRIPTION
## Summary
- Render base64 images in span input/output as inline `<img>` instead of unreadable raw text.
- Detects both `data:image/...;base64,...` data URIs and **bare** base64 (magic-byte sniffing for png/jpeg/gif/webp). The bare-base64 case covers OpenAI's `image_generation_call.result`, which carries no `data:` prefix.
- Detection is shared via a single `imageSrc()` helper used by both `JsonRenderer` (images nested in structured JSON, e.g. LLM-call spans) and `ContentRenderer` (a bare image string returned directly by a span, e.g. a tool span).
- SVG is deliberately excluded — data-URI SVG can execute embedded script (XSS).
- Display-only: zero storage cost, since the data already lives in the trace.
- Adds `examples/typescript/openai/agent-image.ts` (two-step text→image then image→image flow) as a test case exercising images on both the input and output sides.

Closes #979

## Test plan
- [x] Run `pnpm demo:images` in `examples/typescript/openai` (needs `OPENAI_API_KEY`, `TRACEROOT_API_KEY`).
- [x] Open the resulting `image_demo_session` trace in the UI.
- [x] Verify the step-2 `generate_image` span renders both the **input** `input_image` and the **output** `image_generation_call.result` as inline images.
- [x] Verify non-image plain-text span output still renders as text (no regression).

## Screenshots

<img width="1499" height="957" alt="Screenshot 2026-05-28 at 3 12 27 PM" src="https://github.com/user-attachments/assets/b3327881-9669-4e5f-a953-53aca337cf47" />
<img width="1512" height="917" alt="Screenshot 2026-05-28 at 3 12 36 PM" src="https://github.com/user-attachments/assets/8f9e6bb5-3967-4c8f-bf3a-5c3acb6cb7a7" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render base64 images inline in the trace viewer so spans show actual images instead of raw text. Supports data URIs and bare base64 (png/jpeg/gif/webp), with SVG excluded for safety.

- **New Features**
  - Added shared `imageSrc()` and `InlineImage` used by `JsonRenderer` and `ContentRenderer` to detect and render images.
  - Bare base64 detection via magic-byte prefixes; SVG blocked to prevent XSS.
  - Added `examples/typescript/openai/agent-image.ts` and `demo:images` script to exercise input/output image rendering.

<sup>Written for commit c8b76272fb8062a26d47e6bdec99ff7ba5de4bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/980?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

