### PR TITLE
fix: migrate middleware convention to proxy

### DIFF
--- a/frontend/ui/src/proxy.ts
+++ b/frontend/ui/src/proxy.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export function middleware(req: NextRequest) {
+export function proxy(req: NextRequest) {
   // better-auth prefixes cookies with __Secure- in HTTPS environments
   const token =
     req.cookies.get("better-auth.session_token") ??


### PR DESCRIPTION
Fixes #982

## Summary

Renames the Next.js middleware file to use the new proxy convention.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Renamed `frontend/ui/src/middleware.ts` to `frontend/ui/src/proxy.ts`.
- Renamed the exported handler from `middleware` to `proxy`.
- Kept the existing matcher and auth redirect behavior unchanged.

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates our Next.js middleware to the new proxy convention to align with the framework and Fixes #982. Renames `frontend/ui/src/middleware.ts` to `frontend/ui/src/proxy.ts` and changes the exported handler from `middleware` to `proxy`; routing matcher and auth redirect behavior remain the same.

<sup>Written for commit b7971611ded193f47008240312c03a432b3e9a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/986?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

