### PR TITLE
docs(git-context): dev-only auto-detect + build-time injection for production

### DIFF
--- a/docs/tracing/git-context.mdx
+++ b/docs/tracing/git-context.mdx
@@ -19,36 +19,43 @@ TraceRoot automatically captures the git repository, commit, and the exact sourc
 
 ## Configuration
 
-Git context is auto-detected from your working directory. Override it via environment variables:
+TraceRoot resolves git context in this order: explicit init args →
+`TRACEROOT_GIT_REPO` / `TRACEROOT_GIT_REF` env vars → GitHub Actions env vars
+(`GITHUB_REPOSITORY` / `GITHUB_SHA`) → local `.git` auto-detection.
+
+Local `.git` auto-detection is a **development convenience only**. Production containers usually ship without a `.git` directory or the `git` binary, so auto-detection silently finds nothing and the AI agent cannot correlate traces to source. In production, always inject git context explicitly (see below).
+
+Set them explicitly via environment variables:
 
 ```bash
-TRACEROOT_GIT_REPO=myorg/myrepo
-TRACEROOT_GIT_REF=abc123
+TRACEROOT_GIT_REPO=your-org/your-repo
+TRACEROOT_GIT_REF=9c1e4f2
 ```
 
-Or at initialization:
+## Git context in production
 
-<Tabs>
-  <Tab title="Python">
-    ```python
-    traceroot.initialize(
-        git_repo="myorg/myrepo",
-        git_ref="abc123",
-    )
-    ```
-  </Tab>
-  <Tab title="TypeScript">
-    ```typescript
-    // Set via environment variables — auto-detected from your working directory
-    // TRACEROOT_GIT_REPO=myorg/myrepo
-    // TRACEROOT_GIT_REF=abc123
+Use **build-time injection**: inject the repo (static) and commit SHA (per-build) as environment variables at build time. The SDK reads them automatically — no code change required.
 
-    TraceRoot.initialize({
-      instrumentModules: { openAI: OpenAI },
-    });
-    ```
-  </Tab>
-</Tabs>
+```dockerfile Dockerfile
+ARG GIT_SHA
+ENV TRACEROOT_GIT_REPO=your-org/your-repo   # static
+ENV TRACEROOT_GIT_REF=$GIT_SHA              # dynamic, per build
+```
+
+```yaml .github/workflows/deploy.yml
+- name: Build image
+  run: docker build --build-arg GIT_SHA=${{ github.sha }} -t myapp:${{ github.sha }} .
+```
+
+In **GitHub Actions**, TraceRoot reads the standard `GITHUB_REPOSITORY` and
+`GITHUB_SHA` automatically — no Dockerfile change needed. On other CI/platform
+providers, use the build-time injection above.
+
+Apply this to **every traced service**, including background workers and cron/queue consumers — not just your API server. Each process resolves git context independently.
+
+For setups that reuse one image across commits, set `TRACEROOT_GIT_REPO` /
+`TRACEROOT_GIT_REF` in the Kubernetes pod spec or ECS task definition at deploy
+time instead.
 
 ## Why It Matters
 


### PR DESCRIPTION
## What

Updates `docs/tracing/git-context.mdx` to reflect how git context actually resolves in production.

- Reframes local `.git` auto-detection as a **development convenience** — production containers usually ship without a `.git` dir or the `git` binary, so it silently finds nothing.
- Documents the production path: **build-time injection** of `TRACEROOT_GIT_REPO` / `TRACEROOT_GIT_REF` (Dockerfile `ARG`→`ENV` fed by the CI commit), applied to **every traced service** (incl. background workers).
- Notes automatic GitHub Actions pickup (`GITHUB_REPOSITORY` / `GITHUB_SHA`).
- Style cleanups: plain-prose callouts to match the rest of the doc, shorter heading, real-looking placeholders.

Docs-only; no SDK change (the SDKs already read these env vars).

Closes #1025. Part of epic #1028.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies how git context resolves in production. Reframes `.git` auto-detect as dev-only and documents build-time injection of `TRACEROOT_GIT_REPO`/`TRACEROOT_GIT_REF`, including GitHub Actions pickup, so traces link to source across services.

- **Migration**
  - Set `TRACEROOT_GIT_REPO` and `TRACEROOT_GIT_REF` at build time (Docker `ARG`→`ENV`, e.g., pass `github.sha`).
  - Apply to every traced service (API, workers, cron).
  - If reusing one image across commits, set the envs at deploy (Kubernetes pod or ECS task).

<sup>Written for commit 67a0c63d102caf5464b1ee8cb8bbf6e4c32ac58a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

