### PR TITLE
feat(ui): add a button to open the current trace in a new fullscreen tab

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { ChevronRight, Flag, History } from "lucide-react";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ListPagination } from "@/components/list-pagination";
@@ -20,8 +20,15 @@ const tabs = [
 export default function DetectorDetailPage() {
   const params = useParams();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const projectId = params.projectId as string;
   const detectorId = params.detectorId as string;
+
+  // Deep-link params: set when a trace is popped out into a new tab from the
+  // panel's "open in new tab" button, so it reopens here in the detector tab.
+  const traceIdFromUrl = searchParams.get("traceId");
+  const [startFullscreen, setStartFullscreen] = useState(searchParams.get("fullscreen") === "1");
+  const [didAutoOpen, setDidAutoOpen] = useState(false);
 
   const [activeTab, setActiveTab] = useState("findings");
   const [selectedFinding, setSelectedFinding] = useState<BackendFinding | null>(null);
@@ -64,6 +71,18 @@ export default function DetectorDetailPage() {
       setSelectedFinding(null);
     }
   }, [findings, selectedFinding]);
+
+  // Deep-link: when arriving with ?traceId=... (popped out from another tab),
+  // open that finding's trace once the findings list has loaded. Runs once, so
+  // closing the panel doesn't reopen it.
+  useEffect(() => {
+    if (didAutoOpen || !traceIdFromUrl) return;
+    const match = findings.find((f) => f.trace_id === traceIdFromUrl);
+    if (match) {
+      setSelectedFinding(match);
+      setDidAutoOpen(true);
+    }
+  }, [didAutoOpen, traceIdFromUrl, findings]);
 
   const selectedIndex = selectedFinding
     ? findings.findIndex((f) => f.finding_id === selectedFinding.finding_id)
@@ -302,7 +321,10 @@ export default function DetectorDetailPage() {
         <TraceViewerPanel
           projectId={projectId}
           traceId={selectedFinding.trace_id}
-          onClose={() => setSelectedFinding(null)}
+          onClose={() => {
+            setSelectedFinding(null);
+            setStartFullscreen(false);
+          }}
           onNavigate={handleNavigate}
           canNavigateUp={selectedIndex > 0}
           canNavigateDown={selectedIndex < findings.length - 1}
@@ -310,6 +332,8 @@ export default function DetectorDetailPage() {
           customStartDate={state.customStartDate}
           customEndDate={state.customEndDate}
           autoOpenRca={true}
+          initialFullscreen={startFullscreen}
+          newTabPath={`/projects/${projectId}/detectors/${detectorId}`}
         />
       )}
     </div>

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -43,6 +43,9 @@ export default function TracesPage() {
   const { isPending: authPending } = useAuthSession();
   const userId = searchParams.get("user_id");
   const traceIdFromUrl = searchParams.get("traceId");
+  // Set when a trace is opened in a new tab via the panel's "open in new tab"
+  // button, so the panel mounts already expanded to full width.
+  const startFullscreen = searchParams.get("fullscreen") === "1";
 
   // Use URL-synced state management hook (shares date filter with other pages)
   const {
@@ -373,6 +376,7 @@ export default function TracesPage() {
           dateFilter={state.dateFilter}
           customStartDate={state.customStartDate}
           customEndDate={state.customEndDate}
+          initialFullscreen={startFullscreen}
         />
       )}
     </div>

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -44,8 +44,11 @@ export default function TracesPage() {
   const userId = searchParams.get("user_id");
   const traceIdFromUrl = searchParams.get("traceId");
   // Set when a trace is opened in a new tab via the panel's "open in new tab"
-  // button, so the panel mounts already expanded to full width.
-  const startFullscreen = searchParams.get("fullscreen") === "1";
+  // button, so the panel mounts already expanded to full width. Held as state
+  // (not a derived value) so it only seeds the first trace opened from the URL:
+  // once the user closes the panel, opening another trace defaults back to the
+  // unexpanded width rather than re-expanding from the lingering URL param.
+  const [startFullscreen, setStartFullscreen] = useState(searchParams.get("fullscreen") === "1");
 
   // Use URL-synced state management hook (shares date filter with other pages)
   const {
@@ -357,7 +360,10 @@ export default function TracesPage() {
         <TraceViewerPanel
           projectId={projectId}
           traceId={selectedTraceId}
-          onClose={() => setSelectedTraceId(null)}
+          onClose={() => {
+            setSelectedTraceId(null);
+            setStartFullscreen(false);
+          }}
           onNavigate={(direction) => {
             const currentIndex = traces.findIndex(
               (t: TraceListItem) => t.trace_id === selectedTraceId,

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -12,8 +12,9 @@ import {
   SquareGanttChart,
   Expand,
   Shrink,
+  SquareArrowOutUpRight,
 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { cn, buildUrlWithFilters } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { getTrace } from "@/lib/api";
@@ -39,6 +40,8 @@ interface TraceViewerPanelProps {
   customEndDate?: Date | null;
   /** When true, auto-opens chat with RCA loaded on mount (detector findings page only) */
   autoOpenRca?: boolean;
+  /** When true, the panel mounts already expanded to full width (e.g. opened in a new tab). */
+  initialFullscreen?: boolean;
 }
 
 /**
@@ -64,14 +67,16 @@ export function TraceViewerPanel({
   customStartDate,
   customEndDate,
   autoOpenRca,
+  initialFullscreen,
 }: TraceViewerPanelProps) {
   const [selection, setSelection] = useState<TraceSelection>({ type: "trace" });
   const [viewMode, setViewMode] = useState<"tree" | "timeline">("tree");
   // Fullscreen widens the slide-in overlay from ~70% to the full viewport.
+  // Seeded from initialFullscreen so a trace opened in a new tab lands expanded.
   // Local + resets when the panel unmounts (i.e. on close/reopen); it
   // intentionally persists while navigating between traces, since the panel
   // instance stays mounted across ↑/↓ navigation.
-  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(initialFullscreen ?? false);
   const {
     aiPanelOpen,
     setAiPanelOpen,
@@ -274,6 +279,25 @@ export function TraceViewerPanel({
               title={isFullscreen ? "Restore default size" : "Expand to full screen"}
             >
               {isFullscreen ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                window.open(
+                  buildUrlWithFilters(`/projects/${projectId}/traces`, {
+                    dateFilter,
+                    customStartDate,
+                    customEndDate,
+                    extraParams: { traceId, fullscreen: "1" },
+                  }),
+                  "_blank",
+                )
+              }
+              className="h-7 w-7 p-0"
+              title="Open in new tab"
+            >
+              <SquareArrowOutUpRight className="h-4 w-4" />
             </Button>
             <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
               <X className="h-4 w-4" />

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -254,23 +254,6 @@ export function TraceViewerPanel({
             >
               <ArrowDown className="h-4 w-4" />
             </Button>
-            <div className="w-2" />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setAiContext({ traceId });
-                // Bot button always opens a fresh chat; an active RCA session
-                // would otherwise hijack the next message into the worker's
-                // session instead of starting a new one.
-                setAiInitialSessionId(undefined);
-                setAiPanelOpen(!aiPanelOpen);
-              }}
-              className="h-7 w-7 p-0"
-              title="AI Assistant"
-            >
-              <BotMessageSquare className="h-4 w-4" />
-            </Button>
             <Button
               variant="outline"
               size="sm"
@@ -298,6 +281,26 @@ export function TraceViewerPanel({
               title="Open in new tab"
             >
               <SquareArrowOutUpRight className="h-4 w-4" />
+            </Button>
+            <div className="w-2" />
+            {/* AI Assistant sits immediately left of Close, separated by a gap
+                from the navigation/view controls, so the agent button stays the
+                rightmost action regardless of the other header controls. */}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setAiContext({ traceId });
+                // Bot button always opens a fresh chat; an active RCA session
+                // would otherwise hijack the next message into the worker's
+                // session instead of starting a new one.
+                setAiInitialSessionId(undefined);
+                setAiPanelOpen(!aiPanelOpen);
+              }}
+              className="h-7 w-7 p-0"
+              title="AI Assistant"
+            >
+              <BotMessageSquare className="h-4 w-4" />
             </Button>
             <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
               <X className="h-4 w-4" />

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -42,6 +42,13 @@ interface TraceViewerPanelProps {
   autoOpenRca?: boolean;
   /** When true, the panel mounts already expanded to full width (e.g. opened in a new tab). */
   initialFullscreen?: boolean;
+  /**
+   * Base path the "open in new tab" button targets, so the trace pops out back
+   * into the page it was opened from. Defaults to the project traces page; the
+   * detector page passes its own path so the popped-out trace stays in the
+   * detector tab.
+   */
+  newTabPath?: string;
 }
 
 /**
@@ -68,6 +75,7 @@ export function TraceViewerPanel({
   customEndDate,
   autoOpenRca,
   initialFullscreen,
+  newTabPath,
 }: TraceViewerPanelProps) {
   const [selection, setSelection] = useState<TraceSelection>({ type: "trace" });
   const [viewMode, setViewMode] = useState<"tree" | "timeline">("tree");
@@ -268,7 +276,7 @@ export function TraceViewerPanel({
               size="sm"
               onClick={() =>
                 window.open(
-                  buildUrlWithFilters(`/projects/${projectId}/traces`, {
+                  buildUrlWithFilters(newTabPath ?? `/projects/${projectId}/traces`, {
                     dateFilter,
                     customStartDate,
                     customEndDate,


### PR DESCRIPTION
Closes #1077 · part of the trace-view improvements epic (#1078).

## Stacked on #1091
Bases on `feat/trace-view-fullscreen-toggle` (the in-app fullscreen toggle in #1091), so the diff here is **only the new button**. Merge #1091 first; GitHub will then retarget this PR's base to `main` automatically (or set it manually).

## What & why
The trace detail can be widened in-app (#1091), but the open trace can't be popped out into its own browser tab for sharing or side-by-side comparison. This adds a header button that opens the current trace in a new tab, landing directly in the full-width (fullscreen) view.

## Changes
- **`TraceViewerPanel.tsx`** — a new `SquareArrowOutUpRight` "Open in new tab" button beside the fullscreen toggle. It `window.open`s the trace URL built with `buildUrlWithFilters` (preserving the active date filter) and `extraParams: { traceId, fullscreen: "1" }`. Adds an `initialFullscreen?: boolean` prop and seeds `isFullscreen` from it (the only line of #1091's code touched).
- **`traces/page.tsx`** — reads `?fullscreen=1` and passes `initialFullscreen` to the panel.

## Behavior / acceptance
- Clicking the button opens the current trace in a new tab, full-width.
- Copying that new tab's URL and reopening it elsewhere lands on the same trace, in fullscreen.
- Plain row-click in the original tab is unchanged.

## Out of scope (deliberately)
- No dedicated `/traces/[traceId]` route, no row-anchors / ⌘-click handling, no URL-writeback on selection — the button generates a shareable URL directly.

## Video


https://github.com/user-attachments/assets/ac2ccb81-4145-4edf-ad92-e1971c103dc9







## Testing
- `tsc --noEmit` clean for the changed files; `eslint` exit 0; `prettier --check` clean.
- Verified manually against a locally-ingested trace: button opens a new tab at full width; the `&fullscreen=1` URL opens already-expanded; plain click unaffected.
- Frontend Vitest runs `environment: "node"` (no jsdom), so there's no proportionate unit test for this presentational change — consistent with #1091.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Open in new tab” button to the trace viewer to open the current trace in a fullscreen tab. Preserves filters, keeps the left navbar and top breadcrumb visible, keeps the Assistant button immediately left of Close, and uses `Expand`/`Shrink` for the fullscreen toggle.

- New Features
  - Adds a button in `TraceViewerPanel` that opens a new tab via `buildUrlWithFilters` (preserves date filters; includes `traceId` and `fullscreen=1`); `traces/page.tsx` seeds `initialFullscreen` once from the URL and clears it on close to avoid forcing later opens fullscreen.
  - Supports the detector page: `TraceViewerPanel` accepts `newTabPath`, and the detector page reads `traceId`/`fullscreen=1` to auto-open the matching finding once in fullscreen and pop out back into the detector tab.

<sup>Written for commit 6d7f09af90654973d9b1b14fb9261806c7494f17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->







