### PR TITLE
fix: store filter state in sessionStorage

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
@@ -77,6 +77,16 @@ export default function DetectorDetailPage() {
     }
   }
 
+  const handleDetectorsClick = () => {
+    const returnUrl = sessionStorage.getItem("detectorsReturnUrl");
+    if (returnUrl) {
+      sessionStorage.removeItem("detectorsReturnUrl");
+      router.push(returnUrl);
+    } else {
+      router.push(`/projects/${projectId}/detectors`);
+    }
+  };
+
   return (
     <div className="relative flex h-full text-[13px]">
       <ProjectBreadcrumb projectId={projectId} />
@@ -86,7 +96,7 @@ export default function DetectorDetailPage() {
         <div className="flex items-center gap-2 border-b border-border px-4 py-3">
           <button
             type="button"
-            onClick={() => router.push(`/projects/${projectId}/detectors`)}
+            onClick={handleDetectorsClick}
             className="text-[13px] text-muted-foreground transition-colors hover:text-foreground"
           >
             Detectors

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -66,6 +66,12 @@ export default function DetectorsPage() {
     });
   };
 
+  const handleRowClick = (detectorId: string) => {
+    const currentUrl = `/projects/${projectId}/detectors/${window.location.search}`;
+    sessionStorage.setItem("detectorsReturnUrl", currentUrl);
+    router.push(`/projects/${projectId}/detectors/${detectorId}`);
+  };
+
   const openPanel = (detectorId: string) => setSelectedDetectorId(detectorId);
   const closePanel = () => setSelectedDetectorId(null);
 
@@ -195,7 +201,7 @@ export default function DetectorsPage() {
                   return (
                     <tr
                       key={detector.id}
-                      onClick={() => router.push(`/projects/${projectId}/detectors/${detector.id}`)}
+                      onClick={() => handleRowClick(detector.id)}
                       className={cn(
                         "cursor-pointer border-b border-border/50 transition-colors last:border-0",
                         selectedDetectorId === detector.id ? "bg-muted" : "hover:bg-muted/50",


### PR DESCRIPTION
Fixes #951 

## Summary
Storing the URL with filter state in sessionStorage and setting it again on navigation.
## Type of Change

- [ ] feat - A new feature
- [X] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

https://github.com/user-attachments/assets/661fc85d-4758-4c31-bbd8-59d810a97767


## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [X] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist filter and search state on the Detectors list by saving the current query string in session storage and restoring it when returning from a Detector detail. Users land back on the list with the same filters applied.

- **Bug Fixes**
  - Store the current list URL (with query params) in `sessionStorage` as `detectorsReturnUrl` on row click, then navigate to the detail page.
  - On the detail page, the “Detectors” button restores and clears `detectorsReturnUrl`; falls back to `/projects/:projectId/detectors` if missing.
  - Replace direct `router.push` calls with `handleRowClick` and `handleDetectorsClick` to manage this flow.

<sup>Written for commit 420963f3ad3900e533896127a83ddf00852fda19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

