### PR TITLE
perf(ui): truncate & collapse span I/O renderer (#1042)

### DIFF
--- a/frontend/ui/src/features/traces/components/ContentRenderer.test.ts
+++ b/frontend/ui/src/features/traces/components/ContentRenderer.test.ts
@@ -1,11 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { STRING_TRUNCATE_AT, shouldTruncate, truncateString } from "./json-render-utils";
+import {
+  AUTO_EXPAND_MAX_DEPTH,
+  AUTO_EXPAND_MAX_ITEMS,
+  AUTO_EXPAND_MAX_ITEMS_ROOT,
+  STRING_TRUNCATE_AT,
+  shouldAutoExpand,
+  shouldTruncate,
+  truncateString,
+} from "./json-render-utils";
 
-// These tests cover the pure truncation policy that backs the span I/O
-// renderer. The renderer collapses nested objects/arrays by default and hides
-// the tail of long strings behind a "show more" toggle so selecting a span
-// with a large (~300 KB) blob doesn't render thousands of expanded DOM nodes
-// up front. The vitest environment here is "node" (no DOM), so we assert the
+// These tests cover the pure policy that backs the span I/O renderer. The
+// renderer expands shallow/small objects by default but collapses deep or large
+// ones, and hides the tail of long strings behind a "show more" toggle, so
+// selecting a span with a large (~300 KB) blob doesn't render thousands of
+// expanded DOM nodes up front while a normal span stays readable on first
+// paint. The vitest environment here is "node" (no DOM), so we assert the
 // policy rather than the rendered output.
 
 describe("shouldTruncate", () => {
@@ -38,5 +47,61 @@ describe("truncateString", () => {
     const value = "PREFIX-" + "x".repeat(STRING_TRUNCATE_AT);
     expect(truncateString(value).startsWith("PREFIX-")).toBe(true);
     expect(truncateString(value).length).toBe(STRING_TRUNCATE_AT);
+  });
+
+  it("leaves a string of exactly the threshold length untouched (boundary)", () => {
+    const exact = "x".repeat(STRING_TRUNCATE_AT);
+    expect(truncateString(exact)).toBe(exact);
+    // One char over is where truncation kicks in.
+    expect(truncateString(exact + "y").length).toBe(STRING_TRUNCATE_AT);
+  });
+
+  it("never returns more than the threshold for any input", () => {
+    for (const len of [
+      STRING_TRUNCATE_AT - 1,
+      STRING_TRUNCATE_AT,
+      STRING_TRUNCATE_AT + 1,
+      10_000,
+    ]) {
+      expect(truncateString("z".repeat(len)).length).toBeLessThanOrEqual(STRING_TRUNCATE_AT);
+    }
+  });
+});
+
+describe("shouldAutoExpand", () => {
+  it("expands the root and other shallow, small nodes so a normal span reads on first paint", () => {
+    expect(shouldAutoExpand(0, 1)).toBe(true);
+    expect(shouldAutoExpand(0, AUTO_EXPAND_MAX_ITEMS_ROOT)).toBe(true);
+    expect(shouldAutoExpand(1, AUTO_EXPAND_MAX_ITEMS)).toBe(true);
+  });
+
+  it("collapses large nodes so a big blob doesn't flood the DOM up front", () => {
+    expect(shouldAutoExpand(0, AUTO_EXPAND_MAX_ITEMS_ROOT + 1)).toBe(false);
+    expect(shouldAutoExpand(1, AUTO_EXPAND_MAX_ITEMS + 1)).toBe(false);
+    // A 5k-item array stays collapsed regardless of depth.
+    expect(shouldAutoExpand(0, 5000)).toBe(false);
+  });
+
+  it("collapses deeply nested nodes even when small", () => {
+    expect(shouldAutoExpand(AUTO_EXPAND_MAX_DEPTH, 1)).toBe(true);
+    expect(shouldAutoExpand(AUTO_EXPAND_MAX_DEPTH + 1, 1)).toBe(false);
+  });
+
+  it("gives the root a larger entry budget than nested nodes", () => {
+    const between = AUTO_EXPAND_MAX_ITEMS + 1;
+    expect(shouldAutoExpand(0, between)).toBe(true);
+    expect(shouldAutoExpand(1, between)).toBe(false);
+  });
+
+  it("applies the depth and size guards together, not just one", () => {
+    // A node at the deepest allowed level still collapses if it is also large,
+    // so a deep-and-wide blob can't slip past on depth alone.
+    expect(shouldAutoExpand(AUTO_EXPAND_MAX_DEPTH, AUTO_EXPAND_MAX_ITEMS)).toBe(true);
+    expect(shouldAutoExpand(AUTO_EXPAND_MAX_DEPTH, AUTO_EXPAND_MAX_ITEMS + 1)).toBe(false);
+  });
+
+  it("treats empty nodes as expandable (the renderer short-circuits them anyway)", () => {
+    expect(shouldAutoExpand(0, 0)).toBe(true);
+    expect(shouldAutoExpand(5, 0)).toBe(true);
   });
 });

--- a/frontend/ui/src/features/traces/components/ContentRenderer.test.ts
+++ b/frontend/ui/src/features/traces/components/ContentRenderer.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { STRING_TRUNCATE_AT, shouldTruncate, truncateString } from "./json-render-utils";
+
+// These tests cover the pure truncation policy that backs the span I/O
+// renderer. The renderer collapses nested objects/arrays by default and hides
+// the tail of long strings behind a "show more" toggle so selecting a span
+// with a large (~300 KB) blob doesn't render thousands of expanded DOM nodes
+// up front. The vitest environment here is "node" (no DOM), so we assert the
+// policy rather than the rendered output.
+
+describe("shouldTruncate", () => {
+  it("leaves short strings untouched", () => {
+    expect(shouldTruncate("")).toBe(false);
+    expect(shouldTruncate("hello world")).toBe(false);
+    expect(shouldTruncate("x".repeat(STRING_TRUNCATE_AT))).toBe(false);
+  });
+
+  it("truncates strings longer than the threshold", () => {
+    expect(shouldTruncate("x".repeat(STRING_TRUNCATE_AT + 1))).toBe(true);
+    // A realistic large-blob field is well over the threshold.
+    expect(shouldTruncate("a".repeat(300_000))).toBe(true);
+  });
+});
+
+describe("truncateString", () => {
+  it("returns short strings unchanged", () => {
+    expect(truncateString("hello")).toBe("hello");
+  });
+
+  it("caps long strings at the threshold so the DOM payload stays bounded", () => {
+    const huge = "a".repeat(300_000);
+    const visible = truncateString(huge);
+    expect(visible.length).toBe(STRING_TRUNCATE_AT);
+    expect(huge.length).toBeGreaterThan(visible.length);
+  });
+
+  it("preserves the leading content that is shown while collapsed", () => {
+    const value = "PREFIX-" + "x".repeat(STRING_TRUNCATE_AT);
+    expect(truncateString(value).startsWith("PREFIX-")).toBe(true);
+    expect(truncateString(value).length).toBe(STRING_TRUNCATE_AT);
+  });
+});

--- a/frontend/ui/src/features/traces/components/ContentRenderer.test.ts
+++ b/frontend/ui/src/features/traces/components/ContentRenderer.test.ts
@@ -11,7 +11,7 @@ import {
 
 // These tests cover the pure policy that backs the span I/O renderer. The
 // renderer expands shallow/small objects by default but collapses deep or large
-// ones, and hides the tail of long strings behind a "show more" toggle, so
+// ones, and hides the tail of long strings behind an inline "…expand" toggle, so
 // selecting a span with a large (~300 KB) blob doesn't render thousands of
 // expanded DOM nodes up front while a normal span stays readable on first
 // paint. The vitest environment here is "node" (no DOM), so we assert the

--- a/frontend/ui/src/features/traces/components/ContentRenderer.tsx
+++ b/frontend/ui/src/features/traces/components/ContentRenderer.tsx
@@ -22,32 +22,19 @@ export function ContentRenderer({ content }: ContentRendererProps) {
     return <InlineMedia {...directMedia} />;
   }
 
-  // Try to parse as JSON
+  // Try to parse as JSON; on failure fall back to the raw text. Either way the
+  // value is rendered through JsonRenderer, which truncates long strings behind
+  // a "show more" toggle and starts nested objects collapsed so selecting a
+  // span with a large I/O blob doesn't flood the DOM on click.
+  let value: unknown = content;
   try {
-    const parsed = JSON.parse(content);
-    if (typeof parsed === "object" && parsed !== null) {
-      return (
-        <div className="font-mono text-[11px] leading-relaxed">
-          <JsonRenderer value={parsed} />
-        </div>
-      );
-    }
-    // If it's a primitive after parsing, just show it
-    const parsedMedia = typeof parsed === "string" ? mediaSrc(parsed) : null;
-    if (parsedMedia) {
-      return <InlineMedia {...parsedMedia} />;
-    }
-    return (
-      <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
-        {content}
-      </pre>
-    );
+    value = JSON.parse(content);
   } catch {
-    // Not valid JSON, show as plain text
-    return (
-      <pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed">
-        {content}
-      </pre>
-    );
+    // Not valid JSON — render the raw text.
   }
+  return (
+    <div className="font-mono text-[11px] leading-relaxed">
+      <JsonRenderer value={value} />
+    </div>
+  );
 }

--- a/frontend/ui/src/features/traces/components/JsonRenderer.tsx
+++ b/frontend/ui/src/features/traces/components/JsonRenderer.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 
 import { InlineMedia, mediaSrc } from "./inline-media";
-import { shouldTruncate, truncateString } from "./json-render-utils";
+import { shouldAutoExpand, shouldTruncate, truncateString } from "./json-render-utils";
 
 interface JsonRendererProps {
   value: unknown;
@@ -41,22 +41,25 @@ function TruncatableString({ value }: { value: string }) {
 }
 
 /**
- * A nested object/array rendered collapsed by default. The summary line shows
- * the bracket and entry count; clicking expands the children on demand so we
- * never render thousands of nested rows up front.
+ * A nested object/array. Shallow, small nodes start expanded (`defaultExpanded`)
+ * so a normal span's I/O is readable on first paint; deep or large nodes start
+ * collapsed, showing the bracket and entry count, and expand their children on
+ * demand so we never render thousands of nested rows up front.
  */
 function CollapsibleNode({
   open,
   close,
   count,
+  defaultExpanded,
   children,
 }: {
   open: string;
   close: string;
   count: number;
+  defaultExpanded: boolean;
   children: React.ReactNode;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(defaultExpanded);
 
   if (!expanded) {
     return (
@@ -74,8 +77,10 @@ function CollapsibleNode({
     );
   }
 
+  // Block container, not a <span>: the children wrapper below is a <div>, which
+  // is invalid nested inside an inline <span> and warns during hydration.
   return (
-    <span>
+    <div className="inline">
       <button
         type="button"
         onClick={() => setExpanded(false)}
@@ -85,16 +90,17 @@ function CollapsibleNode({
       </button>
       <div className="ml-3">{children}</div>
       <span className="text-muted-foreground">{close}</span>
-    </span>
+    </div>
   );
 }
 
 /**
  * Recursive JSON renderer with syntax highlighting.
  *
- * Long string values are truncated behind a toggle and nested objects/arrays
- * start collapsed, so selecting a span with a large I/O blob renders without a
- * main-thread stall instead of materializing the entire expanded tree at once.
+ * Long string values are truncated behind a toggle, and deep or large nested
+ * objects/arrays start collapsed (shallow, small ones stay expanded), so
+ * selecting a span with a large I/O blob renders without a main-thread stall
+ * instead of materializing the entire expanded tree at once.
  */
 export function JsonRenderer({ value, depth = 0 }: JsonRendererProps) {
   if (value === null) {
@@ -136,7 +142,12 @@ export function JsonRenderer({ value, depth = 0 }: JsonRendererProps) {
     }
 
     return (
-      <CollapsibleNode open="[" close="]" count={value.length}>
+      <CollapsibleNode
+        open="["
+        close="]"
+        count={value.length}
+        defaultExpanded={shouldAutoExpand(depth, value.length)}
+      >
         {value.map((item, index) => (
           <div key={index}>
             <JsonRenderer value={item} depth={depth + 1} />
@@ -154,7 +165,12 @@ export function JsonRenderer({ value, depth = 0 }: JsonRendererProps) {
     }
 
     return (
-      <CollapsibleNode open="{" close="}" count={keys.length}>
+      <CollapsibleNode
+        open="{"
+        close="}"
+        count={keys.length}
+        defaultExpanded={shouldAutoExpand(depth, keys.length)}
+      >
         {keys.map((key, index) => (
           <div key={key}>
             <span className="text-sky-600 dark:text-sky-400">{key}</span>

--- a/frontend/ui/src/features/traces/components/JsonRenderer.tsx
+++ b/frontend/ui/src/features/traces/components/JsonRenderer.tsx
@@ -3,7 +3,12 @@
 import { useState } from "react";
 
 import { InlineMedia, mediaSrc } from "./inline-media";
-import { shouldAutoExpand, shouldTruncate, truncateString } from "./json-render-utils";
+import {
+  STRING_TRUNCATE_AT,
+  shouldAutoExpand,
+  shouldTruncate,
+  truncateString,
+} from "./json-render-utils";
 
 interface JsonRendererProps {
   value: unknown;
@@ -11,13 +16,18 @@ interface JsonRendererProps {
 }
 
 /**
- * A long string value rendered with an inline "show more"/"show less" toggle.
- * Collapsed by default so a single very large field never floods the DOM.
+ * A long string value, truncated by default with a "…expand (N more characters)"
+ * control on its own line (blank line above) so it's easy to spot. Expand-only:
+ * there is no "collapse" affordance — the value re-collapses when the selected
+ * span/trace changes, because the renderer is keyed by selection at the panel.
+ * Truncated by default so a single very large field never floods the DOM. The
+ * control inherits the surrounding font size and has no underline.
  */
 function TruncatableString({ value }: { value: string }) {
   const [expanded, setExpanded] = useState(false);
 
-  if (!shouldTruncate(value)) {
+  // Full value once expanded, or when it was never long enough to truncate.
+  if (expanded || !shouldTruncate(value)) {
     return (
       <span className="whitespace-pre-wrap break-words text-green-700 dark:text-green-400">
         &quot;{value}&quot;
@@ -25,17 +35,22 @@ function TruncatableString({ value }: { value: string }) {
     );
   }
 
+  const hiddenCount = value.length - STRING_TRUNCATE_AT;
+
+  // The surrounding span is whitespace-pre-wrap, so the explicit newlines put
+  // the control on its own line, with a blank line above, to make it easy to spot.
   return (
     <span className="whitespace-pre-wrap break-words text-green-700 dark:text-green-400">
-      &quot;{expanded ? value : truncateString(value)}
-      {!expanded && <span className="text-muted-foreground">…</span>}&quot;
+      &quot;{truncateString(value)}
+      {"\n\n"}
       <button
         type="button"
-        onClick={() => setExpanded((prev) => !prev)}
-        className="ml-1 align-baseline text-[10px] text-muted-foreground underline-offset-2 hover:underline"
+        onClick={() => setExpanded(true)}
+        className="cursor-pointer align-baseline text-muted-foreground hover:text-foreground"
       >
-        {expanded ? "show less" : `show more (${value.length} chars)`}
+        ...expand ({hiddenCount} more characters)
       </button>
+      {"\n"}&quot;
     </span>
   );
 }
@@ -66,7 +81,7 @@ function CollapsibleNode({
       <button
         type="button"
         onClick={() => setExpanded(true)}
-        className="text-left align-baseline hover:underline"
+        className="cursor-pointer text-left align-baseline"
       >
         <span className="text-muted-foreground">{open}</span>
         <span className="mx-0.5 text-[10px] text-muted-foreground">
@@ -84,7 +99,7 @@ function CollapsibleNode({
       <button
         type="button"
         onClick={() => setExpanded(false)}
-        className="align-baseline text-muted-foreground hover:underline"
+        className="cursor-pointer align-baseline text-muted-foreground"
       >
         {open}
       </button>

--- a/frontend/ui/src/features/traces/components/JsonRenderer.tsx
+++ b/frontend/ui/src/features/traces/components/JsonRenderer.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import { useState } from "react";
+
 import { InlineMedia, mediaSrc } from "./inline-media";
+import { shouldTruncate, truncateString } from "./json-render-utils";
 
 interface JsonRendererProps {
   value: unknown;
@@ -8,7 +11,90 @@ interface JsonRendererProps {
 }
 
 /**
- * Recursive JSON renderer with syntax highlighting
+ * A long string value rendered with an inline "show more"/"show less" toggle.
+ * Collapsed by default so a single very large field never floods the DOM.
+ */
+function TruncatableString({ value }: { value: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!shouldTruncate(value)) {
+    return (
+      <span className="whitespace-pre-wrap break-words text-green-700 dark:text-green-400">
+        &quot;{value}&quot;
+      </span>
+    );
+  }
+
+  return (
+    <span className="whitespace-pre-wrap break-words text-green-700 dark:text-green-400">
+      &quot;{expanded ? value : truncateString(value)}
+      {!expanded && <span className="text-muted-foreground">…</span>}&quot;
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="ml-1 align-baseline text-[10px] text-muted-foreground underline-offset-2 hover:underline"
+      >
+        {expanded ? "show less" : `show more (${value.length} chars)`}
+      </button>
+    </span>
+  );
+}
+
+/**
+ * A nested object/array rendered collapsed by default. The summary line shows
+ * the bracket and entry count; clicking expands the children on demand so we
+ * never render thousands of nested rows up front.
+ */
+function CollapsibleNode({
+  open,
+  close,
+  count,
+  children,
+}: {
+  open: string;
+  close: string;
+  count: number;
+  children: React.ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="text-left align-baseline hover:underline"
+      >
+        <span className="text-muted-foreground">{open}</span>
+        <span className="mx-0.5 text-[10px] text-muted-foreground">
+          {count} {count === 1 ? "item" : "items"}
+        </span>
+        <span className="text-muted-foreground">{close}</span>
+      </button>
+    );
+  }
+
+  return (
+    <span>
+      <button
+        type="button"
+        onClick={() => setExpanded(false)}
+        className="align-baseline text-muted-foreground hover:underline"
+      >
+        {open}
+      </button>
+      <div className="ml-3">{children}</div>
+      <span className="text-muted-foreground">{close}</span>
+    </span>
+  );
+}
+
+/**
+ * Recursive JSON renderer with syntax highlighting.
+ *
+ * Long string values are truncated behind a toggle and nested objects/arrays
+ * start collapsed, so selecting a span with a large I/O blob renders without a
+ * main-thread stall instead of materializing the entire expanded tree at once.
  */
 export function JsonRenderer({ value, depth = 0 }: JsonRendererProps) {
   if (value === null) {
@@ -41,11 +127,7 @@ export function JsonRenderer({ value, depth = 0 }: JsonRendererProps) {
         // Not valid JSON, render as plain string
       }
     }
-    return (
-      <span className="whitespace-pre-wrap break-words text-green-700 dark:text-green-400">
-        &quot;{value}&quot;
-      </span>
-    );
+    return <TruncatableString value={value} />;
   }
 
   if (Array.isArray(value)) {
@@ -54,18 +136,14 @@ export function JsonRenderer({ value, depth = 0 }: JsonRendererProps) {
     }
 
     return (
-      <span>
-        <span className="text-muted-foreground">[</span>
-        <div className="ml-3">
-          {value.map((item, index) => (
-            <div key={index}>
-              <JsonRenderer value={item} depth={depth + 1} />
-              {index < value.length - 1 && <span className="text-muted-foreground">,</span>}
-            </div>
-          ))}
-        </div>
-        <span className="text-muted-foreground">]</span>
-      </span>
+      <CollapsibleNode open="[" close="]" count={value.length}>
+        {value.map((item, index) => (
+          <div key={index}>
+            <JsonRenderer value={item} depth={depth + 1} />
+            {index < value.length - 1 && <span className="text-muted-foreground">,</span>}
+          </div>
+        ))}
+      </CollapsibleNode>
     );
   }
 
@@ -76,20 +154,16 @@ export function JsonRenderer({ value, depth = 0 }: JsonRendererProps) {
     }
 
     return (
-      <span>
-        <span className="text-muted-foreground">{"{"}</span>
-        <div className="ml-3">
-          {keys.map((key, index) => (
-            <div key={key}>
-              <span className="text-sky-600 dark:text-sky-400">{key}</span>
-              <span className="text-muted-foreground">: </span>
-              <JsonRenderer value={(value as Record<string, unknown>)[key]} depth={depth + 1} />
-              {index < keys.length - 1 && <span className="text-muted-foreground">,</span>}
-            </div>
-          ))}
-        </div>
-        <span className="text-muted-foreground">{"}"}</span>
-      </span>
+      <CollapsibleNode open="{" close="}" count={keys.length}>
+        {keys.map((key, index) => (
+          <div key={key}>
+            <span className="text-sky-600 dark:text-sky-400">{key}</span>
+            <span className="text-muted-foreground">: </span>
+            <JsonRenderer value={(value as Record<string, unknown>)[key]} depth={depth + 1} />
+            {index < keys.length - 1 && <span className="text-muted-foreground">,</span>}
+          </div>
+        ))}
+      </CollapsibleNode>
     );
   }
 

--- a/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
@@ -70,14 +70,14 @@ function TraceCard({
           defaultOpen={true}
           onCopy={trace.input ? () => navigator.clipboard.writeText(trace.input!) : undefined}
         >
-          <ContentRenderer content={trace.input} />
+          <ContentRenderer key={trace.trace_id} content={trace.input} />
         </ExpandableSection>
         <ExpandableSection
           title="Output"
           defaultOpen={true}
           onCopy={trace.output ? () => navigator.clipboard.writeText(trace.output!) : undefined}
         >
-          <ContentRenderer content={trace.output} />
+          <ContentRenderer key={trace.trace_id} content={trace.output} />
         </ExpandableSection>
       </div>
     </div>

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -51,6 +51,10 @@ export function SpanInfoPanel({
     buildUrlWithFilters(basePath, { dateFilter, customStartDate, customEndDate, extraParams });
 
   const isTrace = selection.type === "trace";
+  // Identity of the current selection. Used to key the I/O renderers so their
+  // per-value "expand" state resets when you switch spans/traces (and persists
+  // within the same selection, e.g. across live updates).
+  const selectionId = isTrace ? trace.trace_id : selection.span.span_id;
   const name = isTrace ? trace.name : selection.span.name;
   const kind = isTrace ? "trace" : selection.span.span_kind;
   const duration = isTrace ? getTraceDuration(trace) : getSpanDuration(selection.span);
@@ -292,7 +296,7 @@ export function SpanInfoPanel({
           defaultOpen={true}
           onCopy={input ? () => copyToClipboard(input) : undefined}
         >
-          <ContentRenderer content={input} />
+          <ContentRenderer key={selectionId} content={input} />
         </ExpandableSection>
 
         {/* Output */}
@@ -301,7 +305,7 @@ export function SpanInfoPanel({
           defaultOpen={true}
           onCopy={output ? () => copyToClipboard(output) : undefined}
         >
-          <ContentRenderer content={output} />
+          <ContentRenderer key={selectionId} content={output} />
         </ExpandableSection>
 
         {/* Metadata */}
@@ -310,7 +314,7 @@ export function SpanInfoPanel({
           defaultOpen={true}
           onCopy={metadata ? () => copyToClipboard(metadata) : undefined}
         >
-          <ContentRenderer content={metadata} />
+          <ContentRenderer key={selectionId} content={metadata} />
         </ExpandableSection>
       </div>
     </div>

--- a/frontend/ui/src/features/traces/components/json-render-utils.ts
+++ b/frontend/ui/src/features/traces/components/json-render-utils.ts
@@ -1,17 +1,31 @@
 /**
- * Pure truncation policy for the span I/O renderer.
+ * Pure policy for the span I/O renderer.
  *
  * Long string values are truncated to a bounded prefix by default (revealed
- * behind a "show more" toggle), and nested objects/arrays start collapsed.
- * Together these keep a large (~300 KB) input/output blob from rendering
- * thousands of expanded DOM nodes up front, which is what janks the main
- * thread when a span is selected.
+ * behind a "show more" toggle). Nested objects/arrays are expanded by default
+ * at shallow depths / small sizes, and collapsed (rendered as `{ N items }`)
+ * once a node is deep or large. Together these keep a large (~300 KB)
+ * input/output blob from rendering thousands of expanded DOM nodes up front —
+ * what janks the main thread when a span is selected — while keeping a normal
+ * span's I/O readable on first paint without a click.
+ *
+ * (A future change will window very large expanded structures with
+ * virtualization; until then the size guards below bound the up-front cost.)
  *
  * Kept JSX-free so the policy can be unit-tested without a DOM environment.
  */
 
 /** Long string values are truncated to this many characters by default. */
-export const STRING_TRUNCATE_AT = 240;
+export const STRING_TRUNCATE_AT = 500;
+
+/** Deepest level expanded by default; deeper nodes start collapsed. */
+export const AUTO_EXPAND_MAX_DEPTH = 8;
+
+/** A nested node expands by default only if it has at most this many entries. */
+export const AUTO_EXPAND_MAX_ITEMS = 20;
+
+/** The root node is allowed to expand with more entries than a nested one. */
+export const AUTO_EXPAND_MAX_ITEMS_ROOT = 100;
 
 /** Whether a string value is long enough to be truncated by default. */
 export function shouldTruncate(value: string): boolean {
@@ -21,4 +35,21 @@ export function shouldTruncate(value: string): boolean {
 /** The leading portion of a string shown while collapsed. */
 export function truncateString(value: string): string {
   return value.length > STRING_TRUNCATE_AT ? value.slice(0, STRING_TRUNCATE_AT) : value;
+}
+
+/**
+ * Whether an object/array node should render expanded by default.
+ *
+ * "Smart expansion": shallow, small nodes open on first paint so a normal
+ * span's I/O is readable without a click, while deep or large nodes stay
+ * collapsed so a huge blob can't flood the DOM up front. The root
+ * (`depth === 0`) gets a higher entry budget since it's the one node the user
+ * always wants to see.
+ */
+export function shouldAutoExpand(depth: number, count: number): boolean {
+  if (depth > AUTO_EXPAND_MAX_DEPTH) {
+    return false;
+  }
+  const maxItems = depth === 0 ? AUTO_EXPAND_MAX_ITEMS_ROOT : AUTO_EXPAND_MAX_ITEMS;
+  return count <= maxItems;
 }

--- a/frontend/ui/src/features/traces/components/json-render-utils.ts
+++ b/frontend/ui/src/features/traces/components/json-render-utils.ts
@@ -2,7 +2,7 @@
  * Pure policy for the span I/O renderer.
  *
  * Long string values are truncated to a bounded prefix by default (revealed
- * behind a "show more" toggle). Nested objects/arrays are expanded by default
+ * behind an inline "…expand" toggle). Nested objects/arrays are expanded by default
  * at shallow depths / small sizes, and collapsed (rendered as `{ N items }`)
  * once a node is deep or large. Together these keep a large (~300 KB)
  * input/output blob from rendering thousands of expanded DOM nodes up front —

--- a/frontend/ui/src/features/traces/components/json-render-utils.ts
+++ b/frontend/ui/src/features/traces/components/json-render-utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure truncation policy for the span I/O renderer.
+ *
+ * Long string values are truncated to a bounded prefix by default (revealed
+ * behind a "show more" toggle), and nested objects/arrays start collapsed.
+ * Together these keep a large (~300 KB) input/output blob from rendering
+ * thousands of expanded DOM nodes up front, which is what janks the main
+ * thread when a span is selected.
+ *
+ * Kept JSX-free so the policy can be unit-tested without a DOM environment.
+ */
+
+/** Long string values are truncated to this many characters by default. */
+export const STRING_TRUNCATE_AT = 240;
+
+/** Whether a string value is long enough to be truncated by default. */
+export function shouldTruncate(value: string): boolean {
+  return value.length > STRING_TRUNCATE_AT;
+}
+
+/** The leading portion of a string shown while collapsed. */
+export function truncateString(value: string): string {
+  return value.length > STRING_TRUNCATE_AT ? value.slice(0, STRING_TRUNCATE_AT) : value;
+}


### PR DESCRIPTION
## What
Selecting a span with a large input/output/metadata blob used to render the **fully-expanded** JSON synchronously, janking the main thread.

`JsonRenderer` now bounds DOM cost without hiding the content you actually want to see:
- **Smart default expansion** — shallow, small objects/arrays render **expanded by default** (root ≤ 100 entries, nested ≤ 20, max depth 8) so a normal span's I/O is readable on first paint. Deep or large nodes start **collapsed** (`{ N items }` / `[ N items ]`) and mount their children only on click, so a ~300 KB blob no longer materializes thousands of nested DOM nodes up front.
- **Truncates** long string values (500 chars), with an inline **`...expand (N more characters)`** control on its own line (blank line above) so it's easy to spot. Expand-only — no "collapse" control; the value re-collapses when you switch selection (below). The control matches the surrounding font size and has no underline.

`ContentRenderer` routes raw/unparsed blobs through the same renderer so long primitive/text values are truncated too. The expansion + truncation policy is extracted to `json-render-utils.ts` (`shouldAutoExpand`, `shouldTruncate`, `truncateString`) for unit testing.

**Resets on selection change:** each `ContentRenderer` is keyed by the selected span/trace id, so per-value expand state resets when you switch spans/traces (and persists within the same selection, e.g. across live updates). This also fixes expand state leaking positionally between spans.

Also fixes invalid HTML in the expanded collapsible node (a `<div>` was nested inside a `<span>`, which warns during hydration) — the wrapper is now an inline `<div>`.

> Note: virtualization for genuinely huge expanded structures is tracked separately in #1060; until that lands, the size/depth guards above bound the up-front render cost.

## Screenshots

<img width="1717" height="934" alt="Screenshot 2026-06-04 at 12 39 40 PM" src="https://github.com/user-attachments/assets/29654ab1-fe78-4361-bd6f-b12659995e9c" />


## Tests
`ContentRenderer.test.ts` — 13 tests on the pure policy:
- **Truncation** — short strings untouched; over-threshold truncated (incl. a 300 KB blob); exact-threshold boundary; visible prefix bounded; never exceeds the threshold for any input.
- **Auto-expansion** — root/shallow-small nodes expand; large or deep nodes collapse; depth and size guards compose (a deep-and-wide node can't slip past on depth alone); root gets a larger entry budget than nested nodes.

Pure-function level; render-level (DOM click) assertions would need jsdom + Testing Library added to `frontend/ui` — noted as a follow-up (pairs naturally with #1060).

Closes #1042 · part of #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Truncate long strings and use smart collapsed/expanded defaults for JSON in the span I/O renderer to avoid main-thread jank on large blobs. Raw text uses the same renderer, and expand state resets when switching spans/traces (closes #1042; part of #1040).

- **New Features**
  - Long strings truncated at 500 chars with an expand-only “…expand (N more characters)” control on its own line; `ContentRenderer` always renders through `JsonRenderer`, keyed by span/trace id to reset expansion on selection change.
  - Objects/arrays auto-expand only when shallow/small (root ≤100 items, nested ≤20, max depth 8); large/deep nodes start collapsed and mount children on expand. Policy lives in `json-render-utils.ts` with unit tests.

<sup>Written for commit e286ba565767a96698dd569065f03156ccad180f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

