### PR TITLE
Show trace error counts in trace list

### DIFF
--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -43,7 +43,7 @@ class TraceListItem(BaseModel):
     session_id: str | None
     span_count: int
     duration_ms: float | None
-    status: str  # "ok" or "error"
+    error_count: int
     input: str | None
     output: str | None
     total_input_tokens: int | None = 0

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -75,7 +75,7 @@ class TraceReaderService:
                     dateDiff('millisecond', min(s.span_start_time), max(s.span_end_time)),
                     NULL
                 ) as duration_ms,
-                if(countIf(s.status = 'ERROR') > 0, 'error', 'ok') as status,
+                countIf(s.status = 'ERROR') as error_count,
                 t.input,
                 t.output,
                 sum(s.input_tokens) as total_input_tokens,
@@ -114,7 +114,7 @@ class TraceReaderService:
                     "session_id": row[5],
                     "span_count": row[6] or 0,
                     "duration_ms": float(row[7]) if row[7] is not None else None,
-                    "status": row[8],
+                    "error_count": int(row[8]) if row[8] is not None else 0,
                     "input": row[9],
                     "output": row[10],
                     "total_input_tokens": int(row[11]) if row[11] is not None else 0,

--- a/backend/shared/enums.py
+++ b/backend/shared/enums.py
@@ -13,11 +13,6 @@ class SpanStatus(StrEnum):
     ERROR = "ERROR"
 
 
-class TraceStatus(StrEnum):
-    OK = "ok"
-    ERROR = "error"
-
-
 class MemberRole(StrEnum):
     VIEWER = "VIEWER"
     MEMBER = "MEMBER"

--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -59,7 +59,7 @@ def _passes_trigger(trace_summary: dict, conditions: list[dict]) -> bool:
 def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dict]:
     """
     Query ClickHouse for the fields needed for trigger evaluation.
-    Returns {trace_id: {root_span_finished, status, environment}}
+    Returns {trace_id: {root_span_finished, environment}}
     """
     from db.clickhouse.client import get_clickhouse_client
 
@@ -73,7 +73,6 @@ def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dic
         SELECT
             trace_id,
             max(CASE WHEN parent_span_id IS NULL THEN 1 ELSE 0 END) AS root_span_finished,
-            max(CASE WHEN status = 'ERROR' THEN 1 ELSE 0 END)       AS has_error,
             anyIf(environment, parent_span_id IS NULL)               AS environment
         FROM spans
         WHERE project_id = {project_id:String}
@@ -87,9 +86,7 @@ def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dic
     for row in result.result_rows:
         summaries[row[0]] = {
             "root_span_finished": bool(row[1]),
-            # Expose status as a string matching what users configure ("ERROR" or "OK")
-            "status": "ERROR" if bool(row[2]) else "OK",
-            "environment": row[3],  # Nullable — None if not set
+            "environment": row[2],  # Nullable — None if not set
         }
     return summaries
 

--- a/backend/worker/tests/test_detector_tasks.py
+++ b/backend/worker/tests/test_detector_tasks.py
@@ -10,29 +10,29 @@ from worker.detector_tasks import _enqueue_to_bullmq, _eval_condition, _passes_t
 
 def test_eval_condition_equality_operator():
     """Test equality operator (=)."""
-    trace_summary = {"status": "completed"}
-    condition = {"field": "status", "op": "=", "value": "completed"}
+    trace_summary = {"environment": "production"}
+    condition = {"field": "environment", "op": "=", "value": "production"}
     assert _eval_condition(trace_summary, condition) is True
 
 
 def test_eval_condition_equality_operator_fail():
     """Test equality operator fails when values differ."""
-    trace_summary = {"status": "pending"}
-    condition = {"field": "status", "op": "=", "value": "completed"}
+    trace_summary = {"environment": "staging"}
+    condition = {"field": "environment", "op": "=", "value": "production"}
     assert _eval_condition(trace_summary, condition) is False
 
 
 def test_eval_condition_not_equal_operator():
     """Test inequality operator (!=)."""
-    trace_summary = {"status": "pending"}
-    condition = {"field": "status", "op": "!=", "value": "completed"}
+    trace_summary = {"environment": "staging"}
+    condition = {"field": "environment", "op": "!=", "value": "production"}
     assert _eval_condition(trace_summary, condition) is True
 
 
 def test_eval_condition_not_equal_operator_fail():
     """Test inequality operator fails when values are equal."""
-    trace_summary = {"status": "completed"}
-    condition = {"field": "status", "op": "!=", "value": "completed"}
+    trace_summary = {"environment": "production"}
+    condition = {"field": "environment", "op": "!=", "value": "production"}
     assert _eval_condition(trace_summary, condition) is False
 
 
@@ -118,16 +118,16 @@ def test_eval_condition_numeric_strings_in_comparisons():
 
 def test_passes_trigger_empty_conditions():
     """Empty conditions list returns True (always passes)."""
-    trace_summary = {"status": "pending"}
+    trace_summary = {"environment": "staging"}
     conditions = []
     assert _passes_trigger(trace_summary, conditions) is True
 
 
 def test_passes_trigger_all_conditions_pass():
     """All conditions pass returns True."""
-    trace_summary = {"status": "completed", "cost": 100.0, "tokens": 5000}
+    trace_summary = {"environment": "production", "cost": 100.0, "tokens": 5000}
     conditions = [
-        {"field": "status", "op": "=", "value": "completed"},
+        {"field": "environment", "op": "=", "value": "production"},
         {"field": "cost", "op": ">", "value": 50.0},
         {"field": "tokens", "op": ">=", "value": 5000},
     ]
@@ -136,9 +136,9 @@ def test_passes_trigger_all_conditions_pass():
 
 def test_passes_trigger_one_condition_fails():
     """One failing condition makes entire trigger fail."""
-    trace_summary = {"status": "completed", "cost": 30.0, "tokens": 5000}
+    trace_summary = {"environment": "production", "cost": 30.0, "tokens": 5000}
     conditions = [
-        {"field": "status", "op": "=", "value": "completed"},
+        {"field": "environment", "op": "=", "value": "production"},
         {"field": "cost", "op": ">", "value": 50.0},  # This will fail
         {"field": "tokens", "op": ">=", "value": 5000},
     ]
@@ -147,11 +147,18 @@ def test_passes_trigger_one_condition_fails():
 
 def test_passes_trigger_missing_field_fails():
     """Missing field in a condition causes trigger to fail."""
-    trace_summary = {"status": "completed"}
+    trace_summary = {"environment": "production"}
     conditions = [
-        {"field": "status", "op": "=", "value": "completed"},
+        {"field": "environment", "op": "=", "value": "production"},
         {"field": "missing_field", "op": "=", "value": "some_value"},
     ]
+    assert _passes_trigger(trace_summary, conditions) is False
+
+
+def test_passes_trigger_legacy_status_condition_is_inert():
+    """Legacy status conditions no longer fire because summaries omit trace status."""
+    trace_summary = {"environment": "production"}
+    conditions = [{"field": "status", "op": "=", "value": "ERROR"}]
     assert _passes_trigger(trace_summary, conditions) is False
 
 

--- a/frontend/packages/agent/src/prompts/system.ts
+++ b/frontend/packages/agent/src/prompts/system.ts
@@ -22,8 +22,8 @@ You help users analyze telemetry data (traces and spans) from their AI agent sys
 ## Available Tools
 
 ### Discovery: query_traces
-Use this to search and filter traces. Returns a summary table (trace IDs, names, timestamps, status, error counts).
-Parameters: filters (object) — optional filters like limit, userId, sessionId, name, hasError, startTime, endTime.
+Use this to search and filter traces. Returns a summary table (trace IDs, names, timestamps, error counts, spans, duration).
+Parameters: filters (object) — optional filters like limit, userId, name, searchQuery, startAfter, endBefore.
 Use this first to find relevant traces before diving deeper.
 
 ### Session Discovery: query_sessions

--- a/frontend/packages/agent/src/tools/query-traces.ts
+++ b/frontend/packages/agent/src/tools/query-traces.ts
@@ -28,7 +28,7 @@ export function createQueryTracesTool(projectId: string, userId: string): AgentT
     name: "query_traces",
     label: "Query traces",
     description:
-      "Search and filter traces for the current project. Returns a summary table of matching traces (IDs, names, timestamps, status, error counts). Use this for discovery before downloading specific traces.",
+      "Search and filter traces for the current project. Returns a summary table of matching traces (IDs, names, timestamps, error counts, spans, duration). Use this for discovery before downloading specific traces.",
     parameters: queryTracesSchema,
     execute: async (
       _toolCallId: string,
@@ -75,7 +75,7 @@ export function createQueryTracesTool(projectId: string, userId: string): AgentT
       // Format as summary table for the agent
       const lines = traces.map((t: any) => {
         const duration = t.duration_ms != null ? `${Math.round(t.duration_ms)}ms` : "?";
-        return `- ${t.trace_id} | ${t.name || "(unnamed)"} | ${t.trace_start_time} | ${t.status} | ${t.span_count} spans | ${duration}`;
+        return `- ${t.trace_id} | ${t.name || "(unnamed)"} | ${t.trace_start_time} | ${t.error_count ?? 0} errors | ${t.span_count} spans | ${duration}`;
       });
 
       const totalInfo = meta.total ? ` (${meta.total} total, showing ${traces.length})` : "";

--- a/frontend/packages/core/src/constants.ts
+++ b/frontend/packages/core/src/constants.ts
@@ -13,7 +13,3 @@ export type SpanKind = (typeof SpanKind)[keyof typeof SpanKind];
 // SpanStatus — ClickHouse values
 export const SpanStatus = { OK: "OK", ERROR: "ERROR" } as const;
 export type SpanStatus = (typeof SpanStatus)[keyof typeof SpanStatus];
-
-// TraceStatus — lowercase, computed at query time
-export const TraceStatus = { OK: "ok", ERROR: "error" } as const;
-export type TraceStatus = (typeof TraceStatus)[keyof typeof TraceStatus];

--- a/frontend/packages/core/src/schemas.ts
+++ b/frontend/packages/core/src/schemas.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
-import { Role, SpanKind, SpanStatus, TraceStatus } from "./constants.js";
+import { Role, SpanKind, SpanStatus } from "./constants.js";
 
 export const RoleSchema = z.enum(Role);
 export const SpanKindSchema = z.enum(SpanKind);
 export const SpanStatusSchema = z.enum(SpanStatus);
-export const TraceStatusSchema = z.enum(TraceStatus);

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -237,7 +237,7 @@ export default function TracesPage() {
                         Trace ID
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
-                        Status
+                        Errors
                       </th>
                       <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Spans
@@ -282,13 +282,13 @@ export default function TracesPage() {
                             {trace.trace_id}
                           </span>
                         </td>
-                        <td className="border-r border-border/50 px-3 py-1.5">
-                          {trace.status === "error" ? (
-                            <span className="rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
-                              ERROR
+                        <td className="border-r border-border/50 px-3 py-1.5 text-center">
+                          {trace.error_count > 0 ? (
+                            <span className="inline-flex min-w-5 justify-center rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
+                              {trace.error_count}
                             </span>
                           ) : (
-                            <span className="text-[10px] text-muted-foreground">OK</span>
+                            <span className="text-[10px] text-muted-foreground">0</span>
                           )}
                         </td>
                         <td className="border-r border-border/50 px-3 py-1.5 text-center text-[12px] text-muted-foreground">

--- a/frontend/ui/src/features/detectors/components/trigger-editor.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.tsx
@@ -33,16 +33,6 @@ const FIELD_DEFS: FieldDef[] = [
     ops: ["=", "!="],
     valueType: "text",
   },
-  {
-    field: "status",
-    label: "Status",
-    ops: ["="],
-    valueType: "select",
-    options: [
-      { label: "Error", value: "ERROR" },
-      { label: "Success", value: "OK" },
-    ],
-  },
 ];
 
 const defaultValueForField = (field: string): unknown => {

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -14,7 +14,6 @@ export async function getTraces(
   if (options.page !== undefined) params.set("page", String(options.page));
   if (options.limit !== undefined) params.set("limit", String(options.limit));
   if (options.name) params.set("name", options.name);
-  if (options.status) params.set("status", options.status);
   if (options.user_id) params.set("user_id", options.user_id);
   if (options.session_id) params.set("session_id", options.session_id);
   if (options.start_after) params.set("start_after", options.start_after);

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -2,7 +2,7 @@
  * Shared API types for TraceRoot UI
  */
 
-import type { Role, SpanKind, SpanStatus, TraceStatus } from "@traceroot/core";
+import type { Role, SpanKind, SpanStatus } from "@traceroot/core";
 
 export type { Role };
 
@@ -100,7 +100,7 @@ export interface TraceListItem {
   session_id: string | null;
   span_count: number;
   duration_ms: number | null;
-  status: TraceStatus;
+  error_count: number;
   input: string | null;
   output: string | null;
   total_input_tokens?: number;
@@ -162,7 +162,6 @@ export interface TraceQueryOptions {
   page?: number;
   limit?: number;
   name?: string;
-  status?: TraceStatus;
   user_id?: string;
   session_id?: string;
   // Date range filtering

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -21,7 +21,7 @@ TRACE_LIST_ITEM = {
     "session_id": None,
     "span_count": 3,
     "duration_ms": 1500.0,
-    "status": "ok",
+    "error_count": 0,
     "input": "hello",
     "output": "world",
 }
@@ -98,6 +98,8 @@ class TestListTraces:
         data = response.json()
         assert len(data["data"]) == 1
         assert data["data"][0]["trace_id"] == "abc123"
+        assert data["data"][0]["error_count"] == 0
+        assert "status" not in data["data"][0]
         assert data["meta"]["total"] == 1
 
     def test_with_name_and_user_filters(self, client, mock_trace_reader):


### PR DESCRIPTION
## Summary
- replace the trace-list status field with computed error_count from errored spans
- render the Errors column with centered 0/count values in the trace table
- remove trace-level status from detector trigger options and stale shared types
- update agent trace search output and tests for the new contract

Resolves #960

## Testing
- git diff --check origin/main..HEAD
- pytest backend/worker/tests/test_detector_tasks.py

Note: tests/rest/test_traces_router.py was updated for the new response contract, but local collection is blocked on Python 3.10 because the app imports datetime.UTC, which requires Python 3.11+.

## Screenshots
<img width="1629" height="831" alt="Screenshot 2026-05-29 at 10 45 59 AM" src="https://github.com/user-attachments/assets/51889c79-a3cf-4dc4-afc6-741dc4f02480" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show error counts per trace in the list and remove the trace-level status across API, UI, and detectors for a clearer, consistent contract. This improves error visibility and simplifies filtering. Resolves #960.

- New Features
  - Trace list now shows an Errors column with error_count (number of ERROR spans); backend returns error_count instead of status.
  - Agent `query_traces` output includes error counts alongside spans and duration.

- Migration
  - API: TraceListItem now includes error_count: number; status removed. Update clients and tests.
  - UI/SDK: Remove status filter from getTraces options and drop `TraceStatus` types/constants from `@traceroot/core`.
  - Detectors: Remove trace-level status condition. Legacy status conditions no longer fire; use environment or span-level fields instead.

<sup>Written for commit e6a8b7a8810075d9042eec58e601d59bb68df3e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

