### PR TITLE
Render audio inline in trace viewer + fix WAV/WebP misdetection

### DIFF
--- a/examples/typescript/openai/agent-voice.ts
+++ b/examples/typescript/openai/agent-voice.ts
@@ -1,0 +1,126 @@
+/**
+ * OpenAI Voice Agent — TraceRoot Observability
+ *
+ * A two-step flow that tests how the platform tracks audio as both output AND
+ * input:
+ *   step 1: text          → speech (audio output)
+ *   step 2: speech (audio) → transcribed text (audio input)
+ * The generated audio from step 1 is fed back into step 2 as the input, so the
+ * trace carries voice on both the output and input sides.
+ *
+ * Uses the gpt-4o-audio chat API: it returns audio as base64 inside the response
+ * (message.audio.data) and accepts an input_audio content part — so the audio
+ * rides the auto-instrumented OpenAI call as STRUCTURED content (the same shape
+ * images took). Each step is also wrapped in observe() as a tool span, whose
+ * input/output is a bare audio data URI — covering the non-instrumented
+ * (bare-string) path too, so one example exercises both render paths.
+ *
+ * Env vars required: OPENAI_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm demo:voice
+ */
+
+import 'dotenv/config';
+import { writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import OpenAI from 'openai';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
+
+// ── TraceRoot setup ───────────────────────────────────────────────────────────
+TraceRoot.initialize({
+  instrumentModules: { openAI: OpenAI },
+});
+
+const openai = new OpenAI();
+console.log('[Observability: TraceRoot]');
+
+const MODEL = 'gpt-audio-mini';
+const VOICE = 'alloy';
+const FORMAT = 'wav';
+const OUTPUT_DIR = join(process.cwd(), 'generated-audio');
+
+// ── Agent ─────────────────────────────────────────────────────────────────────
+// text → speech. Returns the audio as a data URI so it can be fed back in as the
+// input to the transcription step (and rendered inline in the trace viewer).
+async function textToSpeech(text: string): Promise<string> {
+  const completion = await openai.chat.completions.create({
+    model: MODEL,
+    modalities: ['text', 'audio'],
+    audio: { voice: VOICE, format: FORMAT },
+    messages: [{ role: 'user', content: text }],
+  });
+
+  const data = completion.choices[0].message.audio?.data;
+  if (!data) throw new Error('No audio returned');
+
+  await mkdir(OUTPUT_DIR, { recursive: true });
+  const filePath = join(OUTPUT_DIR, 'speech.wav');
+  await writeFile(filePath, Buffer.from(data, 'base64'));
+  console.log(`  [Saved: ${filePath}]`);
+
+  return `data:audio/wav;base64,${data}`;
+}
+
+// speech (audio data URI) → transcribed text.
+async function speechToText(audioDataUri: string): Promise<string> {
+  const base64 = audioDataUri.slice(audioDataUri.indexOf(',') + 1);
+  const completion = await openai.chat.completions.create({
+    model: MODEL,
+    modalities: ['text'],
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'Transcribe this audio exactly, returning only the spoken words.' },
+          { type: 'input_audio', input_audio: { data: base64, format: FORMAT } },
+        ],
+      },
+    ],
+  });
+
+  return completion.choices[0].message.content ?? '';
+}
+
+// ── Demo ──────────────────────────────────────────────────────────────────────
+const PROMPT = 'Hello from TraceRoot! This message was spoken by an AI voice, then transcribed back to text.';
+
+async function main() {
+  try {
+    await usingAttributes(
+      {
+        sessionId: 'openai-voice-session',
+        userId: 'demo-user',
+        tags: ['demo', 'openai', 'voice'],
+        metadata: { example: 'openai-voice-agent', sdkFeature: 'usingAttributes' },
+      },
+      () => observe({ name: 'voice_demo_session' }, async () => {
+        console.log('='.repeat(60));
+        console.log('OpenAI Voice Agent — Demo (TraceRoot)');
+        console.log('='.repeat(60));
+
+        // Step 1: text → speech
+        console.log(`\n${'='.repeat(60)}`);
+        console.log(`Step 1 (text → speech): ${PROMPT}`);
+        console.log('='.repeat(60));
+        const audio = await observe({ name: 'text_to_speech', type: 'tool' }, textToSpeech, PROMPT);
+
+        // Step 2: speech (as input) → transcribed text
+        console.log(`\n${'='.repeat(60)}`);
+        console.log('Step 2 (speech → text): transcribing generated audio');
+        console.log('='.repeat(60));
+        const transcript = await observe(
+          { name: 'speech_to_text', type: 'tool' },
+          speechToText,
+          audio,
+        );
+        console.log(`  [Transcript: ${transcript}]`);
+      }),
+    );
+  } finally {
+    await TraceRoot.shutdown();
+    console.log('[Traces exported]');
+  }
+}
+
+main().catch(console.error);

--- a/examples/typescript/openai/package.json
+++ b/examples/typescript/openai/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "demo": "tsx agent.ts",
     "demo:images": "tsx agent-image.ts",
+    "demo:voice": "tsx agent-voice.ts",
     "streaming": "tsx streaming-pipeline.ts"
   },
   "dependencies": {

--- a/frontend/ui/src/features/traces/components/ContentRenderer.tsx
+++ b/frontend/ui/src/features/traces/components/ContentRenderer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { InlineImage, JsonRenderer, imageSrc } from "./JsonRenderer";
+import { JsonRenderer } from "./JsonRenderer";
+import { InlineMedia, mediaSrc } from "./inline-media";
 
 interface ContentRendererProps {
   content: string | null;
@@ -14,11 +15,11 @@ export function ContentRenderer({ content }: ContentRendererProps) {
     return <span className="text-[11px] text-muted-foreground">-</span>;
   }
 
-  // A bare image string (data URI or raw base64) won't reach JsonRenderer, so
+  // A bare media string (data URI or raw base64) won't reach JsonRenderer, so
   // detect it here too.
-  const directImage = imageSrc(content);
-  if (directImage) {
-    return <InlineImage src={directImage} />;
+  const directMedia = mediaSrc(content);
+  if (directMedia) {
+    return <InlineMedia {...directMedia} />;
   }
 
   // Try to parse as JSON
@@ -32,9 +33,9 @@ export function ContentRenderer({ content }: ContentRendererProps) {
       );
     }
     // If it's a primitive after parsing, just show it
-    const parsedImage = typeof parsed === "string" ? imageSrc(parsed) : null;
-    if (parsedImage) {
-      return <InlineImage src={parsedImage} />;
+    const parsedMedia = typeof parsed === "string" ? mediaSrc(parsed) : null;
+    if (parsedMedia) {
+      return <InlineMedia {...parsedMedia} />;
     }
     return (
       <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">

--- a/frontend/ui/src/features/traces/components/JsonRenderer.tsx
+++ b/frontend/ui/src/features/traces/components/JsonRenderer.tsx
@@ -1,42 +1,10 @@
 "use client";
 
+import { InlineMedia, mediaSrc } from "./inline-media";
+
 interface JsonRendererProps {
   value: unknown;
   depth?: number;
-}
-
-// Raster image data URIs only — image/svg+xml is excluded because data-URI SVG
-// can execute embedded script (XSS).
-const IMAGE_DATA_URI = /^data:image\/(?:png|jpe?g|gif|webp);base64,[A-Za-z0-9+/=]+$/i;
-
-// Base64-encoded magic-byte prefixes for raster image formats. Used to detect
-// bare base64 (no data: prefix), e.g. OpenAI's image_generation_call.result.
-const BASE64_IMAGE_PREFIXES: ReadonlyArray<readonly [string, string]> = [
-  ["iVBORw0KGgo", "image/png"],
-  ["/9j/", "image/jpeg"],
-  ["R0lGOD", "image/gif"],
-  ["UklGR", "image/webp"],
-];
-
-// Returns a renderable <img> src for inline base64 images, or null.
-export function imageSrc(value: string): string | null {
-  if (IMAGE_DATA_URI.test(value)) return value;
-  if (value.length < 100) return null;
-  const match = BASE64_IMAGE_PREFIXES.find(([prefix]) => value.startsWith(prefix));
-  if (match && /^[A-Za-z0-9+/=]+$/.test(value)) {
-    return `data:${match[1]};base64,${value}`;
-  }
-  return null;
-}
-
-export function InlineImage({ src }: { src: string }) {
-  return (
-    <img
-      src={src}
-      alt="Inline image"
-      className="my-1 max-h-64 max-w-full rounded border border-border"
-    />
-  );
 }
 
 /**
@@ -56,10 +24,10 @@ export function JsonRenderer({ value, depth = 0 }: JsonRendererProps) {
   }
 
   if (typeof value === "string") {
-    // Render inline base64 images (data URIs and bare base64) as images.
-    const src = imageSrc(value);
-    if (src) {
-      return <InlineImage src={src} />;
+    // Render inline base64 media (data URIs and bare base64) as image/audio.
+    const media = mediaSrc(value);
+    if (media) {
+      return <InlineMedia {...media} />;
     }
 
     // Try to parse JSON strings and render them as structured objects

--- a/frontend/ui/src/features/traces/components/inline-media.test.ts
+++ b/frontend/ui/src/features/traces/components/inline-media.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { mediaSrc } from "./inline-media";
+
+// Build a base64 string from a binary header, padded past the bare-base64
+// length threshold (mediaSrc ignores strings shorter than 100 chars).
+function bare(header: number[] | string, totalBytes = 90): string {
+  const head = typeof header === "string" ? Array.from(header, (c) => c.charCodeAt(0)) : header;
+  const buf = Buffer.alloc(totalBytes);
+  buf.set(head, 0);
+  return buf.toString("base64");
+}
+
+// RIFF container: "RIFF" + 4-byte size + a form tag at offset 8.
+function riff(form: string): string {
+  const buf = Buffer.alloc(90);
+  buf.set(
+    Array.from("RIFF", (c) => c.charCodeAt(0)),
+    0,
+  );
+  buf.set([0x24, 0, 0, 0], 4);
+  buf.set(
+    Array.from(form, (c) => c.charCodeAt(0)),
+    8,
+  );
+  return buf.toString("base64");
+}
+
+const PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const JPEG = [0xff, 0xd8, 0xff, 0xe0];
+const MP3_FRAME = [0xff, 0xfb];
+
+describe("mediaSrc — data URIs", () => {
+  it("detects an image data URI", () => {
+    const uri = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==";
+    expect(mediaSrc(uri)).toEqual({ src: uri, kind: "image" });
+  });
+
+  it("detects an audio data URI", () => {
+    const uri = "data:audio/mpeg;base64,SUQzAAAAAAAA";
+    expect(mediaSrc(uri)).toEqual({ src: uri, kind: "audio" });
+  });
+
+  it("rejects svg data URIs (XSS)", () => {
+    expect(mediaSrc("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=")).toBeNull();
+  });
+});
+
+describe("mediaSrc — bare base64 (magic-byte sniffing)", () => {
+  it("detects PNG", () => {
+    expect(mediaSrc(bare(PNG))?.kind).toBe("image");
+    expect(mediaSrc(bare(PNG))?.src).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("detects JPEG", () => {
+    expect(mediaSrc(bare(JPEG))?.kind).toBe("image");
+    expect(mediaSrc(bare(JPEG))?.src).toMatch(/^data:image\/jpeg;base64,/);
+  });
+
+  it("detects GIF", () => {
+    expect(mediaSrc(bare("GIF89a"))?.kind).toBe("image");
+  });
+
+  it("detects MP3 via ID3 tag", () => {
+    expect(mediaSrc(bare("ID3"))?.kind).toBe("audio");
+    expect(mediaSrc(bare("ID3"))?.src).toMatch(/^data:audio\/mpeg;base64,/);
+  });
+
+  it("detects MP3 via frame sync", () => {
+    expect(mediaSrc(bare(MP3_FRAME))?.kind).toBe("audio");
+  });
+
+  it("detects OGG", () => {
+    expect(mediaSrc(bare("OggS"))?.kind).toBe("audio");
+  });
+
+  // The RIFF collision: WAV and WebP share the "UklGR" base64 prefix and can
+  // only be told apart by the format tag at byte offset 8.
+  it("distinguishes WAV (audio) from WebP (image) — both are RIFF", () => {
+    expect(mediaSrc(riff("WAVE"))).toMatchObject({ kind: "audio" });
+    expect(mediaSrc(riff("WAVE"))?.src).toMatch(/^data:audio\/wav;base64,/);
+    expect(mediaSrc(riff("WEBP"))).toMatchObject({ kind: "image" });
+    expect(mediaSrc(riff("WEBP"))?.src).toMatch(/^data:image\/webp;base64,/);
+  });
+
+  it("ignores other RIFF containers (e.g. AVI)", () => {
+    expect(mediaSrc(riff("AVI "))).toBeNull();
+  });
+});
+
+describe("mediaSrc — non-media", () => {
+  it("returns null for short strings", () => {
+    expect(mediaSrc("hello")).toBeNull();
+    expect(mediaSrc("data:image/png;base64,iVBOR")).not.toBeNull(); // sanity: valid short data URI still matches
+  });
+
+  it("returns null for long plain text", () => {
+    expect(mediaSrc("the quick brown fox jumps over the lazy dog ".repeat(5))).toBeNull();
+  });
+
+  it("returns null for long non-media base64", () => {
+    expect(mediaSrc(bare("hello world this is not media"))).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/traces/components/inline-media.tsx
+++ b/frontend/ui/src/features/traces/components/inline-media.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+export type Media = { src: string; kind: "image" | "audio" };
+
+// Raster images + audio. image/svg+xml is excluded because data-URI SVG can
+// execute embedded script (XSS).
+const MEDIA_DATA_URI =
+  /^data:(image\/(?:png|jpe?g|gif|webp)|audio\/(?:mpeg|mp3|wav|x-wav|ogg|webm));base64,[A-Za-z0-9+/=]+$/i;
+
+// Sniff real magic bytes from a decoded base64 prefix. This correctly
+// disambiguates RIFF containers (WEBP image vs WAVE audio), which share the
+// same base64 prefix and cannot be told apart by string matching alone.
+function sniffBase64(b64: string): Media | null {
+  let bytes: Uint8Array;
+  try {
+    const bin = atob(b64.slice(0, 24)); // ~18 bytes — enough for the RIFF format tag at offset 8
+    bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  } catch {
+    return null;
+  }
+  const tag = (i: number, n: number) => String.fromCharCode(...bytes.slice(i, i + n));
+  const image = (mime: string): Media => ({ src: `data:${mime};base64,${b64}`, kind: "image" });
+  const audio = (mime: string): Media => ({ src: `data:${mime};base64,${b64}`, kind: "audio" });
+
+  if (bytes[0] === 0x89 && tag(1, 3) === "PNG") return image("image/png");
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return image("image/jpeg");
+  if (tag(0, 4) === "GIF8") return image("image/gif");
+  if (tag(0, 4) === "RIFF") {
+    const form = tag(8, 4);
+    if (form === "WEBP") return image("image/webp");
+    if (form === "WAVE") return audio("audio/wav");
+    return null; // other RIFF (e.g. AVI) — not handled
+  }
+  if (tag(0, 3) === "ID3" || (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0))
+    return audio("audio/mpeg");
+  if (tag(0, 4) === "OggS") return audio("audio/ogg");
+  return null;
+}
+
+// Returns renderable media for inline base64 (data URIs and bare base64), or null.
+export function mediaSrc(value: string): Media | null {
+  const m = value.match(MEDIA_DATA_URI);
+  if (m) return { src: value, kind: m[1].toLowerCase().startsWith("image/") ? "image" : "audio" };
+  if (value.length < 100) return null;
+  return sniffBase64(value);
+}
+
+export function InlineMedia({ src, kind }: Media) {
+  if (kind === "audio") {
+    return <audio controls src={src} className="my-1 max-w-full" />;
+  }
+  return (
+    <img
+      src={src}
+      alt="Inline image"
+      className="my-1 max-h-64 max-w-full rounded border border-border"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Extend inline trace-viewer media rendering to **audio**: detect `data:audio/...` URIs and bare base64 (wav/mp3/ogg) and render an `<audio controls>` player.
- Replace prefix-string matching with **decoded magic-byte sniffing**, which correctly disambiguates RIFF containers by the format tag at byte offset 8 (`WEBP` → image vs `WAVE` → audio). This **fixes WAV audio being mis-rendered as a broken image** (the false positive flagged on #980).
- Extract the media concern into a dedicated `inline-media` module (`mediaSrc`, `InlineMedia`) shared by `JsonRenderer` and `ContentRenderer`, so the JSON renderer stays focused and there's one source of truth. This is also the seam where a future storage-backed (Tier-2) media pipeline would plug in.
- Add unit tests for the detection logic (14 cases), including the WAV/WebP disambiguation and SVG/XSS exclusion.
- Add `examples/typescript/openai/agent-voice.ts` (OpenAI `gpt-audio` two-step text→speech→text flow) + `demo:voice` script as a test case exercising audio on both the input and output sides.

Display-only, like the image work — zero storage cost since the data already lives in the trace.

Closes #983

## Test plan
- [x] `pnpm vitest run inline-media` (frontend/ui) — detection unit tests pass.
- [x] Run `pnpm demo:voice` in `examples/typescript/openai` (needs `OPENAI_API_KEY` with `gpt-audio` access, `TRACEROOT_API_KEY`).
- [x] Open the `voice_demo_session` trace; verify `message.audio.data` renders as an `<audio>` player (not a broken image) on both the speech output and the transcription input.
- [x] Regression: re-open an image trace and confirm images still render inline.

## Screenshots

<img width="1526" height="871" alt="Screenshot 2026-05-28 at 5 05 50 PM" src="https://github.com/user-attachments/assets/6d6899c3-03b5-4836-98b4-5956c1ae6254" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add inline audio rendering to the trace viewer and switch media detection to decoded magic-byte sniffing; fixes WAV vs WebP misdetection and renders `data:audio/...` and bare base64 (wav/mp3/ogg) with an audio player. Display-only; no storage changes.

- New Features
  - Inline audio via <audio controls> in JsonRenderer and ContentRenderer.
  - Detects data URIs and bare base64; blocks `image/svg+xml`.
  - Voice demo: `examples/typescript/openai/agent-voice.ts` (`pnpm demo:voice`) using `openai` and `@traceroot-ai/traceroot`.

- Refactors
  - Extracted shared `inline-media` module (`mediaSrc`, `InlineMedia`).
  - Added detection unit tests, including WAV/WebP disambiguation and SVG/XSS cases.

<sup>Written for commit 19bb2a7554c6cfa133b334a9d47db255d2547d4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/984?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

