### PR TITLE
fix: add tooltip to Project API Keys info icon

### DIFF
--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -8,7 +8,7 @@ import { AddButton } from "@/components/ui/add-button";
 import { DeleteIconButton } from "@/components/ui/delete-button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -111,15 +111,17 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1.5">
           <h2 className="text-lg font-semibold">Project API Keys</h2>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Info className="h-3.5 w-3.5 cursor-help text-muted-foreground" />
-            </TooltipTrigger>
-            <TooltipContent>
-              API keys authenticate your application with TraceRoot. Use them in the SDK to send
-              traces, or in the env block below.
-            </TooltipContent>
-          </Tooltip>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Info className="h-3.5 w-3.5 cursor-help text-muted-foreground" />
+              </TooltipTrigger>
+              <TooltipContent>
+                API keys authenticate your application with TraceRoot. Use them in the SDK to send
+                traces, or in the env block below.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
         <AddButton onClick={() => setShowCreateDialog(true)}>Create new API key</AddButton>
       </div>

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -113,7 +113,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
           <h2 className="text-lg font-semibold">Project API Keys</h2>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Info className="text-muted-foreground h-3.5 w-3.5 cursor-help" />
+              <Info className="h-3.5 w-3.5 cursor-help text-muted-foreground" />
             </TooltipTrigger>
             <TooltipContent>
               API keys authenticate your application with TraceRoot. Use them in the SDK to send
@@ -126,7 +126,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
       <div className="border">
         <div className="flex items-center justify-between border-b px-4 py-2">
-          <span className="text-muted-foreground text-xs">.env</span>
+          <span className="text-xs text-muted-foreground">.env</span>
           <CopyButton value={envBlockContent} className="h-6 w-6" />
         </div>
         <div className="bg-muted px-4 py-3 font-mono text-xs">
@@ -229,9 +229,9 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
             </DialogDescription>
           </DialogHeader>
           <div className="py-2">
-            <p className="text-muted-foreground mb-2 text-sm">
+            <p className="mb-2 text-sm text-muted-foreground">
               Type{" "}
-              <span className="text-foreground font-mono font-semibold">
+              <span className="font-mono font-semibold text-foreground">
                 {keyToDelete?.name || "delete"}
               </span>{" "}
               to confirm:
@@ -266,27 +266,27 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
       <div className="border">
         {isLoading ? (
-          <div className="text-muted-foreground px-3 py-3 text-[13px]">Loading API keys...</div>
+          <div className="px-3 py-3 text-[13px] text-muted-foreground">Loading API keys...</div>
         ) : accessKeys.length === 0 ? (
-          <div className="text-muted-foreground px-3 py-3 text-[13px]">
+          <div className="px-3 py-3 text-[13px] text-muted-foreground">
             No API keys yet. Create one to start using the SDK.
           </div>
         ) : (
           <table className="w-full text-[13px]">
             <thead>
-              <tr className="bg-muted/30 border-b text-left">
-                <th className="text-muted-foreground px-3 py-2 text-[12px] font-medium">Name</th>
-                <th className="text-muted-foreground px-3 py-2 text-[12px] font-medium">Key</th>
-                <th className="text-muted-foreground px-3 py-2 text-[12px] font-medium">Created</th>
-                <th className="text-muted-foreground px-3 py-2 text-[12px] font-medium">
+              <tr className="border-b bg-muted/30 text-left">
+                <th className="px-3 py-2 text-[12px] font-medium text-muted-foreground">Name</th>
+                <th className="px-3 py-2 text-[12px] font-medium text-muted-foreground">Key</th>
+                <th className="px-3 py-2 text-[12px] font-medium text-muted-foreground">Created</th>
+                <th className="px-3 py-2 text-[12px] font-medium text-muted-foreground">
                   Last Used
                 </th>
-                <th className="text-muted-foreground w-10 px-3 py-2 text-[12px] font-medium"></th>
+                <th className="w-10 px-3 py-2 text-[12px] font-medium text-muted-foreground"></th>
               </tr>
             </thead>
             <tbody>
               {accessKeys.map((key: AccessKey) => (
-                <tr key={key.id} className="hover:bg-muted/20 border-b last:border-b-0">
+                <tr key={key.id} className="border-b last:border-b-0 hover:bg-muted/20">
                   <td className="px-3 py-2">
                     <button
                       onClick={() => setEditingKey({ id: key.id, name: key.name || "" })}
@@ -300,10 +300,10 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
                       {formatKeyHint(key.key_hint)}
                     </code>
                   </td>
-                  <td className="text-muted-foreground px-3 py-2">
+                  <td className="px-3 py-2 text-muted-foreground">
                     {formatRelativeTime(key.create_time)}
                   </td>
-                  <td className="text-muted-foreground px-3 py-2">
+                  <td className="px-3 py-2 text-muted-foreground">
                     {key.last_use_time ? formatRelativeTime(key.last_use_time) : "Never"}
                   </td>
                   <td className="px-3 py-2">

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -1,4 +1,4 @@
-"use client";
+﻿"use client";
 
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
@@ -8,11 +8,7 @@ import { AddButton } from "@/components/ui/add-button";
 import { DeleteIconButton } from "@/components/ui/delete-button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -117,10 +113,11 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
           <h2 className="text-lg font-semibold">Project API Keys</h2>
           <Tooltip>
             <TooltipTrigger asChild>
-              <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
+              <Info className="text-muted-foreground h-3.5 w-3.5 cursor-help" />
             </TooltipTrigger>
             <TooltipContent>
-              API keys authenticate your application with TraceRoot. Use them in the SDK to send traces, or in the env block below.
+              API keys authenticate your application with TraceRoot. Use them in the SDK to send
+              traces, or in the env block below.
             </TooltipContent>
           </Tooltip>
         </div>
@@ -129,7 +126,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
       <div className="border">
         <div className="flex items-center justify-between border-b px-4 py-2">
-          <span className="text-xs text-muted-foreground">.env</span>
+          <span className="text-muted-foreground text-xs">.env</span>
           <CopyButton value={envBlockContent} className="h-6 w-6" />
         </div>
         <div className="bg-muted px-4 py-3 font-mono text-xs">
@@ -232,9 +229,9 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
             </DialogDescription>
           </DialogHeader>
           <div className="py-2">
-            <p className="mb-2 text-sm text-muted-foreground">
+            <p className="text-muted-foreground mb-2 text-sm">
               Type{" "}
-              <span className="font-mono font-semibold text-foreground">
+              <span className="text-foreground font-mono font-semibold">
                 {keyToDelete?.name || "delete"}
               </span>{" "}
               to confirm:
@@ -269,27 +266,27 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
       <div className="border">
         {isLoading ? (
-          <div className="px-3 py-3 text-[13px] text-muted-foreground">Loading API keys...</div>
+          <div className="text-muted-foreground px-3 py-3 text-[13px]">Loading API keys...</div>
         ) : accessKeys.length === 0 ? (
-          <div className="px-3 py-3 text-[13px] text-muted-foreground">
+          <div className="text-muted-foreground px-3 py-3 text-[13px]">
             No API keys yet. Create one to start using the SDK.
           </div>
         ) : (
           <table className="w-full text-[13px]">
             <thead>
-              <tr className="border-b bg-muted/30 text-left">
-                <th className="px-3 py-2 text-[12px] font-medium text-muted-foreground">Name</th>
-                <th className="px-3 py-2 text-[12px] font-medium text-muted-foreground">Key</th>
-                <th className="px-3 py-2 text-[12px] font-medium text-muted-foreground">Created</th>
-                <th className="px-3 py-2 text-[12px] font-medium text-muted-foreground">
+              <tr className="bg-muted/30 border-b text-left">
+                <th className="text-muted-foreground px-3 py-2 text-[12px] font-medium">Name</th>
+                <th className="text-muted-foreground px-3 py-2 text-[12px] font-medium">Key</th>
+                <th className="text-muted-foreground px-3 py-2 text-[12px] font-medium">Created</th>
+                <th className="text-muted-foreground px-3 py-2 text-[12px] font-medium">
                   Last Used
                 </th>
-                <th className="w-10 px-3 py-2 text-[12px] font-medium text-muted-foreground"></th>
+                <th className="text-muted-foreground w-10 px-3 py-2 text-[12px] font-medium"></th>
               </tr>
             </thead>
             <tbody>
               {accessKeys.map((key: AccessKey) => (
-                <tr key={key.id} className="border-b last:border-b-0 hover:bg-muted/20">
+                <tr key={key.id} className="hover:bg-muted/20 border-b last:border-b-0">
                   <td className="px-3 py-2">
                     <button
                       onClick={() => setEditingKey({ id: key.id, name: key.name || "" })}
@@ -303,10 +300,10 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
                       {formatKeyHint(key.key_hint)}
                     </code>
                   </td>
-                  <td className="px-3 py-2 text-muted-foreground">
+                  <td className="text-muted-foreground px-3 py-2">
                     {formatRelativeTime(key.create_time)}
                   </td>
-                  <td className="px-3 py-2 text-muted-foreground">
+                  <td className="text-muted-foreground px-3 py-2">
                     {key.last_use_time ? formatRelativeTime(key.last_use_time) : "Never"}
                   </td>
                   <td className="px-3 py-2">

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -9,6 +9,11 @@ import { DeleteIconButton } from "@/components/ui/delete-button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -110,7 +115,14 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1.5">
           <h2 className="text-lg font-semibold">Project API Keys</h2>
-          <Info className="h-3.5 w-3.5 text-muted-foreground" />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-3.5 w-3.5 text-muted-foreground cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent>
+              API keys authenticate your application with TraceRoot. Use them in the SDK to send traces, or in the env block below.
+            </TooltipContent>
+          </Tooltip>
         </div>
         <AddButton onClick={() => setShowCreateDialog(true)}>Create new API key</AddButton>
       </div>


### PR DESCRIPTION
﻿Fixes #993

## Problem
The Info icon next to "Project API Keys" in AccessKeysTab.tsx had no tooltip or onClick. Users got no feedback about what API keys are.

## Fix
Added a Radix UI Tooltip explaining: "API keys authenticate your application with TraceRoot. Use them in the SDK to send traces, or in the env block below."

Changes: imported Tooltip/TooltipContent/TooltipTrigger, wrapped icon, added cursor-help class.

## Testing
Tooltip appears on hover over info icon with clear explanation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tooltip to the Info icon next to "Project API Keys" explaining what API keys are and how to use them, using `@/components/ui/tooltip` and showing: "API keys authenticate your application with TraceRoot. Use them in the SDK to send traces, or in the env block below."

Also formats `AccessKeysTab.tsx`, reruns project API keys checks, and wraps the tooltip with `TooltipProvider` to ensure correct behavior; addresses #993.

<sup>Written for commit 6caf4c1d859fba8f214ece87c9d45cea53723e17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

