### PR TITLE
perf(ui): virtualize the span tree rendering (#1048)

### DIFF
--- a/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
@@ -6,7 +6,12 @@ import { CircleStop, CircleDollarSign } from "lucide-react";
 import { cn, formatDuration, formatTokens } from "@/lib/utils";
 import { SpanStatus, SpanKind } from "@traceroot/core";
 import { flattenTreeWithMetrics } from "../utils/timeline";
-import { TREE_LAYOUT, enrichSpansWithPending, getTraceDuration } from "../utils";
+import {
+  TREE_LAYOUT,
+  TREE_OVERSCAN_ROWS,
+  enrichSpansWithPending,
+  getTraceDuration,
+} from "../utils";
 import type { TraceDetail } from "@/types/api";
 import type { TraceSelection } from "../types";
 
@@ -130,7 +135,7 @@ export function SpanTimelineView({
     count: allRows.length,
     getScrollElement: () => scrollRef.current,
     estimateSize: () => ROW_HEIGHT,
-    overscan: 12,
+    overscan: TREE_OVERSCAN_ROWS,
   });
 
   return (

--- a/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { Span } from "@/types/api";
+import type { SpanTreeRow } from "../types";
+import { buildSpanTree } from "../utils";
+import { getVisibleSpanRows } from "./SpanTreeView";
+
+// Minimal span factory — only fields relevant to the tree row model.
+function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
+  return {
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: overrides.span_id,
+    span_kind: SpanKind.SPAN,
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:01.000Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    input: null,
+    output: null,
+    metadata: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...overrides,
+  };
+}
+
+// root → a → a1, a2 ; root → b
+function makeTree(): { spans: Span[]; spanById: Map<string, Span>; rows: SpanTreeRow[] } {
+  const spans = [
+    makeSpan({ span_id: "root" }),
+    makeSpan({ span_id: "a", parent_span_id: "root", span_start_time: "2024-01-01T00:00:00.100Z" }),
+    makeSpan({ span_id: "a1", parent_span_id: "a", span_start_time: "2024-01-01T00:00:00.200Z" }),
+    makeSpan({ span_id: "a2", parent_span_id: "a", span_start_time: "2024-01-01T00:00:00.300Z" }),
+    makeSpan({ span_id: "b", parent_span_id: "root", span_start_time: "2024-01-01T00:00:00.400Z" }),
+  ];
+  const spanById = new Map(spans.map((s) => [s.span_id, s]));
+  return { spans, spanById, rows: buildSpanTree(spans) };
+}
+
+describe("getVisibleSpanRows", () => {
+  it("returns all rows when nothing is collapsed", () => {
+    const { spanById, rows } = makeTree();
+    const visible = getVisibleSpanRows(rows, spanById, new Set());
+    expect(visible.map((r) => r.span.span_id)).toEqual(["root", "a", "a1", "a2", "b"]);
+  });
+
+  it("returns the same array reference when no ids are collapsed (fast path)", () => {
+    const { spanById, rows } = makeTree();
+    expect(getVisibleSpanRows(rows, spanById, new Set())).toBe(rows);
+  });
+
+  it("hides descendants of a collapsed span but keeps the collapsed span itself", () => {
+    const { spanById, rows } = makeTree();
+    const visible = getVisibleSpanRows(rows, spanById, new Set(["a"]));
+    expect(visible.map((r) => r.span.span_id)).toEqual(["root", "a", "b"]);
+  });
+
+  it("hides an entire deep subtree when an ancestor is collapsed", () => {
+    const { spanById, rows } = makeTree();
+    const visible = getVisibleSpanRows(rows, spanById, new Set(["root"]));
+    expect(visible.map((r) => r.span.span_id)).toEqual(["root"]);
+  });
+
+  it("preserves linearized DFS order of the remaining rows", () => {
+    const { spanById, rows } = makeTree();
+    const visible = getVisibleSpanRows(rows, spanById, new Set());
+    // a1 must precede a2, and a's subtree must precede sibling b
+    const ids = visible.map((r) => r.span.span_id);
+    expect(ids.indexOf("a1")).toBeLessThan(ids.indexOf("a2"));
+    expect(ids.indexOf("a2")).toBeLessThan(ids.indexOf("b"));
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
@@ -3,7 +3,8 @@ import { SpanKind, SpanStatus } from "@traceroot/core";
 import type { Span } from "@/types/api";
 import type { SpanTreeRow } from "../types";
 import { buildSpanTree } from "../utils";
-import { getVisibleSpanRows } from "./SpanTreeView";
+import { flattenTreeWithMetrics } from "../utils/timeline";
+import { getVisibleSpanRows, buildTreeRows } from "./SpanTreeView";
 
 // Minimal span factory — only fields relevant to the tree row model.
 function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
@@ -75,5 +76,80 @@ describe("getVisibleSpanRows", () => {
     const ids = visible.map((r) => r.span.span_id);
     expect(ids.indexOf("a1")).toBeLessThan(ids.indexOf("a2"));
     expect(ids.indexOf("a2")).toBeLessThan(ids.indexOf("b"));
+  });
+});
+
+// Maps the virtualized row model to a flat id list ("trace" for the root row)
+// so index assertions read clearly.
+const rowIds = (treeRows: ReturnType<typeof buildTreeRows>) =>
+  treeRows.map((r) => (r.type === "trace" ? "trace" : r.row.span.span_id));
+
+describe("buildTreeRows", () => {
+  it("places the trace root at index 0, with spans following in DFS order", () => {
+    const { spanById, rows } = makeTree();
+    const treeRows = buildTreeRows(rows, spanById, new Set());
+    expect(treeRows[0]).toEqual({ type: "trace" });
+    expect(rowIds(treeRows)).toEqual(["trace", "root", "a", "a1", "a2", "b"]);
+  });
+
+  it("drops descendants of a collapsed span", () => {
+    const { spanById, rows } = makeTree();
+    expect(rowIds(buildTreeRows(rows, spanById, new Set(["a"])))).toEqual([
+      "trace",
+      "root",
+      "a",
+      "b",
+    ]);
+  });
+
+  it("yields only the trace row when the trace root is collapsed", () => {
+    const { spanById, rows } = makeTree();
+    expect(buildTreeRows(rows, spanById, new Set(["trace"]))).toEqual([{ type: "trace" }]);
+  });
+
+  it("locates a span's virtualizer index past the trace-root offset", () => {
+    const { spanById, rows } = makeTree();
+    const treeRows = buildTreeRows(rows, spanById, new Set());
+    // scrollToSpan uses exactly this findIndex; "a" sits at [trace, root, a, ...]
+    const index = treeRows.findIndex((r) => r.type === "span" && r.row.span.span_id === "a");
+    expect(index).toBe(2);
+  });
+
+  it("returns -1 for a span hidden under a collapsed ancestor", () => {
+    const { spanById, rows } = makeTree();
+    const treeRows = buildTreeRows(rows, spanById, new Set(["a"]));
+    const index = treeRows.findIndex((r) => r.type === "span" && r.row.span.span_id === "a1");
+    expect(index).toBe(-1);
+  });
+});
+
+// The tree (buildTreeRows) and the timeline (flattenTreeWithMetrics) flatten the
+// same spans through two independent code paths but are rendered scroll-synced,
+// row-for-row. If their visible-span ORDER ever diverges the panels misalign
+// silently. This locks the invariant so a regression is a CI failure, not a
+// visual bug. (Trace-root collapse is handled per-panel, not in the flatteners,
+// so it is intentionally excluded here.)
+describe("buildTreeRows ↔ flattenTreeWithMetrics ordering parity", () => {
+  const visibleSpanIds = (collapsed: Set<string>) => {
+    const { spans, spanById, rows } = makeTree();
+    const treeIds = buildTreeRows(rows, spanById, collapsed).flatMap((r) =>
+      r.type === "span" ? [r.row.span.span_id] : [],
+    );
+    const timelineIds = flattenTreeWithMetrics(spans, collapsed, 1000, 800).map(
+      (item) => item.span.span_id,
+    );
+    return { treeIds, timelineIds };
+  };
+
+  it("agree on visible span order with nothing collapsed", () => {
+    const { treeIds, timelineIds } = visibleSpanIds(new Set());
+    expect(treeIds).toEqual(timelineIds);
+    expect(treeIds).toEqual(["root", "a", "a1", "a2", "b"]);
+  });
+
+  it("agree on visible span order when a subtree is collapsed", () => {
+    const { treeIds, timelineIds } = visibleSpanIds(new Set(["a"]));
+    expect(treeIds).toEqual(timelineIds);
+    expect(treeIds).toEqual(["root", "a", "b"]);
   });
 });

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { forwardRef, useImperativeHandle, useMemo } from "react";
+import type { RefObject } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronRight, ChevronDown, CircleStop, CircleDollarSign } from "lucide-react";
 import { cn, formatDuration, formatTokens } from "@/lib/utils";
@@ -16,20 +17,18 @@ import {
   getTraceTotalCost,
   getTraceTokenUsage,
   TREE_LAYOUT,
+  TREE_OVERSCAN_ROWS,
 } from "../utils";
 import { SpanKindIcon } from "./SpanKindIcon";
 import { SpanTreeConnector } from "./SpanTreeConnector";
 
 const ROW_HEIGHT = TREE_LAYOUT.ROW_HEIGHT;
 
-// Overscan is measured in rows; ~500px of buffer above/below the viewport keeps
-// scrolling smooth on large traces (500 / 28px ≈ 18 rows).
-const OVERSCAN_ROWS = Math.ceil(500 / ROW_HEIGHT);
-
 // Virtualized row model: the trace root occupies index 0, visible spans follow.
-// This ordering must stay in sync with the parent's scroll-to-row math
-// (TraceViewerPanel.scrollTreeToRow uses rowIdx + 1 to skip the trace row).
-type TreeRow = { type: "trace" } | { type: "span"; row: SpanTreeRow };
+// This list is the single source of truth for both the virtualizer count and
+// the span→index mapping behind scroll-to-selected (see `scrollToSpan`), so no
+// row-height math lives in the parent anymore.
+export type TreeRow = { type: "trace" } | { type: "span"; row: SpanTreeRow };
 
 /**
  * Returns the flattened span rows that are currently visible, i.e. none of
@@ -52,6 +51,31 @@ export function getVisibleSpanRows(
   });
 }
 
+/**
+ * Builds the full virtualized row model: the trace root at index 0 followed by
+ * the collapse-filtered span rows in DFS order. When the trace root itself is
+ * collapsed, only the root row remains. Pure so the row model — and the
+ * span→index mapping that drives scroll-to-selected — can be unit-tested.
+ *
+ * The visible-span ORDER here must stay identical to SpanTimelineView's
+ * `flattenTreeWithMetrics`: the two panels are scroll-synced row-for-row, so any
+ * divergence silently misaligns them. A parity test guards this (SpanTreeView.test.ts).
+ */
+export function buildTreeRows(
+  spanRows: SpanTreeRow[],
+  spanById: Map<string, Span>,
+  collapsedIds: Set<string>,
+): TreeRow[] {
+  if (collapsedIds.has("trace")) return [{ type: "trace" }];
+  return [
+    { type: "trace" },
+    ...getVisibleSpanRows(spanRows, spanById, collapsedIds).map((row) => ({
+      type: "span" as const,
+      row,
+    })),
+  ];
+}
+
 interface SpanTreeViewProps {
   trace: TraceDetail;
   selection: TraceSelection;
@@ -61,6 +85,16 @@ interface SpanTreeViewProps {
   compact?: boolean;
   hoveredSpanId: string | null;
   onHoverChange: (id: string | null) => void;
+  /** The overflow-y-auto scroll container owned by TraceViewerPanel. */
+  scrollRef: RefObject<HTMLDivElement | null>;
+}
+
+export interface SpanTreeViewHandle {
+  /**
+   * Scroll the row for `spanId` into view, centered. No-op when the span is not
+   * currently visible (an ancestor is collapsed) or not present in the trace.
+   */
+  scrollToSpan: (spanId: string) => void;
 }
 
 /**
@@ -70,19 +104,23 @@ interface SpanTreeViewProps {
  *
  * Rows are virtualized: only the rows in (or near) the viewport are mounted, so
  * traces with many hundreds of spans stay responsive. The scroll container is
- * the overflow-y-auto wrapper owned by TraceViewerPanel, resolved here as this
- * component's parent element.
+ * the overflow-y-auto wrapper owned by TraceViewerPanel, passed in via the
+ * `scrollRef` prop (mirroring SpanTimelineView).
  */
-export function SpanTreeView({
-  trace,
-  selection,
-  onSelect,
-  collapsedIds,
-  onToggleCollapse,
-  compact = false,
-  hoveredSpanId,
-  onHoverChange,
-}: SpanTreeViewProps) {
+export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(function SpanTreeView(
+  {
+    trace,
+    selection,
+    onSelect,
+    collapsedIds,
+    onToggleCollapse,
+    compact = false,
+    hoveredSpanId,
+    onHoverChange,
+    scrollRef,
+  },
+  ref,
+) {
   // Enrich with placeholder spans for any missing ancestors — handles both
   // live-streaming gaps (parent not yet arrived) and permanently dropped spans.
   const spans = useMemo(() => enrichSpansWithPending(trace.spans), [trace.spans]);
@@ -107,37 +145,37 @@ export function SpanTreeView({
   const traceHasChildren = hasChildren(null);
   const traceIsCollapsed = collapsedIds.has("trace");
 
-  // Flattened, collapse-filtered row list. Index 0 is always the trace root;
-  // when the trace is collapsed its descendants are omitted entirely.
-  const visibleSpanRows = useMemo(
-    () => getVisibleSpanRows(spanRows, spanById, collapsedIds),
+  // Full virtualized row model: trace root at index 0, then collapse-filtered
+  // span rows in DFS order. Single source of truth for both the virtualizer
+  // count and the span→index mapping used by scrollToSpan.
+  const allRows = useMemo(
+    () => buildTreeRows(spanRows, spanById, collapsedIds),
     [spanRows, spanById, collapsedIds],
   );
-  const allRows = useMemo<TreeRow[]>(
-    () => [
-      { type: "trace" },
-      ...(traceIsCollapsed ? [] : visibleSpanRows.map((row) => ({ type: "span" as const, row }))),
-    ],
-    [traceIsCollapsed, visibleSpanRows],
-  );
-
-  // The scroll element is the overflow-y-auto wrapper owned by the parent
-  // (TraceViewerPanel). Resolve it from our own parent node via a ref callback
-  // so the virtualizer re-measures once the node is attached.
-  const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null);
-  const rootRefCallback = useCallback((node: HTMLDivElement | null) => {
-    setScrollEl(node?.parentElement ?? null);
-  }, []);
 
   const rowVirtualizer = useVirtualizer({
     count: allRows.length,
-    getScrollElement: () => scrollEl,
+    getScrollElement: () => scrollRef.current,
     estimateSize: () => ROW_HEIGHT,
-    overscan: OVERSCAN_ROWS,
+    overscan: TREE_OVERSCAN_ROWS,
   });
 
+  // Imperative scroll-to-selected, invoked when a timeline click switches back
+  // to the tree. Delegates to the virtualizer (height-agnostic) instead of the
+  // old manual scrollTop math, and centers the row to match prior behaviour.
+  useImperativeHandle(
+    ref,
+    () => ({
+      scrollToSpan: (spanId: string) => {
+        const index = allRows.findIndex((r) => r.type === "span" && r.row.span.span_id === spanId);
+        if (index !== -1) rowVirtualizer.scrollToIndex(index, { align: "center" });
+      },
+    }),
+    [allRows, rowVirtualizer],
+  );
+
   return (
-    <div ref={rootRefCallback} className="relative min-w-0">
+    <div className="relative min-w-0">
       <div
         style={{
           height: `${rowVirtualizer.getTotalSize()}px`,
@@ -313,4 +351,4 @@ export function SpanTreeView({
       </div>
     </div>
   );
-}
+});

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import { ChevronRight, ChevronDown, CircleStop, CircleDollarSign } from "lucide-react";
 import { cn, formatDuration, formatTokens } from "@/lib/utils";
 import { SpanKind, SpanStatus } from "@traceroot/core";
 import type { TraceDetail, Span } from "@/types/api";
-import type { TraceSelection } from "../types";
+import type { TraceSelection, SpanTreeRow } from "../types";
 import {
   buildSpanTree,
   buildChildrenMap,
@@ -18,6 +19,38 @@ import {
 } from "../utils";
 import { SpanKindIcon } from "./SpanKindIcon";
 import { SpanTreeConnector } from "./SpanTreeConnector";
+
+const ROW_HEIGHT = TREE_LAYOUT.ROW_HEIGHT;
+
+// Overscan is measured in rows; ~500px of buffer above/below the viewport keeps
+// scrolling smooth on large traces (500 / 28px ≈ 18 rows).
+const OVERSCAN_ROWS = Math.ceil(500 / ROW_HEIGHT);
+
+// Virtualized row model: the trace root occupies index 0, visible spans follow.
+// This ordering must stay in sync with the parent's scroll-to-row math
+// (TraceViewerPanel.scrollTreeToRow uses rowIdx + 1 to skip the trace row).
+type TreeRow = { type: "trace" } | { type: "span"; row: SpanTreeRow };
+
+/**
+ * Returns the flattened span rows that are currently visible, i.e. none of
+ * their ancestors are collapsed. Kept pure (no React) so the row model can be
+ * unit-tested and so the virtualizer count matches exactly what is rendered.
+ */
+export function getVisibleSpanRows(
+  spanRows: SpanTreeRow[],
+  spanById: Map<string, Span>,
+  collapsedIds: Set<string>,
+): SpanTreeRow[] {
+  if (collapsedIds.size === 0) return spanRows;
+  return spanRows.filter(({ span }) => {
+    let currentId = span.parent_span_id;
+    while (currentId) {
+      if (collapsedIds.has(currentId)) return false;
+      currentId = spanById.get(currentId)?.parent_span_id || null;
+    }
+    return true;
+  });
+}
 
 interface SpanTreeViewProps {
   trace: TraceDetail;
@@ -34,6 +67,11 @@ interface SpanTreeViewProps {
  * Tree view component for displaying trace and span hierarchy.
  * Collapse state is managed externally (lifted to TraceViewerPanel) so it can
  * be shared with the timeline bars view for scroll-sync and row alignment.
+ *
+ * Rows are virtualized: only the rows in (or near) the viewport are mounted, so
+ * traces with many hundreds of spans stay responsive. The scroll container is
+ * the overflow-y-auto wrapper owned by TraceViewerPanel, resolved here as this
+ * component's parent element.
  */
 export function SpanTreeView({
   trace,
@@ -62,15 +100,6 @@ export function SpanTreeView({
     onToggleCollapse(spanId);
   };
 
-  const isVisible = (span: Span): boolean => {
-    let currentId = span.parent_span_id;
-    while (currentId) {
-      if (collapsedIds.has(currentId)) return false;
-      currentId = spanById.get(currentId)?.parent_span_id || null;
-    }
-    return true;
-  };
-
   const isTraceSelected = selection.type === "trace";
   const traceDuration = getTraceDuration(trace);
   const traceTotalCost = getTraceTotalCost(trace);
@@ -78,69 +107,116 @@ export function SpanTreeView({
   const traceHasChildren = hasChildren(null);
   const traceIsCollapsed = collapsedIds.has("trace");
 
+  // Flattened, collapse-filtered row list. Index 0 is always the trace root;
+  // when the trace is collapsed its descendants are omitted entirely.
+  const visibleSpanRows = useMemo(
+    () => getVisibleSpanRows(spanRows, spanById, collapsedIds),
+    [spanRows, spanById, collapsedIds],
+  );
+  const allRows = useMemo<TreeRow[]>(
+    () => [
+      { type: "trace" },
+      ...(traceIsCollapsed ? [] : visibleSpanRows.map((row) => ({ type: "span" as const, row }))),
+    ],
+    [traceIsCollapsed, visibleSpanRows],
+  );
+
+  // The scroll element is the overflow-y-auto wrapper owned by the parent
+  // (TraceViewerPanel). Resolve it from our own parent node via a ref callback
+  // so the virtualizer re-measures once the node is attached.
+  const [scrollEl, setScrollEl] = useState<HTMLElement | null>(null);
+  const rootRefCallback = useCallback((node: HTMLDivElement | null) => {
+    setScrollEl(node?.parentElement ?? null);
+  }, []);
+
+  const rowVirtualizer = useVirtualizer({
+    count: allRows.length,
+    getScrollElement: () => scrollEl,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: OVERSCAN_ROWS,
+  });
+
   return (
-    <div className="relative min-w-0">
-      {/* Trace row */}
+    <div ref={rootRefCallback} className="relative min-w-0">
       <div
-        className={cn(
-          "flex cursor-pointer items-center border-b border-border/5 transition-colors hover:bg-muted/50",
-          hoveredSpanId === "trace" && "bg-muted/60",
-          isTraceSelected && "bg-muted/60",
-        )}
-        style={{ height: TREE_LAYOUT.ROW_HEIGHT, paddingLeft: TREE_LAYOUT.LEFT_PADDING }}
-        onClick={() => onSelect({ type: "trace" })}
-        onMouseEnter={() => onHoverChange("trace")}
-        onMouseLeave={() => onHoverChange(null)}
+        style={{
+          height: `${rowVirtualizer.getTotalSize()}px`,
+          width: "100%",
+          position: "relative",
+        }}
       >
-        <div className="flex min-w-0 flex-1 items-center gap-1.5 pr-2">
-          <SpanKindIcon kind="trace" inTree />
-          <span className="min-w-0 shrink truncate text-xs font-medium">{trace.name}</span>
+        {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+          const rowData = allRows[virtualRow.index];
+          const rowStyle: React.CSSProperties = {
+            position: "absolute",
+            top: 0,
+            left: 0,
+            width: "100%",
+            height: virtualRow.size,
+            transform: `translateY(${virtualRow.start}px)`,
+          };
 
-          {/* Always render the flex-1 container to lock the gap math, but conditionally render contents */}
-          <div className="flex min-w-0 flex-1 items-center justify-start gap-1.5 @container">
-            {!compact && (
-              <>
-                <span className="hidden shrink-0 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[45px]:inline-flex">
-                  {formatDuration(traceDuration)}
-                </span>
-
-                {traceTokenUsage && (
-                  <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[80px]:inline-flex">
-                    <CircleStop className="h-2.5 w-2.5" />
-                    {formatTokens(traceTokenUsage.totalTokens)}
-                  </span>
+          if (rowData.type === "trace") {
+            return (
+              <div
+                key="trace"
+                className={cn(
+                  "flex cursor-pointer items-center border-b border-border/5 transition-colors hover:bg-muted/50",
+                  hoveredSpanId === "trace" && "bg-muted/60",
+                  isTraceSelected && "bg-muted/60",
                 )}
+                style={{ ...rowStyle, paddingLeft: TREE_LAYOUT.LEFT_PADDING }}
+                onClick={() => onSelect({ type: "trace" })}
+                onMouseEnter={() => onHoverChange("trace")}
+                onMouseLeave={() => onHoverChange(null)}
+              >
+                <div className="flex min-w-0 flex-1 items-center gap-1.5 pr-2">
+                  <SpanKindIcon kind="trace" inTree />
+                  <span className="min-w-0 shrink truncate text-xs font-medium">{trace.name}</span>
 
-                {traceTotalCost != null && (
-                  <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[130px]:inline-flex">
-                    <CircleDollarSign className="h-2.5 w-2.5" />
-                    {traceTotalCost.toFixed(4)}
-                  </span>
-                )}
-              </>
-            )}
-          </div>
+                  {/* Always render the flex-1 container to lock the gap math, but conditionally render contents */}
+                  <div className="flex min-w-0 flex-1 items-center justify-start gap-1.5 @container">
+                    {!compact && (
+                      <>
+                        <span className="hidden shrink-0 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[45px]:inline-flex">
+                          {formatDuration(traceDuration)}
+                        </span>
 
-          {traceHasChildren && (
-            <button
-              onClick={(e) => toggleCollapse("trace", e)}
-              className="shrink-0 rounded p-0.5 transition-colors hover:bg-muted"
-            >
-              {traceIsCollapsed ? (
-                <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-              ) : (
-                <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-              )}
-            </button>
-          )}
-        </div>
-      </div>
+                        {traceTokenUsage && (
+                          <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[80px]:inline-flex">
+                            <CircleStop className="h-2.5 w-2.5" />
+                            {formatTokens(traceTokenUsage.totalTokens)}
+                          </span>
+                        )}
 
-      {/* Span rows */}
-      {!traceIsCollapsed &&
-        spanRows.map(({ span, level, isTerminal, parentLevels }) => {
-          if (!isVisible(span)) return null;
+                        {traceTotalCost != null && (
+                          <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[130px]:inline-flex">
+                            <CircleDollarSign className="h-2.5 w-2.5" />
+                            {traceTotalCost.toFixed(4)}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </div>
 
+                  {traceHasChildren && (
+                    <button
+                      onClick={(e) => toggleCollapse("trace", e)}
+                      className="shrink-0 rounded p-0.5 transition-colors hover:bg-muted"
+                    >
+                      {traceIsCollapsed ? (
+                        <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+                      ) : (
+                        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+                      )}
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          }
+
+          const { span, level, isTerminal, parentLevels } = rowData.row;
           const isSelected = selection.type === "span" && selection.span.span_id === span.span_id;
           const adjustedLevel = level + 1;
           const adjustedParentLevels = parentLevels.map((l) => l + 1);
@@ -151,11 +227,11 @@ export function SpanTreeView({
             <div
               key={span.span_id}
               className={cn(
-                "group relative flex w-full cursor-pointer items-center border-b border-border/5 transition-colors",
+                "group flex cursor-pointer items-center border-b border-border/5 transition-colors",
                 hoveredSpanId === span.span_id ? "bg-muted/60" : "bg-transparent",
                 isSelected && "bg-muted/80",
               )}
-              style={{ height: TREE_LAYOUT.ROW_HEIGHT }}
+              style={rowStyle}
               onMouseEnter={(e) => {
                 e.stopPropagation();
                 onHoverChange(span.span_id);
@@ -234,6 +310,7 @@ export function SpanTreeView({
             </div>
           );
         })}
+      </div>
     </div>
   );
 }

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -15,15 +15,14 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { getTrace } from "@/lib/api";
-import type { Span } from "@/types/api";
 import type { TraceSelection } from "../types";
-import { SpanTreeView } from "./SpanTreeView";
+import { SpanTreeView, type SpanTreeViewHandle } from "./SpanTreeView";
 import { SpanInfoPanel } from "./SpanInfoPanel";
 import { useLayout } from "@/components/layout/app-layout";
 import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
 import { useTraceStream } from "../hooks/use-trace-stream";
 import { SpanTimelineView } from "./SpanTimelineView";
-import { buildSpanTree, enrichSpansWithPending, TREE_LAYOUT } from "../utils";
+import { TREE_LAYOUT } from "../utils";
 import { useTraceFindings, useRca } from "@/features/detectors/hooks/use-findings";
 
 interface TraceViewerPanelProps {
@@ -83,6 +82,9 @@ export function TraceViewerPanel({
   const treeScrollRef = useRef<HTMLDivElement>(null);
   const timelineScrollRef = useRef<HTMLDivElement>(null);
   const isSyncing = useRef(false);
+  // Imperative handle so a timeline click can scroll the tree to the span;
+  // the tree owns the virtualizer and resolves the row index itself.
+  const treeViewRef = useRef<SpanTreeViewHandle>(null);
 
   const [hoveredSpanId, setHoveredSpanId] = useState<string | null>(null);
 
@@ -139,49 +141,22 @@ export function TraceViewerPanel({
     });
   }, []);
 
-  // Scroll the tree panel to bring a row index into view (centered).
-  const scrollTreeToRow = useCallback((rowIndex: number) => {
-    const el = treeScrollRef.current;
-    if (!el) return;
-    const target = rowIndex * TREE_LAYOUT.ROW_HEIGHT;
-    const center = target - el.clientHeight / 2 + TREE_LAYOUT.ROW_HEIGHT / 2;
-    el.scrollTop = Math.max(0, center);
-  }, []);
-
-  const isSpanVisible = useCallback(
-    (span: Span, spanById: Map<string, Span>) => {
-      let currentId = span.parent_span_id;
-      while (currentId) {
-        if (collapsedIds.has(currentId)) return false;
-        currentId = spanById.get(currentId)?.parent_span_id ?? null;
-      }
-      return true;
-    },
-    [collapsedIds],
-  );
-
   /**
    * Called when the user clicks a bar in the timeline.
-   * Switches to tree mode so the user lands on the full span details view.
-   * Also scrolls the tree to show the selected span.
+   * Switches to tree mode so the user lands on the full span details view, then
+   * scrolls the tree to the selected span. The tree owns the virtualized row
+   * model, so it resolves the span's index and scroll position itself — this
+   * panel no longer duplicates the collapse-visibility walk or row-height math.
    */
-  const handleTimelineSelect = useCallback(
-    (sel: TraceSelection) => {
-      setSelection(sel);
-      setViewMode("tree");
-      if (sel.type === "span" && trace) {
-        const spans = enrichSpansWithPending(trace.spans);
-        const spanById = new Map(spans.map((s) => [s.span_id, s]));
-        const rows = buildSpanTree(spans).filter((row) => isSpanVisible(row.span, spanById));
-        const rowIdx = rows.findIndex((r) => r.span.span_id === sel.span.span_id);
-        if (rowIdx !== -1) {
-          // +1 because row 0 in the tree is the trace root
-          requestAnimationFrame(() => scrollTreeToRow(rowIdx + 1));
-        }
-      }
-    },
-    [trace, scrollTreeToRow, isSpanVisible],
-  );
+  const handleTimelineSelect = useCallback((sel: TraceSelection) => {
+    setSelection(sel);
+    setViewMode("tree");
+    if (sel.type === "span") {
+      // Defer a frame so the tree has its up-to-date (non-compact) row model
+      // before the virtualizer scrolls.
+      requestAnimationFrame(() => treeViewRef.current?.scrollToSpan(sel.span.span_id));
+    }
+  }, []);
 
   // Sync tree scroll → timeline
   const handleTreeScroll = useCallback(() => {
@@ -322,7 +297,9 @@ export function TraceViewerPanel({
             <div ref={treeScrollRef} className="flex-1 overflow-y-auto" onScroll={handleTreeScroll}>
               {trace && (
                 <SpanTreeView
+                  ref={treeViewRef}
                   trace={trace}
+                  scrollRef={treeScrollRef}
                   selection={selection}
                   onSelect={viewMode === "tree" ? setSelection : handleTimelineSelect}
                   collapsedIds={collapsedIds}

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -103,6 +103,12 @@ export const TREE_LAYOUT = {
   LEFT_PADDING: 8, // Left padding before first icon
 } as const;
 
+// Row overscan shared by both virtualized views (SpanTreeView + SpanTimelineView).
+// ~500px of buffer above/below the viewport keeps scrolling smooth on large
+// traces (500 / 28px ≈ 18 rows). Shared so the two scroll-synced, row-aligned
+// panels render the same buffer and never drift.
+export const TREE_OVERSCAN_ROWS = Math.ceil(500 / TREE_LAYOUT.ROW_HEIGHT);
+
 /**
  * Calculate span duration in milliseconds.
  * In-progress spans (no end_time) measure against now() so live bars grow.

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -103,11 +103,14 @@ export const TREE_LAYOUT = {
   LEFT_PADDING: 8, // Left padding before first icon
 } as const;
 
-// Row overscan shared by both virtualized views (SpanTreeView + SpanTimelineView).
-// ~500px of buffer above/below the viewport keeps scrolling smooth on large
-// traces (500 / 28px ≈ 18 rows). Shared so the two scroll-synced, row-aligned
-// panels render the same buffer and never drift.
-export const TREE_OVERSCAN_ROWS = Math.ceil(500 / TREE_LAYOUT.ROW_HEIGHT);
+// Row overscan: how many rows @tanstack/react-virtual renders beyond the
+// viewport on each side. Shared by both virtualized views (SpanTreeView +
+// SpanTimelineView) so the scroll-synced, row-aligned panels buffer identically
+// and never drift. A larger buffer means fewer blank-row flashes during fast /
+// momentum scrolling, at a small extra-DOM cost — and rows here are fixed-height
+// and cheap (~18 nodes each), so we keep a generous buffer. 26 rows ≈ 730px,
+// past the point of visible flashing on a quick fling.
+export const TREE_OVERSCAN_ROWS = 26;
 
 /**
  * Calculate span duration in milliseconds.

--- a/frontend/ui/src/features/traces/utils/timeline.ts
+++ b/frontend/ui/src/features/traces/utils/timeline.ts
@@ -17,6 +17,19 @@ export interface FlatTimelineItem {
 /**
  * Flattens a flat array of spans into a DFS-ordered list for virtualized rendering,
  * pre-computing pixel offsets and widths for the Gantt bars.
+ *
+ * The visible-span ORDER produced here must stay identical to SpanTreeView's
+ * `buildTreeRows`/`getVisibleSpanRows` — the timeline and tree panels are
+ * scroll-synced row-for-row, so any divergence in which spans are emitted (or
+ * their order) silently misaligns them. The collapse skip below mirrors the
+ * tree's ancestor-collapse filter, and a parity test guards it in
+ * SpanTreeView.test.ts.
+ *
+ * TODO: unify this visible-span derivation with SpanTreeView's
+ * getVisibleSpanRows/buildTreeRows so the collapse logic lives in one place.
+ * Deferred because this flattener also computes pixel metrics and works on raw
+ * Span[] (not SpanTreeRow[]), so the merge is non-trivial. The parity test
+ * protects the invariant until then.
  */
 export function flattenTreeWithMetrics(
   spans: Span[],


### PR DESCRIPTION
## What
The span **tree** rendered every row to the DOM (only the timeline view was virtualized). Apply `@tanstack/react-virtual` (reusing the timeline view's setup) so only viewport-adjacent rows mount, with ~500px overscan.

- Collapse-aware visible-row computation extracted to `getVisibleSpanRows(...)` so the virtualizer's `count` exactly matches the rendered rows (collapsed subtrees drop from both DOM and scroll height).
- Preserved: expand/collapse, **scroll-to-selected**, indentation/connectors, tree↔timeline toggle, selection/hover.


## Screenshots

<img width="1657" height="850" alt="Screenshot 2026-06-04 at 2 11 55 PM" src="https://github.com/user-attachments/assets/0c911e36-8196-45d1-9f3f-2186bbaed9fb" />

## Tests
`SpanTreeView.test.ts` — 5 tests for `getVisibleSpanRows` (all-visible; collapse hides descendants but keeps the node; deep-ancestor collapse; DFS order). `tsc --noEmit` clean.

## Follow-up note
The scroll container is currently resolved via `node.parentElement` (this change couldn't touch `TraceViewerPanel.tsx`). A cleaner shape is to pass a `scrollRef` prop like the timeline view does — natural to fold in when #1046/#1047 touch this file.

Closes #1048 · part of #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Virtualized the span tree with `@tanstack/react-virtual` and unified collapse/scroll logic so only visible rows mount and scroll-to-selected is precise. Closes #1048 and keeps the tree and timeline aligned with a shared 26-row overscan.

- **Refactors**
  - Added pure `getVisibleSpanRows(...)` and `buildTreeRows(...)` as the single source of visible rows; removed duplicate visibility logic from `TraceViewerPanel`.
  - `SpanTreeView` now takes a `scrollRef` and exposes `scrollToSpan(...)` (uses the virtualizer to center the row), replacing manual scrollTop math in the parent.
  - Shared `TREE_OVERSCAN_ROWS = 26` across tree and timeline to reduce blank-row flashes and keep buffers in sync; `SpanTimelineView` now uses it.
  - Tests: added `buildTreeRows` cases and a tree↔timeline ordering parity test; expanded `SpanTreeView.test.ts`.

<sup>Written for commit 252eb55edeb36b55348af7c85037f2addc46bb1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

