### PR TITLE
perf(api): gzip-compress REST responses (#1041)

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -15,6 +15,7 @@ load_dotenv()
 import uvicorn
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 
 from rest.routers.internal import router as internal_router
 from rest.routers.live import router as live_router
@@ -30,6 +31,11 @@ app = FastAPI(
     description="Observability platform for LLM applications",
     version="0.1.0",
 )
+
+# Compress responses (e.g. large trace payloads). Added before CORS so that
+# CORS remains the outermost middleware and its headers apply to every
+# response, including gzipped ones.
+app.add_middleware(GZipMiddleware, minimum_size=1024)
 
 # CORS configuration
 app.add_middleware(

--- a/tests/rest/test_gzip_middleware.py
+++ b/tests/rest/test_gzip_middleware.py
@@ -1,0 +1,42 @@
+"""Unit tests for gzip compression of REST responses (issue #1041).
+
+Guards that GZipMiddleware stays wired so large JSON responses (e.g. trace
+detail, which can be tens of MB) are compressed on the wire.
+
+NOTE: SSE/streaming responses (text/event-stream, e.g. the /live endpoint) are
+intentionally NOT covered here. Starlette's GZipMiddleware leaves streaming
+responses uncompressed and real-time, but that is timing-dependent behavior
+that TestClient cannot observe (it buffers the whole response). It is verified
+by an out-of-band streaming repro instead. See issue #1041 / the design doc.
+"""
+
+from fastapi.testclient import TestClient
+
+from rest.main import app
+
+
+def test_gzip_middleware_is_registered():
+    """Defensive regression guard: the middleware must not be silently removed."""
+    assert any(m.cls.__name__ == "GZipMiddleware" for m in app.user_middleware), (
+        "GZipMiddleware is not registered on the REST app"
+    )
+
+
+def test_large_json_response_is_gzipped():
+    """A response over minimum_size is gzip-encoded when the client accepts it."""
+    client = TestClient(app)
+    # /openapi.json is unauthenticated and comfortably exceeds the 1024-byte
+    # minimum_size threshold.
+    resp = client.get("/openapi.json", headers={"Accept-Encoding": "gzip"})
+    assert resp.status_code == 200
+    assert resp.headers.get("content-encoding") == "gzip"
+    # Body still decodes correctly after compression.
+    assert resp.json()["info"]["title"]
+
+
+def test_response_not_gzipped_when_client_declines():
+    """No content-encoding when the client does not accept gzip."""
+    client = TestClient(app)
+    resp = client.get("/openapi.json", headers={"Accept-Encoding": "identity"})
+    assert resp.status_code == 200
+    assert resp.headers.get("content-encoding") != "gzip"


### PR DESCRIPTION
Adds `GZipMiddleware(minimum_size=1024)` to the REST app, before CORS so CORS stays the outermost middleware. Large trace-detail payloads were shipping uncompressed.

## Verification (end-to-end, real data)
- Real LangChain trace detail: **95,953 → 7,337 B (13.1×)**, body decodes to valid JSON.
- Customer-trace blob content: ~5× (unique natural-language text compresses less than boilerplate).
- `/live` SSE (`text/event-stream`) left **uncompressed and real-time** — verified on the live endpoint (42 span batches streamed over ~176s) and via an isolated Starlette repro (no event buffering).
- Unit test `tests/rest/test_gzip_middleware.py`: middleware wired · large JSON gzipped · not gzipped when the client declines.

## Screenshots
<img width="2073" height="1068" alt="Screenshot 2026-06-04 at 12 23 16 AM" src="https://github.com/user-attachments/assets/e6ecf2eb-a72e-466f-ab8b-e42362b2c1f1" />


Note: the SSE-skip behavior is version-dependent (Starlette 0.50.0); re-verify if Starlette is upgraded.

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable gzip compression for large REST responses to reduce payload size and speed up clients. Adds `GZipMiddleware(minimum_size=1024)` before CORS; `/live` SSE stays uncompressed and real-time.

- **Performance**
  - Real trace detail compresses ~5–13x; JSON still decodes correctly.
  - Tests cover middleware registration, gzipping when accepted, and skipping when declined.
  - SSE behavior depends on `Starlette` 0.50.0; re-check on version upgrades.

<sup>Written for commit c1db1b981e5879b0952421af11b9bc730dc1002b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

