### PR TITLE
fix(worker): price cache read/write tokens at ingest (#956)

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -493,8 +493,8 @@ def transform_otel_to_clickhouse(
                         span_record["output_tokens"] = output_tokens
                         span_record["total_tokens"] = total_tokens
 
-                        # Cost: normalize gross counts into disjoint buckets keyed on
-                        # the instrumentation scope, then price each bucket once.
+                        # Cost: normalize counts into disjoint buckets keyed on the
+                        # instrumentation scope, then price each bucket once.
                         from worker.tokens.buckets import normalize_token_usage
                         from worker.tokens.pricing import (
                             cost_from_buckets,

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -84,6 +84,27 @@ def first_present(attrs: dict[str, Any], keys: list[str]) -> Any:
     return None
 
 
+def first_present_number(attrs: dict[str, Any], keys: list[str]) -> Any:
+    """Like ``first_present`` but for numeric token attributes: skip keys whose
+    value is missing or malformed (empty / non-numeric) so a malformed
+    high-priority attribute cannot suppress a valid lower-priority fallback.
+
+    Validity mirrors ``int_or_zero`` (the value must coerce via ``int``); a present
+    but unusable value is skipped rather than short-circuiting the candidate list.
+    Returns the first usable value, or None if none qualify.
+    """
+    for key in keys:
+        value = attrs.get(key)
+        if value is None or value == "":
+            continue
+        try:
+            int(value)
+        except (TypeError, ValueError):
+            continue
+        return value
+    return None
+
+
 def int_or_zero(value: Any) -> int:
     """Convert a present OTEL numeric attribute to int; missing/invalid -> 0.
 
@@ -409,7 +430,7 @@ def transform_otel_to_clickhouse(
 
                     # Try API-provided token counts first (from instrumentors).
                     # OpenInference: llm.token_count.*  ·  GenAI semconv: gen_ai.usage.*
-                    api_input_tokens = first_present(
+                    api_input_tokens = first_present_number(
                         span_attrs,
                         [
                             "llm.token_count.prompt",
@@ -417,7 +438,7 @@ def transform_otel_to_clickhouse(
                             "gen_ai.usage.prompt_tokens",
                         ],
                     )
-                    api_output_tokens = first_present(
+                    api_output_tokens = first_present_number(
                         span_attrs,
                         [
                             "llm.token_count.completion",
@@ -425,14 +446,14 @@ def transform_otel_to_clickhouse(
                             "gen_ai.usage.completion_tokens",
                         ],
                     )
-                    api_total_tokens = first_present(
+                    api_total_tokens = first_present_number(
                         span_attrs,
                         ["llm.token_count.total", "gen_ai.usage.total_tokens"],
                     )
                     # Cache buckets. The OpenInference keys (prompt_details.*) are the
                     # verified path for Anthropic/OpenAI and MUST be listed first —
                     # they are the same family as llm.token_count.prompt (read above).
-                    api_cache_read_tokens = first_present(
+                    api_cache_read_tokens = first_present_number(
                         span_attrs,
                         [
                             "llm.token_count.prompt_details.cache_read",
@@ -445,7 +466,7 @@ def transform_otel_to_clickhouse(
                             "gen_ai.usage.details.cache_read_input_tokens",
                         ],
                     )
-                    api_cache_write_tokens = first_present(
+                    api_cache_write_tokens = first_present_number(
                         span_attrs,
                         [
                             "llm.token_count.prompt_details.cache_write",

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -558,7 +558,7 @@ def transform_otel_to_clickhouse(
                         trace_attrs[trace_id]["session_id"] or span_session_id
                     )
 
-                # Eager trace creation (Langfuse-style):
+                # Eager trace creation:
                 # Create a "shallow" trace record on the FIRST span we see for
                 # a trace_id, so it appears in the UI immediately. When the root
                 # span arrives later, upgrade to a "full" trace with rich metadata.

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -85,8 +85,19 @@ def first_present(attrs: dict[str, Any], keys: list[str]) -> Any:
 
 
 def int_or_zero(value: Any) -> int:
-    """Convert a present OTEL numeric attribute to int; missing -> 0."""
-    return int(value) if value is not None else 0
+    """Convert a present OTEL numeric attribute to int; missing/invalid -> 0.
+
+    ``first_present`` returns falsy-but-present values (e.g. an empty string for
+    an attribute that exists with a non-numeric value), so guard the cast — a
+    single malformed attribute must not crash ingestion of the whole batch.
+    """
+    if value is None or value == "":
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        logger.warning("Non-numeric OTEL token attribute %r; treating as 0", value)
+        return 0
 
 
 def decode_otel_id(b64_value: str | None) -> str | None:

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -440,6 +440,9 @@ def transform_otel_to_clickhouse(
                             "gen_ai.usage.cache_read_input_tokens",
                             "gen_ai.usage.input_cached_tokens",
                             "gen_ai.usage.details.cache_read_tokens",
+                            # pydantic-ai version variants (names differ by release):
+                            "gen_ai.usage.cache_read_tokens",
+                            "gen_ai.usage.details.cache_read_input_tokens",
                         ],
                     )
                     api_cache_write_tokens = first_present(
@@ -449,6 +452,8 @@ def transform_otel_to_clickhouse(
                             "gen_ai.usage.cache_creation.input_tokens",
                             "gen_ai.usage.cache_creation_input_tokens",
                             "gen_ai.usage.details.cache_write_tokens",
+                            # pydantic-ai version variant:
+                            "gen_ai.usage.details.cache_creation_input_tokens",
                         ],
                     )
 

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -84,6 +84,11 @@ def first_present(attrs: dict[str, Any], keys: list[str]) -> Any:
     return None
 
 
+def int_or_zero(value: Any) -> int:
+    """Convert a present OTEL numeric attribute to int; missing -> 0."""
+    return int(value) if value is not None else 0
+
+
 def decode_otel_id(b64_value: str | None) -> str | None:
     """Decode base64-encoded OTEL trace/span ID to hex string.
 
@@ -279,6 +284,7 @@ def transform_otel_to_clickhouse(
 
         for scope_span in scope_spans:
             otel_spans = scope_span.get("spans", [])
+            scope_name = (scope_span.get("scope") or {}).get("name")
 
             for otel_span in otel_spans:
                 # Decode IDs (camelCase: traceId, spanId, parentSpanId)
@@ -390,55 +396,86 @@ def transform_otel_to_clickhouse(
                 if model_name:
                     span_record["model_name"] = model_name
 
-                    # Try API-provided token counts first (from instrumentors)
-                    # OpenInference: llm.token_count.*
-                    # GenAI semconv: gen_ai.usage.*
-                    api_input_tokens = (
-                        span_attrs.get("llm.token_count.prompt")
-                        or span_attrs.get("gen_ai.usage.input_tokens")
-                        or span_attrs.get("gen_ai.usage.prompt_tokens")
+                    # Try API-provided token counts first (from instrumentors).
+                    # OpenInference: llm.token_count.*  ·  GenAI semconv: gen_ai.usage.*
+                    api_input_tokens = first_present(
+                        span_attrs,
+                        [
+                            "llm.token_count.prompt",
+                            "gen_ai.usage.input_tokens",
+                            "gen_ai.usage.prompt_tokens",
+                        ],
                     )
-                    api_output_tokens = (
-                        span_attrs.get("llm.token_count.completion")
-                        or span_attrs.get("gen_ai.usage.output_tokens")
-                        or span_attrs.get("gen_ai.usage.completion_tokens")
+                    api_output_tokens = first_present(
+                        span_attrs,
+                        [
+                            "llm.token_count.completion",
+                            "gen_ai.usage.output_tokens",
+                            "gen_ai.usage.completion_tokens",
+                        ],
                     )
-                    api_total_tokens = span_attrs.get("llm.token_count.total") or span_attrs.get(
-                        "gen_ai.usage.total_tokens"
+                    api_total_tokens = first_present(
+                        span_attrs,
+                        ["llm.token_count.total", "gen_ai.usage.total_tokens"],
+                    )
+                    # Cache buckets. The OpenInference keys (prompt_details.*) are the
+                    # verified path for Anthropic/OpenAI and MUST be listed first —
+                    # they are the same family as llm.token_count.prompt (read above).
+                    api_cache_read_tokens = first_present(
+                        span_attrs,
+                        [
+                            "llm.token_count.prompt_details.cache_read",
+                            "gen_ai.usage.cache_read.input_tokens",
+                            "gen_ai.usage.cache_read_input_tokens",
+                            "gen_ai.usage.input_cached_tokens",
+                            "gen_ai.usage.details.cache_read_tokens",
+                        ],
+                    )
+                    api_cache_write_tokens = first_present(
+                        span_attrs,
+                        [
+                            "llm.token_count.prompt_details.cache_write",
+                            "gen_ai.usage.cache_creation.input_tokens",
+                            "gen_ai.usage.cache_creation_input_tokens",
+                            "gen_ai.usage.details.cache_write_tokens",
+                        ],
                     )
 
                     if api_input_tokens is not None or api_output_tokens is not None:
-                        # Use API-provided counts (accurate)
-                        input_tokens = int(api_input_tokens) if api_input_tokens is not None else 0
-                        output_tokens = (
-                            int(api_output_tokens) if api_output_tokens is not None else 0
-                        )
+                        # Use API-provided counts (accurate).
+                        input_tokens = int_or_zero(api_input_tokens)
+                        output_tokens = int_or_zero(api_output_tokens)
                         total_tokens = (
-                            int(api_total_tokens)
+                            int_or_zero(api_total_tokens)
                             if api_total_tokens is not None
                             else input_tokens + output_tokens
                         )
+                        # Stored token columns stay GROSS (display continuity; PR B
+                        # adds first-class cache columns). Only cost changes here.
                         span_record["input_tokens"] = input_tokens
                         span_record["output_tokens"] = output_tokens
                         span_record["total_tokens"] = total_tokens
 
-                        # Calculate cost from actual token counts
-                        from worker.tokens.pricing import get_model_price
+                        # Cost: normalize gross counts into disjoint buckets keyed on
+                        # the instrumentation scope, then price each bucket once.
+                        from worker.tokens.buckets import normalize_token_usage
+                        from worker.tokens.pricing import (
+                            cost_from_buckets,
+                            get_model_price,
+                        )
 
-                        prices = get_model_price(model_name)
-                        if prices:
-                            from decimal import Decimal
-
-                            # Prices are in USD per token — multiply directly
-                            input_cost = Decimal(input_tokens) * Decimal(
-                                str(prices.get("input", 0))
-                            )
-                            output_cost = Decimal(output_tokens) * Decimal(
-                                str(prices.get("output", 0))
-                            )
-                            span_record["cost"] = float(input_cost + output_cost)
+                        buckets = normalize_token_usage(
+                            scope_name,
+                            input_tokens=input_tokens,
+                            output_tokens=output_tokens,
+                            cache_read_tokens=int_or_zero(api_cache_read_tokens),
+                            cache_write_tokens=int_or_zero(api_cache_write_tokens),
+                        )
+                        cost = cost_from_buckets(get_model_price(model_name), buckets)
+                        if cost is not None:
+                            span_record["cost"] = cost
                     else:
-                        # Fall back to text-based estimation
+                        # Fall back to text-based estimation.
                         from worker.tokens import calculate_cost
 
                         usage = calculate_cost(

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -1,11 +1,18 @@
-"""Normalize gross (cache-inclusive) instrumentor token counts into DISJOINT
-priced buckets — each physical token in exactly one bucket, priced once.
+"""Normalize an instrumentor's token counts into DISJOINT priced buckets — each
+physical token in exactly one bucket, priced once.
 
-Every instrumentor traceroot ingests reports a GROSS input that already contains
-the cache read/write tokens (per the OpenTelemetry GenAI semconv, where
-``gen_ai.usage.input_tokens`` is the *total* prompt:
-https://opentelemetry.io/docs/specs/semconv/gen-ai/anthropic/). We subtract cache
-from the input so the downstream cost math prices each token exactly once.
+The reported input may be GROSS (cache-inclusive — the common case, e.g.
+OpenInference's ``llm.token_count.prompt``, which already contains the cache
+tokens) or NET (cache-exclusive — e.g. the claude-agent-sdk instrumentor, which
+passes Anthropic's exclusive ``input_tokens`` straight through with cache reported
+as separate additive buckets).
+
+A single rule handles both: subtract cache from the input to recover the uncached
+bucket, flooring at zero, and keep the cache buckets UNCAPPED. For gross emitters
+the cache is a subset that subtracts cleanly; for net emitters the cache simply
+exceeds the input, so the uncached bucket floors to zero while the additive cache
+is still priced in full. Each physical token is therefore priced exactly once
+without a per-emitter convention branch.
 """
 
 from __future__ import annotations
@@ -30,14 +37,10 @@ class TokenBuckets:
     cache_write: int = 0
 
 
-# Instrumentation scopes known to report a GROSS (cache-inclusive) input — every
-# emitter traceroot reads today. Matched by case-insensitive scope-name prefix.
-# An unrecognized scope is still treated as inclusive (the dominant convention)
-# but warned about once, so a future raw-passthrough emitter surfaces instead of
-# silently mispricing. Add a prefix here only after verifying the emitter is
-# cache-inclusive firsthand from its source (NOT from raw provider API docs — the
-# raw SDK field can be exclusive while the instrumented span is gross).
-_KNOWN_INCLUSIVE_SCOPE_PREFIXES: tuple[str, ...] = (
+# Instrumentation scopes traceroot recognizes today. Used only to surface an
+# UNKNOWN emitter once (so a new token convention gets a human look) — the pricing
+# math below is the same for every scope. Matched by case-insensitive prefix.
+_KNOWN_SCOPE_PREFIXES: tuple[str, ...] = (
     "openinference",  # Python OpenInference (openinference.instrumentation.*)
     "@arizeai/openinference",  # JS/TS OpenInference (@arizeai/openinference-instrumentation-*)
     "opentelemetry.instrumentation",
@@ -54,16 +57,15 @@ _warned_scopes: set[str] = set()
 
 
 def _warn_once_if_unknown_scope(scope_name: str | None) -> None:
-    """Warn (once per scope) if the emitter isn't a known cache-inclusive one."""
-    if scope_name and scope_name.lower().startswith(_KNOWN_INCLUSIVE_SCOPE_PREFIXES):
+    """Warn (once per scope) if the emitter isn't one traceroot recognizes."""
+    if scope_name and scope_name.lower().startswith(_KNOWN_SCOPE_PREFIXES):
         return
     key = scope_name or "<missing>"
     if key not in _warned_scopes and len(_warned_scopes) < _MAX_WARNED_SCOPES:
         _warned_scopes.add(key)
         logger.warning(
-            "Pricing tokens from unknown instrumentation scope %r; assuming "
-            "input is cache-inclusive (subtracting cache). Verify this emitter's "
-            "convention and add it to _KNOWN_INCLUSIVE_SCOPE_PREFIXES.",
+            "Pricing tokens from unknown instrumentation scope %r; verify its "
+            "token convention and add it to _KNOWN_SCOPE_PREFIXES.",
             key,
         )
 
@@ -76,20 +78,19 @@ def normalize_token_usage(
     cache_read_tokens: int,
     cache_write_tokens: int,
 ) -> TokenBuckets:
-    """Convert a gross (cache-inclusive) instrumentor count into disjoint buckets.
+    """Convert an instrumentor's token counts into disjoint priced buckets.
 
-    Cache is subtracted from the gross input so each physical token is priced
-    exactly once. All buckets are clamped non-negative, and cache is capped to the
-    gross input so inconsistent emitter data (cache counts exceeding the reported
-    input) can never price more tokens than were reported. The reconciliation
-    invariant ``input_uncached + cache_read + cache_write == input_tokens`` holds.
+    The uncached bucket is ``max(input - cache_read - cache_write, 0)``; cache is
+    kept uncapped. This is correct for GROSS emitters (cache is a subset of the
+    input, so it subtracts out) and for NET emitters such as claude-agent-sdk
+    (cache exceeds the input, so the uncached bucket floors to zero while the
+    additive cache is still priced in full). All buckets are clamped non-negative.
     """
     _warn_once_if_unknown_scope(scope_name)
-    gross_input = max(input_tokens, 0)
-    cache_read = min(max(cache_read_tokens, 0), gross_input)
-    cache_write = min(max(cache_write_tokens, 0), gross_input - cache_read)
+    cache_read = max(cache_read_tokens, 0)
+    cache_write = max(cache_write_tokens, 0)
     return TokenBuckets(
-        input_uncached=gross_input - cache_read - cache_write,
+        input_uncached=max(max(input_tokens, 0) - cache_read - cache_write, 0),
         output=max(output_tokens, 0),
         cache_read=cache_read,
         cache_write=cache_write,

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -1,64 +1,50 @@
-"""Normalize provider/instrumentor token counts into DISJOINT priced buckets.
+"""Normalize gross (cache-inclusive) instrumentor token counts into DISJOINT
+priced buckets — each physical token in exactly one bucket, priced once.
 
-Every instrumentor traceroot ingests reports a GROSS (cache-inclusive) input
-count — the cache read/write tokens are a *breakdown of* the input, not
-additive to it. Verified firsthand from installed source: OpenInference
-Anthropic/OpenAI and pydantic-ai/genai-prices both behave this way, and the
-OpenTelemetry GenAI semconv *requires* it: ``gen_ai.usage.input_tokens`` MUST be
-the total prompt — for Anthropic, ``input_tokens + cache_read_input_tokens +
-cache_creation_input_tokens`` — with the cache fields a subset breakdown of the
-total, not additive on top. Spec:
-https://opentelemetry.io/docs/specs/semconv/gen-ai/anthropic/
-
-We therefore subtract cache from the input to get disjoint buckets, so the
-downstream cost math can price each physical token exactly once with zero
-provider branches. The convention is keyed on the OTel instrumentation *scope*
-(the emitter), not the provider name — that is where the convention actually
-varies. Today every known emitter is inclusive, so the table collapses to
-"subtract everywhere"; the EXCLUSIVE branch + unknown-scope warning are the
-extension point for a hypothetical future raw-passthrough emitter.
+Every instrumentor traceroot ingests reports a GROSS input that already contains
+the cache read/write tokens (per the OpenTelemetry GenAI semconv, where
+``gen_ai.usage.input_tokens`` is the *total* prompt:
+https://opentelemetry.io/docs/specs/semconv/gen-ai/anthropic/). We subtract cache
+from the input so the downstream cost math prices each token exactly once.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from enum import Enum
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class TokenBuckets:
-    """Disjoint token buckets — each physical token is in exactly one bucket."""
+    """Disjoint token buckets — each physical token is in exactly one bucket.
 
-    input_uncached: int
-    output: int
-    cache_read: int
-    cache_write: int
+    Fields default to ``0`` so new token categories (e.g. reasoning, audio) can be
+    added as purely additive changes without touching existing call sites.
+    """
+
+    input_uncached: int = 0
+    output: int = 0
+    cache_read: int = 0
+    cache_write: int = 0
 
 
-class InputConvention(Enum):
-    INCLUSIVE = "inclusive"  # input already contains cache -> subtract
-    EXCLUSIVE = "exclusive"  # input excludes cache -> additive (no known emitter)
-
-
-# Matched by scope-name prefix (case-insensitive). Every emitter traceroot
-# reads today is INCLUSIVE. Add an EXCLUSIVE entry here only after verifying a
-# new emitter firsthand from its source (NOT from raw provider API docs — the
+# Instrumentation scopes known to report a GROSS (cache-inclusive) input — every
+# emitter traceroot reads today. Matched by case-insensitive scope-name prefix.
+# An unrecognized scope is still treated as inclusive (the dominant convention)
+# but warned about once, so a future raw-passthrough emitter surfaces instead of
+# silently mispricing. Add a prefix here only after verifying the emitter is
+# cache-inclusive firsthand from its source (NOT from raw provider API docs — the
 # raw SDK field can be exclusive while the instrumented span is gross).
-_SCOPE_CONVENTIONS: tuple[tuple[str, InputConvention], ...] = (
-    ("openinference", InputConvention.INCLUSIVE),
-    ("opentelemetry.instrumentation", InputConvention.INCLUSIVE),
-    ("pydantic", InputConvention.INCLUSIVE),  # pydantic-ai / pydantic_ai
-    ("logfire", InputConvention.INCLUSIVE),
-    ("traceroot", InputConvention.INCLUSIVE),
+_KNOWN_INCLUSIVE_SCOPE_PREFIXES: tuple[str, ...] = (
+    "openinference",  # Python OpenInference (openinference.instrumentation.*)
+    "@arizeai/openinference",  # JS/TS OpenInference (@arizeai/openinference-instrumentation-*)
+    "opentelemetry.instrumentation",
+    "pydantic",  # pydantic-ai / pydantic_ai
+    "logfire",
+    "traceroot",
 )
-
-# Safe default: the dominant convention is inclusive, so an unrecognized emitter
-# is far more likely to be gross than net. We subtract and warn rather than risk
-# a silent ~2x overcharge.
-_DEFAULT_CONVENTION = InputConvention.INCLUSIVE
 
 # Bound the dedup set so a high-cardinality (or adversarial) stream of unknown
 # scope names cannot grow it without limit. Real emitters are few; this ceiling
@@ -67,24 +53,19 @@ _MAX_WARNED_SCOPES = 1024
 _warned_scopes: set[str] = set()
 
 
-def _convention_for_scope(scope_name: str | None) -> InputConvention:
-    if scope_name:
-        lowered = scope_name.lower()
-        for prefix, convention in _SCOPE_CONVENTIONS:
-            if lowered.startswith(prefix):
-                return convention
-    # Unknown / missing scope: warn once per scope so a future emitter surfaces
-    # instead of silently mispricing.
+def _warn_once_if_unknown_scope(scope_name: str | None) -> None:
+    """Warn (once per scope) if the emitter isn't a known cache-inclusive one."""
+    if scope_name and scope_name.lower().startswith(_KNOWN_INCLUSIVE_SCOPE_PREFIXES):
+        return
     key = scope_name or "<missing>"
     if key not in _warned_scopes and len(_warned_scopes) < _MAX_WARNED_SCOPES:
         _warned_scopes.add(key)
         logger.warning(
             "Pricing tokens from unknown instrumentation scope %r; assuming "
             "input is cache-inclusive (subtracting cache). Verify this emitter's "
-            "convention and add it to _SCOPE_CONVENTIONS.",
+            "convention and add it to _KNOWN_INCLUSIVE_SCOPE_PREFIXES.",
             key,
         )
-    return _DEFAULT_CONVENTION
 
 
 def normalize_token_usage(
@@ -95,36 +76,21 @@ def normalize_token_usage(
     cache_read_tokens: int,
     cache_write_tokens: int,
 ) -> TokenBuckets:
-    """Convert gross instrumentor counts into disjoint priced buckets.
+    """Convert a gross (cache-inclusive) instrumentor count into disjoint buckets.
 
-    All returned bucket values are clamped to be non-negative. For the
-    INCLUSIVE convention the cache buckets are additionally capped to the gross
-    input, so inconsistent emitter data (cache counts exceeding the reported
-    input) can never price more tokens than were reported.
-
-    The reconciliation invariant ``input_uncached + cache_read + cache_write
-    == input_tokens`` holds for the INCLUSIVE convention (after the non-negative
-    clamp); for EXCLUSIVE the input is not reduced, so the sum of the returned
-    buckets will exceed the raw input count.
+    Cache is subtracted from the gross input so each physical token is priced
+    exactly once. All buckets are clamped non-negative, and cache is capped to the
+    gross input so inconsistent emitter data (cache counts exceeding the reported
+    input) can never price more tokens than were reported. The reconciliation
+    invariant ``input_uncached + cache_read + cache_write == input_tokens`` holds.
     """
-    convention = _convention_for_scope(scope_name)
+    _warn_once_if_unknown_scope(scope_name)
     gross_input = max(input_tokens, 0)
-    cache_read = max(cache_read_tokens, 0)
-    cache_write = max(cache_write_tokens, 0)
-    output = max(output_tokens, 0)
-    if convention is InputConvention.INCLUSIVE:
-        # Cap cache to the gross input so inconsistent emitter data (cache counts
-        # exceeding the reported input) can never price more tokens than were
-        # reported. This keeps the reconciliation invariant
-        # input_uncached + cache_read + cache_write == gross_input intact.
-        cache_read = min(cache_read, gross_input)
-        cache_write = min(cache_write, gross_input - cache_read)
-        input_uncached = gross_input - cache_read - cache_write
-    else:  # EXCLUSIVE — input already excludes cache
-        input_uncached = gross_input
+    cache_read = min(max(cache_read_tokens, 0), gross_input)
+    cache_write = min(max(cache_write_tokens, 0), gross_input - cache_read)
     return TokenBuckets(
-        input_uncached=input_uncached,
-        output=output,
+        input_uncached=gross_input - cache_read - cache_write,
+        output=max(output_tokens, 0),
         cache_read=cache_read,
         cache_write=cache_write,
     )

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -3,8 +3,8 @@
 Every instrumentor traceroot ingests reports a GROSS (cache-inclusive) input
 count — the cache read/write tokens are a *breakdown of* the input, not
 additive to it. Verified firsthand from installed source (see
-issue-956-token-cost-worklog.html §2): OpenInference Anthropic/OpenAI,
-pydantic-ai/genai-prices, and Langfuse all behave this way; the OpenTelemetry
+issue-956-token-cost-worklog.html §2): OpenInference Anthropic/OpenAI
+and pydantic-ai/genai-prices both behave this way; the OpenTelemetry
 GenAI semconv mandates it ("input_tokens SHOULD include ... cached tokens").
 
 We therefore subtract cache from the input to get disjoint buckets, so the

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -57,6 +57,10 @@ _SCOPE_CONVENTIONS: tuple[tuple[str, InputConvention], ...] = (
 # a silent ~2x overcharge.
 _DEFAULT_CONVENTION = InputConvention.INCLUSIVE
 
+# Bound the dedup set so a high-cardinality (or adversarial) stream of unknown
+# scope names cannot grow it without limit. Real emitters are few; this ceiling
+# is far above any legitimate count.
+_MAX_WARNED_SCOPES = 1024
 _warned_scopes: set[str] = set()
 
 
@@ -69,7 +73,7 @@ def _convention_for_scope(scope_name: str | None) -> InputConvention:
     # Unknown / missing scope: warn once per scope so a future emitter surfaces
     # instead of silently mispricing.
     key = scope_name or "<missing>"
-    if key not in _warned_scopes:
+    if key not in _warned_scopes and len(_warned_scopes) < _MAX_WARNED_SCOPES:
         _warned_scopes.add(key)
         logger.warning(
             "Pricing tokens from unknown instrumentation scope %r; assuming "
@@ -90,23 +94,31 @@ def normalize_token_usage(
 ) -> TokenBuckets:
     """Convert gross instrumentor counts into disjoint priced buckets.
 
-    All returned bucket values are clamped to be non-negative, defensive
-    against inconsistent emitter data where cache counts exceed the reported
-    input total.
+    All returned bucket values are clamped to be non-negative. For the
+    INCLUSIVE convention the cache buckets are additionally capped to the gross
+    input, so inconsistent emitter data (cache counts exceeding the reported
+    input) can never price more tokens than were reported.
 
     The reconciliation invariant ``input_uncached + cache_read + cache_write
-    == input_tokens`` holds only for the INCLUSIVE convention; for EXCLUSIVE
-    the input is not reduced, so the sum of the returned buckets will exceed
-    the raw input count.
+    == input_tokens`` holds for the INCLUSIVE convention (after the non-negative
+    clamp); for EXCLUSIVE the input is not reduced, so the sum of the returned
+    buckets will exceed the raw input count.
     """
     convention = _convention_for_scope(scope_name)
+    gross_input = max(input_tokens, 0)
     cache_read = max(cache_read_tokens, 0)
     cache_write = max(cache_write_tokens, 0)
     output = max(output_tokens, 0)
     if convention is InputConvention.INCLUSIVE:
-        input_uncached = max(input_tokens - cache_read - cache_write, 0)
+        # Cap cache to the gross input so inconsistent emitter data (cache counts
+        # exceeding the reported input) can never price more tokens than were
+        # reported. This keeps the reconciliation invariant
+        # input_uncached + cache_read + cache_write == gross_input intact.
+        cache_read = min(cache_read, gross_input)
+        cache_write = min(cache_write, gross_input - cache_read)
+        input_uncached = gross_input - cache_read - cache_write
     else:  # EXCLUSIVE — input already excludes cache
-        input_uncached = max(input_tokens, 0)
+        input_uncached = gross_input
     return TokenBuckets(
         input_uncached=input_uncached,
         output=output,

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -93,6 +93,11 @@ def normalize_token_usage(
     All returned bucket values are clamped to be non-negative, defensive
     against inconsistent emitter data where cache counts exceed the reported
     input total.
+
+    The reconciliation invariant ``input_uncached + cache_read + cache_write
+    == input_tokens`` holds only for the INCLUSIVE convention; for EXCLUSIVE
+    the input is not reduced, so the sum of the returned buckets will exceed
+    the raw input count.
     """
     convention = _convention_for_scope(scope_name)
     cache_read = max(cache_read_tokens, 0)

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -1,0 +1,110 @@
+"""Normalize provider/instrumentor token counts into DISJOINT priced buckets.
+
+Every instrumentor traceroot ingests reports a GROSS (cache-inclusive) input
+count — the cache read/write tokens are a *breakdown of* the input, not
+additive to it. Verified firsthand from installed source (see
+issue-956-token-cost-worklog.html §2): OpenInference Anthropic/OpenAI,
+pydantic-ai/genai-prices, and Langfuse all behave this way; the OpenTelemetry
+GenAI semconv mandates it ("input_tokens SHOULD include ... cached tokens").
+
+We therefore subtract cache from the input to get disjoint buckets, so the
+downstream cost math can price each physical token exactly once with zero
+provider branches. The convention is keyed on the OTel instrumentation *scope*
+(the emitter), not the provider name — that is where the convention actually
+varies. Today every known emitter is inclusive, so the table collapses to
+"subtract everywhere"; the EXCLUSIVE branch + unknown-scope warning are the
+extension point for a hypothetical future raw-passthrough emitter.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TokenBuckets:
+    """Disjoint token buckets — each physical token is in exactly one bucket."""
+
+    input_uncached: int
+    output: int
+    cache_read: int
+    cache_write: int
+
+
+class InputConvention(Enum):
+    INCLUSIVE = "inclusive"  # input already contains cache -> subtract
+    EXCLUSIVE = "exclusive"  # input excludes cache -> additive (no known emitter)
+
+
+# Matched by scope-name prefix (case-insensitive). Every emitter traceroot
+# reads today is INCLUSIVE. Add an EXCLUSIVE entry here only after verifying a
+# new emitter firsthand from its source (NOT from raw provider API docs — the
+# raw SDK field can be exclusive while the instrumented span is gross).
+_SCOPE_CONVENTIONS: tuple[tuple[str, InputConvention], ...] = (
+    ("openinference", InputConvention.INCLUSIVE),
+    ("opentelemetry.instrumentation", InputConvention.INCLUSIVE),
+    ("pydantic", InputConvention.INCLUSIVE),  # pydantic-ai / pydantic_ai
+    ("logfire", InputConvention.INCLUSIVE),
+    ("traceroot", InputConvention.INCLUSIVE),
+)
+
+# Safe default: the dominant convention is inclusive, so an unrecognized emitter
+# is far more likely to be gross than net. We subtract and warn rather than risk
+# a silent ~2x overcharge.
+_DEFAULT_CONVENTION = InputConvention.INCLUSIVE
+
+_warned_scopes: set[str] = set()
+
+
+def _convention_for_scope(scope_name: str | None) -> InputConvention:
+    if scope_name:
+        lowered = scope_name.lower()
+        for prefix, convention in _SCOPE_CONVENTIONS:
+            if lowered.startswith(prefix):
+                return convention
+    # Unknown / missing scope: warn once per scope so a future emitter surfaces
+    # instead of silently mispricing.
+    key = scope_name or "<missing>"
+    if key not in _warned_scopes:
+        _warned_scopes.add(key)
+        logger.warning(
+            "Pricing tokens from unknown instrumentation scope %r; assuming "
+            "input is cache-inclusive (subtracting cache). Verify this emitter's "
+            "convention and add it to _SCOPE_CONVENTIONS.",
+            key,
+        )
+    return _DEFAULT_CONVENTION
+
+
+def normalize_token_usage(
+    scope_name: str | None,
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_write_tokens: int,
+) -> TokenBuckets:
+    """Convert gross instrumentor counts into disjoint priced buckets.
+
+    All returned bucket values are clamped to be non-negative, defensive
+    against inconsistent emitter data where cache counts exceed the reported
+    input total.
+    """
+    convention = _convention_for_scope(scope_name)
+    cache_read = max(cache_read_tokens, 0)
+    cache_write = max(cache_write_tokens, 0)
+    output = max(output_tokens, 0)
+    if convention is InputConvention.INCLUSIVE:
+        input_uncached = max(input_tokens - cache_read - cache_write, 0)
+    else:  # EXCLUSIVE — input already excludes cache
+        input_uncached = max(input_tokens, 0)
+    return TokenBuckets(
+        input_uncached=input_uncached,
+        output=output,
+        cache_read=cache_read,
+        cache_write=cache_write,
+    )

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -2,10 +2,13 @@
 
 Every instrumentor traceroot ingests reports a GROSS (cache-inclusive) input
 count — the cache read/write tokens are a *breakdown of* the input, not
-additive to it. Verified firsthand from installed source (see
-issue-956-token-cost-worklog.html §2): OpenInference Anthropic/OpenAI
-and pydantic-ai/genai-prices both behave this way; the OpenTelemetry
-GenAI semconv mandates it ("input_tokens SHOULD include ... cached tokens").
+additive to it. Verified firsthand from installed source: OpenInference
+Anthropic/OpenAI and pydantic-ai/genai-prices both behave this way, and the
+OpenTelemetry GenAI semconv *requires* it: ``gen_ai.usage.input_tokens`` MUST be
+the total prompt — for Anthropic, ``input_tokens + cache_read_input_tokens +
+cache_creation_input_tokens`` — with the cache fields a subset breakdown of the
+total, not additive on top. Spec:
+https://opentelemetry.io/docs/specs/semconv/gen-ai/anthropic/
 
 We therefore subtract cache from the input to get disjoint buckets, so the
 downstream cost math can price each physical token exactly once with zero

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -57,10 +57,14 @@ _warned_scopes: set[str] = set()
 
 
 def _warn_once_if_unknown_scope(scope_name: str | None) -> None:
-    """Warn (once per scope) if the emitter isn't one traceroot recognizes."""
-    if scope_name and scope_name.lower().startswith(_KNOWN_SCOPE_PREFIXES):
+    """Warn (once per scope) if the emitter isn't one traceroot recognizes.
+
+    ``scope_name`` is typed ``str | None`` but comes from untrusted OTLP, so a
+    malformed (non-string) value is guarded — it must never crash ingestion.
+    """
+    if isinstance(scope_name, str) and scope_name.lower().startswith(_KNOWN_SCOPE_PREFIXES):
         return
-    key = scope_name or "<missing>"
+    key = scope_name if isinstance(scope_name, str) and scope_name else "<missing>"
     if key not in _warned_scopes and len(_warned_scopes) < _MAX_WARNED_SCOPES:
         _warned_scopes.add(key)
         logger.warning(

--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -159,9 +159,16 @@ def calculate_cost(
 
     prices = get_model_price(model)
     if prices:
-        # Prices are in USD per token — multiply directly
-        input_cost = Decimal(input_tokens) * Decimal(str(prices.get("input", 0)))
-        output_cost = Decimal(output_tokens) * Decimal(str(prices.get("output", 0)))
-        result["cost"] = float(input_cost + output_cost)
+        # Text estimation has no cache visibility, so cache buckets are zero.
+        # Routing through cost_from_buckets keeps one cost formula across paths.
+        result["cost"] = cost_from_buckets(
+            prices,
+            TokenBuckets(
+                input_uncached=input_tokens,
+                output=output_tokens,
+                cache_read=0,
+                cache_write=0,
+            ),
+        )
 
     return result

--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -16,6 +16,7 @@ import psycopg2
 
 from shared.config import settings
 
+from .buckets import TokenBuckets
 from .usage import count_tokens
 
 logger = logging.getLogger(__name__)
@@ -102,6 +103,29 @@ def get_model_price(model: str) -> dict[str, float] | None:
             continue
 
     return None
+
+
+def cost_from_buckets(prices: dict[str, float] | None, buckets: TokenBuckets) -> float | None:
+    """Price DISJOINT token buckets — the single source of truth for cost.
+
+    Each bucket is priced at its own rate exactly once. `prices` must already be
+    resolved (e.g. via get_model_price). Returns None when no prices are known,
+    so callers can leave cost unset rather than recording $0. Missing cacheRead /
+    cacheWrite rates are treated as 0 (e.g. OpenAI has no cache-write rate).
+
+    Both the inline ingest path (otel_transform.py) and calculate_cost() call
+    this, so the cost formula lives in exactly one place.
+    """
+    if not prices:
+        return None
+
+    cost = (
+        Decimal(buckets.input_uncached) * Decimal(str(prices.get("input", 0)))
+        + Decimal(buckets.output) * Decimal(str(prices.get("output", 0)))
+        + Decimal(buckets.cache_read) * Decimal(str(prices.get("cacheRead") or 0))
+        + Decimal(buckets.cache_write) * Decimal(str(prices.get("cacheWrite") or 0))
+    )
+    return float(cost)
 
 
 def calculate_cost(

--- a/tests/fixtures/otel_payloads.py
+++ b/tests/fixtures/otel_payloads.py
@@ -50,13 +50,13 @@ def make_span(
     return span
 
 
-def make_otel_payload(spans: list[dict]) -> dict:
+def make_otel_payload(spans: list[dict], scope_name: str = "test") -> dict:
     """Wrap span dicts into a full OTEL resourceSpans payload."""
     return {
         "resourceSpans": [
             {
                 "resource": {"attributes": []},
-                "scopeSpans": [{"scope": {"name": "test"}, "spans": spans}],
+                "scopeSpans": [{"scope": {"name": scope_name}, "spans": spans}],
             }
         ]
     }

--- a/tests/fixtures/otel_payloads.py
+++ b/tests/fixtures/otel_payloads.py
@@ -50,7 +50,9 @@ def make_span(
     return span
 
 
-def make_otel_payload(spans: list[dict], scope_name: str = "test") -> dict:
+def make_otel_payload(
+    spans: list[dict], scope_name: str = "openinference.instrumentation.test"
+) -> dict:
     """Wrap span dicts into a full OTEL resourceSpans payload."""
     return {
         "resourceSpans": [

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -426,6 +426,20 @@ class TestTransformOtelToClickhouse:
                 "gen_ai.usage.cache_read.input_tokens",
                 "gen_ai.usage.cache_creation.input_tokens",
             ),
+            # pydantic-ai version variants whose cache key names differ — must
+            # still be detected so cache isn't silently missed (then overcharged).
+            (
+                "pydantic-ai",
+                "gen_ai.usage.input_tokens",
+                "gen_ai.usage.cache_read_tokens",
+                "gen_ai.usage.details.cache_creation_input_tokens",
+            ),
+            (
+                "pydantic-ai",
+                "gen_ai.usage.input_tokens",
+                "gen_ai.usage.details.cache_read_input_tokens",
+                "gen_ai.usage.details.cache_write_tokens",
+            ),
         ],
     )
     def test_cache_heavy_span_subtracts_before_pricing(

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -10,11 +10,35 @@ from worker.otel_transform import (
     attributes_to_dict,
     decode_otel_id,
     extract_attribute_value,
+    first_present_number,
     get_span_kind,
     int_or_zero,
     nanos_to_datetime,
     transform_otel_to_clickhouse,
 )
+
+
+class TestFirstPresentNumber:
+    """A malformed high-priority token attr must not suppress a valid fallback."""
+
+    def test_malformed_high_priority_falls_through_to_valid_fallback(self):
+        # "" (present-but-empty) and "abc" (non-numeric) must be skipped so the
+        # valid lower-priority key is used — otherwise the cache/token count is
+        # silently undercounted and the cost is wrong.
+        attrs = {"high": "", "mid": "abc", "low": 1000}
+        assert first_present_number(attrs, ["high", "mid", "low"]) == 1000
+
+    def test_valid_zero_is_not_skipped(self):
+        # 0 is a legitimate token count and must win over lower-priority keys.
+        attrs = {"high": 0, "low": 500}
+        assert first_present_number(attrs, ["high", "low"]) == 0
+
+    def test_all_missing_or_malformed_returns_none(self):
+        attrs = {"high": "", "mid": None, "low": "x"}
+        assert first_present_number(attrs, ["high", "mid", "low"]) is None
+
+    def test_numeric_string_is_usable(self):
+        assert first_present_number({"k": "4528"}, ["k"]) == "4528"
 
 
 class TestIntOrZero:
@@ -485,6 +509,35 @@ class TestTransformOtelToClickhouse:
         assert spans[0]["cost"] == pytest.approx(expected)
         # Stored input_tokens stays GROSS (display continuity; PR B revisits).
         assert spans[0]["input_tokens"] == 1000
+
+    def test_malformed_high_priority_token_attr_falls_through_to_valid_key(self):
+        """A present-but-malformed high-priority token attr must not suppress a
+        valid lower-priority fallback (else usage is undercounted and cost wrong)."""
+        from unittest.mock import patch
+
+        prices = {"input": 0.000003, "output": 0.000015, "cacheRead": 0.0, "cacheWrite": 0.0}
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=[
+                        make_attr("gen_ai.request.model", "claude-3-5-sonnet"),
+                        # high-priority key present but malformed (empty string)...
+                        make_attr("llm.token_count.prompt", ""),
+                        # ...valid count only on a lower-priority fallback key.
+                        make_attr("gen_ai.usage.input_tokens", 1000),
+                        make_attr("gen_ai.usage.output_tokens", 200),
+                    ],
+                )
+            ],
+            scope_name="openinference.instrumentation.anthropic",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+        # The fallback's 1000 (not 0) must be used.
+        assert spans[0]["input_tokens"] == 1000
+        assert spans[0]["cost"] == pytest.approx(1000 * prices["input"] + 200 * prices["output"])
 
     def test_cache_heavy_costs_less_than_uncached_equivalent(self):
         """Monotonicity: caching must DISCOUNT, never surcharge."""

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -3,6 +3,8 @@
 import base64
 from datetime import datetime
 
+import pytest
+
 from tests.fixtures.otel_payloads import make_attr, make_otel_payload, make_span
 from worker.otel_transform import (
     attributes_to_dict,
@@ -382,6 +384,100 @@ class TestTransformOtelToClickhouse:
         assert spans[0]["output_tokens"] == 50
         assert spans[0]["total_tokens"] == 150
         assert spans[0]["cost"] is not None
+
+    @pytest.mark.parametrize(
+        ("scope_name", "input_attr", "cache_read_attr", "cache_write_attr"),
+        [
+            # OpenInference Anthropic — the verified dominant path. Cache is under
+            # llm.token_count.prompt_details.* and the prompt is GROSS.
+            (
+                "openinference.instrumentation.anthropic",
+                "llm.token_count.prompt",
+                "llm.token_count.prompt_details.cache_read",
+                "llm.token_count.prompt_details.cache_write",
+            ),
+            # pydantic-ai native gen_ai.usage.* keys.
+            (
+                "pydantic-ai",
+                "gen_ai.usage.input_tokens",
+                "gen_ai.usage.cache_read.input_tokens",
+                "gen_ai.usage.cache_creation.input_tokens",
+            ),
+        ],
+    )
+    def test_cache_heavy_span_subtracts_before_pricing(
+        self, scope_name, input_attr, cache_read_attr, cache_write_attr
+    ):
+        """Cost must price each token once: gross input is reduced by cache."""
+        from unittest.mock import patch
+
+        prices = {
+            "input": 0.000003,
+            "output": 0.000015,
+            "cacheRead": 0.0000003,
+            "cacheWrite": 0.00000375,
+        }
+        # gross input = 1000, of which 900 cache-read + 50 cache-write => 50 uncached
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=[
+                        make_attr("gen_ai.request.model", "claude-3-5-sonnet"),
+                        make_attr(input_attr, 1000),
+                        make_attr("llm.token_count.completion", 0)
+                        if input_attr.startswith("llm.")
+                        else make_attr("gen_ai.usage.output_tokens", 0),
+                        make_attr(cache_read_attr, 900),
+                        make_attr(cache_write_attr, 50),
+                    ],
+                )
+            ],
+            scope_name=scope_name,
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        expected = (
+            50 * prices["input"]
+            + 0 * prices["output"]
+            + 900 * prices["cacheRead"]
+            + 50 * prices["cacheWrite"]
+        )
+        assert spans[0]["cost"] == pytest.approx(expected)
+        # Stored input_tokens stays GROSS (display continuity; PR B revisits).
+        assert spans[0]["input_tokens"] == 1000
+
+    def test_cache_heavy_costs_less_than_uncached_equivalent(self):
+        """Monotonicity: caching must DISCOUNT, never surcharge."""
+        from unittest.mock import patch
+
+        prices = {
+            "input": 0.000003,
+            "output": 0.000015,
+            "cacheRead": 0.0000003,
+            "cacheWrite": 0.00000375,
+        }
+
+        def cost_for(attrs):
+            payload = make_otel_payload(
+                [make_span("aa" * 16, "bb" * 8, attributes=attrs)],
+                scope_name="openinference.instrumentation.anthropic",
+            )
+            with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+                _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+            return spans[0]["cost"]
+
+        base = [
+            make_attr("gen_ai.request.model", "claude-3-5-sonnet"),
+            make_attr("llm.token_count.prompt", 1000),
+            make_attr("llm.token_count.completion", 0),
+        ]
+        cached = base + [
+            make_attr("llm.token_count.prompt_details.cache_read", 950),
+        ]
+        assert cost_for(cached) < cost_for(base)
 
     def test_text_estimation_fallback(self):
         """Falls back to text-based token estimation when no API counts."""

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -11,9 +11,32 @@ from worker.otel_transform import (
     decode_otel_id,
     extract_attribute_value,
     get_span_kind,
+    int_or_zero,
     nanos_to_datetime,
     transform_otel_to_clickhouse,
 )
+
+
+class TestIntOrZero:
+    """int_or_zero must never crash ingestion on present-but-non-numeric values."""
+
+    def test_none_and_missing_become_zero(self):
+        assert int_or_zero(None) == 0
+
+    def test_empty_string_becomes_zero(self):
+        # first_present returns "" for a present-but-empty attribute; int("") would raise.
+        assert int_or_zero("") == 0
+
+    def test_non_numeric_string_becomes_zero(self):
+        assert int_or_zero("abc") == 0
+
+    def test_numeric_string_parses(self):
+        assert int_or_zero("4528") == 4528
+
+    def test_ints_and_floats_parse(self):
+        assert int_or_zero(42) == 42
+        assert int_or_zero(3.9) == 3
+
 
 # ── decode_otel_id ──────────────────────────────────────────────────────
 

--- a/tests/worker/tokens/test_buckets.py
+++ b/tests/worker/tokens/test_buckets.py
@@ -75,3 +75,43 @@ def test_missing_scope_does_not_crash(caplog):
         )
     assert b == TokenBuckets(input_uncached=100, output=20, cache_read=0, cache_write=0)
     assert any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
+
+
+def test_cache_capped_to_gross_input_prevents_overbill():
+    # Inconsistent emitter data: cache counts exceed the gross input. Cache must
+    # be capped so the priced buckets never sum to more than the reported input.
+    b = normalize_token_usage(
+        "openinference.instrumentation.anthropic",
+        input_tokens=100,
+        output_tokens=5,
+        cache_read_tokens=80,
+        cache_write_tokens=80,
+    )
+    # cache_read capped to gross (80 <= 100); cache_write capped to the remainder (20).
+    assert b == TokenBuckets(input_uncached=0, output=5, cache_read=80, cache_write=20)
+    assert b.input_uncached + b.cache_read + b.cache_write == 100
+
+
+def test_cache_read_alone_capped_to_gross_input():
+    b = normalize_token_usage(
+        "openinference.instrumentation.openai",
+        input_tokens=50,
+        output_tokens=1,
+        cache_read_tokens=900,
+        cache_write_tokens=0,
+    )
+    assert b == TokenBuckets(input_uncached=0, output=1, cache_read=50, cache_write=0)
+    assert b.input_uncached + b.cache_read + b.cache_write == 50
+
+
+def test_warned_scopes_set_is_bounded():
+    # Unknown scope names must not grow the dedup set without bound.
+    for i in range(buckets_mod._MAX_WARNED_SCOPES + 50):
+        normalize_token_usage(
+            f"unknown.scope.{i}",
+            input_tokens=10,
+            output_tokens=0,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+        )
+    assert len(buckets_mod._warned_scopes) <= buckets_mod._MAX_WARNED_SCOPES

--- a/tests/worker/tokens/test_buckets.py
+++ b/tests/worker/tokens/test_buckets.py
@@ -77,6 +77,19 @@ def test_missing_scope_does_not_crash(caplog):
     assert any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
 
 
+def test_non_string_scope_does_not_crash():
+    # scope.name comes from untrusted OTLP; a malformed non-string value must be
+    # guarded (treated as unknown) rather than crashing ingestion on .lower().
+    b = normalize_token_usage(
+        123,  # type: ignore[arg-type]
+        input_tokens=100,
+        output_tokens=10,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+    )
+    assert b == TokenBuckets(input_uncached=100, output=10, cache_read=0, cache_write=0)
+
+
 def test_cache_exceeding_input_is_kept_uncapped_for_net_emitters():
     # NET/exclusive emitters (e.g. claude-agent-sdk, whose instrumentor passes
     # Anthropic's exclusive input straight through) report a small input with the

--- a/tests/worker/tokens/test_buckets.py
+++ b/tests/worker/tokens/test_buckets.py
@@ -77,31 +77,33 @@ def test_missing_scope_does_not_crash(caplog):
     assert any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
 
 
-def test_cache_capped_to_gross_input_prevents_overbill():
-    # Inconsistent emitter data: cache counts exceed the gross input. Cache must
-    # be capped so the priced buckets never sum to more than the reported input.
+def test_cache_exceeding_input_is_kept_uncapped_for_net_emitters():
+    # NET/exclusive emitters (e.g. claude-agent-sdk, whose instrumentor passes
+    # Anthropic's exclusive input straight through) report a small input with the
+    # cache as separate ADDITIVE buckets that legitimately exceed it. Cache must
+    # NOT be capped to the input — it is priced in full; only the uncached bucket
+    # floors to zero.
     b = normalize_token_usage(
-        "openinference.instrumentation.anthropic",
-        input_tokens=100,
-        output_tokens=5,
-        cache_read_tokens=80,
-        cache_write_tokens=80,
+        "openinference.instrumentation.claude_agent_sdk",
+        input_tokens=2,
+        output_tokens=54,
+        cache_read_tokens=15801,
+        cache_write_tokens=4897,
     )
-    # cache_read capped to gross (80 <= 100); cache_write capped to the remainder (20).
-    assert b == TokenBuckets(input_uncached=0, output=5, cache_read=80, cache_write=20)
-    assert b.input_uncached + b.cache_read + b.cache_write == 100
+    assert b == TokenBuckets(input_uncached=0, output=54, cache_read=15801, cache_write=4897)
 
 
-def test_cache_read_alone_capped_to_gross_input():
+def test_inclusive_cache_subtracts_as_a_subset():
+    # GROSS emitters: cache is a subset of the input and subtracts out cleanly,
+    # leaving the uncached remainder.
     b = normalize_token_usage(
         "openinference.instrumentation.openai",
-        input_tokens=50,
+        input_tokens=1000,
         output_tokens=1,
         cache_read_tokens=900,
-        cache_write_tokens=0,
+        cache_write_tokens=40,
     )
-    assert b == TokenBuckets(input_uncached=0, output=1, cache_read=50, cache_write=0)
-    assert b.input_uncached + b.cache_read + b.cache_write == 50
+    assert b == TokenBuckets(input_uncached=60, output=1, cache_read=900, cache_write=40)
 
 
 def test_warned_scopes_set_is_bounded():

--- a/tests/worker/tokens/test_buckets.py
+++ b/tests/worker/tokens/test_buckets.py
@@ -1,0 +1,77 @@
+"""Unit tests for the scope-keyed token normalization layer."""
+
+import logging
+
+import pytest
+
+import worker.tokens.buckets as buckets_mod
+from worker.tokens.buckets import TokenBuckets, normalize_token_usage
+
+
+@pytest.fixture(autouse=True)
+def _reset_warned_scopes():
+    buckets_mod._warned_scopes.clear()
+    yield
+
+
+def test_inclusive_scope_subtracts_cache_from_input():
+    # OpenInference/pydantic-ai emit a GROSS input that already contains cache.
+    b = normalize_token_usage(
+        "openinference.instrumentation.anthropic",
+        input_tokens=1000,
+        output_tokens=50,
+        cache_read_tokens=900,
+        cache_write_tokens=40,
+    )
+    assert b == TokenBuckets(input_uncached=60, output=50, cache_read=900, cache_write=40)
+
+
+def test_buckets_reconcile_to_gross_input():
+    b = normalize_token_usage(
+        "openinference.instrumentation.openai",
+        input_tokens=1000,
+        output_tokens=0,
+        cache_read_tokens=900,
+        cache_write_tokens=0,
+    )
+    # gross_input == input_uncached + cache_read + cache_write
+    assert b.input_uncached + b.cache_read + b.cache_write == 1000
+
+
+def test_input_clamped_at_zero_when_cache_exceeds_input():
+    # Defensive: never go negative even if counts are inconsistent.
+    b = normalize_token_usage(
+        "pydantic-ai",
+        input_tokens=900,
+        output_tokens=10,
+        cache_read_tokens=900,
+        cache_write_tokens=50,
+    )
+    assert b.input_uncached == 0
+
+
+def test_unknown_scope_warns_but_still_subtracts(caplog):
+    with caplog.at_level(logging.WARNING):
+        b = normalize_token_usage(
+            "com.acme.someNewInstrumentor",
+            input_tokens=1000,
+            output_tokens=0,
+            cache_read_tokens=300,
+            cache_write_tokens=0,
+        )
+    # Safe default: treat unknown emitters as inclusive (the dominant convention).
+    assert b.input_uncached == 700
+    assert any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
+
+
+def test_missing_scope_does_not_crash(caplog):
+    with caplog.at_level(logging.WARNING):
+        b = normalize_token_usage(
+            None,
+            input_tokens=100,
+            output_tokens=20,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+        )
+    assert b == TokenBuckets(input_uncached=100, output=20, cache_read=0, cache_write=0)
+    assert any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)

--- a/tests/worker/tokens/test_buckets.py
+++ b/tests/worker/tokens/test_buckets.py
@@ -115,3 +115,25 @@ def test_warned_scopes_set_is_bounded():
             cache_write_tokens=0,
         )
     assert len(buckets_mod._warned_scopes) <= buckets_mod._MAX_WARNED_SCOPES
+
+
+def test_js_openinference_scope_is_known_inclusive_no_warning(caplog):
+    # The JS/TS OpenInference instrumentors emit under the "@arizeai/openinference-*"
+    # scope, which must be recognized as cache-inclusive (same as Python's
+    # "openinference.*") so TS traces are priced explicitly and without a warning.
+    with caplog.at_level(logging.WARNING):
+        b = normalize_token_usage(
+            "@arizeai/openinference-instrumentation-openai",
+            input_tokens=1000,
+            output_tokens=50,
+            cache_read_tokens=900,
+            cache_write_tokens=40,
+        )
+    assert b == TokenBuckets(input_uncached=60, output=50, cache_read=900, cache_write=40)
+    assert not any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
+
+
+def test_token_buckets_fields_default_to_zero():
+    # Defaults make future token categories (reasoning/audio) purely additive.
+    assert TokenBuckets() == TokenBuckets(input_uncached=0, output=0, cache_read=0, cache_write=0)
+    assert TokenBuckets(output=5).cache_read == 0

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -327,3 +327,19 @@ def test_cost_from_buckets_returns_none_without_prices():
     buckets = TokenBuckets(input_uncached=100, output=50, cache_read=0, cache_write=0)
     assert cost_from_buckets(None, buckets) is None
     assert cost_from_buckets({}, buckets) is None
+
+
+def test_calculate_cost_matches_cost_from_buckets_for_text_path():
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import calculate_cost, cost_from_buckets
+
+    prices = {"input": 0.0000025, "output": 0.00001}
+    with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+        result = calculate_cost("gpt-4o", "hello world", "hi there")
+
+    in_tok = result["input_tokens"]
+    out_tok = result["output_tokens"]
+    expected = cost_from_buckets(
+        prices, TokenBuckets(input_uncached=in_tok, output=out_tok, cache_read=0, cache_write=0)
+    )
+    assert result["cost"] == pytest.approx(expected)

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -292,3 +292,38 @@ class TestClaudeBedrockAndVertexIds:
     def test_unrelated_model_still_none(self, real_cache):
         with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
             assert get_model_price("totally-not-a-real-model-2099") is None
+
+
+def test_cost_from_buckets_prices_each_bucket_once():
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    prices = {
+        "input": 0.000003,
+        "output": 0.000015,
+        "cacheRead": 0.0000003,
+        "cacheWrite": 0.00000375,
+    }
+    buckets = TokenBuckets(input_uncached=60, output=50, cache_read=900, cache_write=40)
+    expected = 60 * 0.000003 + 50 * 0.000015 + 900 * 0.0000003 + 40 * 0.00000375
+    assert cost_from_buckets(prices, buckets) == pytest.approx(expected)
+
+
+def test_cost_from_buckets_treats_missing_cache_rates_as_zero():
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    # Model with no cache rates (e.g. OpenAI has no cacheWrite).
+    prices = {"input": 0.0000025, "output": 0.00001}
+    buckets = TokenBuckets(input_uncached=100, output=50, cache_read=900, cache_write=0)
+    expected = 100 * 0.0000025 + 50 * 0.00001  # cache_read priced at 0 (no rate)
+    assert cost_from_buckets(prices, buckets) == pytest.approx(expected)
+
+
+def test_cost_from_buckets_returns_none_without_prices():
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    buckets = TokenBuckets(input_uncached=100, output=50, cache_read=0, cache_write=0)
+    assert cost_from_buckets(None, buckets) is None
+    assert cost_from_buckets({}, buckets) is None


### PR DESCRIPTION
Fixes #956

## Summary

At ingest, span cost only applied the `input` and `output` per-token rates —
cache read/write tokens were never priced at their own rates, so cache-heavy
traces were mis-costed. This normalizes each LLM span's gross (cache-inclusive)
token count into disjoint buckets — uncached input / output / cache read /
cache write — and prices each bucket exactly once at its own rate, so cost
reflects the cache discount instead of dropping it on the floor.

## Type of Change

- [x] fix - A bug fix

(Also includes a small refactor — consolidating cost onto one helper — and new
tests, but the user-facing change is the cost fix.)

## Details

- **`tokens/buckets.py` (new) — `normalize_token_usage`**: converts gross
  instrumentor counts into disjoint buckets, keyed on the OTel instrumentation
  *scope* (the convention is inclusive: cache is a breakdown of input, per the
  GenAI semconv, so cache is subtracted from input). Reconciliation invariant:
  `uncached + cache_read + cache_write == gross_input`.
- **`tokens/pricing.py` — `cost_from_buckets`**: single source of truth for
  cost; prices each disjoint bucket once (`input`/`output`/`cacheRead`/
  `cacheWrite`). `calculate_cost` now routes through it, so there's one cost
  formula across paths.
- **`otel_transform.py`**: at ingest, reads the cache read/write token
  attributes (both the OpenInference `llm.token_count.prompt_details.*` and
  GenAI `gen_ai.usage.cache_*` key families), normalizes, and prices
  cache-aware. Stored token columns stay gross for display continuity — only
  cost changes.

## How validated

- **186 unit tests pass** across `tests/worker/tokens/test_buckets.py`,
  `test_pricing.py`, and `tests/worker/test_otel_transform.py` — covering the
  reconciliation invariant, monotonicity (a cache-read call costs *less* than
  the same call uncached), no double-counting, and the multiple attribute-key
  families / provider conventions.
- pre-commit (ruff + format) passes.
- Manually verified the bucketed split and resulting cost against real cached
  OpenAI (`gpt-4o`) and Anthropic (`claude-sonnet-4-5`) calls; cache read and
  cache write are each priced once and reconcile to the gross input.

## Screenshots / Recordings
deepagents run
<img width="1728" height="989" alt="Screenshot 2026-06-03 at 4 42 47 PM" src="https://github.com/user-attachments/assets/7a546ecf-0401-4cc1-92da-034f82f7e493" />

anthropic run
<img width="1728" height="996" alt="Screenshot 2026-06-03 at 4 40 44 PM" src="https://github.com/user-attachments/assets/cf08ef70-9f2e-4d86-bc14-996a3b2c213f" />








<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LLM span cost by pricing cache read/write tokens at ingest using scope‑aware, disjoint buckets, with cache uncapped so net/exclusive emitters (e.g. claude‑agent‑sdk) are priced correctly. Stored token columns remain gross; only cost changes.

- **Bug Fixes**
  - Subtract cache read/write from input before pricing, with uncached = max(input − cache_read − cache_write, 0); keep cache buckets uncapped and non‑negative. Price each bucket once via `normalize_token_usage` + `cost_from_buckets`.
  - Read cache details from OpenInference `llm.token_count.prompt_details.*` and GenAI `gen_ai.usage.*` keys, including pydantic‑ai variants; treat `@arizeai/openinference*` scopes as cache‑inclusive.
  - Use `first_present_number` and `int_or_zero` to skip malformed numeric attrs so valid fallbacks are used; warn once per unknown scope, guard non‑string `scope.name` values, and bound the dedup set.

- **Refactors**
  - Added `tokens/buckets.py` for scope‑keyed normalization; `cost_from_buckets` is the single source of cost math. Routed `calculate_cost` through it (cache buckets zero on text estimation).

<sup>Written for commit d8a299e2a300fd0cab5462e39299d25a70c054e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





