### PR TITLE
fix: hide AI button when navigating to onboarding page

### DIFF
--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -66,12 +66,18 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
 
   // Close the global AI panel whenever the user navigates.
-  // NOTE: do NOT reset hideAiButton here. Observability pages own that flag.
-  useEffect(() => {
-    setAiPanelOpen(false);
-    setAiContext(null);
-    setAiInitialSessionId(undefined);
-  }, [pathname]);
+// Reset hideAiButton when leaving observability pages so stale visibility
+// state doesn't carry over to unrelated pages (e.g. the onboarding flow).
+// Observability pages still own the flag once they mount via setHideAiButton.
+const isObservabilityPage = /^\/projects\/[^/]+\/(traces|users|sessions)(\/|$)/.test(pathname);
+useEffect(() => {
+  setAiPanelOpen(false);
+  setAiContext(null);
+  setAiInitialSessionId(undefined);
+  if (!isObservabilityPage) {
+    setHideAiButton(true);
+  }
+}, [pathname, isObservabilityPage]);
 
   const registerAiHost = useCallback(() => {
     setAiHostRefCount((c) => c + 1);
@@ -80,7 +86,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
 
   const viewerOwnsAiSlot = aiHostRefCount > 0;
 
-  const isObservabilityPage = /^\/projects\/[^/]+\/(traces|users|sessions)(\/|$)/.test(pathname);
+  
   const showAiButton = isObservabilityPage && !hideAiButton;
   const projectIdMatch = pathname.match(/^\/projects\/([^/]+)/);
   const projectId = projectIdMatch?.[1];


### PR DESCRIPTION
Closes #679

## Summary
When navigating away from an observability page (traces/users/sessions) that had 
already shown the AI button, the `hideAiButton` flag was not being reset. This 
caused the AI button to briefly appear on the onboarding page before the page's 
own effect could hide it.

## Type of Change
- [x] fix - A bug fix

## Details
Moved `isObservabilityPage` above the navigation `useEffect` and added a reset 
of `hideAiButton` to `true` when leaving observability pages. Observability pages 
still own the flag on mount via their own `setHideAiButton` call.

## Checklist
- [x] I have read the CONTRIBUTING.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flicker where the AI button briefly appeared on the onboarding page after navigating from traces/users/sessions. Resets the button’s hidden state on route change so it stays hidden outside observability pages.

- **Bug Fixes**
  - Reset `hideAiButton` to `true` when navigating to non-observability routes.
  - Evaluate `isObservabilityPage` before the navigation effect to avoid stale state.

<sup>Written for commit bc1ff0193eaf435a110a40740e9c57d083d52dba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/989?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

