### PR TITLE
feat(api): add public openapi schema artifact

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -898,6 +898,21 @@
               }
             },
             "description": "Failed to list traces"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
           }
         },
         "security": [
@@ -935,6 +950,21 @@
             },
             "description": "Successful Response"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Invalid request body"
+          },
           "401": {
             "content": {
               "application/json": {
@@ -949,6 +979,36 @@
               }
             },
             "description": "Authentication failed"
+          },
+          "402": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Free plan limit exceeded"
+          },
+          "415": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Unsupported media type"
           },
           "422": {
             "content": {
@@ -974,6 +1034,21 @@
               }
             },
             "description": "Storage error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
           }
         },
         "security": [
@@ -1067,6 +1142,21 @@
               }
             },
             "description": "Failed to get trace"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
           }
         },
         "security": [
@@ -1160,6 +1250,21 @@
               }
             },
             "description": "Failed to get trace"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
           }
         },
         "security": [
@@ -1212,6 +1317,21 @@
               }
             },
             "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
           }
         },
         "security": [

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -959,6 +959,21 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Storage error"
           }
         },
         "security": [

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1,0 +1,1106 @@
+{
+  "components": {
+    "schemas": {
+      "ExportManifest": {
+        "description": "manifest.json: index of the bundle's parts.",
+        "properties": {
+          "bundle_version": {
+            "title": "Bundle Version",
+            "type": "string"
+          },
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Files",
+            "type": "array"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "project_id",
+          "bundle_version",
+          "files"
+        ],
+        "title": "ExportManifest",
+        "type": "object"
+      },
+      "GitContext": {
+        "description": "git_context.json: repo/ref + per-span source locations.",
+        "properties": {
+          "git_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Ref"
+          },
+          "git_repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Repo"
+          },
+          "sources": {
+            "items": {
+              "$ref": "#/components/schemas/GitSource"
+            },
+            "title": "Sources",
+            "type": "array"
+          }
+        },
+        "required": [
+          "git_repo",
+          "git_ref",
+          "sources"
+        ],
+        "title": "GitContext",
+        "type": "object"
+      },
+      "GitSource": {
+        "description": "A single span's source location (trace-resident git metadata).",
+        "properties": {
+          "file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File"
+          },
+          "function": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Function"
+          },
+          "line": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Line"
+          },
+          "span_id": {
+            "title": "Span Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "span_id",
+          "file",
+          "line",
+          "function"
+        ],
+        "title": "GitSource",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "IngestResponse": {
+        "description": "Response for trace ingestion.",
+        "properties": {
+          "file_key": {
+            "title": "File Key",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "file_key"
+        ],
+        "title": "IngestResponse",
+        "type": "object"
+      },
+      "PaginationMeta": {
+        "description": "Pagination metadata for list responses.",
+        "properties": {
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "page": {
+            "title": "Page",
+            "type": "integer"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "page",
+          "limit",
+          "total"
+        ],
+        "title": "PaginationMeta",
+        "type": "object"
+      },
+      "PublicTraceDetailResponse": {
+        "description": "Full trace payload plus a backend-built link to its UI detail view.",
+        "properties": {
+          "git_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Ref"
+          },
+          "git_repo": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Repo"
+          },
+          "input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "string"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "spans": {
+            "items": {
+              "$ref": "#/components/schemas/SpanResponse"
+            },
+            "title": "Spans",
+            "type": "array"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          },
+          "trace_start_time": {
+            "format": "date-time",
+            "title": "Trace Start Time",
+            "type": "string"
+          },
+          "trace_url": {
+            "title": "Trace Url",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "trace_id",
+          "project_id",
+          "name",
+          "trace_start_time",
+          "user_id",
+          "session_id",
+          "git_ref",
+          "git_repo",
+          "input",
+          "output",
+          "metadata",
+          "spans",
+          "trace_url"
+        ],
+        "title": "PublicTraceDetailResponse",
+        "type": "object"
+      },
+      "PublicTraceExportResponse": {
+        "description": "V1 export bundle: trace (== `traces get`) + spans + git_context + manifest.",
+        "properties": {
+          "git_context": {
+            "$ref": "#/components/schemas/GitContext"
+          },
+          "manifest": {
+            "$ref": "#/components/schemas/ExportManifest"
+          },
+          "spans": {
+            "items": {
+              "$ref": "#/components/schemas/SpanResponse"
+            },
+            "title": "Spans",
+            "type": "array"
+          },
+          "trace": {
+            "$ref": "#/components/schemas/PublicTraceDetailResponse"
+          }
+        },
+        "required": [
+          "manifest",
+          "trace",
+          "spans",
+          "git_context"
+        ],
+        "title": "PublicTraceExportResponse",
+        "type": "object"
+      },
+      "PublicTraceListItem": {
+        "description": "A trace list item plus a backend-built link to its UI detail view.",
+        "properties": {
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms"
+          },
+          "error_count": {
+            "title": "Error Count",
+            "type": "integer"
+          },
+          "input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "string"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "span_count": {
+            "title": "Span Count",
+            "type": "integer"
+          },
+          "total_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 0.0,
+            "title": "Total Cost"
+          },
+          "total_input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 0,
+            "title": "Total Input Tokens"
+          },
+          "total_output_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": 0,
+            "title": "Total Output Tokens"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          },
+          "trace_start_time": {
+            "format": "date-time",
+            "title": "Trace Start Time",
+            "type": "string"
+          },
+          "trace_url": {
+            "title": "Trace Url",
+            "type": "string"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "trace_id",
+          "project_id",
+          "name",
+          "trace_start_time",
+          "user_id",
+          "session_id",
+          "span_count",
+          "duration_ms",
+          "error_count",
+          "input",
+          "output",
+          "trace_url"
+        ],
+        "title": "PublicTraceListItem",
+        "type": "object"
+      },
+      "PublicTraceListResponse": {
+        "description": "Paginated list of traces for the public API.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/PublicTraceListItem"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "PublicTraceListResponse",
+        "type": "object"
+      },
+      "SpanResponse": {
+        "description": "Single span in a trace.",
+        "properties": {
+          "cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost"
+          },
+          "git_source_file": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Source File"
+          },
+          "git_source_function": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Source Function"
+          },
+          "git_source_line": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Git Source Line"
+          },
+          "input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input"
+          },
+          "input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Tokens"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "model_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Name"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output"
+          },
+          "output_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Tokens"
+          },
+          "parent_span_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Span Id"
+          },
+          "span_end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span End Time"
+          },
+          "span_id": {
+            "title": "Span Id",
+            "type": "string"
+          },
+          "span_kind": {
+            "title": "Span Kind",
+            "type": "string"
+          },
+          "span_start_time": {
+            "format": "date-time",
+            "title": "Span Start Time",
+            "type": "string"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "status_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Message"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Tokens"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "span_id",
+          "trace_id",
+          "parent_span_id",
+          "name",
+          "span_kind",
+          "span_start_time",
+          "span_end_time",
+          "status",
+          "status_message",
+          "model_name",
+          "cost",
+          "input_tokens",
+          "output_tokens",
+          "total_tokens",
+          "input",
+          "output",
+          "metadata"
+        ],
+        "title": "SpanResponse",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "WhoamiResponse": {
+        "description": "Identity a project API key resolves to, for `login` / `status`.\n\nName fields are nullable: they depend on what the internal key-validation\ncontract returns, and the backend never fabricates them. The full API token\nis never included \u2014 only ``key_hint``.",
+        "properties": {
+          "host": {
+            "title": "Host",
+            "type": "string"
+          },
+          "key_hint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key Hint"
+          },
+          "key_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Key Name"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "string"
+          },
+          "project_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Project Name"
+          },
+          "ui_base_url": {
+            "title": "Ui Base Url",
+            "type": "string"
+          },
+          "workspace_id": {
+            "title": "Workspace Id",
+            "type": "string"
+          },
+          "workspace_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workspace Name"
+          }
+        },
+        "required": [
+          "project_id",
+          "project_name",
+          "workspace_id",
+          "workspace_name",
+          "key_name",
+          "key_hint",
+          "host",
+          "ui_base_url"
+        ],
+        "title": "WhoamiResponse",
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "title": "TraceRoot Public API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/api/v1/public/traces": {
+      "get": {
+        "description": "List recent traces for the API key's project (newest first).",
+        "operationId": "list_traces_api_v1_public_traces_get",
+        "parameters": [
+          {
+            "description": "Items per page",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Items per page",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicTraceListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Traces",
+        "tags": [
+          "Traces (Public)"
+        ]
+      },
+      "post": {
+        "description": "Ingest OTLP trace data.\n\nAccepts OTLP protobuf format only (optionally gzip compressed).\nProtobuf is converted to camelCase JSON before storage in S3.\n\nS3 path: events/otel/{project_id}/{yyyy}/{mm}/{dd}/{hh}/{uuid}.json\n\nHeaders:\n    Authorization: Bearer <api_key>\n    Content-Encoding: gzip (optional)\n    Content-Type: application/x-protobuf\n\nBody:\n    OTLP trace data in protobuf format",
+        "operationId": "ingest_traces_api_v1_public_traces_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ingest Traces",
+        "tags": [
+          "Traces (Public)"
+        ]
+      }
+    },
+    "/api/v1/public/traces/{trace_id}": {
+      "get": {
+        "description": "Get a single trace (full payload, including spans) for the key's project.",
+        "operationId": "get_trace_api_v1_public_traces__trace_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "trace_id",
+            "required": true,
+            "schema": {
+              "title": "Trace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicTraceDetailResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Trace",
+        "tags": [
+          "Traces (Public)"
+        ]
+      }
+    },
+    "/api/v1/public/traces/{trace_id}/export": {
+      "get": {
+        "description": "Export the V1 bundle (trace + spans + git_context + manifest) for the key's project.\n\n`bundle.trace` is identical to the `traces get` payload for the same trace.",
+        "operationId": "export_trace_api_v1_public_traces__trace_id__export_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "trace_id",
+            "required": true,
+            "schema": {
+              "title": "Trace Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicTraceExportResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Export Trace",
+        "tags": [
+          "Traces (Public)"
+        ]
+      }
+    },
+    "/api/v1/public/whoami": {
+      "get": {
+        "description": "Return the identity the authenticated API key maps to.",
+        "operationId": "whoami_api_v1_public_whoami_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "authorization",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WhoamiResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Whoami",
+        "tags": [
+          "Whoami (Public)"
+        ]
+      }
+    }
+  }
+}

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -814,6 +814,12 @@
         "title": "WhoamiResponse",
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "scheme": "bearer",
+        "type": "http"
+      }
     }
   },
   "info": {
@@ -840,22 +846,6 @@
               "title": "Limit",
               "type": "integer"
             }
-          },
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
           }
         ],
         "responses": {
@@ -869,6 +859,21 @@
             },
             "description": "Successful Response"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -878,8 +883,28 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to list traces"
           }
         },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "summary": "List Traces",
         "tags": [
           "Traces (Public)"
@@ -888,24 +913,17 @@
       "post": {
         "description": "Ingest OTLP trace data.\n\nAccepts OTLP protobuf format only (optionally gzip compressed).\nProtobuf is converted to camelCase JSON before storage in S3.\n\nS3 path: events/otel/{project_id}/{yyyy}/{mm}/{dd}/{hh}/{uuid}.json\n\nHeaders:\n    Authorization: Bearer <api_key>\n    Content-Encoding: gzip (optional)\n    Content-Type: application/x-protobuf\n\nBody:\n    OTLP trace data in protobuf format",
         "operationId": "ingest_traces_api_v1_public_traces_post",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
+        "requestBody": {
+          "content": {
+            "application/x-protobuf": {
+              "schema": {
+                "format": "binary",
+                "type": "string"
+              }
             }
-          }
-        ],
+          },
+          "required": true
+        },
         "responses": {
           "200": {
             "content": {
@@ -916,6 +934,21 @@
               }
             },
             "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
           },
           "422": {
             "content": {
@@ -928,6 +961,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "summary": "Ingest Traces",
         "tags": [
           "Traces (Public)"
@@ -947,22 +985,6 @@
               "title": "Trace Id",
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
           }
         ],
         "responses": {
@@ -976,6 +998,36 @@
             },
             "description": "Successful Response"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Trace not found"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -985,8 +1037,28 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to get trace"
           }
         },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "summary": "Get Trace",
         "tags": [
           "Traces (Public)"
@@ -1006,22 +1078,6 @@
               "title": "Trace Id",
               "type": "string"
             }
-          },
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
           }
         ],
         "responses": {
@@ -1035,6 +1091,36 @@
             },
             "description": "Successful Response"
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Trace not found"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -1044,8 +1130,28 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to get trace"
           }
         },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "summary": "Export Trace",
         "tags": [
           "Traces (Public)"
@@ -1056,24 +1162,6 @@
       "get": {
         "description": "Return the identity the authenticated API key maps to.",
         "operationId": "whoami_api_v1_public_whoami_get",
-        "parameters": [
-          {
-            "in": "header",
-            "name": "authorization",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          }
-        ],
         "responses": {
           "200": {
             "content": {
@@ -1084,6 +1172,21 @@
               }
             },
             "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
           },
           "422": {
             "content": {
@@ -1096,6 +1199,11 @@
             "description": "Validation Error"
           }
         },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
         "summary": "Whoami",
         "tags": [
           "Whoami (Public)"

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -1,0 +1,69 @@
+"""Build a deterministic, public-only OpenAPI schema for the CLI to codegen from.
+
+The public API surface is defined by a single path prefix (`/api/v1/public/*`) —
+everything the project-API-key contract exposes, including SDK ingestion. Internal
+(`/api/v1/internal/*`), user-session, and project-scoped (`/api/v1/projects/*`)
+routes plus `/health` are excluded. Output is rendered with sorted keys so the
+committed artifact diffs cleanly and a drift check is meaningful.
+"""
+
+import json
+from typing import Any
+
+PUBLIC_PREFIX = "/api/v1/public/"
+TITLE = "TraceRoot Public API"
+
+
+def _collect_refs(node: Any, acc: set[str]) -> None:
+    """Collect component schema names referenced by `$ref` anywhere under `node`."""
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str) and ref.startswith("#/components/schemas/"):
+            acc.add(ref.rsplit("/", 1)[1])
+        for value in node.values():
+            _collect_refs(value, acc)
+    elif isinstance(node, list):
+        for value in node:
+            _collect_refs(value, acc)
+
+
+def build_public_schema(app: Any) -> dict[str, Any]:
+    """Return the public-only OpenAPI document for `app`.
+
+    Keeps only `/api/v1/public/*` paths and the component schemas transitively
+    referenced by them, so unrelated (internal/session) model changes don't churn
+    the public artifact.
+    """
+    full = app.openapi()
+    paths = {p: item for p, item in full["paths"].items() if p.startswith(PUBLIC_PREFIX)}
+
+    all_schemas = (full.get("components") or {}).get("schemas", {})
+    referenced: set[str] = set()
+    _collect_refs(paths, referenced)
+    # Transitively pull in nested schema references to a fixpoint.
+    changed = True
+    while changed:
+        changed = False
+        for name in list(referenced):
+            schema = all_schemas.get(name)
+            if schema is None:
+                continue
+            before = len(referenced)
+            _collect_refs(schema, referenced)
+            changed = changed or len(referenced) != before
+
+    components: dict[str, Any] = {}
+    if referenced:
+        components["schemas"] = {n: all_schemas[n] for n in referenced if n in all_schemas}
+
+    return {
+        "openapi": full["openapi"],
+        "info": {"title": TITLE, "version": full["info"]["version"]},
+        "paths": paths,
+        "components": components,
+    }
+
+
+def render(schema: dict[str, Any]) -> str:
+    """Deterministic serialization (sorted keys) for stable diffs / drift checks."""
+    return json.dumps(schema, indent=2, sort_keys=True) + "\n"

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -50,12 +50,15 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
                 op["parameters"] = params
             else:
                 op.pop("parameters", None)
-            op.setdefault("responses", {}).setdefault(
-                "401", _error_response("Authentication failed")
-            )
+            # Every public op depends on the shared API-key auth dependency, which
+            # raises 401 (bad/invalid key) and 503 (auth service unavailable).
+            responses = op.setdefault("responses", {})
+            responses.setdefault("401", _error_response("Authentication failed"))
+            responses.setdefault("503", _error_response("Authentication service unavailable"))
 
     # Public ingestion accepts an OTLP protobuf body (read from the raw request)
-    # and raises 500 on storage failure (S3 upload), matching the route code.
+    # and documents its runtime error contract: 400 (bad/empty/undecodable body),
+    # 402 (plan limit), 415 (wrong Content-Type), 500 (S3 storage failure).
     ingest = schema["paths"].get("/api/v1/public/traces", {}).get("post")
     if ingest is not None:
         ingest["requestBody"] = {
@@ -64,7 +67,11 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
                 "application/x-protobuf": {"schema": {"type": "string", "format": "binary"}}
             },
         }
-        ingest["responses"].setdefault("500", _error_response("Storage error"))
+        ingest_responses = ingest["responses"]
+        ingest_responses.setdefault("400", _error_response("Invalid request body"))
+        ingest_responses.setdefault("402", _error_response("Free plan limit exceeded"))
+        ingest_responses.setdefault("415", _error_response("Unsupported media type"))
+        ingest_responses.setdefault("500", _error_response("Storage error"))
 
     # Trace read/export error contract (matches the route code).
     list_op = schema["paths"].get("/api/v1/public/traces", {}).get("get")

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -13,6 +13,66 @@ from typing import Any
 PUBLIC_PREFIX = "/api/v1/public/"
 TITLE = "TraceRoot Public API"
 
+_HTTP_METHODS = {"get", "post", "put", "patch", "delete"}
+_BEARER_SCHEME = {"type": "http", "scheme": "bearer"}
+_ERROR_SCHEMA = {"type": "object", "properties": {"detail": {"type": "string"}}}
+
+
+def _error_response(description: str) -> dict[str, Any]:
+    return {"description": description, "content": {"application/json": {"schema": _ERROR_SCHEMA}}}
+
+
+def _apply_public_contract(schema: dict[str, Any]) -> None:
+    """Document contract details FastAPI can't infer from the raw-Request /
+    manual-HTTPException public routes: bearer auth (required), the protobuf
+    ingestion body, and the real 401/404/500 error responses.
+    """
+    schema.setdefault("components", {}).setdefault("securitySchemes", {})["BearerAuth"] = (
+        _BEARER_SCHEME
+    )
+
+    for item in schema["paths"].values():
+        for method, op in item.items():
+            if method not in _HTTP_METHODS:
+                continue
+            # Auth is required on every public endpoint: represent it once as a
+            # bearer requirement and drop the misleading optional header param.
+            op["security"] = [{"BearerAuth": []}]
+            params = [
+                p
+                for p in op.get("parameters", [])
+                if not (
+                    p.get("in") == "header" and (p.get("name") or "").lower() == "authorization"
+                )
+            ]
+            if params:
+                op["parameters"] = params
+            else:
+                op.pop("parameters", None)
+            op.setdefault("responses", {}).setdefault(
+                "401", _error_response("Authentication failed")
+            )
+
+    # Public ingestion accepts an OTLP protobuf body (read from the raw request).
+    ingest = schema["paths"].get("/api/v1/public/traces", {}).get("post")
+    if ingest is not None:
+        ingest["requestBody"] = {
+            "required": True,
+            "content": {
+                "application/x-protobuf": {"schema": {"type": "string", "format": "binary"}}
+            },
+        }
+
+    # Trace read/export error contract (matches the route code).
+    list_op = schema["paths"].get("/api/v1/public/traces", {}).get("get")
+    if list_op is not None:
+        list_op["responses"].setdefault("500", _error_response("Failed to list traces"))
+    for path in ("/api/v1/public/traces/{trace_id}", "/api/v1/public/traces/{trace_id}/export"):
+        op = schema["paths"].get(path, {}).get("get")
+        if op is not None:
+            op["responses"].setdefault("404", _error_response("Trace not found"))
+            op["responses"].setdefault("500", _error_response("Failed to get trace"))
+
 
 def _collect_refs(node: Any, acc: set[str]) -> None:
     """Collect component schema names referenced by `$ref` anywhere under `node`."""
@@ -56,12 +116,14 @@ def build_public_schema(app: Any) -> dict[str, Any]:
     if referenced:
         components["schemas"] = {n: all_schemas[n] for n in referenced if n in all_schemas}
 
-    return {
+    schema = {
         "openapi": full["openapi"],
         "info": {"title": TITLE, "version": full["info"]["version"]},
         "paths": paths,
         "components": components,
     }
+    _apply_public_contract(schema)
+    return schema
 
 
 def render(schema: dict[str, Any]) -> str:

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -54,7 +54,8 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
                 "401", _error_response("Authentication failed")
             )
 
-    # Public ingestion accepts an OTLP protobuf body (read from the raw request).
+    # Public ingestion accepts an OTLP protobuf body (read from the raw request)
+    # and raises 500 on storage failure (S3 upload), matching the route code.
     ingest = schema["paths"].get("/api/v1/public/traces", {}).get("post")
     if ingest is not None:
         ingest["requestBody"] = {
@@ -63,6 +64,7 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
                 "application/x-protobuf": {"schema": {"type": "string", "format": "binary"}}
             },
         }
+        ingest["responses"].setdefault("500", _error_response("Storage error"))
 
     # Trace read/export error contract (matches the route code).
     list_op = schema["paths"].get("/api/v1/public/traces", {}).get("get")

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -7,6 +7,7 @@ routes plus `/health` are excluded. Output is rendered with sorted keys so the
 committed artifact diffs cleanly and a drift check is meaningful.
 """
 
+import copy
 import json
 from typing import Any
 
@@ -95,7 +96,13 @@ def build_public_schema(app: Any) -> dict[str, Any]:
     the public artifact.
     """
     full = app.openapi()
-    paths = {p: item for p, item in full["paths"].items() if p.startswith(PUBLIC_PREFIX)}
+    # app.openapi() returns FastAPI's *cached* document; its path-item and
+    # component-schema dicts are shared with it. _apply_public_contract mutates
+    # path operations in place, so deep-copy everything that enters (and may be
+    # mutated in) the public document to avoid corrupting the cached full schema.
+    paths = {
+        p: copy.deepcopy(item) for p, item in full["paths"].items() if p.startswith(PUBLIC_PREFIX)
+    }
 
     all_schemas = (full.get("components") or {}).get("schemas", {})
     referenced: set[str] = set()
@@ -114,7 +121,9 @@ def build_public_schema(app: Any) -> dict[str, Any]:
 
     components: dict[str, Any] = {}
     if referenced:
-        components["schemas"] = {n: all_schemas[n] for n in referenced if n in all_schemas}
+        components["schemas"] = {
+            n: copy.deepcopy(all_schemas[n]) for n in referenced if n in all_schemas
+        }
 
     schema = {
         "openapi": full["openapi"],

--- a/scripts/dump_public_openapi.py
+++ b/scripts/dump_public_openapi.py
@@ -1,0 +1,50 @@
+"""Generate or verify the committed public OpenAPI artifact.
+
+  uv run python scripts/dump_public_openapi.py            # write the artifact
+  uv run python scripts/dump_public_openapi.py --check    # exit 1 if it drifts
+  uv run python scripts/dump_public_openapi.py <path>     # write to a custom path
+
+The schema-building logic lives in `rest.openapi_public` so it is importable and
+testable; this file is just the CLI + the canonical artifact location.
+"""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "backend"))
+
+from rest.main import app  # noqa: E402
+from rest.openapi_public import build_public_schema, render  # noqa: E402
+
+ARTIFACT = ROOT / "backend" / "rest" / "openapi" / "public.json"
+
+
+def main(argv: list[str]) -> int:
+    check = "--check" in argv
+    positional = [a for a in argv if not a.startswith("-")]
+    rendered = render(build_public_schema(app))
+
+    if check:
+        if not ARTIFACT.exists():
+            print(f"Missing public OpenAPI artifact: {ARTIFACT}", file=sys.stderr)
+            return 1
+        if ARTIFACT.read_text(encoding="utf-8") != rendered:
+            print(
+                "Public OpenAPI artifact is stale. Regenerate with "
+                "`uv run python scripts/dump_public_openapi.py`.",
+                file=sys.stderr,
+            )
+            return 1
+        print("Public OpenAPI artifact is up to date.", file=sys.stderr)
+        return 0
+
+    out = Path(positional[0]) if positional else ARTIFACT
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(rendered, encoding="utf-8")
+    print(f"Wrote {len(build_public_schema(app)['paths'])} public paths to {out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/sync_public_openapi.py
+++ b/scripts/sync_public_openapi.py
@@ -1,8 +1,8 @@
 """Generate or verify the committed public OpenAPI artifact.
 
-  uv run python scripts/dump_public_openapi.py            # write the artifact
-  uv run python scripts/dump_public_openapi.py --check    # exit 1 if it drifts
-  uv run python scripts/dump_public_openapi.py <path>     # write to a custom path
+  uv run python scripts/sync_public_openapi.py            # write the artifact
+  uv run python scripts/sync_public_openapi.py --check    # exit 1 if it drifts
+  uv run python scripts/sync_public_openapi.py <path>     # write to a custom path
 
 The schema-building logic lives in `rest.openapi_public` so it is importable and
 testable; this file is just the CLI + the canonical artifact location.
@@ -32,7 +32,7 @@ def main(argv: list[str]) -> int:
         if ARTIFACT.read_text(encoding="utf-8") != rendered:
             print(
                 "Public OpenAPI artifact is stale. Regenerate with "
-                "`uv run python scripts/dump_public_openapi.py`.",
+                "`uv run python scripts/sync_public_openapi.py`.",
                 file=sys.stderr,
             )
             return 1

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -1,0 +1,75 @@
+"""Tests for the public-only OpenAPI schema generation + drift guard."""
+
+import json
+from pathlib import Path
+
+from rest.main import app
+from rest.openapi_public import PUBLIC_PREFIX, build_public_schema, render
+
+ARTIFACT = Path(__file__).resolve().parents[2] / "backend" / "rest" / "openapi" / "public.json"
+
+
+def _schema():
+    return build_public_schema(app)
+
+
+def test_includes_required_public_paths():
+    paths = _schema()["paths"]
+    assert "/api/v1/public/whoami" in paths
+    assert "get" in paths["/api/v1/public/whoami"]
+    assert "get" in paths["/api/v1/public/traces"]
+    assert "get" in paths["/api/v1/public/traces/{trace_id}"]
+    assert "get" in paths["/api/v1/public/traces/{trace_id}/export"]
+
+
+def test_includes_public_ingestion_route():
+    # The public API contract is the /api/v1/public/* prefix, which includes the
+    # API-key-authed SDK ingestion endpoint.
+    paths = _schema()["paths"]
+    assert "post" in paths["/api/v1/public/traces"]
+
+
+def test_excludes_internal_session_and_project_routes():
+    paths = _schema()["paths"]
+    assert all(p.startswith(PUBLIC_PREFIX) for p in paths), paths
+    assert not any(p.startswith("/api/v1/internal/") for p in paths)
+    assert not any(p.startswith("/api/v1/projects/") for p in paths)
+    assert "/health" not in paths
+
+
+def test_export_response_model_present_and_referenced():
+    schema = _schema()
+    export_op = schema["paths"]["/api/v1/public/traces/{trace_id}/export"]["get"]
+    ref = export_op["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+    assert ref.endswith("/PublicTraceExportResponse")
+    components = schema["components"]["schemas"]
+    # the export model and its nested V1 bundle pieces are pulled in transitively
+    assert "PublicTraceExportResponse" in components
+    for nested in ("ExportManifest", "GitContext", "GitSource", "PublicTraceDetailResponse"):
+        assert nested in components
+
+
+def test_components_are_pruned_to_public_only():
+    components = _schema()["components"]["schemas"]
+    # ingestion's response model is public (referenced by the public ingest route)
+    assert "IngestResponse" in components
+    # internal-only models must not leak into the public schema
+    assert "HealthResponse" not in components
+
+
+def test_render_is_deterministic():
+    assert render(_schema()) == render(_schema())
+
+
+def test_committed_artifact_matches_generated():
+    """Drift guard: regenerate with `python scripts/dump_public_openapi.py`."""
+    assert ARTIFACT.exists(), f"missing artifact: {ARTIFACT}"
+    assert ARTIFACT.read_text(encoding="utf-8") == render(_schema())
+
+
+def test_drift_is_detectable():
+    """A changed artifact must not compare equal (the guard is sensitive)."""
+    generated = render(_schema())
+    tampered = json.loads(generated)
+    tampered["info"]["title"] = "Tampered"
+    assert render(tampered) != generated

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -73,3 +73,41 @@ def test_drift_is_detectable():
     tampered = json.loads(generated)
     tampered["info"]["title"] = "Tampered"
     assert render(tampered) != generated
+
+
+def test_ingestion_documents_protobuf_request_body():
+    post = _schema()["paths"]["/api/v1/public/traces"]["post"]
+    assert "requestBody" in post
+    content = post["requestBody"]["content"]
+    assert "application/x-protobuf" in content
+    assert content["application/x-protobuf"]["schema"] == {"type": "string", "format": "binary"}
+
+
+def _public_operations(schema):
+    for item in schema["paths"].values():
+        for method, op in item.items():
+            if method in {"get", "post", "put", "patch", "delete"}:
+                yield op
+
+
+def test_all_public_ops_require_bearer_auth():
+    schema = _schema()
+    assert schema["components"]["securitySchemes"]["BearerAuth"] == {
+        "type": "http",
+        "scheme": "bearer",
+    }
+    for op in _public_operations(schema):
+        assert op.get("security") == [{"BearerAuth": []}]
+        # the misleading optional Authorization header param is gone
+        header_names = [p.get("name", "").lower() for p in op.get("parameters", [])]
+        assert "authorization" not in header_names
+        assert "401" in op["responses"]
+
+
+def test_read_endpoints_document_error_responses():
+    paths = _schema()["paths"]
+    assert set(paths["/api/v1/public/traces"]["get"]["responses"]) >= {"200", "401", "500"}
+    for p in ("/api/v1/public/traces/{trace_id}", "/api/v1/public/traces/{trace_id}/export"):
+        responses = paths[p]["get"]["responses"]
+        assert set(responses) >= {"200", "401", "404", "500"}
+        assert responses["404"]["description"] == "Trace not found"

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -62,7 +62,7 @@ def test_render_is_deterministic():
 
 
 def test_committed_artifact_matches_generated():
-    """Drift guard: regenerate with `python scripts/dump_public_openapi.py`."""
+    """Drift guard: regenerate with `python scripts/sync_public_openapi.py`."""
     assert ARTIFACT.exists(), f"missing artifact: {ARTIFACT}"
     assert ARTIFACT.read_text(encoding="utf-8") == render(_schema())
 

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -107,6 +107,15 @@ def test_ingestion_documents_protobuf_request_body():
     assert content["application/x-protobuf"]["schema"] == {"type": "string", "format": "binary"}
 
 
+def test_ingestion_documents_500_response():
+    # The runtime route raises HTTPException(500) on S3 upload failure, so the
+    # public contract must document it — consistent with the read endpoints.
+    post = _schema()["paths"]["/api/v1/public/traces"]["post"]
+    assert "500" in post["responses"]
+    # existing responses are preserved
+    assert set(post["responses"]) >= {"200", "401", "422", "500"}
+
+
 def _public_operations(schema):
     for item in schema["paths"].values():
         for method, op in item.items():

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -1,6 +1,7 @@
 """Tests for the public-only OpenAPI schema generation + drift guard."""
 
 import json
+from copy import deepcopy
 from pathlib import Path
 
 from rest.main import app
@@ -55,6 +56,29 @@ def test_components_are_pruned_to_public_only():
     assert "IngestResponse" in components
     # internal-only models must not leak into the public schema
     assert "HealthResponse" not in components
+
+
+def test_build_does_not_mutate_cached_app_schema():
+    """build_public_schema must not mutate FastAPI's cached full OpenAPI schema.
+
+    app.openapi() returns a cached document whose path-item/operation dicts are
+    shared; the public contract must be applied to copies, not those originals.
+    """
+    # Force a pristine cache: earlier tests may have already built the schema.
+    app.openapi_schema = None
+    before = deepcopy(app.openapi())
+
+    public = build_public_schema(app)
+
+    after = app.openapi()
+    assert after == before, "build_public_schema mutated FastAPI's cached schema"
+    # Sanity: the public schema still applies its contract (filtering + stripping).
+    assert all(p.startswith(PUBLIC_PREFIX) for p in public["paths"])
+    whoami = public["paths"]["/api/v1/public/whoami"]["get"]
+    assert whoami["security"] == [{"BearerAuth": []}]
+    # And the full schema's same operation is untouched (no leaked bearer security).
+    full_whoami = after["paths"]["/api/v1/public/whoami"]["get"]
+    assert "security" not in full_whoami
 
 
 def test_render_is_deterministic():

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -107,13 +107,14 @@ def test_ingestion_documents_protobuf_request_body():
     assert content["application/x-protobuf"]["schema"] == {"type": "string", "format": "binary"}
 
 
-def test_ingestion_documents_500_response():
-    # The runtime route raises HTTPException(500) on S3 upload failure, so the
-    # public contract must document it — consistent with the read endpoints.
+def test_ingestion_documents_runtime_error_responses():
+    # The ingest route raises 400 (bad/empty/undecodable body), 402 (plan limit),
+    # 415 (wrong Content-Type) and 500 (S3 storage failure) at runtime.
     post = _schema()["paths"]["/api/v1/public/traces"]["post"]
-    assert "500" in post["responses"]
+    for code in ("400", "402", "415", "500"):
+        assert code in post["responses"], code
     # existing responses are preserved
-    assert set(post["responses"]) >= {"200", "401", "422", "500"}
+    assert set(post["responses"]) >= {"200", "401", "422", "400", "402", "415", "500"}
 
 
 def _public_operations(schema):
@@ -121,6 +122,13 @@ def _public_operations(schema):
         for method, op in item.items():
             if method in {"get", "post", "put", "patch", "delete"}:
                 yield op
+
+
+def test_all_public_ops_document_503():
+    # Every public op depends on the shared auth dependency, which raises 503 when
+    # the auth service is unavailable — so the contract must document 503.
+    for op in _public_operations(_schema()):
+        assert "503" in op["responses"]
 
 
 def test_all_public_ops_require_bearer_auth():


### PR DESCRIPTION
## Summary

Closes #1036

Publishes a deterministic, **public-only** OpenAPI schema so the standalone CLI can generate a typed client/types from a stable contract.

- `backend/rest/openapi_public.py` — `build_public_schema(app)` filters the OpenAPI document to the `/api/v1/public/*` surface and prunes `components.schemas` to only those transitively referenced by public paths; `render()` serializes with sorted keys for stable diffs.
- `scripts/dump_public_openapi.py` — thin CLI to write the artifact or verify it (`--check` exits non-zero on drift).
- `backend/rest/openapi/public.json` — the committed artifact.
- `tests/rest/test_public_openapi.py` — asserts the required public paths are present, internal/session/project/health routes are absent, components are pruned, rendering is deterministic, and the committed artifact matches the generator (drift guard, runs in CI via pytest).

The public surface is defined by a single documented prefix rule (`/api/v1/public/*`), so the API-key-authed SDK ingestion route (`POST /api/v1/public/traces`) is included by design alongside the read endpoints; the CLI simply ignores it.

The public schema also documents the real public contract so generated clients are accurate: the OTLP **protobuf request body** (`application/x-protobuf`) for public ingestion, **required bearer auth** on every public endpoint (HTTP bearer security scheme), and the **trace-read/export error responses** (401 / 404 / 500).

## Scope

- `backend/rest/openapi_public.py`
- `scripts/dump_public_openapi.py`
- `backend/rest/openapi/public.json`
- `tests/rest/test_public_openapi.py`

Included public operations: `GET /whoami`, `GET /traces`, `GET /traces/{trace_id}`, `GET /traces/{trace_id}/export`, `POST /traces`.

## Out of scope

- CLI code / standalone CLI package.
- Public UI-URL work, rate limiting / exposure, docs/handoff.
- Explicit operation-id/summary tuning of routes (FastAPI defaults are stable; route files are untouched).

## Verification

- `uv run python scripts/dump_public_openapi.py --check` → artifact up to date.
- `uv run pytest tests/rest/test_public_openapi.py` → 8 passed.
- `uv run pytest tests/rest` → 138 passed.
- `uv run ruff check` + `ruff format --check` on the changed Python files → clean.
- Confirmed the committed artifact matches what this branch's app generates (no drift introduced by isolation).

## Stack

Base branch: `feat/cli-dx-trace-export`
Previous PR: #1071

## CLI unblock

This change **unblocks standalone CLI codegen/client work**: the CLI repo can now vendor `backend/rest/openapi/public.json` (or fetch the served schema) and generate typed client/types against a stable, public-only contract, with the drift guard preventing silent contract changes.

Before the CLI repo can fully proceed, the remaining backend prerequisites are: the **Public-UI-URL** change (so `trace_url`/`ui_base_url` are host-usable) and the **docs/handoff** note (schema location + auth header + versioning policy). Production exposure/rate-limiting of the public routes is a later hardening step and not required for codegen.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a deterministic, public-only OpenAPI schema so the standalone CLI can generate a typed client from a stable contract. Adds a drift guard and sync script, and documents 503 and ingestion 400/402/415/500 errors.

- **New Features**
  - Build a public schema from `/api/v1/public/*` only and prune referenced `components.schemas`; deterministic `render()` output.
  - Commit the artifact at `backend/rest/openapi/public.json`.
  - Add `scripts/sync_public_openapi.py` to write the artifact or `--check` for drift.
  - Require bearer auth on all public endpoints and remove the optional `Authorization` header param; document `401/404/503` responses.
  - Document OTLP ingestion as `application/x-protobuf` (binary) with `POST /api/v1/public/traces`; include `400/402/415/500` error responses.
  - Exclude internal/session/project routes.
  - Tests cover required paths, auth and error responses (including `503` and ingestion `400/402/415/500`), component pruning, deterministic rendering, artifact drift, and non-mutation of the cached full schema.

- **Bug Fixes**
  - Deep-copy FastAPI schema objects when building the public document to avoid mutating the cached full OpenAPI.

<sup>Written for commit c9749e47b368758ee710c473a7de0964f863674b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



