### PR TITLE
fix(worker): populate trace-level git_repo and git_ref from child spans

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -296,11 +296,11 @@ def transform_otel_to_clickhouse(
     traces: dict[str, dict] = {}  # trace_id -> trace record
     spans: list[dict] = []
 
-    # Track user_id/session_id per trace, collected from ANY span
+    # Track user_id/session_id/git info per trace, collected from ANY span
     # Priority: root span values > first child span values
     trace_attrs: dict[
         str, dict[str, str | None]
-    ] = {}  # trace_id -> {"user_id": ..., "session_id": ...}
+    ] = {}  # trace_id -> {"user_id": ..., "session_id": ..., "git_ref": ..., "git_repo": ...}
 
     # Best-known root name per trace: (ids_path_length, name).
     # Shortest ids_path = closest to root. Used to correct eager trace names
@@ -583,30 +583,33 @@ def transform_otel_to_clickhouse(
 
                 spans.append(span_record)
 
-                # Collect user_id/session_id from ANY span (not just root)
+                # Collect user_id/session_id/git info from ANY span (not just root)
                 # Priority: root span values overwrite, child span values only set if empty
                 span_user_id = _extract_user_id(span_attrs)
                 span_session_id = _extract_session_id(span_attrs)
+                span_git_ref = span_attrs.get("traceroot.git.ref")
+                span_git_repo = span_attrs.get("traceroot.git.repo")
 
                 if trace_id not in trace_attrs:
-                    trace_attrs[trace_id] = {"user_id": None, "session_id": None}
+                    trace_attrs[trace_id] = {
+                        "user_id": None,
+                        "session_id": None,
+                        "git_ref": None,
+                        "git_repo": None,
+                    }
 
                 if not parent_span_id:
                     # Root span: always use its values if present (overwrites child values)
-                    trace_attrs[trace_id]["user_id"] = (
-                        span_user_id or trace_attrs[trace_id]["user_id"]
-                    )
-                    trace_attrs[trace_id]["session_id"] = (
-                        span_session_id or trace_attrs[trace_id]["session_id"]
-                    )
+                    trace_attrs[trace_id]["user_id"] = span_user_id or trace_attrs[trace_id]["user_id"]
+                    trace_attrs[trace_id]["session_id"] = span_session_id or trace_attrs[trace_id]["session_id"]
+                    trace_attrs[trace_id]["git_ref"] = span_git_ref or trace_attrs[trace_id]["git_ref"]
+                    trace_attrs[trace_id]["git_repo"] = span_git_repo or trace_attrs[trace_id]["git_repo"]
                 else:
                     # Child span: only set if not already set (first child wins)
-                    trace_attrs[trace_id]["user_id"] = (
-                        trace_attrs[trace_id]["user_id"] or span_user_id
-                    )
-                    trace_attrs[trace_id]["session_id"] = (
-                        trace_attrs[trace_id]["session_id"] or span_session_id
-                    )
+                    trace_attrs[trace_id]["user_id"] = trace_attrs[trace_id]["user_id"] or span_user_id
+                    trace_attrs[trace_id]["session_id"] = trace_attrs[trace_id]["session_id"] or span_session_id
+                    trace_attrs[trace_id]["git_ref"] = trace_attrs[trace_id]["git_ref"] or span_git_ref
+                    trace_attrs[trace_id]["git_repo"] = trace_attrs[trace_id]["git_repo"] or span_git_repo
 
                 # Eager trace creation:
                 # Create a "shallow" trace record on the FIRST span we see for
@@ -625,6 +628,10 @@ def transform_otel_to_clickhouse(
                         "user_id": trace_attrs[trace_id]["user_id"],
                         "session_id": trace_attrs[trace_id]["session_id"],
                     }
+                    if trace_attrs[trace_id]["git_ref"]:
+                        traces[trace_id]["git_ref"] = trace_attrs[trace_id]["git_ref"]
+                    if trace_attrs[trace_id]["git_repo"]:
+                        traces[trace_id]["git_repo"] = trace_attrs[trace_id]["git_repo"]
 
                 # Track the best-known root name for this trace using the span
                 # closest to the root (shortest ids_path). Batches may contain
@@ -648,9 +655,6 @@ def transform_otel_to_clickhouse(
 
                 if not parent_span_id:
                     # Root span arrived — upgrade to full trace with rich metadata
-                    git_ref = span_attrs.get("traceroot.git.ref")
-                    git_repo = span_attrs.get("traceroot.git.repo")
-
                     traces[trace_id].update(
                         {
                             "trace_start_time": start_time,
@@ -662,10 +666,10 @@ def transform_otel_to_clickhouse(
 
                     if environment is not None:
                         traces[trace_id]["environment"] = environment
-                    if git_ref is not None:
-                        traces[trace_id]["git_ref"] = git_ref
-                    if git_repo is not None:
-                        traces[trace_id]["git_repo"] = git_repo
+                    if trace_attrs[trace_id]["git_ref"] is not None:
+                        traces[trace_id]["git_ref"] = trace_attrs[trace_id]["git_ref"]
+                    if trace_attrs[trace_id]["git_repo"] is not None:
+                        traces[trace_id]["git_repo"] = trace_attrs[trace_id]["git_repo"]
 
                     # Extract trace-level metadata
                     trace_metadata = span_attrs.get("traceroot.trace.metadata")
@@ -696,7 +700,7 @@ def transform_otel_to_clickhouse(
         if trace_id in traces:
             traces[trace_id]["name"] = best_name
 
-    # Update trace records with user_id/session_id collected from child spans
+    # Update trace records with user_id/session_id/git info collected from child spans
     # (in case child spans with these attrs came after the root span was processed)
     for trace_id, attrs in trace_attrs.items():
         if trace_id in traces:
@@ -704,5 +708,9 @@ def transform_otel_to_clickhouse(
                 traces[trace_id]["user_id"] = attrs["user_id"]
             if attrs["session_id"] and not traces[trace_id].get("session_id"):
                 traces[trace_id]["session_id"] = attrs["session_id"]
+            if attrs["git_ref"] and not traces[trace_id].get("git_ref"):
+                traces[trace_id]["git_ref"] = attrs["git_ref"]
+            if attrs["git_repo"] and not traces[trace_id].get("git_repo"):
+                traces[trace_id]["git_repo"] = attrs["git_repo"]
 
     return list(traces.values()), spans

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -600,16 +600,32 @@ def transform_otel_to_clickhouse(
 
                 if not parent_span_id:
                     # Root span: always use its values if present (overwrites child values)
-                    trace_attrs[trace_id]["user_id"] = span_user_id or trace_attrs[trace_id]["user_id"]
-                    trace_attrs[trace_id]["session_id"] = span_session_id or trace_attrs[trace_id]["session_id"]
-                    trace_attrs[trace_id]["git_ref"] = span_git_ref or trace_attrs[trace_id]["git_ref"]
-                    trace_attrs[trace_id]["git_repo"] = span_git_repo or trace_attrs[trace_id]["git_repo"]
+                    trace_attrs[trace_id]["user_id"] = (
+                        span_user_id or trace_attrs[trace_id]["user_id"]
+                    )
+                    trace_attrs[trace_id]["session_id"] = (
+                        span_session_id or trace_attrs[trace_id]["session_id"]
+                    )
+                    trace_attrs[trace_id]["git_ref"] = (
+                        span_git_ref or trace_attrs[trace_id]["git_ref"]
+                    )
+                    trace_attrs[trace_id]["git_repo"] = (
+                        span_git_repo or trace_attrs[trace_id]["git_repo"]
+                    )
                 else:
                     # Child span: only set if not already set (first child wins)
-                    trace_attrs[trace_id]["user_id"] = trace_attrs[trace_id]["user_id"] or span_user_id
-                    trace_attrs[trace_id]["session_id"] = trace_attrs[trace_id]["session_id"] or span_session_id
-                    trace_attrs[trace_id]["git_ref"] = trace_attrs[trace_id]["git_ref"] or span_git_ref
-                    trace_attrs[trace_id]["git_repo"] = trace_attrs[trace_id]["git_repo"] or span_git_repo
+                    trace_attrs[trace_id]["user_id"] = (
+                        trace_attrs[trace_id]["user_id"] or span_user_id
+                    )
+                    trace_attrs[trace_id]["session_id"] = (
+                        trace_attrs[trace_id]["session_id"] or span_session_id
+                    )
+                    trace_attrs[trace_id]["git_ref"] = (
+                        trace_attrs[trace_id]["git_ref"] or span_git_ref
+                    )
+                    trace_attrs[trace_id]["git_repo"] = (
+                        trace_attrs[trace_id]["git_repo"] or span_git_repo
+                    )
 
                 # Eager trace creation:
                 # Create a "shallow" trace record on the FIRST span we see for

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -326,6 +326,51 @@ class TestTransformOtelToClickhouse:
         assert traces[0].get("git_repo") == "traceroot-ai/traceroot"
         assert traces[0].get("git_ref") == "main"
 
+    def test_git_repo_ref_from_root_span(self):
+        """Root span git_ref/git_repo populate the trace record."""
+        trace_hex = "aa" * 16
+        root_hex = "bb" * 8
+        payload = make_otel_payload(
+            [
+                make_span(
+                    trace_hex,
+                    root_hex,
+                    attributes=[
+                        make_attr("traceroot.git.repo", "traceroot-ai/traceroot"),
+                        make_attr("traceroot.git.ref", "main"),
+                    ],
+                ),
+            ]
+        )
+        traces, _ = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert traces[0].get("git_repo") == "traceroot-ai/traceroot"
+        assert traces[0].get("git_ref") == "main"
+
+    def test_git_repo_ref_child_arrives_before_root_in_same_batch(self):
+        """Child span sets git attrs; root span in same batch should not overwrite with None."""
+        trace_hex = "aa" * 16
+        root_hex = "bb" * 8
+        child_hex = "cc" * 8
+        payload = make_otel_payload(
+            [
+                make_span(
+                    trace_hex,
+                    child_hex,
+                    parent_span_id_hex=root_hex,
+                    attributes=[
+                        make_attr("traceroot.git.repo", "traceroot-ai/traceroot"),
+                        make_attr("traceroot.git.ref", "main"),
+                    ],
+                ),
+                make_span(trace_hex, root_hex),
+            ]
+        )
+        traces, _ = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert traces[0].get("git_repo") == "traceroot-ai/traceroot"
+        assert traces[0].get("git_ref") == "main"
+
     def test_skip_span_with_missing_ids(self):
         """Spans without traceId/spanId are skipped."""
         payload = {

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -303,6 +303,29 @@ class TestTransformOtelToClickhouse:
 
         assert traces[0]["user_id"] == "child-user"
 
+    def test_git_repo_ref_from_child_span_without_root(self):
+        trace_hex = "aa" * 16
+        root_hex = "bb" * 8
+        child_hex = "cc" * 8
+        # Batch contains child span only (root span hasn't arrived yet)
+        payload = make_otel_payload(
+            [
+                make_span(
+                    trace_hex,
+                    child_hex,
+                    parent_span_id_hex=root_hex,
+                    attributes=[
+                        make_attr("traceroot.git.repo", "traceroot-ai/traceroot"),
+                        make_attr("traceroot.git.ref", "main"),
+                    ],
+                ),
+            ]
+        )
+        traces, _ = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert traces[0].get("git_repo") == "traceroot-ai/traceroot"
+        assert traces[0].get("git_ref") == "main"
+
     def test_skip_span_with_missing_ids(self):
         """Spans without traceId/spanId are skipped."""
         payload = {


### PR DESCRIPTION
Trace-level git_repo / git_ref only populated from the root span, causing them to appear late during live trace streaming since root spans arrive last in batch exports.

This lifts git_ref / git_repo extraction into the generic span loop, tracking them in trace_attrs alongside user_id and session_id so they populate from the first span that carries them (mirroring the trace name pattern).

Fixes #1099

## Summary

- **Lifted `git_repo` / `git_ref` extraction:** Extracted Git fields out of the `if not parent_span_id` block in `otel_transform.py`.
- **Stored in `trace_attrs`:** Git values are now tracked across all spans and populated from the first child span that carries them, ensuring they appear immediately during live trace streaming before the root span arrives.
- **Added regression test:** Added `test_git_repo_ref_from_child_span_without_root` to verify that child spans correctly populate the repo/ref fields on a trace when the root span is missing from the batch.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

The root cause was that `backend/worker/otel_transform.py` historically only extracted trace-level git fields from the root span. Because the root span wraps the entire run, it ends last and arrives last in the live stream, causing the GitHub repo/ref context to populate late. By applying the same "shallowest-candidate" mechanism already used for `user_id` and `session_id`, the UI will now display the Git metadata as soon as the first span lands. 

## Screenshots / Recordings (if applicable)

<img width="2186" height="1238" alt="image" src="https://github.com/user-attachments/assets/4664f8e4-4688-4821-b174-4d21831daeb2" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes delayed Git metadata in live traces by populating trace-level `git_repo` and `git_ref` from any span, not just the root. Git fields now appear as soon as the first span with them arrives.

- **Bug Fixes**
  - Extract `git_repo`/`git_ref` from any span and track per-trace with root-overrides-first-child precedence; use them during eager trace creation and on root upgrade, and backfill late arrivals.
  - Expand tests to cover child-only, root-only, and child-before-root-in-same-batch cases; formatted `otel_transform.py` with `ruff` (no logic changes).

<sup>Written for commit 521507985884751d3b0e5f4b2a13e4c9d83c0916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

