### PR TITLE
Replace trace list status column with error_count (#960)

### DIFF
--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -43,7 +43,7 @@ class TraceListItem(BaseModel):
     session_id: str | None
     span_count: int
     duration_ms: float | None
-    status: str  # "ok" or "error"
+    error_count: int
     input: str | None
     output: str | None
     total_input_tokens: int | None = 0

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -75,7 +75,7 @@ class TraceReaderService:
                     dateDiff('millisecond', min(s.span_start_time), max(s.span_end_time)),
                     NULL
                 ) as duration_ms,
-                if(countIf(s.status = 'ERROR') > 0, 'error', 'ok') as status,
+                countIf(s.status = 'ERROR') as error_count,
                 t.input,
                 t.output,
                 sum(s.input_tokens) as total_input_tokens,
@@ -114,7 +114,7 @@ class TraceReaderService:
                     "session_id": row[5],
                     "span_count": row[6] or 0,
                     "duration_ms": float(row[7]) if row[7] is not None else None,
-                    "status": row[8],
+                    "error_count": int(row[8]) if row[8] is not None else 0,
                     "input": row[9],
                     "output": row[10],
                     "total_input_tokens": int(row[11]) if row[11] is not None else 0,

--- a/backend/shared/enums.py
+++ b/backend/shared/enums.py
@@ -13,11 +13,6 @@ class SpanStatus(StrEnum):
     ERROR = "ERROR"
 
 
-class TraceStatus(StrEnum):
-    OK = "ok"
-    ERROR = "error"
-
-
 class MemberRole(StrEnum):
     VIEWER = "VIEWER"
     MEMBER = "MEMBER"

--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -59,7 +59,7 @@ def _passes_trigger(trace_summary: dict, conditions: list[dict]) -> bool:
 def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dict]:
     """
     Query ClickHouse for the fields needed for trigger evaluation.
-    Returns {trace_id: {root_span_finished, status, environment}}
+    Returns {trace_id: {root_span_finished, environment}}
     """
     from db.clickhouse.client import get_clickhouse_client
 
@@ -73,7 +73,6 @@ def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dic
         SELECT
             trace_id,
             max(CASE WHEN parent_span_id IS NULL THEN 1 ELSE 0 END) AS root_span_finished,
-            max(CASE WHEN status = 'ERROR' THEN 1 ELSE 0 END)       AS has_error,
             anyIf(environment, parent_span_id IS NULL)               AS environment
         FROM spans
         WHERE project_id = {project_id:String}
@@ -87,9 +86,7 @@ def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dic
     for row in result.result_rows:
         summaries[row[0]] = {
             "root_span_finished": bool(row[1]),
-            # Expose status as a string matching what users configure ("ERROR" or "OK")
-            "status": "ERROR" if bool(row[2]) else "OK",
-            "environment": row[3],  # Nullable — None if not set
+            "environment": row[2],  # Nullable — None if not set
         }
     return summaries
 

--- a/frontend/packages/agent/src/tools/query-traces.ts
+++ b/frontend/packages/agent/src/tools/query-traces.ts
@@ -28,7 +28,7 @@ export function createQueryTracesTool(projectId: string, userId: string): AgentT
     name: "query_traces",
     label: "Query traces",
     description:
-      "Search and filter traces for the current project. Returns a summary table of matching traces (IDs, names, timestamps, status, error counts). Use this for discovery before downloading specific traces.",
+      "Search and filter traces for the current project. Returns a summary table of matching traces (IDs, names, timestamps, error counts). Use this for discovery before downloading specific traces.",
     parameters: queryTracesSchema,
     execute: async (
       _toolCallId: string,
@@ -75,7 +75,7 @@ export function createQueryTracesTool(projectId: string, userId: string): AgentT
       // Format as summary table for the agent
       const lines = traces.map((t: any) => {
         const duration = t.duration_ms != null ? `${Math.round(t.duration_ms)}ms` : "?";
-        return `- ${t.trace_id} | ${t.name || "(unnamed)"} | ${t.trace_start_time} | ${t.status} | ${t.span_count} spans | ${duration}`;
+        return `- ${t.trace_id} | ${t.name || "(unnamed)"} | ${t.trace_start_time} | ${t.error_count} errors | ${t.span_count} spans | ${duration}`;
       });
 
       const totalInfo = meta.total ? ` (${meta.total} total, showing ${traces.length})` : "";

--- a/frontend/packages/core/src/constants.ts
+++ b/frontend/packages/core/src/constants.ts
@@ -13,7 +13,3 @@ export type SpanKind = (typeof SpanKind)[keyof typeof SpanKind];
 // SpanStatus — ClickHouse values
 export const SpanStatus = { OK: "OK", ERROR: "ERROR" } as const;
 export type SpanStatus = (typeof SpanStatus)[keyof typeof SpanStatus];
-
-// TraceStatus — lowercase, computed at query time
-export const TraceStatus = { OK: "ok", ERROR: "error" } as const;
-export type TraceStatus = (typeof TraceStatus)[keyof typeof TraceStatus];

--- a/frontend/packages/core/src/schemas.ts
+++ b/frontend/packages/core/src/schemas.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
-import { Role, SpanKind, SpanStatus, TraceStatus } from "./constants.js";
+import { Role, SpanKind, SpanStatus } from "./constants.js";
 
 export const RoleSchema = z.enum(Role);
 export const SpanKindSchema = z.enum(SpanKind);
 export const SpanStatusSchema = z.enum(SpanStatus);
-export const TraceStatusSchema = z.enum(TraceStatus);

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -237,7 +237,7 @@ export default function TracesPage() {
                         Trace ID
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Status
+                        Errors
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Spans
@@ -283,12 +283,12 @@ export default function TracesPage() {
                           </span>
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5">
-                          {trace.status === "error" ? (
+                          {trace.error_count > 0 ? (
                             <span className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
-                              ERROR
+                              {trace.error_count}
                             </span>
                           ) : (
-                            <span className="text-[10px] text-muted-foreground">OK</span>
+                            <span className="text-[10px] text-muted-foreground">—</span>
                           )}
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5 text-center text-[12px] text-muted-foreground">

--- a/frontend/ui/src/features/detectors/components/trigger-editor.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.tsx
@@ -33,16 +33,6 @@ const FIELD_DEFS: FieldDef[] = [
     ops: ["=", "!="],
     valueType: "text",
   },
-  {
-    field: "status",
-    label: "Status",
-    ops: ["="],
-    valueType: "select",
-    options: [
-      { label: "Error", value: "ERROR" },
-      { label: "Success", value: "OK" },
-    ],
-  },
 ];
 
 const defaultValueForField = (field: string): unknown => {

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -2,7 +2,7 @@
  * Shared API types for TraceRoot UI
  */
 
-import type { Role, SpanKind, SpanStatus, TraceStatus } from "@traceroot/core";
+import type { Role, SpanKind, SpanStatus } from "@traceroot/core";
 
 export type { Role };
 
@@ -100,7 +100,7 @@ export interface TraceListItem {
   session_id: string | null;
   span_count: number;
   duration_ms: number | null;
-  status: TraceStatus;
+  error_count: number;
   input: string | null;
   output: string | null;
   total_input_tokens?: number;
@@ -162,7 +162,6 @@ export interface TraceQueryOptions {
   page?: number;
   limit?: number;
   name?: string;
-  status?: TraceStatus;
   user_id?: string;
   session_id?: string;
   // Date range filtering

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -21,7 +21,7 @@ TRACE_LIST_ITEM = {
     "session_id": None,
     "span_count": 3,
     "duration_ms": 1500.0,
-    "status": "ok",
+    "error_count": 0,
     "input": "hello",
     "output": "world",
 }


### PR DESCRIPTION
Fixes #960

#### Summary
- Trace list shows span error counts instead of OK/ERROR. Detector status triggers removed.

#### Type of Change
- feat

### Details
- error_count on trace list API and UI (badge if > 0, dash if 0)
- TraceStatus removed
- Detector triggers: status dropped from editor and worker summaries

#### Screenshots / Recordings (if applicable)
N/A

#### Checklist

 - Tests updated (test_traces_router.py)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the trace list Status column with an Errors count to show how many spans failed. Removed trace-level status and detector status triggers; updated API, types, UI, and the agent tool.

- **Migration**
  - REST trace list: replace status with error_count (number; 0 when no errors).
  - `@traceroot/core`: removed TraceStatus and TraceStatusSchema; update TraceListItem to use error_count.
  - Clients: remove status filters from queries; read error_count instead. Agent tool summary now shows “X errors”.
  - Detectors: removed status from trigger editor and worker summaries; delete any status-based triggers.

<sup>Written for commit b566c63d46eab073152d63d04e8d15737e62340c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/988?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

