### PR TITLE
fix(dev): auto-setup host deps in dev-lite/prod-lite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ dev-autoreload: install-hooks
 
 ## Windows contributors: full dev env without tmux requirement.
 dev-lite: install-hooks
+	@test -f .env || cp .env.example .env
+	@test -d frontend/node_modules || pnpm --dir frontend install
 	@echo "Starting TraceRoot at http://localhost:3000 - Ctrl+C to stop"
 	$(PROD_COMPOSE) up --build
 
@@ -36,6 +38,7 @@ prod:
 
 ## Self-hosting on any platform (Windows, CI, no tmux). Docker Desktop only.
 prod-lite:
+	@test -f .env || cp .env.example .env
 	@echo "Starting TraceRoot at http://localhost:3000 - Ctrl+C to stop"
 	$(PROD_COMPOSE) up --build
 


### PR DESCRIPTION
## Summary

`make dev-lite` and `make prod-lite` call `docker compose` directly, bypassing `tmux_tools/launcher.py` — so they skip the host-side setup that `make dev`/`make prod` perform. On a fresh clone this causes silent, confusing breakage:

- **No `.env`** → compose substitutes blank strings for every secret without a default (Anthropic/OpenAI/AWS/Stripe keys), so the app boots broken.
- **No host `frontend/node_modules`** → VS Code reports missing modules even though the app runs in Docker. This is the reported issue (#952).

The fix mirrors the idempotent guards `launcher.py` already uses (`ensure_env_file`, `ensure_frontend_deps`), scoped by audience:

| Concern | Added to | Why |
|---|---|---|
| `.env` | `dev-lite` **and** `prod-lite` | Runtime — the containers need config to work at all |
| host `node_modules` | `dev-lite` only | Editor-only; meaningless to a self-hoster/CI, and keeps `prod-lite`'s "Docker Desktop only" promise intact |

```makefile
dev-lite: install-hooks
	@test -f .env || cp .env.example .env
	@test -d frontend/node_modules || pnpm --dir frontend install
	...

prod-lite:
	@test -f .env || cp .env.example .env
	...
```

Both guards are idempotent (skip when the file/dir already exists), matching the launcher's behavior.

Fixes #952

## Type of Change
- [x] fix - A bug fix

## Testing
- `make -n dev-lite` and `make -n prod-lite` show the new guards in the plan
- Verified a fresh clone has only `.env.example` (no `.env`) and no `frontend/node_modules`, and that the prod compose pulls config via `${VAR}` substitution from the auto-loaded `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-run host setup for `dev-lite`/`prod-lite` so fresh clones work without manual steps. Adds idempotent guards to create `.env` and install frontend deps (dev-lite only), matching the launcher’s behavior.

- **Bug Fixes**
  - `dev-lite`: create `.env` if missing; install `frontend/node_modules` via `pnpm` when absent.
  - `prod-lite`: create `.env` if missing; no host `node_modules` install to keep Docker-only flow.
  - Prevents broken boots from empty env vars and VS Code “missing modules” errors. Fixes #952.

<sup>Written for commit 644770d1d643896b39a2fde84329df516ca08027. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

