### PR TITLE
Onboarding: surface Slack so users can connect during trace setup

### DIFF
--- a/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/AITab.tsx
@@ -2,6 +2,7 @@
 
 import { CopyButton } from "@/components/ui/copy-button";
 import { GitHubConnectButton } from "@/components/github/GitHubConnectButton";
+import { SlackConnectButton } from "@/components/slack/SlackConnectButton";
 import { useProject } from "@/features/projects/hooks";
 import { ApiKeyBlock } from "./ApiKeyBlock";
 
@@ -46,6 +47,21 @@ export function AITab({ projectId }: AITabProps) {
           </p>
           <div className="mt-3">
             <GitHubConnectButton workspaceId={workspaceId} />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">
+          4. Optionally connect Slack for alerts
+        </p>
+        <div className="rounded-sm border border-border bg-muted/30 px-4 py-3">
+          <p className="text-xs text-muted-foreground">
+            Connect Slack to get detector alerts posted to a channel so your team is notified about
+            issues.
+          </p>
+          <div className="mt-3">
+            <SlackConnectButton workspaceId={workspaceId} />
           </div>
         </div>
       </div>

--- a/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/ManualTab.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { cn } from "@/lib/utils";
 import { CopyButton } from "@/components/ui/copy-button";
 import { GitHubConnectButton } from "@/components/github/GitHubConnectButton";
+import { SlackConnectButton } from "@/components/slack/SlackConnectButton";
 import { useProject } from "@/features/projects/hooks";
 import { ApiKeyBlock } from "./ApiKeyBlock";
 import { IntegrationPickerCard } from "./IntegrationPickerCard";
@@ -174,6 +175,21 @@ export function ManualTab({ projectId }: ManualTabProps) {
           </p>
           <div className="mt-3">
             <GitHubConnectButton workspaceId={workspaceId} />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-foreground">
+          6. Optionally connect Slack for alerts
+        </p>
+        <div className="rounded-sm border border-border bg-muted/30 px-4 py-3">
+          <p className="text-xs text-muted-foreground">
+            Connect Slack to get detector alerts posted to a channel so your team is notified about
+            issues.
+          </p>
+          <div className="mt-3">
+            <SlackConnectButton workspaceId={workspaceId} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What

Surfaces Slack in the trace onboarding screen (`GettingStarted`, shown before the first trace) so new users can discover and connect Slack alerts during setup — previously the Slack connect UI lived only in workspace settings.

Adds an optional **"Optionally connect Slack for alerts"** card to both onboarding tabs, right after the existing GitHub step:
- **AI tab** — step 4
- **Manual tab** — step 6

## How

- Reuses the existing `SlackConnectButton` (backed by `useSlackIntegration`), so onboarding reflects whether Slack is already connected and uses the **same connect flow/state** as settings — no second source of truth.
- The card mirrors the existing GitHub card markup, so styling stays consistent.
- It's non-blocking: skipping Slack still lets onboarding proceed to the first-trace state.

## Acceptance

- [x] Onboarding shows Slack availability and a connect affordance.
- [x] Connecting from onboarding uses the same flow/state as settings (no divergence).
- [x] Skipping Slack still lets onboarding proceed normally.

## Screenshots
<img width="3452" height="1924" alt="image" src="https://github.com/user-attachments/assets/713e7d52-b0da-4a73-b2b4-1f6585d14f64" />
<img width="1728" height="991" alt="Screenshot 2026-06-08 at 12 43 21 PM" src="https://github.com/user-attachments/assets/e60742c2-606d-4c17-8dc6-a9dfdac5cc88" />



Closes #1079

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surface Slack connect in trace onboarding so users can enable alerts during setup. Implements Linear #1079 by surfacing Slack during the Getting Started flow.

- **New Features**
  - Adds an optional “Optionally connect Slack for alerts” card to `GettingStarted`: AI tab (step 4) and Manual tab (step 6).
  - Reuses `SlackConnectButton` (via `useSlackIntegration`) to share the same connect flow and status as workspace settings.
  - Non-blocking: skipping Slack does not prevent completing onboarding.

<sup>Written for commit 6870b29fe63543a8a734cbc8eb9632a511497222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

