### PR TITLE
feat(api): add public trace export endpoint

### DIFF
--- a/backend/rest/routers/public/serialize.py
+++ b/backend/rest/routers/public/serialize.py
@@ -1,0 +1,57 @@
+"""Serializers shared by the public trace read + export endpoints.
+
+Keeping these in one place guarantees `traces get` and `export.trace` produce
+the identical payload, and that `git_context` is assembled the same way
+everywhere.
+"""
+
+from rest.url_utils import build_trace_url
+from shared.config import settings
+
+
+def public_trace_detail(trace: dict, project_id: str) -> dict:
+    """The public `traces get` payload: the trace dict + a backend-built trace_url."""
+    return {
+        **trace,
+        "trace_url": build_trace_url(settings.traceroot_ui_url, project_id, trace["trace_id"]),
+    }
+
+
+def git_context(trace: dict) -> dict:
+    """git_context.json: repo/ref + per-span source locations (trace-resident git only).
+
+    This is NOT GitHub commit/PR/issue history — only the git metadata already
+    captured on the trace and its spans.
+    """
+    sources = [
+        {
+            "span_id": span["span_id"],
+            "file": span.get("git_source_file"),
+            "line": span.get("git_source_line"),
+            "function": span.get("git_source_function"),
+        }
+        for span in trace.get("spans", [])
+        # A source row needs at least a file or a function to be meaningful.
+        if span.get("git_source_file") or span.get("git_source_function")
+    ]
+    return {
+        "git_repo": trace.get("git_repo"),
+        "git_ref": trace.get("git_ref"),
+        "sources": sources,
+    }
+
+
+def export_bundle(trace: dict, project_id: str) -> dict:
+    """Assemble the V1 export bundle (trace + spans + git_context + manifest)."""
+    detail = public_trace_detail(trace, project_id)
+    return {
+        "manifest": {
+            "trace_id": trace["trace_id"],
+            "project_id": project_id,
+            "bundle_version": "v1",
+            "files": ["trace.json", "spans.json", "git_context.json", "manifest.json"],
+        },
+        "trace": detail,
+        "spans": detail["spans"],
+        "git_context": git_context(trace),
+    }

--- a/backend/rest/routers/public/serialize.py
+++ b/backend/rest/routers/public/serialize.py
@@ -13,7 +13,9 @@ def public_trace_detail(trace: dict, project_id: str) -> dict:
     """The public `traces get` payload: the trace dict + a backend-built trace_url."""
     return {
         **trace,
-        "trace_url": build_trace_url(settings.traceroot_ui_url, project_id, trace["trace_id"]),
+        "trace_url": build_trace_url(
+            settings.traceroot_public_ui_url, project_id, trace["trace_id"]
+        ),
     }
 
 

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -11,7 +11,12 @@ import logging
 from fastapi import APIRouter, HTTPException, Query, status
 
 from rest.routers.public.deps import Auth
-from rest.schemas.public import PublicTraceDetailResponse, PublicTraceListResponse
+from rest.routers.public.serialize import export_bundle, public_trace_detail
+from rest.schemas.public import (
+    PublicTraceDetailResponse,
+    PublicTraceExportResponse,
+    PublicTraceListResponse,
+)
 from rest.services.trace_reader import get_trace_reader_service
 from rest.url_utils import build_trace_url
 from shared.config import settings
@@ -47,21 +52,39 @@ async def list_traces(
 @router.get("/{trace_id}", response_model=PublicTraceDetailResponse)
 async def get_trace(auth: Auth, trace_id: str):
     """Get a single trace (full payload, including spans) for the key's project."""
+    trace = _require_trace(auth.project_id, trace_id)
+    return public_trace_detail(trace, auth.project_id)
+
+
+@router.get("/{trace_id}/export", response_model=PublicTraceExportResponse)
+async def export_trace(auth: Auth, trace_id: str):
+    """Export the V1 bundle (trace + spans + git_context + manifest) for the key's project.
+
+    `bundle.trace` is identical to the `traces get` payload for the same trace.
+    """
+    trace = _require_trace(auth.project_id, trace_id)
+    return export_bundle(trace, auth.project_id)
+
+
+def _require_trace(project_id: str, trace_id: str) -> dict:
+    """Fetch a trace scoped to the project, or raise 404 (500 on reader failure).
+
+    Centralizing the read here keeps `get` and `export` consistent: a reader
+    failure is a controlled 500 (matching `list_traces`), a missing/cross-project
+    trace is a 404, and internal exception text is never leaked to clients.
+    """
     try:
         service = get_trace_reader_service()
-        trace = service.get_trace(project_id=auth.project_id, trace_id=trace_id)
+        trace = service.get_trace(project_id=project_id, trace_id=trace_id)
     except Exception as e:
         logger.exception(f"Error getting trace: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to get trace",
         ) from e
-
     if not trace:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Trace not found",
         )
-
-    trace["trace_url"] = build_trace_url(settings.traceroot_ui_url, auth.project_id, trace_id)
     return trace

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -3,7 +3,7 @@
 from pydantic import BaseModel
 
 from rest.schemas.common import PaginationMeta
-from rest.schemas.traces import TraceDetailResponse, TraceListItem
+from rest.schemas.traces import SpanResponse, TraceDetailResponse, TraceListItem
 
 
 class WhoamiResponse(BaseModel):
@@ -41,3 +41,38 @@ class PublicTraceDetailResponse(TraceDetailResponse):
     """Full trace payload plus a backend-built link to its UI detail view."""
 
     trace_url: str
+
+
+class GitSource(BaseModel):
+    """A single span's source location (trace-resident git metadata)."""
+
+    span_id: str
+    file: str | None
+    line: int | None
+    function: str | None
+
+
+class GitContext(BaseModel):
+    """git_context.json: repo/ref + per-span source locations."""
+
+    git_repo: str | None
+    git_ref: str | None
+    sources: list[GitSource]
+
+
+class ExportManifest(BaseModel):
+    """manifest.json: index of the bundle's parts."""
+
+    trace_id: str
+    project_id: str
+    bundle_version: str
+    files: list[str]
+
+
+class PublicTraceExportResponse(BaseModel):
+    """V1 export bundle: trace (== `traces get`) + spans + git_context + manifest."""
+
+    manifest: ExportManifest
+    trace: PublicTraceDetailResponse
+    spans: list[SpanResponse]
+    git_context: GitContext

--- a/tests/rest/test_public_traces_export.py
+++ b/tests/rest/test_public_traces_export.py
@@ -184,6 +184,19 @@ class TestExportBundle:
             == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
         )
 
+    def test_trace_url_uses_public_ui_url_not_internal(self, client, mock_reader, monkeypatch):
+        """Export trace_url must use the host-usable public UI URL, never the
+        internal backend-to-web URL (which can be a Docker service host)."""
+        from shared.config import settings
+
+        monkeypatch.setattr(settings, "traceroot_ui_url", "http://web:3000")
+        monkeypatch.setattr(settings, "traceroot_public_ui_url", "http://localhost:3000")
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        body = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()
+        url = body["trace"]["trace_url"]
+        assert url == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
+        assert "web:3000" not in url
+
     def test_404_when_missing(self, client, mock_reader):
         mock_reader.get_trace.return_value = None
         resp = client.get("/api/v1/public/traces/nope/export", headers=AUTH)
@@ -207,3 +220,60 @@ class TestExportAuth:
             headers={"Authorization": "Bearer bad"},
         )
         assert resp.status_code == 401
+
+
+TRACE_LIST_ITEM = {
+    "trace_id": "abc123",
+    "project_id": "proj-A",
+    "name": "test-trace",
+    "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+    "user_id": "user-1",
+    "session_id": None,
+    "span_count": 3,
+    "duration_ms": 1500.0,
+    "error_count": 0,
+    "input": "hello",
+    "output": "world",
+}
+
+
+class TestPublicUrlAcrossStack:
+    """Top-of-stack guard: every client-facing URL the public API emits —
+    whoami ``ui_base_url`` and the list/get/export ``trace_url`` — is built from
+    the public UI URL, never the internal backend-to-web URL (``web:3000``)."""
+
+    def test_all_public_urls_use_public_ui_url(self, client, mock_reader, monkeypatch):
+        from shared.config import settings
+
+        monkeypatch.setattr(settings, "traceroot_ui_url", "http://web:3000")
+        monkeypatch.setattr(settings, "traceroot_public_ui_url", "http://localhost:3000")
+        app.dependency_overrides[authenticate_api_key] = lambda: AuthResult(
+            project_id="proj-A",
+            workspace_id="ws-1",
+            billing_plan="pro",
+            ingestion_blocked=False,
+            project_name="P",
+            workspace_name="W",
+            key_name="k",
+            key_hint="tr_ab…yz",
+        )
+        mock_reader.list_traces.return_value = {
+            "data": [dict(TRACE_LIST_ITEM)],
+            "meta": {"page": 0, "limit": 50, "total": 1},
+        }
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+
+        whoami = client.get("/api/v1/public/whoami", headers=AUTH).json()
+        listed = client.get("/api/v1/public/traces", headers=AUTH).json()
+        got = client.get("/api/v1/public/traces/abc123", headers=AUTH).json()
+        exported = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()
+
+        urls = [
+            whoami["ui_base_url"],
+            listed["data"][0]["trace_url"],
+            got["trace_url"],
+            exported["trace"]["trace_url"],
+        ]
+        for url in urls:
+            assert url.startswith("http://localhost:3000")
+            assert "web:3000" not in url

--- a/tests/rest/test_public_traces_export.py
+++ b/tests/rest/test_public_traces_export.py
@@ -1,0 +1,209 @@
+"""Unit tests for the public trace export endpoint.
+
+GET /api/v1/public/traces/{trace_id}/export. V1 bundle = trace + spans +
+git_context + manifest (no logs/metrics/related). Scoped to the API key's
+project. `bundle.trace` must equal the public `traces get` payload.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+import respx
+from fastapi.testclient import TestClient
+from httpx import Response
+
+from rest.main import app
+from rest.routers.public.deps import AuthResult, authenticate_api_key
+
+BASE_URL = "http://localhost:3000"
+
+TRACE_DETAIL = {
+    "trace_id": "abc123",
+    "project_id": "proj-A",
+    "name": "test-trace",
+    "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+    "user_id": None,
+    "session_id": None,
+    "git_ref": "main",
+    "git_repo": "org/repo",
+    "input": "in",
+    "output": "out",
+    "metadata": "{}",
+    "spans": [
+        {
+            "span_id": "span-1",
+            "trace_id": "abc123",
+            "parent_span_id": None,
+            "name": "root-span",
+            "span_kind": "SPAN",
+            "span_start_time": datetime(2024, 1, 15, 12, 0, 0),
+            "span_end_time": datetime(2024, 1, 15, 12, 0, 1),
+            "status": "ERROR",
+            "status_message": "boom",
+            "model_name": None,
+            "cost": None,
+            "input_tokens": None,
+            "output_tokens": None,
+            "total_tokens": None,
+            "input": None,
+            "output": None,
+            "metadata": None,
+            "git_source_file": "app/main.py",
+            "git_source_line": 42,
+            "git_source_function": "handler",
+        }
+    ],
+}
+
+
+def make_auth(project_id: str = "proj-A") -> AuthResult:
+    return AuthResult(
+        project_id=project_id,
+        workspace_id="ws-1",
+        billing_plan="pro",
+        ingestion_blocked=False,
+    )
+
+
+@pytest.fixture()
+def mock_reader():
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(mock_reader):
+    app.dependency_overrides[authenticate_api_key] = lambda: make_auth()
+
+    import rest.routers.public.traces_read as mod
+
+    original = mod.get_trace_reader_service
+    mod.get_trace_reader_service = lambda: mock_reader
+    yield TestClient(app)
+    mod.get_trace_reader_service = original
+
+
+AUTH = {"Authorization": "Bearer tr_sometoken"}
+
+
+class TestExportBundle:
+    def test_returns_v1_bundle_parts(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        resp = client.get("/api/v1/public/traces/abc123/export", headers=AUTH)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == {"manifest", "trace", "spans", "git_context"}
+
+    def test_manifest_lists_only_v1_files(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        manifest = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()[
+            "manifest"
+        ]
+        assert manifest["files"] == [
+            "trace.json",
+            "spans.json",
+            "git_context.json",
+            "manifest.json",
+        ]
+        assert manifest["trace_id"] == "abc123"
+        assert manifest["project_id"] == "proj-A"
+        # excluded deferred files
+        for excluded in ("logs.json", "metrics.json", "related_context.json"):
+            assert excluded not in manifest["files"]
+
+    def test_export_trace_equals_get_payload(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        got = client.get("/api/v1/public/traces/abc123", headers=AUTH).json()
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        exported = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()
+        assert exported["trace"] == got
+
+    def test_spans_match_trace_spans(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        body = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()
+        assert body["spans"] == body["trace"]["spans"]
+        assert body["spans"][0]["span_id"] == "span-1"
+
+    def test_git_context_from_trace_and_spans(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        gc = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()["git_context"]
+        assert gc["git_repo"] == "org/repo"
+        assert gc["git_ref"] == "main"
+        assert gc["sources"] == [
+            {"span_id": "span-1", "file": "app/main.py", "line": 42, "function": "handler"}
+        ]
+
+    def test_git_context_omits_spans_without_git_fields(self, client, mock_reader):
+        gitless = {
+            **TRACE_DETAIL["spans"][0],
+            "span_id": "span-2",
+            "git_source_file": None,
+            "git_source_line": None,
+            "git_source_function": None,
+        }
+        trace = {**TRACE_DETAIL, "spans": [TRACE_DETAIL["spans"][0], gitless]}
+        mock_reader.get_trace.return_value = trace
+        gc = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()["git_context"]
+        assert [s["span_id"] for s in gc["sources"]] == ["span-1"]
+
+    def test_git_context_typed_empty_when_no_git(self, client, mock_reader):
+        """A trace with no git data yields a stable, typed-empty git_context."""
+        gitless_span = {
+            **TRACE_DETAIL["spans"][0],
+            "git_source_file": None,
+            "git_source_line": None,
+            "git_source_function": None,
+        }
+        trace = {**TRACE_DETAIL, "git_ref": None, "git_repo": None, "spans": [gitless_span]}
+        mock_reader.get_trace.return_value = trace
+        gc = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()["git_context"]
+        assert gc == {"git_repo": None, "git_ref": None, "sources": []}
+
+    def test_export_spans_equal_public_get_spans(self, client, mock_reader):
+        """spans.json matches the spans from the public `traces get` payload."""
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        get_spans = client.get("/api/v1/public/traces/abc123", headers=AUTH).json()["spans"]
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        export_spans = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()[
+            "spans"
+        ]
+        assert export_spans == get_spans
+
+    def test_scopes_to_auth_project_id(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        client.get("/api/v1/public/traces/abc123/export?project_id=evil", headers=AUTH)
+        kw = mock_reader.get_trace.call_args.kwargs
+        assert kw["project_id"] == "proj-A"
+        assert kw["trace_id"] == "abc123"
+
+    def test_trace_url_present(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        body = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()
+        assert (
+            body["trace"]["trace_url"]
+            == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
+        )
+
+    def test_404_when_missing(self, client, mock_reader):
+        mock_reader.get_trace.return_value = None
+        resp = client.get("/api/v1/public/traces/nope/export", headers=AUTH)
+        assert resp.status_code == 404
+
+
+class TestExportAuth:
+    def test_missing_api_key_returns_401(self):
+        test_client = TestClient(app, raise_server_exceptions=False)
+        resp = test_client.get("/api/v1/public/traces/abc123/export")
+        assert resp.status_code == 401
+
+    @respx.mock
+    def test_invalid_api_key_returns_401(self):
+        respx.post(f"{BASE_URL}/api/internal/validate-api-key").mock(
+            return_value=Response(200, json={"valid": False, "error": "Invalid API key"})
+        )
+        test_client = TestClient(app, raise_server_exceptions=False)
+        resp = test_client.get(
+            "/api/v1/public/traces/abc123/export",
+            headers={"Authorization": "Bearer bad"},
+        )
+        assert resp.status_code == 401

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -197,6 +197,18 @@ class TestPublicGetTrace:
         assert data["spans"][0]["span_id"] == "span-1"
         assert data["trace_url"] == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
 
+    def test_trace_url_uses_public_ui_url_not_internal(self, client, mock_reader, monkeypatch):
+        """Get trace_url must use the host-usable public UI URL, never the
+        internal backend-to-web URL (which can be a Docker service host)."""
+        from shared.config import settings
+
+        monkeypatch.setattr(settings, "traceroot_ui_url", "http://web:3000")
+        monkeypatch.setattr(settings, "traceroot_public_ui_url", "http://localhost:3000")
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        url = client.get("/api/v1/public/traces/abc123", headers=AUTH_HEADER).json()["trace_url"]
+        assert url == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
+        assert "web:3000" not in url
+
     def test_404_when_trace_missing(self, client, mock_reader):
         mock_reader.get_trace.return_value = None
         resp = client.get("/api/v1/public/traces/nonexistent", headers=AUTH_HEADER)


### PR DESCRIPTION
## Summary

Closes #1035

Adds the public, API-key-authenticated trace **export** endpoint the CLI's `traces export` builds on:

- `GET /api/v1/public/traces/{trace_id}/export` — returns a backend-assembled V1 bundle for a single trace, scoped to the API key's project.
- The bundle has exactly four parts: `trace`, `spans`, `git_context`, and `manifest` (written by the client as `trace.json`, `spans.json`, `git_context.json`, `manifest.json`).
- `bundle.trace` is identical to the public `traces get` payload for the same trace — both routes serialize through the shared `public_trace_detail` helper, so there is no duplicated serialization and the two can't drift.
- `git_context` is assembled only from trace-resident git metadata (`git_repo`, `git_ref`, and per-span `git_source_file`/`git_source_line`/`git_source_function`); it is stable/typed-empty when git fields are absent (`{git_repo: null, git_ref: null, sources: []}`).
- `manifest` records the trace id, project id, bundle version, and the exact file list.

## Scope

- `backend/rest/routers/public/serialize.py` — `public_trace_detail`, `git_context`, `export_bundle` helpers.
- `backend/rest/routers/public/traces_read.py` — the `/export` route, a `_require_trace` helper, and `get` refactored to share the serializer with export.
- `backend/rest/schemas/public.py` — `GitSource`, `GitContext`, `ExportManifest`, `PublicTraceExportResponse`.
- `tests/rest/test_public_traces_export.py` — 13 tests.

## Out of scope

- `logs.json` / `metrics.json` / `related_context.json` (no first-class public readers for these yet).
- Public-UI-URL work, OpenAPI artifact, CLI code, docs/handoff, rate limiting — separate changes.

## Verification

- `uv run pytest tests/rest/test_public_traces_export.py` → 13 passed.
- `uv run pytest tests/rest` → 126 passed (existing public list/get/whoami unaffected).
- `uv run ruff check` + `ruff format --check` on the four changed files → clean.
- Tests cover: exact V1 bundle keys; manifest lists only the 4 files and excludes the deferred ones; `export.trace == traces get`; `export.spans == get spans`; `git_context` populated and typed-empty; project scoping (client `project_id` ignored); 404 on missing/cross-project; 401 on missing/invalid key.

## Stack

Base branch: `feat/cli-dx-traces-read`

Previous PR: #1067

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public, API-key-authenticated trace export endpoint that returns a V1 bundle (trace, spans, git_context, manifest) for CLI use. Aligns with Linear #1035 and ensures all public URLs use the public UI base.

- **New Features**
  - GET `/api/v1/public/traces/{trace_id}/export` returns a V1 bundle scoped to the API key’s project.
  - Bundle files: `trace.json`, `spans.json`, `git_context.json`, `manifest.json`.
  - `bundle.trace` equals the public get payload; spans mirror get spans.
  - `git_context` comes from trace git fields; typed-empty when absent.
  - `manifest` includes trace_id, project_id, bundle_version, and file list.
  - Added response models: `GitSource`, `GitContext`, `ExportManifest`, `PublicTraceExportResponse`.

- **Refactors**
  - Shared serializers keep get and export in lockstep.
  - Public trace URLs (list/get/export) are built from the public UI URL, never the internal backend URL.
  - Centralized `_require_trace` for scoped fetch; 404 on missing; controlled 500 on reader errors.
  - Tests cover bundle shape, payload parity, scoping, auth, `git_context`, and public UI URLs.

<sup>Written for commit f5e0be60ea02b2f6118a751bb7780d027f0265c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

