### PR TITLE
feat(traces): persist the Live toggle per project

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -20,6 +20,7 @@ import {
 import type { TraceListItem } from "@/types/api";
 import { useTraces } from "@/features/traces/hooks";
 import { useListPageState } from "@/lib/hooks/use-list-page-state";
+import { useLocalStorage } from "@/lib/hooks/use-local-storage";
 import { TraceViewerPanel, GettingStarted } from "@/features/traces/components";
 import { formatContentPreview } from "@/features/traces/utils";
 import { useSession as useAuthSession } from "@/lib/auth-client";
@@ -54,7 +55,12 @@ export default function TracesPage() {
   } = useListPageState();
 
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(traceIdFromUrl);
-  const [autoRefresh, setAutoRefresh] = useState(false);
+  // Persisted per-project so a live view survives reloads, navigation, and re-login.
+  // Default false: a project the user never toggled behaves exactly as before.
+  const [autoRefresh, setAutoRefresh] = useLocalStorage(
+    `traceroot:traces:live:v1:${projectId}`,
+    false,
+  );
 
   // Fetch traces with combined query options + user filter from URL
   const { data, isLoading, error } = useTraces(

--- a/frontend/ui/src/lib/hooks/use-local-storage.test.ts
+++ b/frontend/ui/src/lib/hooks/use-local-storage.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { readStored, writeStored } from "./use-local-storage";
+
+// Minimal in-memory Storage stand-in (env is "node", so there is no real window).
+function makeStorage(initial: Record<string, string> = {}): Storage {
+  const data = new Map(Object.entries(initial));
+  return {
+    getItem: (k: string) => (data.has(k) ? (data.get(k) as string) : null),
+    setItem: (k: string, v: string) => {
+      data.set(k, v);
+    },
+    removeItem: (k: string) => {
+      data.delete(k);
+    },
+    clear: () => data.clear(),
+    key: (i: number) => Array.from(data.keys())[i] ?? null,
+    get length() {
+      return data.size;
+    },
+  } as Storage;
+}
+
+// The hook reads `window.localStorage`; in the node test env we install a fake
+// `window` on globalThis (a bare `window` reference resolves to globalThis.window).
+function setWindow(storage: Storage | undefined): void {
+  (globalThis as unknown as { window?: { localStorage: Storage } }).window = storage
+    ? { localStorage: storage }
+    : undefined;
+}
+
+afterEach(() => {
+  delete (globalThis as unknown as { window?: unknown }).window;
+});
+
+describe("readStored", () => {
+  it("returns the fallback when window/localStorage is unavailable (SSR)", () => {
+    setWindow(undefined);
+    expect(readStored("k", false)).toBe(false);
+  });
+
+  it("returns the fallback when the key is absent", () => {
+    setWindow(makeStorage());
+    expect(readStored("missing", "fallback")).toBe("fallback");
+  });
+
+  it("parses and returns a stored value", () => {
+    setWindow(makeStorage({ k: JSON.stringify(true) }));
+    expect(readStored("k", false)).toBe(true);
+  });
+
+  it("returns the fallback on malformed JSON", () => {
+    setWindow(makeStorage({ k: "{not json" }));
+    expect(readStored("k", 42)).toBe(42);
+  });
+
+  it("returns the fallback when getItem throws (private mode)", () => {
+    const throwing = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+    } as unknown as Storage;
+    setWindow(throwing);
+    expect(readStored("k", "safe")).toBe("safe");
+  });
+});
+
+describe("writeStored", () => {
+  it("persists a JSON-serialized value", () => {
+    const storage = makeStorage();
+    setWindow(storage);
+    writeStored("k", true);
+    expect(storage.getItem("k")).toBe(JSON.stringify(true));
+  });
+
+  it("does not throw when storage is unavailable (SSR)", () => {
+    setWindow(undefined);
+    expect(() => writeStored("k", true)).not.toThrow();
+  });
+
+  it("does not throw when setItem throws (quota/private mode)", () => {
+    const throwing = {
+      setItem: () => {
+        throw new Error("quota");
+      },
+    } as unknown as Storage;
+    setWindow(throwing);
+    expect(() => writeStored("k", true)).not.toThrow();
+  });
+});

--- a/frontend/ui/src/lib/hooks/use-local-storage.ts
+++ b/frontend/ui/src/lib/hooks/use-local-storage.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { useCallback, useEffect, useState } from "react";
+
 // localStorage lives on `window` in the browser and is undefined during SSR.
 // Accessing it can also throw in some privacy modes, so the access itself is guarded.
 function getLocalStorage(): Storage | null {
@@ -38,4 +40,60 @@ export function writeStored<T>(key: string, value: T): void {
   } catch {
     // Best-effort — keep the in-memory value if persistence fails.
   }
+}
+
+/**
+ * SSR-safe, localStorage-backed state. Mirrors the `useState` API:
+ *
+ *   const [live, setLive] = useLocalStorage(`traceroot:traces:live:v1:${projectId}`, false);
+ *
+ * - Hydration: the first render always returns `defaultValue` (the server has no
+ *   localStorage), and the stored value is adopted in an effect after mount, so the
+ *   server and first client render are identical and React logs no hydration warning.
+ *   On a hard load where the saved value differs from the default there is a brief
+ *   flash at the default before the stored value applies — expected and acceptable.
+ * - Storage unavailable (private mode / quota / disabled): reads and writes are
+ *   guarded by `readStored` / `writeStored`. The value is real React state, so the
+ *   setter always updates the UI in-session even when persistence silently fails.
+ * - Cross-tab sync: a `storage` event (fired only in *other* tabs) re-reads the value.
+ */
+export function useLocalStorage<T>(
+  key: string,
+  defaultValue: T,
+): [T, (value: T | ((prev: T) => T)) => void] {
+  // Start from the default so the first client render matches the server render.
+  const [value, setValue] = useState<T>(defaultValue);
+
+  // Adopt the persisted value after mount, and re-read if the key changes.
+  useEffect(() => {
+    setValue(readStored(key, defaultValue));
+    // defaultValue is intentionally excluded: it is the initial fallback, not a
+    // trigger to re-read storage on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  // Reflect writes made by other tabs. `e.key` is null when storage is cleared.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === key || e.key === null) {
+        setValue(readStored(key, defaultValue));
+      }
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const set = useCallback(
+    (next: T | ((prev: T) => T)) => {
+      setValue((prev) => {
+        const resolved = typeof next === "function" ? (next as (p: T) => T)(prev) : next;
+        writeStored(key, resolved);
+        return resolved;
+      });
+    },
+    [key],
+  );
+
+  return [value, set];
 }

--- a/frontend/ui/src/lib/hooks/use-local-storage.ts
+++ b/frontend/ui/src/lib/hooks/use-local-storage.ts
@@ -1,0 +1,41 @@
+"use client";
+
+// localStorage lives on `window` in the browser and is undefined during SSR.
+// Accessing it can also throw in some privacy modes, so the access itself is guarded.
+function getLocalStorage(): Storage | null {
+  try {
+    return typeof window !== "undefined" ? window.localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read and JSON-parse a value from localStorage, falling back to `fallback` on
+ * any failure: SSR (no window), missing key, malformed JSON, or a throwing read.
+ */
+export function readStored<T>(key: string, fallback: T): T {
+  const storage = getLocalStorage();
+  if (!storage) return fallback;
+  try {
+    const raw = storage.getItem(key);
+    if (raw === null) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * JSON-serialize and persist a value to localStorage. Persistence is best-effort:
+ * SSR, quota-exceeded, private mode, or disabled storage are swallowed silently.
+ */
+export function writeStored<T>(key: string, value: T): void {
+  const storage = getLocalStorage();
+  if (!storage) return;
+  try {
+    storage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Best-effort — keep the in-memory value if persistence fails.
+  }
+}


### PR DESCRIPTION
## Summary

The traces list **Live** auto-refresh toggle resets to off on every reload, navigation, and re-login because it is backed by ephemeral component state. This persists the toggle per project in `localStorage`, so an explicit opt-in is remembered across sessions. Date range and pagination already persist (to the URL); this brings the Live toggle in line.

Closes #1019.

## What changed

- **New reusable, SSR-safe `useLocalStorage` hook** (`frontend/ui/src/lib/hooks/use-local-storage.ts`):
  - First render returns the default so it matches the server render — no hydration warning; the stored value is adopted in an effect after mount.
  - Every `localStorage` read/write is wrapped in try/catch, so it degrades safely in private mode or when storage is disabled — the toggle still works in-session from React state.
  - Cross-tab sync via the `storage` event.
  - Built on small pure helpers (`readStored` / `writeStored`) that hold all the guard logic and are unit-tested.
- **Wire the Live toggle to the hook**, keyed per project: `traceroot:traces:live:v1:{projectId}`, default `false`. A project that was never toggled behaves exactly as before — polling cost is unchanged unless a user opts in.

## Why this approach

Uses `useState` + an adopt-after-mount effect rather than `useSyncExternalStore`: it keeps the first client render identical to the server render (no hydration mismatch) and guarantees the toggle still functions in-session even when `localStorage` throws, which a pure external-store-over-`localStorage` cannot.

## Validation

- **8 unit tests** (Vitest, node env) for the storage helpers: SSR-absent window, missing key, valid parse, malformed JSON, and throwing `getItem` / `setItem`.
- **Manually verified in the running app** with the trace detail panel closed (to isolate the list behavior from the detail live-stream):
  - Live **ON** → a newly ingested trace appears in the list within ~5s, no reload.
  - Live **OFF** → the list stays frozen; the trace appears only after a manual reload.
  - Toggle state survives reload, is independent per project (distinct `localStorage` keys), defaults to off for never-toggled projects, produces no hydration warnings, and does not crash when storage is unavailable.

## Scope

Persists the toggle only. Out of scope (deferred per the issue): a separate manual refresh button, configurable poll interval, auto-pausing Live on historical ranges, and switching the list to a push/streaming transport.

## Demo


https://github.com/user-attachments/assets/80716bee-4ec1-4dfa-bdb2-641bac491e47



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the Traces “Live” auto‑refresh toggle per project using `localStorage`, so the user’s choice survives reloads, navigation, and re-login. Defaults remain off; behavior is unchanged unless a user opts in.

- **New Features**
  - Added SSR-safe `useLocalStorage` hook with guarded read/write, adopt-after-mount to avoid hydration warnings, and cross‑tab sync; helpers are unit‑tested.
  - Wired the Traces Live toggle to the hook with key `traceroot:traces:live:v1:{projectId}`; per‑project persistence with default off.

<sup>Written for commit 8ba6c3c667571d8976498036bb4e5c12628f8bdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

