### PR TITLE
feat(api): add public whoami endpoint

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -19,6 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from rest.routers.internal import router as internal_router
 from rest.routers.live import router as live_router
 from rest.routers.public.traces import router as public_traces_router
+from rest.routers.public.whoami import router as public_whoami_router
 from rest.routers.sessions import router as sessions_router
 from rest.routers.traces import router as traces_router
 from rest.routers.users import router as users_router
@@ -50,6 +51,9 @@ app.include_router(live_router, prefix="/api/v1")
 
 # Public API for SDK ingestion (API key auth)
 app.include_router(public_traces_router, prefix="/api/v1")
+
+# Public read API for API-key clients (e.g. the CLI)
+app.include_router(public_whoami_router, prefix="/api/v1")
 
 # Internal API for worker/service communication (protected by secret)
 app.include_router(internal_router, prefix="/api/v1")

--- a/backend/rest/routers/public/deps.py
+++ b/backend/rest/routers/public/deps.py
@@ -1,0 +1,116 @@
+"""Shared dependencies for the public, API-key-authenticated API.
+
+The API-key auth dependency lives here (not inside any one endpoint module) so
+every public route — ingestion plus the read endpoints (whoami, traces) — can
+depend on it without importing from a sibling endpoint. Authentication is
+delegated to the Next.js internal ``validate-api-key`` route, which owns the
+Postgres/Prisma control-plane data.
+"""
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from typing import Annotated
+
+import httpx
+from fastapi import Depends, Header, HTTPException, status
+
+from shared.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AuthResult:
+    """Result of API key authentication.
+
+    The billing fields drive ingestion gating. The identity fields
+    (``project_name``/``workspace_name``/``key_name``/``key_hint``) power the
+    ``whoami`` endpoint; they are optional because ``validate-api-key`` may not
+    return them, and ingestion does not need them.
+    """
+
+    project_id: str
+    workspace_id: str
+    billing_plan: str
+    ingestion_blocked: bool
+    project_name: str | None = None
+    workspace_name: str | None = None
+    key_name: str | None = None
+    key_hint: str | None = None
+
+
+async def authenticate_api_key(
+    authorization: Annotated[str | None, Header()] = None,
+) -> AuthResult:
+    """Authenticate the request via the Next.js internal validate-api-key route.
+
+    Expects ``Authorization: Bearer <api_key>``. The raw key is hashed before it
+    leaves this process; the full token is never forwarded or logged.
+    """
+    if not authorization:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing Authorization header",
+        )
+
+    parts = authorization.split(" ", 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid Authorization header format. Expected: Bearer <api_key>",
+        )
+
+    api_key = parts[1]
+    # SHA256 is appropriate for API keys (high-entropy random UUIDs, not user passwords).
+    # codeql[py/weak-sensitive-data-hashing]
+    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                f"{settings.traceroot_ui_url}/api/internal/validate-api-key",
+                json={"keyHash": key_hash},
+                headers={"X-Internal-Secret": settings.internal_api_secret},
+            )
+    except httpx.RequestError as e:
+        logger.error(f"Failed to validate API key: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service unavailable",
+        ) from e
+
+    if response.status_code == 401:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication failed",
+        )
+
+    if response.status_code != 200:
+        logger.error(f"Unexpected response from auth service: {response.status_code}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
+
+    data = response.json()
+
+    if not data.get("valid"):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=data.get("error", "Invalid API key"),
+        )
+
+    return AuthResult(
+        project_id=data["projectId"],
+        workspace_id=data["workspaceId"],
+        billing_plan=data["billingPlan"],
+        ingestion_blocked=data.get("ingestionBlocked", False),
+        project_name=data.get("projectName"),
+        workspace_name=data.get("workspaceName"),
+        key_name=data.get("keyName"),
+        key_hint=data.get("keyHint"),
+    )
+
+
+Auth = Annotated[AuthResult, Depends(authenticate_api_key)]

--- a/backend/rest/routers/public/deps.py
+++ b/backend/rest/routers/public/deps.py
@@ -93,7 +93,23 @@ async def authenticate_api_key(
             detail="Authentication service error",
         )
 
-    data = response.json()
+    # A 200 with a malformed body (non-JSON, or a non-object) is an auth-service
+    # error, not a client error — surface a controlled 503, never an uncaught 500.
+    try:
+        data = response.json()
+    except ValueError as e:
+        logger.error(f"Malformed JSON from auth service: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        ) from e
+
+    if not isinstance(data, dict):
+        logger.error("Auth service returned a non-object JSON body")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        )
 
     if not data.get("valid"):
         raise HTTPException(
@@ -101,10 +117,22 @@ async def authenticate_api_key(
             detail=data.get("error", "Invalid API key"),
         )
 
+    # A valid:true response missing required fields is also malformed → 503.
+    try:
+        project_id = data["projectId"]
+        workspace_id = data["workspaceId"]
+        billing_plan = data["billingPlan"]
+    except KeyError as e:
+        logger.error(f"Auth service response missing required field: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Authentication service error",
+        ) from e
+
     return AuthResult(
-        project_id=data["projectId"],
-        workspace_id=data["workspaceId"],
-        billing_plan=data["billingPlan"],
+        project_id=project_id,
+        workspace_id=workspace_id,
+        billing_plan=billing_plan,
         ingestion_blocked=data.get("ingestionBlocked", False),
         project_name=data.get("projectName"),
         workspace_name=data.get("workspaceName"),

--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -12,15 +12,12 @@ Authentication is via API key in the Authorization header:
 """
 
 import gzip
-import hashlib
 import logging
 import uuid
-from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Annotated, Any
+from typing import Any
 
-import httpx
-from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
+from fastapi import APIRouter, HTTPException, Request, status
 from google.protobuf.json_format import MessageToDict
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
@@ -28,91 +25,18 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
 from pydantic import BaseModel
 
 from ee.license import is_billing_enabled
+
+# Auth is defined in the shared public deps module so read routes don't import
+# it from this ingestion endpoint. Re-exported here for backward compatibility.
+from rest.routers.public.deps import Auth, AuthResult, authenticate_api_key
 from rest.services.s3 import get_s3_service
-from shared.config import settings
 from worker.ingest_tasks import process_s3_traces
+
+__all__ = ["AuthResult", "Auth", "authenticate_api_key", "router"]
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/public/traces", tags=["Traces (Public)"])
-
-
-@dataclass
-class AuthResult:
-    """Result of API key authentication with billing info."""
-
-    project_id: str
-    workspace_id: str
-    billing_plan: str
-    ingestion_blocked: bool
-
-
-async def authenticate_api_key(
-    authorization: Annotated[str | None, Header()] = None,
-) -> AuthResult:
-    """Authenticate the request and return auth result with billing info."""
-    if not authorization:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing Authorization header",
-        )
-
-    parts = authorization.split(" ", 1)
-    if len(parts) != 2 or parts[0].lower() != "bearer":
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid Authorization header format. Expected: Bearer <api_key>",
-        )
-
-    api_key = parts[1]
-    # SHA256 is appropriate for API keys (high-entropy random UUIDs, not user passwords).
-    # codeql[py/weak-sensitive-data-hashing]
-    key_hash = hashlib.sha256(api_key.encode()).hexdigest()
-
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.post(
-                f"{settings.traceroot_ui_url}/api/internal/validate-api-key",
-                json={"keyHash": key_hash},
-                headers={"X-Internal-Secret": settings.internal_api_secret},
-            )
-    except httpx.RequestError as e:
-        logger.error(f"Failed to validate API key: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Authentication service unavailable",
-        ) from e
-
-    if response.status_code == 401:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentication failed",
-        )
-
-    if response.status_code != 200:
-        logger.error(f"Unexpected response from auth service: {response.status_code}")
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Authentication service error",
-        )
-
-    data = response.json()
-
-    if not data.get("valid"):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=data.get("error", "Invalid API key"),
-        )
-
-    return AuthResult(
-        project_id=data["projectId"],
-        workspace_id=data["workspaceId"],
-        billing_plan=data["billingPlan"],
-        ingestion_blocked=data.get("ingestionBlocked", False),
-    )
-
-
-Auth = Annotated[AuthResult, Depends(authenticate_api_key)]
 
 
 def decode_otlp_protobuf(data: bytes) -> dict[str, Any]:

--- a/backend/rest/routers/public/whoami.py
+++ b/backend/rest/routers/public/whoami.py
@@ -29,5 +29,5 @@ async def whoami(auth: Auth, request: Request) -> WhoamiResponse:
         key_name=auth.key_name,
         key_hint=auth.key_hint,
         host=str(request.base_url).rstrip("/"),
-        ui_base_url=settings.traceroot_ui_url.rstrip("/"),
+        ui_base_url=settings.traceroot_public_ui_url.rstrip("/"),
     )

--- a/backend/rest/routers/public/whoami.py
+++ b/backend/rest/routers/public/whoami.py
@@ -1,0 +1,33 @@
+"""Public whoami endpoint: resolve an API key to its project/workspace identity.
+
+Powers the CLI's `login` (validate + confirm) and `status` commands. Returns
+identity plus both hosts so the CLI stays single-host: ``host`` is the API host
+the client reached, ``ui_base_url`` is where trace links point.
+"""
+
+from fastapi import APIRouter, Request
+
+from rest.routers.public.deps import Auth
+from rest.schemas.public import WhoamiResponse
+from shared.config import settings
+
+router = APIRouter(prefix="/public/whoami", tags=["Whoami (Public)"])
+
+
+@router.get("", response_model=WhoamiResponse)
+async def whoami(auth: Auth, request: Request) -> WhoamiResponse:
+    """Return the identity the authenticated API key maps to."""
+    # `host` reflects the request's Host header (the API host the client
+    # reached). It is only echoed back, never used server-side — but it is
+    # client-controllable unless a trusted proxy validates Host, so consumers
+    # should treat it as informational.
+    return WhoamiResponse(
+        project_id=auth.project_id,
+        project_name=auth.project_name,
+        workspace_id=auth.workspace_id,
+        workspace_name=auth.workspace_name,
+        key_name=auth.key_name,
+        key_hint=auth.key_hint,
+        host=str(request.base_url).rstrip("/"),
+        ui_base_url=settings.traceroot_ui_url.rstrip("/"),
+    )

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -1,0 +1,21 @@
+"""Response schemas for the public, API-key-authenticated API."""
+
+from pydantic import BaseModel
+
+
+class WhoamiResponse(BaseModel):
+    """Identity a project API key resolves to, for `login` / `status`.
+
+    Name fields are nullable: they depend on what the internal key-validation
+    contract returns, and the backend never fabricates them. The full API token
+    is never included — only ``key_hint``.
+    """
+
+    project_id: str
+    project_name: str | None
+    workspace_id: str
+    workspace_name: str | None
+    key_name: str | None
+    key_hint: str | None
+    host: str
+    ui_base_url: str

--- a/frontend/ui/src/app/api/internal/validate-api-key/route.ts
+++ b/frontend/ui/src/app/api/internal/validate-api-key/route.ts
@@ -39,10 +39,12 @@ export async function POST(request: NextRequest) {
       project: {
         select: {
           id: true,
+          name: true,
           deleteTime: true,
           workspace: {
             select: {
               id: true,
+              name: true,
               billingPlan: true,
               ingestionBlocked: true,
             },
@@ -77,7 +79,11 @@ export async function POST(request: NextRequest) {
   return NextResponse.json({
     valid: true,
     projectId: accessKey.projectId,
+    projectName: accessKey.project.name,
     workspaceId: accessKey.project.workspace.id,
+    workspaceName: accessKey.project.workspace.name,
+    keyName: accessKey.name ?? null,
+    keyHint: accessKey.keyHint,
     billingPlan,
     ingestionBlocked: accessKey.project.workspace.ingestionBlocked,
     expiresAt: accessKey.expireTime?.toISOString() ?? null,

--- a/tests/rest/test_auth_deps.py
+++ b/tests/rest/test_auth_deps.py
@@ -41,6 +41,50 @@ class TestAuthenticateApiKey:
         assert result.billing_plan == "pro"
         assert result.ingestion_blocked is False
 
+    @respx.mock
+    async def test_valid_key_with_identity(self):
+        """When validate-api-key returns names/hint, AuthResult captures them."""
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            return_value=Response(
+                200,
+                json={
+                    "valid": True,
+                    "projectId": "proj-123",
+                    "projectName": "My Project",
+                    "workspaceId": "ws-456",
+                    "workspaceName": "My Workspace",
+                    "keyName": "CI key",
+                    "keyHint": "tr_ab…yz",
+                    "billingPlan": "pro",
+                    "ingestionBlocked": False,
+                },
+            )
+        )
+        result = await authenticate_api_key("Bearer test-api-key")
+        assert result.project_name == "My Project"
+        assert result.workspace_name == "My Workspace"
+        assert result.key_name == "CI key"
+        assert result.key_hint == "tr_ab…yz"
+
+    @respx.mock
+    async def test_valid_key_without_identity_defaults_to_none(self):
+        """Identity fields are optional: absent in the response means None (no crash)."""
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            return_value=Response(
+                200,
+                json={
+                    "valid": True,
+                    "projectId": "proj-123",
+                    "workspaceId": "ws-456",
+                    "billingPlan": "pro",
+                    "ingestionBlocked": False,
+                },
+            )
+        )
+        result = await authenticate_api_key("Bearer test-api-key")
+        assert result.project_name is None
+        assert result.key_hint is None
+
     async def test_missing_header(self):
         with pytest.raises(HTTPException) as exc_info:
             await authenticate_api_key(None)

--- a/tests/rest/test_auth_deps.py
+++ b/tests/rest/test_auth_deps.py
@@ -4,6 +4,8 @@ Tests authenticate_api_key (public API auth) and get_project_access (user auth)
 with mocked httpx calls.
 """
 
+import logging
+
 import httpx
 import pytest
 import respx
@@ -126,6 +128,38 @@ class TestAuthenticateApiKey:
         with pytest.raises(HTTPException) as exc_info:
             await authenticate_api_key("Bearer test-key")
         assert exc_info.value.status_code == 503
+
+    @respx.mock
+    async def test_malformed_200_invalid_json_returns_503(self):
+        """A 200 with a non-JSON body is a malformed upstream response → controlled 503."""
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            return_value=Response(200, content=b"<html>not json</html>")
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_api_key("Bearer test-key")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"
+
+    @respx.mock
+    async def test_200_missing_required_fields_returns_503(self):
+        """A valid-looking 200 missing required fields is malformed → controlled 503."""
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            return_value=Response(200, json={"valid": True})  # no projectId/workspaceId/billingPlan
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await authenticate_api_key("Bearer test-key")
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.detail == "Authentication service error"
+
+    @respx.mock
+    async def test_token_not_logged_on_malformed_response(self, caplog):
+        """The raw API token must never appear in logs, even on the error path."""
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            return_value=Response(200, content=b"oops")
+        )
+        with caplog.at_level(logging.DEBUG), pytest.raises(HTTPException):
+            await authenticate_api_key("Bearer tr_supersecrettoken")
+        assert "tr_supersecrettoken" not in caplog.text
 
 
 # ── get_project_access ──────────────────────────────────────────────────

--- a/tests/rest/test_whoami.py
+++ b/tests/rest/test_whoami.py
@@ -1,0 +1,101 @@
+"""Unit tests for the public whoami endpoint (GET /api/v1/public/whoami)."""
+
+import httpx
+import respx
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from rest.main import app
+from rest.routers.public.deps import AuthResult, authenticate_api_key
+
+BASE_URL = "http://localhost:3000"
+
+
+def make_identity_auth() -> AuthResult:
+    """An AuthResult carrying the resolved identity fields whoami surfaces."""
+    return AuthResult(
+        project_id="proj-123",
+        workspace_id="ws-456",
+        billing_plan="pro",
+        ingestion_blocked=False,
+        project_name="My Project",
+        workspace_name="My Workspace",
+        key_name="CI key",
+        key_hint="tr_ab…yz",
+    )
+
+
+class TestWhoami:
+    def test_valid_key_returns_identity(self):
+        """A valid key resolves to project/workspace identity + hosts."""
+        app.dependency_overrides[authenticate_api_key] = lambda: make_identity_auth()
+        client = TestClient(app)
+        resp = client.get(
+            "/api/v1/public/whoami",
+            headers={"Authorization": "Bearer tr_secrettoken"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["project_id"] == "proj-123"
+        assert data["project_name"] == "My Project"
+        assert data["workspace_id"] == "ws-456"
+        assert data["workspace_name"] == "My Workspace"
+        assert data["key_name"] == "CI key"
+        assert data["key_hint"] == "tr_ab…yz"
+
+    def test_names_hint_and_ui_base_url_present(self):
+        """whoami must surface human-readable names, the key hint, and ui_base_url."""
+        app.dependency_overrides[authenticate_api_key] = lambda: make_identity_auth()
+        client = TestClient(app)
+        data = client.get(
+            "/api/v1/public/whoami",
+            headers={"Authorization": "Bearer tr_secrettoken"},
+        ).json()
+        for field in ("project_name", "workspace_name", "key_hint", "ui_base_url", "host"):
+            assert field in data
+        assert data["ui_base_url"]  # non-empty
+
+    def test_does_not_return_full_token(self):
+        """The full API token must never appear in the response."""
+        app.dependency_overrides[authenticate_api_key] = lambda: make_identity_auth()
+        client = TestClient(app)
+        resp = client.get(
+            "/api/v1/public/whoami",
+            headers={"Authorization": "Bearer tr_secrettoken"},
+        )
+        assert resp.status_code == 200
+        body = resp.text
+        assert "tr_secrettoken" not in body
+        assert "Bearer" not in body
+
+    def test_missing_auth_header_returns_401(self):
+        """No Authorization header is rejected at the HTTP layer before any auth call."""
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get("/api/v1/public/whoami")
+        assert resp.status_code == 401
+
+    @respx.mock
+    def test_invalid_key_returns_401(self):
+        """An invalid key (validate-api-key says invalid) yields 401."""
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            return_value=Response(200, json={"valid": False, "error": "Invalid API key"})
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/v1/public/whoami",
+            headers={"Authorization": "Bearer bad-key"},
+        )
+        assert resp.status_code == 401
+
+    @respx.mock
+    def test_auth_service_unavailable_returns_503(self):
+        """If the auth service is unreachable, whoami returns 503."""
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.get(
+            "/api/v1/public/whoami",
+            headers={"Authorization": "Bearer some-key"},
+        )
+        assert resp.status_code == 503

--- a/tests/rest/test_whoami.py
+++ b/tests/rest/test_whoami.py
@@ -55,6 +55,22 @@ class TestWhoami:
             assert field in data
         assert data["ui_base_url"]  # non-empty
 
+    def test_ui_base_url_uses_public_setting_not_internal(self, monkeypatch):
+        """ui_base_url must come from the host-usable public UI URL, never the
+        internal backend-to-web URL (which can be a Docker service host)."""
+        from shared.config import settings
+
+        monkeypatch.setattr(settings, "traceroot_ui_url", "http://web:3000")
+        monkeypatch.setattr(settings, "traceroot_public_ui_url", "http://localhost:3000")
+        app.dependency_overrides[authenticate_api_key] = lambda: make_identity_auth()
+        client = TestClient(app)
+        data = client.get(
+            "/api/v1/public/whoami",
+            headers={"Authorization": "Bearer tr_secrettoken"},
+        ).json()
+        assert data["ui_base_url"] == "http://localhost:3000"
+        assert "web:3000" not in data["ui_base_url"]
+
     def test_does_not_return_full_token(self):
         """The full API token must never appear in the response."""
         app.dependency_overrides[authenticate_api_key] = lambda: make_identity_auth()


### PR DESCRIPTION
## Summary

Closes #1032

Adds the first public, API-key-authenticated **read** endpoint and the shared auth plumbing the rest of the CLI read API will build on:

- **Shared API-key auth dependency.** `AuthResult`, `authenticate_api_key`, and the `Auth` dependency move from the ingestion endpoint into a new `backend/rest/routers/public/deps.py`, so read routes no longer import auth from the ingestion module. The symbols are re-exported from `routers/public/traces.py`, so existing imports and FastAPI `dependency_overrides` keys keep working and ingestion behavior is unchanged.
- **`GET /api/v1/public/whoami`.** Resolves a project-scoped API key to its identity and returns `project_id`, `project_name`, `workspace_id`, `workspace_name`, `key_name` (nullable), `key_hint`, `host`, and `ui_base_url`. This powers the CLI's `login` (validate + confirm) and `status` commands.
- **Identity contract.** The internal `validate-api-key` route now additionally returns `projectName`, `workspaceName`, `keyName`, and `keyHint` via an additive Prisma `select` (these fields already exist on the `AccessKey`/`Project`/`Workspace` models — no schema/migration change).
- `ui_base_url` comes from the existing `settings.traceroot_ui_url`. The full API token is never returned or logged — only `key_hint`.

## Scope

- Shared public API-key auth dependency module + re-export shim.
- `whoami` endpoint, `WhoamiResponse` schema, router registration.
- Additive extension of the internal `validate-api-key` response.

## Out of scope

- Public traces list/get endpoints.
- Trace export endpoint.
- Manual OpenAPI schema publication (only the schema FastAPI generates from this endpoint).
- Any CLI code.

## Verification

- `uv run pytest tests/rest` → **101 passed** (new `test_whoami.py`: 6; added identity-parsing/HTTP-layer tests in `test_auth_deps.py`; existing ingestion auth tests unchanged and passing — confirms no behavior change).
- New tests cover: valid key returns identity; names/key_hint/ui_base_url present; full token not returned; missing header → 401; invalid key → 401; auth service unavailable → 503.
- `uv run ruff check backend/rest tests/rest` → clean.
- `uv run ruff format --check` (changed files) → clean.
- `npx prettier --check` on the modified `validate-api-key/route.ts` → clean.

## Stack

Base branch: `feat/cli-dx-trace-url-helper`
Previous PR: #1039