### PR TITLE
chore: remove unused openai dep from TS examples

### DIFF
--- a/examples/typescript/anthropic/package.json
+++ b/examples/typescript/anthropic/package.json
@@ -8,9 +8,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.40.0",
-    "@traceroot-ai/traceroot": "0.1.2",
-    "dotenv": "^16.4.5",
-    "openai": "^6.34.0"
+    "@traceroot-ai/traceroot": "^0.1.6",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/typescript/bedrock/package.json
+++ b/examples/typescript/bedrock/package.json
@@ -8,9 +8,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1040.0",
-    "@traceroot-ai/traceroot": "^0.1.4",
-    "dotenv": "^16.4.5",
-    "openai": "^6.37.0"
+    "@traceroot-ai/traceroot": "^0.1.6",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/typescript/claude-agent-sdk/package.json
+++ b/examples/typescript/claude-agent-sdk/package.json
@@ -7,9 +7,8 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.0",
-    "@traceroot-ai/traceroot": "0.1.5",
-    "dotenv": "^16.4.5",
-    "openai": "^6.34.0"
+    "@traceroot-ai/traceroot": "^0.1.6",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/examples/typescript/deepagents/package.json
+++ b/examples/typescript/deepagents/package.json
@@ -9,11 +9,10 @@
   "dependencies": {
     "@langchain/anthropic": "^1.3.26",
     "@langchain/core": "^1.1.38",
-    "@traceroot-ai/traceroot": "0.1.2",
+    "@traceroot-ai/traceroot": "^0.1.6",
     "deepagents": "^1.8.0",
     "dotenv": "^16.4.5",
     "langchain": "^1.2.39",
-    "openai": "^6.34.0",
     "zod": "^3.0.0"
   },
   "devDependencies": {

--- a/examples/typescript/mastra/package.json
+++ b/examples/typescript/mastra/package.json
@@ -12,8 +12,7 @@
     "@mastra/core": "^1.0.0",
     "@mastra/observability": "^1.0.0",
     "@traceroot-ai/mastra": "0.1.0",
-    "@traceroot-ai/traceroot": "0.1.2",
-    "openai": "^6.0.0",
+    "@traceroot-ai/traceroot": "^0.1.6",
     "dotenv": "^16.4.5",
     "zod": "^3.22.0"
   },

--- a/examples/typescript/vercel-ai/package.json
+++ b/examples/typescript/vercel-ai/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.0.0",
-    "@traceroot-ai/traceroot": "^0.1.4",
+    "@traceroot-ai/traceroot": "^0.1.6",
     "ai": "^4.0.0",
     "dotenv": "^16.0.0",
     "openai": "^6.0.0",


### PR DESCRIPTION
With traceroot-ts#99 merged, OpenInference instrumentations are lazy-loaded so examples that don't use OpenAI no longer need the openai package installed. Remove it from 5 examples (anthropic, bedrock, claude-agent-sdk, deepagents, mastra) and bump @traceroot-ai/traceroot to ^0.1.6 across all 6.

vercel-ai keeps openai because @ai-sdk/openai requires it as a peer dependency.

## Summary

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [x] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)
<img width="3316" height="1740" alt="image" src="https://github.com/user-attachments/assets/b0d788f1-9318-4007-a339-480d106ae4ea" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

 ## Verified

  Locally installed each example without `openai`, confirmed `TraceRoot.initialize()` succeeds without crash.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `openai` from TypeScript examples that don’t use OpenAI, thanks to lazy-loaded OpenInference instrumentations. Also bumped `@traceroot-ai/traceroot` to `^0.1.6` across all examples.

- **Dependencies**
  - Removed `openai` from `anthropic`, `bedrock`, `claude-agent-sdk`, `deepagents`, `mastra`.
  - Kept `openai` in `vercel-ai` because `@ai-sdk/openai` requires it as a peer dependency.
  - Upgraded `@traceroot-ai/traceroot` to `^0.1.6` in all six examples.

<sup>Written for commit cbb15cba4550c1a62e5fe28912d0ab1dd46a1045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

