### PR TITLE
feat(api): add public trace read endpoints

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -19,6 +19,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from rest.routers.internal import router as internal_router
 from rest.routers.live import router as live_router
 from rest.routers.public.traces import router as public_traces_router
+from rest.routers.public.traces_read import router as public_traces_read_router
 from rest.routers.public.whoami import router as public_whoami_router
 from rest.routers.sessions import router as sessions_router
 from rest.routers.traces import router as traces_router
@@ -54,6 +55,7 @@ app.include_router(public_traces_router, prefix="/api/v1")
 
 # Public read API for API-key clients (e.g. the CLI)
 app.include_router(public_whoami_router, prefix="/api/v1")
+app.include_router(public_traces_read_router, prefix="/api/v1")
 
 # Internal API for worker/service communication (protected by secret)
 app.include_router(internal_router, prefix="/api/v1")

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -1,0 +1,60 @@
+"""Public, API-key-authenticated trace read endpoints (for the CLI).
+
+`GET /api/v1/public/traces` (list) and `GET /api/v1/public/traces/{trace_id}`
+(get). Reads are scoped to the project the API key belongs to — the client
+never supplies a project id. Kept separate from the ingestion route so read and
+write concerns stay decoupled; both reuse the shared API-key auth dependency.
+"""
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from rest.routers.public.deps import Auth
+from rest.schemas.public import PublicTraceDetailResponse, PublicTraceListResponse
+from rest.services.trace_reader import get_trace_reader_service
+from rest.url_utils import build_trace_url
+from shared.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/public/traces", tags=["Traces (Public)"])
+
+
+@router.get("", response_model=PublicTraceListResponse)
+async def list_traces(
+    auth: Auth,
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+):
+    """List recent traces for the API key's project (newest first)."""
+    try:
+        service = get_trace_reader_service()
+        result = service.list_traces(project_id=auth.project_id, limit=limit)
+    except Exception as e:
+        logger.exception(f"Error listing traces: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list traces",
+        ) from e
+
+    for item in result["data"]:
+        item["trace_url"] = build_trace_url(
+            settings.traceroot_ui_url, auth.project_id, item["trace_id"]
+        )
+    return result
+
+
+@router.get("/{trace_id}", response_model=PublicTraceDetailResponse)
+async def get_trace(auth: Auth, trace_id: str):
+    """Get a single trace (full payload, including spans) for the key's project."""
+    service = get_trace_reader_service()
+    trace = service.get_trace(project_id=auth.project_id, trace_id=trace_id)
+
+    if not trace:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Trace not found",
+        )
+
+    trace["trace_url"] = build_trace_url(settings.traceroot_ui_url, auth.project_id, trace_id)
+    return trace

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -47,8 +47,15 @@ async def list_traces(
 @router.get("/{trace_id}", response_model=PublicTraceDetailResponse)
 async def get_trace(auth: Auth, trace_id: str):
     """Get a single trace (full payload, including spans) for the key's project."""
-    service = get_trace_reader_service()
-    trace = service.get_trace(project_id=auth.project_id, trace_id=trace_id)
+    try:
+        service = get_trace_reader_service()
+        trace = service.get_trace(project_id=auth.project_id, trace_id=trace_id)
+    except Exception as e:
+        logger.exception(f"Error getting trace: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to get trace",
+        ) from e
 
     if not trace:
         raise HTTPException(

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -63,5 +63,7 @@ async def get_trace(auth: Auth, trace_id: str):
             detail="Trace not found",
         )
 
-    trace["trace_url"] = build_trace_url(settings.traceroot_ui_url, auth.project_id, trace_id)
+    trace["trace_url"] = build_trace_url(
+        settings.traceroot_public_ui_url, auth.project_id, trace_id
+    )
     return trace

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -39,7 +39,7 @@ async def list_traces(
 
     for item in result["data"]:
         item["trace_url"] = build_trace_url(
-            settings.traceroot_ui_url, auth.project_id, item["trace_id"]
+            settings.traceroot_public_ui_url, auth.project_id, item["trace_id"]
         )
     return result
 

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -2,6 +2,9 @@
 
 from pydantic import BaseModel
 
+from rest.schemas.common import PaginationMeta
+from rest.schemas.traces import TraceDetailResponse, TraceListItem
+
 
 class WhoamiResponse(BaseModel):
     """Identity a project API key resolves to, for `login` / `status`.
@@ -19,3 +22,22 @@ class WhoamiResponse(BaseModel):
     key_hint: str | None
     host: str
     ui_base_url: str
+
+
+class PublicTraceListItem(TraceListItem):
+    """A trace list item plus a backend-built link to its UI detail view."""
+
+    trace_url: str
+
+
+class PublicTraceListResponse(BaseModel):
+    """Paginated list of traces for the public API."""
+
+    data: list[PublicTraceListItem]
+    meta: PaginationMeta
+
+
+class PublicTraceDetailResponse(TraceDetailResponse):
+    """Full trace payload plus a backend-built link to its UI detail view."""
+
+    trace_url: str

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -147,6 +147,23 @@ class TestPublicListTraces:
         assert item["trace_url"] == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
         assert "status" not in item
 
+    def test_trace_url_uses_public_ui_url_not_internal(self, client, mock_reader, monkeypatch):
+        """List trace_url must use the host-usable public UI URL, never the
+        internal backend-to-web URL (which can be a Docker service host)."""
+        from shared.config import settings
+
+        monkeypatch.setattr(settings, "traceroot_ui_url", "http://web:3000")
+        monkeypatch.setattr(settings, "traceroot_public_ui_url", "http://localhost:3000")
+        mock_reader.list_traces.return_value = {
+            "data": [dict(TRACE_LIST_ITEM)],
+            "meta": {"page": 0, "limit": 50, "total": 1},
+        }
+        resp = client.get("/api/v1/public/traces", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        url = resp.json()["data"][0]["trace_url"]
+        assert url == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
+        assert "web:3000" not in url
+
     def test_limit_over_200_rejected(self, client, mock_reader):
         resp = client.get("/api/v1/public/traces?limit=500", headers=AUTH_HEADER)
         assert resp.status_code == 422

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -185,6 +185,13 @@ class TestPublicGetTrace:
         resp = client.get("/api/v1/public/traces/nonexistent", headers=AUTH_HEADER)
         assert resp.status_code == 404
 
+    def test_reader_error_returns_generic_500(self, client, mock_reader):
+        """A reader failure surfaces as a controlled 500, matching `list_traces`."""
+        mock_reader.get_trace.side_effect = Exception("ClickHouse down")
+        resp = client.get("/api/v1/public/traces/abc123", headers=AUTH_HEADER)
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Failed to get trace"
+
 
 class TestPublicTraceReadAuth:
     def test_missing_api_key_returns_401(self):

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -197,6 +197,18 @@ class TestPublicGetTrace:
         assert data["spans"][0]["span_id"] == "span-1"
         assert data["trace_url"] == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
 
+    def test_trace_url_uses_public_ui_url_not_internal(self, client, mock_reader, monkeypatch):
+        """Get trace_url must use the host-usable public UI URL, never the
+        internal backend-to-web URL (which can be a Docker service host)."""
+        from shared.config import settings
+
+        monkeypatch.setattr(settings, "traceroot_ui_url", "http://web:3000")
+        monkeypatch.setattr(settings, "traceroot_public_ui_url", "http://localhost:3000")
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        url = client.get("/api/v1/public/traces/abc123", headers=AUTH_HEADER).json()["trace_url"]
+        assert url == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
+        assert "web:3000" not in url
+
     def test_404_when_trace_missing(self, client, mock_reader):
         mock_reader.get_trace.return_value = None
         resp = client.get("/api/v1/public/traces/nonexistent", headers=AUTH_HEADER)

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -1,0 +1,205 @@
+"""Unit tests for the public API-key-authenticated trace read endpoints.
+
+GET /api/v1/public/traces and GET /api/v1/public/traces/{trace_id}. Reads are
+scoped to the API key's project; the client never supplies a project id.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from rest.main import app
+from rest.routers.public.deps import AuthResult, authenticate_api_key
+
+BASE_URL = "http://localhost:3000"
+
+TRACE_LIST_ITEM = {
+    "trace_id": "abc123",
+    "project_id": "proj-A",
+    "name": "test-trace",
+    "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+    "user_id": "user-1",
+    "session_id": None,
+    "span_count": 3,
+    "duration_ms": 1500.0,
+    "error_count": 0,
+    "input": "hello",
+    "output": "world",
+}
+
+TRACE_DETAIL = {
+    "trace_id": "abc123",
+    "project_id": "proj-A",
+    "name": "test-trace",
+    "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+    "user_id": None,
+    "session_id": None,
+    "git_ref": "main",
+    "git_repo": "org/repo",
+    "input": "in",
+    "output": "out",
+    "metadata": "{}",
+    "spans": [
+        {
+            "span_id": "span-1",
+            "trace_id": "abc123",
+            "parent_span_id": None,
+            "name": "root-span",
+            "span_kind": "SPAN",
+            "span_start_time": datetime(2024, 1, 15, 12, 0, 0),
+            "span_end_time": datetime(2024, 1, 15, 12, 0, 1),
+            "status": "OK",
+            "status_message": None,
+            "model_name": None,
+            "cost": None,
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "input": None,
+            "output": None,
+            "metadata": None,
+        }
+    ],
+}
+
+
+def make_auth(project_id: str = "proj-A") -> AuthResult:
+    return AuthResult(
+        project_id=project_id,
+        workspace_id="ws-1",
+        billing_plan="pro",
+        ingestion_blocked=False,
+    )
+
+
+@pytest.fixture()
+def mock_reader():
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(mock_reader):
+    """TestClient with mocked API-key auth and trace reader."""
+    app.dependency_overrides[authenticate_api_key] = lambda: make_auth()
+
+    import rest.routers.public.traces_read as mod
+
+    original = mod.get_trace_reader_service
+    mod.get_trace_reader_service = lambda: mock_reader
+    yield TestClient(app)
+    mod.get_trace_reader_service = original
+
+
+AUTH_HEADER = {"Authorization": "Bearer tr_sometoken"}
+
+
+class TestPublicListTraces:
+    def test_scopes_to_auth_project_id(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+        resp = client.get("/api/v1/public/traces", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        assert mock_reader.list_traces.call_args.kwargs["project_id"] == "proj-A"
+
+    def test_client_cannot_override_project_id(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+        resp = client.get("/api/v1/public/traces?project_id=evil-project", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        # The client-supplied project_id is ignored; scope stays the key's project.
+        assert mock_reader.list_traces.call_args.kwargs["project_id"] == "proj-A"
+
+    def test_supports_limit(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 5, "total": 0},
+        }
+        resp = client.get("/api/v1/public/traces?limit=5", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        assert mock_reader.list_traces.call_args.kwargs["limit"] == 5
+
+    def test_no_status_filter_accepted_or_forwarded(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+        resp = client.get("/api/v1/public/traces?status=error", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        # No status filter exists in V1: it is neither a parameter nor forwarded.
+        assert "status" not in mock_reader.list_traces.call_args.kwargs
+
+    def test_items_include_backend_built_trace_url(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [dict(TRACE_LIST_ITEM)],
+            "meta": {"page": 0, "limit": 50, "total": 1},
+        }
+        resp = client.get("/api/v1/public/traces", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        item = resp.json()["data"][0]
+        assert item["trace_url"] == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
+        assert "status" not in item
+
+    def test_limit_over_200_rejected(self, client, mock_reader):
+        resp = client.get("/api/v1/public/traces?limit=500", headers=AUTH_HEADER)
+        assert resp.status_code == 422
+
+    def test_reader_error_returns_generic_500(self, client, mock_reader):
+        """A reader failure surfaces as a controlled 500 with no internal detail."""
+        mock_reader.list_traces.side_effect = Exception("ClickHouse down")
+        resp = client.get("/api/v1/public/traces", headers=AUTH_HEADER)
+        assert resp.status_code == 500
+        assert resp.json()["detail"] == "Failed to list traces"
+
+
+class TestPublicGetTrace:
+    def test_scopes_to_auth_project_id(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        resp = client.get("/api/v1/public/traces/abc123", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        kw = mock_reader.get_trace.call_args.kwargs
+        assert kw["project_id"] == "proj-A"
+        assert kw["trace_id"] == "abc123"
+
+    def test_returns_full_payload_with_trace_url(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        resp = client.get("/api/v1/public/traces/abc123", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["trace_id"] == "abc123"
+        assert data["git_ref"] == "main"
+        assert data["metadata"] == "{}"
+        assert len(data["spans"]) == 1
+        assert data["spans"][0]["span_id"] == "span-1"
+        assert data["trace_url"] == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
+
+    def test_404_when_trace_missing(self, client, mock_reader):
+        mock_reader.get_trace.return_value = None
+        resp = client.get("/api/v1/public/traces/nonexistent", headers=AUTH_HEADER)
+        assert resp.status_code == 404
+
+
+class TestPublicTraceReadAuth:
+    def test_missing_api_key_returns_401(self):
+        test_client = TestClient(app, raise_server_exceptions=False)
+        resp = test_client.get("/api/v1/public/traces")
+        assert resp.status_code == 401
+
+    @respx.mock
+    def test_invalid_api_key_returns_401(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            return_value=Response(200, json={"valid": False, "error": "Invalid API key"})
+        )
+        test_client = TestClient(app, raise_server_exceptions=False)
+        resp = test_client.get(
+            "/api/v1/public/traces/abc123",
+            headers={"Authorization": "Bearer bad-key"},
+        )
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Closes #1034

Adds the public, API-key-authenticated trace **read** endpoints the CLI's `traces list` / `traces get` build on:

- `GET /api/v1/public/traces` — lists recent traces for the API key's project. Supports `limit` only (V1).
- `GET /api/v1/public/traces/{trace_id}` — returns the full trace payload (trace + spans), or `404` if not found.

Both are scoped to the project resolved from the API key (`auth.project_id`); the client never supplies a project id, so a key cannot read another project's traces. Each response carries a backend-built `trace_url` (via the existing `build_trace_url` helper) so clients get a ready-to-use UI link without knowing the UI host. Reads live in a dedicated `routers/public/traces_read.py` module (separate from ingestion) and reuse the shared API-key auth dependency.

## Scope

- `GET /api/v1/public/traces` (list, `limit` only) and `GET /api/v1/public/traces/{trace_id}` (get, full payload).
- Public response schemas (`PublicTraceListItem`/`PublicTraceListResponse`/`PublicTraceDetailResponse`) that extend the existing trace schemas with `trace_url`.
- Router registration in `main.py`.

## Out of scope

- Trace export endpoint.
- Any `status` filter / parameter (none in V1).
- List filters beyond `limit` (no page/name/user/date filters exposed publicly in V1).
- Manual OpenAPI schema publication (only what FastAPI generates from these routes).
- Any CLI code.

## Verification

- `uv run pytest tests/rest/test_public_traces_read.py` → 12 passed. Covers: list/get scope to `auth.project_id`; client-supplied `project_id` is ignored; `limit` forwarding + `>200` → 422; no `status` filter accepted or forwarded; `trace_url` present on list items and get; get returns full payload (spans + git fields + metadata); `404` on missing trace; reader error → controlled 500; missing/invalid API key → 401.
- `uv run pytest tests/rest` → 113 passed (existing user-session trace routes unchanged and passing — no regression).
- `uv run ruff check backend/rest tests/rest` → clean. `ruff format --check` (touched files) → clean.

## Stack

Base branch: `feat/cli-dx-public-whoami`
Previous PR: #1065