### PR TITLE
Feature/budget alerts and cache pricing

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -311,6 +311,10 @@ async def list_detector_runs(
     detector_id: str,
     page: int = Query(0, ge=0, description="Page number (0-indexed)"),
     limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    finding_id: str | None = Query(
+        None,
+        description="Exact match on finding_id — use to check if a specific alert already fired",
+    ),
     start_after: datetime | None = Query(
         None, description="Filter runs at/after this timestamp (inclusive)"
     ),
@@ -346,6 +350,10 @@ async def list_detector_runs(
         "project_id": project_id,
         "detector_id": detector_id,
     }
+
+    if finding_id is not None:
+        conditions.append("r.finding_id = {finding_id:String}")
+        params["finding_id"] = finding_id
 
     if start_after is not None:
         conditions.append("r.timestamp >= {start_after:DateTime64(3)}")

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -192,6 +192,49 @@ async def get_usage_details(
 
 
 # =============================================================================
+# Budget Alert Endpoints (for reconciliation safety net)
+# =============================================================================
+
+
+class ProjectSpendResponse(BaseModel):
+    total_cost: float
+
+
+@router.get(
+    "/projects/{project_id}/spend",
+    response_model=ProjectSpendResponse,
+    dependencies=[Depends(verify_internal_secret)],
+)
+async def get_project_spend(
+    project_id: str,
+    start_time: datetime = Query(..., description="Start of window (ISO format)"),
+) -> ProjectSpendResponse:
+    """Get total span cost for a project since start_time.
+
+    Used by the hourly billing cron as a reconciliation safety net for the
+    event-driven Redis budget check in the Python ingest path.
+    """
+    ch = get_clickhouse_client()
+    start_str = to_utc_naive(start_time).strftime("%Y-%m-%d %H:%M:%S")
+
+    result = ch.query(
+        """
+        SELECT sum(cost) as total_cost
+        FROM spans
+        WHERE project_id = {project_id:String}
+          AND ch_create_time >= {start_time:String}
+          AND cost IS NOT NULL
+        """,
+        parameters={"project_id": project_id, "start_time": start_str},
+    )
+
+    total = (
+        float(result.result_rows[0][0]) if result.result_rows and result.result_rows[0][0] else 0.0
+    )
+    return ProjectSpendResponse(total_cost=total)
+
+
+# =============================================================================
 # Detector Endpoints (for worker/TypeScript service writes and reads)
 # =============================================================================
 

--- a/backend/worker/budget_alerts.py
+++ b/backend/worker/budget_alerts.py
@@ -1,0 +1,319 @@
+"""Budget alert checks — inline in the Python ingest path.
+
+After every span batch is inserted into ClickHouse, this module:
+1. Sums the batch cost (already computed, in memory)
+2. Increments a per-project Redis counter (INCRBYFLOAT, O(1))
+3. If the counter crosses a configured threshold and no cooldown key
+   exists, enqueues a pre-resolved budget finding to the TS detector
+   worker via BullMQ.
+
+Performance: ~1-3ms per ingest batch (Redis round-trips only).
+ClickHouse queries: zero. LLM cost: zero.
+
+Reconciliation safety net: the hourly billing cron in usageMetering.ts
+re-checks authoritative ClickHouse data and catches Redis data loss.
+"""
+
+import hashlib
+import json
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+# BullMQ queue name — must match TypeScript DETECTOR_RUN_QUEUE constant
+DETECTOR_RUN_QUEUE = "detector-run"
+
+# Window durations in seconds
+WINDOW_SECONDS = {
+    "1h": 3600,
+    "24h": 86400,
+    "7d": 604800,
+    "30d": 2592000,
+}
+
+# Cache TTL for budget detector config (seconds)
+_DETECTOR_CACHE_TTL = 60
+
+
+def _get_redis():
+    """Get Redis client using same connection as Celery broker."""
+    import redis
+
+    from worker.celery_app import app as celery_app
+
+    return redis.from_url(celery_app.conf.broker_url)
+
+
+def _get_budget_detectors_cached(redis_client, project_id: str) -> list[dict]:
+    """Load budget detectors for a project, cached in Redis for 60s.
+
+    Returns list of dicts: [{id, name, threshold_usd, window}, ...]
+    """
+    cache_key = f"budget:detectors:{project_id}"
+
+    # Try cache first
+    cached = redis_client.get(cache_key)
+    if cached is not None:
+        try:
+            return json.loads(cached)
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    # Cache miss — query PostgreSQL
+    detectors = _fetch_budget_detectors(project_id)
+
+    # Cache the result (even empty list, to avoid repeated DB queries)
+    redis_client.set(cache_key, json.dumps(detectors), ex=_DETECTOR_CACHE_TTL)
+
+    return detectors
+
+
+def _fetch_budget_detectors(project_id: str) -> list[dict]:
+    """Fetch budget detectors and their config from PostgreSQL.
+
+    Budget config is stored in detector_triggers.conditions as:
+    [
+        {"field": "budget_threshold_usd", "op": "=", "value": 100.0},
+        {"field": "budget_window", "op": "=", "value": "24h"},
+    ]
+    """
+    import psycopg2
+
+    from shared.config import settings
+
+    conn = psycopg2.connect(settings.database_url)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT d.id, d.name, dt.conditions
+                FROM detectors d
+                LEFT JOIN detector_triggers dt ON dt.detector_id = d.id
+                WHERE d.project_id = %s
+                  AND d.enabled = TRUE
+                  AND d.template = 'budget'
+                """,
+                (project_id,),
+            )
+            rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    detectors = []
+    for detector_id, detector_name, conditions in rows:
+        # Parse conditions JSONB
+        if conditions is None:
+            continue
+        if isinstance(conditions, str):
+            conditions = json.loads(conditions)
+        if not isinstance(conditions, list):
+            continue
+
+        # Extract budget config from conditions
+        threshold_usd = None
+        window = None
+        for cond in conditions:
+            field = cond.get("field")
+            value = cond.get("value")
+            if field == "budget_threshold_usd":
+                threshold_usd = float(value)
+            elif field == "budget_window":
+                window = str(value)
+
+        if threshold_usd is None or window not in WINDOW_SECONDS:
+            logger.warning(
+                f"Budget detector {detector_id} has invalid config: "
+                f"threshold={threshold_usd}, window={window}"
+            )
+            continue
+
+        detectors.append(
+            {
+                "id": detector_id,
+                "name": detector_name,
+                "threshold_usd": threshold_usd,
+                "window": window,
+            }
+        )
+
+    return detectors
+
+
+def _deterministic_finding_id(project_id: str, detector_id: str, window_key: str) -> str:
+    """Generate a stable finding ID for deduplication.
+
+    Uses the project, detector, and window key so the same budget breach
+    in the same window always produces the same finding ID. ClickHouse's
+    ReplacingMergeTree deduplicates on this.
+    """
+    raw = f"budget:{project_id}:{detector_id}:{window_key}"
+    h = hashlib.sha256(raw.encode()).hexdigest()[:32]
+    # Format as UUID-like string
+    return f"{h[:8]}-{h[8:12]}-{h[12:16]}-{h[16:20]}-{h[20:32]}"
+
+
+def _enqueue_budget_finding(
+    redis_client,
+    project_id: str,
+    detector: dict,
+    current_spend: float,
+) -> None:
+    """Enqueue a pre-resolved budget finding to BullMQ.
+
+    The TS detector-run-processor recognizes the `budgetAlert` field
+    and skips LLM eval — it writes the finding directly and triggers
+    notification fan-out.
+    """
+    # Window key for dedup: e.g. "24h-1716883200" (window + epoch of window start)
+    window_secs = WINDOW_SECONDS[detector["window"]]
+    window_epoch = int(time.time()) // window_secs * window_secs
+    window_key = f"{detector['window']}-{window_epoch}"
+
+    finding_id = _deterministic_finding_id(project_id, detector["id"], window_key)
+
+    summary = (
+        f"Budget alert: ${current_spend:.2f} spent in the last {detector['window']} "
+        f"(threshold: ${detector['threshold_usd']:.2f})"
+    )
+
+    job_data = {
+        "traceId": "",  # budget alerts are project-level, not trace-specific
+        "detectorIds": [],
+        "projectId": project_id,
+        "budgetAlert": {
+            "findingId": finding_id,
+            "detectorId": detector["id"],
+            "detectorName": detector["name"],
+            "summary": summary,
+            "data": {
+                "threshold_usd": detector["threshold_usd"],
+                "current_spend_usd": round(current_spend, 4),
+                "window": detector["window"],
+            },
+        },
+    }
+
+    job_id = f"budget-{project_id}-{detector['id']}-{window_key}"
+    timestamp_ms = int(time.time() * 1000)
+    job_hash_key = f"bull:{DETECTOR_RUN_QUEUE}:{job_id}"
+
+    redis_client.hset(
+        job_hash_key,
+        mapping={
+            "name": "budget-alert",
+            "data": json.dumps(job_data),
+            "opts": json.dumps(
+                {
+                    "jobId": job_id,
+                    "removeOnComplete": 100,
+                    "removeOnFail": 50,
+                    "attempts": 3,
+                }
+            ),
+            "timestamp": str(timestamp_ms),
+            "delay": "0",
+            "priority": "0",
+            "attempts": "0",
+        },
+    )
+    redis_client.rpush(f"bull:{DETECTOR_RUN_QUEUE}:wait", job_id)
+
+    logger.info(
+        f"Budget alert enqueued: project={project_id} detector={detector['id']} "
+        f"spend=${current_spend:.2f} threshold=${detector['threshold_usd']:.2f} "
+        f"window={detector['window']}"
+    )
+
+
+def check_budget_thresholds(
+    project_id: str,
+    batch_cost: float,
+    idempotency_key: str | None = None,
+) -> None:
+    """Inline budget check on every ingest batch.
+
+    Called from ingest_tasks.py after span insert. O(1) Redis ops per
+    budget detector, no ClickHouse queries.
+
+    Args:
+        project_id: The project whose spans were just ingested.
+        batch_cost: Total cost from the current span batch (already computed).
+        idempotency_key: Optional stable key to prevent overcounting on Celery retries.
+    """
+    if batch_cost <= 0:
+        return
+
+    try:
+        redis_client = _get_redis()
+    except Exception:
+        logger.warning("Failed to get Redis client for budget check", exc_info=True)
+        return
+
+    # Prevent duplicate processing on Celery retries
+    if idempotency_key:
+        processed_key = f"budget:processed:{idempotency_key}"
+        # Set processed key in Redis with 24h expiry to automatically reclaim memory
+        was_set = redis_client.set(processed_key, "1", ex=86400, nx=True)
+        if not was_set:
+            logger.info(
+                f"Budget check skipped for project {project_id} (idempotency key {idempotency_key} already processed)"
+            )
+            return
+
+    budget_detectors = _get_budget_detectors_cached(redis_client, project_id)
+    if not budget_detectors:
+        return
+
+    for detector in budget_detectors:
+        try:
+            _check_single_detector(redis_client, project_id, detector, batch_cost)
+        except Exception:
+            logger.error(
+                f"Budget check failed for detector {detector['id']}",
+                exc_info=True,
+            )
+
+
+def _check_single_detector(
+    redis_client,
+    project_id: str,
+    detector: dict,
+    batch_cost: float,
+) -> None:
+    """Check a single budget detector against the running Redis counter."""
+    threshold_usd = detector["threshold_usd"]
+    window = detector["window"]
+    window_secs = WINDOW_SECONDS[window]
+    detector_id = detector["id"]
+
+    # 1. INCRBYFLOAT — O(1), atomic
+    counter_key = f"budget:project:{project_id}:{detector_id}:{window}"
+    new_total = float(redis_client.incrbyfloat(counter_key, batch_cost))
+
+    # Set TTL only on first write (when no expiry is set)
+    ttl = redis_client.ttl(counter_key)
+    if ttl == -1:  # no expiry set yet (key is new or lost TTL)
+        redis_client.expire(counter_key, window_secs)
+
+    # 2. Threshold check + cooldown
+    if new_total >= threshold_usd:
+        # Window key for cooldown: e.g. "24h-1716883200" (same epoch used for deduplicating finding IDs)
+        window_epoch = int(time.time()) // window_secs * window_secs
+        window_key = f"{window}-{window_epoch}"
+
+        # Cooldown key includes window_key so it is scoped entirely to the specific window epoch.
+        # This prevents a cooldown in the previous window from suppressing the first alert in the next.
+        cooldown_key = f"budget:alert:cooldown:{project_id}:{detector_id}:{window_key}"
+        # SET NX = only set if key does not exist (atomic check-and-set)
+        was_set = redis_client.set(cooldown_key, "1", ex=window_secs, nx=True)
+
+        if was_set:
+            # First breach in this window — enqueue finding
+            _enqueue_budget_finding(redis_client, project_id, detector, new_total)
+        else:
+            logger.debug(
+                f"Budget alert suppressed (cooldown active): "
+                f"project={project_id} detector={detector_id} "
+                f"spend=${new_total:.2f}"
+            )

--- a/backend/worker/budget_alerts.py
+++ b/backend/worker/budget_alerts.py
@@ -18,6 +18,7 @@ import hashlib
 import json
 import logging
 import time
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -104,10 +105,29 @@ def _fetch_budget_detectors(project_id: str) -> list[dict]:
     for detector_id, detector_name, conditions in rows:
         # Parse conditions JSONB
         if conditions is None:
+            logger.error(
+                f"Budget detector {detector_id} ({detector_name!r}) has no trigger "
+                f"conditions — it will be silently excluded from spend enforcement. "
+                f"Ensure a detector_triggers row exists with a valid conditions array."
+            )
             continue
         if isinstance(conditions, str):
-            conditions = json.loads(conditions)
+            try:
+                conditions = json.loads(conditions)
+            except (json.JSONDecodeError, ValueError) as exc:
+                logger.error(
+                    f"Budget detector {detector_id} ({detector_name!r}) has unparseable "
+                    f"conditions JSON: {exc}. Raw value: {conditions[:200]!r}. "
+                    f"Detector excluded from spend enforcement."
+                )
+                continue
         if not isinstance(conditions, list):
+            logger.error(
+                f"Budget detector {detector_id} ({detector_name!r}) has conditions of "
+                f"type {type(conditions).__name__!r} (expected list). "
+                f"Actual value: {str(conditions)[:200]!r}. "
+                f"Detector excluded from spend enforcement — fix the trigger config."
+            )
             continue
 
         # Extract budget config from conditions
@@ -250,29 +270,60 @@ def check_budget_thresholds(
         logger.warning("Failed to get Redis client for budget check", exc_info=True)
         return
 
-    # Prevent duplicate processing on Celery retries
-    if idempotency_key:
-        processed_key = f"budget:processed:{idempotency_key}"
-        # Set processed key in Redis with 24h expiry to automatically reclaim memory
-        was_set = redis_client.set(processed_key, "1", ex=86400, nx=True)
-        if not was_set:
-            logger.info(
-                f"Budget check skipped for project {project_id} (idempotency key {idempotency_key} already processed)"
-            )
-            return
+    # Prevent duplicate processing on Celery retries.
+    # Strategy: per-detector sub-keys (budget:processed:{key}:{detector_id})
+    # are written immediately after each detector succeeds. The batch-level key
+    # (budget:processed:{key}) is written only once every detector is done.
+    #
+    # This means:
+    # - A retry skips detectors that already succeeded (no duplicate alerts).
+    # - A retry re-runs only the detectors that failed (no silent misses).
+    processed_key = f"budget:processed:{idempotency_key}" if idempotency_key else None
+    if processed_key and redis_client.get(processed_key):
+        logger.info(
+            f"Budget check skipped for project {project_id} "
+            f"(idempotency key {idempotency_key} already processed)"
+        )
+        return
 
     budget_detectors = _get_budget_detectors_cached(redis_client, project_id)
     if not budget_detectors:
+        # Nothing to do — mark processed so future retries skip the DB lookup too.
+        if processed_key:
+            redis_client.set(processed_key, "1", ex=86400, nx=True)
         return
 
+    failed = False
     for detector in budget_detectors:
+        detector_id = detector["id"]
+
+        # Skip detectors that already succeeded on a previous attempt.
+        detector_processed_key = (
+            f"{processed_key}:{detector_id}" if processed_key else None
+        )
+        if detector_processed_key and redis_client.get(detector_processed_key):
+            logger.debug(
+                f"Detector {detector_id} already processed for batch "
+                f"{idempotency_key}, skipping"
+            )
+            continue
+
         try:
-            _check_single_detector(redis_client, project_id, detector, batch_cost)
+            _check_single_detector(redis_client, project_id, detector, batch_cost, idempotency_key)
+            # Mark this detector as done immediately so a retry won't repeat it.
+            if detector_processed_key:
+                redis_client.set(detector_processed_key, "1", ex=86400, nx=True)
         except Exception:
+            failed = True
             logger.error(
-                f"Budget check failed for detector {detector['id']}",
+                f"Budget check failed for detector {detector_id}",
                 exc_info=True,
             )
+
+    # Write the batch-level key only when every detector has been individually
+    # marked. On the next retry the top-level GET will short-circuit immediately.
+    if processed_key and not failed:
+        redis_client.set(processed_key, "1", ex=86400, nx=True)
 
 
 def _check_single_detector(
@@ -280,6 +331,7 @@ def _check_single_detector(
     project_id: str,
     detector: dict,
     batch_cost: float,
+    idempotency_key: str | None = None,
 ) -> None:
     """Check a single budget detector against the running Redis counter."""
     threshold_usd = detector["threshold_usd"]
@@ -287,35 +339,53 @@ def _check_single_detector(
     window_secs = WINDOW_SECONDS[window]
     detector_id = detector["id"]
 
-    # 1. INCRBYFLOAT — O(1), atomic
+    # 1. Rolling-window spend accumulation via a Redis Sorted Set.
     #
-    # Counter key is scoped to the current window EPOCH (same as the cooldown
-    # and finding-ID keys) so that spend from adjacent windows never pollutes
-    # each other. Without the epoch, an un-expired counter from window N would
-    # be incremented into window N+1, producing false-positive alerts.
-    window_epoch = int(time.time()) // window_secs * window_secs
-    counter_key = f"budget:project:{project_id}:{detector_id}:{window}-{window_epoch}"
-    new_total = float(redis_client.incrbyfloat(counter_key, batch_cost))
+    # Key is scoped to project + detector + window only — no epoch bucket.
+    # Each ingest batch writes a unique member that encodes the batch cost,
+    # with the current Unix timestamp as its score. ZREMRANGEBYSCORE prunes
+    # entries older than one full window on every write, so the set always
+    # holds at most one window's worth of batches.
+    #
+    # This gives a true rolling lookback (now − window_secs → now) rather
+    # than snapping to a fixed UTC boundary. The old INCRBYFLOAT approach
+    # keyed on `floor(now / window_secs) * window_secs`, meaning "24h"
+    # measured "since the start of the current UTC day" — undercounting early
+    # in the day and potentially overcounting/missing alerts near midnight.
+    now = time.time()
+    counter_key = f"budget:project:{project_id}:{detector_id}:{window}"
+    # Member encodes cost so we can sum without an extra round-trip.
+    #
+    # When an idempotency_key is available (Celery task ID or batch hash), use
+    # it as the member suffix instead of a random UUID. ZADD on an existing
+    # member only updates its score (timestamp) — it does NOT add a new entry —
+    # so a Celery retry that reaches this line before `budget:processed:*` is
+    # written will be a no-op on the sorted set rather than adding the same
+    # batch cost a second time.
+    #
+    # Without idempotency_key (fire-and-forget call sites), fall back to a
+    # random UUID so concurrent batches at the same millisecond don’t collapse.
+    if idempotency_key:
+        member = f"{batch_cost}:{idempotency_key}:{detector_id}"
+    else:
+        member = f"{batch_cost}:{uuid.uuid4().hex[:8]}"
+    redis_client.zadd(counter_key, {member: now})
+    # Prune entries that have rolled out of the window.
+    redis_client.zremrangebyscore(counter_key, "-inf", now - window_secs)
+    # Self-expiry after one idle window + small buffer for clock drift.
+    redis_client.expire(counter_key, window_secs + 60)
 
-    # Set TTL on first write — key expires naturally when the window ends.
-    ttl = redis_client.ttl(counter_key)
-    if ttl == -1:  # no expiry set yet (key is new or lost TTL)
-        # Rollout migration: if the old un-scoped key exists, migrate its spend to the new key
-        # and delete the old key atomically (using delete return value as a lock) to avoid double counting.
-        old_key = f"budget:project:{project_id}:{detector_id}:{window}"
-        old_val = redis_client.get(old_key)
-        if old_val:
-            try:
-                if isinstance(old_val, bytes):
-                    old_val = old_val.decode("utf-8")
-                # delete returns 1 if the key was deleted, 0 if it was already deleted by another worker
-                if redis_client.delete(old_key):
-                    old_spend = float(old_val)
-                    if old_spend > 0:
-                        new_total = float(redis_client.incrbyfloat(counter_key, old_spend))
-            except (ValueError, TypeError):
-                pass
-        redis_client.expire(counter_key, window_secs)
+    # Sum the cost of all entries still within the rolling window.
+    entries = redis_client.zrangebyscore(counter_key, now - window_secs, "+inf")
+    new_total = 0.0
+    for entry in entries:
+        if isinstance(entry, bytes):
+            entry = entry.decode("utf-8")
+        try:
+            # Member format: "{cost}:{unique_suffix}" — first segment is cost.
+            new_total += float(entry.split(":")[0])
+        except (ValueError, TypeError):
+            pass
 
     # 2. Threshold check + cooldown
     if new_total >= threshold_usd:
@@ -330,8 +400,15 @@ def _check_single_detector(
         was_set = redis_client.set(cooldown_key, "1", ex=window_secs, nx=True)
 
         if was_set:
-            # First breach in this window — enqueue finding
-            _enqueue_budget_finding(redis_client, project_id, detector, new_total)
+            # First breach in this window — enqueue finding.
+            # If enqueueing fails we MUST release the cooldown key so the next
+            # ingest batch can retry. Leaving a cooldown key without a durably
+            # queued job would silently suppress the alert for the whole window.
+            try:
+                _enqueue_budget_finding(redis_client, project_id, detector, new_total)
+            except Exception:
+                redis_client.delete(cooldown_key)
+                raise
         else:
             logger.debug(
                 f"Budget alert suppressed (cooldown active): "

--- a/backend/worker/budget_alerts.py
+++ b/backend/worker/budget_alerts.py
@@ -288,10 +288,16 @@ def _check_single_detector(
     detector_id = detector["id"]
 
     # 1. INCRBYFLOAT — O(1), atomic
-    counter_key = f"budget:project:{project_id}:{detector_id}:{window}"
+    #
+    # Counter key is scoped to the current window EPOCH (same as the cooldown
+    # and finding-ID keys) so that spend from adjacent windows never pollutes
+    # each other. Without the epoch, an un-expired counter from window N would
+    # be incremented into window N+1, producing false-positive alerts.
+    window_epoch = int(time.time()) // window_secs * window_secs
+    counter_key = f"budget:project:{project_id}:{detector_id}:{window}-{window_epoch}"
     new_total = float(redis_client.incrbyfloat(counter_key, batch_cost))
 
-    # Set TTL only on first write (when no expiry is set)
+    # Set TTL on first write — key expires naturally when the window ends.
     ttl = redis_client.ttl(counter_key)
     if ttl == -1:  # no expiry set yet (key is new or lost TTL)
         redis_client.expire(counter_key, window_secs)

--- a/backend/worker/budget_alerts.py
+++ b/backend/worker/budget_alerts.py
@@ -300,6 +300,21 @@ def _check_single_detector(
     # Set TTL on first write — key expires naturally when the window ends.
     ttl = redis_client.ttl(counter_key)
     if ttl == -1:  # no expiry set yet (key is new or lost TTL)
+        # Rollout migration: if the old un-scoped key exists, migrate its spend to the new key
+        # and delete the old key atomically (using delete return value as a lock) to avoid double counting.
+        old_key = f"budget:project:{project_id}:{detector_id}:{window}"
+        old_val = redis_client.get(old_key)
+        if old_val:
+            try:
+                if isinstance(old_val, bytes):
+                    old_val = old_val.decode("utf-8")
+                # delete returns 1 if the key was deleted, 0 if it was already deleted by another worker
+                if redis_client.delete(old_key):
+                    old_spend = float(old_val)
+                    if old_spend > 0:
+                        new_total = float(redis_client.incrbyfloat(counter_key, old_spend))
+            except (ValueError, TypeError):
+                pass
         redis_client.expire(counter_key, window_secs)
 
     # 2. Threshold check + cooldown

--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -112,6 +112,7 @@ def _get_active_detectors(project_id: str) -> list[dict]:
                 FROM detectors d
                 LEFT JOIN detector_triggers dt ON dt.detector_id = d.id
                 WHERE d.project_id = %s AND d.enabled = TRUE
+                  AND d.template != 'budget'
                 """,
                 (project_id,),
             )

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -138,6 +138,18 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
                 ch_client.insert_spans_batch(spans)
                 logger.info(f"Inserted {len(spans)} spans into ClickHouse")
 
+        # Budget alert: accumulate batch cost in Redis, check thresholds.
+        # Cost is already computed in span records — no additional queries.
+        if spans:
+            batch_cost = sum(float(s.get("cost") or 0) for s in spans)
+            if batch_cost > 0:
+                try:
+                    from worker.budget_alerts import check_budget_thresholds
+
+                    check_budget_thresholds(project_id, batch_cost, idempotency_key=s3_key)
+                except Exception as e:
+                    logger.error(f"Budget alert check failed: {e}", exc_info=True)
+
         # Trigger detector runs for ingested traces (fire-and-forget, non-blocking).
         # Union over traces AND spans so late-arriving spans for an existing
         # trace (no fresh trace row in this batch) still enqueue detection;

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -407,6 +407,20 @@ def transform_otel_to_clickhouse(
                         "gen_ai.usage.total_tokens"
                     )
 
+                    # Prompt caching tokens
+                    api_cache_read_tokens = span_attrs.get(
+                        "gen_ai.usage.details.cache_read_tokens"
+                    ) or span_attrs.get("llm.token_count.cache_read")
+                    api_cache_write_tokens = span_attrs.get(
+                        "gen_ai.usage.details.cache_write_tokens"
+                    ) or span_attrs.get("llm.token_count.cache_write")
+                    cache_read_tokens = (
+                        int(api_cache_read_tokens) if api_cache_read_tokens is not None else 0
+                    )
+                    cache_write_tokens = (
+                        int(api_cache_write_tokens) if api_cache_write_tokens is not None else 0
+                    )
+
                     if api_input_tokens is not None or api_output_tokens is not None:
                         # Use API-provided counts (accurate)
                         input_tokens = int(api_input_tokens) if api_input_tokens is not None else 0
@@ -436,7 +450,24 @@ def transform_otel_to_clickhouse(
                             output_cost = Decimal(output_tokens) * Decimal(
                                 str(prices.get("output", 0))
                             )
-                            span_record["cost"] = float(input_cost + output_cost)
+
+                            cache_read_rate = prices.get("cacheRead")
+                            if cache_read_rate is None:
+                                cache_read_rate = 0
+                            cache_write_rate = prices.get("cacheWrite")
+                            if cache_write_rate is None:
+                                cache_write_rate = 0
+
+                            cache_read_cost = Decimal(cache_read_tokens) * Decimal(
+                                str(cache_read_rate)
+                            )
+                            cache_write_cost = Decimal(cache_write_tokens) * Decimal(
+                                str(cache_write_rate)
+                            )
+
+                            span_record["cost"] = float(
+                                input_cost + output_cost + cache_read_cost + cache_write_cost
+                            )
                     else:
                         # Fall back to text-based estimation
                         from worker.tokens import calculate_cost
@@ -445,6 +476,8 @@ def transform_otel_to_clickhouse(
                             model=model_name,
                             input_text=span_record.get("input"),
                             output_text=span_record.get("output"),
+                            cache_read_tokens=cache_read_tokens,
+                            cache_write_tokens=cache_write_tokens,
                         )
                         if usage["input_tokens"] is not None:
                             span_record["input_tokens"] = usage["input_tokens"]

--- a/backend/worker/tests/test_budget_alerts.py
+++ b/backend/worker/tests/test_budget_alerts.py
@@ -1,0 +1,357 @@
+"""Tests for the budget alert module.
+
+Tests cover:
+- Redis INCRBYFLOAT counter accumulation
+- Threshold detection (below/at/above)
+- Cooldown suppression (no duplicate alerts)
+- Budget detector config caching
+- BullMQ enqueue on threshold breach
+- No-op when no budget detectors exist
+"""
+
+import json
+
+# Patch psycopg2 and celery before importing the module under test
+import sys
+from unittest.mock import MagicMock, patch
+
+# Create mock modules for psycopg2 and celery
+sys.modules.setdefault("psycopg2", MagicMock())
+sys.modules.setdefault("worker.celery_app", MagicMock())
+
+
+from worker.budget_alerts import (  # noqa: E402
+    WINDOW_SECONDS,
+    _check_single_detector,
+    _deterministic_finding_id,
+    _get_budget_detectors_cached,
+    check_budget_thresholds,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_detector(
+    detector_id="det-1",
+    name="Budget $100/24h",
+    threshold_usd=100.0,
+    window="24h",
+):
+    return {
+        "id": detector_id,
+        "name": name,
+        "threshold_usd": threshold_usd,
+        "window": window,
+    }
+
+
+def _make_redis_mock(
+    counter_value=0.0,
+    ttl_value=-1,
+    cooldown_exists=False,
+    cached_detectors=None,
+):
+    """Create a mock Redis client with configurable behavior."""
+    mock = MagicMock()
+    mock.incrbyfloat.return_value = counter_value
+    mock.ttl.return_value = ttl_value
+    mock.exists.return_value = cooldown_exists
+    # SET NX returns True if key was set (no existing key), False otherwise
+    mock.set.return_value = not cooldown_exists
+
+    if cached_detectors is not None:
+        mock.get.return_value = json.dumps(cached_detectors)
+    else:
+        mock.get.return_value = None
+
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests: _deterministic_finding_id
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicFindingId:
+    def test_same_inputs_produce_same_id(self):
+        id1 = _deterministic_finding_id("proj-1", "det-1", "24h-1716883200")
+        id2 = _deterministic_finding_id("proj-1", "det-1", "24h-1716883200")
+        assert id1 == id2
+
+    def test_different_inputs_produce_different_ids(self):
+        id1 = _deterministic_finding_id("proj-1", "det-1", "24h-1716883200")
+        id2 = _deterministic_finding_id("proj-1", "det-2", "24h-1716883200")
+        assert id1 != id2
+
+    def test_id_format_is_uuid_like(self):
+        fid = _deterministic_finding_id("proj-1", "det-1", "24h-1716883200")
+        parts = fid.split("-")
+        assert len(parts) == 5
+        assert len(parts[0]) == 8
+        assert len(parts[1]) == 4
+        assert len(parts[2]) == 4
+        assert len(parts[3]) == 4
+        assert len(parts[4]) == 12
+
+
+# ---------------------------------------------------------------------------
+# Tests: _check_single_detector
+# ---------------------------------------------------------------------------
+
+
+class TestCheckSingleDetector:
+    def test_below_threshold_no_enqueue(self):
+        """When spend is below threshold, no finding should be enqueued."""
+        detector = _make_detector(threshold_usd=100.0)
+        redis_mock = _make_redis_mock(counter_value=50.0, ttl_value=86000)
+
+        _check_single_detector(redis_mock, "proj-1", detector, batch_cost=10.0)
+
+        # INCRBYFLOAT should be called
+        redis_mock.incrbyfloat.assert_called_once()
+        # No BullMQ enqueue (hset/rpush not called)
+        redis_mock.hset.assert_not_called()
+        redis_mock.rpush.assert_not_called()
+
+    def test_at_threshold_enqueues_finding(self):
+        """When spend reaches threshold, a finding should be enqueued."""
+        detector = _make_detector(threshold_usd=100.0)
+        redis_mock = _make_redis_mock(
+            counter_value=100.0,  # exactly at threshold
+            ttl_value=86000,
+            cooldown_exists=False,
+        )
+
+        _check_single_detector(redis_mock, "proj-1", detector, batch_cost=10.0)
+
+        # Cooldown should be set (SET NX)
+        redis_mock.set.assert_called_once()
+        # BullMQ enqueue should happen
+        redis_mock.hset.assert_called_once()
+        redis_mock.rpush.assert_called_once()
+
+    def test_above_threshold_enqueues_finding(self):
+        """When spend exceeds threshold, a finding should be enqueued."""
+        detector = _make_detector(threshold_usd=100.0)
+        redis_mock = _make_redis_mock(
+            counter_value=150.0,
+            ttl_value=86000,
+            cooldown_exists=False,
+        )
+
+        _check_single_detector(redis_mock, "proj-1", detector, batch_cost=50.0)
+
+        redis_mock.set.assert_called_once()
+        redis_mock.hset.assert_called_once()
+        redis_mock.rpush.assert_called_once()
+
+    def test_cooldown_suppresses_duplicate(self):
+        """When cooldown key exists, no finding should be enqueued."""
+        detector = _make_detector(threshold_usd=100.0)
+        redis_mock = _make_redis_mock(
+            counter_value=150.0,
+            ttl_value=86000,
+            cooldown_exists=True,  # cooldown active
+        )
+
+        _check_single_detector(redis_mock, "proj-1", detector, batch_cost=50.0)
+
+        # SET NX returns False (key already exists), so no enqueue
+        redis_mock.hset.assert_not_called()
+        redis_mock.rpush.assert_not_called()
+
+    def test_cooldown_key_includes_window_epoch(self):
+        """Verify that the cooldown key includes the window epoch to avoid bleeding across windows."""
+        detector = _make_detector(threshold_usd=100.0, window="24h")
+        redis_mock = _make_redis_mock(
+            counter_value=150.0,
+            ttl_value=86000,
+            cooldown_exists=False,
+        )
+
+        _check_single_detector(redis_mock, "proj-1", detector, batch_cost=50.0)
+
+        redis_mock.set.assert_called_once()
+        cooldown_key = redis_mock.set.call_args[0][0]
+        # Should be formatted as: budget:alert:cooldown:proj-1:det-1:24h-<epoch>
+        assert cooldown_key.startswith("budget:alert:cooldown:proj-1:det-1:24h-")
+
+    def test_new_counter_sets_ttl(self):
+        """When counter key has no TTL (new key), TTL should be set."""
+        detector = _make_detector(threshold_usd=1000.0, window="24h")
+        redis_mock = _make_redis_mock(
+            counter_value=10.0,
+            ttl_value=-1,  # no TTL set
+        )
+
+        _check_single_detector(redis_mock, "proj-1", detector, batch_cost=10.0)
+
+        redis_mock.expire.assert_called_once()
+        args = redis_mock.expire.call_args[0]
+        assert args[1] == WINDOW_SECONDS["24h"]
+
+    def test_existing_counter_skips_ttl(self):
+        """When counter key already has a TTL, don't reset it."""
+        detector = _make_detector(threshold_usd=1000.0)
+        redis_mock = _make_redis_mock(
+            counter_value=10.0,
+            ttl_value=50000,  # TTL already set
+        )
+
+        _check_single_detector(redis_mock, "proj-1", detector, batch_cost=10.0)
+
+        redis_mock.expire.assert_not_called()
+
+    def test_enqueued_job_contains_budget_alert_payload(self):
+        """Verify the BullMQ job payload structure."""
+        detector = _make_detector(
+            detector_id="det-42",
+            name="Budget Alert",
+            threshold_usd=50.0,
+            window="1h",
+        )
+        redis_mock = _make_redis_mock(
+            counter_value=60.0,
+            ttl_value=3000,
+            cooldown_exists=False,
+        )
+
+        _check_single_detector(redis_mock, "proj-99", detector, batch_cost=15.0)
+
+        # Check the BullMQ hset call
+        hset_call = redis_mock.hset.call_args
+        mapping = hset_call[1]["mapping"]
+        job_data = json.loads(mapping["data"])
+
+        assert job_data["projectId"] == "proj-99"
+        assert "budgetAlert" in job_data
+
+        alert = job_data["budgetAlert"]
+        assert alert["detectorId"] == "det-42"
+        assert alert["detectorName"] == "Budget Alert"
+        assert "$60.00" in alert["summary"]
+        assert alert["data"]["threshold_usd"] == 50.0
+        assert alert["data"]["current_spend_usd"] == 60.0
+        assert alert["data"]["window"] == "1h"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_budget_detectors_cached
+# ---------------------------------------------------------------------------
+
+
+class TestGetBudgetDetectorsCached:
+    def test_returns_cached_value(self):
+        """When cache exists, return it without DB query."""
+        detectors = [_make_detector()]
+        redis_mock = _make_redis_mock(cached_detectors=detectors)
+
+        result = _get_budget_detectors_cached(redis_mock, "proj-1")
+
+        assert len(result) == 1
+        assert result[0]["id"] == "det-1"
+        redis_mock.get.assert_called_once_with("budget:detectors:proj-1")
+
+    def test_cache_miss_queries_db(self):
+        """When cache is empty, fetch from DB and cache the result."""
+        redis_mock = _make_redis_mock(cached_detectors=None)
+
+        with patch("worker.budget_alerts._fetch_budget_detectors") as mock_fetch:
+            mock_fetch.return_value = [_make_detector()]
+            result = _get_budget_detectors_cached(redis_mock, "proj-1")
+
+        assert len(result) == 1
+        mock_fetch.assert_called_once_with("proj-1")
+        # Should cache the result
+        redis_mock.set.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests: check_budget_thresholds (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBudgetThresholds:
+    @patch("worker.budget_alerts._get_redis")
+    @patch("worker.budget_alerts._get_budget_detectors_cached")
+    def test_zero_cost_is_noop(self, mock_cached, mock_redis):
+        """Batch with zero cost should not touch Redis at all."""
+        check_budget_thresholds("proj-1", batch_cost=0.0)
+        mock_redis.assert_not_called()
+
+    @patch("worker.budget_alerts._get_redis")
+    @patch("worker.budget_alerts._get_budget_detectors_cached")
+    def test_negative_cost_is_noop(self, mock_cached, mock_redis):
+        """Negative cost (shouldn't happen) is safely ignored."""
+        check_budget_thresholds("proj-1", batch_cost=-5.0)
+        mock_redis.assert_not_called()
+
+    @patch("worker.budget_alerts._get_redis")
+    @patch("worker.budget_alerts._get_budget_detectors_cached")
+    def test_no_detectors_is_noop(self, mock_cached, mock_redis):
+        """When no budget detectors exist, skip processing."""
+        mock_cached.return_value = []
+        mock_redis.return_value = MagicMock()
+
+        check_budget_thresholds("proj-1", batch_cost=10.0)
+
+        # Should call _get_redis and cache lookup, but no INCRBYFLOAT
+        mock_redis.return_value.incrbyfloat.assert_not_called()
+
+    @patch("worker.budget_alerts._get_redis")
+    @patch("worker.budget_alerts._get_budget_detectors_cached")
+    @patch("worker.budget_alerts._check_single_detector")
+    def test_calls_check_for_each_detector(self, mock_check, mock_cached, mock_redis):
+        """Should call _check_single_detector for each budget detector."""
+        det1 = _make_detector(detector_id="det-1")
+        det2 = _make_detector(detector_id="det-2")
+        mock_cached.return_value = [det1, det2]
+        mock_redis.return_value = MagicMock()
+
+        check_budget_thresholds("proj-1", batch_cost=10.0)
+
+        assert mock_check.call_count == 2
+
+    @patch("worker.budget_alerts._get_redis")
+    @patch("worker.budget_alerts._get_budget_detectors_cached")
+    @patch("worker.budget_alerts._check_single_detector")
+    def test_one_detector_failure_doesnt_block_others(self, mock_check, mock_cached, mock_redis):
+        """If one detector check fails, others should still be checked."""
+        det1 = _make_detector(detector_id="det-1")
+        det2 = _make_detector(detector_id="det-2")
+        mock_cached.return_value = [det1, det2]
+        mock_redis.return_value = MagicMock()
+
+        # First detector raises, second succeeds
+        mock_check.side_effect = [RuntimeError("boom"), None]
+
+        # Should not raise
+        check_budget_thresholds("proj-1", batch_cost=10.0)
+
+        assert mock_check.call_count == 2
+
+    @patch("worker.budget_alerts._get_redis")
+    @patch("worker.budget_alerts._get_budget_detectors_cached")
+    @patch("worker.budget_alerts._check_single_detector")
+    def test_idempotency_key_prevents_duplicate_processing(
+        self, mock_check, mock_cached, mock_redis
+    ):
+        """When an idempotency key is provided, duplicate calls should be skipped."""
+        det = _make_detector(detector_id="det-1")
+        mock_cached.return_value = [det]
+        redis_mock = MagicMock()
+        mock_redis.return_value = redis_mock
+
+        # First call with idempotency key
+        redis_mock.set.return_value = True  # NX set succeeds (new key)
+        check_budget_thresholds("proj-1", batch_cost=10.0, idempotency_key="unique-s3-key")
+        assert mock_check.call_count == 1
+
+        mock_check.reset_mock()
+
+        # Second call with the same idempotency key
+        redis_mock.set.return_value = False  # NX set fails (already exists)
+        check_budget_thresholds("proj-1", batch_cost=10.0, idempotency_key="unique-s3-key")
+        assert mock_check.call_count == 0  # Should skip single detector checks

--- a/backend/worker/tests/test_budget_alerts.py
+++ b/backend/worker/tests/test_budget_alerts.py
@@ -192,6 +192,29 @@ class TestCheckSingleDetector:
         args = redis_mock.expire.call_args[0]
         assert args[1] == WINDOW_SECONDS["24h"]
 
+    def test_rollout_migration_migrates_old_key_spend(self):
+        """Verify that when a new counter is initialized (TTL=-1) and an old un-scoped key exists,
+        its spend is migrated and the old key is deleted to prevent double counting.
+        """
+        detector = _make_detector(threshold_usd=100.0, window="24h")
+
+        mock_redis = MagicMock()
+        mock_redis.incrbyfloat.side_effect = [10.0, 35.0]
+        mock_redis.ttl.return_value = -1
+        mock_redis.get.return_value = b"25.0"
+        mock_redis.delete.return_value = 1
+        mock_redis.exists.return_value = False
+        mock_redis.set.return_value = True
+
+        _check_single_detector(mock_redis, "proj-1", detector, batch_cost=10.0)
+
+        # Should fetch the old key
+        mock_redis.get.assert_called_with("budget:project:proj-1:det-1:24h")
+        # Should delete the old key atomically
+        mock_redis.delete.assert_called_once_with("budget:project:proj-1:det-1:24h")
+        # Should set the TTL
+        mock_redis.expire.assert_called_once()
+
     def test_existing_counter_skips_ttl(self):
         """When counter key already has a TTL, don't reset it."""
         detector = _make_detector(threshold_usd=1000.0)

--- a/backend/worker/tests/test_otel_transform_cache_pricing.py
+++ b/backend/worker/tests/test_otel_transform_cache_pricing.py
@@ -1,0 +1,120 @@
+import base64
+import json
+from unittest.mock import patch
+
+from worker.otel_transform import transform_otel_to_clickhouse
+
+
+def _make_trace_id() -> str:
+    return base64.b64encode(b"\x01" * 16).decode()
+
+
+def _make_span_id(byte: int = 0x02) -> str:
+    return base64.b64encode(bytes([byte] * 8)).decode()
+
+
+def _attr(key: str, value) -> dict:
+    if isinstance(value, str):
+        return {"key": key, "value": {"stringValue": value}}
+    if isinstance(value, bool):
+        return {"key": key, "value": {"boolValue": value}}
+    if isinstance(value, int):
+        return {"key": key, "value": {"intValue": str(value)}}
+    if isinstance(value, float):
+        return {"key": key, "value": {"doubleValue": value}}
+    return {
+        "key": key,
+        "value": {"stringValue": json.dumps(value) if not isinstance(value, str) else value},
+    }
+
+
+def _otel_payload(span_attributes: list[dict]) -> dict:
+    span = {
+        "traceId": _make_trace_id(),
+        "spanId": _make_span_id(),
+        "name": "test-span",
+        "kind": "SPAN_KIND_INTERNAL",
+        "startTimeUnixNano": "1700000000000000000",
+        "endTimeUnixNano": "1700000001000000000",
+        "attributes": span_attributes,
+        "status": {},
+    }
+    return {
+        "resourceSpans": [
+            {
+                "resource": {"attributes": []},
+                "scopeSpans": [{"scope": {"name": "test"}, "spans": [span]}],
+            }
+        ]
+    }
+
+
+def test_otel_transform_includes_cache_pricing():
+    """Verify that OTel transformation correctly calculates prompt caching costs and rescues cache keys into metadata."""
+    span_attributes = [
+        _attr("gen_ai.request.model", "claude-3-5-sonnet"),
+        _attr("gen_ai.usage.input_tokens", 1000),
+        _attr("gen_ai.usage.output_tokens", 200),
+        _attr("gen_ai.usage.details.cache_read_tokens", 400),
+        _attr("gen_ai.usage.details.cache_write_tokens", 100),
+    ]
+    payload = _otel_payload(span_attributes)
+
+    mock_prices = {
+        "input": 0.000003,
+        "output": 0.000015,
+        "cacheRead": 0.0000003,
+        "cacheWrite": 0.00000375,
+    }
+
+    with patch("worker.tokens.pricing.get_model_price", return_value=mock_prices):
+        _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span["input_tokens"] == 1000
+    assert span["output_tokens"] == 200
+
+    # Expected cost:
+    # 1000 * 0.000003 + 200 * 0.000015 + 400 * 0.0000003 + 100 * 0.00000375
+    # = 0.003 + 0.003 + 0.00012 + 0.000375
+    # = 0.006495
+    expected_cost = 1000 * 0.000003 + 200 * 0.000015 + 400 * 0.0000003 + 100 * 0.00000375
+    assert abs(span["cost"] - expected_cost) < 1e-9
+
+    # Verify that cache keys are rescued/preserved in metadata
+    assert "metadata" in span
+    meta = json.loads(span["metadata"])
+    assert meta["gen_ai.usage.details.cache_read_tokens"] == 400
+    assert meta["gen_ai.usage.details.cache_write_tokens"] == 100
+
+
+def test_otel_transform_fallback_caching():
+    """Verify that OTel transformation fallback calculate_cost path uses cache tokens."""
+    span_attributes = [
+        _attr("gen_ai.request.model", "claude-3-5-sonnet"),
+        _attr("gen_ai.usage.details.cache_read_tokens", 500),
+        _attr("gen_ai.usage.details.cache_write_tokens", 200),
+    ]
+    payload = _otel_payload(span_attributes)
+
+    mock_prices = {
+        "input": 0.000003,
+        "output": 0.000015,
+        "cacheRead": 0.0000003,
+        "cacheWrite": 0.00000375,
+    }
+
+    # Under fallback path, input_text / output_text are used to estimate tokens (both 0 tokens if None).
+    # Since input/output are None, estimated tokens are 0.
+    # Cost should be calculated purely on the cache read and write tokens.
+    with patch("worker.tokens.pricing.get_model_price", return_value=mock_prices):
+        _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+
+    assert len(spans) == 1
+    span = spans[0]
+
+    # Expected cost: 500 * 0.0000003 + 200 * 0.00000375 = 0.00015 + 0.00075 = 0.0009
+    expected_cost = 500 * 0.0000003 + 200 * 0.00000375
+    assert abs(span["cost"] - expected_cost) < 1e-9

--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -12,8 +12,6 @@ import logging
 import re
 from decimal import Decimal
 
-import psycopg2
-
 from shared.config import settings
 
 from .usage import count_tokens
@@ -32,7 +30,10 @@ def _load_cache() -> list[dict]:
     if _cache is not None:
         return _cache
 
+    import psycopg2
+
     models: list[dict] = []
+
     try:
         conn = psycopg2.connect(settings.database_url)
         try:
@@ -108,6 +109,8 @@ def calculate_cost(
     model: str,
     input_text: str | None,
     output_text: str | None,
+    cache_read_tokens: int | None = None,
+    cache_write_tokens: int | None = None,
 ) -> dict[str, int | float | None]:
     """Calculate token usage and cost.
 
@@ -138,6 +141,18 @@ def calculate_cost(
         # Prices are in USD per token — multiply directly
         input_cost = Decimal(input_tokens) * Decimal(str(prices.get("input", 0)))
         output_cost = Decimal(output_tokens) * Decimal(str(prices.get("output", 0)))
-        result["cost"] = float(input_cost + output_cost)
+
+        # Get cache read / write rates safely
+        cache_read_rate = prices.get("cacheRead")
+        if cache_read_rate is None:
+            cache_read_rate = 0
+        cache_write_rate = prices.get("cacheWrite")
+        if cache_write_rate is None:
+            cache_write_rate = 0
+
+        cache_read_cost = Decimal(cache_read_tokens or 0) * Decimal(str(cache_read_rate))
+        cache_write_cost = Decimal(cache_write_tokens or 0) * Decimal(str(cache_write_rate))
+
+        result["cost"] = float(input_cost + output_cost + cache_read_cost + cache_write_cost)
 
     return result

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -347,7 +347,7 @@ model Detector {
   id           String   @id @default(cuid()) @db.VarChar
   projectId    String   @map("project_id") @db.VarChar
   name         String   @db.VarChar
-  template     String   @db.VarChar  // "failure"|"hallucination"|"logic"|"task"|"safety"|"intent"|"blank"
+  template     String   @db.VarChar  // "failure"|"hallucination"|"logic"|"task"|"safety"|"intent"|"blank"|"budget"
   prompt       String   @db.Text
   outputSchema       Json     @map("output_schema") @db.JsonB
   sampleRate         Int      @default(100) @map("sample_rate")  // 1–100

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
@@ -109,7 +109,13 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   if (name !== undefined && (typeof name !== "string" || name.trim().length === 0)) {
     return errorResponse("name must be a non-empty string", 400);
   }
-  if (prompt !== undefined && (typeof prompt !== "string" || prompt.trim().length === 0)) {
+  // Budget and blank templates legitimately have an empty prompt (no LLM call).
+  // Only reject empty prompts for other template types.
+  if (
+    prompt !== undefined &&
+    (typeof prompt !== "string" ||
+      (prompt.trim().length === 0 && !new Set(["budget", "blank"]).has(existing.template)))
+  ) {
     return errorResponse("prompt must be a non-empty string", 400);
   }
 

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -94,7 +94,12 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   if (typeof template !== "string" || template.trim().length === 0) {
     return errorResponse("template must be a non-empty string", 400);
   }
-  if (typeof prompt !== "string" || prompt.trim().length === 0) {
+  // Budget and blank templates have no LLM prompt — allow empty string for those.
+  const noPromptTemplates = new Set(["budget", "blank"]);
+  if (
+    typeof prompt !== "string" ||
+    (prompt.trim().length === 0 && !noPromptTemplates.has(template as string))
+  ) {
     return errorResponse("prompt must be a non-empty string", 400);
   }
 

--- a/frontend/ui/src/features/detectors/templates.ts
+++ b/frontend/ui/src/features/detectors/templates.ts
@@ -93,6 +93,21 @@ Report identified=true only for clear, concrete safety violations.`,
     defaultConditions: [],
   },
   {
+    id: "budget",
+    label: "Budget Alert",
+    description: "Alert when project LLM spend crosses a USD threshold",
+    prompt: "", // mathematical evaluation — no LLM prompt needed
+    outputSchema: [
+      { name: "threshold_usd", type: "number" },
+      { name: "current_spend_usd", type: "number" },
+      { name: "window", type: "string" },
+    ],
+    defaultConditions: [
+      { field: "budget_threshold_usd", op: "=", value: 100.0 },
+      { field: "budget_window", op: "=", value: "24h" },
+    ],
+  },
+  {
     id: "blank",
     label: "Blank",
     description: "Write your own detector from scratch",

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -30,6 +30,8 @@ import {
   EVENT_QUOTAS,
 } from "@traceroot/core";
 import { getWorkspaceUsageDetails } from "./clickhouse.js";
+import crypto from "crypto";
+import { createRedisConnection, createDetectorRunQueue } from "../../queues/detector-run-queue.js";
 
 let stripe: Stripe | null = null;
 
@@ -560,6 +562,20 @@ async function processWorkspace(
     data: updateData,
   });
 
+  // =========================================================================
+  // 7. Budget alert reconciliation (safety net for Redis data loss)
+  //
+  // The primary budget alert path is event-driven in the Python ingest
+  // worker (Redis INCRBYFLOAT per batch). This hourly reconciliation
+  // catches Redis crashes/evictions by re-checking authoritative
+  // ClickHouse data against configured budget thresholds.
+  // =========================================================================
+  try {
+    await reconcileBudgetAlerts(workspace.id, projectIds);
+  } catch (e) {
+    console.error(`[Billing] Budget reconciliation failed for workspace ${workspace.id}:`, e);
+  }
+
   console.log(
     `[Billing] Workspace ${workspace.id} (${workspace.billingPlan}): ` +
       `${usage.traces} traces, ${usage.spans} spans | ` +
@@ -812,5 +828,167 @@ export async function reportRcaRunOverageToStripe(
       error,
     );
     return false;
+  }
+}
+
+// =============================================================================
+// Budget Alert Reconciliation
+//
+// Safety net for the event-driven Redis budget check in the Python ingest path.
+// Runs hourly as part of the billing cron. For each project with budget
+// detectors, queries authoritative ClickHouse spend and enqueues a budget
+// finding if the threshold is exceeded and no recent finding exists.
+// =============================================================================
+
+const BUDGET_WINDOW_MS: Record<string, number> = {
+  "1h": 3_600_000,
+  "24h": 86_400_000,
+  "7d": 604_800_000,
+  "30d": 2_592_000_000,
+};
+
+const BACKEND_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
+const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
+
+function deterministicFindingId(projectId: string, detectorId: string, windowKey: string): string {
+  const raw = `budget:${projectId}:${detectorId}:${windowKey}`;
+  const h = crypto.createHash("sha256").update(raw).digest("hex").slice(0, 32);
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20, 32)}`;
+}
+
+async function reconcileBudgetAlerts(workspaceId: string, projectIds: string[]): Promise<void> {
+  if (projectIds.length === 0) return;
+
+  // 1. Find budget detectors across all projects in this workspace
+  const budgetDetectors = await prisma.detector.findMany({
+    where: {
+      projectId: { in: projectIds },
+      template: "budget",
+      enabled: true,
+    },
+    include: { trigger: true },
+  });
+
+  if (budgetDetectors.length === 0) return;
+
+  for (const detector of budgetDetectors) {
+    try {
+      // 2. Extract budget config from trigger conditions
+      const conditions = Array.isArray(detector.trigger?.conditions)
+        ? (detector.trigger.conditions as Array<{ field: string; value: unknown }>)
+        : [];
+
+      let thresholdUsd: number | null = null;
+      let window: string | null = null;
+      for (const cond of conditions) {
+        if (cond.field === "budget_threshold_usd") thresholdUsd = Number(cond.value);
+        if (cond.field === "budget_window") window = String(cond.value);
+      }
+
+      if (thresholdUsd == null || !window || !(window in BUDGET_WINDOW_MS)) continue;
+
+      // 3. Query ClickHouse for project spend in the configured window
+      const windowMs = BUDGET_WINDOW_MS[window];
+      const startTime = new Date(Date.now() - windowMs);
+
+      const response = await fetch(
+        `${BACKEND_URL}/api/v1/internal/projects/${detector.projectId}/spend?start_time=${startTime.toISOString()}`,
+        { headers: { "X-Internal-Secret": INTERNAL_API_SECRET } },
+      );
+
+      if (!response.ok) {
+        console.warn(
+          `[Billing] Budget reconciliation: failed to query spend for project ${detector.projectId}: HTTP ${response.status}`,
+        );
+        continue;
+      }
+
+      const { total_cost } = (await response.json()) as { total_cost: number };
+
+      if (total_cost < thresholdUsd) continue;
+
+      // 4. Check if a recent finding already exists (don't duplicate)
+      const findingResponse = await fetch(
+        `${BACKEND_URL}/api/v1/internal/detector-runs?project_id=${detector.projectId}&detector_id=${detector.id}&limit=1`,
+        { headers: { "X-Internal-Secret": INTERNAL_API_SECRET } },
+      );
+
+      if (findingResponse.ok) {
+        const { data } = (await findingResponse.json()) as {
+          data: Array<{ timestamp: string; finding_id: string | null }>;
+        };
+        if (data.length > 0 && data[0].finding_id) {
+          const lastFindingTime = new Date(data[0].timestamp).getTime();
+          if (Date.now() - lastFindingTime < windowMs) {
+            // A finding already exists within this window — skip
+            continue;
+          }
+        }
+      }
+
+      // 5. No recent finding — log, reset Redis counter, and enqueue the alert to recover it
+      console.log(
+        `[Billing] Budget reconciliation: project ${detector.projectId} ` +
+          `detector ${detector.id} spend $${total_cost.toFixed(2)} >= threshold $${thresholdUsd} ` +
+          `in ${window} window. Recovering lost alert and resetting Redis counter...`,
+      );
+
+      const windowSecs = windowMs / 1000;
+      const windowEpoch = Math.floor(Date.now() / 1000 / windowSecs) * windowSecs;
+      const windowKey = `${window}-${windowEpoch}`;
+
+      const findingId = deterministicFindingId(detector.projectId, detector.id, windowKey);
+      const summary =
+        `Budget alert: $${total_cost.toFixed(2)} spent in the last ${window} ` +
+        `(threshold: $${thresholdUsd.toFixed(2)})`;
+
+      const jobData = {
+        traceId: "",
+        detectorIds: [],
+        projectId: detector.projectId,
+        budgetAlert: {
+          findingId,
+          detectorId: detector.id,
+          detectorName: detector.name,
+          summary,
+          data: {
+            threshold_usd: thresholdUsd,
+            current_spend_usd: Number(total_cost.toFixed(4)),
+            window,
+          },
+        },
+      };
+
+      const jobId = `budget-${detector.projectId}-${detector.id}-${windowKey}`;
+      const connection = createRedisConnection();
+      try {
+        const queue = createDetectorRunQueue(connection);
+
+        // Enqueue the alert finding to BullMQ
+        await queue.add("budget-alert", jobData, {
+          jobId,
+          removeOnComplete: 100,
+          removeOnFail: 50,
+          attempts: 3,
+        });
+
+        // Sync the Redis spend counter and set TTL to authoritative ClickHouse spend
+        const counterKey = `budget:project:${detector.projectId}:${detector.id}:${window}`;
+        await connection.set(counterKey, String(total_cost), "EX", windowSecs);
+
+        // Set cooldown key to avoid double alerting in ingestion path
+        const cooldownKey = `budget:alert:cooldown:${detector.projectId}:${detector.id}:${windowKey}`;
+        await connection.set(cooldownKey, "1", "EX", windowSecs);
+
+        console.log(
+          `[Billing] Budget reconciliation alert enqueued & Redis counter synced for detector ${detector.id}`,
+        );
+        await queue.close();
+      } finally {
+        await connection.quit();
+      }
+    } catch (e) {
+      console.error(`[Billing] Budget reconciliation failed for detector ${detector.id}:`, e);
+    }
   }
 }

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -887,9 +887,22 @@ async function reconcileBudgetAlerts(workspaceId: string, projectIds: string[]):
 
       if (thresholdUsd == null || !window || !(window in BUDGET_WINDOW_MS)) continue;
 
-      // 3. Query ClickHouse for project spend in the configured window
+      // 3. Query ClickHouse for project spend in the configured window.
+      //
+      // Use a true rolling lookback (now − windowMs) so the reconciliation
+      // measures the same slice as the Python sorted-set counter, which also
+      // uses [now − window_secs, now] as its ZRANGEBYSCORE range. The old
+      // epoch-bucketed start (floor(now/windowSecs)*windowSecs) snapped to UTC
+      // boundaries, causing under/overcounting near rollovers.
+      //
+      // windowKey stays epoch-bucketed: it is only used for the deterministic
+      // finding-ID and cooldown key, which need a stable per-slot label — not
+      // an accurate spend measurement.
       const windowMs = BUDGET_WINDOW_MS[window];
+      const windowSecs = windowMs / 1000;
       const startTime = new Date(Date.now() - windowMs);
+      const windowEpoch = Math.floor(Date.now() / 1000 / windowSecs) * windowSecs;
+      const windowKey = `${window}-${windowEpoch}`;
 
       const response = await fetch(
         `${BACKEND_URL}/api/v1/internal/projects/${detector.projectId}/spend?start_time=${startTime.toISOString()}`,
@@ -907,9 +920,16 @@ async function reconcileBudgetAlerts(workspaceId: string, projectIds: string[]):
 
       if (total_cost < thresholdUsd) continue;
 
-      // 4. Check if a recent finding already exists (don't duplicate)
+      // 4. Check if a finding already exists for this exact window epoch.
+      //
+      // Filter by finding_id directly instead of fetching the most-recent run
+      // and inspecting data[0]. The data[0] check broke whenever a later run
+      // (e.g. a regular trace scan) existed for the same detector — data[0]
+      // would be that newer run, not the budget alert, so the matching
+      // finding_id was missed and the cron re-enqueued a duplicate every hour.
+      const expectedFindingId = deterministicFindingId(detector.projectId, detector.id, windowKey);
       const findingResponse = await fetch(
-        `${BACKEND_URL}/api/v1/internal/detector-runs?project_id=${detector.projectId}&detector_id=${detector.id}&limit=1`,
+        `${BACKEND_URL}/api/v1/internal/detector-runs?project_id=${detector.projectId}&detector_id=${detector.id}&finding_id=${expectedFindingId}&limit=1`,
         { headers: { "X-Internal-Secret": INTERNAL_API_SECRET } },
       );
 
@@ -917,25 +937,20 @@ async function reconcileBudgetAlerts(workspaceId: string, projectIds: string[]):
         const { data } = (await findingResponse.json()) as {
           data: Array<{ timestamp: string; finding_id: string | null }>;
         };
-        if (data.length > 0 && data[0].finding_id) {
-          const lastFindingTime = new Date(data[0].timestamp).getTime();
-          if (Date.now() - lastFindingTime < windowMs) {
-            // A finding already exists within this window — skip
-            continue;
-          }
+        // Any non-empty result means a run row exists for exactly this finding
+        // ID — the alert already fired for this window slot, skip recovery.
+        if (data.length > 0) {
+          // Alert already fired for this epoch window — skip.
+          continue;
         }
       }
 
-      // 5. No recent finding — log, reset Redis counter, and enqueue the alert to recover it
+      // 5. No finding for this epoch window — log, reset Redis counter, and enqueue.
       console.log(
         `[Billing] Budget reconciliation: project ${detector.projectId} ` +
           `detector ${detector.id} spend $${total_cost.toFixed(2)} >= threshold $${thresholdUsd} ` +
-          `in ${window} window. Recovering lost alert and resetting Redis counter...`,
+          `in ${window} window (epoch ${windowEpoch}). Recovering lost alert and resetting Redis counter...`,
       );
-
-      const windowSecs = windowMs / 1000;
-      const windowEpoch = Math.floor(Date.now() / 1000 / windowSecs) * windowSecs;
-      const windowKey = `${window}-${windowEpoch}`;
 
       const findingId = deterministicFindingId(detector.projectId, detector.id, windowKey);
       const summary =
@@ -972,18 +987,15 @@ async function reconcileBudgetAlerts(workspaceId: string, projectIds: string[]):
           attempts: 3,
         });
 
-        // Sync the Redis spend counter and set TTL to authoritative ClickHouse spend.
-        // Counter key must include the epoch to match the Python ingest path format:
-        //   budget:project:{projectId}:{detectorId}:{window}-{epoch}
-        const counterKey = `budget:project:${detector.projectId}:${detector.id}:${windowKey}`;
-        await connection.set(counterKey, String(total_cost), "EX", windowSecs);
-
-        // Set cooldown key to avoid double alerting in ingestion path
+        // Set cooldown key so the Python ingest path won't double-alert within
+        // this reconciliation's window slot. The sorted-set counter is NOT seeded
+        // here — it will rebuild naturally from new ingest batches, and the
+        // reconciliation cron provides the authoritative safety net via ClickHouse.
         const cooldownKey = `budget:alert:cooldown:${detector.projectId}:${detector.id}:${windowKey}`;
         await connection.set(cooldownKey, "1", "EX", windowSecs);
 
         console.log(
-          `[Billing] Budget reconciliation alert enqueued & Redis counter synced for detector ${detector.id}`,
+          `[Billing] Budget reconciliation alert enqueued for detector ${detector.id}`,
         );
         await queue.close();
       } finally {

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -972,8 +972,10 @@ async function reconcileBudgetAlerts(workspaceId: string, projectIds: string[]):
           attempts: 3,
         });
 
-        // Sync the Redis spend counter and set TTL to authoritative ClickHouse spend
-        const counterKey = `budget:project:${detector.projectId}:${detector.id}:${window}`;
+        // Sync the Redis spend counter and set TTL to authoritative ClickHouse spend.
+        // Counter key must include the epoch to match the Python ingest path format:
+        //   budget:project:{projectId}:{detectorId}:{window}-{epoch}
+        const counterKey = `budget:project:${detector.projectId}:${detector.id}:${windowKey}`;
         await connection.set(counterKey, String(total_cost), "EX", windowSecs);
 
         // Set cooldown key to avoid double alerting in ingestion path

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -212,7 +212,58 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
   const worker = new Worker<DetectorRcaJob>(
     DETECTOR_RCA_QUEUE,
     async (job: Job<DetectorRcaJob>) => {
-      const { findingId, projectId, traceId, workspaceId, projectName, findings } = job.data;
+      const { findingId, projectId, traceId, workspaceId, projectName, findings, skipRca } =
+        job.data;
+
+      // Budget alerts (and similar pre-resolved findings) skip the LLM RCA
+      // session entirely — just load alert config and send notifications.
+      if (skipRca) {
+        console.log(
+          `[RCA] Skipping RCA for finding ${findingId} (skipRca=true, e.g. budget alert)`,
+        );
+        try {
+          const project = await prisma.project.findUnique({
+            where: { id: projectId },
+            select: {
+              alertConfig: {
+                select: { emailAddresses: true, slackChannelId: true },
+              },
+              workspace: {
+                select: {
+                  slackIntegration: {
+                    select: { channelId: true, botToken: true },
+                  },
+                },
+              },
+            },
+          });
+          const emailAddresses = project?.alertConfig?.emailAddresses ?? [];
+          const slack = project?.workspace?.slackIntegration ?? null;
+          const slackChannelId = project?.alertConfig?.slackChannelId ?? slack?.channelId ?? null;
+          const slackBotTokenEnc = slack?.botToken ?? null;
+
+          const summary = findings.map((f) => `[${f.detectorName}] ${f.summary}`).join("\n");
+          const detectorName = findings.map((f) => f.detectorName).join(", ");
+          const common = {
+            detectorName,
+            projectName,
+            summary,
+            rcaResult: null,
+            traceId,
+            projectId,
+          };
+          await runFanOut({
+            workspaceId,
+            emailAddresses,
+            slackChannelId,
+            slackBotTokenEnc,
+            common,
+          });
+        } catch (e) {
+          console.error(`[RCA] Failed to send budget alert notifications for ${findingId}:`, e);
+        }
+        return;
+      }
 
       // Free-plan RCA cap enforcement — read the cached `rcaBlocked` flag
       // set by the hourly billing job (same pattern as `detectorBlocked` in

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -260,7 +260,11 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
             common,
           });
         } catch (e) {
+          // Re-throw so BullMQ marks the job as failed and retries it.
+          // Swallowing the error here would let notification failures go
+          // undetected: BullMQ would record a success and never retry.
           console.error(`[RCA] Failed to send budget alert notifications for ${findingId}:`, e);
+          throw e;
         }
         return;
       }

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -397,6 +397,32 @@ export function startDetectorRunWorker(): Worker<DetectorRunJob> {
           ]),
         });
 
+        // Write a detector_run row so the hourly reconciliation can see that
+        // a finding was already created for this detector in this window.
+        // Without this, reconcileBudgetAlerts() finds no row with a non-null
+        // finding_id and re-enqueues an alert on every hourly cron cycle.
+        //
+        // Do NOT swallow this error. If the run write fails we let the job
+        // throw so BullMQ retries it. Both writeDetectorFinding (above) and
+        // writeDetectorRun use deterministic IDs and ClickHouse
+        // ReplacingMergeTree, so retrying is fully idempotent and avoids the
+        // finding-exists-but-no-run-row state that causes infinite re-enqueueing.
+        //
+        // Use findingId (window-scoped) as the second hash input instead of
+        // traceId. Budget alerts have traceId = "" so every alert for the same
+        // project+detector would otherwise collapse onto a single ClickHouse
+        // row, letting ReplacingMergeTree overwrite prior windows and making
+        // older alerts invisible to reconciliation and usage totals.
+        const budgetRunId = deterministicRunId(projectId, budgetAlert.findingId, budgetAlert.detectorId);
+        await writeDetectorRun({
+          runId: budgetRunId,
+          detectorId: budgetAlert.detectorId,
+          projectId,
+          traceId: traceId || "",
+          findingId: budgetAlert.findingId,
+          status: "completed",
+        });
+
         const rcaFinding: DetectorRcaFinding = {
           detectorId: budgetAlert.detectorId,
           detectorName: budgetAlert.detectorName,

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -368,7 +368,61 @@ export function startDetectorRunWorker(): Worker<DetectorRunJob> {
   const worker = new Worker<DetectorRunJob>(
     DETECTOR_RUN_QUEUE,
     async (job: Job<DetectorRunJob>) => {
-      const { traceId, detectorIds, projectId } = job.data;
+      const { traceId, detectorIds, projectId, budgetAlert } = job.data;
+
+      // Budget alert: pre-resolved finding from Python ingest path.
+      // No LLM eval needed — write finding and dispatch notifications.
+      if (budgetAlert) {
+        console.log(`[Detector] Budget alert for project ${projectId}: ${budgetAlert.summary}`);
+
+        const project = await prisma.project.findUnique({
+          where: { id: projectId },
+          select: { name: true, workspaceId: true },
+        });
+        const workspaceId = project?.workspaceId ?? "";
+        const projectName = project?.name ?? "";
+
+        await writeDetectorFinding({
+          findingId: budgetAlert.findingId,
+          projectId,
+          traceId: traceId || "",
+          summary: budgetAlert.summary,
+          payload: JSON.stringify([
+            {
+              detectorId: budgetAlert.detectorId,
+              detectorName: budgetAlert.detectorName,
+              summary: budgetAlert.summary,
+              data: budgetAlert.data,
+            },
+          ]),
+        });
+
+        const rcaFinding: DetectorRcaFinding = {
+          detectorId: budgetAlert.detectorId,
+          detectorName: budgetAlert.detectorName,
+          summary: budgetAlert.summary,
+        };
+
+        await rcaQueue.add(
+          `rca-${budgetAlert.findingId}`,
+          {
+            findingId: budgetAlert.findingId,
+            projectId,
+            traceId: traceId || "",
+            workspaceId,
+            projectName,
+            findings: [rcaFinding],
+            skipRca: true,
+          },
+          {
+            jobId: `rca-${budgetAlert.findingId}`,
+            removeOnComplete: 100,
+            removeOnFail: 50,
+          },
+        );
+        return;
+      }
+
       if (!detectorIds || detectorIds.length === 0) return;
       await processTrace(traceId, projectId, detectorIds);
     },

--- a/frontend/worker/src/queues/detector-run-queue.ts
+++ b/frontend/worker/src/queues/detector-run-queue.ts
@@ -5,6 +5,14 @@ export interface DetectorRunJob {
   traceId: string;
   detectorIds: string[];
   projectId: string;
+  /** Pre-resolved budget alert — skips LLM eval, writes finding directly. */
+  budgetAlert?: {
+    findingId: string;
+    detectorId: string;
+    detectorName: string;
+    summary: string;
+    data: Record<string, unknown>;
+  };
 }
 
 export interface DetectorRcaFinding {
@@ -20,6 +28,8 @@ export interface DetectorRcaJob {
   workspaceId: string;
   projectName: string;
   findings: DetectorRcaFinding[];
+  /** When true, skip LLM RCA session — just send notifications. */
+  skipRca?: boolean;
 }
 
 const REDIS_URL = process.env.REDIS_URL || "redis://localhost:6379";

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -24,12 +24,22 @@ MOCK_CACHE = [
     {
         "model_name": "gpt-4o",
         "match_pattern": "(?i)^(openai\\/)?(gpt-4o)(-[\\d-]+)?$",
-        "prices": {"input": 0.0000025, "output": 0.00001},
+        "prices": {
+            "input": 0.0000025,
+            "output": 0.00001,
+            "cacheRead": 0.00000125,
+            "cacheWrite": None,
+        },
     },
     {
         "model_name": "claude-3-5-sonnet",
         "match_pattern": "(?i)^(anthropic\\/)?(claude-3-5-sonnet)(-[\\d-]+)?$",
-        "prices": {"input": 0.000003, "output": 0.000015},
+        "prices": {
+            "input": 0.000003,
+            "output": 0.000015,
+            "cacheRead": 0.0000003,
+            "cacheWrite": 0.00000375,
+        },
     },
 ]
 
@@ -231,6 +241,60 @@ class TestCalculateCost:
         # Cost should be a reasonable float, not have floating-point artifacts
         cost_str = f"{result['cost']:.10f}"
         assert "999999" not in cost_str  # No floating-point weirdness
+
+    @patch("worker.tokens.pricing.count_tokens", return_value=25)
+    def test_cost_with_prompt_caching(self, mock_count):
+        """Verify cost calculation includes cache_read_tokens and cache_write_tokens."""
+        # Using claude-3-5-sonnet prices (from MOCK_CACHE above):
+        # input=0.000003, output=0.000015, cacheRead=0.0000003, cacheWrite=0.00000375
+        result = calculate_cost(
+            model="claude-3-5-sonnet",
+            input_text="x" * 100,  # about 25 tokens
+            output_text="y" * 100,  # about 25 tokens
+            cache_read_tokens=10000,
+            cache_write_tokens=5000,
+        )
+        assert result["input_tokens"] == 25
+        assert result["output_tokens"] == 25
+        assert result["cost"] is not None
+
+        expected_input_cost = 25.0 * 0.000003
+        expected_output_cost = 25.0 * 0.000015
+        expected_cache_read_cost = 10000 * 0.0000003
+        expected_cache_write_cost = 5000 * 0.00000375
+        expected_total = (
+            expected_input_cost
+            + expected_output_cost
+            + expected_cache_read_cost
+            + expected_cache_write_cost
+        )
+
+        assert abs(result["cost"] - expected_total) < 1e-9
+
+    @patch("worker.tokens.pricing.count_tokens", return_value=25)
+    def test_cost_with_missing_cache_rates(self, mock_count):
+        """Verify None cache pricing rates are safely handled as 0."""
+        # gpt-4o has cacheWrite=None
+        result = calculate_cost(
+            model="gpt-4o",
+            input_text="x" * 100,
+            output_text="y" * 100,
+            cache_read_tokens=1000,
+            cache_write_tokens=1000,
+        )
+        assert result["cost"] is not None
+        # Should not crash and should calculate correctly with cacheWrite treated as 0
+        expected_input_cost = 25.0 * 0.0000025
+        expected_output_cost = 25.0 * 0.00001
+        expected_cache_read_cost = 1000 * 0.00000125
+        expected_cache_write_cost = 1000 * 0.0
+        expected_total = (
+            expected_input_cost
+            + expected_output_cost
+            + expected_cache_read_cost
+            + expected_cache_write_cost
+        )
+        assert abs(result["cost"] - expected_total) < 1e-9
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Real Time Budget Alerts and Prompt Caching Cost Correction

This PR implements real time inline budget enforcement alongside a self healing reconciliation system, and fixes a token cost undercounting bug for prompt cached LLM models.

## Real Time Budget Alerts and Self Healing Reconciliation

1. Rolling Window Spend Tracking
   Tracks project spends inline inside the Python ingestion worker using Redis sorted sets (ZADD, ZREMRANGEBYSCORE, ZRANGEBYSCORE) for accurate sliding time windows instead of epoch bucketed increments.

2. Idempotence and Retry Safety
   Applies an idempotency key to sorted set members to prevent double counting of token spends during ingestion retries.

3. Reconciliation and Deduplication
   Filters past runs by the exact finding ID during hourly reconciliation to determine if a budget alert has already fired for a given window, preventing duplicate alerts from being enqueued after unrelated subsequent runs.

4. Cooldown Rollback
   Reverts Redis spend increments gracefully if a downstream alert enqueuing task fails, preventing false budget exhaustion states.

5. Robust Config Parsing
   Raises explicit errors to logs when a budget detector's trigger condition is malformed or not a JSON list, failing closed safely rather than silently skipping enforcement.

## Prompt Caching Cost Correction

1. Token Cost Accuracy
   Fixes a bug causing silent token cost undercounting for models utilizing prompt caching (such as Anthropic Claude 3.5 and OpenAI GPT 4o) in the Python ingest path, ensuring accurate billing.

## Changed Files

### Backend
1. backend/worker/budget_alerts.py
   Implements rolling window spend tracking, retry recovery, and strict config validation.
2. backend/worker/tests/test_budget_alerts.py
   Validates rolling window logic, duplicate detection, and config safety.
3. backend/worker/otel_transform.py and backend/worker/tokens/pricing.py
   Corrects prompt caching token cost calculations.
4. backend/rest/routers/internal.py
   Exposes finding ID filtering capability for internal queries.

### Frontend
1. frontend/worker/src/ee/billing/usageMetering.ts
   Updates reconciliation query logic to match exact finding IDs.
2. frontend/worker/src/processors/detector-run-processor.ts and detector-rca-processor.ts
   Integrates updated parameter passing during job execution and RCA pipeline steps.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds real-time, rolling-window budget alerts with a reconciliation safety net, and fixes undercounted LLM costs when prompt caching is used. Teams get instant overspend alerts and accurate cost reporting.

- New Features
  - Inline budget checks in the Python ingest path: Redis ZSET rolling windows (1h/24h/7d/30d), deterministic finding IDs, per-window cooldown, idempotent retries, and enqueue to `detector-run` (`BullMQ`).
  - Hourly reconciliation in `usageMetering.ts`: queries backend spend since a start time, dedups via exact `finding_id`, and recovers missed alerts while setting cooldown.
  - Backend internal APIs: project spend endpoint and detector runs list with `finding_id` filter for precise reconciliation.
  - Detector pipeline updates: `budget` detector template (empty prompt allowed), excluded from normal LLM runs, skip-LMM RCA path with notification fan-out only, and deterministic `detector_run` rows to avoid duplicates.
  - Ingest uses batch idempotency keys to prevent double counting during retries.

- Bug Fixes
  - Accurate pricing for prompt-cached models by including cache read/write tokens in cost (OTel path and fallback), with safe handling when `cacheRead`/`cacheWrite` rates are missing. Tests added.

<sup>Written for commit e90549c0c1b283914a8a084dfc7a20aed77b7427. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

