### PR TITLE
feat(ui): per-detector RCA toggle + agent-analysis surfacing

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
@@ -8,7 +8,12 @@ import { ListPagination } from "@/components/list-pagination";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import { formatDate, cn } from "@/lib/utils";
 import { useDetector } from "@/features/detectors/hooks/use-detectors";
-import { useFindings, useRuns, type BackendFinding } from "@/features/detectors/hooks/use-findings";
+import {
+  useFindings,
+  useRuns,
+  describeRcaStatus,
+  type BackendFinding,
+} from "@/features/detectors/hooks/use-findings";
 import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { TraceViewerPanel } from "@/features/traces/components/TraceViewerPanel";
 
@@ -265,8 +270,11 @@ export default function DetectorDetailPage() {
                   <th className="w-[280px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                     Trace ID
                   </th>
-                  <th className="px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                     Summary
+                  </th>
+                  <th className="w-[110px] px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                    Agent analysis
                   </th>
                 </tr>
               </thead>
@@ -295,10 +303,20 @@ export default function DetectorDetailPage() {
                         {f.trace_id}
                       </span>
                     </td>
-                    <td className="max-w-[400px] px-3 py-1.5 text-[12px] text-foreground">
+                    <td className="max-w-[400px] border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
                       <span className="block truncate" title={f.summary}>
                         {f.summary.length > 100 ? f.summary.slice(0, 100) + "…" : f.summary}
                       </span>
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-1.5 text-[12px]">
+                      {(() => {
+                        const rca = describeRcaStatus(f.rca_status);
+                        return (
+                          <span className={rca.className} title={rca.title}>
+                            {rca.label}
+                          </span>
+                        );
+                      })()}
                     </td>
                   </tr>
                 ))}

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -14,6 +14,7 @@ import type { CreateDetectorInput } from "@/features/detectors/hooks/use-detecto
 import { TriggerEditor } from "@/features/detectors/components/trigger-editor";
 import type { TriggerCondition } from "@/features/detectors/components/trigger-editor";
 import { AgentModelLink } from "@/features/detectors/components/agent-model-link";
+import { RcaToggle } from "@/features/detectors/components/rca-toggle";
 import { useProject } from "@/features/projects/hooks";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 
@@ -44,6 +45,7 @@ export default function NewDetectorPage() {
     source: "system",
     adapter: "",
   });
+  const [enableRca, setEnableRca] = useState(true);
 
   const handleTemplateChange = (templateId: string) => {
     const template = DETECTOR_TEMPLATES.find((t) => t.id === templateId);
@@ -64,6 +66,7 @@ export default function NewDetectorPage() {
       prompt,
       outputSchema: template.outputSchema,
       sampleRate,
+      enableRca,
       triggerConditions,
       detectionModel: modelSelection.model || undefined,
       detectionProvider: modelSelection.provider || undefined,
@@ -166,6 +169,7 @@ export default function NewDetectorPage() {
                   <p className="mt-1 text-[11px] text-muted-foreground">
                     Used for deep analysis when findings are triggered. Shared across all detectors.
                   </p>
+                  <RcaToggle id="enable-rca" checked={enableRca} onCheckedChange={setEnableRca} />
                 </div>
               </div>
             </div>

--- a/frontend/ui/src/components/ui/switch.tsx
+++ b/frontend/ui/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface SwitchProps {
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  id?: string;
+  disabled?: boolean;
+}
+
+/** Lightweight on/off toggle. Monochrome to match the detector forms. */
+export function Switch({ checked, onCheckedChange, id, disabled }: SwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      id={id}
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        "relative inline-flex h-4 w-7 shrink-0 cursor-pointer items-center rounded-full transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        checked ? "bg-foreground" : "bg-muted-foreground/30",
+      )}
+    >
+      <span
+        className={cn(
+          "pointer-events-none inline-block h-3 w-3 transform rounded-full bg-background shadow transition-transform",
+          checked ? "translate-x-3.5" : "translate-x-0.5",
+        )}
+      />
+    </button>
+  );
+}

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -7,6 +7,7 @@ import { useProject } from "@/features/projects/hooks";
 import { TriggerEditor } from "./trigger-editor";
 import type { TriggerCondition } from "./trigger-editor";
 import { AgentModelLink } from "./agent-model-link";
+import { RcaToggle } from "./rca-toggle";
 import {
   ModelSelector,
   type ModelSelection,
@@ -46,6 +47,7 @@ export function DetectorPanel({
     adapter: "",
   });
   const [editConditions, setEditConditions] = useState<TriggerCondition[]>([]);
+  const [editEnableRca, setEditEnableRca] = useState(true);
 
   const populate = (d: typeof detector) => {
     if (!d) return;
@@ -59,6 +61,7 @@ export function DetectorPanel({
       adapter: "",
     });
     setEditConditions((d.trigger?.conditions ?? []) as TriggerCondition[]);
+    setEditEnableRca(d.enableRca ?? true);
   };
 
   // When the loaded detector matches the requested id, populate edit state.
@@ -75,6 +78,7 @@ export function DetectorPanel({
       setEditSampleRate(100);
       setEditModelSelection({ model: "", provider: "", source: "system", adapter: "" });
       setEditConditions([]);
+      setEditEnableRca(true);
     }
   }, [detectorId, detector]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -99,6 +103,7 @@ export function DetectorPanel({
         name: editName,
         prompt: editPrompt,
         sampleRate: editSampleRate,
+        enableRca: editEnableRca,
         triggerConditions: editConditions,
         detectionModel: editModelSelection.model || undefined,
         detectionProvider: editModelSelection.provider || undefined,
@@ -204,6 +209,11 @@ export function DetectorPanel({
               <p className="mt-1 text-[11px] text-muted-foreground">
                 Used for deep analysis when findings are triggered. Shared across all detectors.
               </p>
+              <RcaToggle
+                id="edit-enable-rca"
+                checked={editEnableRca}
+                onCheckedChange={setEditEnableRca}
+              />
             </div>
           </div>
         </div>

--- a/frontend/ui/src/features/detectors/components/rca-toggle.tsx
+++ b/frontend/ui/src/features/detectors/components/rca-toggle.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Switch } from "@/components/ui/switch";
+
+interface RcaToggleProps {
+  /** Unique id so the label/switch pair doesn't collide across forms. */
+  id: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+/**
+ * Per-detector "run root cause analysis" toggle. Shared by the create form and
+ * the edit panel so the label, copy, and layout stay in one place.
+ */
+export function RcaToggle({ id, checked, onCheckedChange }: RcaToggleProps) {
+  return (
+    <div className="mt-3 flex flex-col gap-2">
+      <label htmlFor={id} className="cursor-pointer text-[11px] text-muted-foreground">
+        <span className="font-medium text-foreground">Run root cause analysis on findings</span>
+        <br />
+        Uses the agent model when this detector fires. Turn off to reduce cost.
+      </label>
+      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.ts
@@ -8,6 +8,7 @@ export interface Detector {
   prompt: string;
   outputSchema: Array<{ name: string; type: string }>;
   sampleRate: number;
+  enableRca: boolean;
   detectionModel: string | null;
   detectionProvider: string | null;
   detectionSource: "system" | "byok" | null;
@@ -39,6 +40,7 @@ export interface CreateDetectorInput {
   prompt: string;
   outputSchema: Array<{ name: string; type: string }>;
   sampleRate?: number;
+  enableRca?: boolean;
   triggerConditions?: Array<{ field: string; op: string; value: unknown }>;
   detectionModel?: string;
   detectionProvider?: string;
@@ -83,6 +85,7 @@ export interface UpdateDetectorInput {
   name?: string;
   prompt?: string;
   sampleRate?: number;
+  enableRca?: boolean;
   triggerConditions?: Array<{ field: string; op: string; value: unknown }>;
   detectionModel?: string;
   detectionProvider?: string;

--- a/frontend/ui/src/features/detectors/hooks/use-findings.test.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-findings.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { describeRcaStatus } from "./use-findings";
+
+describe("describeRcaStatus — the Agent analysis column vocabulary", () => {
+  it("renders an em dash when the field is absent (enrichment unavailable)", () => {
+    const p = describeRcaStatus(undefined);
+    expect(p.label).toBe("—");
+    expect(p.title).toBeUndefined();
+  });
+
+  it("renders Skipped with an explanatory tooltip when no RCA row exists", () => {
+    const p = describeRcaStatus(null);
+    expect(p.label).toBe("Skipped");
+    expect(p.title).toMatch(/off for the detector/i);
+    expect(p.className).toContain("text-muted-foreground");
+  });
+
+  it("renders Done for a completed analysis", () => {
+    expect(describeRcaStatus("done")).toEqual({
+      label: "Done",
+      className: "text-foreground",
+    });
+  });
+
+  it("renders Failed in destructive styling", () => {
+    const p = describeRcaStatus("failed");
+    expect(p.label).toBe("Failed");
+    expect(p.className).toContain("text-destructive");
+  });
+
+  it("renders Running… for both pending and running (in-flight states)", () => {
+    expect(describeRcaStatus("pending").label).toBe("Running…");
+    expect(describeRcaStatus("running").label).toBe("Running…");
+  });
+
+  it("falls back to the raw value for an unrecognized future status", () => {
+    // Guards against a new worker status (e.g. "canceled") silently rendering
+    // as Running… forever.
+    const p = describeRcaStatus("canceled" as never);
+    expect(p.label).toBe("canceled");
+    expect(p.title).toBeUndefined();
+  });
+});

--- a/frontend/ui/src/features/detectors/hooks/use-findings.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-findings.ts
@@ -8,6 +8,44 @@ export interface BackendFinding {
   timestamp: string;
   summary: string;
   payload: string;
+  /**
+   * Stored RCA status for this finding, enriched by the findings proxy route.
+   * null = no DetectorRca row (RCA skipped — disabled on every detector that
+   * fired); absent = enrichment unavailable.
+   */
+  rca_status?: "pending" | "running" | "done" | "failed" | null;
+}
+
+/** How a finding's `rca_status` renders in the "Agent analysis" column. */
+export interface RcaStatusPresentation {
+  label: string;
+  className: string;
+  title?: string;
+}
+
+/**
+ * Single source of truth for the agent-analysis status vocabulary:
+ * absent field (enrichment unavailable) -> "—", null (no stored RCA row) ->
+ * "Skipped", terminal/in-flight statuses -> their labels. An unrecognized
+ * future status renders as its raw value rather than a misleading "Running…".
+ */
+export function describeRcaStatus(status: BackendFinding["rca_status"]): RcaStatusPresentation {
+  if (status === undefined) {
+    return { label: "—", className: "font-mono text-[11px] text-muted-foreground" };
+  }
+  if (status === null) {
+    return {
+      label: "Skipped",
+      className: "text-muted-foreground",
+      title: "Root cause analysis was off for the detector(s) that fired",
+    };
+  }
+  if (status === "failed") return { label: "Failed", className: "text-destructive" };
+  if (status === "done") return { label: "Done", className: "text-foreground" };
+  if (status === "pending" || status === "running") {
+    return { label: "Running…", className: "text-muted-foreground" };
+  }
+  return { label: status, className: "text-muted-foreground" };
 }
 
 /** Pagination metadata returned alongside data arrays. */

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -116,11 +116,14 @@ export function TraceViewerPanel({
 
   // Detector findings → Alert button + auto-open RCA chat when entered from
   // the findings page. The trace-level finding (at most one per trace) carries
-  // the RCA session the worker already populated.
+  // the RCA session the worker already populated. The Alert button opens that
+  // analysis, so it only renders when an RCA record exists — a finding from an
+  // RCA-disabled detector has no analysis to open (gate on the record, not the
+  // sessionId, so the button doesn't flicker while the RCA is still pending).
   const { data: traceFindingsData } = useTraceFindings(projectId, traceId);
   const traceFinding = traceFindingsData?.findings?.[0];
-  const hasFindings = !!traceFinding;
   const { data: rcaData } = useRca(projectId, traceFinding?.finding_id ?? "");
+  const hasRca = !!traceFinding && !!rcaData?.rca;
   const rcaSessionId = rcaData?.rca?.sessionId ?? undefined;
 
   // Auto-open chat with RCA session loaded when arriving from /detectors.
@@ -228,7 +231,7 @@ export function TraceViewerPanel({
             <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
           </div>
           <div className="flex items-center gap-1">
-            {hasFindings && (
+            {hasRca && (
               <button
                 type="button"
                 onClick={() => {


### PR DESCRIPTION
Part 2 of 2 — **stacked on** #1101's backend split (`rca-gating-backend`, https://github.com/traceroot-ai/traceroot/pull/1109). Review/merge that one first; this PR's base is `rca-gating-backend`, so its diff shows only the UI changes.

## Summary
The UI for the per-detector RCA toggle, plus surfacing whether the agent analysis ran.

## Changes
- **Toggle:** a lightweight `Switch` + shared `RcaToggle`, wired into the create form and edit panel (default on; seeded/reset/saved). `enableRca` added to detector types.
- **Findings tab:** new **Agent analysis** column — Done / Running… / Failed / **Skipped** — via `describeRcaStatus`, fed by the backend route's `rca_status` enrichment.
- **Trace viewer:** the red **Alert** button now renders only when an RCA record exists, so a finding whose RCA was skipped no longer offers a dead-end empty chat.
- **Tests:** `describeRcaStatus` vocabulary, incl. an unknown-status fallback.

## Stacking
Fast-forwardable on `rca-gating-backend`; once that merges to `main`, retarget this PR's base to `main` (no conflicts — disjoint file sets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a per-detector “Run root cause analysis” toggle (default on) and surfaces agent-analysis status in Findings. Also hides the Trace Viewer Alert button unless an RCA record exists.

- **New Features**
  - `enableRca` on detectors; shared `RcaToggle` built on a lightweight `Switch` for create/edit.
  - Findings tab: new “Agent analysis” column (Done / Running… / Failed / Skipped) via `describeRcaStatus` using `rca_status` enrichment.
  - Tests for status vocabulary, including unknown-status fallback.

- **Bug Fixes**
  - Trace Viewer shows the red Alert button only when an RCA record exists, preventing empty chats when RCA is skipped.

<sup>Written for commit 4ab8ab244891802e8bbaa8f5ccb96e9401c1c22e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

