### PR TITLE
fix(worker): populate git fields before root span

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -559,11 +559,15 @@ def transform_otel_to_clickhouse(
                     if existing is None or depth < existing[0]:
                         _trace_name_candidates[trace_id] = (depth, candidate_name)
 
+                git_ref = span_attrs.get("traceroot.git.ref")
+                git_repo = span_attrs.get("traceroot.git.repo")
+                if git_ref is not None and traces[trace_id].get("git_ref") is None:
+                    traces[trace_id]["git_ref"] = git_ref
+                if git_repo is not None and traces[trace_id].get("git_repo") is None:
+                    traces[trace_id]["git_repo"] = git_repo
+
                 if not parent_span_id:
                     # Root span arrived — upgrade to full trace with rich metadata
-                    git_ref = span_attrs.get("traceroot.git.ref")
-                    git_repo = span_attrs.get("traceroot.git.repo")
-
                     traces[trace_id].update(
                         {
                             "trace_start_time": start_time,
@@ -575,10 +579,6 @@ def transform_otel_to_clickhouse(
 
                     if environment is not None:
                         traces[trace_id]["environment"] = environment
-                    if git_ref is not None:
-                        traces[trace_id]["git_ref"] = git_ref
-                    if git_repo is not None:
-                        traces[trace_id]["git_repo"] = git_repo
 
                     # Extract trace-level metadata
                     trace_metadata = span_attrs.get("traceroot.trace.metadata")

--- a/backend/worker/tests/test_otel_transform_metadata.py
+++ b/backend/worker/tests/test_otel_transform_metadata.py
@@ -1,7 +1,9 @@
 """Tests for metadata extraction in otel_transform."""
 
 import base64
+import sys
 import json
+from types import SimpleNamespace
 
 from worker.otel_transform import transform_otel_to_clickhouse
 
@@ -60,12 +62,25 @@ def _otel_payload(span_attributes: list[dict], *, parent_span_id: str | None = N
 # ── Tests ──────────────────────────────────────────────────────────
 
 
+def _transform_without_cost(payload: dict) -> tuple[list[dict], list[dict]]:
+    fake_tokens = SimpleNamespace(calculate_cost=lambda *args, **kwargs: {"input_tokens": None, "output_tokens": None, "total_tokens": None, "cost": None})
+    original = sys.modules.get("worker.tokens")
+    sys.modules["worker.tokens"] = fake_tokens
+    try:
+        return transform_otel_to_clickhouse(payload, project_id="proj-1")
+    finally:
+        if original is None:
+            sys.modules.pop("worker.tokens", None)
+        else:
+            sys.modules["worker.tokens"] = original
+
+
 def test_explicit_metadata_extracted():
     """traceroot.span.metadata attribute is captured as span metadata."""
     meta = {"custom_key": "custom_value", "run_id": 42}
     payload = _otel_payload([_attr("traceroot.span.metadata", json.dumps(meta))])
 
-    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+    _traces, spans = _transform_without_cost(payload)
 
     assert len(spans) == 1
     assert "metadata" in spans[0]
@@ -81,7 +96,7 @@ def test_extra_attributes_become_metadata():
         ]
     )
 
-    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+    _traces, spans = _transform_without_cost(payload)
 
     assert len(spans) == 1
     meta = json.loads(spans[0]["metadata"])
@@ -109,7 +124,7 @@ def test_known_attributes_excluded_from_metadata():
         ]
     )
 
-    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+    _traces, spans = _transform_without_cost(payload)
 
     meta = json.loads(spans[0]["metadata"])
     assert "my.custom.flag" in meta
@@ -139,7 +154,7 @@ def test_trace_metadata_extracted():
         ]
     )
 
-    traces, _spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+    traces, _spans = _transform_without_cost(payload)
 
     assert len(traces) == 1
     assert "metadata" in traces[0]
@@ -156,7 +171,44 @@ def test_no_metadata_when_no_extra_attributes():
         ]
     )
 
-    _traces, spans = transform_otel_to_clickhouse(payload, project_id="proj-1")
+    _traces, spans = _transform_without_cost(payload)
 
     assert len(spans) == 1
     assert "metadata" not in spans[0]
+
+
+def test_git_repo_ref_populate_from_child_before_root():
+    """Trace-level git fields should populate from child spans before the root arrives."""
+    trace_id = _make_trace_id()
+    root_span_id = _make_span_id(0x10)
+
+    child = {
+        "traceId": trace_id,
+        "spanId": _make_span_id(0x11),
+        "parentSpanId": root_span_id,
+        "name": "child",
+        "kind": "SPAN_KIND_INTERNAL",
+        "startTimeUnixNano": "1700000000000000000",
+        "endTimeUnixNano": "1700000001000000000",
+        "attributes": [
+            _attr("traceroot.git.repo", "owner/repo"),
+            _attr("traceroot.git.ref", "main"),
+        ],
+        "status": {},
+    }
+
+    traces, _spans = transform_otel_to_clickhouse(
+        {
+            "resourceSpans": [
+                {
+                    "resource": {"attributes": []},
+                    "scopeSpans": [{"scope": {"name": "test"}, "spans": [child]}],
+                }
+            ]
+        },
+        project_id="proj-1",
+    )
+
+    assert len(traces) == 1
+    assert traces[0]["git_repo"] == "owner/repo"
+    assert traces[0]["git_ref"] == "main"


### PR DESCRIPTION
## Summary
- Fixes #1099 by populating trace-level `git_repo` / `git_ref` from child spans before the root span arrives.
- Keeps the existing root-span upgrade path for trace naming and metadata intact.
- Adds a focused worker regression test for child-before-root git field population.

## Testing
- [x] `python3 -m py_compile backend/worker/otel_transform.py backend/worker/tests/test_otel_transform_metadata.py`
- [x] `python3 -m pytest backend/worker/tests/test_otel_transform_metadata.py backend/worker/tests/test_otel_transform_trace_naming.py -q`
- [x] `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate trace-level `git_repo` and `git_ref` from child spans when they arrive before the root span (fixes #1099). Keeps the root-span upgrade path intact.

- **Bug Fixes**
  - Set `git_ref` and `git_repo` on the trace as soon as any span includes `traceroot.git.ref` or `traceroot.git.repo`, if not already set.
  - Added a regression test to ensure git fields populate from child spans before the root.

<sup>Written for commit 80d575fdc9d6b22478eeccced1e849dd91237db9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

