### PR TITLE
perf(traces): two-phase trace detail loading (skeleton + lazy per-span I/O)

### DIFF
--- a/backend/db/clickhouse/client.py
+++ b/backend/db/clickhouse/client.py
@@ -25,6 +25,14 @@ class ClickHouseClient:
             username=ch.user,
             password=ch.password,
             database=ch.database,
+            # Disable the sticky server-side session so this shared singleton client
+            # can serve concurrent queries (the two-phase trace view fans out a
+            # skeleton + many per-span /io requests at once). Otherwise clickhouse-
+            # connect raises "concurrent queries within the same session". Our usage
+            # is stateless reads/inserts/DDL — no temp tables or session SETs — so
+            # this is a no-op semantically — just the standard sessionless, pooled
+            # shared-client pattern used by mature ClickHouse-backed services.
+            autogenerate_session_id=False,
         )
         return cls(client)
 

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -78,16 +78,25 @@ async def get_span_io(
 ):
     """Get full input/output/metadata for a single span on demand."""
     service = get_trace_reader_service()
-    result = service.get_span_io(
-        project_id=project_id,
-        trace_id=trace_id,
-        span_id=span_id,
-    )
-
-    if not result:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Span not found",
+    try:
+        result = service.get_span_io(
+            project_id=project_id,
+            trace_id=trace_id,
+            span_id=span_id,
         )
 
-    return result
+        if not result:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Span not found",
+            )
+
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.exception(f"Error getting span I/O: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to get span I/O",
+        ) from e

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from fastapi import APIRouter, HTTPException, Query, status
 
 from rest.routers.deps import ProjectAccess
-from rest.schemas.traces import TraceDetailResponse, TraceListResponse
+from rest.schemas.traces import SpanIOResponse, TraceDetailResponse, TraceListResponse
 from rest.services.trace_reader import get_trace_reader_service
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ async def get_trace(
     trace_id: str,
     _access: ProjectAccess,  # Validates user has access to project
 ):
-    """Get a single trace with all spans."""
+    """Get a single trace with span skeletons (no per-span I/O)."""
     service = get_trace_reader_service()
     trace = service.get_trace(project_id=project_id, trace_id=trace_id)
 
@@ -67,3 +67,27 @@ async def get_trace(
         )
 
     return trace
+
+
+@router.get("/{trace_id}/spans/{span_id}/io", response_model=SpanIOResponse)
+async def get_span_io(
+    project_id: str,
+    trace_id: str,
+    span_id: str,
+    _access: ProjectAccess,  # Validates user has access to project
+):
+    """Get full input/output/metadata for a single span on demand."""
+    service = get_trace_reader_service()
+    result = service.get_span_io(
+        project_id=project_id,
+        trace_id=trace_id,
+        span_id=span_id,
+    )
+
+    if not result:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Span not found",
+        )
+
+    return result

--- a/backend/rest/schemas/__init__.py
+++ b/backend/rest/schemas/__init__.py
@@ -2,7 +2,6 @@
 
 from rest.schemas.common import HealthResponse, PaginationMeta
 from rest.schemas.traces import (
-    SpanResponse,
     TraceDetailResponse,
     TraceListItem,
     TraceListResponse,
@@ -12,7 +11,6 @@ from rest.schemas.users import UserItem, UserListResponse
 __all__ = [
     "HealthResponse",
     "PaginationMeta",
-    "SpanResponse",
     "TraceDetailResponse",
     "TraceListItem",
     "TraceListResponse",

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -7,8 +7,17 @@ from pydantic import BaseModel
 from rest.schemas.common import PaginationMeta
 
 
-class SpanResponse(BaseModel):
-    """Single span in a trace."""
+class SpanSkeletonResponse(BaseModel):
+    """Span skeleton — tree-building / display fields only, no I/O blobs.
+
+    Used by the trace-detail endpoint so the initial payload stays sub-MB
+    regardless of trace size. Full I/O (input/output/metadata) is fetched
+    per-span on demand via the dedicated ``/spans/{span_id}/io`` endpoint.
+
+    Note: the token/cost breakdown maps (``usage_details``/``cost_details``)
+    stay on the skeleton — they are small and drive the tree's token/cost
+    chips. Only the large free-text I/O blobs are omitted.
+    """
 
     span_id: str
     trace_id: str
@@ -24,19 +33,21 @@ class SpanResponse(BaseModel):
     input_tokens: int | None
     output_tokens: int | None
     total_tokens: int | None
-    # Generic token breakdown (e.g. cache_read_tokens, cache_write_tokens,
-    # reasoning_tokens) — a map so new provider dimensions need no schema change.
     usage_details: dict[str, int] = {}
-    # Per-category dollar breakdown derived at read time:
-    # input_uncached_cost, cache_read_cost, cache_write_cost, output_cost.
-    # Empty when the model has no known prices. Display-only; sums to `cost`.
     cost_details: dict[str, float] = {}
-    input: str | None
-    output: str | None
-    metadata: str | None
     git_source_file: str | None = None
     git_source_line: int | None = None
     git_source_function: str | None = None
+
+
+class SpanIOResponse(BaseModel):
+    """Full I/O payload for a single span, fetched on demand."""
+
+    span_id: str
+    trace_id: str
+    input: str | None
+    output: str | None
+    metadata: str | None
 
 
 class TraceListItem(BaseModel):
@@ -66,7 +77,7 @@ class TraceListResponse(BaseModel):
 
 
 class TraceDetailResponse(BaseModel):
-    """Single trace with all spans."""
+    """Single trace with span skeletons (no per-span I/O)."""
 
     trace_id: str
     project_id: str
@@ -79,4 +90,4 @@ class TraceDetailResponse(BaseModel):
     input: str | None
     output: str | None
     metadata: str | None
-    spans: list[SpanResponse]
+    spans: list[SpanSkeletonResponse]

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -194,7 +194,17 @@ class TraceReaderService:
         }
 
     def get_trace(self, project_id: str, trace_id: str) -> dict | None:
-        """Get single trace with all spans."""
+        """Get single trace with span skeletons (no per-span I/O).
+
+        Returns trace metadata plus lightweight span skeletons that omit the
+        large free-text input/output/metadata blobs. This keeps the payload
+        sub-MB even for large traces. Per-span I/O is fetched on demand via
+        get_span_io(). Columnar storage means dropping those columns from the
+        SELECT avoids reading them entirely — no schema change needed.
+
+        Trace-level input/output/metadata (on the trace row) are kept: they're
+        small and already present.
+        """
         # Fetch trace
         trace_query = """
             SELECT
@@ -227,15 +237,17 @@ class TraceReaderService:
             "metadata": row[10],
         }
 
-        # Fetch spans. Duration is derived on the client from start/end so
-        # in-progress spans can grow against `now()` for live traces.
+        # Fetch span skeletons — omit the large input/output/metadata blobs to
+        # keep the payload lightweight (fetched per-span on demand instead).
+        # usage_details is kept (small map) to derive cost_details. Duration is
+        # derived on the client from start/end so in-progress spans can grow
+        # against `now()` for live traces.
         spans_query = """
             SELECT
                 span_id, trace_id, parent_span_id, name, span_kind,
                 span_start_time, span_end_time, status, status_message,
                 model_name, cost, input_tokens, output_tokens, total_tokens,
                 usage_details,
-                input, output, metadata,
                 git_source_file, git_source_line, git_source_function
             FROM spans FINAL
             WHERE project_id = {project_id:String} AND trace_id = {trace_id:String}
@@ -271,17 +283,47 @@ class TraceReaderService:
                         int(row[12]) if row[12] is not None else None,  # output_tokens
                         dict(row[14]) if row[14] else {},  # usage_details
                     ),
-                    "input": row[15],
-                    "output": row[16],
-                    "metadata": row[17],
-                    "git_source_file": row[18],
-                    "git_source_line": int(row[19]) if row[19] is not None else None,
-                    "git_source_function": row[20],
+                    "git_source_file": row[15],
+                    "git_source_line": int(row[16]) if row[16] is not None else None,
+                    "git_source_function": row[17],
                 }
             )
 
         trace["spans"] = spans
         return trace
+
+    def get_span_io(self, project_id: str, trace_id: str, span_id: str) -> dict | None:
+        """Fetch full input/output/metadata for a single span on demand.
+
+        Called when the user selects a span in the UI. Returns None when the
+        span does not exist (router translates that to a 404).
+        """
+        query = """
+            SELECT span_id, trace_id, input, output, metadata
+            FROM spans FINAL
+            WHERE project_id = {project_id:String}
+              AND trace_id = {trace_id:String}
+              AND span_id = {span_id:String}
+            LIMIT 1
+        """
+        result = self._client.query(
+            query,
+            parameters={
+                "project_id": project_id,
+                "trace_id": trace_id,
+                "span_id": span_id,
+            },
+        )
+        if not result.result_rows:
+            return None
+        row = result.result_rows[0]
+        return {
+            "span_id": row[0],
+            "trace_id": row[1],
+            "input": row[2],
+            "output": row[3],
+            "metadata": row[4],
+        }
 
     def list_sessions(
         self,

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -10,6 +10,7 @@ import {
   GitBranch,
   GitCommitHorizontal,
   FileCode,
+  Loader2,
 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
 import { formatDuration, formatDate, buildUrlWithFilters } from "@/lib/utils";
@@ -28,6 +29,7 @@ import {
 import { SpanKindIcon } from "./SpanKindIcon";
 import { ContentRenderer } from "./ContentRenderer";
 import { ExpandableSection } from "@/components/ui/expandable-section";
+import { useSpanIO } from "../hooks";
 
 interface SpanInfoPanelProps {
   projectId: string;
@@ -65,9 +67,18 @@ export function SpanInfoPanel({
   const kind = isTrace ? "trace" : selection.span.span_kind;
   const duration = isTrace ? getTraceDuration(trace) : getSpanDuration(selection.span);
   const timestamp = isTrace ? trace.trace_start_time : selection.span.span_start_time;
-  const input = isTrace ? trace.input : selection.span.input;
-  const output = isTrace ? trace.output : selection.span.output;
-  const rawMetadata = isTrace ? trace.metadata : selection.span.metadata;
+  // Per-span I/O is fetched lazily (the trace skeleton no longer ships it).
+  // Trace-level I/O still lives on the trace object and needs no fetch.
+  const selectedSpanId = isTrace ? null : selection.span.span_id;
+  const { data: spanIO, isLoading: isLoadingIO } = useSpanIO(
+    projectId,
+    trace.trace_id,
+    selectedSpanId,
+  );
+
+  const input = isTrace ? trace.input : (spanIO?.input ?? null);
+  const output = isTrace ? trace.output : (spanIO?.output ?? null);
+  const rawMetadata = isTrace ? trace.metadata : (spanIO?.metadata ?? null);
   const metadata = (() => {
     if (!rawMetadata) return rawMetadata;
     try {
@@ -93,6 +104,18 @@ export function SpanInfoPanel({
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
   };
+
+  // Show a spinner while a selected span's I/O is in flight; trace-level I/O is
+  // already loaded so it never spins.
+  const renderIOContent = (content: string | null) =>
+    !isTrace && isLoadingIO ? (
+      <div className="flex items-center gap-2 py-3 text-xs text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Loading…
+      </div>
+    ) : (
+      <ContentRenderer key={selectionId} content={content} />
+    );
 
   return (
     <div className="h-full overflow-y-auto">
@@ -297,7 +320,7 @@ export function SpanInfoPanel({
           defaultOpen={true}
           onCopy={input ? () => copyToClipboard(input) : undefined}
         >
-          <ContentRenderer key={selectionId} content={input} />
+          {renderIOContent(input)}
         </ExpandableSection>
 
         {/* Output */}
@@ -306,7 +329,7 @@ export function SpanInfoPanel({
           defaultOpen={true}
           onCopy={output ? () => copyToClipboard(output) : undefined}
         >
-          <ContentRenderer key={selectionId} content={output} />
+          {renderIOContent(output)}
         </ExpandableSection>
 
         {/* Metadata */}
@@ -315,7 +338,7 @@ export function SpanInfoPanel({
           defaultOpen={true}
           onCopy={metadata ? () => copyToClipboard(metadata) : undefined}
         >
-          <ContentRenderer key={selectionId} content={metadata} />
+          {renderIOContent(metadata)}
         </ExpandableSection>
       </div>
     </div>

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -151,9 +151,11 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
   const runSpanIOPrefetch = useCallback(
     (span: Span) => {
       if (span.pending) return;
-      const user = authSession?.user
-        ? { id: authSession.user.id, email: authSession.user.email }
-        : undefined;
+      // Skip prefetch until the auth session is ready: prefetching with no user
+      // would trigger a fallback session fetch per hover and could cache an
+      // unauthenticated result under the shared span-io query key.
+      if (!authSession?.user) return;
+      const user = { id: authSession.user.id, email: authSession.user.email };
       queryClient.prefetchQuery({
         queryKey: spanIOQueryKey(trace.project_id, trace.trace_id, span.span_id),
         queryFn: () => getSpanIO(trace.project_id, trace.trace_id, span.span_id, user),

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { forwardRef, useImperativeHandle, useMemo } from "react";
+import { forwardRef, useImperativeHandle, useMemo, useCallback, useRef, useEffect } from "react";
 import type { RefObject } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import { useQueryClient } from "@tanstack/react-query";
+import { useSession as useAuthSession } from "@/lib/auth-client";
+import { getSpanIO } from "@/lib/api";
 import { ChevronRight, ChevronDown, CircleStop, CircleDollarSign } from "lucide-react";
 import { cn, formatDuration, formatTokenFlow } from "@/lib/utils";
 import { SpanKind, SpanStatus } from "@traceroot/core";
@@ -19,10 +22,16 @@ import {
   TREE_LAYOUT,
   TREE_OVERSCAN_ROWS,
 } from "../utils";
+import { spanIOQueryKey, SPAN_IO_STALE_TIME_MS } from "../hooks";
 import { SpanKindIcon } from "./SpanKindIcon";
 import { SpanTreeConnector } from "./SpanTreeConnector";
 
 const ROW_HEIGHT = TREE_LAYOUT.ROW_HEIGHT;
+
+// Debounce hover-prefetch so an incidental cursor sweep across rows doesn't fire a
+// request per row — only an intentional hover (cursor resting past this delay)
+// prefetches. (Reference: peer tools debounce prefetch ~100-250ms.)
+const SPAN_IO_PREFETCH_DEBOUNCE_MS = 150;
 
 // Virtualized row model: the trace root occupies index 0, visible spans follow.
 // This list is the single source of truth for both the virtualizer count and
@@ -132,6 +141,50 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
     const children = childrenByParent.get(spanId) || [];
     return children.length > 0;
   };
+
+  // Prefetch a span's I/O on hover so the click → SpanInfoPanel render is
+  // instant. Skips placeholder (pending) spans, which have no row in ClickHouse.
+  const queryClient = useQueryClient();
+  const { data: authSession } = useAuthSession();
+  const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const runSpanIOPrefetch = useCallback(
+    (span: Span) => {
+      if (span.pending) return;
+      const user = authSession?.user
+        ? { id: authSession.user.id, email: authSession.user.email }
+        : undefined;
+      queryClient.prefetchQuery({
+        queryKey: spanIOQueryKey(trace.project_id, trace.trace_id, span.span_id),
+        queryFn: () => getSpanIO(trace.project_id, trace.trace_id, span.span_id, user),
+        staleTime: SPAN_IO_STALE_TIME_MS,
+      });
+    },
+    [queryClient, authSession, trace.project_id, trace.trace_id],
+  );
+
+  // Schedule the prefetch after a short hover delay; cancel on leave / unmount so a
+  // quick cursor pass-over doesn't fire a request.
+  const scheduleSpanIOPrefetch = useCallback(
+    (span: Span) => {
+      if (span.pending) return;
+      if (prefetchTimerRef.current) clearTimeout(prefetchTimerRef.current);
+      prefetchTimerRef.current = setTimeout(
+        () => runSpanIOPrefetch(span),
+        SPAN_IO_PREFETCH_DEBOUNCE_MS,
+      );
+    },
+    [runSpanIOPrefetch],
+  );
+
+  const cancelSpanIOPrefetch = useCallback(() => {
+    if (prefetchTimerRef.current) {
+      clearTimeout(prefetchTimerRef.current);
+      prefetchTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => () => cancelSpanIOPrefetch(), [cancelSpanIOPrefetch]);
 
   const toggleCollapse = (spanId: string, e: React.MouseEvent) => {
     e.stopPropagation();
@@ -277,10 +330,12 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
               onMouseEnter={(e) => {
                 e.stopPropagation();
                 onHoverChange(span.span_id);
+                scheduleSpanIOPrefetch(span);
               }}
               onMouseLeave={(e) => {
                 e.stopPropagation();
                 onHoverChange(null);
+                cancelSpanIOPrefetch();
               }}
               onClick={() => onSelect({ type: "span", span })}
             >

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -3,7 +3,7 @@
  */
 import { useQuery } from "@tanstack/react-query";
 import { useSession as useAuthSession } from "@/lib/auth-client";
-import { getTraces, getTrace } from "@/lib/api";
+import { getTraces, getTrace, getSpanIO } from "@/lib/api";
 import { getSessions, getSession, type SessionDetailOptions } from "@/lib/api/sessions";
 import { getUsers, type UserQueryOptions } from "@/lib/api/users";
 import type { SessionQueryOptions, TraceQueryOptions } from "@/types/api";
@@ -62,6 +62,38 @@ export function useTrace(projectId: string, traceId: string, enabled: boolean = 
     queryKey: ["trace", projectId, traceId],
     queryFn: () => getTrace(projectId, traceId, "", user),
     enabled: sessionReady && enabled,
+  });
+}
+
+// Per-span I/O is cached for 5 minutes: the blobs are immutable once a span
+// completes, and this lets a hover-prefetch satisfy the subsequent click
+// without a refetch. Shared by useSpanIO and the SpanTreeView hover prefetch.
+export const SPAN_IO_STALE_TIME_MS = 5 * 60 * 1000;
+
+/**
+ * React Query key for a single span's lazily-fetched I/O. Exported so the
+ * SpanTreeView hover-prefetch and the useSpanIO hook key identically.
+ */
+export function spanIOQueryKey(projectId: string, traceId: string, spanId: string) {
+  return ["span-io", projectId, traceId, spanId] as const;
+}
+
+/**
+ * Hook for lazily fetching a single span's full I/O (input/output/metadata).
+ * Only fetches when spanId is provided (i.e. the user selected a span); the
+ * trace-detail skeleton no longer ships per-span I/O.
+ */
+export function useSpanIO(projectId: string, traceId: string, spanId: string | null) {
+  const { data: authSession, isPending } = useAuthSession();
+  const sessionReady = !isPending && !!authSession?.user;
+  const user: TraceApiUser | undefined = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
+  return useQuery({
+    queryKey: spanIOQueryKey(projectId, traceId, spanId ?? ""),
+    queryFn: () => getSpanIO(projectId, traceId, spanId!, user),
+    enabled: sessionReady && !!spanId,
+    staleTime: SPAN_IO_STALE_TIME_MS,
   });
 }
 

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -8,8 +8,12 @@ import { enrichSpansWithPending } from "../utils";
 /**
  * Merge incoming spans into existing spans array.
  * Incoming spans replace existing ones with the same span_id — real spans replace placeholders.
+ *
+ * Exported for unit testing: with two-phase loading the `existing` array holds
+ * skeleton spans (no I/O) while `incoming` live-SSE spans carry full I/O +
+ * metadata; both must flow through here without type/shape errors.
  */
-function mergeSpans(existing: Span[], incoming: Span[]): Span[] {
+export function mergeSpans(existing: Span[], incoming: Span[]): Span[] {
   const incomingIds = new Set(incoming.map((s) => s.span_id));
   return [...existing.filter((s) => !incomingIds.has(s.span_id)), ...incoming];
 }

--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -8,6 +8,7 @@ import {
   summarizeCostDetails,
   getTraceCostBreakdown,
 } from "./index";
+import { mergeSpans } from "../hooks/use-trace-stream";
 import type { TraceDetail } from "@/types/api";
 
 // Pin a non-UTC timezone so timezone-naive timestamp regressions (a whole-second
@@ -390,5 +391,137 @@ describe("getTraceCostBreakdown", () => {
   it("returns null when no span has cost_details", () => {
     const trace = { spans: [makeSpan({ span_id: "a" })] } as unknown as TraceDetail;
     expect(getTraceCostBreakdown(trace)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Two-phase loading: skeleton spans (no input/output/metadata) and full
+// live-SSE spans (with I/O + metadata) must both flow through the merge +
+// enrichment path without errors. This guards the live-tracing compat.
+// ---------------------------------------------------------------------------
+
+// Skeleton span: exactly what the trace-detail endpoint now ships — tree fields
+// only, NO input/output/metadata keys at all (they're undefined).
+function makeSkeletonSpan(overrides: Partial<Span> & { span_id: string }): Span {
+  return {
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: overrides.span_id,
+    span_kind: SpanKind.SPAN,
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:01.000Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...overrides,
+  };
+}
+
+describe("two-phase loading compatibility", () => {
+  it("enrichSpansWithPending handles skeleton spans with no metadata key", () => {
+    // Skeleton spans omit metadata entirely (undefined, not null).
+    const root = makeSkeletonSpan({ span_id: "root" });
+    const child = makeSkeletonSpan({ span_id: "child", parent_span_id: "root" });
+    expect(child.metadata).toBeUndefined();
+
+    const result = enrichSpansWithPending([root, child]);
+    // No placeholders synthesized (no ids_path metadata), no crash.
+    expect(result.map((s) => s.span_id).sort()).toEqual(["child", "root"]);
+    expect(result.every((s) => !s.pending)).toBe(true);
+  });
+
+  it("enrichSpansWithPending still synthesizes ancestors from live spans carrying metadata", () => {
+    // A full live-SSE span carries metadata with ids_path/path; enrichment must
+    // still create the missing parent placeholder even though OTHER spans are
+    // metadata-less skeletons.
+    const rootId = "demo-session-id";
+    const liveChild = makeSpan({
+      span_id: "llm-completion",
+      parent_span_id: rootId,
+      metadata: metadataWith([rootId], ["demo_session", "llm_completion"]),
+      input: '{"prompt":"x"}',
+      output: '{"completion":"y"}',
+    });
+    const skeletonSibling = makeSkeletonSpan({ span_id: "other", parent_span_id: rootId });
+
+    const result = enrichSpansWithPending([liveChild, skeletonSibling]);
+    const placeholder = result.find((s) => s.span_id === rootId);
+    expect(placeholder).toBeDefined();
+    expect(placeholder!.pending).toBe(true);
+    expect(placeholder!.name).toBe("demo_session");
+  });
+
+  it("getTraceDuration works over a mix of skeleton and full live spans", () => {
+    const trace = {
+      spans: [
+        makeSkeletonSpan({
+          span_id: "root",
+          span_start_time: "2024-01-01T00:00:00.000Z",
+          span_end_time: "2024-01-01T00:00:02.000Z",
+        }),
+        makeSpan({
+          span_id: "live",
+          parent_span_id: "root",
+          span_start_time: "2024-01-01T00:00:00.500Z",
+          span_end_time: "2024-01-01T00:00:03.000Z",
+          input: "live-input",
+        }),
+      ],
+    } as unknown as TraceDetail;
+    // 3s extent (max end − min start).
+    expect(getTraceDuration(trace)).toBe(3000);
+  });
+});
+
+describe("mergeSpans (live-SSE compat)", () => {
+  it("replaces skeleton spans with full live spans carrying I/O + metadata", () => {
+    // Initial cache state: skeletons from the trace-detail endpoint (no I/O).
+    const skeletons = [makeSkeletonSpan({ span_id: "a" }), makeSkeletonSpan({ span_id: "b" })];
+    // A live-SSE event delivers a full span (with I/O + metadata) for "a"
+    // plus a brand-new span "c".
+    const live = [
+      makeSpan({
+        span_id: "a",
+        input: "full-input",
+        output: "full-output",
+        metadata: metadataWith(["root"], ["root", "a"]),
+      }),
+      makeSpan({ span_id: "c", input: "c-input" }),
+    ];
+
+    const merged = mergeSpans(skeletons, live);
+    const ids = merged.map((s) => s.span_id).sort();
+    expect(ids).toEqual(["a", "b", "c"]);
+    // "a" now carries full I/O (live span replaced the skeleton).
+    const a = merged.find((s) => s.span_id === "a")!;
+    expect(a.input).toBe("full-input");
+    expect(a.metadata).toContain("ids_path");
+    // "b" remains a skeleton (no I/O keys).
+    const b = merged.find((s) => s.span_id === "b")!;
+    expect(b.input).toBeUndefined();
+  });
+
+  it("merged skeleton+live spans enrich without error", () => {
+    const skeletons = [makeSkeletonSpan({ span_id: "root" })];
+    const live = [
+      makeSpan({
+        span_id: "child",
+        parent_span_id: "mid",
+        metadata: metadataWith(["root", "mid"], ["root", "mid", "child"]),
+        input: "x",
+      }),
+    ];
+    const enriched = enrichSpansWithPending(mergeSpans(skeletons, live));
+    // The missing intermediate "mid" is synthesized from the live span's metadata.
+    expect(enriched.find((s) => s.span_id === "mid")?.pending).toBe(true);
+    expect(enriched.find((s) => s.span_id === "root")).toBeDefined();
+    expect(enriched.find((s) => s.span_id === "child")).toBeDefined();
   });
 });

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -38,7 +38,9 @@ export function enrichSpansWithPending(spans: Span[]): Span[] {
   for (const span of spans) {
     if (!span.parent_span_id) continue;
 
-    const meta = parseMetadata(span.metadata);
+    // Skeleton spans omit metadata (parseMetadata(null|undefined) → {}); live
+    // SSE spans still carry it, so enrichment keeps working from live events.
+    const meta = parseMetadata(span.metadata ?? null);
     const idsPath = meta["traceroot.span.ids_path"] as string[] | undefined;
     const namePath = meta["traceroot.span.path"] as string[] | undefined;
 

--- a/frontend/ui/src/lib/api/index.ts
+++ b/frontend/ui/src/lib/api/index.ts
@@ -58,7 +58,7 @@ export {
 } from "./model-providers";
 
 // Trace APIs
-export { getTraces, getTrace } from "./traces";
+export { getTraces, getTrace, getSpanIO } from "./traces";
 
 // Re-export all types from types/api.ts for backward compatibility
 export type {
@@ -72,6 +72,7 @@ export type {
   AccessKeyCreatedResponse,
   TraceListItem,
   Span,
+  SpanIO,
   TraceDetail,
   TraceListResponse,
   TraceQueryOptions,

--- a/frontend/ui/src/lib/api/traces.test.ts
+++ b/frontend/ui/src/lib/api/traces.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the auth client so fetchTraceApi never hits a real session lookup.
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { getSession: vi.fn().mockResolvedValue({ data: null }) },
+}));
+
+import { getSpanIO } from "./traces";
+
+describe("getSpanIO", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("calls the per-span /io endpoint and returns the parsed body", async () => {
+    const body = {
+      span_id: "span-1",
+      trace_id: "trace-9",
+      input: "in",
+      output: "out",
+      metadata: "{}",
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => body,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getSpanIO("proj-1", "trace-9", "span-1", {
+      id: "user-1",
+      email: "u@example.com",
+    });
+
+    expect(result).toEqual(body);
+    // URL is built from the path params, in order.
+    const url = fetchMock.mock.calls[0][0] as string;
+    expect(url).toContain("/projects/proj-1/traces/trace-9/spans/span-1/io");
+    // User identity is forwarded as headers.
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-user-id"]).toBe("user-1");
+    expect(headers["x-user-email"]).toBe("u@example.com");
+  });
+
+  it("throws on a non-ok response (e.g. 404 unknown span)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({ detail: "Span not found" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getSpanIO("proj-1", "trace-9", "missing", { id: "user-1" })).rejects.toThrow(
+      "Span not found",
+    );
+  });
+});

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -2,7 +2,7 @@
  * Trace API functions (Python backend - ClickHouse)
  */
 import { fetchTraceApi, type TraceApiUser } from "./client";
-import type { TraceDetail, TraceListResponse, TraceQueryOptions } from "@/types/api";
+import type { SpanIO, TraceDetail, TraceListResponse, TraceQueryOptions } from "@/types/api";
 
 export async function getTraces(
   projectId: string,
@@ -33,4 +33,21 @@ export async function getTrace(
   user?: TraceApiUser,
 ): Promise<TraceDetail> {
   return fetchTraceApi<TraceDetail>(`/projects/${projectId}/traces/${traceId}`, {}, user);
+}
+
+/**
+ * Fetch full input/output/metadata for a single span on demand.
+ * Backed by GET /projects/{projectId}/traces/{traceId}/spans/{spanId}/io.
+ */
+export async function getSpanIO(
+  projectId: string,
+  traceId: string,
+  spanId: string,
+  user?: TraceApiUser,
+): Promise<SpanIO> {
+  return fetchTraceApi<SpanIO>(
+    `/projects/${projectId}/traces/${traceId}/spans/${spanId}/io`,
+    {},
+    user,
+  );
 }

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -129,13 +129,29 @@ export interface Span {
   // Per-category dollar breakdown: input_uncached_cost,
   // cache_read_cost, cache_write_cost, output_cost. Empty when no known prices.
   cost_details?: Record<string, number>;
-  input: string | null;
-  output: string | null;
-  metadata: string | null;
+  // I/O blobs are OPTIONAL on the cache span type: the trace-detail skeleton
+  // omits them entirely (fetched per-span on demand via getSpanIO), while live
+  // SSE spans still carry them. Both shapes flow through mergeSpans /
+  // enrichSpansWithPending without a type error.
+  input?: string | null;
+  output?: string | null;
+  metadata?: string | null;
   git_source_file: string | null;
   git_source_line: number | null;
   git_source_function: string | null;
   pending?: boolean;
+}
+
+/**
+ * Full I/O payload for a single span, fetched on demand from
+ * GET /projects/{projectId}/traces/{traceId}/spans/{spanId}/io.
+ */
+export interface SpanIO {
+  span_id: string;
+  trace_id: string;
+  input: string | null;
+  output: string | null;
+  metadata: string | null;
 }
 
 export interface TraceDetail {

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -3,7 +3,9 @@
 Pure logic — get_model_price is patched, so no DB/ClickHouse is needed.
 """
 
-from unittest.mock import patch
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -52,3 +54,171 @@ def test_span_cost_details_empty_for_unknown_model():
 
     with patch("rest.services.trace_reader.get_model_price", return_value=None):
         assert span_cost_details("mystery-model", 100, 50, {}) == {}
+
+
+# ---------------------------------------------------------------------------
+# Two-phase loading: get_trace skeleton + get_span_io.
+# The ClickHouse client is mocked; we assert on the SQL issued and the dicts
+# produced, never touching a real database.
+# ---------------------------------------------------------------------------
+
+
+def _make_service(query_side_effect):
+    """Build a TraceReaderService backed by a mock ClickHouse client.
+
+    ``query_side_effect`` is a callable invoked with each query string; it
+    returns an object exposing ``result_rows`` (mirroring clickhouse_connect).
+    """
+    from rest.services.trace_reader import TraceReaderService
+
+    client = MagicMock()
+    client.query.side_effect = query_side_effect
+    with patch(
+        "rest.services.trace_reader.get_clickhouse_client",
+        return_value=client,
+    ):
+        service = TraceReaderService()
+    return service, client
+
+
+def _rows(rows):
+    return SimpleNamespace(result_rows=rows)
+
+
+class TestGetTraceSkeleton:
+    def test_spans_query_omits_io_columns(self):
+        """The spans SELECT must not read input/output/metadata blobs."""
+        captured = {}
+
+        def side_effect(query, parameters=None):
+            if "FROM traces FINAL" in query:
+                return _rows(
+                    [
+                        (
+                            "abc123",  # trace_id
+                            "proj",  # project_id
+                            "trace-name",  # name
+                            datetime(2024, 1, 1),  # trace_start_time
+                            None,  # user_id
+                            None,  # session_id
+                            None,  # git_ref
+                            None,  # git_repo
+                            "trace-in",  # input (trace-level, kept)
+                            "trace-out",  # output (trace-level, kept)
+                            "trace-meta",  # metadata (trace-level, kept)
+                        )
+                    ]
+                )
+            # spans query
+            captured["spans_query"] = query
+            return _rows(
+                [
+                    (
+                        "span-1",  # span_id
+                        "abc123",  # trace_id
+                        None,  # parent_span_id
+                        "root",  # name
+                        "SPAN",  # span_kind
+                        datetime(2024, 1, 1),  # span_start_time
+                        datetime(2024, 1, 1),  # span_end_time
+                        "OK",  # status
+                        None,  # status_message
+                        None,  # model_name
+                        None,  # cost
+                        None,  # input_tokens
+                        None,  # output_tokens
+                        None,  # total_tokens
+                        {},  # usage_details
+                        "file.py",  # git_source_file
+                        12,  # git_source_line
+                        "fn",  # git_source_function
+                    )
+                ]
+            )
+
+        service, _ = _make_service(side_effect)
+        result = service.get_trace("proj", "abc123")
+
+        spans_sql = captured["spans_query"]
+        # No blob columns in the SELECT clause. Tokenize on commas/whitespace so
+        # `input_tokens` / `output_tokens` (which legitimately remain) don't
+        # trip a naive substring check.
+        select_clause = spans_sql.split("FROM spans")[0]
+        cols = {c.strip() for c in select_clause.replace("SELECT", "").split(",")}
+        assert "input" not in cols
+        assert "output" not in cols
+        assert "metadata" not in cols
+        # The token columns (which share a prefix with the blobs) are still there.
+        assert "input_tokens" in cols
+        assert "output_tokens" in cols
+        # Still selects via FINAL (correctness for ReplacingMergeTree).
+        assert "FROM spans FINAL" in spans_sql
+
+        # Resulting span dict carries NO I/O keys, but keeps tree fields.
+        span = result["spans"][0]
+        assert "input" not in span
+        assert "output" not in span
+        assert "metadata" not in span
+        assert span["span_id"] == "span-1"
+        assert span["git_source_file"] == "file.py"
+        assert span["git_source_line"] == 12
+        assert span["git_source_function"] == "fn"
+
+        # Trace-level I/O is preserved.
+        assert result["input"] == "trace-in"
+        assert result["output"] == "trace-out"
+        assert result["metadata"] == "trace-meta"
+
+    def test_returns_none_when_trace_missing(self):
+        def side_effect(query, parameters=None):
+            return _rows([])
+
+        service, _ = _make_service(side_effect)
+        assert service.get_trace("proj", "missing") is None
+
+
+class TestGetSpanIO:
+    def test_returns_blobs_for_existing_span(self):
+        def side_effect(query, parameters=None):
+            assert "FROM spans FINAL" in query
+            # All three blob columns must be in the SELECT.
+            assert "input" in query
+            assert "output" in query
+            assert "metadata" in query
+            assert parameters == {
+                "project_id": "proj",
+                "trace_id": "abc123",
+                "span_id": "span-1",
+            }
+            return _rows([("span-1", "abc123", "the-input", "the-output", "the-meta")])
+
+        service, _ = _make_service(side_effect)
+        result = service.get_span_io("proj", "abc123", "span-1")
+        assert result == {
+            "span_id": "span-1",
+            "trace_id": "abc123",
+            "input": "the-input",
+            "output": "the-output",
+            "metadata": "the-meta",
+        }
+
+    def test_returns_none_for_unknown_span(self):
+        def side_effect(query, parameters=None):
+            return _rows([])
+
+        service, _ = _make_service(side_effect)
+        assert service.get_span_io("proj", "abc123", "missing") is None
+
+    def test_null_blobs_pass_through(self):
+        def side_effect(query, parameters=None):
+            return _rows([("span-1", "abc123", None, None, None)])
+
+        service, _ = _make_service(side_effect)
+        result = service.get_span_io("proj", "abc123", "span-1")
+        assert result == {
+            "span_id": "span-1",
+            "trace_id": "abc123",
+            "input": None,
+            "output": None,
+            "metadata": None,
+        }

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -272,6 +272,13 @@ class TestGetSpanIO:
         response = client.get("/api/v1/projects/test-project/traces/abc123/spans/missing/io")
         assert response.status_code == 404
 
+    def test_500_on_service_error(self, client, mock_trace_reader):
+        """An unexpected reader error maps to the controlled 500 contract."""
+        mock_trace_reader.get_span_io.side_effect = RuntimeError("clickhouse down")
+        response = client.get("/api/v1/projects/test-project/traces/abc123/spans/span-1/io")
+        assert response.status_code == 500
+        assert response.json()["detail"] == "Failed to get span I/O"
+
     def test_null_io_fields_serialize(self, client, mock_trace_reader):
         """A span row that exists but has empty I/O still returns 200 with nulls."""
         mock_trace_reader.get_span_io.return_value = {

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -54,11 +54,19 @@ TRACE_DETAIL = {
             "input_tokens": None,
             "output_tokens": None,
             "total_tokens": None,
-            "input": None,
-            "output": None,
-            "metadata": None,
+            "usage_details": {},
+            "cost_details": {},
         }
     ],
+}
+
+# Full I/O payload returned by the dedicated per-span endpoint.
+SPAN_IO = {
+    "span_id": "span-1",
+    "trace_id": "abc123",
+    "input": '{"prompt": "hello"}',
+    "output": '{"completion": "world"}',
+    "metadata": '{"traceroot.span.path": ["root"]}',
 }
 
 
@@ -186,6 +194,99 @@ class TestGetTrace:
         mock_trace_reader.get_trace.return_value = None
         response = client.get("/api/v1/projects/test-project/traces/nonexistent")
         assert response.status_code == 404
+
+    def test_spans_are_skeletons_without_io(self, client, mock_trace_reader):
+        """The trace-detail response must NOT carry per-span input/output/metadata.
+
+        This is the core of two-phase loading: the bulk response stays sub-MB by
+        omitting the large free-text blobs. Even if the service were to leak them,
+        the SpanSkeletonResponse model strips them out.
+        """
+        # Service returns blobs (simulating a stale/over-fetching service) —
+        # the response model must still drop them.
+        leaky_detail = {
+            **TRACE_DETAIL,
+            "spans": [
+                {
+                    **TRACE_DETAIL["spans"][0],
+                    "input": "should-not-appear",
+                    "output": "should-not-appear",
+                    "metadata": "should-not-appear",
+                }
+            ],
+        }
+        mock_trace_reader.get_trace.return_value = leaky_detail
+        response = client.get("/api/v1/projects/test-project/traces/abc123")
+        assert response.status_code == 200
+        span = response.json()["spans"][0]
+        assert "input" not in span
+        assert "output" not in span
+        assert "metadata" not in span
+        # Tree/display fields are still present on the skeleton.
+        assert span["span_id"] == "span-1"
+        assert span["parent_span_id"] is None
+        assert "usage_details" in span
+        assert "cost_details" in span
+
+    def test_trace_level_io_is_preserved(self, client, mock_trace_reader):
+        """Trace-level input/output/metadata stay on the trace (only spans drop I/O)."""
+        detail = {
+            **TRACE_DETAIL,
+            "input": "trace-input",
+            "output": "trace-output",
+            "metadata": "trace-metadata",
+        }
+        mock_trace_reader.get_trace.return_value = detail
+        response = client.get("/api/v1/projects/test-project/traces/abc123")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["input"] == "trace-input"
+        assert data["output"] == "trace-output"
+        assert data["metadata"] == "trace-metadata"
+
+
+class TestGetSpanIO:
+    def test_200_returns_span_blobs(self, client, mock_trace_reader):
+        mock_trace_reader.get_span_io.return_value = SPAN_IO
+        response = client.get("/api/v1/projects/test-project/traces/abc123/spans/span-1/io")
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {
+            "span_id": "span-1",
+            "trace_id": "abc123",
+            "input": '{"prompt": "hello"}',
+            "output": '{"completion": "world"}',
+            "metadata": '{"traceroot.span.path": ["root"]}',
+        }
+
+    def test_passes_through_path_params(self, client, mock_trace_reader):
+        mock_trace_reader.get_span_io.return_value = SPAN_IO
+        client.get("/api/v1/projects/test-project/traces/abc123/spans/span-1/io")
+        kw = mock_trace_reader.get_span_io.call_args.kwargs
+        assert kw["project_id"] == "test-project"
+        assert kw["trace_id"] == "abc123"
+        assert kw["span_id"] == "span-1"
+
+    def test_404_for_unknown_span(self, client, mock_trace_reader):
+        mock_trace_reader.get_span_io.return_value = None
+        response = client.get("/api/v1/projects/test-project/traces/abc123/spans/missing/io")
+        assert response.status_code == 404
+
+    def test_null_io_fields_serialize(self, client, mock_trace_reader):
+        """A span row that exists but has empty I/O still returns 200 with nulls."""
+        mock_trace_reader.get_span_io.return_value = {
+            "span_id": "span-1",
+            "trace_id": "abc123",
+            "input": None,
+            "output": None,
+            "metadata": None,
+        }
+        response = client.get("/api/v1/projects/test-project/traces/abc123/spans/span-1/io")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["input"] is None
+        assert data["output"] is None
+        assert data["metadata"] is None
 
     def test_trace_with_multiple_spans(self, client, mock_trace_reader):
         detail = {


### PR DESCRIPTION
## What
Two-phase trace-detail loading. The trace endpoint returns a lightweight **skeleton** (span tree + small fields, no `input`/`output`/`metadata`); each span's I/O is fetched **on demand** via a new `GET /projects/{p}/traces/{t}/spans/{s}/io` endpoint, with **debounced (150 ms) hover-prefetch** so the click feels instant.

## Impact (measured on the heaviest real trace, 67 spans)
| | Before | After |
|---|---|---|
| Initial trace load | ~24 MB, ~7.3 s | **~39 KB, ~0.028 s** |
| Spans in initial payload | all I/O inline | skeleton, **zero I/O** |
| A heavy span's I/O | bundled in the 24 MB | ~700 KB, **only when selected** |

No ClickHouse migration needed — columnar pruning makes the skeleton query cheap (measured 0.74 s vs 4.5 s for the blob read).

## Also in this PR
- **Dead code removed:** the orphaned `SpanResponse` schema (trace detail now uses `SpanSkeletonResponse`).
- **ClickHouse concurrency fix (#1093):** the shared `clickhouse-connect` client used a sticky server-side session, so concurrent queries 500'd ("concurrent queries within the same session"). The per-span `/io` fan-out turned this from rare to frequent. Fixed with `autogenerate_session_id=False` — a semantic no-op for our stateless reads/inserts/DDL, just removes the lock. Verified: 11/12 concurrent queries failing → 0.

## Live-tracing safety (verified)
The live SSE path is **untouched** — the channel still publishes full spans, and I/O is **optional** on the cache span type, so skeleton + live spans both flow through `mergeSpans` / `enrichSpansWithPending`. The tree + timeline render from timing/structure (present in the skeleton), so live updates are unaffected.

## Screenshots

<img width="2373" height="1058" alt="Screenshot 2026-06-08 at 1 13 12 AM" src="https://github.com/user-attachments/assets/9b90b6ad-65ce-42e3-9b57-cf9382341197" />


## Tests
- **Backend:** skeleton has no I/O; the `/io` endpoint (200 / params / 404 / null); `get_span_io` service; full REST suite **105 passing**.
- **Frontend:** the live-compat cases (`mergeSpans`/`enrich` with skeleton + full live spans, null-metadata tolerance), `getSpanIO`; feature suite **69 passing**, `tsc` clean.
- **e2e** on the running stack against the real 24 MB trace: skeleton-fast load, lazy per-span `/io`, **0 errors** under heavy clicking (incl. the concurrency fix).

Closes #1046
Closes #1047
Closes #1044
Closes #1093

(#1044 is superseded — a skeleton response can't be oversized.) Part of #1040.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
