### PR TITLE
feat(backend): Add public trace URL helper and UI base URL contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ CORS_ORIGINS=["http://localhost:3000"]
 
 # --- Internal API (Python <-> Next.js service communication) ------------------
 TRACEROOT_UI_URL=http://localhost:3000
+# Host/browser-usable UI URL used in client-facing links (trace_url, whoami).
+# Keep host-reachable (e.g. http://localhost:3000); do NOT set to http://web:3000.
+TRACEROOT_PUBLIC_UI_URL=http://localhost:3000
 INTERNAL_API_SECRET=dev-internal-secret  # CHANGEME in production
 
 # --- Worker (Python/Celery) ---------------------------------------------------

--- a/backend/rest/url_utils.py
+++ b/backend/rest/url_utils.py
@@ -1,0 +1,28 @@
+"""Shared helpers for building TraceRoot UI links.
+
+The backend owns the UI URL shape so API clients (e.g. the CLI) never need to
+know the frontend route layout or a second host — they receive ready-to-use
+links. This is a feature-neutral utility: `whoami` and the public traces
+list/get endpoints all build their `trace_url` / `ui_base_url` through here.
+"""
+
+from urllib.parse import quote, urlencode
+
+
+def build_trace_url(ui_base_url: str, project_id: str, trace_id: str) -> str:
+    """Build the UI link to a single trace's detail view.
+
+    Shape: ``{ui_base_url}/projects/{project_id}/traces?traceId={trace_id}``
+    (matches the frontend route, which selects the trace via the ``traceId``
+    query param).
+
+    ``ui_base_url`` is the absolute UI base (scheme + host, optionally with a
+    path prefix; no query or fragment) — typically ``settings.traceroot_ui_url``.
+    Passing it in keeps this helper pure and free of any credential material.
+    ``project_id`` is encoded as a single path segment and ``trace_id`` as a
+    query value, so reserved characters in them can't break the resulting URL.
+    """
+    base = ui_base_url.rstrip("/")
+    project_segment = quote(project_id, safe="")
+    query = urlencode({"traceId": trace_id})
+    return f"{base}/projects/{project_segment}/traces?{query}"

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -68,8 +68,12 @@ class Settings(BaseSettings):
     # CORS
     cors_origins: list[str] = ["http://localhost:3000"]
 
-    # Internal communication (Python <-> Next.js)
+    # Internal backend-to-web URL for server-to-server calls (e.g. validate-api-key);
+    # may be a Docker-internal host like http://web:3000.
     traceroot_ui_url: str = "http://localhost:3000"
+    # Host/browser-usable UI URL used in links handed to clients (whoami.ui_base_url,
+    # trace_url). Must NOT be a Docker-internal service URL.
+    traceroot_public_ui_url: str = "http://localhost:3000"
     internal_api_secret: str = ""
 
     # Service-specific settings

--- a/backend/shared/config.py
+++ b/backend/shared/config.py
@@ -7,6 +7,7 @@ Environment variables are loaded from .env by entrypoints (rest/main.py,
 worker/celery_app.py) before this module is first imported.
 """
 
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -72,8 +73,12 @@ class Settings(BaseSettings):
     # may be a Docker-internal host like http://web:3000.
     traceroot_ui_url: str = "http://localhost:3000"
     # Host/browser-usable UI URL used in links handed to clients (whoami.ui_base_url,
-    # trace_url). Must NOT be a Docker-internal service URL.
-    traceroot_public_ui_url: str = "http://localhost:3000"
+    # trace_url). Falls back to NEXT_PUBLIC_APP_URL so operators need not set a second
+    # var. Must NOT be a Docker-internal service URL.
+    traceroot_public_ui_url: str = Field(
+        "http://localhost:3000",
+        validation_alias=AliasChoices("TRACEROOT_PUBLIC_UI_URL", "NEXT_PUBLIC_APP_URL"),
+    )
     internal_api_secret: str = ""
 
     # Service-specific settings

--- a/deploy/helm/templates/rest/deployment.yaml
+++ b/deploy/helm/templates/rest/deployment.yaml
@@ -68,6 +68,14 @@ spec:
                   key: {{ .Values.secrets.keys.internalApiSecret }}
             - name: TRACEROOT_UI_URL
               value: "http://{{ include "traceroot.fullname" . }}-web:{{ .Values.web.port }}"
+            # Host/browser-usable public UI URL for client-facing links the public
+            # API returns (trace_url, whoami.ui_base_url). Reuses the public app URL
+            # operators already set (betterAuth.url) — no new required value. When
+            # unset, the backend falls back to NEXT_PUBLIC_APP_URL / localhost.
+            {{- if .Values.betterAuth.url }}
+            - name: TRACEROOT_PUBLIC_UI_URL
+              value: {{ .Values.betterAuth.url | quote }}
+            {{- end }}
             - name: CORS_ORIGINS
               value: '["{{ .Values.betterAuth.url }}"]'
             {{- with .Values.additionalEnv }}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -213,6 +213,8 @@ services:
       S3_BUCKET_NAME: ${S3_BUCKET_NAME:-traceroot}
       S3_REGION: ${S3_REGION:-us-east-1}
       TRACEROOT_UI_URL: http://web:3000
+      # Host/browser-usable UI URL for client-facing links (trace_url, whoami).
+      TRACEROOT_PUBLIC_UI_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
       # --- Secrets ---
       INTERNAL_API_SECRET: ${INTERNAL_API_SECRET:-internal-secret}
       CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000"]}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -214,7 +214,8 @@ services:
       S3_REGION: ${S3_REGION:-us-east-1}
       TRACEROOT_UI_URL: http://web:3000
       # Host/browser-usable UI URL for client-facing links (trace_url, whoami).
-      TRACEROOT_PUBLIC_UI_URL: ${TRACEROOT_PUBLIC_UI_URL:-http://localhost:3000}
+      # Prefers TRACEROOT_PUBLIC_UI_URL; falls back to the public app URL.
+      TRACEROOT_PUBLIC_UI_URL: ${TRACEROOT_PUBLIC_UI_URL:-${NEXT_PUBLIC_APP_URL:-http://localhost:3000}}
       # --- Secrets ---
       INTERNAL_API_SECRET: ${INTERNAL_API_SECRET:-internal-secret}
       CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000"]}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -214,7 +214,7 @@ services:
       S3_REGION: ${S3_REGION:-us-east-1}
       TRACEROOT_UI_URL: http://web:3000
       # Host/browser-usable UI URL for client-facing links (trace_url, whoami).
-      TRACEROOT_PUBLIC_UI_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+      TRACEROOT_PUBLIC_UI_URL: ${TRACEROOT_PUBLIC_UI_URL:-http://localhost:3000}
       # --- Secrets ---
       INTERNAL_API_SECRET: ${INTERNAL_API_SECRET:-internal-secret}
       CORS_ORIGINS: ${CORS_ORIGINS:-["http://localhost:3000"]}

--- a/tests/rest/test_url_utils.py
+++ b/tests/rest/test_url_utils.py
@@ -1,0 +1,43 @@
+"""Tests for the TraceRoot UI URL helper (rest.url_utils)."""
+
+import inspect
+
+from rest.url_utils import build_trace_url
+
+
+def test_builds_trace_detail_url():
+    """Basic shape: {ui_base_url}/projects/{project_id}/traces?traceId={trace_id}."""
+    url = build_trace_url("https://app.traceroot.ai", "proj1", "abc123")
+    assert url == "https://app.traceroot.ai/projects/proj1/traces?traceId=abc123"
+
+
+def test_strips_trailing_slash_on_base_url():
+    """A trailing slash on ui_base_url must not produce a double slash."""
+    with_slash = build_trace_url("https://app.traceroot.ai/", "proj1", "abc123")
+    without_slash = build_trace_url("https://app.traceroot.ai", "proj1", "abc123")
+    assert with_slash == without_slash
+    assert "//projects" not in with_slash.split("://", 1)[1]
+
+
+def test_url_encodes_project_id_path_segment():
+    """project_id is a single path segment; reserved chars must be percent-encoded."""
+    url = build_trace_url("https://app.traceroot.ai", "team/proj", "abc123")
+    assert "/projects/team%2Fproj/traces" in url
+    assert "/projects/team/proj/traces" not in url
+
+
+def test_url_encodes_trace_id_query_value():
+    """trace_id is a query value; reserved chars must be encoded so the URL is well-formed."""
+    url = build_trace_url("https://app.traceroot.ai", "proj1", "a b&c=d")
+    assert url == "https://app.traceroot.ai/projects/proj1/traces?traceId=a+b%26c%3Dd"
+
+
+def test_takes_only_base_project_trace_and_carries_no_credentials():
+    """The helper must not involve any API key/token: only the three inputs, no leakage."""
+    params = list(inspect.signature(build_trace_url).parameters)
+    assert params == ["ui_base_url", "project_id", "trace_id"]
+
+    url = build_trace_url("https://app.traceroot.ai", "proj1", "abc123")
+    lowered = url.lower()
+    for forbidden in ("bearer", "api_key", "apikey", "token", "authorization", "secret"):
+        assert forbidden not in lowered

--- a/tests/rest/test_url_utils.py
+++ b/tests/rest/test_url_utils.py
@@ -41,3 +41,15 @@ def test_takes_only_base_project_trace_and_carries_no_credentials():
     lowered = url.lower()
     for forbidden in ("bearer", "api_key", "apikey", "token", "authorization", "secret"):
         assert forbidden not in lowered
+
+
+def test_public_ui_url_setting_is_independent_of_internal(monkeypatch):
+    """Client-facing links use the public UI URL, which can differ from the
+    Docker-internal traceroot_ui_url used for backend-to-web calls."""
+    from shared.config import settings
+
+    monkeypatch.setattr(settings, "traceroot_ui_url", "http://web:3000")
+    monkeypatch.setattr(settings, "traceroot_public_ui_url", "http://localhost:3000")
+    url = build_trace_url(settings.traceroot_public_ui_url, "proj1", "abc123")
+    assert url == "http://localhost:3000/projects/proj1/traces?traceId=abc123"
+    assert "web:3000" not in url


### PR DESCRIPTION
## Summary

Fixes #1033

Establishes the backend contract for client-facing UI links so public API endpoints can hand clients ready-to-use trace links, and the CLI never needs to know the UI host or frontend route shape.

**1. Shared trace URL helper** — `build_trace_url(ui_base_url, project_id, trace_id)` → `{ui_base_url}/projects/{project_id}/traces?traceId={trace_id}`
- Lives in `backend/rest/url_utils.py`, mirroring the feature-neutral `backend/rest/sql_utils.py`.
- `project_id` is encoded as a single path segment and `trace_id` as a query value, so reserved characters can't break or inject into the URL.
- Pure function (no I/O, no logging, no credential material).

**2. Public-vs-internal UI URL distinction** — adds `settings.traceroot_public_ui_url`:
- `traceroot_ui_url` stays the **internal** backend→web URL for server-to-server calls (e.g. validate-api-key); may be a Docker-internal host like `http://web:3000`.
- `traceroot_public_ui_url` is the **host/browser-usable** URL used in client-facing links (`whoami.ui_base_url`, `trace_url`), so the Docker-internal host never leaks to clients.
- **No new var to set:** it falls back to `NEXT_PUBLIC_APP_URL` via `AliasChoices`, with `TRACEROOT_PUBLIC_UI_URL` as an optional override. Locally it defaults to `http://localhost:3000`; in prod, the public app URL operators already configure is used automatically. `docker-compose.prod.yml` mirrors this precedence for the rest service.

## Scope

- The `build_trace_url` helper.
- The `traceroot_public_ui_url` setting + `TRACEROOT_PUBLIC_UI_URL` / `NEXT_PUBLIC_APP_URL` env wiring (`.env.example`, `docker-compose.prod.yml`).

**Out of scope** (lands in the stacked PRs that own those files): wiring the public URL into `whoami.ui_base_url` (#1065), list `trace_url` (#1067), and get/export `trace_url` (#1071). Production public API host / exposure / rate limiting remains P1-6.

## Tests

- `tests/rest/test_url_utils.py`: basic URL shape, trailing-slash handling, `project_id`/`trace_id` URL-encoding (incl. `&`/`=`/space injection), no-credential signature, and a config test proving the public link URL can differ from the internal `traceroot_ui_url` (no `web:3000` in client-facing links).
- `uv run pytest tests/rest/test_url_utils.py` → 6 passed. Full `tests/rest` → 94 passed (no regressions). `ruff check` / `ruff format --check` clean.

Closes #1033
