### PR TITLE
ci: gate PRs at >=80% diff-coverage (closes #1050)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,3 +98,71 @@ jobs:
 
       - name: Print coverage summary
         run: cat code-coverage-results.md >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Coverage gate  (diff-cover >= 80% on changed lines)
+  # ---------------------------------------------------------------------------
+  # Enforces coverage on *changed lines only* (not whole-project), so the gate
+  # ratchets quality forward on new code without requiring a backfill. Reuses
+  # the coverage-backend.xml (Cobertura) already produced by backend-tests --
+  # diff-cover reads Cobertura directly, so no change to coverage generation.
+  # Pattern adapted from the OpenHuman project's CI (tinyhumansai/openhuman).
+  coverage-gate:
+    name: Coverage Gate (diff-cover >= 80%)
+    runs-on: ubuntu-24.04
+    needs: [backend-tests]
+    # Intentionally PR-only: diff-coverage compares changed lines against the PR
+    # base branch, and the gate already runs before a PR can enter the merge
+    # queue. On merge_group events github.base_ref is empty, so the compare-ref
+    # logic below would have no base to diff against -- supporting it would need
+    # github.event.merge_group.base_ref instead.
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # diff-cover needs history for the merge-base with the PR base; a
+          # shallow checkout silently breaks the comparison.
+          fetch-depth: 0
+
+      - name: Fetch PR base branch
+        run: git fetch origin "${{ github.base_ref }}" --depth=200
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install diff-cover
+        run: pip install 'diff-cover>=9.2.0'
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-backend
+
+      - name: Enforce >= 80% coverage on changed lines
+        run: |
+          set -euo pipefail
+          diff-cover coverage-backend.xml \
+            --compare-branch="origin/${{ github.base_ref }}" \
+            --fail-under=80 \
+            --format markdown:diff-coverage.md,html:diff-coverage.html
+
+      - name: Print diff-coverage summary
+        if: always()
+        run: |
+          if [ -f diff-coverage.md ]; then
+            cat diff-coverage.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload diff-coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diff-coverage-report
+          path: |
+            diff-coverage.md
+            diff-coverage.html
+          retention-days: 14
+          if-no-files-found: warn


### PR DESCRIPTION
## What

Adds a **Coverage Gate** job to the Tests workflow that fails a PR when **less than 80% of the changed lines** are covered by tests, using [`diff-cover`](https://github.com/Bachmann1234/diff_cover).

Closes #1050.

## Why diff-coverage (changed lines) not whole-project

A global coverage floor is painful on an uneven codebase — one untested module blocks every PR. `diff-cover` measures only the lines touched in the PR, so the rule is *"≥80% of the lines you changed must be covered."* It ratchets quality forward on new code without a big-bang backfill.

## Why it's low-cost

`diff-cover` reads **Cobertura XML** directly, and `backend-tests` already produces `coverage-backend.xml`. So this adds a gate that consumes the existing artifact — **no change to how coverage is generated.**

## Verified locally

- Gate **fails** (exit 1) when changed-line coverage is 40%; **passes** (exit 0) at ≥80%.
- Confirmed against **real** `coverage.py` output that diff-cover correctly matches its `<source>`-relative paths (`rest/main.py`) to git's repo-root paths (`backend/rest/main.py`) — no path normalization needed.
- Non-Python changes (e.g. this PR's YAML) are correctly ignored.

## Scope / intentional decisions

- **PR-only trigger.** `diff-coverage` needs a base branch to diff against, and the gate runs before a PR can enter the merge queue. `merge_group` events have an empty `base_ref`, so they're intentionally excluded (documented inline).
- **`backend/` scope.** Matches the existing `[tool.coverage.run] source = ["backend"]`. Changes under `ee/` / `tmux_tools/` aren't measured by this gate.

## ⚠️ Rollout note

Please merge this as a **non-required** check first and watch it on a few real PRs before promoting it to a required status check in branch protection — so a misbehaving gate can't block all merges.

## Credit

Pattern adapted from the OpenHuman project's CI (`tinyhumansai/openhuman`). 🙏

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a CI coverage gate using `diff-cover` to require at least 80% test coverage on changed lines. Closes #1050 and reuses the existing backend Cobertura report, so no changes to coverage generation.

- **New Features**
  - Adds `coverage-gate` job in the Tests workflow; runs on pull requests only.
  - Diffs against the PR base branch; scope matches `backend/`.
  - Fails when diff coverage < 80%; uploads markdown and HTML reports and posts a summary.

- **Migration**
  - Enable as a non-required check first; make it required after confirming stability.

<sup>Written for commit c18b7e08f47ef81560557cda65bb2fd39154132c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

