### PR TITLE
fix(dev): warn when dev-lite host deps are missing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,12 +34,12 @@ On Windows or in environments without tmux, use `make dev-lite` instead.
 |---------|-------------|
 | `make dev` | Start dev environment. Idempotent - reattaches to existing tmux session if running and installs the pre-commit hook. |
 | `make dev-autoreload` | Same as `make dev`, but services auto-restart on code changes. |
-| `make dev-lite` | Start the local Docker workflow without tmux and install the pre-commit hook. Helpful on Windows. |
+| `make dev-lite` | Start the local Docker workflow without tmux and install the pre-commit hook. Helpful on Windows; prints a host dependency hint if `frontend/node_modules` is missing. |
 | `make dev-reset` | Nuclear reset: kills tmux, destroys containers/volumes/node_modules. Run `make dev` after. |
 | `make prod` | Start all services in Docker with tmux log viewer. |
 | `make prod-lite` | Run the Docker stack directly without tmux. Helpful on Windows and in environments without tmux. |
 
-`make dev`, `make dev-autoreload`, and `make dev-lite` install the pre-commit hook automatically on first run.
+`make dev`, `make dev-autoreload`, and `make dev-lite` install the pre-commit hook automatically on first run. `make dev-lite` runs the app in Docker, so if your editor reports missing frontend modules, run `pnpm --dir frontend install` on the host for local TypeScript/VS Code support.
 
 The tmux-based commands handle deps, Docker containers, migrations, and launch services in tmux (one window per service).
 

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,15 @@
 
 PROD_COMPOSE := docker compose -f docker-compose.prod.yml
 
-.PHONY: install-hooks dev dev-lite dev-autoreload dev-reset prod prod-lite prod-reset
+.PHONY: install-hooks check-frontend-deps dev dev-lite dev-autoreload dev-reset prod prod-lite prod-reset
 
 ## Install repository git hooks for contributors.
 install-hooks:
 	uv run pre-commit install
+
+## Warn when host frontend dependencies are missing for editor support.
+check-frontend-deps:
+	@test -d frontend/node_modules || echo "hint: run 'pnpm --dir frontend install' for VS Code/TypeScript support; Docker installs its own dependencies."
 
 ## Start developing. Handles everything: deps, infra, migrations, tmux launch.
 ## Idempotent - safe to run repeatedly. Reattaches if already running.
@@ -20,7 +24,7 @@ dev-autoreload: install-hooks
 	uv run python tmux_tools/launcher.py --autoreload
 
 ## Windows contributors: full dev env without tmux requirement.
-dev-lite: install-hooks
+dev-lite: install-hooks check-frontend-deps
 	@echo "Starting TraceRoot at http://localhost:3000 - Ctrl+C to stop"
 	$(PROD_COMPOSE) up --build
 

--- a/tests/dev_tools/test_makefile_dev_lite.py
+++ b/tests/dev_tools/test_makefile_dev_lite.py
@@ -1,0 +1,29 @@
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def make_dev_lite_plan() -> str:
+    result = subprocess.run(
+        ["make", "-n", "dev-lite"],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def test_dev_lite_warns_when_host_frontend_deps_are_missing():
+    output = make_dev_lite_plan()
+
+    assert "test -d frontend/node_modules" in output
+    assert "pnpm --dir frontend install" in output
+    assert "VS Code/TypeScript support" in output
+
+
+def test_dev_lite_still_uses_docker_compose_directly():
+    output = make_dev_lite_plan()
+
+    assert "docker compose -f docker-compose.prod.yml up --build" in output


### PR DESCRIPTION
## Summary
- Add a `check-frontend-deps` Make target that warns when `frontend/node_modules` is missing.
- Run that check before `make dev-lite` starts Docker Compose, so Windows/no-tmux contributors get a clear host-side editor hint.
- Update the contributor guide to explain that `dev-lite` runs in Docker and `pnpm --dir frontend install` is only needed for local TypeScript/VS Code support.

Fixes #952

## Type of Change
- [x] fix - A bug fix

## Details
`make dev-lite` still starts the Docker workflow directly. The new check only prints a hint and does not install host dependencies automatically.

## Screenshots / Recordings (if applicable)

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

## Testing
- `make -n dev-lite`
- `make check-frontend-deps`
- `uv run pytest tests/dev_tools/test_makefile_dev_lite.py -q`
- `uv run ruff check tests/dev_tools/test_makefile_dev_lite.py`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a preflight warning in `make dev-lite` when `frontend/node_modules` is missing to help host editors. Introduces `check-frontend-deps` and updates docs; runtime behavior is unchanged. Fixes #952.

- **Bug Fixes**
  - Run `check-frontend-deps` before `dev-lite`; prints a hint to run `pnpm --dir frontend install` for VS Code/TypeScript support.
  - Keep `dev-lite` using Docker Compose directly; no host deps installed.
  - Add tests for the Make plan and update CONTRIBUTING.

<sup>Written for commit eab79edce59d057f905b1b2651d9609d296302d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/985?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

