### PR TITLE
feat(detectors): per-detector RCA gating (schema, worker, API)

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260608000000_add_detector_enable_rca/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260608000000_add_detector_enable_rca/migration.sql
@@ -1,0 +1,3 @@
+-- Per-detector toggle for the agent-model root cause analysis.
+-- Default true so existing detectors and new ones keep running RCA.
+ALTER TABLE "detectors" ADD COLUMN "enable_rca" BOOLEAN NOT NULL DEFAULT true;

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -352,6 +352,7 @@ model Detector {
   outputSchema       Json     @map("output_schema") @db.JsonB
   sampleRate         Int      @default(100) @map("sample_rate")  // 1–100
   enabled            Boolean  @default(true)
+  enableRca          Boolean  @default(true) @map("enable_rca")  // run agent-model RCA on this detector's findings
   detectionModel     String?  @map("detection_model") @db.VarChar    // model id; null = worker picks default
   detectionProvider  String?  @map("detection_provider") @db.VarChar // provider label (system: "anthropic"/"openai"; BYOK: ModelProvider.provider row label)
   detectionSource    String?  @map("detection_source") @db.VarChar   // "system" | "byok" | null (legacy/seeded)

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/findings/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/findings/route.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({ NextRequest: class {} }));
+
+vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
+
+const rcaFindManyMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    detectorRca: {
+      findMany: (...args: unknown[]) => rcaFindManyMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+}));
+
+import { GET } from "./route";
+
+const backendFetchMock = vi.fn();
+vi.stubGlobal("fetch", backendFetchMock);
+
+function makeRequest(query: Record<string, string> = {}) {
+  const params = new URLSearchParams(query);
+  return { nextUrl: { searchParams: params } } as unknown as Parameters<typeof GET>[0];
+}
+
+function makeParams() {
+  return { params: Promise.resolve({ projectId: "proj-1", detectorId: "det-1" }) };
+}
+
+/** Backend response double: status + JSON body. */
+function backendResponse(body: unknown, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+function finding(id: string, extra: Record<string, unknown> = {}) {
+  return { finding_id: id, trace_id: `trace-${id}`, summary: `s-${id}`, ...extra };
+}
+
+beforeEach(() => {
+  rcaFindManyMock.mockReset();
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  backendFetchMock.mockReset();
+  // Default: authenticated with project access.
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+});
+
+describe("GET .../detectors/[detectorId]/findings — auth & proxy", () => {
+  it("returns the auth error when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(401);
+    expect(backendFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the access error when the user lacks project access", async () => {
+    requireProjectAccessMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(403);
+    expect(backendFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 when the backend is unreachable", async () => {
+    backendFetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(502);
+    expect(rcaFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("passes a backend error through without attempting enrichment", async () => {
+    const body = { detail: "boom" };
+    backendFetchMock.mockResolvedValue(backendResponse(body, 500));
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual(body);
+    expect(rcaFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("clamps limit to [1,200] and page to >=0, defaulting NaN", async () => {
+    backendFetchMock.mockResolvedValue(backendResponse({ data: [], meta: {} }));
+    await GET(makeRequest({ limit: "999", page: "-5" }), makeParams());
+    let url = new URL(backendFetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get("limit")).toBe("200");
+    expect(url.searchParams.get("page")).toBe("0");
+
+    backendFetchMock.mockClear();
+    backendFetchMock.mockResolvedValue(backendResponse({ data: [], meta: {} }));
+    await GET(makeRequest({ limit: "abc", page: "abc" }), makeParams());
+    url = new URL(backendFetchMock.mock.calls[0][0] as string);
+    expect(url.searchParams.get("limit")).toBe("50");
+    expect(url.searchParams.get("page")).toBe("0");
+  });
+});
+
+describe("GET .../findings — RCA status enrichment", () => {
+  it("attaches each finding's stored RCA status; absent row maps to null (skipped)", async () => {
+    backendFetchMock.mockResolvedValue(
+      backendResponse({ data: [finding("f1"), finding("f2"), finding("f3")], meta: {} }),
+    );
+    rcaFindManyMock.mockResolvedValue([
+      { findingId: "f1", status: "done" },
+      { findingId: "f3", status: "failed" },
+    ]);
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = (await res.json()) as { data: Array<{ rca_status: unknown }> };
+
+    expect(res.status).toBe(200);
+    expect(body.data.map((f) => f.rca_status)).toEqual(["done", null, "failed"]);
+    // One batched lookup with all page ids — never one query per finding.
+    expect(rcaFindManyMock).toHaveBeenCalledTimes(1);
+    expect(rcaFindManyMock.mock.calls[0][0]).toMatchObject({
+      where: { findingId: { in: ["f1", "f2", "f3"] } },
+    });
+  });
+
+  it("passes pending/running statuses through unchanged", async () => {
+    backendFetchMock.mockResolvedValue(
+      backendResponse({ data: [finding("a"), finding("b")], meta: {} }),
+    );
+    rcaFindManyMock.mockResolvedValue([
+      { findingId: "a", status: "pending" },
+      { findingId: "b", status: "running" },
+    ]);
+    const res = await GET(makeRequest(), makeParams());
+    const body = (await res.json()) as { data: Array<{ rca_status: unknown }> };
+    expect(body.data.map((f) => f.rca_status)).toEqual(["pending", "running"]);
+  });
+
+  it("skips the lookup entirely for an empty findings page", async () => {
+    backendFetchMock.mockResolvedValue(backendResponse({ data: [], meta: {} }));
+    const res = await GET(makeRequest(), makeParams());
+    expect(res.status).toBe(200);
+    expect(rcaFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves a malformed body untouched (data not an array)", async () => {
+    const body = { data: "not-an-array", meta: {} };
+    backendFetchMock.mockResolvedValue(backendResponse(body));
+    const res = await GET(makeRequest(), makeParams());
+    expect(await res.json()).toEqual(body);
+    expect(rcaFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves a null body untouched", async () => {
+    backendFetchMock.mockResolvedValue(backendResponse(null));
+    const res = await GET(makeRequest(), makeParams());
+    expect(await res.json()).toBeNull();
+    expect(rcaFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("excludes findings without a string finding_id from the lookup but still nulls their status", async () => {
+    backendFetchMock.mockResolvedValue(
+      backendResponse({
+        data: [finding("good"), { trace_id: "t", summary: "no id" }, { finding_id: 42 }],
+        meta: {},
+      }),
+    );
+    rcaFindManyMock.mockResolvedValue([{ findingId: "good", status: "done" }]);
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = (await res.json()) as { data: Array<{ rca_status: unknown }> };
+
+    expect(rcaFindManyMock.mock.calls[0][0]).toMatchObject({
+      where: { findingId: { in: ["good"] } },
+    });
+    expect(body.data.map((f) => f.rca_status)).toEqual(["done", null, null]);
+  });
+
+  it("returns findings WITHOUT rca_status when the lookup fails (absent, not Skipped)", async () => {
+    backendFetchMock.mockResolvedValue(backendResponse({ data: [finding("f1")], meta: {} }));
+    rcaFindManyMock.mockRejectedValue(new Error("pg down"));
+
+    const res = await GET(makeRequest(), makeParams());
+    const body = (await res.json()) as { data: Array<Record<string, unknown>> };
+
+    expect(res.status).toBe(200);
+    // Field absent — the UI renders "—", never a misleading "Skipped".
+    expect("rca_status" in body.data[0]).toBe(false);
+  });
+
+  it("handles duplicate finding_ids on a page (shared trace finding across rows)", async () => {
+    backendFetchMock.mockResolvedValue(
+      backendResponse({ data: [finding("dup"), finding("dup")], meta: {} }),
+    );
+    rcaFindManyMock.mockResolvedValue([{ findingId: "dup", status: "done" }]);
+    const res = await GET(makeRequest(), makeParams());
+    const body = (await res.json()) as { data: Array<{ rca_status: unknown }> };
+    expect(body.data.map((f) => f.rca_status)).toEqual(["done", "done"]);
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/findings/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/findings/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
 import { requireAuth, requireProjectAccess, errorResponse } from "@/lib/auth-helpers";
 import { env } from "@/env";
 
@@ -54,5 +55,35 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
   }
 
   const data: unknown = await response.json();
+
+  // Enrich each finding with its stored RCA status (one batched Postgres
+  // lookup) so the findings table can show whether the agent analysis ran.
+  // Same source of truth as the trace viewer's Alert gating: a DetectorRca row
+  // exists iff RCA ran; an absent row means it was skipped (RCA disabled on
+  // every detector that fired). Best-effort: on lookup failure the field is
+  // simply absent and the UI renders "—" rather than a misleading "Skipped".
+  if (response.ok && data !== null && typeof data === "object") {
+    const findings = (data as { data?: unknown }).data;
+    if (Array.isArray(findings)) {
+      const ids = findings
+        .map((f) => (f as { finding_id?: unknown }).finding_id)
+        .filter((id): id is string => typeof id === "string");
+      if (ids.length > 0) {
+        try {
+          const rcas = await prisma.detectorRca.findMany({
+            where: { findingId: { in: ids } },
+            select: { findingId: true, status: true },
+          });
+          const statusByFinding = new Map(rcas.map((r) => [r.findingId, r.status]));
+          for (const f of findings as Array<Record<string, unknown>>) {
+            f.rca_status = statusByFinding.get(f.finding_id as string) ?? null;
+          }
+        } catch (err) {
+          console.error("[findings proxy] RCA status lookup failed:", err);
+        }
+      }
+    }
+  }
+
   return Response.json(data, { status: response.status });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
@@ -63,6 +63,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     outputSchema,
     sampleRate,
     enabled,
+    enableRca,
     triggerConditions,
     detectionModel,
     detectionProvider,
@@ -74,6 +75,9 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   // require a strict boolean. sampleRate must be an integer 0-100.
   if (enabled !== undefined && typeof enabled !== "boolean") {
     return errorResponse("enabled must be a boolean", 400);
+  }
+  if (enableRca !== undefined && typeof enableRca !== "boolean") {
+    return errorResponse("enableRca must be a boolean", 400);
   }
   if (sampleRate !== undefined) {
     if (
@@ -121,6 +125,7 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   if (outputSchema !== undefined) detectorData.outputSchema = outputSchema;
   if (sampleRate !== undefined) detectorData.sampleRate = sampleRate;
   if (enabled !== undefined) detectorData.enabled = enabled;
+  if (enableRca !== undefined) detectorData.enableRca = enableRca;
   if (detectionModel !== undefined) detectorData.detectionModel = detectionModel || null;
   if (detectionProvider !== undefined) detectorData.detectionProvider = detectionProvider || null;
   if (detectionSource !== undefined) {

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -85,6 +85,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     detectionModel,
     detectionProvider,
     detectionSource,
+    enableRca,
   } = body as Record<string, unknown>;
 
   // Required fields must be non-empty strings (trim catches whitespace-only).
@@ -137,6 +138,13 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   const resolvedProvider =
     typeof detectionProvider === "string" && detectionProvider ? detectionProvider : null;
 
+  // enableRca: optional boolean, defaults true (RCA on). Reject non-booleans
+  // so "false"/0 can't silently coerce.
+  if (enableRca !== undefined && typeof enableRca !== "boolean") {
+    return errorResponse("enableRca must be a boolean", 400);
+  }
+  const resolvedEnableRca = enableRca ?? true;
+
   const detector = await prisma.detector.create({
     data: {
       projectId,
@@ -145,6 +153,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
       prompt,
       outputSchema: (outputSchema as object) ?? [],
       sampleRate: resolvedSampleRate,
+      enableRca: resolvedEnableRca,
       detectionModel: resolvedModel,
       detectionProvider: resolvedProvider,
       detectionSource: sourceStr,

--- a/frontend/worker/src/processors/__tests__/rca-gating.test.ts
+++ b/frontend/worker/src/processors/__tests__/rca-gating.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from "vitest";
+import { shouldRunRca, traceFindingId, buildRcaFindings } from "../detector-run-processor.js";
+
+/**
+ * RCA is decided ONCE per trace (one aggregated finding per trace), not per
+ * detector. These tests lock in three properties:
+ *
+ *  1. shouldRunRca — run the RCA iff at least one detector that ACTUALLY FIRED
+ *     on the trace has its toggle on. Detectors that are merely configured/
+ *     enabled but did not fire never influence the decision.
+ *  2. traceFindingId — the finding id (and therefore the RCA job id) depends
+ *     only on (projectId, traceId), so every detector that fires on a trace
+ *     maps to the SAME finding and the SAME single RCA job.
+ *  3. buildRcaFindings — that single RCA job carries every fired detector's
+ *     summary, so one agent analyzes the whole trace.
+ */
+
+// ---- helpers ---------------------------------------------------------------
+
+const fired = (...ids: string[]) => ids.map((detectorId) => ({ detectorId }));
+const det = (id: string, enableRca: boolean) => ({ id, enableRca });
+
+// ---- 1. shouldRunRca -------------------------------------------------------
+
+describe("shouldRunRca: only detectors that FIRED count", () => {
+  it("runs when the single fired detector has RCA on", () => {
+    expect(shouldRunRca(fired("a"), [det("a", true)])).toBe(true);
+  });
+
+  it("skips when the single fired detector has RCA off", () => {
+    expect(shouldRunRca(fired("a"), [det("a", false)])).toBe(false);
+  });
+
+  it("scenario: 3 detectors all RCA-on and all fired -> runs (one agent, see other tests)", () => {
+    const detectors = [det("a", true), det("b", true), det("c", true)];
+    expect(shouldRunRca(fired("a", "b", "c"), detectors)).toBe(true);
+  });
+
+  it("scenario: 2 off fired while the 1 on detector did NOT fire -> skips", () => {
+    // The RCA-on detector ("c") is configured & enabled but never produced a
+    // finding, so it is absent from `fired`. Only the two RCA-off detectors
+    // fired -> no RCA.
+    const detectors = [det("a", false), det("b", false), det("c", true)];
+    expect(shouldRunRca(fired("a", "b"), detectors)).toBe(false);
+  });
+
+  it("mixed fired (one on, one off) -> runs", () => {
+    expect(shouldRunRca(fired("a", "b"), [det("a", false), det("b", true)])).toBe(true);
+  });
+
+  it("all fired detectors off -> skips", () => {
+    const detectors = [det("a", false), det("b", false), det("c", false)];
+    expect(shouldRunRca(fired("a", "b", "c"), detectors)).toBe(false);
+  });
+
+  it("a configured RCA-on detector that did not fire never flips the decision", () => {
+    // Many RCA-on detectors exist, but only an RCA-off one fired.
+    const detectors = [det("on1", true), det("on2", true), det("off1", false)];
+    expect(shouldRunRca(fired("off1"), detectors)).toBe(false);
+  });
+
+  it("nothing fired -> skips even when on detectors are configured", () => {
+    expect(shouldRunRca([], [det("a", true), det("b", true)])).toBe(false);
+  });
+
+  it("empty inputs -> skips", () => {
+    expect(shouldRunRca([], [])).toBe(false);
+  });
+});
+
+describe("shouldRunRca: fail-open and robustness", () => {
+  it("fails open when a fired detector is missing from the detectors list", () => {
+    // Defensive: an unexpected gap must not silently suppress analysis.
+    expect(shouldRunRca(fired("ghost"), [])).toBe(true);
+  });
+
+  it("a missing (fail-open) fired detector forces RCA even alongside an off one", () => {
+    expect(shouldRunRca(fired("off1", "ghost"), [det("off1", false)])).toBe(true);
+  });
+
+  it("treats a malformed detector row with undefined enableRca as on (default-on)", () => {
+    const malformed = [{ id: "a" }] as unknown as { id: string; enableRca: boolean }[];
+    expect(shouldRunRca(fired("a"), malformed)).toBe(true);
+  });
+
+  it("is order-independent", () => {
+    const detectors = [det("a", false), det("b", false), det("c", true)];
+    expect(shouldRunRca(fired("a", "b", "c"), detectors)).toBe(true);
+    expect(shouldRunRca(fired("c", "b", "a"), detectors)).toBe(true);
+  });
+
+  it("duplicate fired ids do not change the outcome", () => {
+    expect(shouldRunRca(fired("a", "a"), [det("a", false)])).toBe(false);
+    expect(shouldRunRca(fired("b", "b"), [det("b", true)])).toBe(true);
+  });
+
+  it("ignores enableRca of detectors that did not fire", () => {
+    // `b` is on but absent from `fired`; only off `a` fired.
+    expect(shouldRunRca(fired("a"), [det("a", false), det("b", true)])).toBe(false);
+  });
+
+  it("duplicate detector rows: the last occurrence wins in the lookup", () => {
+    // Can't happen via the DB (id is the primary key) but pins the Map
+    // semantics so a future data-shape change fails loudly here.
+    expect(shouldRunRca(fired("a"), [det("a", true), det("a", false)])).toBe(false);
+    expect(shouldRunRca(fired("a"), [det("a", false), det("a", true)])).toBe(true);
+  });
+
+  it("scales: 50 off + 1 on, only the on fired -> runs; only offs fired -> skips", () => {
+    const offs = Array.from({ length: 50 }, (_, i) => det(`off${i}`, false));
+    const detectors = [...offs, det("on", true)];
+    expect(shouldRunRca(fired("on"), detectors)).toBe(true);
+    expect(
+      shouldRunRca(
+        offs.slice(0, 50).map((d) => ({ detectorId: d.id })),
+        detectors,
+      ),
+    ).toBe(false);
+  });
+});
+
+// ---- 2. traceFindingId -----------------------------------------------------
+
+describe("traceFindingId: one finding (and one RCA job) per trace", () => {
+  it("is deterministic for the same project + trace", () => {
+    expect(traceFindingId("proj", "trace")).toBe(traceFindingId("proj", "trace"));
+  });
+
+  it("does not depend on which/how many detectors fired -> same single RCA job per trace", () => {
+    // The processor enqueues the RCA job as `rca-${traceFindingId(p, t)}`. Since
+    // the id ignores the detector set, 3 detectors firing on a trace and 1
+    // detector firing on the same trace produce the SAME job id -> exactly one
+    // RCA agent per trace (BullMQ dedups by job id on retries too).
+    const jobForThreeDetectors = `rca-${traceFindingId("proj", "trace")}`;
+    const jobForOneDetector = `rca-${traceFindingId("proj", "trace")}`;
+    expect(jobForThreeDetectors).toBe(jobForOneDetector);
+  });
+
+  it("differs across traces and across projects", () => {
+    expect(traceFindingId("proj", "traceA")).not.toBe(traceFindingId("proj", "traceB"));
+    expect(traceFindingId("projA", "trace")).not.toBe(traceFindingId("projB", "trace"));
+  });
+
+  it("is formatted as a uuid-shaped string", () => {
+    expect(traceFindingId("proj", "trace")).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("is order-sensitive: swapping project and trace yields a different id", () => {
+    expect(traceFindingId("a", "b")).not.toBe(traceFindingId("b", "a"));
+  });
+
+  it("stays uuid-shaped and deterministic even for empty inputs", () => {
+    const uuidShape = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+    expect(traceFindingId("", "")).toMatch(uuidShape);
+    expect(traceFindingId("", "")).toBe(traceFindingId("", ""));
+  });
+});
+
+// ---- 3. buildRcaFindings ---------------------------------------------------
+
+describe("buildRcaFindings: one RCA payload aggregates every fired detector", () => {
+  const triggered = [
+    { detectorId: "a", detectorName: "Failure", summary: "tool errored", data: { x: 1 } },
+    { detectorId: "b", detectorName: "Hallucination", summary: "ungrounded claim", data: null },
+    { detectorId: "c", detectorName: "Safety", summary: "PII leak", data: 42 },
+  ];
+
+  it("includes one entry per fired detector (3 detectors -> one job, 3 findings)", () => {
+    const findings = buildRcaFindings(triggered);
+    expect(findings).toHaveLength(3);
+    expect(findings.map((f) => f.detectorName)).toEqual(["Failure", "Hallucination", "Safety"]);
+  });
+
+  it("carries detectorId, detectorName and summary and drops other fields", () => {
+    expect(buildRcaFindings(triggered)[0]).toEqual({
+      detectorId: "a",
+      detectorName: "Failure",
+      summary: "tool errored",
+    });
+  });
+
+  it("preserves order", () => {
+    expect(buildRcaFindings(triggered).map((f) => f.detectorId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns an empty payload for no fired detectors", () => {
+    expect(buildRcaFindings([])).toEqual([]);
+  });
+
+  it("keeps one entry per fired item even for repeated detector ids", () => {
+    const twice = [
+      { detectorId: "a", detectorName: "Failure", summary: "first" },
+      { detectorId: "a", detectorName: "Failure", summary: "second" },
+    ];
+    expect(buildRcaFindings(twice).map((f) => f.summary)).toEqual(["first", "second"]);
+  });
+});

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -23,12 +23,57 @@ const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
  * collapse with detector_findings.findingId rather than producing duplicate
  * run rows for the same (detector, trace).
  */
-function deterministicRunId(projectId: string, traceId: string, detectorId: string): string {
+/** Hash a string to a uuid-shaped id (first 128 bits of sha256, 8-4-4-4-12). */
+function hashToUuid(input: string): string {
   return createHash("sha256")
-    .update(`${projectId}:${traceId}:${detectorId}`)
+    .update(input)
     .digest("hex")
     .slice(0, 32)
     .replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, "$1-$2-$3-$4-$5");
+}
+
+function deterministicRunId(projectId: string, traceId: string, detectorId: string): string {
+  return hashToUuid(`${projectId}:${traceId}:${detectorId}`);
+}
+
+/**
+ * Decide whether to run the per-trace RCA. RCA is shared across all detectors
+ * that fired on a trace; we run it when AT LEAST ONE triggered detector has
+ * RCA enabled. A triggered detector missing from `detectors` defaults to "run"
+ * so an unexpected gap never silently suppresses analysis.
+ */
+export function shouldRunRca(
+  triggered: { detectorId: string }[],
+  detectors: { id: string; enableRca: boolean }[],
+): boolean {
+  const rcaEnabledById = new Map(detectors.map((d) => [d.id, d.enableRca]));
+  return triggered.some((t) => rcaEnabledById.get(t.detectorId) !== false);
+}
+
+/**
+ * Deterministic finding id for a trace — a hash of (projectId, traceId) only.
+ * It does NOT depend on which/how many detectors fired, so every detector that
+ * triggers on the same trace maps to the SAME finding, and therefore the SAME
+ * RCA job (`rca-${findingId}`): exactly one RCA per trace, and a BullMQ retry
+ * lands on the same row instead of duplicating it.
+ */
+export function traceFindingId(projectId: string, traceId: string): string {
+  return hashToUuid(`${projectId}:${traceId}`);
+}
+
+/**
+ * Build the per-trace RCA payload from every detector that fired. The single
+ * RCA job carries all triggered detectors' summaries, so one agent analyzes the
+ * whole trace rather than one agent per detector.
+ */
+export function buildRcaFindings(
+  triggered: { detectorId: string; detectorName: string; summary: string }[],
+): DetectorRcaFinding[] {
+  return triggered.map((r) => ({
+    detectorId: r.detectorId,
+    detectorName: r.detectorName,
+    summary: r.summary,
+  }));
 }
 
 let rcaQueue: Queue<DetectorRcaJob>;
@@ -287,11 +332,7 @@ async function processTrace(
   // a duplicate. ClickHouse-level dedup of finding rows is a follow-up
   // (ReplacingMergeTree on finding_id), but Postgres DetectorRca + the RCA
   // queue jobId are now both keyed by this stable id.
-  const findingId = createHash("sha256")
-    .update(`${projectId}:${traceId}`)
-    .digest("hex")
-    .slice(0, 32)
-    .replace(/^(.{8})(.{4})(.{4})(.{4})(.{12})$/, "$1-$2-$3-$4-$5");
+  const findingId = traceFindingId(projectId, traceId);
   const combinedSummary = triggered.map((r) => `[${r.detectorName}] ${r.summary}`).join("\n");
   const payload = JSON.stringify(
     triggered.map((r) => ({
@@ -328,35 +369,40 @@ async function processTrace(
     `[Detector] Finding ${findingId} created for trace ${traceId} (${triggered.length} detector(s) triggered)`,
   );
 
-  // Always run RCA for any finding — one combined job per trace.
-  const rcaFindings: DetectorRcaFinding[] = triggered.map((r) => ({
-    detectorId: r.detectorId,
-    detectorName: r.detectorName,
-    summary: r.summary,
-  }));
+  // RCA is shared per trace. Run it only when at least one triggered detector
+  // has RCA enabled; otherwise skip both the seed row and the queue job so a
+  // noisy RCA-disabled detector doesn't incur agent-model cost. Consumers
+  // null-check an absent DetectorRca record, so skipping the row is safe.
+  const rcaFindings: DetectorRcaFinding[] = buildRcaFindings(triggered);
 
-  await prisma.detectorRca
-    .upsert({
-      where: { findingId },
-      create: { findingId, projectId, status: "pending" },
-      update: { projectId, status: "pending" },
-    })
-    .catch((e) =>
-      console.error(`[Detector] Failed to seed DetectorRca for finding ${findingId}:`, e),
+  if (shouldRunRca(triggered, detectors)) {
+    await prisma.detectorRca
+      .upsert({
+        where: { findingId },
+        create: { findingId, projectId, status: "pending" },
+        update: { projectId, status: "pending" },
+      })
+      .catch((e) =>
+        console.error(`[Detector] Failed to seed DetectorRca for finding ${findingId}:`, e),
+      );
+
+    await rcaQueue.add(
+      `rca-${findingId}`,
+      {
+        findingId,
+        projectId,
+        traceId,
+        workspaceId,
+        projectName,
+        findings: rcaFindings,
+      },
+      { jobId: `rca-${findingId}`, removeOnComplete: 100, removeOnFail: 50 },
     );
-
-  await rcaQueue.add(
-    `rca-${findingId}`,
-    {
-      findingId,
-      projectId,
-      traceId,
-      workspaceId,
-      projectName,
-      findings: rcaFindings,
-    },
-    { jobId: `rca-${findingId}`, removeOnComplete: 100, removeOnFail: 50 },
-  );
+  } else {
+    console.log(
+      `[Detector] All triggered detectors have RCA disabled; skipping RCA for finding ${findingId}`,
+    );
+  }
 }
 
 export function startDetectorRunWorker(): Worker<DetectorRunJob> {


### PR DESCRIPTION
Part 1 of 2 — splits #1101 into a backend layer and a UI layer.

## Summary
Adds a per-detector **`enableRca`** flag and gates the agent-model root cause analysis on it, so a noisy detector doesn't run the expensive RCA on every finding.

RCA is decided **per trace**: it runs iff **at least one detector that fired** on the trace has RCA enabled; when all fired detectors have it off, both the `detector_rcas` seed row and the queue job are skipped (no agent, no cost). One trace → one shared RCA agent covering all fired detectors.

## Changes
- **DB:** `Detector.enableRca Boolean @default(true)` + migration. Existing rows backfill to `true`, so behavior is unchanged on upgrade.
- **Worker:** `shouldRunRca` gate; extracted `traceFindingId` + `buildRcaFindings` (one finding/RCA job per trace; payload aggregates every fired detector).
- **API:** POST/PATCH accept + validate `enableRca`; the findings-list route enriches each row with its stored RCA status via one batched lookup.
- **Tests:** `rca-gating.test.ts` (gate, fail-open, per-trace id, aggregation) + findings-route enrichment tests.

## Notes
- Run `prisma migrate deploy` before rolling out app code (the worker/API read the column).
- The UI that consumes this is in the stacked PR (Part 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-detector RCA gating with a new `enableRca` flag. RCA now runs once per trace only if at least one fired detector has RCA enabled; otherwise we skip seeding and the queue job to cut cost and noise.

- **New Features**
  - DB: add `Detector.enableRca` (default true) with a migration.
  - Worker: add `shouldRunRca`; extract `traceFindingId` (one finding/job per trace) and `buildRcaFindings` (aggregate fired detectors).
  - API: POST/PATCH accept and validate `enableRca`; findings list enriches each row with `rca_status` via one batched lookup.
  - Tests: coverage for gating (incl. fail-open), per-trace id, aggregation, and findings route enrichment.

- **Migration**
  - Run `prisma migrate deploy` before deploying worker/API.
  - Existing detectors backfill to `enableRca = true`, so behavior is unchanged on upgrade.

<sup>Written for commit a5e4b0b55a0f7b18d5b4edbf49d1356e00e61149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

