### PR TITLE
fix(docs): standardize integration ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,41 +88,41 @@ The fastest way to get started. Ample storages and LLM tokens for testing, no cr
 
 ## Integrations
 
-### Model Providers
-
-| Integration | Supports | Description |
-| ----------- | -------- | ----------- |
-| [OpenAI](https://traceroot.ai/docs/integrations/openai) | Python, JS/TS | Automated instrumentation of Chat Completions and Responses API. |
-| [Anthropic](https://traceroot.ai/docs/integrations/anthropic) | Python, JS/TS | Automated instrumentation of the Messages API. |
-| [Google Gemini](https://traceroot.ai/docs/integrations/gemini) | Python | Automated instrumentation via the Google GenAI SDK. |
-| [Mistral](https://traceroot.ai/docs/integrations/mistral) | Python | Automated instrumentation of Mistral chat completions, tool calls, and streaming responses. |
-
-### Agent Frameworks
-
-| Integration | Supports | Description |
-| ----------- | -------- | ----------- |
-| [LangChain & LangGraph](https://traceroot.ai/docs/integrations/langchain) | Python, JS/TS | Automated instrumentation by passing callback handler to LangChain application. |
-| [LangChain DeepAgents](https://traceroot.ai/docs/integrations/langchain-deepagents) | Python, JS/TS | Automated instrumentation by passing callback handler to DeepAgents pipeline. |
-| [Claude Agent SDK](https://traceroot.ai/docs/integrations/claude-agent-sdk) | Python, JS/TS | Automated instrumentation of agent invocations, subagent delegations, tool calls, and token usage. |
-| [OpenAI Agents SDK](https://traceroot.ai/docs/integrations/openai-agents-sdk) | Python, JS/TS | Automated instrumentation of agent runs, tool executions, and handoff transitions. |
-| [Mastra](https://traceroot.ai/docs/integrations/mastra) | JS/TS | Automated instrumentation via the TraceRoot OTLP exporter. |
-| [Vercel AI SDK](https://traceroot.ai/docs/integrations/vercel-ai) | JS/TS | Native OpenTelemetry tracing via `experimental_telemetry` — no `instrumentModules` config required. |
-| [AutoGen](https://traceroot.ai/docs/integrations/autogen) | Python | Automated instrumentation of multi-agent conversations, agent loops, and tool calls. |
-| [LlamaIndex](https://traceroot.ai/docs/integrations/llamaindex) | Python | Automated instrumentation of RAG pipelines, document ingestion, retrieval, and LLM synthesis. |
-| [CrewAI](https://traceroot.ai/docs/integrations/crewai) | Python | Automated instrumentation of multi-agent collaborative workflows and task executions. |
-| [Agno](https://traceroot.ai/docs/integrations/agno) | Python | Automated instrumentation of agent runs, tool calls, and multi-step reasoning. |
-| [DSPy](https://traceroot.ai/docs/integrations/dspy) | Python | Automated instrumentation of module executions, signature predictions, and underlying LLM calls. |
-| [Google ADK](https://traceroot.ai/docs/integrations/google-adk) | Python | Automated instrumentation of agent runs, tool executions, and the multi-turn agent loop. |
-| [Pydantic AI](https://traceroot.ai/docs/integrations/pydantic-ai) | Python | Automated instrumentation of agent runs, LLM calls, and tool invocations via pydantic-ai's native OpenTelemetry support. |
-
-> Don't see your framework or provider? [Request an integration](https://github.com/traceroot-ai/traceroot/issues).
-
-## SDK
+### Native SDKs
 
 | Language | Repository |
 | -------- | ---------- |
 | Python | [traceroot-py](https://github.com/traceroot-ai/traceroot-py) |
 | TypeScript | [traceroot-ts](https://github.com/traceroot-ai/traceroot-ts) |
+
+### Agent Frameworks
+
+| Integration | Supports | Description |
+| ----------- | -------- | ----------- |
+| [Agno](https://traceroot.ai/docs/integrations/agno) | Python | Automated instrumentation of agent runs, tool calls, and multi-step reasoning. |
+| [AutoGen](https://traceroot.ai/docs/integrations/autogen) | Python | Automated instrumentation of multi-agent conversations, agent loops, and tool calls. |
+| [Claude Agent SDK](https://traceroot.ai/docs/integrations/claude-agent-sdk) | Python, JS/TS | Automated instrumentation of agent invocations, subagent delegations, tool calls, and token usage. |
+| [CrewAI](https://traceroot.ai/docs/integrations/crewai) | Python | Automated instrumentation of multi-agent collaborative workflows and task executions. |
+| [DSPy](https://traceroot.ai/docs/integrations/dspy) | Python | Automated instrumentation of module executions, signature predictions, and underlying LLM calls. |
+| [Google ADK](https://traceroot.ai/docs/integrations/google-adk) | Python | Automated instrumentation of agent runs, tool executions, and the multi-turn agent loop. |
+| [LangChain & LangGraph](https://traceroot.ai/docs/integrations/langchain) | Python, JS/TS | Automated instrumentation by passing callback handler to LangChain application. |
+| [LangChain DeepAgents](https://traceroot.ai/docs/integrations/langchain-deepagents) | Python, JS/TS | Automated instrumentation by passing callback handler to DeepAgents pipeline. |
+| [LlamaIndex](https://traceroot.ai/docs/integrations/llamaindex) | Python | Automated instrumentation of RAG pipelines, document ingestion, retrieval, and LLM synthesis. |
+| [Mastra](https://traceroot.ai/docs/integrations/mastra) | JS/TS | Automated instrumentation via the TraceRoot OTLP exporter. |
+| [OpenAI Agents SDK](https://traceroot.ai/docs/integrations/openai-agents-sdk) | Python, JS/TS | Automated instrumentation of agent runs, tool executions, and handoff transitions. |
+| [Pydantic AI](https://traceroot.ai/docs/integrations/pydantic-ai) | Python | Automated instrumentation of agent runs, LLM calls, and tool invocations via pydantic-ai's native OpenTelemetry support. |
+| [Vercel AI SDK](https://traceroot.ai/docs/integrations/vercel-ai) | JS/TS | Native OpenTelemetry tracing via `experimental_telemetry` — no `instrumentModules` config required. |
+
+### Model Providers
+
+| Integration | Supports | Description |
+| ----------- | -------- | ----------- |
+| [Anthropic](https://traceroot.ai/docs/integrations/anthropic) | Python, JS/TS | Automated instrumentation of the Messages API. |
+| [Google Gemini](https://traceroot.ai/docs/integrations/gemini) | Python | Automated instrumentation via the Google GenAI SDK. |
+| [Mistral](https://traceroot.ai/docs/integrations/mistral) | Python | Automated instrumentation of Mistral chat completions, tool calls, and streaming responses. |
+| [OpenAI](https://traceroot.ai/docs/integrations/openai) | Python, JS/TS | Automated instrumentation of Chat Completions and Responses API. |
+
+> Don't see your framework or provider? [Request an integration](https://github.com/traceroot-ai/traceroot/issues).
 
 ## Python SDK Quickstart
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -147,28 +147,28 @@
           {
             "group": "Frameworks",
             "pages": [
-              "integrations/langchain",
-              "integrations/langchain-deepagents",
-              "integrations/claude-agent-sdk",
-              "integrations/openai-agents-sdk",
-              "integrations/mastra",
-              "integrations/vercel-ai",
-              "integrations/autogen",
-              "integrations/llamaindex",
-              "integrations/crewai",
               "integrations/agno",
+              "integrations/autogen",
+              "integrations/claude-agent-sdk",
+              "integrations/crewai",
               "integrations/dspy",
               "integrations/google-adk",
-              "integrations/pydantic-ai"
+              "integrations/langchain",
+              "integrations/langchain-deepagents",
+              "integrations/llamaindex",
+              "integrations/mastra",
+              "integrations/openai-agents-sdk",
+              "integrations/pydantic-ai",
+              "integrations/vercel-ai"
             ]
           },
           {
             "group": "Model Providers",
             "pages": [
-              "integrations/openai",
               "integrations/anthropic",
               "integrations/gemini",
-              "integrations/mistral"
+              "integrations/mistral",
+              "integrations/openai"
             ]
           },
           {


### PR DESCRIPTION
Fixes #947

## Summary

Standardizes integration ordering in the README and docs navigation.

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [x] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Reordered README integrations to Native SDKs, Agent Frameworks, then Model Providers.
- Alphabetized framework and provider entries.
- Reordered the Mintlify integrations nav to match the docs overview.

## Screenshots / Recordings (if applicable)

<img width="339" height="908" alt="image" src="https://github.com/user-attachments/assets/37ad1699-1b45-475e-afb4-b2f4639b234d" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary