### PR TITLE
feat(ui): add a fullscreen toggle to the trace viewer panel

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
@@ -297,22 +297,20 @@ export default function DetectorDetailPage() {
         />
       </div>
 
-      {/* Detail panel — fixed overlay sliding in from right, same pattern as traces page */}
+      {/* Detail panel — TraceViewerPanel renders its own fixed slide-in overlay */}
       {selectedFinding && (
-        <div className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 w-[70%] border-l border-border bg-background shadow-xl">
-          <TraceViewerPanel
-            projectId={projectId}
-            traceId={selectedFinding.trace_id}
-            onClose={() => setSelectedFinding(null)}
-            onNavigate={handleNavigate}
-            canNavigateUp={selectedIndex > 0}
-            canNavigateDown={selectedIndex < findings.length - 1}
-            dateFilter={state.dateFilter}
-            customStartDate={state.customStartDate}
-            customEndDate={state.customEndDate}
-            autoOpenRca={true}
-          />
-        </div>
+        <TraceViewerPanel
+          projectId={projectId}
+          traceId={selectedFinding.trace_id}
+          onClose={() => setSelectedFinding(null)}
+          onNavigate={handleNavigate}
+          canNavigateUp={selectedIndex > 0}
+          canNavigateDown={selectedIndex < findings.length - 1}
+          dateFilter={state.dateFilter}
+          customStartDate={state.customStartDate}
+          customEndDate={state.customEndDate}
+          autoOpenRca={true}
+        />
       )}
     </div>
   );

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -349,35 +349,31 @@ export default function TracesPage() {
         </div>
       </div>
 
-      {/* Detail panel - overlays header, takes 70% width, slides in from right */}
+      {/* Detail panel — TraceViewerPanel renders its own fixed slide-in overlay */}
       {selectedTraceId && (
-        <div className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 w-[70%] border-l border-border bg-background shadow-xl">
-          <TraceViewerPanel
-            projectId={projectId}
-            traceId={selectedTraceId}
-            onClose={() => setSelectedTraceId(null)}
-            onNavigate={(direction) => {
-              const currentIndex = traces.findIndex(
-                (t: TraceListItem) => t.trace_id === selectedTraceId,
-              );
-              if (direction === "up" && currentIndex > 0) {
-                setSelectedTraceId(traces[currentIndex - 1].trace_id);
-              } else if (direction === "down" && currentIndex < traces.length - 1) {
-                setSelectedTraceId(traces[currentIndex + 1].trace_id);
-              }
-            }}
-            canNavigateUp={
-              traces.findIndex((t: TraceListItem) => t.trace_id === selectedTraceId) > 0
+        <TraceViewerPanel
+          projectId={projectId}
+          traceId={selectedTraceId}
+          onClose={() => setSelectedTraceId(null)}
+          onNavigate={(direction) => {
+            const currentIndex = traces.findIndex(
+              (t: TraceListItem) => t.trace_id === selectedTraceId,
+            );
+            if (direction === "up" && currentIndex > 0) {
+              setSelectedTraceId(traces[currentIndex - 1].trace_id);
+            } else if (direction === "down" && currentIndex < traces.length - 1) {
+              setSelectedTraceId(traces[currentIndex + 1].trace_id);
             }
-            canNavigateDown={
-              traces.findIndex((t: TraceListItem) => t.trace_id === selectedTraceId) <
-              traces.length - 1
-            }
-            dateFilter={state.dateFilter}
-            customStartDate={state.customStartDate}
-            customEndDate={state.customEndDate}
-          />
-        </div>
+          }}
+          canNavigateUp={traces.findIndex((t: TraceListItem) => t.trace_id === selectedTraceId) > 0}
+          canNavigateDown={
+            traces.findIndex((t: TraceListItem) => t.trace_id === selectedTraceId) <
+            traces.length - 1
+          }
+          dateFilter={state.dateFilter}
+          customStartDate={state.customStartDate}
+          customEndDate={state.customEndDate}
+        />
       )}
     </div>
   );

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -194,15 +194,16 @@ export function TraceViewerPanel({
   return (
     <div
       className={cn(
-        "animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 border-l border-border bg-background shadow-xl transition-[width] duration-200",
-        // Fullscreen stops at the left navbar's right edge (so it isn't covered)
-        // rather than spanning the whole viewport. Width = 100% minus the
-        // sidebar's width, which differs when the sidebar is collapsed.
+        "animate-slide-in-right fixed bottom-0 right-0 z-50 border-l border-border bg-background shadow-xl transition-[width,top] duration-200",
+        // Fullscreen stays clear of the chrome it would otherwise cover: it
+        // starts below the top breadcrumb/header bar (h-14) and to the right of
+        // the left navbar. Width = 100% minus the sidebar's width, which differs
+        // when the sidebar is collapsed.
         isFullscreen
           ? sidebarCollapsed
-            ? "w-[calc(100%-3.5rem)]"
-            : "w-[calc(100%-10rem)]"
-          : "w-[70%]",
+            ? "top-14 w-[calc(100%-3.5rem)]"
+            : "top-14 w-[calc(100%-10rem)]"
+          : "top-0 w-[70%]",
       )}
     >
       <div className="flex h-full flex-col bg-background">

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -10,8 +10,8 @@ import {
   BotMessageSquare,
   ListTree,
   SquareGanttChart,
-  Maximize2,
-  Minimize2,
+  Expand,
+  Shrink,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -273,7 +273,7 @@ export function TraceViewerPanel({
               className="h-7 w-7 p-0"
               title={isFullscreen ? "Restore default size" : "Expand to full screen"}
             >
-              {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+              {isFullscreen ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
             </Button>
             <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
               <X className="h-4 w-4" />

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -10,6 +10,8 @@ import {
   BotMessageSquare,
   ListTree,
   SquareGanttChart,
+  Maximize2,
+  Minimize2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -65,6 +67,11 @@ export function TraceViewerPanel({
 }: TraceViewerPanelProps) {
   const [selection, setSelection] = useState<TraceSelection>({ type: "trace" });
   const [viewMode, setViewMode] = useState<"tree" | "timeline">("tree");
+  // Fullscreen widens the slide-in overlay from ~70% to the full viewport.
+  // Local + resets when the panel unmounts (i.e. on close/reopen); it
+  // intentionally persists while navigating between traces, since the panel
+  // instance stays mounted across ↑/↓ navigation.
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const { aiPanelOpen, setAiPanelOpen, setAiContext, setAiInitialSessionId, registerAiHost } =
     useLayout();
 
@@ -179,214 +186,230 @@ export function TraceViewerPanel({
   }, []);
 
   return (
-    <div className="flex h-full flex-col bg-background">
-      {/* ── MAIN HEADER ── */}
-      <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
-        <div className="flex min-w-0 items-center gap-2">
-          <Workflow className="h-4 w-4 text-muted-foreground" />
-          <span className="text-sm font-medium">Trace</span>
-          <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
-        </div>
-        <div className="flex items-center gap-1">
-          {hasFindings && (
-            <button
-              type="button"
+    <div
+      className={cn(
+        "animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 border-l border-border bg-background shadow-xl transition-[width] duration-200",
+        isFullscreen ? "w-full" : "w-[70%]",
+      )}
+    >
+      <div className="flex h-full flex-col bg-background">
+        {/* ── MAIN HEADER ── */}
+        <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
+          <div className="flex min-w-0 items-center gap-2">
+            <Workflow className="h-4 w-4 text-muted-foreground" />
+            <span className="text-sm font-medium">Trace</span>
+            <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            {hasFindings && (
+              <button
+                type="button"
+                onClick={() => {
+                  setAiContext({ traceId });
+                  setAiInitialSessionId(rcaSessionId);
+                  setAiPanelOpen(true);
+                }}
+                className="rounded-md border border-red-300 bg-red-50 px-2 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60"
+                title="Findings detected — open root cause analysis"
+              >
+                Alert
+              </button>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onNavigate("up")}
+              disabled={!canNavigateUp}
+              className="h-7 w-7 p-0"
+              title="Previous trace"
+            >
+              <ArrowUp className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onNavigate("down")}
+              disabled={!canNavigateDown}
+              className="h-7 w-7 p-0"
+              title="Next trace"
+            >
+              <ArrowDown className="h-4 w-4" />
+            </Button>
+            <div className="w-2" />
+            <Button
+              variant="outline"
+              size="sm"
               onClick={() => {
                 setAiContext({ traceId });
-                setAiInitialSessionId(rcaSessionId);
-                setAiPanelOpen(true);
+                // Bot button always opens a fresh chat; an active RCA session
+                // would otherwise hijack the next message into the worker's
+                // session instead of starting a new one.
+                setAiInitialSessionId(undefined);
+                setAiPanelOpen(!aiPanelOpen);
               }}
-              className="rounded-md border border-red-300 bg-red-50 px-2 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60"
-              title="Findings detected — open root cause analysis"
+              className="h-7 w-7 p-0"
+              title="AI Assistant"
             >
-              Alert
+              <BotMessageSquare className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setIsFullscreen((v) => !v)}
+              className="h-7 w-7 p-0"
+              title={isFullscreen ? "Restore default size" : "Expand to full screen"}
+            >
+              {isFullscreen ? <Minimize2 className="h-4 w-4" /> : <Maximize2 className="h-4 w-4" />}
+            </Button>
+            <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+
+        {/* ── VIEW TOGGLE SUB-HEADER ── */}
+        <div className="flex h-10 items-center border-b border-border">
+          <div className="flex items-center rounded-lg px-2 py-1">
+            <button
+              onClick={() => setViewMode("tree")}
+              className={cn(
+                "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+                viewMode === "tree"
+                  ? "bg-muted text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <ListTree className="h-3.5 w-3.5" /> Trace
             </button>
-          )}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => onNavigate("up")}
-            disabled={!canNavigateUp}
-            className="h-7 w-7 p-0"
-            title="Previous trace"
-          >
-            <ArrowUp className="h-4 w-4" />
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => onNavigate("down")}
-            disabled={!canNavigateDown}
-            className="h-7 w-7 p-0"
-            title="Next trace"
-          >
-            <ArrowDown className="h-4 w-4" />
-          </Button>
-          <div className="w-2" />
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              setAiContext({ traceId });
-              // Bot button always opens a fresh chat; an active RCA session
-              // would otherwise hijack the next message into the worker's
-              // session instead of starting a new one.
-              setAiInitialSessionId(undefined);
-              setAiPanelOpen(!aiPanelOpen);
-            }}
-            className="h-7 w-7 p-0"
-            title="AI Assistant"
-          >
-            <BotMessageSquare className="h-4 w-4" />
-          </Button>
-          <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
-            <X className="h-4 w-4" />
-          </Button>
+            <button
+              onClick={() => setViewMode("timeline")}
+              className={cn(
+                "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+                viewMode === "timeline"
+                  ? "bg-muted text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <SquareGanttChart className="h-3.5 w-3.5" /> Timeline
+            </button>
+          </div>
         </div>
-      </div>
 
-      {/* ── VIEW TOGGLE SUB-HEADER ── */}
-      <div className="flex h-10 items-center border-b border-border">
-        <div className="flex items-center rounded-lg px-2 py-1">
-          <button
-            onClick={() => setViewMode("tree")}
-            className={cn(
-              "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
-              viewMode === "tree"
-                ? "bg-muted text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <ListTree className="h-3.5 w-3.5" /> Trace
-          </button>
-          <button
-            onClick={() => setViewMode("timeline")}
-            className={cn(
-              "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
-              viewMode === "timeline"
-                ? "bg-muted text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <SquareGanttChart className="h-3.5 w-3.5" /> Timeline
-          </button>
-        </div>
-      </div>
-
-      {/* ── CONTENT AREA ── */}
-      {/* ResizablePanelGroup stays mounted across trace switches so the AI
+        {/* ── CONTENT AREA ── */}
+        {/* ResizablePanelGroup stays mounted across trace switches so the AI
           panel inside doesn't get torn down while the next trace is
           fetching (#784: chat survives ↑/↓ navigation). Loading and error
           states are isolated to the detail panel's content. */}
-      <div className="relative flex flex-1 overflow-hidden">
-        <ResizablePanelGroup orientation="horizontal" className="h-full min-w-0">
-          {/* LEFT: tree panel — outer group */}
-          <ResizablePanel
-            id="trace-tree"
-            defaultSize="32%"
-            minSize="260px"
-            maxSize="50%"
-            className="flex min-w-0 flex-col bg-muted/30"
-          >
-            <div
-              className="flex flex-shrink-0 items-center border-b border-border bg-muted/10 px-3"
-              style={{ height: TREE_LAYOUT.ROW_HEIGHT }}
+        <div className="relative flex flex-1 overflow-hidden">
+          <ResizablePanelGroup orientation="horizontal" className="h-full min-w-0">
+            {/* LEFT: tree panel — outer group */}
+            <ResizablePanel
+              id="trace-tree"
+              defaultSize="32%"
+              minSize="260px"
+              maxSize="50%"
+              className="flex min-w-0 flex-col bg-muted/30"
             >
-              <span className="text-[11px] font-medium text-muted-foreground">Trace Tree</span>
-            </div>
-            <div
-              ref={treeScrollRef}
-              className="flex-1 overflow-y-auto overflow-x-hidden"
-              onScroll={handleTreeScroll}
-            >
-              {trace && (
-                <SpanTreeView
-                  ref={treeViewRef}
-                  trace={trace}
-                  scrollRef={treeScrollRef}
-                  selection={selection}
-                  onSelect={viewMode === "tree" ? setSelection : handleTimelineSelect}
-                  collapsedIds={collapsedIds}
-                  onToggleCollapse={handleToggleCollapse}
-                  compact={viewMode === "timeline"}
-                  hoveredSpanId={hoveredSpanId}
-                  onHoverChange={setHoveredSpanId}
-                />
-              )}
-            </div>
-          </ResizablePanel>
-
-          <ResizableHandle />
-
-          {/* RIGHT: workspace (details + optional AI) — inner group */}
-          <ResizablePanel
-            id="trace-right-workspace"
-            minSize="420px"
-            className="min-w-0 overflow-hidden border-l border-border bg-background"
-          >
-            <ResizablePanelGroup orientation="horizontal" className="h-full min-w-0">
-              <ResizablePanel
-                id="trace-detail"
-                minSize="320px"
-                className="min-w-0 overflow-hidden bg-background"
+              <div
+                className="flex flex-shrink-0 items-center border-b border-border bg-muted/10 px-3"
+                style={{ height: TREE_LAYOUT.ROW_HEIGHT }}
               >
-                {isLoading ? (
-                  <div className="flex h-full items-center justify-center">
-                    <p className="text-sm text-muted-foreground">Loading trace...</p>
-                  </div>
-                ) : error || !trace ? (
-                  <div className="flex h-full items-center justify-center">
-                    <p className="text-sm text-destructive">Error loading trace</p>
-                  </div>
-                ) : viewMode === "tree" ? (
-                  <SpanInfoPanel
-                    projectId={projectId}
+                <span className="text-[11px] font-medium text-muted-foreground">Trace Tree</span>
+              </div>
+              <div
+                ref={treeScrollRef}
+                className="flex-1 overflow-y-auto overflow-x-hidden"
+                onScroll={handleTreeScroll}
+              >
+                {trace && (
+                  <SpanTreeView
+                    ref={treeViewRef}
                     trace={trace}
+                    scrollRef={treeScrollRef}
                     selection={selection}
-                    onClose={onClose}
-                    dateFilter={dateFilter}
-                    customStartDate={customStartDate}
-                    customEndDate={customEndDate}
-                  />
-                ) : (
-                  <SpanTimelineView
-                    trace={trace}
-                    selection={selection}
-                    onSelect={handleTimelineSelect}
+                    onSelect={viewMode === "tree" ? setSelection : handleTimelineSelect}
                     collapsedIds={collapsedIds}
-                    scrollRef={timelineScrollRef}
-                    onScroll={handleTimelineScroll}
+                    onToggleCollapse={handleToggleCollapse}
+                    compact={viewMode === "timeline"}
                     hoveredSpanId={hoveredSpanId}
                     onHoverChange={setHoveredSpanId}
                   />
                 )}
-              </ResizablePanel>
+              </div>
+            </ResizablePanel>
 
-              {aiPanelOpen && (
-                <>
-                  <ResizableHandle />
-                  <ResizablePanel
-                    id="trace-ai-chat"
-                    defaultSize="46%"
-                    minSize="320px"
-                    maxSize="55%"
-                    className="min-w-0 border-border bg-background"
-                  >
-                    <AiAssistantPanel
+            <ResizableHandle />
+
+            {/* RIGHT: workspace (details + optional AI) — inner group */}
+            <ResizablePanel
+              id="trace-right-workspace"
+              minSize="420px"
+              className="min-w-0 overflow-hidden border-l border-border bg-background"
+            >
+              <ResizablePanelGroup orientation="horizontal" className="h-full min-w-0">
+                <ResizablePanel
+                  id="trace-detail"
+                  minSize="320px"
+                  className="min-w-0 overflow-hidden bg-background"
+                >
+                  {isLoading ? (
+                    <div className="flex h-full items-center justify-center">
+                      <p className="text-sm text-muted-foreground">Loading trace...</p>
+                    </div>
+                  ) : error || !trace ? (
+                    <div className="flex h-full items-center justify-center">
+                      <p className="text-sm text-destructive">Error loading trace</p>
+                    </div>
+                  ) : viewMode === "tree" ? (
+                    <SpanInfoPanel
                       projectId={projectId}
-                      compact
-                      onClose={() => {
-                        setAiPanelOpen(false);
-                        setAiContext(null);
-                        setAiInitialSessionId(undefined);
-                      }}
+                      trace={trace}
+                      selection={selection}
+                      onClose={onClose}
+                      dateFilter={dateFilter}
+                      customStartDate={customStartDate}
+                      customEndDate={customEndDate}
                     />
-                  </ResizablePanel>
-                </>
-              )}
-            </ResizablePanelGroup>
-          </ResizablePanel>
-        </ResizablePanelGroup>
+                  ) : (
+                    <SpanTimelineView
+                      trace={trace}
+                      selection={selection}
+                      onSelect={handleTimelineSelect}
+                      collapsedIds={collapsedIds}
+                      scrollRef={timelineScrollRef}
+                      onScroll={handleTimelineScroll}
+                      hoveredSpanId={hoveredSpanId}
+                      onHoverChange={setHoveredSpanId}
+                    />
+                  )}
+                </ResizablePanel>
+
+                {aiPanelOpen && (
+                  <>
+                    <ResizableHandle />
+                    <ResizablePanel
+                      id="trace-ai-chat"
+                      defaultSize="46%"
+                      minSize="320px"
+                      maxSize="55%"
+                      className="min-w-0 border-border bg-background"
+                    >
+                      <AiAssistantPanel
+                        projectId={projectId}
+                        compact
+                        onClose={() => {
+                          setAiPanelOpen(false);
+                          setAiContext(null);
+                          setAiInitialSessionId(undefined);
+                        }}
+                      />
+                    </ResizablePanel>
+                  </>
+                )}
+              </ResizablePanelGroup>
+            </ResizablePanel>
+          </ResizablePanelGroup>
+        </div>
       </div>
     </div>
   );

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -72,8 +72,14 @@ export function TraceViewerPanel({
   // intentionally persists while navigating between traces, since the panel
   // instance stays mounted across ↑/↓ navigation.
   const [isFullscreen, setIsFullscreen] = useState(false);
-  const { aiPanelOpen, setAiPanelOpen, setAiContext, setAiInitialSessionId, registerAiHost } =
-    useLayout();
+  const {
+    aiPanelOpen,
+    setAiPanelOpen,
+    setAiContext,
+    setAiInitialSessionId,
+    registerAiHost,
+    sidebarCollapsed,
+  } = useLayout();
 
   // Claim the AI slot for this viewer so AppLayout's project rail steps aside.
   // `registerAiHost()` returns its own cleanup, which we return from the effect
@@ -189,7 +195,14 @@ export function TraceViewerPanel({
     <div
       className={cn(
         "animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 border-l border-border bg-background shadow-xl transition-[width] duration-200",
-        isFullscreen ? "w-full" : "w-[70%]",
+        // Fullscreen stops at the left navbar's right edge (so it isn't covered)
+        // rather than spanning the whole viewport. Width = 100% minus the
+        // sidebar's width, which differs when the sidebar is collapsed.
+        isFullscreen
+          ? sidebarCollapsed
+            ? "w-[calc(100%-3.5rem)]"
+            : "w-[calc(100%-10rem)]"
+          : "w-[70%]",
       )}
     >
       <div className="flex h-full flex-col bg-background">


### PR DESCRIPTION
Closes #1076

## What & why

The trace detail opens as a fixed ~70%-width slide-in, which makes reading a
whole trace cramped. This adds a lightweight way to widen it: a control in the
panel header that expands `TraceViewerPanel` to full width and a matching control
to restore it.

Part of the trace-view improvements epic (#1078).

## Changes

- **`TraceViewerPanel.tsx`** — the component now owns its own `fixed` slide-in
  overlay (previously duplicated by each page) and a local `isFullscreen` state.
  Width is driven by state (`w-[70%]` ↔ `w-full`) with a `transition-[width]`
  for a smooth grow/shrink. A `Maximize2`/`Minimize2` button sits in the header,
  just left of the close button.
- **`traces/page.tsx`** & **`detectors/[detectorId]/page.tsx`** — render
  `<TraceViewerPanel/>` directly instead of each wrapping it in an identical
  overlay `div`.

## Behavior

- One click expands the panel to full screen; another restores ~70%.
- Resets to the default width when the panel is closed and reopened.
- Stays put while navigating between traces (↑/↓), since the panel instance
  persists across navigation.

## Video

https://github.com/user-attachments/assets/04aff66d-2a45-475f-9a86-b691c5019015





## Scope note

This PR implements the **expand-to-full-width** portion of #1076. The other two
tasks listed in that issue — an expand-all / collapse-all control on the span
tree, and remembering the width choice for the session — are **not** included
here. Per the agreed scope we're treating those as deferred; if they should ship
before #1076 is considered done, hold this `Closes` or split them into a
follow-up issue.

## Testing

- `tsc --noEmit` and `eslint` clean for the changed files.
- Verified manually on both the traces list and detector findings pages: expand →
  full width, restore → ~70%, reset on reopen, inner resize handles and the AI
  panel still work in both widths.

> Note: this is a purely presentational change (a Tailwind width class toggled
> by local state). The frontend test runner uses Vitest with `environment:
> "node"` (no jsdom / `@testing-library/react`), so there is no proportionate
> unit test to add; verification is typecheck + lint + manual.