### PR TITLE
fix(billing): clear ingestion_blocked when a free workspace upgrades to a paid plan

### DIFF
--- a/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
+++ b/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
@@ -3,10 +3,12 @@ import {
   AI_RUN_QUOTAS,
   RCA_RUN_QUOTAS,
   DETECTOR_RUN_QUOTAS,
+  USAGE_CONFIG,
   PlanType,
   isAiRunBlocked,
   isRcaRunBlocked,
   isDetectorRunBlocked,
+  isIngestionBlocked,
 } from "../plans.js";
 
 describe("RCA_RUN_QUOTAS", () => {
@@ -60,6 +62,40 @@ describe("DETECTOR_RUN_QUOTAS", () => {
     expect(DETECTOR_RUN_QUOTAS[PlanType.STARTER].included).toBe(Infinity);
     expect(DETECTOR_RUN_QUOTAS[PlanType.PRO].included).toBe(Infinity);
     expect(DETECTOR_RUN_QUOTAS[PlanType.ENTERPRISE].included).toBe(Infinity);
+  });
+});
+
+describe("isIngestionBlocked", () => {
+  beforeEach(() => {
+    vi.stubEnv("ENABLE_BILLING", "true");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("Free: blocked at exactly the 50k span cap (hard cap)", () => {
+    const cap = USAGE_CONFIG.includedUnits;
+    expect(isIngestionBlocked(PlanType.FREE, 0)).toBe(false);
+    expect(isIngestionBlocked(PlanType.FREE, cap - 1)).toBe(false);
+    expect(isIngestionBlocked(PlanType.FREE, cap)).toBe(true);
+    expect(isIngestionBlocked(PlanType.FREE, cap + 100_000)).toBe(true);
+  });
+
+  // Regression: the free→paid upgrade case. A workspace that tripped the Free
+  // cap (ingestion_blocked=true) and upgraded must NOT remain blocked — paid
+  // ingestion overage is billed via Stripe, never hard-blocked. Mirrors the
+  // paid-plan unblock branch already present for AI/RCA/detector.
+  it("Paid plans: never blocked, even far above the free cap", () => {
+    const wayOverFreeCap = USAGE_CONFIG.includedUnits * 100;
+    expect(isIngestionBlocked(PlanType.STARTER, wayOverFreeCap)).toBe(false);
+    expect(isIngestionBlocked(PlanType.PRO, wayOverFreeCap)).toBe(false);
+    expect(isIngestionBlocked(PlanType.ENTERPRISE, wayOverFreeCap)).toBe(false);
+  });
+
+  it("respects ENABLE_BILLING=false (unblocks all)", () => {
+    vi.stubEnv("ENABLE_BILLING", "false");
+    expect(isIngestionBlocked(PlanType.FREE, 9_999_999)).toBe(false);
   });
 });
 

--- a/frontend/packages/core/src/ee/billing/index.ts
+++ b/frontend/packages/core/src/ee/billing/index.ts
@@ -35,6 +35,7 @@ export {
   isBillingEnabled,
   // Free plan blocking
   isFreePlanBlocked,
+  isIngestionBlocked,
   isAiRunBlocked,
   isRcaRunBlocked,
   isDetectorRunBlocked,

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -69,6 +69,25 @@ export function isFreePlanBlocked(currentUsage: number): boolean {
 }
 
 /**
+ * Check if event ingestion should be blocked for a given plan and usage.
+ * Free plan: hard cap at the included span allowance (50k).
+ * Paid plans: never blocked (overage is billed via Stripe).
+ *
+ * Mirrors isAiRunBlocked / isRcaRunBlocked / isDetectorRunBlocked. Ingestion
+ * previously had only isFreePlanBlocked (no plan argument), so processWorkspace
+ * gated it behind `if (isFreePlan)` and never cleared the flag on upgrade — a
+ * workspace that tripped the Free cap and then upgraded stayed blocked
+ * indefinitely. Returning false for paid plans here clears that stale block.
+ */
+export function isIngestionBlocked(plan: PlanType, totalEvents: number): boolean {
+  if (!isBillingEnabled()) return false;
+  if (plan === PlanType.FREE) {
+    return totalEvents >= EVENT_QUOTAS[plan].included;
+  }
+  return false;
+}
+
+/**
  * Check if AI runs should be blocked for a given plan and usage.
  * Free plan: hard cap at included runs (30).
  * Paid plans: never blocked (overage is billed via Stripe).

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -23,6 +23,7 @@ import {
   isAiRunBlocked,
   isRcaRunBlocked,
   isDetectorRunBlocked,
+  isIngestionBlocked,
   DETECTOR_HOSTED_LLM_FREE_THRESHOLD,
   AI_RUN_QUOTAS,
   RCA_RUN_QUOTAS,
@@ -294,15 +295,19 @@ async function processWorkspace(
   // 4. Update blocking flags
   // =========================================================================
 
-  // 4a. Event ingestion blocking (free plan only)
-  if (isFreePlan) {
-    const shouldBeBlocked = totalEvents >= USAGE_CONFIG.includedUnits;
-    if (workspace.ingestionBlocked !== shouldBeBlocked) {
-      updateData.ingestionBlocked = shouldBeBlocked;
-      console.log(
-        `[Billing] Workspace ${workspace.id}: ${totalEvents}/${USAGE_CONFIG.includedUnits} events, blocked: ${shouldBeBlocked}`,
-      );
-    }
+  // 4a. Event ingestion blocking.
+  // Computed for ALL plans (not gated on isFreePlan): free plans hard-cap at
+  // the included span allowance, paid plans always resolve to false. Evaluating
+  // this unconditionally is what clears a stale block when a previously-blocked
+  // free workspace upgrades — gating it behind `if (isFreePlan)` left the flag
+  // stuck true forever (paid plans never re-entered the branch). Mirrors the
+  // paid-plan unblock already done for AI (4c) and RCA (4c-ter).
+  const shouldBlockIngestion = isIngestionBlocked(plan, totalEvents);
+  if (workspace.ingestionBlocked !== shouldBlockIngestion) {
+    updateData.ingestionBlocked = shouldBlockIngestion;
+    console.log(
+      `[Billing] Workspace ${workspace.id}: ${totalEvents}/${USAGE_CONFIG.includedUnits} events, ingestion_blocked: ${shouldBlockIngestion}`,
+    );
   }
 
   // 4b. AI run blocking


### PR DESCRIPTION
## What & why

A workspace that exceeded the **Free** span cap (`ingestion_blocked = true`) and then **upgraded to a paid plan** (Starter/Pro) stayed blocked **indefinitely** — `POST /api/v1/public/traces` kept returning `402 Payment Required` even though the upgrade fully succeeded (plan, subscription status, and billing period all correct). This is the exact conversion path: hit the cap → prompted to upgrade → pay → still can't send traces.

Fixes #1111.

## Root cause

The hourly billing job (`usageMetering.ts`) evaluated ingestion blocking only inside `if (isFreePlan)`, with **no paid-plan unblock branch** — unlike AI runs (4c) and RCA runs (4c-ter), which both clear their flag for paid plans. So once `ingestion_blocked` was set on the Free tier, it was never re-evaluated for a paid workspace and stayed stuck `true`. The `ai_blocked`/`rca_blocked` flags cleared correctly, which is why the symptom was "ingestion blocked but AI/RCA work."

Underlying inconsistency: the predicate `isFreePlanBlocked(currentUsage)` took **no plan argument**, so it couldn't express the paid case — out of step with `isAiRunBlocked(plan, …)` / `isRcaRunBlocked(plan, …)` / `isDetectorRunBlocked(plan, …)`.

## Change

- **New** `isIngestionBlocked(plan, totalEvents)` in `packages/core/.../plans.ts` — Free hard-caps at the included span allowance, paid plans always return `false`. Mirrors the three sibling predicates exactly.
- `processWorkspace` section 4a now calls it **unconditionally** (removed the `if (isFreePlan)` gate), so paid plans clear a stale flag and **self-heal on the next hourly run** — no manual DB edit needed going forward.
- Exported from the `ee/billing` barrel.

## Testing

- New unit tests in `plans.test.ts`, including the regression case: a paid plan far above the Free cap → **not blocked**. Written test-first (watched it fail before implementing).
- `packages/core`: 37 tests pass, typecheck clean.
- `worker`: 26 tests pass, typecheck clean.

## Notes

- Brings ingestion to full parity with AI/RCA/detector — it was the only blocking flag lacking a plan-aware predicate and test coverage.
- Any workspace currently stuck will auto-recover within one billing-job cycle once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where workspaces that hit the Free span cap stayed ingestion_blocked after upgrading to a paid plan. Paid workspaces now auto-unblock on the next hourly billing run, restoring trace ingestion. Fixes #1111.

- **Bug Fixes**
  - Added plan-aware `isIngestionBlocked(plan, totalEvents)` (Free hard-cap; paid always false), mirroring the AI/RCA/detector predicates.
  - Updated the billing worker to evaluate ingestion blocking for all plans (removed the `if (isFreePlan)` gate) so stale blocks clear after upgrade.
  - Exported the new predicate and added unit tests, including the regression case (paid plan far above Free cap → not blocked).

<sup>Written for commit 13967a2aa8eb18c159a672d600a3be90410ac627. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

