### PR TITLE
fix(infra): stabilize ClickHouse memory — disable system-log tables, bump to 8Gi, pin RDS version

### DIFF
--- a/deploy/terraform/aws/rds.tf
+++ b/deploy/terraform/aws/rds.tf
@@ -29,7 +29,7 @@ resource "aws_rds_cluster" "postgres" {
   cluster_identifier = "${var.name}-postgres"
   engine             = "aurora-postgresql"
   engine_mode        = "provisioned"
-  engine_version     = "17.4"
+  engine_version     = "17.7"
   database_name      = "traceroot"
   master_username    = "traceroot"
   master_password    = random_password.postgres.result
@@ -46,6 +46,11 @@ resource "aws_rds_cluster" "postgres" {
     max_capacity = var.postgres_max_capacity
   }
 
+  # AWS auto-applies minor version upgrades; don't let Terraform revert them.
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
+
   tags = local.tags
 }
 
@@ -55,6 +60,10 @@ resource "aws_rds_cluster_instance" "postgres" {
   instance_class     = "db.serverless"
   engine             = aws_rds_cluster.postgres.engine
   engine_version     = aws_rds_cluster.postgres.engine_version
+
+  lifecycle {
+    ignore_changes = [engine_version]
+  }
 
   tags = local.tags
 }

--- a/deploy/terraform/aws/traceroot.tf
+++ b/deploy/terraform/aws/traceroot.tf
@@ -146,11 +146,11 @@ clickhouse:
     storageClass: "efs"
   resources:
     requests:
-      cpu: "1"
-      memory: "2Gi"
+      cpu: "2"
+      memory: "8Gi"
     limits:
       cpu: "2"
-      memory: "4Gi"
+      memory: "8Gi"
   extraEnvVars:
     - name: MALLOC_CONF
       value: "background_thread:true,dirty_decay_ms:1000,muzzy_decay_ms:1000"
@@ -244,6 +244,22 @@ additionalEnv:
 %{endif~}
 %{endfor~}
 EOT
+
+  # System-log tables grow unbounded; their merges OOM-kill ClickHouse on a
+  # memory-capped box (#963). When disabled (default), drop the high-volume tables
+  # and keep query_log/part_log/error_log for debugging.
+  clickhouse_log_table_overrides = var.enable_clickhouse_log_tables ? "" : <<EOT
+clickhouse:
+  extraOverrides: |
+      <clickhouse>
+        <trace_log remove="1"/>
+        <text_log remove="1"/>
+        <opentelemetry_span_log remove="1"/>
+        <asynchronous_metric_log remove="1"/>
+        <metric_log remove="1"/>
+        <latency_log remove="1"/>
+      </clickhouse>
+EOT
 }
 
 resource "helm_release" "traceroot" {
@@ -263,6 +279,7 @@ resource "helm_release" "traceroot" {
     local.enterprise_values,
     local.feature_values,
     local.additional_env_values,
+    local.clickhouse_log_table_overrides,
   ])
 
   # Ensure global.security.allowInsecureImages is set for bitnamilegacy images

--- a/deploy/terraform/aws/variables.tf
+++ b/deploy/terraform/aws/variables.tf
@@ -88,6 +88,12 @@ variable "clickhouse_storage_size" {
   default     = "20Gi"
 }
 
+variable "enable_clickhouse_log_tables" {
+  description = "Enable ClickHouse's built-in system log tables (trace_log, metric_log, asynchronous_metric_log, etc.). Disabled by default: their unbounded growth and background merges can OOM-kill ClickHouse on a memory-capped box. query_log/part_log/error_log are always kept for debugging."
+  type        = bool
+  default     = false
+}
+
 variable "clickhouse_namespace" {
   description = "Kubernetes namespace where ClickHouse will be deployed. Defaults to traceroot-{environment}."
   type        = string


### PR DESCRIPTION
## Problem

Users hit intermittent **"Error loading findings"** on the detector page and **500s on the traces page** (issue #963). Root cause: ClickHouse's built-in **system-log tables** (`trace_log`, `metric_log`, `asynchronous_metric_log`, …) grow **unbounded with no TTL**. On our memory-capped Fargate ClickHouse, their background merges exceeded the server memory cap and OOM-killed the instance — so any user query in flight (the tiny findings `SELECT`, the traces query, detector writes) was killed by the OvercommitTracker (`code 241`).

On staging this had grown to ~19 GiB of system-log data (e.g. `trace_log` at 537M rows) and the ClickHouse pod was OOM-restarting; production showed the same pattern.

## Changes

- **`traceroot.tf`** — add an `enable_clickhouse_log_tables` toggle (default **off**) that injects a ClickHouse config override removing the high-volume system-log tables. The debuggable tables (`query_log`, `part_log`, `error_log`) are intentionally kept. Also bump ClickHouse resources to **cpu 2 / 8Gi** (from 4Gi) for merge headroom.
- **`variables.tf`** — declare the `enable_clickhouse_log_tables` variable.
- **`rds.tf`** — add `lifecycle { ignore_changes = [engine_version] }` to the Aurora cluster + instance and align the literal to the live `17.7`. AWS auto-applies minor version upgrades; without this, an apply would attempt a Postgres **downgrade** (17.7 → 17.4). This defuses a latent landmine for any future apply.

## Verification

Applied to the **staging** workspace (targeted `helm_release` apply) and verified live:
- ClickHouse container now 8 GiB; system-log writes **frozen** (no longer growing).
- ClickHouse memory ~150 MiB idle (was pinned near the cap); **0** `code 241` failures after the change.
- Findings page loads (~30 ms query); traces page loads.

## Follow-ups (separate PRs)

- Rewrite the trace **list** queries (`trace_reader.py` `list_traces` / `list_sessions`) which aggregate spans across the whole project on every list call — the real durable fix for traces-page memory use.
- Apply the same ClickHouse config to **production** (same latent bloat).

Closes #963

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes ClickHouse memory to resolve intermittent “Error loading findings” and traces 500s by disabling high-volume system-log tables by default and increasing resources to 2 CPU / 8Gi. Also pins Aurora Postgres to 17.7 and prevents Terraform from undoing AWS minor upgrades.

- **Bug Fixes**
  - Add Terraform toggle `enable_clickhouse_log_tables` (default false) to remove high-volume ClickHouse system logs (`trace_log`, `metric_log`, `asynchronous_metric_log`, `text_log`, `opentelemetry_span_log`, `latency_log`) while keeping `query_log`, `part_log`, `error_log`.
  - Bump ClickHouse resources to 2 CPU / 8Gi for merge headroom.

- **Dependencies**
  - Set Aurora Postgres `engine_version` to "17.7" and add `lifecycle.ignore_changes = [engine_version]` on cluster and instance to avoid unintended downgrades during apply.

<sup>Written for commit fdde00d88322c2a76db33b8bdb5a56a9479dd440. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

