### PR TITLE
fix(detectors): support BYOK models for automatic RCA

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260613000000_add_rca_provider_source/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260613000000_add_rca_provider_source/migration.sql
@@ -1,0 +1,7 @@
+-- Add project scoped RCA provider and source columns for BYOK support
+-- These track which provider and source (system|byok) the user selected
+-- for the project's RCA agent model, so the worker can route correctly
+-- without guessing from model name prefixes.
+
+ALTER TABLE "projects" ADD COLUMN "rca_provider" VARCHAR;
+ALTER TABLE "projects" ADD COLUMN "rca_source" VARCHAR;

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -138,6 +138,8 @@ model Project {
   updateTime   DateTime  @default(now()) @map("update_time") @db.Timestamp(6)
   // Agent model for Step 2 deep analysis — project-scoped, shared across all detectors
   rcaModel     String?   @map("rca_model") @db.VarChar
+  rcaProvider  String?   @map("rca_provider") @db.VarChar
+  rcaSource    String?   @map("rca_source") @db.VarChar
   accessKeys   AccessKey[]
   aiSessions   AISession[]
   detectors    Detector[]

--- a/frontend/ui/src/app/api/projects/[projectId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/route.ts
@@ -41,6 +41,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     name: project.name,
     trace_ttl_days: project.traceTtlDays,
     rca_model: project.rcaModel,
+    rca_provider: project.rcaProvider,
+    rca_source: project.rcaSource,
     alert_emails: project.alertConfig?.emailAddresses ?? [],
     access_key_count: project._count.accessKeys,
     create_time: project.createTime,

--- a/frontend/ui/src/app/api/projects/__tests__/route.test.ts
+++ b/frontend/ui/src/app/api/projects/__tests__/route.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from "vitest";
+
+const mockRequireAuth = vi.fn();
+const mockRequireProjectAccess = vi.fn();
+const mockFindFirst = vi.fn();
+
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...a: any[]) => mockRequireAuth(...a),
+  requireProjectAccess: (...a: any[]) => mockRequireProjectAccess(...a),
+  errorResponse: (msg: string, s: number) =>
+    new Response(JSON.stringify({ error: msg }), { status: s }),
+  successResponse: (d: any) => new Response(JSON.stringify(d), { status: 200 }),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: { project: { findFirst: (...a: any[]) => mockFindFirst(...a) } },
+}));
+
+describe("GET /api/projects/[projectId]", () => {
+  it("includes rca_provider and rca_source in response", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" }, error: null });
+    mockRequireProjectAccess.mockResolvedValue({ error: null });
+    mockFindFirst.mockResolvedValue({
+      id: "p1",
+      workspaceId: "ws1",
+      name: "test",
+      traceTtlDays: 30,
+      rcaModel: "gpt-5.3",
+      rcaProvider: "my-openai",
+      rcaSource: "byok",
+      alertConfig: { emailAddresses: [] },
+      _count: { accessKeys: 0 },
+      createTime: new Date(),
+      updateTime: new Date(),
+    });
+
+    const { GET } = await import("../[projectId]/route");
+    const res = await GET(new Request("http://localhost/"), {
+      params: Promise.resolve({ projectId: "p1" }),
+    } as any);
+    const body = await res.json();
+    expect(body.rca_provider).toBe("my-openai");
+    expect(body.rca_source).toBe("byok");
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/projects/[projectId]/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/projects/[projectId]/route.ts
@@ -12,6 +12,8 @@ const updateProjectSchema = z.object({
   name: z.string().min(1, "Name is required").max(100, "Name too long").optional(),
   trace_ttl_days: z.number().int().min(1).max(365).nullable().optional(),
   rca_model: z.string().min(1).max(200).nullable().optional(),
+  rca_provider: z.string().min(1).max(200).nullable().optional(),
+  rca_source: z.string().min(1).max(200).nullable().optional(),
   alert_emails: z.array(z.string().email().max(254)).max(50).optional(),
 });
 
@@ -59,6 +61,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     name: project.name,
     trace_ttl_days: project.traceTtlDays,
     rca_model: project.rcaModel,
+    rca_provider: project.rcaProvider,
+    rca_source: project.rcaSource,
     alert_emails: project.alertConfig?.emailAddresses ?? [],
     access_keys: project.accessKeys.map((k) => ({
       id: k.id,
@@ -109,7 +113,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     return errorResponse(result.error.issues[0].message, 400);
   }
 
-  const { name, trace_ttl_days, rca_model, alert_emails } = result.data;
+  const { name, trace_ttl_days, rca_model, rca_provider, rca_source, alert_emails } = result.data;
 
   // Check for duplicate name if name is being changed
   if (name && name !== existingProject.name) {
@@ -133,6 +137,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       ...(name !== undefined && { name }),
       ...(trace_ttl_days !== undefined && { traceTtlDays: trace_ttl_days }),
       ...(rca_model !== undefined && { rcaModel: rca_model }),
+      ...(rca_provider !== undefined && { rcaProvider: rca_provider }),
+      ...(rca_source !== undefined && { rcaSource: rca_source }),
       ...(alert_emails !== undefined && {
         alertConfig: {
           upsert: {
@@ -151,6 +157,8 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     name: project.name,
     trace_ttl_days: project.traceTtlDays,
     rca_model: project.rcaModel,
+    rca_provider: project.rcaProvider,
+    rca_source: project.rcaSource,
     alert_emails: project.alertConfig?.emailAddresses ?? [],
     update_time: project.updateTime,
   });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/projects/__tests__/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/projects/__tests__/route.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi } from "vitest";
+import path from "path";
+import { pathToFileURL } from "url";
+import { z } from "zod";
+
+const updateProjectSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  trace_ttl_days: z.number().int().min(1).max(365).nullable().optional(),
+  rca_model: z.string().min(1).max(200).nullable().optional(),
+  rca_provider: z.string().min(1).max(200).nullable().optional(),
+  rca_source: z.string().min(1).max(200).nullable().optional(),
+  alert_emails: z.array(z.string().email().max(254)).max(50).optional(),
+});
+
+const mockRequireAuth = vi.fn();
+const mockRequireWorkspaceMembership = vi.fn();
+const mockFindFirst = vi.fn();
+const mockProjectUpdate = vi.fn();
+
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...a: any[]) => mockRequireAuth(...a),
+  requireWorkspaceMembership: (...a: any[]) => mockRequireWorkspaceMembership(...a),
+  errorResponse: (msg: string, s: number) =>
+    new Response(JSON.stringify({ error: msg }), { status: s }),
+  successResponse: (d: any) => new Response(JSON.stringify(d), { status: 200 }),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    project: {
+      findFirst: (...a: any[]) => mockFindFirst(...a),
+      update: (...a: any[]) => mockProjectUpdate(...a),
+    },
+  },
+  Role: { ADMIN: "ADMIN" },
+}));
+
+const project = {
+  id: "p1",
+  workspaceId: "ws1",
+  name: "test",
+  traceTtlDays: 30,
+  rcaModel: "gpt-5.3",
+  rcaProvider: "my-openai",
+  rcaSource: "byok",
+  alertConfig: { emailAddresses: [] },
+  accessKeys: [],
+  createTime: new Date(),
+  updateTime: new Date(),
+};
+
+const routePath = path.join(__dirname, "..", "[projectId]", "route.ts");
+
+describe("Workspace project route", () => {
+  it("schema accepts rca_provider and rca_source", () => {
+    const r = updateProjectSchema.safeParse({ rca_provider: "anthropic", rca_source: "system" });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.rca_provider).toBe("anthropic");
+      expect(r.data.rca_source).toBe("system");
+    }
+  });
+
+  it("GET response includes rca_provider and rca_source", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" }, error: null });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+    mockFindFirst.mockResolvedValue(project);
+
+    const mod = await import(pathToFileURL(routePath).href);
+    const res = await mod.GET(new Request("http://localhost/"), {
+      params: Promise.resolve({ workspaceId: "ws1", projectId: "p1" }),
+    });
+    const body = await res.json();
+    expect(body.rca_provider).toBe("my-openai");
+    expect(body.rca_source).toBe("byok");
+  });
+
+  it("PATCH updates rca_provider and rca_source", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" }, error: null });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+    mockFindFirst.mockResolvedValue({ ...project });
+    mockProjectUpdate.mockResolvedValue({ ...project });
+
+    const mod = await import(pathToFileURL(routePath).href);
+    const res = await mod.PATCH(
+      new Request("http://localhost/", {
+        method: "PATCH",
+        body: JSON.stringify({ rca_provider: "anthropic", rca_source: "system" }),
+      }),
+      { params: Promise.resolve({ workspaceId: "ws1", projectId: "p1" }) },
+    );
+    const body = await res.json();
+    expect(body.rca_provider).toBe("my-openai");
+    expect(body.rca_source).toBe("byok");
+    expect(mockProjectUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ rcaProvider: "anthropic", rcaSource: "system" }),
+      }),
+    );
+  });
+});

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
@@ -34,7 +34,12 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
 
   useEffect(() => {
     if (project) {
-      setAgentModelSelection((prev) => ({ ...prev, model: project.rca_model ?? "" }));
+      setAgentModelSelection((prev) => ({
+        ...prev,
+        model: project.rca_model ?? "",
+        provider: project.rca_provider ?? "",
+        source: (project.rca_source as "system" | "byok") ?? "system",
+      }));
       setEmailAddresses(project.alert_emails ?? []);
     }
   }, [project]);
@@ -44,6 +49,8 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
       if (!project) throw new Error("Project not found");
       return updateProject(project.workspace_id!, projectId, {
         rca_model: selection.model || null,
+        rca_provider: selection.provider || null,
+        rca_source: selection.source === "byok" ? "byok" : "system",
       });
     },
     onSuccess: () => {
@@ -63,7 +70,10 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
     },
   });
 
-  const isModelDirty = agentModelSelection.model !== (project?.rca_model ?? "");
+  const isModelDirty =
+    agentModelSelection.model !== (project?.rca_model ?? "") ||
+    agentModelSelection.provider !== (project?.rca_provider ?? "") ||
+    agentModelSelection.source !== (project?.rca_source ?? "system");
   const savedEmails = project?.alert_emails ?? [];
   const isEmailsDirty =
     emailAddresses.length !== savedEmails.length ||

--- a/frontend/ui/src/lib/api/projects.ts
+++ b/frontend/ui/src/lib/api/projects.ts
@@ -33,6 +33,8 @@ export async function updateProject(
     name?: string;
     trace_ttl_days?: number | null;
     rca_model?: string | null;
+    rca_provider?: string | null;
+    rca_source?: string | null;
     alert_emails?: string[];
   },
 ): Promise<Project> {

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -45,6 +45,8 @@ export interface Project {
   name: string;
   trace_ttl_days: number | null;
   rca_model?: string | null;
+  rca_provider?: string | null;
+  rca_source?: string | null;
   alert_emails?: string[];
   access_key_count?: number;
   delete_time?: string | null;

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -105,6 +105,16 @@ describe("resolveProjectModel", () => {
     expect(await resolveProjectModel(null, null, null, "ws-123")).toBeNull();
     expect(await resolveProjectModel(undefined, null, null, "ws-123")).toBeNull();
   });
+
+  it("handles errors in legacy BYOK provider lookup gracefully", async () => {
+    modelProviderFindMany.mockRejectedValue(new Error("DB down"));
+
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("unknown-custom-model", null, null, "ws-123");
+
+    expect(res).toBeNull();
+    expect(modelProviderFindMany).toHaveBeenCalled();
+  });
 });
 
 const mockFetch = vi.fn();
@@ -193,6 +203,68 @@ describe("processRcaJob", () => {
     expect(projectFindUnique).toHaveBeenCalledWith(
       expect.objectContaining({
         select: expect.objectContaining({ rcaProvider: true, rcaSource: true }),
+      }),
+    );
+  });
+
+  it("skips RCA when workspace is free plan and rcaBlocked", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.workspace, "findUnique").mockResolvedValue({
+      billingPlan: "free",
+      rcaBlocked: true,
+    } as any);
+    const detectorRcaUpdate = vi.spyOn(p.detectorRca, "update").mockResolvedValue({} as any);
+    const projectFindUnique = vi.spyOn(p.project, "findUnique");
+
+    const { processRcaJob } = await import("../detector-rca-processor.js");
+    await processRcaJob({
+      data: {
+        findingId: "f1",
+        projectId: "p1",
+        traceId: "t1",
+        workspaceId: "ws1",
+        projectName: "test",
+        findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+      },
+    } as any);
+
+    expect(detectorRcaUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { findingId: "f1" },
+        data: expect.objectContaining({ status: "failed" }),
+      }),
+    );
+    expect(projectFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("marks RCA as failed and rethrows on error", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.workspace, "findUnique").mockResolvedValue({
+      billingPlan: "pro",
+      rcaBlocked: false,
+    } as any);
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+    const detectorRcaUpdate = vi.spyOn(p.detectorRca, "update").mockResolvedValue({} as any);
+    vi.spyOn(p.project, "findUnique").mockRejectedValue(new Error("Prisma error"));
+
+    const { processRcaJob } = await import("../detector-rca-processor.js");
+    await expect(
+      processRcaJob({
+        data: {
+          findingId: "f1",
+          projectId: "p1",
+          traceId: "t1",
+          workspaceId: "ws1",
+          projectName: "test",
+          findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+        },
+      } as any),
+    ).rejects.toThrow("Prisma error");
+
+    expect(detectorRcaUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { findingId: "f1" },
+        data: { status: "failed" },
       }),
     );
   });

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -2,120 +2,32 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const fetchProviderConfigMock = vi.fn();
 const resolvePiModelMock = vi.fn();
+const modelProviderFindMany = vi.fn().mockResolvedValue([]);
 
 vi.mock("@traceroot/core/model-resolver", async () => ({
   fetchProviderConfig: (...args: any[]) => fetchProviderConfigMock(...args),
   resolvePiModel: (...args: any[]) => resolvePiModelMock(...args),
 }));
 
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return {
+    ...actual,
+    prisma: {
+      ...actual.prisma,
+      modelProvider: {
+        ...actual.prisma.modelProvider,
+        findMany: (...a: any[]) => modelProviderFindMany(...a),
+      },
+    },
+  };
+});
+
 afterEach(() => {
   fetchProviderConfigMock.mockReset();
   resolvePiModelMock.mockReset();
-});
-
-describe("RCA prompt construction", () => {
-  it("includes detector name and summary", () => {
-    const detectorName = "error detector";
-    const summary = "Tool errored 3 times";
-    const traceId = "trace-abcdef123456";
-    const hasGitHub = false;
-
-    const githubNote = hasGitHub
-      ? "If any spans contain git_source_file and git_source_line, read that source code and check recent commits/PRs touching that file."
-      : "";
-
-    const prompt = `Detector fired: "${detectorName}".
-Finding: ${summary}
-Trace ID: ${traceId}
-
-Download and analyze this trace. Identify the root cause.
-${githubNote}
-
-Output your findings in this format:
-- Root cause: [one sentence]
-- Code location: [file:line if found, else "not identified"]
-- Recent changes: [relevant commits/PRs if found, else "not checked"]
-- Recommendation: [one actionable sentence]`;
-
-    expect(prompt).toContain("error detector");
-    expect(prompt).toContain("Tool errored 3 times");
-    expect(prompt).toContain("trace-abcdef123456");
-    expect(prompt).not.toContain("git_source_file"); // hasGitHub=false
-  });
-
-  it("includes GitHub instruction when hasGitHub=true", () => {
-    const hasGitHub = true;
-    const githubNote = hasGitHub
-      ? "If any spans contain git_source_file and git_source_line, read that source code and check recent commits/PRs touching that file."
-      : "";
-
-    expect(githubNote).toContain("git_source_file");
-    expect(githubNote).toContain("git_source_line");
-  });
-
-  it("session title includes detector name and trace id prefix", () => {
-    const detectorName = "error detector";
-    const traceId = "trace-abcdef123456";
-    const title = `[RCA] ${detectorName} — ${traceId.slice(0, 8)}`;
-    expect(title).toBe("[RCA] error detector — trace-ab");
-  });
-});
-
-describe("SSE parsing logic", () => {
-  it("accumulates text_delta events", () => {
-    // Simulate the SSE parsing logic
-    const sseLines = [
-      'data: {"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"Root cause: "}}',
-      'data: {"type":"message_update","assistantMessageEvent":{"type":"text_delta","delta":"missing dedup"}}',
-      'data: {"type":"done","data":"{}"}',
-      "data: invalid json {{",
-    ];
-
-    let result = "";
-    for (const line of sseLines) {
-      if (line.startsWith("data: ")) {
-        try {
-          const event = JSON.parse(line.slice(6));
-          if (
-            event.type === "message_update" &&
-            event.assistantMessageEvent?.type === "text_delta" &&
-            event.assistantMessageEvent.delta
-          ) {
-            result += event.assistantMessageEvent.delta;
-          }
-        } catch {
-          // skip malformed
-        }
-      }
-    }
-
-    expect(result).toBe("Root cause: missing dedup");
-  });
-
-  it("ignores non-text_delta events", () => {
-    const sseLines = [
-      'data: {"type":"message_start"}',
-      'data: {"type":"message_end","message":{}}',
-    ];
-
-    let result = "";
-    for (const line of sseLines) {
-      if (line.startsWith("data: ")) {
-        try {
-          const event = JSON.parse(line.slice(6));
-          if (
-            event.type === "message_update" &&
-            event.assistantMessageEvent?.type === "text_delta"
-          ) {
-            result += event.assistantMessageEvent.delta || "";
-          }
-        } catch {
-          // skip malformed
-        }
-      }
-    }
-    expect(result).toBe("");
-  });
+  modelProviderFindMany.mockReset();
+  modelProviderFindMany.mockResolvedValue([]);
 });
 
 describe("resolveProjectModel", () => {
@@ -160,17 +72,29 @@ describe("resolveProjectModel", () => {
     });
   });
 
+  it("resolves legacy BYOK via model provider lookup when rcaSource is null", async () => {
+    modelProviderFindMany.mockResolvedValue([
+      { provider: "my-deepseek", customModels: ["deepseek-chat"] },
+    ]);
+    fetchProviderConfigMock.mockResolvedValue({
+      adapter: "deepseek",
+      key: "sk-xxx",
+      baseUrl: null,
+      config: null,
+    });
+    resolvePiModelMock.mockReturnValue({ id: "deepseek-chat", provider: "openai" });
+
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("deepseek-chat", null, null, "ws-123");
+
+    expect(modelProviderFindMany).toHaveBeenCalled();
+    expect(fetchProviderConfigMock).toHaveBeenCalledWith("ws-123", "my-deepseek");
+    expect(res).toEqual({ model: "deepseek-chat", providerName: "openai", source: "byok" });
+  });
+
   it("returns null for unknown models not in system catalog", async () => {
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
     const res = await resolveProjectModel("unknown-model", null, null, "ws-123");
-
-    expect(res).toBeNull();
-    expect(fetchProviderConfigMock).not.toHaveBeenCalled();
-  });
-
-  it("falls back to null when rcaSource is byok but rcaProvider is missing", async () => {
-    const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("some-model", null, "byok", "ws-123");
 
     expect(res).toBeNull();
     expect(fetchProviderConfigMock).not.toHaveBeenCalled();
@@ -180,5 +104,96 @@ describe("resolveProjectModel", () => {
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
     expect(await resolveProjectModel(null, null, null, "ws-123")).toBeNull();
     expect(await resolveProjectModel(undefined, null, null, "ws-123")).toBeNull();
+  });
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("runRcaSession", () => {
+  it("calls resolveProjectModel and builds message body", async () => {
+    fetchProviderConfigMock.mockResolvedValue({
+      adapter: "openai",
+      key: "sk-xxx",
+      baseUrl: null,
+      config: null,
+    });
+    resolvePiModelMock.mockReturnValue({ id: "gpt-5.3", provider: "openai" });
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {
+          getReader: () => ({ read: () => Promise.resolve({ done: true, value: undefined }) }),
+        },
+      });
+
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+    const result = await runRcaSession({
+      findingId: "f1",
+      projectId: "p1",
+      workspaceId: "ws1",
+      traceId: "t1",
+      findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+      hasGitHub: false,
+      rcaModel: "gpt-5.3",
+      rcaProvider: "my-openai",
+      rcaSource: "byok",
+    });
+
+    expect(result.sessionId).toBe("s1");
+    expect(fetchProviderConfigMock).toHaveBeenCalledWith("ws1", "my-openai");
+  });
+});
+
+describe("processRcaJob", () => {
+  it("reads rcaProvider and rcaSource from project select", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.workspace, "findUnique").mockResolvedValue({
+      billingPlan: "pro",
+      rcaBlocked: false,
+    } as any);
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+    vi.spyOn(p.detectorRca, "update").mockResolvedValue({} as any);
+    vi.spyOn(p.gitHubInstallation, "count").mockResolvedValue(0);
+
+    const projectFindUnique = vi.spyOn(p.project, "findUnique").mockResolvedValue({
+      rcaModel: "gpt-5.3",
+      rcaProvider: "my-openai",
+      rcaSource: "byok",
+      alertConfig: { emailAddresses: [""], slackChannelId: null, slackChannelName: null },
+      workspace: { slackIntegration: null },
+    } as any);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        body: {
+          getReader: () => ({ read: () => Promise.resolve({ done: true, value: undefined }) }),
+        },
+      });
+
+    const { processRcaJob } = await import("../detector-rca-processor.js");
+    await processRcaJob({
+      data: {
+        findingId: "f1",
+        projectId: "p1",
+        traceId: "t1",
+        workspaceId: "ws1",
+        projectName: "test",
+        findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+      },
+    } as any);
+
+    expect(projectFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ rcaProvider: true, rcaSource: true }),
+      }),
+    );
   });
 });

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -1,18 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const modelProviderFindMany = vi.fn();
+const fetchProviderConfigMock = vi.fn();
+const resolvePiModelMock = vi.fn();
 
 vi.mock("@traceroot/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@traceroot/core")>();
   return {
     ...actual,
-    prisma: {
-      ...actual.prisma,
-      modelProvider: {
-        findMany: (...a: any[]) => modelProviderFindMany(...a),
-      },
-    },
+    fetchProviderConfig: (...args: any[]) => fetchProviderConfigMock(...args),
+    resolvePiModel: (...args: any[]) => resolvePiModelMock(...args),
   };
+});
+
+afterEach(() => {
+  fetchProviderConfigMock.mockReset();
+  resolvePiModelMock.mockReset();
 });
 
 describe("RCA prompt construction", () => {
@@ -121,140 +123,64 @@ describe("SSE parsing logic", () => {
 });
 
 describe("resolveProjectModel", () => {
-  beforeEach(() => {
-    modelProviderFindMany.mockReset();
-  });
-
-  it("resolves model directly when rcaProvider and rcaSource are provided", async () => {
-    const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("my-custom-model", "my-provider", "byok", "ws-123");
-    expect(res).toEqual({
-      model: "my-custom-model",
-      providerName: "my-provider",
-      source: "byok",
+  it("resolves a BYOK model via fetchProviderConfig and resolvePiModel", async () => {
+    fetchProviderConfigMock.mockResolvedValue({
+      adapter: "openai",
+      key: "sk-xxx",
+      baseUrl: null,
+      config: null,
     });
-    expect(modelProviderFindMany).not.toHaveBeenCalled();
+    resolvePiModelMock.mockReturnValue({ id: "gpt-5.3", provider: "openai" });
+
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("gpt-5.3", "my-openai", "byok", "ws-123");
+
+    expect(fetchProviderConfigMock).toHaveBeenCalledWith("ws-123", "my-openai");
+    expect(resolvePiModelMock).toHaveBeenCalledWith("gpt-5.3", expect.any(Object));
+    expect(res).toEqual({ model: "gpt-5.3", providerName: "openai", source: "byok" });
   });
 
-  it("resolves a system model correctly", async () => {
+  it("returns null when BYOK provider is not found or disabled", async () => {
+    fetchProviderConfigMock.mockResolvedValue(null);
+
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("gpt-5.3", "missing-provider", "byok", "ws-123");
+
+    expect(res).toBeNull();
+    expect(resolvePiModelMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves a system model via resolvePiModel", async () => {
+    resolvePiModelMock.mockReturnValue({ id: "claude-sonnet-4-5", provider: "anthropic" });
+
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
     const res = await resolveProjectModel("claude-sonnet-4-5", null, null, "ws-123");
+
+    expect(resolvePiModelMock).toHaveBeenCalledWith("claude-sonnet-4-5", null);
     expect(res).toEqual({
       model: "claude-sonnet-4-5",
       providerName: "anthropic",
       source: "system",
     });
-    expect(modelProviderFindMany).not.toHaveBeenCalled();
   });
 
-  it("resolves an enabled BYOK model correctly", async () => {
-    modelProviderFindMany.mockResolvedValue([
-      {
-        provider: "deepseek-byok",
-        adapter: "deepseek",
-        customModels: ["deepseek/deepseek-chat-v3", "deepseek-chat"],
-      },
-    ]);
-    const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("deepseek/deepseek-chat-v3", null, null, "ws-123");
-    expect(res).toEqual({
-      model: "deepseek/deepseek-chat-v3",
-      providerName: "deepseek-byok",
-      source: "byok",
-    });
-    expect(modelProviderFindMany).toHaveBeenCalledWith({
-      where: { workspaceId: "ws-123", enabled: true },
-      orderBy: { id: "asc" },
-      select: { provider: true, adapter: true, customModels: true },
-    });
-  });
-
-  it("disambiguates based on model ID prefix matching provider adapter", async () => {
-    modelProviderFindMany.mockResolvedValue([
-      {
-        provider: "my-openrouter",
-        adapter: "openrouter",
-        customModels: ["deepseek/deepseek-chat-v3"],
-      },
-      {
-        provider: "my-deepseek",
-        adapter: "deepseek",
-        customModels: ["deepseek/deepseek-chat-v3"],
-      },
-    ]);
-    const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("deepseek/deepseek-chat-v3", null, null, "ws-123");
-    expect(res).toEqual({
-      model: "deepseek/deepseek-chat-v3",
-      providerName: "my-deepseek",
-      source: "byok",
-    });
-  });
-
-  it("no longer disambiguates based on model ID in curated catalog matching provider adapter", async () => {
-    modelProviderFindMany.mockResolvedValue([
-      {
-        provider: "my-openai",
-        adapter: "openai",
-        customModels: ["deepseek-chat"],
-      },
-      {
-        provider: "my-deepseek",
-        adapter: "deepseek",
-        customModels: ["deepseek-chat"],
-      },
-    ]);
-    const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("deepseek-chat", null, null, "ws-123");
-    expect(res).toEqual({
-      model: "deepseek-chat",
-      providerName: "my-openai",
-      source: "byok",
-    });
-  });
-
-  it("falls back to the first provider if no adapter matches prefix or catalog", async () => {
-    modelProviderFindMany.mockResolvedValue([
-      {
-        provider: "provider-1",
-        adapter: "openai",
-        customModels: ["custom-model-id"],
-      },
-      {
-        provider: "provider-2",
-        adapter: "google",
-        customModels: ["custom-model-id"],
-      },
-    ]);
-    const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("custom-model-id", null, null, "ws-123");
-    expect(res).toEqual({
-      model: "custom-model-id",
-      providerName: "provider-1",
-      source: "byok",
-    });
-  });
-
-  it("proves deterministic provider selection by verifying orderBy in findMany when multiple providers share customModel", async () => {
-    // Assert that the findMany query is requested with a stable orderBy: { id: "asc" }
-    modelProviderFindMany.mockResolvedValue([]);
-    const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    await resolveProjectModel("custom-model-id", null, null, "ws-123");
-    expect(modelProviderFindMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        orderBy: { id: "asc" },
-      }),
-    );
-  });
-
-  it("returns null for unknown/disabled models", async () => {
-    modelProviderFindMany.mockResolvedValue([]);
+  it("returns null for unknown models not in system catalog", async () => {
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
     const res = await resolveProjectModel("unknown-model", null, null, "ws-123");
+
     expect(res).toBeNull();
+    expect(fetchProviderConfigMock).not.toHaveBeenCalled();
   });
 
-  it("returns null for empty/undefined models", async () => {
+  it("falls back to null when rcaSource is byok but rcaProvider is missing", async () => {
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("some-model", null, "byok", "ws-123");
+
+    expect(res).toBeNull();
+    expect(fetchProviderConfigMock).not.toHaveBeenCalled();
+  });
+
+  it("returns null for empty or undefined models", async () => {
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
     expect(await resolveProjectModel(null, null, null, "ws-123")).toBeNull();
     expect(await resolveProjectModel(undefined, null, null, "ws-123")).toBeNull();

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -45,7 +45,7 @@ describe("resolveProjectModel", () => {
 
     expect(fetchProviderConfigMock).toHaveBeenCalledWith("ws-123", "my-openai");
     expect(resolvePiModelMock).toHaveBeenCalledWith("gpt-5.3", expect.any(Object));
-    expect(res).toEqual({ model: "gpt-5.3", providerName: "openai", source: "byok" });
+    expect(res).toEqual({ model: "gpt-5.3", providerName: "my-openai", source: "byok" });
   });
 
   it("returns null when BYOK provider is not found or disabled", async () => {
@@ -89,7 +89,7 @@ describe("resolveProjectModel", () => {
 
     expect(modelProviderFindMany).toHaveBeenCalled();
     expect(fetchProviderConfigMock).toHaveBeenCalledWith("ws-123", "my-deepseek");
-    expect(res).toEqual({ model: "deepseek-chat", providerName: "openai", source: "byok" });
+    expect(res).toEqual({ model: "deepseek-chat", providerName: "my-deepseek", source: "byok" });
   });
 
   it("returns null for unknown models not in system catalog", async () => {

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -1,4 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const modelProviderFindMany = vi.fn();
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  return {
+    ...actual,
+    prisma: {
+      ...actual.prisma,
+      modelProvider: {
+        findMany: (...a: any[]) => modelProviderFindMany(...a),
+      },
+    },
+  };
+});
 
 describe("RCA prompt construction", () => {
   it("includes detector name and summary", () => {
@@ -102,5 +117,55 @@ describe("SSE parsing logic", () => {
       }
     }
     expect(result).toBe("");
+  });
+});
+
+describe("resolveProjectModel", () => {
+  beforeEach(() => {
+    modelProviderFindMany.mockReset();
+  });
+
+  it("resolves a system model correctly", async () => {
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("claude-sonnet-4-5", "ws-123");
+    expect(res).toEqual({
+      model: "claude-sonnet-4-5",
+      providerName: "anthropic",
+      source: "system",
+    });
+    expect(modelProviderFindMany).not.toHaveBeenCalled();
+  });
+
+  it("resolves an enabled BYOK model correctly", async () => {
+    modelProviderFindMany.mockResolvedValue([
+      {
+        provider: "deepseek-byok",
+        customModels: ["deepseek/deepseek-chat-v3", "deepseek-chat"],
+      },
+    ]);
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("deepseek/deepseek-chat-v3", "ws-123");
+    expect(res).toEqual({
+      model: "deepseek/deepseek-chat-v3",
+      providerName: "deepseek-byok",
+      source: "byok",
+    });
+    expect(modelProviderFindMany).toHaveBeenCalledWith({
+      where: { workspaceId: "ws-123", enabled: true },
+      select: { provider: true, customModels: true },
+    });
+  });
+
+  it("returns null for unknown/disabled models", async () => {
+    modelProviderFindMany.mockResolvedValue([]);
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("unknown-model", "ws-123");
+    expect(res).toBeNull();
+  });
+
+  it("returns null for empty/undefined models", async () => {
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    expect(await resolveProjectModel(null, "ws-123")).toBeNull();
+    expect(await resolveProjectModel(undefined, "ws-123")).toBeNull();
   });
 });

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -125,9 +125,20 @@ describe("resolveProjectModel", () => {
     modelProviderFindMany.mockReset();
   });
 
+  it("resolves model directly when rcaProvider and rcaSource are provided", async () => {
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("my-custom-model", "my-provider", "byok", "ws-123");
+    expect(res).toEqual({
+      model: "my-custom-model",
+      providerName: "my-provider",
+      source: "byok",
+    });
+    expect(modelProviderFindMany).not.toHaveBeenCalled();
+  });
+
   it("resolves a system model correctly", async () => {
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("claude-sonnet-4-5", "ws-123");
+    const res = await resolveProjectModel("claude-sonnet-4-5", null, null, "ws-123");
     expect(res).toEqual({
       model: "claude-sonnet-4-5",
       providerName: "anthropic",
@@ -145,7 +156,7 @@ describe("resolveProjectModel", () => {
       },
     ]);
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("deepseek/deepseek-chat-v3", "ws-123");
+    const res = await resolveProjectModel("deepseek/deepseek-chat-v3", null, null, "ws-123");
     expect(res).toEqual({
       model: "deepseek/deepseek-chat-v3",
       providerName: "deepseek-byok",
@@ -172,7 +183,7 @@ describe("resolveProjectModel", () => {
       },
     ]);
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("deepseek/deepseek-chat-v3", "ws-123");
+    const res = await resolveProjectModel("deepseek/deepseek-chat-v3", null, null, "ws-123");
     expect(res).toEqual({
       model: "deepseek/deepseek-chat-v3",
       providerName: "my-deepseek",
@@ -194,7 +205,7 @@ describe("resolveProjectModel", () => {
       },
     ]);
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("deepseek-chat", "ws-123");
+    const res = await resolveProjectModel("deepseek-chat", null, null, "ws-123");
     expect(res).toEqual({
       model: "deepseek-chat",
       providerName: "my-deepseek",
@@ -216,7 +227,7 @@ describe("resolveProjectModel", () => {
       },
     ]);
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("custom-model-id", "ws-123");
+    const res = await resolveProjectModel("custom-model-id", null, null, "ws-123");
     expect(res).toEqual({
       model: "custom-model-id",
       providerName: "provider-1",
@@ -228,7 +239,7 @@ describe("resolveProjectModel", () => {
     // Assert that the findMany query is requested with a stable orderBy: { id: "asc" }
     modelProviderFindMany.mockResolvedValue([]);
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    await resolveProjectModel("custom-model-id", "ws-123");
+    await resolveProjectModel("custom-model-id", null, null, "ws-123");
     expect(modelProviderFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
         orderBy: { id: "asc" },
@@ -239,13 +250,13 @@ describe("resolveProjectModel", () => {
   it("returns null for unknown/disabled models", async () => {
     modelProviderFindMany.mockResolvedValue([]);
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    const res = await resolveProjectModel("unknown-model", "ws-123");
+    const res = await resolveProjectModel("unknown-model", null, null, "ws-123");
     expect(res).toBeNull();
   });
 
   it("returns null for empty/undefined models", async () => {
     const { resolveProjectModel } = await import("../detector-rca-processor.js");
-    expect(await resolveProjectModel(null, "ws-123")).toBeNull();
-    expect(await resolveProjectModel(undefined, "ws-123")).toBeNull();
+    expect(await resolveProjectModel(null, null, null, "ws-123")).toBeNull();
+    expect(await resolveProjectModel(undefined, null, null, "ws-123")).toBeNull();
   });
 });

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -153,6 +153,7 @@ describe("resolveProjectModel", () => {
     });
     expect(modelProviderFindMany).toHaveBeenCalledWith({
       where: { workspaceId: "ws-123", enabled: true },
+      orderBy: { id: "asc" },
       select: { provider: true, adapter: true, customModels: true },
     });
   });
@@ -221,6 +222,18 @@ describe("resolveProjectModel", () => {
       providerName: "provider-1",
       source: "byok",
     });
+  });
+
+  it("proves deterministic provider selection by verifying orderBy in findMany when multiple providers share customModel", async () => {
+    // Assert that the findMany query is requested with a stable orderBy: { id: "asc" }
+    modelProviderFindMany.mockResolvedValue([]);
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    await resolveProjectModel("custom-model-id", "ws-123");
+    expect(modelProviderFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { id: "asc" },
+      }),
+    );
   });
 
   it("returns null for unknown/disabled models", async () => {

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -191,7 +191,7 @@ describe("resolveProjectModel", () => {
     });
   });
 
-  it("disambiguates based on model ID in curated catalog matching provider adapter", async () => {
+  it("no longer disambiguates based on model ID in curated catalog matching provider adapter", async () => {
     modelProviderFindMany.mockResolvedValue([
       {
         provider: "my-openai",
@@ -208,7 +208,7 @@ describe("resolveProjectModel", () => {
     const res = await resolveProjectModel("deepseek-chat", null, null, "ws-123");
     expect(res).toEqual({
       model: "deepseek-chat",
-      providerName: "my-deepseek",
+      providerName: "my-openai",
       source: "byok",
     });
   });

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -140,6 +140,7 @@ describe("resolveProjectModel", () => {
     modelProviderFindMany.mockResolvedValue([
       {
         provider: "deepseek-byok",
+        adapter: "deepseek",
         customModels: ["deepseek/deepseek-chat-v3", "deepseek-chat"],
       },
     ]);
@@ -152,7 +153,73 @@ describe("resolveProjectModel", () => {
     });
     expect(modelProviderFindMany).toHaveBeenCalledWith({
       where: { workspaceId: "ws-123", enabled: true },
-      select: { provider: true, customModels: true },
+      select: { provider: true, adapter: true, customModels: true },
+    });
+  });
+
+  it("disambiguates based on model ID prefix matching provider adapter", async () => {
+    modelProviderFindMany.mockResolvedValue([
+      {
+        provider: "my-openrouter",
+        adapter: "openrouter",
+        customModels: ["deepseek/deepseek-chat-v3"],
+      },
+      {
+        provider: "my-deepseek",
+        adapter: "deepseek",
+        customModels: ["deepseek/deepseek-chat-v3"],
+      },
+    ]);
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("deepseek/deepseek-chat-v3", "ws-123");
+    expect(res).toEqual({
+      model: "deepseek/deepseek-chat-v3",
+      providerName: "my-deepseek",
+      source: "byok",
+    });
+  });
+
+  it("disambiguates based on model ID in curated catalog matching provider adapter", async () => {
+    modelProviderFindMany.mockResolvedValue([
+      {
+        provider: "my-openai",
+        adapter: "openai",
+        customModels: ["deepseek-chat"],
+      },
+      {
+        provider: "my-deepseek",
+        adapter: "deepseek",
+        customModels: ["deepseek-chat"],
+      },
+    ]);
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("deepseek-chat", "ws-123");
+    expect(res).toEqual({
+      model: "deepseek-chat",
+      providerName: "my-deepseek",
+      source: "byok",
+    });
+  });
+
+  it("falls back to the first provider if no adapter matches prefix or catalog", async () => {
+    modelProviderFindMany.mockResolvedValue([
+      {
+        provider: "provider-1",
+        adapter: "openai",
+        customModels: ["custom-model-id"],
+      },
+      {
+        provider: "provider-2",
+        adapter: "google",
+        customModels: ["custom-model-id"],
+      },
+    ]);
+    const { resolveProjectModel } = await import("../detector-rca-processor.js");
+    const res = await resolveProjectModel("custom-model-id", "ws-123");
+    expect(res).toEqual({
+      model: "custom-model-id",
+      providerName: "provider-1",
+      source: "byok",
     });
   });
 

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -3,14 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const fetchProviderConfigMock = vi.fn();
 const resolvePiModelMock = vi.fn();
 
-vi.mock("@traceroot/core", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@traceroot/core")>();
-  return {
-    ...actual,
-    fetchProviderConfig: (...args: any[]) => fetchProviderConfigMock(...args),
-    resolvePiModel: (...args: any[]) => resolvePiModelMock(...args),
-  };
-});
+vi.mock("@traceroot/core/model-resolver", async () => ({
+  fetchProviderConfig: (...args: any[]) => fetchProviderConfigMock(...args),
+  resolvePiModel: (...args: any[]) => resolvePiModelMock(...args),
+}));
 
 afterEach(() => {
   fetchProviderConfigMock.mockReset();

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -31,7 +31,10 @@ export async function resolveProjectModel(
       return null;
     }
     const model = resolvePiModel(rcaModel, providerConfig);
-    return { model: model.id, providerName: model.provider, source: ModelSource.BYOK };
+    // Forward the saved BYOK provider LABEL (e.g. "myopenai"), not the pi-ai
+    // provider name. The agent resolves BYOK via fetchProviderConfig(workspaceId,
+    // providerName), which keys on ModelProvider.provider (the user label).
+    return { model: model.id, providerName: rcaProvider, source: ModelSource.BYOK };
   }
 
   // 2. System model: validate against catalog, then use shared resolver
@@ -69,7 +72,8 @@ async function resolveLegacyByok(
         const providerConfig = await fetchProviderConfig(workspaceId, p.provider);
         if (providerConfig) {
           const model = resolvePiModel(rcaModel, providerConfig);
-          return { model: model.id, providerName: model.provider, source: ModelSource.BYOK };
+          // Forward the BYOK provider LABEL the agent expects (see step 1 above).
+          return { model: model.id, providerName: p.provider, source: ModelSource.BYOK };
         }
       }
     }

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -11,9 +11,20 @@ const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:810
 // Returns null when the model is unset or unknown (caller should omit fields).
 export async function resolveProjectModel(
   rcaModel: string | null | undefined,
+  rcaProvider: string | null | undefined,
+  rcaSource: string | null | undefined,
   workspaceId: string,
 ): Promise<{ model: string; providerName: string; source: ModelSource } | null> {
   if (!rcaModel) return null;
+
+  if (rcaSource && rcaProvider) {
+    return {
+      model: rcaModel,
+      providerName: rcaProvider,
+      source: rcaSource === "byok" ? ModelSource.BYOK : ModelSource.SYSTEM,
+    };
+  }
+
   for (const group of SYSTEM_MODELS) {
     if (group.models.some((m) => m.id === rcaModel)) {
       return { model: rcaModel, providerName: group.piAIProvider, source: ModelSource.SYSTEM };
@@ -79,6 +90,8 @@ async function runRcaSession(params: {
   findings: DetectorRcaJob["findings"];
   hasGitHub: boolean;
   rcaModel?: string | null;
+  rcaProvider?: string | null;
+  rcaSource?: string | null;
 }): Promise<{ result: string; sessionId: string }> {
   const sessionRes = await fetch(
     `${AGENT_SERVICE_URL}/api/v1/projects/${params.projectId}/sessions`,
@@ -142,7 +155,12 @@ Output your findings in this format:
     "x-workspace-id": params.workspaceId,
   };
 
-  const resolved = await resolveProjectModel(params.rcaModel, params.workspaceId);
+  const resolved = await resolveProjectModel(
+    params.rcaModel,
+    params.rcaProvider,
+    params.rcaSource,
+    params.workspaceId,
+  );
   const msgBody: {
     message: string;
     traceId: string;
@@ -329,6 +347,8 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
           where: { id: projectId },
           select: {
             rcaModel: true,
+            rcaProvider: true,
+            rcaSource: true,
             alertConfig: {
               select: { emailAddresses: true, slackChannelId: true, slackChannelName: true },
             },
@@ -362,6 +382,8 @@ export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
           findings,
           hasGitHub,
           rcaModel: project?.rcaModel,
+          rcaProvider: project?.rcaProvider,
+          rcaSource: project?.rcaSource,
         });
 
         await prisma.detectorRca.update({

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -42,7 +42,42 @@ export async function resolveProjectModel(
     }
   }
 
+  // 3. Legacy BYOK fallback for pre-existing configs
+  const legacy = await resolveLegacyByok(rcaModel, workspaceId);
+  if (legacy) return legacy;
+
   console.warn(`[detector-rca] Unknown rca_model "${rcaModel}", falling back to default`);
+  return null;
+}
+
+// 3. Legacy BYOK fallback: projects that saved a BYOK model before
+//    rcaSource and rcaProvider fields existed have both set to NULL.
+//    Try to resolve the model from the workspace's enabled providers.
+async function resolveLegacyByok(
+  rcaModel: string,
+  workspaceId: string,
+): Promise<{ model: string; providerName: string; source: ModelSource } | null> {
+  try {
+    const dbProviders = await prisma.modelProvider.findMany({
+      where: { workspaceId, enabled: true },
+      select: { provider: true, customModels: true },
+    });
+
+    for (const p of dbProviders) {
+      if (p.customModels.some((m) => m.trim() === rcaModel)) {
+        const providerConfig = await fetchProviderConfig(workspaceId, p.provider);
+        if (providerConfig) {
+          const model = resolvePiModel(rcaModel, providerConfig);
+          return { model: model.id, providerName: model.provider, source: ModelSource.BYOK };
+        }
+      }
+    }
+  } catch (err) {
+    console.error(
+      `[detector-rca] Failed to resolve legacy BYOK for workspace ${workspaceId}:`,
+      err,
+    );
+  }
   return null;
 }
 

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -82,7 +82,7 @@ async function resolveLegacyByok(
   return null;
 }
 
-async function runRcaSession(params: {
+export async function runRcaSession(params: {
   findingId: string;
   projectId: string;
   workspaceId: string;
@@ -273,141 +273,141 @@ export async function runFanOut({
   await Promise.allSettled(tasks);
 }
 
+export async function processRcaJob(job: Job<DetectorRcaJob>) {
+  const { findingId, projectId, traceId, workspaceId, projectName, findings } = job.data;
+
+  // Free-plan RCA cap enforcement — read the cached `rcaBlocked` flag
+  // set by the hourly billing job (same pattern as `detectorBlocked` in
+  // detector-run-processor). Worst-case overshoot: ~1h of RCA runs
+  // between cron passes.
+  const ws = await prisma.workspace.findUnique({
+    where: { id: workspaceId },
+    select: { billingPlan: true, rcaBlocked: true },
+  });
+  if (ws?.rcaBlocked && (ws.billingPlan as PlanType) === PlanType.FREE) {
+    // detector-run-processor pre-seeds a DetectorRca row with
+    // status="pending" before enqueuing; mark it terminal so the UI
+    // doesn't show a permanently-stuck "in progress" RCA.
+    await prisma.detectorRca
+      .update({
+        where: { findingId },
+        data: {
+          status: "failed",
+          result: "Skipped — Free plan RCA quota exceeded. Upgrade to continue.",
+          completedAt: new Date(),
+        },
+      })
+      .catch(() => {}); // best-effort; row may not exist if pre-seed failed
+    console.log(
+      `[RCA] Workspace ${workspaceId} is rca-blocked (Free plan cap exceeded); ` +
+        `skipping RCA for finding ${findingId}`,
+    );
+    return;
+  }
+
+  await prisma.detectorRca.upsert({
+    where: { findingId },
+    create: { findingId, projectId, status: "running" },
+    update: { projectId, status: "running" },
+  });
+
+  // emailAddresses is captured inside the try below; declare here so the
+  // outer catch's fallback alert can still use it (defaults to []).
+  let emailAddresses: string[] = [];
+
+  let slackChannelId: string | null = null;
+
+  let slackBotTokenEnc: string | null = null;
+
+  // Always send a combined alert (success: with RCA result; failure: null).
+  // Detector findings should never fail silently on configured channels.
+  const sendAlert = async (rcaResult: string | null) => {
+    const summary = findings.map((f) => `[${f.detectorName}] ${f.summary}`).join("\n");
+    const detectorName = findings.map((f) => f.detectorName).join(", ");
+    const common = { detectorName, projectName, summary, rcaResult, traceId, projectId };
+    await runFanOut({
+      workspaceId,
+      emailAddresses,
+      slackChannelId,
+      slackBotTokenEnc,
+      common,
+    });
+  };
+
+  try {
+    // Pull project-scoped rca_model and alert recipients in one read.
+    // Inside the try so a Prisma failure routes through the catch's
+    // failure-state + fallback-alert handling.
+    const project = await prisma.project.findUnique({
+      where: { id: projectId },
+      select: {
+        rcaModel: true,
+        rcaProvider: true,
+        rcaSource: true,
+        alertConfig: {
+          select: { emailAddresses: true, slackChannelId: true, slackChannelName: true },
+        },
+        workspace: {
+          select: {
+            slackIntegration: {
+              select: { channelId: true, channelName: true, botToken: true },
+            },
+          },
+        },
+      },
+    });
+    emailAddresses = project?.alertConfig?.emailAddresses ?? [];
+
+    const slack = project?.workspace?.slackIntegration ?? null;
+    slackChannelId = project?.alertConfig?.slackChannelId ?? slack?.channelId ?? null;
+    slackBotTokenEnc = slack?.botToken ?? null;
+
+    // Workspace-level GitHub installations now drive the GitHub tool.
+    // Any installation in this workspace is enough to flip the tool on.
+    const ghCount = await prisma.gitHubInstallation.count({
+      where: { workspaceId },
+    });
+    const hasGitHub = ghCount > 0;
+
+    const { result: rcaResult } = await runRcaSession({
+      findingId,
+      projectId,
+      workspaceId,
+      traceId,
+      findings,
+      hasGitHub,
+      rcaModel: project?.rcaModel,
+      rcaProvider: project?.rcaProvider,
+      rcaSource: project?.rcaSource,
+    });
+
+    await prisma.detectorRca.update({
+      where: { findingId },
+      data: {
+        status: "done",
+        result: rcaResult,
+        completedAt: new Date(),
+      },
+    });
+
+    await sendAlert(rcaResult);
+  } catch (e) {
+    await prisma.detectorRca
+      .update({ where: { findingId }, data: { status: "failed" } })
+      .catch(() => {}); // best-effort
+
+    await sendAlert(null);
+
+    throw e; // re-throw so BullMQ marks job as failed
+  }
+}
+
 export function startDetectorRcaWorker(): Worker<DetectorRcaJob> {
   const connection = createRedisConnection();
-
-  const worker = new Worker<DetectorRcaJob>(
-    DETECTOR_RCA_QUEUE,
-    async (job: Job<DetectorRcaJob>) => {
-      const { findingId, projectId, traceId, workspaceId, projectName, findings } = job.data;
-
-      // Free-plan RCA cap enforcement — read the cached `rcaBlocked` flag
-      // set by the hourly billing job (same pattern as `detectorBlocked` in
-      // detector-run-processor). Worst-case overshoot: ~1h of RCA runs
-      // between cron passes.
-      const ws = await prisma.workspace.findUnique({
-        where: { id: workspaceId },
-        select: { billingPlan: true, rcaBlocked: true },
-      });
-      if (ws?.rcaBlocked && (ws.billingPlan as PlanType) === PlanType.FREE) {
-        // detector-run-processor pre-seeds a DetectorRca row with
-        // status="pending" before enqueuing; mark it terminal so the UI
-        // doesn't show a permanently-stuck "in progress" RCA.
-        await prisma.detectorRca
-          .update({
-            where: { findingId },
-            data: {
-              status: "failed",
-              result: "Skipped — Free plan RCA quota exceeded. Upgrade to continue.",
-              completedAt: new Date(),
-            },
-          })
-          .catch(() => {}); // best-effort; row may not exist if pre-seed failed
-        console.log(
-          `[RCA] Workspace ${workspaceId} is rca-blocked (Free plan cap exceeded); ` +
-            `skipping RCA for finding ${findingId}`,
-        );
-        return;
-      }
-
-      await prisma.detectorRca.upsert({
-        where: { findingId },
-        create: { findingId, projectId, status: "running" },
-        update: { projectId, status: "running" },
-      });
-
-      // emailAddresses is captured inside the try below; declare here so the
-      // outer catch's fallback alert can still use it (defaults to []).
-      let emailAddresses: string[] = [];
-
-      let slackChannelId: string | null = null;
-
-      let slackBotTokenEnc: string | null = null;
-
-      // Always send a combined alert (success: with RCA result; failure: null).
-      // Detector findings should never fail silently on configured channels.
-      const sendAlert = async (rcaResult: string | null) => {
-        const summary = findings.map((f) => `[${f.detectorName}] ${f.summary}`).join("\n");
-        const detectorName = findings.map((f) => f.detectorName).join(", ");
-        const common = { detectorName, projectName, summary, rcaResult, traceId, projectId };
-        await runFanOut({
-          workspaceId,
-          emailAddresses,
-          slackChannelId,
-          slackBotTokenEnc,
-          common,
-        });
-      };
-
-      try {
-        // Pull project-scoped rca_model and alert recipients in one read.
-        // Inside the try so a Prisma failure routes through the catch's
-        // failure-state + fallback-alert handling.
-        const project = await prisma.project.findUnique({
-          where: { id: projectId },
-          select: {
-            rcaModel: true,
-            rcaProvider: true,
-            rcaSource: true,
-            alertConfig: {
-              select: { emailAddresses: true, slackChannelId: true, slackChannelName: true },
-            },
-            workspace: {
-              select: {
-                slackIntegration: {
-                  select: { channelId: true, channelName: true, botToken: true },
-                },
-              },
-            },
-          },
-        });
-        emailAddresses = project?.alertConfig?.emailAddresses ?? [];
-
-        const slack = project?.workspace?.slackIntegration ?? null;
-        slackChannelId = project?.alertConfig?.slackChannelId ?? slack?.channelId ?? null;
-        slackBotTokenEnc = slack?.botToken ?? null;
-
-        // Workspace-level GitHub installations now drive the GitHub tool.
-        // Any installation in this workspace is enough to flip the tool on.
-        const ghCount = await prisma.gitHubInstallation.count({
-          where: { workspaceId },
-        });
-        const hasGitHub = ghCount > 0;
-
-        const { result: rcaResult } = await runRcaSession({
-          findingId,
-          projectId,
-          workspaceId,
-          traceId,
-          findings,
-          hasGitHub,
-          rcaModel: project?.rcaModel,
-          rcaProvider: project?.rcaProvider,
-          rcaSource: project?.rcaSource,
-        });
-
-        await prisma.detectorRca.update({
-          where: { findingId },
-          data: {
-            status: "done",
-            result: rcaResult,
-            completedAt: new Date(),
-          },
-        });
-
-        await sendAlert(rcaResult);
-      } catch (e) {
-        await prisma.detectorRca
-          .update({ where: { findingId }, data: { status: "failed" } })
-          .catch(() => {}); // best-effort
-
-        await sendAlert(null);
-
-        throw e; // re-throw so BullMQ marks job as failed
-      }
-    },
-    { connection, concurrency: 3 },
-  );
+  const worker = new Worker<DetectorRcaJob>(DETECTOR_RCA_QUEUE, processRcaJob, {
+    connection,
+    concurrency: 3,
+  });
 
   worker.on("failed", (job, err) => {
     console.error(`[RCA] Job ${job?.id} failed:`, err.message);

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -1,5 +1,12 @@
 import { Worker, type Job } from "bullmq";
-import { prisma, SYSTEM_MODELS, PlanType, ModelSource } from "@traceroot/core";
+import {
+  prisma,
+  SYSTEM_MODELS,
+  PlanType,
+  ModelSource,
+  fetchProviderConfig,
+  resolvePiModel,
+} from "@traceroot/core";
 import type { DetectorRcaJob } from "../queues/detector-run-queue.js";
 import { DETECTOR_RCA_QUEUE, createRedisConnection } from "../queues/detector-run-queue.js";
 import { sendCombinedAlertEmail } from "../notifications/email.js";
@@ -7,7 +14,10 @@ import { sendCombinedAlertSlack } from "../notifications/slack.js";
 
 const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:8100";
 
-// Resolve a project-configured rca_model id to the agent service body fields.
+// Resolve a project-configured rca_model to the agent service body fields.
+// Uses the same pattern as sandbox-eval.ts: reads the provider from saved
+// config (BYOK) or the shared system-model resolver — no fragile prefix
+// matching or adapter guessing.
 // Returns null when the model is unset or unknown (caller should omit fields).
 export async function resolveProjectModel(
   rcaModel: string | null | undefined,
@@ -17,54 +27,25 @@ export async function resolveProjectModel(
 ): Promise<{ model: string; providerName: string; source: ModelSource } | null> {
   if (!rcaModel) return null;
 
-  if (rcaSource && rcaProvider) {
-    return {
-      model: rcaModel,
-      providerName: rcaProvider,
-      source: rcaSource === "byok" ? ModelSource.BYOK : ModelSource.SYSTEM,
-    };
+  // 1. BYOK: read provider from saved config (same pattern as sandbox-eval.ts L126-136)
+  if (rcaSource === "byok" && rcaProvider) {
+    const providerConfig = await fetchProviderConfig(workspaceId, rcaProvider);
+    if (!providerConfig) {
+      console.warn(
+        `[detector-rca] BYOK provider "${rcaProvider}" not found or disabled in workspace ${workspaceId}`,
+      );
+      return null;
+    }
+    const model = resolvePiModel(rcaModel, providerConfig);
+    return { model: model.id, providerName: model.provider, source: ModelSource.BYOK };
   }
 
+  // 2. System model: validate against catalog, then use shared resolver
   for (const group of SYSTEM_MODELS) {
     if (group.models.some((m) => m.id === rcaModel)) {
-      return { model: rcaModel, providerName: group.piAIProvider, source: ModelSource.SYSTEM };
+      const model = resolvePiModel(rcaModel, null);
+      return { model: model.id, providerName: model.provider, source: ModelSource.SYSTEM };
     }
-  }
-
-  try {
-    const dbProviders = await prisma.modelProvider.findMany({
-      where: { workspaceId, enabled: true },
-      orderBy: { id: "asc" },
-      select: {
-        provider: true,
-        adapter: true,
-        customModels: true,
-      },
-    });
-
-    // First pass: try to find a precise match using adapter prefix
-    for (const p of dbProviders) {
-      if (p.customModels.some((m) => m.trim() === rcaModel)) {
-        // 1. Prefix match (e.g. "deepseek/deepseek-chat-v3" -> prefix is "deepseek")
-        const hasSlash = rcaModel.includes("/");
-        const prefix = hasSlash ? rcaModel.split("/")[0].toLowerCase() : null;
-        if (prefix && p.adapter.toLowerCase() === prefix) {
-          return { model: rcaModel, providerName: p.provider, source: ModelSource.BYOK };
-        }
-      }
-    }
-
-    // Second pass: fallback to the first provider containing the model
-    for (const p of dbProviders) {
-      if (p.customModels.some((m) => m.trim() === rcaModel)) {
-        return { model: rcaModel, providerName: p.provider, source: ModelSource.BYOK };
-      }
-    }
-  } catch (err) {
-    console.error(
-      `[detector-rca] Failed to query model providers for workspace ${workspaceId}:`,
-      err,
-    );
   }
 
   console.warn(`[detector-rca] Unknown rca_model "${rcaModel}", falling back to default`);

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -61,6 +61,7 @@ async function resolveLegacyByok(
     const dbProviders = await prisma.modelProvider.findMany({
       where: { workspaceId, enabled: true },
       select: { provider: true, customModels: true },
+      orderBy: { id: "asc" },
     });
 
     for (const p of dbProviders) {

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -23,6 +23,7 @@ export async function resolveProjectModel(
   try {
     const dbProviders = await prisma.modelProvider.findMany({
       where: { workspaceId, enabled: true },
+      orderBy: { id: "asc" },
       select: {
         provider: true,
         adapter: true,

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -1,12 +1,6 @@
 import { Worker, type Job } from "bullmq";
-import {
-  prisma,
-  SYSTEM_MODELS,
-  PlanType,
-  ModelSource,
-  fetchProviderConfig,
-  resolvePiModel,
-} from "@traceroot/core";
+import { prisma, SYSTEM_MODELS, PlanType, ModelSource } from "@traceroot/core";
+import { fetchProviderConfig, resolvePiModel } from "@traceroot/core/model-resolver";
 import type { DetectorRcaJob } from "../queues/detector-run-queue.js";
 import { DETECTOR_RCA_QUEUE, createRedisConnection } from "../queues/detector-run-queue.js";
 import { sendCombinedAlertEmail } from "../notifications/email.js";

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -1,5 +1,5 @@
 import { Worker, type Job } from "bullmq";
-import { prisma, SYSTEM_MODELS, PlanType } from "@traceroot/core";
+import { prisma, SYSTEM_MODELS, PlanType, ModelSource } from "@traceroot/core";
 import type { DetectorRcaJob } from "../queues/detector-run-queue.js";
 import { DETECTOR_RCA_QUEUE, createRedisConnection } from "../queues/detector-run-queue.js";
 import { sendCombinedAlertEmail } from "../notifications/email.js";
@@ -9,15 +9,38 @@ const AGENT_SERVICE_URL = process.env.AGENT_SERVICE_URL || "http://localhost:810
 
 // Resolve a project-configured rca_model id to the agent service body fields.
 // Returns null when the model is unset or unknown (caller should omit fields).
-function resolveSystemModel(
+export async function resolveProjectModel(
   rcaModel: string | null | undefined,
-): { model: string; providerName: string; source: "system" } | null {
+  workspaceId: string,
+): Promise<{ model: string; providerName: string; source: ModelSource } | null> {
   if (!rcaModel) return null;
   for (const group of SYSTEM_MODELS) {
     if (group.models.some((m) => m.id === rcaModel)) {
-      return { model: rcaModel, providerName: group.piAIProvider, source: "system" };
+      return { model: rcaModel, providerName: group.piAIProvider, source: ModelSource.SYSTEM };
     }
   }
+
+  try {
+    const dbProviders = await prisma.modelProvider.findMany({
+      where: { workspaceId, enabled: true },
+      select: {
+        provider: true,
+        customModels: true,
+      },
+    });
+
+    for (const p of dbProviders) {
+      if (p.customModels.some((m) => m.trim() === rcaModel)) {
+        return { model: rcaModel, providerName: p.provider, source: ModelSource.BYOK };
+      }
+    }
+  } catch (err) {
+    console.error(
+      `[detector-rca] Failed to query model providers for workspace ${workspaceId}:`,
+      err,
+    );
+  }
+
   console.warn(`[detector-rca] Unknown rca_model "${rcaModel}", falling back to default`);
   return null;
 }
@@ -92,14 +115,14 @@ Output your findings in this format:
     "Content-Type": "application/json",
     "x-workspace-id": params.workspaceId,
   };
-
-  const resolved = resolveSystemModel(params.rcaModel);
+  console.log("[detector-rca]", "project.rcaModel=", params.rcaModel);
+  const resolved = await resolveProjectModel(params.rcaModel, params.workspaceId);
   const msgBody: {
     message: string;
     traceId: string;
     model?: string;
     providerName?: string;
-    source?: "system";
+    source?: ModelSource;
   } = { message: prompt, traceId: params.traceId };
   if (resolved) {
     msgBody.model = resolved.model;

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -1,5 +1,5 @@
 import { Worker, type Job } from "bullmq";
-import { prisma, SYSTEM_MODELS, PlanType, ModelSource } from "@traceroot/core";
+import { prisma, SYSTEM_MODELS, PlanType, ModelSource, ADAPTER_MODELS } from "@traceroot/core";
 import type { DetectorRcaJob } from "../queues/detector-run-queue.js";
 import { DETECTOR_RCA_QUEUE, createRedisConnection } from "../queues/detector-run-queue.js";
 import { sendCombinedAlertEmail } from "../notifications/email.js";
@@ -25,10 +25,35 @@ export async function resolveProjectModel(
       where: { workspaceId, enabled: true },
       select: {
         provider: true,
+        adapter: true,
         customModels: true,
       },
     });
 
+    // First pass: try to find a precise match using adapter prefix or curated catalogs
+    for (const p of dbProviders) {
+      if (p.customModels.some((m) => m.trim() === rcaModel)) {
+        // 1. Prefix match (e.g. "deepseek/deepseek-chat-v3" -> prefix is "deepseek")
+        const hasSlash = rcaModel.includes("/");
+        const prefix = hasSlash ? rcaModel.split("/")[0].toLowerCase() : null;
+        if (prefix && p.adapter.toLowerCase() === prefix) {
+          return { model: rcaModel, providerName: p.provider, source: ModelSource.BYOK };
+        }
+
+        // 2. Curated catalog match (e.g. "deepseek-chat" belongs to curated deepseek adapter catalog)
+        if (!hasSlash) {
+          const curatedAdapter = Object.keys(ADAPTER_MODELS).find((adapterKey) => {
+            const catalog = ADAPTER_MODELS[adapterKey as keyof typeof ADAPTER_MODELS];
+            return catalog?.some((m) => m.id === rcaModel);
+          });
+          if (curatedAdapter && p.adapter.toLowerCase() === curatedAdapter.toLowerCase()) {
+            return { model: rcaModel, providerName: p.provider, source: ModelSource.BYOK };
+          }
+        }
+      }
+    }
+
+    // Second pass: fallback to the first provider containing the model
     for (const p of dbProviders) {
       if (p.customModels.some((m) => m.trim() === rcaModel)) {
         return { model: rcaModel, providerName: p.provider, source: ModelSource.BYOK };

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -1,5 +1,5 @@
 import { Worker, type Job } from "bullmq";
-import { prisma, SYSTEM_MODELS, PlanType, ModelSource, ADAPTER_MODELS } from "@traceroot/core";
+import { prisma, SYSTEM_MODELS, PlanType, ModelSource } from "@traceroot/core";
 import type { DetectorRcaJob } from "../queues/detector-run-queue.js";
 import { DETECTOR_RCA_QUEUE, createRedisConnection } from "../queues/detector-run-queue.js";
 import { sendCombinedAlertEmail } from "../notifications/email.js";
@@ -42,7 +42,7 @@ export async function resolveProjectModel(
       },
     });
 
-    // First pass: try to find a precise match using adapter prefix or curated catalogs
+    // First pass: try to find a precise match using adapter prefix
     for (const p of dbProviders) {
       if (p.customModels.some((m) => m.trim() === rcaModel)) {
         // 1. Prefix match (e.g. "deepseek/deepseek-chat-v3" -> prefix is "deepseek")
@@ -50,17 +50,6 @@ export async function resolveProjectModel(
         const prefix = hasSlash ? rcaModel.split("/")[0].toLowerCase() : null;
         if (prefix && p.adapter.toLowerCase() === prefix) {
           return { model: rcaModel, providerName: p.provider, source: ModelSource.BYOK };
-        }
-
-        // 2. Curated catalog match (e.g. "deepseek-chat" belongs to curated deepseek adapter catalog)
-        if (!hasSlash) {
-          const curatedAdapter = Object.keys(ADAPTER_MODELS).find((adapterKey) => {
-            const catalog = ADAPTER_MODELS[adapterKey as keyof typeof ADAPTER_MODELS];
-            return catalog?.some((m) => m.id === rcaModel);
-          });
-          if (curatedAdapter && p.adapter.toLowerCase() === curatedAdapter.toLowerCase()) {
-            return { model: rcaModel, providerName: p.provider, source: ModelSource.BYOK };
-          }
         }
       }
     }

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -115,7 +115,7 @@ Output your findings in this format:
     "Content-Type": "application/json",
     "x-workspace-id": params.workspaceId,
   };
-  console.log("[detector-rca]", "project.rcaModel=", params.rcaModel);
+
   const resolved = await resolveProjectModel(params.rcaModel, params.workspaceId);
   const msgBody: {
     message: string;


### PR DESCRIPTION
Fixes #991

## Summary

## Type of Change
- [x] fix - A bug fix


## Details
 Allowing automatic detector RCA sessions to resolve and use workspace BYOK/custom models instead of only models present in SYSTEM_MODELS.

Previously, when a project was configured with a BYOK model such as:

* deepseek/deepseek-chat-v3
* gemini-2.5-flash

the detector RCA worker failed to resolve the model, omitted model, providerName, and source from the agent request, and the agent service fell back to the default Claude model.

## Root Cause

resolveSystemModel() only checked the static SYSTEM_MODELS registry.

## Changes

* Replaced resolveSystemModel() with resolveProjectModel()
* Added support for resolving workspace BYOK models through modelProvider
* Preserved existing behavior for system models
* Added tests covering:
    * system model resolution
    * BYOK model resolution
    * unknown model fallback
    * null/undefined model handling

## Screenshots / Recordings (if applicable)



https://github.com/user-attachments/assets/0a54fbf3-6394-4c3c-a36a-f0eee960c5d2


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes automatic RCA not using workspace BYOK models by resolving and sending the chosen model, provider, and source end-to-end. Also enforces free-plan RCA caps so blocked workspaces don’t run RCA.

- **Bug Fixes**
  - Replaced resolver with async resolveProjectModel(rcaModel, rcaProvider, rcaSource, workspaceId) using `@traceroot/core/model-resolver` (fetchProviderConfig + resolvePiModel); supports system/BYOK, returns ModelSource.SYSTEM or ModelSource.BYOK, and forwards the BYOK provider label to the agent.
  - Made the legacy BYOK fallback deterministic (provider lookup ordered by id) and added error handling; tests cover duplicate provider resolution and DB error path.
  - Removed prefix-based provider guessing and catalog inference; BYOK now requires a saved provider in the workspace or resolves via legacy fallback, otherwise returns null.
  - Persisted rcaProvider and rcaSource on Project; exposed via GET/PATCH APIs (including `/api/projects/[projectId]`) and wired into Detectors settings; worker reads these in processRcaJob and includes them in runRcaSession. Added tests for routes, runRcaSession, and processRcaJob covering system/BYOK resolution, missing provider, unknown/empty models, free-plan skip, and failure path.

- **Migration**
  - Adds rca_provider and rca_source columns; run DB migrations. No manual backfill needed due to the legacy BYOK fallback.

<sup>Written for commit 1b20e485e592fe6a6d2c9b8155c7250f097080d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

