### PR TITLE
perf(api): two phase trace detail, skeleton response + per span I/O endpoint

### DIFF
--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -91,4 +91,3 @@ async def get_span_io(
         )
 
     return result
-

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from fastapi import APIRouter, HTTPException, Query, status
 
 from rest.routers.deps import ProjectAccess
-from rest.schemas.traces import TraceDetailResponse, TraceListResponse
+from rest.schemas.traces import SpanIOResponse, TraceDetailResponse, TraceListResponse
 from rest.services.trace_reader import get_trace_reader_service
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ async def get_trace(
     trace_id: str,
     _access: ProjectAccess,  # Validates user has access to project
 ):
-    """Get a single trace with all spans."""
+    """Get a single trace with span skeletons (no per-span I/O)."""
     service = get_trace_reader_service()
     trace = service.get_trace(project_id=project_id, trace_id=trace_id)
 
@@ -67,3 +67,28 @@ async def get_trace(
         )
 
     return trace
+
+
+@router.get("/{trace_id}/spans/{span_id}/io", response_model=SpanIOResponse)
+async def get_span_io(
+    project_id: str,
+    trace_id: str,
+    span_id: str,
+    _access: ProjectAccess,  # Validates user has access to project
+):
+    """Get full input/output/metadata for a single span on demand."""
+    service = get_trace_reader_service()
+    result = service.get_span_io(
+        project_id=project_id,
+        trace_id=trace_id,
+        span_id=span_id,
+    )
+
+    if not result:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Span not found",
+        )
+
+    return result
+

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -8,7 +8,7 @@ from rest.schemas.common import PaginationMeta
 
 
 class SpanResponse(BaseModel):
-    """Single span in a trace."""
+    """Single span in a trace (full payload including I/O)."""
 
     span_id: str
     trace_id: str
@@ -30,6 +30,43 @@ class SpanResponse(BaseModel):
     git_source_file: str | None = None
     git_source_line: int | None = None
     git_source_function: str | None = None
+
+
+class SpanSkeletonResponse(BaseModel):
+    """Span skeleton — tree-building fields only, no I/O blobs.
+
+    Used by the trace-detail endpoint so the initial payload stays sub-MB
+    regardless of trace size. Full I/O is fetched per-span on demand via
+    the dedicated ``/spans/{span_id}/io`` endpoint.
+    """
+
+    span_id: str
+    trace_id: str
+    parent_span_id: str | None
+    name: str
+    span_kind: str
+    span_start_time: datetime
+    span_end_time: datetime | None
+    status: str
+    status_message: str | None
+    model_name: str | None
+    cost: float | None
+    input_tokens: int | None
+    output_tokens: int | None
+    total_tokens: int | None
+    git_source_file: str | None = None
+    git_source_line: int | None = None
+    git_source_function: str | None = None
+
+
+class SpanIOResponse(BaseModel):
+    """Full I/O payload for a single span, fetched on demand."""
+
+    span_id: str
+    trace_id: str
+    input: str | None
+    output: str | None
+    metadata: str | None
 
 
 class TraceListItem(BaseModel):
@@ -59,7 +96,7 @@ class TraceListResponse(BaseModel):
 
 
 class TraceDetailResponse(BaseModel):
-    """Single trace with all spans."""
+    """Single trace with span skeletons (no per-span I/O)."""
 
     trace_id: str
     project_id: str
@@ -72,4 +109,4 @@ class TraceDetailResponse(BaseModel):
     input: str | None
     output: str | None
     metadata: str | None
-    spans: list[SpanResponse]
+    spans: list[SpanSkeletonResponse]

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -166,7 +166,12 @@ class TraceReaderService:
         }
 
     def get_trace(self, project_id: str, trace_id: str) -> dict | None:
-        """Get single trace with all spans."""
+        """Get single trace with span skeletons (no per-span I/O).
+
+        Returns trace metadata plus lightweight span skeletons that omit
+        input/output/metadata. This keeps the payload sub-MB even for
+        large traces. Per-span I/O is fetched on demand via get_span_io().
+        """
         # Fetch trace
         trace_query = """
             SELECT
@@ -199,14 +204,15 @@ class TraceReaderService:
             "metadata": row[10],
         }
 
-        # Fetch spans. Duration is derived on the client from start/end so
-        # in-progress spans can grow against `now()` for live traces.
+        # Fetch span skeletons — omit input/output/metadata to keep the
+        # payload lightweight. Duration is derived on the client from
+        # start/end so in-progress spans can grow against `now()` for
+        # live traces.
         spans_query = """
             SELECT
                 span_id, trace_id, parent_span_id, name, span_kind,
                 span_start_time, span_end_time, status, status_message,
                 model_name, cost, input_tokens, output_tokens, total_tokens,
-                input, output, metadata,
                 git_source_file, git_source_line, git_source_function
             FROM spans FINAL
             WHERE project_id = {project_id:String} AND trace_id = {trace_id:String}
@@ -235,17 +241,46 @@ class TraceReaderService:
                     "input_tokens": int(row[11]) if row[11] is not None else None,
                     "output_tokens": int(row[12]) if row[12] is not None else None,
                     "total_tokens": int(row[13]) if row[13] is not None else None,
-                    "input": row[14],
-                    "output": row[15],
-                    "metadata": row[16],
-                    "git_source_file": row[17],
-                    "git_source_line": int(row[18]) if row[18] is not None else None,
-                    "git_source_function": row[19],
+                    "git_source_file": row[14],
+                    "git_source_line": int(row[15]) if row[15] is not None else None,
+                    "git_source_function": row[16],
                 }
             )
 
         trace["spans"] = spans
         return trace
+
+    def get_span_io(self, project_id: str, trace_id: str, span_id: str) -> dict | None:
+        """Fetch full input/output/metadata for a single span.
+
+        Called on demand when the user expands a span in the UI.
+        """
+        query = """
+            SELECT span_id, trace_id, input, output, metadata
+            FROM spans FINAL
+            WHERE project_id = {project_id:String}
+              AND trace_id = {trace_id:String}
+              AND span_id = {span_id:String}
+            LIMIT 1
+        """
+        result = self._client.query(
+            query,
+            parameters={
+                "project_id": project_id,
+                "trace_id": trace_id,
+                "span_id": span_id,
+            },
+        )
+        if not result.result_rows:
+            return None
+        row = result.result_rows[0]
+        return {
+            "span_id": row[0],
+            "trace_id": row[1],
+            "input": row[2],
+            "output": row[3],
+            "metadata": row[4],
+        }
 
     def list_sessions(
         self,

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -12,6 +12,7 @@ import {
   GitBranch,
   GitCommitHorizontal,
   FileCode,
+  Loader2,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { formatDuration, formatDate, formatTokens, buildUrlWithFilters } from "@/lib/utils";
@@ -22,6 +23,7 @@ import { getSpanDuration, getTraceDuration, getTraceTotalCost, getTraceTokenUsag
 import { SpanKindIcon } from "./SpanKindIcon";
 import { ContentRenderer } from "./ContentRenderer";
 import { ExpandableSection } from "@/components/ui/expandable-section";
+import { useSpanIO } from "../hooks";
 
 interface SpanInfoPanelProps {
   projectId: string;
@@ -55,9 +57,20 @@ export function SpanInfoPanel({
   const kind = isTrace ? "trace" : selection.span.span_kind;
   const duration = isTrace ? getTraceDuration(trace) : getSpanDuration(selection.span);
   const timestamp = isTrace ? trace.trace_start_time : selection.span.span_start_time;
-  const input = isTrace ? trace.input : selection.span.input;
-  const output = isTrace ? trace.output : selection.span.output;
-  const rawMetadata = isTrace ? trace.metadata : selection.span.metadata;
+
+  // Lazily fetch span I/O on demand (only when a span is selected)
+  const selectedSpanId = !isTrace ? selection.span.span_id : null;
+  const { data: spanIO, isLoading: isLoadingIO } = useSpanIO(
+    projectId,
+    trace.trace_id,
+    selectedSpanId,
+  );
+
+  // For trace-level: I/O comes from the trace object directly.
+  // For span-level: I/O comes from the lazy-fetched spanIO data.
+  const input = isTrace ? trace.input : (spanIO?.input ?? null);
+  const output = isTrace ? trace.output : (spanIO?.output ?? null);
+  const rawMetadata = isTrace ? trace.metadata : (spanIO?.metadata ?? null);
   const metadata = (() => {
     if (!rawMetadata) return rawMetadata;
     try {
@@ -292,7 +305,14 @@ export function SpanInfoPanel({
           defaultOpen={true}
           onCopy={input ? () => copyToClipboard(input) : undefined}
         >
-          <ContentRenderer content={input} />
+          {!isTrace && isLoadingIO ? (
+            <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Loading…
+            </div>
+          ) : (
+            <ContentRenderer content={input} />
+          )}
         </ExpandableSection>
 
         {/* Output */}
@@ -301,7 +321,14 @@ export function SpanInfoPanel({
           defaultOpen={true}
           onCopy={output ? () => copyToClipboard(output) : undefined}
         >
-          <ContentRenderer content={output} />
+          {!isTrace && isLoadingIO ? (
+            <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Loading…
+            </div>
+          ) : (
+            <ContentRenderer content={output} />
+          )}
         </ExpandableSection>
 
         {/* Metadata */}
@@ -310,7 +337,14 @@ export function SpanInfoPanel({
           defaultOpen={true}
           onCopy={metadata ? () => copyToClipboard(metadata) : undefined}
         >
-          <ContentRenderer content={metadata} />
+          {!isTrace && isLoadingIO ? (
+            <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              Loading…
+            </div>
+          ) : (
+            <ContentRenderer content={metadata} />
+          )}
         </ExpandableSection>
       </div>
     </div>

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -3,7 +3,7 @@
  */
 import { useQuery } from "@tanstack/react-query";
 import { useSession as useAuthSession } from "@/lib/auth-client";
-import { getTraces, getTrace } from "@/lib/api";
+import { getTraces, getTrace, getSpanIO } from "@/lib/api";
 import { getSessions, getSession, type SessionDetailOptions } from "@/lib/api/sessions";
 import { getUsers, type UserQueryOptions } from "@/lib/api/users";
 import type { SessionQueryOptions, TraceQueryOptions } from "@/types/api";
@@ -62,6 +62,27 @@ export function useTrace(projectId: string, traceId: string, enabled: boolean = 
     queryKey: ["trace", projectId, traceId],
     queryFn: () => getTrace(projectId, traceId, "", user),
     enabled: sessionReady && enabled,
+  });
+}
+
+/**
+ * Hook for lazily fetching a single span's full I/O (input/output/metadata).
+ * Only fetches when spanId is provided (i.e. user selected a span).
+ */
+export function useSpanIO(
+  projectId: string,
+  traceId: string,
+  spanId: string | null,
+) {
+  const { data: authSession, isPending } = useAuthSession();
+  const sessionReady = !isPending && !!authSession?.user;
+  const user: TraceApiUser | undefined = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
+  return useQuery({
+    queryKey: ["spanIO", projectId, traceId, spanId],
+    queryFn: () => getSpanIO(projectId, traceId, spanId!, user),
+    enabled: sessionReady && !!spanId,
   });
 }
 

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -69,11 +69,7 @@ export function useTrace(projectId: string, traceId: string, enabled: boolean = 
  * Hook for lazily fetching a single span's full I/O (input/output/metadata).
  * Only fetches when spanId is provided (i.e. user selected a span).
  */
-export function useSpanIO(
-  projectId: string,
-  traceId: string,
-  spanId: string | null,
-) {
+export function useSpanIO(projectId: string, traceId: string, spanId: string | null) {
   const { data: authSession, isPending } = useAuthSession();
   const sessionReady = !isPending && !!authSession?.user;
   const user: TraceApiUser | undefined = authSession?.user

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -38,7 +38,7 @@ export function enrichSpansWithPending(spans: Span[]): Span[] {
   for (const span of spans) {
     if (!span.parent_span_id) continue;
 
-    const meta = parseMetadata(span.metadata);
+    const meta = parseMetadata(span.metadata ?? null);
     const idsPath = meta["traceroot.span.ids_path"] as string[] | undefined;
     const namePath = meta["traceroot.span.path"] as string[] | undefined;
 
@@ -78,9 +78,6 @@ export function enrichSpansWithPending(spans: Span[]): Span[] {
         input_tokens: null,
         output_tokens: null,
         total_tokens: null,
-        input: null,
-        output: null,
-        metadata: null,
         git_source_file: null,
         git_source_line: null,
         git_source_function: null,

--- a/frontend/ui/src/lib/api/index.ts
+++ b/frontend/ui/src/lib/api/index.ts
@@ -58,7 +58,7 @@ export {
 } from "./model-providers";
 
 // Trace APIs
-export { getTraces, getTrace } from "./traces";
+export { getTraces, getTrace, getSpanIO } from "./traces";
 
 // Re-export all types from types/api.ts for backward compatibility
 export type {

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -50,4 +50,3 @@ export async function getSpanIO(
     user,
   );
 }
-

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -2,7 +2,7 @@
  * Trace API functions (Python backend - ClickHouse)
  */
 import { fetchTraceApi, type TraceApiUser } from "./client";
-import type { TraceDetail, TraceListResponse, TraceQueryOptions } from "@/types/api";
+import type { SpanIO, TraceDetail, TraceListResponse, TraceQueryOptions } from "@/types/api";
 
 export async function getTraces(
   projectId: string,
@@ -34,3 +34,20 @@ export async function getTrace(
 ): Promise<TraceDetail> {
   return fetchTraceApi<TraceDetail>(`/projects/${projectId}/traces/${traceId}`, {}, user);
 }
+
+/**
+ * Fetch full input/output/metadata for a single span on demand.
+ */
+export async function getSpanIO(
+  projectId: string,
+  traceId: string,
+  spanId: string,
+  user?: TraceApiUser,
+): Promise<SpanIO> {
+  return fetchTraceApi<SpanIO>(
+    `/projects/${projectId}/traces/${traceId}/spans/${spanId}/io`,
+    {},
+    user,
+  );
+}
+

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -108,7 +108,7 @@ export interface TraceListItem {
   total_cost?: number;
 }
 
-export interface Span {
+export interface SpanSkeleton {
   span_id: string;
   trace_id: string;
   parent_span_id: string | null;
@@ -123,14 +123,22 @@ export interface Span {
   input_tokens: number | null;
   output_tokens: number | null;
   total_tokens: number | null;
-  input: string | null;
-  output: string | null;
-  metadata: string | null;
   git_source_file: string | null;
   git_source_line: number | null;
   git_source_function: string | null;
   pending?: boolean;
 }
+
+export interface SpanIO {
+  span_id: string;
+  trace_id: string;
+  input: string | null;
+  output: string | null;
+  metadata: string | null;
+}
+
+/** Full span = skeleton + lazily loaded I/O. */
+export type Span = SpanSkeleton & Partial<SpanIO>;
 
 export interface TraceDetail {
   trace_id: string;
@@ -146,7 +154,7 @@ export interface TraceDetail {
   input: string | null;
   output: string | null;
   metadata: string | null;
-  spans: Span[];
+  spans: SpanSkeleton[];
 }
 
 export interface TraceListResponse {

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -234,9 +234,7 @@ class TestGetTrace:
 class TestGetSpanIO:
     def test_200(self, client, mock_trace_reader):
         mock_trace_reader.get_span_io.return_value = SPAN_IO
-        response = client.get(
-            "/api/v1/projects/test-project/traces/abc123/spans/span-1/io"
-        )
+        response = client.get("/api/v1/projects/test-project/traces/abc123/spans/span-1/io")
         assert response.status_code == 200
         data = response.json()
         assert data["span_id"] == "span-1"
@@ -247,9 +245,7 @@ class TestGetSpanIO:
 
     def test_404(self, client, mock_trace_reader):
         mock_trace_reader.get_span_io.return_value = None
-        response = client.get(
-            "/api/v1/projects/test-project/traces/abc123/spans/nonexistent/io"
-        )
+        response = client.get("/api/v1/projects/test-project/traces/abc123/spans/nonexistent/io")
         assert response.status_code == 404
 
     def test_null_io_fields(self, client, mock_trace_reader):
@@ -261,9 +257,7 @@ class TestGetSpanIO:
             "output": None,
             "metadata": None,
         }
-        response = client.get(
-            "/api/v1/projects/test-project/traces/abc123/spans/span-1/io"
-        )
+        response = client.get("/api/v1/projects/test-project/traces/abc123/spans/span-1/io")
         assert response.status_code == 200
         data = response.json()
         assert data["input"] is None

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -26,6 +26,7 @@ TRACE_LIST_ITEM = {
     "output": "world",
 }
 
+# Skeleton: spans have NO input/output/metadata (fetched via /spans/{id}/io)
 TRACE_DETAIL = {
     "trace_id": "abc123",
     "project_id": "test-project",
@@ -54,11 +55,16 @@ TRACE_DETAIL = {
             "input_tokens": None,
             "output_tokens": None,
             "total_tokens": None,
-            "input": None,
-            "output": None,
-            "metadata": None,
         }
     ],
+}
+
+SPAN_IO = {
+    "span_id": "span-1",
+    "trace_id": "abc123",
+    "input": '{"messages": [{"role": "user", "content": "hello"}]}',
+    "output": '{"role": "assistant", "content": "world"}',
+    "metadata": '{"model": "gpt-4o"}',
 }
 
 
@@ -182,6 +188,16 @@ class TestGetTrace:
         assert len(data["spans"]) == 1
         assert data["spans"][0]["span_id"] == "span-1"
 
+    def test_skeleton_spans_omit_io(self, client, mock_trace_reader):
+        """Skeleton response must NOT include input/output/metadata on spans."""
+        mock_trace_reader.get_trace.return_value = TRACE_DETAIL
+        response = client.get("/api/v1/projects/test-project/traces/abc123")
+        assert response.status_code == 200
+        span = response.json()["spans"][0]
+        assert "input" not in span
+        assert "output" not in span
+        assert "metadata" not in span
+
     def test_404(self, client, mock_trace_reader):
         mock_trace_reader.get_trace.return_value = None
         response = client.get("/api/v1/projects/test-project/traces/nonexistent")
@@ -213,3 +229,43 @@ class TestGetTrace:
         assert len(spans) == 2
         assert spans[1]["model_name"] == "gpt-4o"
         assert spans[1]["cost"] == 0.005
+
+
+class TestGetSpanIO:
+    def test_200(self, client, mock_trace_reader):
+        mock_trace_reader.get_span_io.return_value = SPAN_IO
+        response = client.get(
+            "/api/v1/projects/test-project/traces/abc123/spans/span-1/io"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["span_id"] == "span-1"
+        assert data["trace_id"] == "abc123"
+        assert "messages" in data["input"]
+        assert "assistant" in data["output"]
+        assert data["metadata"] == '{"model": "gpt-4o"}'
+
+    def test_404(self, client, mock_trace_reader):
+        mock_trace_reader.get_span_io.return_value = None
+        response = client.get(
+            "/api/v1/projects/test-project/traces/abc123/spans/nonexistent/io"
+        )
+        assert response.status_code == 404
+
+    def test_null_io_fields(self, client, mock_trace_reader):
+        """Span with no I/O should still return 200 with null fields."""
+        mock_trace_reader.get_span_io.return_value = {
+            "span_id": "span-1",
+            "trace_id": "abc123",
+            "input": None,
+            "output": None,
+            "metadata": None,
+        }
+        response = client.get(
+            "/api/v1/projects/test-project/traces/abc123/spans/span-1/io"
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["input"] is None
+        assert data["output"] is None
+        assert data["metadata"] is None


### PR DESCRIPTION
# Description
This pull request implements a two phase trace detail loading system to reduce the payload size of the main trace detail API endpoint. The main trace detail endpoint now returns a lightweight skeleton of the trace spans, while the detailed input, output, and metadata for individual spans are fetched on demand.

Closes #1046

# Changes

## Backend

* Updated schemas in traces.py:
  1. Created SpanSkeletonResponse containing only structural and timing fields.
  2. Created SpanIOResponse to represent the payload of a single span's input, output, and metadata.
  3. Updated TraceDetailResponse to use a list of SpanSkeletonResponse for the spans field.
* Updated trace_reader.py:
  1. Optimized get_trace to omit loading input, output, and metadata columns from the database query.
  2. Implemented get_span_io to retrieve the raw input, output, and metadata for a specific span.
* Updated traces.py router:
  1. Registered the new GET endpoint to fetch span IO at /projects/{project_id}/traces/{trace_id}/spans/{span_id}/io.

## Frontend

* Updated api.ts:
  1. Split the Span interface into SpanSkeleton and SpanIO.
  2. Redefined Span as the union of SpanSkeleton and Partial<SpanIO> for compatibility.
  3. Updated TraceDetail.spans to expect SpanSkeleton[].
* Updated API client files:
  1. Added and exported getSpanIO API utility.
* Updated hooks/index.ts:
  1. Introduced useSpanIO react query hook to manage fetching and caching span IO.
* Updated SpanInfoPanel.tsx:
  1. Refactored the component to fetch span IO on demand when a span is selected.
  2. Added a spinner to indicate when IO data is loading.
* Updated utils/index.ts:
  1. Adjusted pending span creation utilities to accommodate the partial nature of input, output, and metadata fields.

## Tests

* Updated test_traces_router.py:
  1. Updated existing fixtures to align with the new skeleton response payload.
  2. Added a unit test to verify that the trace detail endpoint omits span IO fields.
  3. Added new test cases verifying the behavior of the span IO endpoint under successful, not found, and empty field scenarios.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements two-phase loading for trace details: the main endpoint returns span skeletons only, and per-span input/output/metadata are fetched on demand via a new endpoint. This reduces payload size and speeds up trace detail loads (addresses #1046). Also runs formatting with `ruff` and `prettier`.

- **New Features**
  - Main trace detail now returns span skeletons only.
  - Added per-span I/O endpoint: `GET /projects/{project_id}/traces/{trace_id}/spans/{span_id}/io`.
  - Backend: skips I/O columns in `get_trace`; adds `get_span_io` and `SpanIOResponse`.
  - Frontend: introduces `SpanSkeleton`, `SpanIO`, and `Span` types; adds `getSpanIO` API and `useSpanIO` hook; `SpanInfoPanel` fetches I/O on selection with a loading spinner.

- **Migration**
  - Do not read `input`, `output`, or `metadata` from items in `TraceDetail.spans`. Fetch via `getSpanIO` or `useSpanIO` when needed.
  - Ensure any code that parses span I/O handles null/undefined until data is loaded.

<sup>Written for commit dc9004bcd0c043262ab933841ff2f71e2d9e1719. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

