### PR TITLE
fix(ui): parse whole-second timestamps as UTC (fixes ~7h timeline render)

### DIFF
--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { SpanKind, SpanStatus } from "@traceroot/core";
 import type { Span } from "@/types/api";
-import { enrichSpansWithPending, getTraceDuration } from "./index";
+import { enrichSpansWithPending, getSpanDuration, getTraceDuration } from "./index";
 import type { TraceDetail } from "@/types/api";
+
+// Pin a non-UTC timezone so timezone-naive timestamp regressions (a whole-second
+// "...:30" end parsed as local → 7h skew) are caught regardless of the CI
+// runner's zone. The Z-suffixed fixtures elsewhere in this file are unaffected.
+process.env.TZ = "America/Los_Angeles";
 
 // Minimal span factory — only fields relevant to enrichSpansWithPending.
 function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
@@ -261,5 +266,63 @@ describe("getTraceDuration", () => {
 
   it("returns null for an empty trace", () => {
     expect(getTraceDuration(traceOf([]))).toBeNull();
+  });
+});
+
+// Regression suite for the timezone-naive backend format. Production timestamps
+// arrive WITHOUT a `Z` (e.g. "2026-06-04T06:37:30.862000"), and Python drops the
+// fractional part when microseconds are zero (e.g. "2026-06-04T06:37:30"). A
+// whole-second tail "...:30" was mistaken for a "-HH:MM" offset and parsed as
+// local time, inflating one span — and the whole trace — to ~7h in non-UTC zones.
+describe("durations with timezone-naive backend timestamps", () => {
+  const traceOf = (spans: Span[]) => ({ spans }) as unknown as TraceDetail;
+
+  it("getSpanDuration: whole-second end is seconds, not 7h (the reported bug)", () => {
+    const span = makeSpan({
+      span_id: "websearch",
+      span_start_time: "2026-06-04T06:37:22.527000",
+      span_end_time: "2026-06-04T06:37:30", // microseconds were zero → no fraction
+    });
+    expect(getSpanDuration(span)).toBe(7_473);
+  });
+
+  it("getSpanDuration: fractional naive timestamps compute normally", () => {
+    const span = makeSpan({
+      span_id: "websearch2",
+      span_start_time: "2026-06-04T06:37:22.527000",
+      span_end_time: "2026-06-04T06:37:30.618000",
+    });
+    expect(getSpanDuration(span)).toBe(8_091);
+  });
+
+  it("getSpanDuration: a naive timestamp equals the same instant written with Z", () => {
+    const naive = makeSpan({
+      span_id: "naive",
+      span_start_time: "2026-06-04T06:37:22",
+      span_end_time: "2026-06-04T06:37:30",
+    });
+    const withZ = makeSpan({
+      span_id: "withZ",
+      span_start_time: "2026-06-04T06:37:22Z",
+      span_end_time: "2026-06-04T06:37:30Z",
+    });
+    expect(getSpanDuration(naive)).toBe(getSpanDuration(withZ));
+  });
+
+  it("getTraceDuration: a child's whole-second end does not blow the trace up to 7h", () => {
+    const root = makeSpan({
+      span_id: "root",
+      span_start_time: "2026-06-04T06:37:01.841000",
+      span_end_time: "2026-06-04T06:41:16.974000",
+    });
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: "root",
+      span_start_time: "2026-06-04T06:37:22.527000",
+      span_end_time: "2026-06-04T06:37:30", // the buggy whole-second value
+    });
+    const dur = getTraceDuration(traceOf([root, child]))!;
+    expect(dur).toBe(255_133); // 06:41:16.974 − 06:37:01.841 ≈ 4m15s
+    expect(dur).toBeLessThan(3_600_000); // never an hour+
   });
 });

--- a/frontend/ui/src/lib/utils.test.ts
+++ b/frontend/ui/src/lib/utils.test.ts
@@ -1,0 +1,61 @@
+// Pin a non-UTC timezone BEFORE importing the module under test. The timezone-
+// naive parsing bug only manifests when the local zone differs from UTC, so
+// without this a UTC CI runner would pass even with the bug present.
+// America/Los_Angeles is UTC-7 (PDT) on this date.
+process.env.TZ = "America/Los_Angeles";
+
+import { describe, it, expect } from "vitest";
+
+import { parseAsUTC } from "./utils";
+
+// The intended UTC instant for a "2026-06-04T06:37:30" backend timestamp.
+const UTC_063730 = Date.UTC(2026, 5, 4, 6, 37, 30);
+
+describe("parseAsUTC", () => {
+  it("parses a naive timestamp with microseconds as UTC", () => {
+    expect(parseAsUTC("2026-06-04T06:37:30.862000").getTime()).toBe(UTC_063730 + 862);
+  });
+
+  it("parses a naive millisecond timestamp as UTC", () => {
+    expect(parseAsUTC("2026-06-04T06:37:30.500").getTime()).toBe(UTC_063730 + 500);
+  });
+
+  // Regression for the 7h-skew bug: the backend drops fractional seconds when
+  // they are zero, so a whole-second timestamp arrives as "...06:37:30". Its
+  // trailing "37:30" was mistaken for a "-HH:MM" offset and parsed as local.
+  it("parses a whole-second naive timestamp as UTC (not local)", () => {
+    expect(parseAsUTC("2026-06-04T06:37:30").getTime()).toBe(UTC_063730);
+  });
+
+  // Same failure class one notch coarser: minute-precision has no seconds either.
+  it("parses a minute-precision naive timestamp as UTC", () => {
+    expect(parseAsUTC("2026-06-04T06:37").getTime()).toBe(Date.UTC(2026, 5, 4, 6, 37, 0));
+  });
+
+  it("treats a whole-second naive timestamp identically to the same instant with an explicit Z", () => {
+    expect(parseAsUTC("2026-06-04T06:37:30").getTime()).toBe(
+      parseAsUTC("2026-06-04T06:37:30Z").getTime(),
+    );
+  });
+
+  it("respects an explicit Z suffix", () => {
+    expect(parseAsUTC("2026-06-04T06:37:30Z").getTime()).toBe(UTC_063730);
+  });
+
+  it("respects an explicit negative offset instead of forcing UTC", () => {
+    // 06:37:30 at -07:00 is 13:37:30 UTC — must NOT be re-interpreted as UTC.
+    expect(parseAsUTC("2026-06-04T06:37:30-07:00").getTime()).toBe(
+      Date.UTC(2026, 5, 4, 13, 37, 30),
+    );
+  });
+
+  it("respects an explicit positive offset", () => {
+    // 06:37:30 at +05:30 is 01:07:30 UTC.
+    expect(parseAsUTC("2026-06-04T06:37:30+05:30").getTime()).toBe(Date.UTC(2026, 5, 4, 1, 7, 30));
+  });
+
+  it("returns a Date instance unchanged", () => {
+    const d = new Date("2026-06-04T06:37:30Z");
+    expect(parseAsUTC(d)).toBe(d);
+  });
+});

--- a/frontend/ui/src/lib/utils.ts
+++ b/frontend/ui/src/lib/utils.ts
@@ -82,8 +82,11 @@ export function formatTokens(count: number | null | undefined): string {
 export function parseAsUTC(date: string | Date): Date {
   if (date instanceof Date) return date;
 
-  // If the string doesn't have timezone info, treat it as UTC
-  if (!date.endsWith("Z") && !date.includes("+") && !/\d{2}:\d{2}$/.test(date.slice(-6))) {
+  // If the string doesn't have timezone info, treat it as UTC.
+  // A real offset must carry a sign (e.g. "-07:00"); require [+-] so the trailing
+  // "MM:SS" of a whole-second timestamp (e.g. "2026-06-04T06:37:30", emitted when
+  // microseconds are zero) is NOT mistaken for an offset and parsed as local time.
+  if (!date.endsWith("Z") && !date.includes("+") && !/[+-]\d{2}:\d{2}$/.test(date.slice(-6))) {
     return new Date(date + "Z");
   }
   return new Date(date);


### PR DESCRIPTION
## Symptom
A span — and the whole trace — could render as **~7h** when the real duration is seconds/minutes. Intermittent; only in non-UTC browser timezones.

## Root cause
`parseAsUTC` (`frontend/ui/src/lib/utils.ts`) detected a trailing timezone offset with `/\d{2}:\d{2}$/`. When the backend emits a whole-second timestamp (Python drops the fraction when microseconds are zero, e.g. `2026-06-04T06:37:30`), the trailing `MM:SS` (`37:30`) matched, so `Z` was not appended and `new Date()` parsed it as **local** time → +7h in UTC-7.


## Screenshots

<img width="2073" height="1068" alt="Screenshot 2026-06-04 at 12 23 16 AM" src="https://github.com/user-attachments/assets/7a8b566f-7b73-4c4b-a32d-736486255fce" />


## Fix
Require a sign on the offset: `/[+-]\d{2}:\d{2}$/`. A bare `MM:SS` is no longer mistaken for a timezone; real offsets like `-07:00` are still respected.

## Tests (pinned to a non-UTC zone so they're deterministic on any CI runner)
- `src/lib/utils.test.ts` — `parseAsUTC` across naive microseconds / millis / whole-second / minute-precision, explicit `Z`, ±offsets, `Date` passthrough.
- `src/features/traces/utils/index.test.ts` — `getSpanDuration` / `getTraceDuration` with whole-second timestamps (the on-screen 7h symptom).

Proven to catch the regression: reverting to the old regex fails exactly these tests (5), all others pass.

Closes #1055
Refs #1054 (durable backend-side explicit-UTC serialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a timezone parsing bug that inflated some spans and entire traces to ~7h in non-UTC browsers. `parseAsUTC` now treats whole-second timestamps as UTC unless a signed offset is present, preventing local-time misparsing.

- **Bug Fixes**
  - Require a signed offset (`/[+-]\d{2}:\d{2}$/`) before trusting timezone info; otherwise append `Z` and parse as UTC.
  - Add deterministic regression tests pinned to `America/Los_Angeles` for whole-second/minute-precision inputs and for `getSpanDuration`/`getTraceDuration`.

<sup>Written for commit 6aeaa63104735a4e5e4d7873aa08270c5e8961a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

