### PR TITLE
feat(ui): add Dashboard nav button that opens a coming-soon page

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { LayoutDashboard } from "lucide-react";
+import { ProjectBreadcrumb } from "@/features/projects/components";
+
+export default function DashboardPage() {
+  const params = useParams();
+  const projectId = params.projectId as string;
+
+  return (
+    <div className="relative flex h-full text-[13px]">
+      <ProjectBreadcrumb projectId={projectId} />
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Page header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          <h1 className="text-[13px] font-medium">Dashboard</h1>
+        </div>
+
+        {/* Coming soon placeholder */}
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 bg-background">
+          <LayoutDashboard className="h-8 w-8 text-muted-foreground/40" />
+          <p className="text-[13px] text-muted-foreground">Coming soon</p>
+          <p className="text-[12px] text-muted-foreground">
+            The dashboard is under construction. Check back later.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -7,6 +7,7 @@ import { useTheme } from "next-themes";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   LayoutGrid,
+  LayoutDashboard,
   LifeBuoy,
   ChevronRight,
   Github,
@@ -170,6 +171,26 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                 {collapsed && (
                   <TooltipContent side="right" sideOffset={16}>
                     Detectors
+                  </TooltipContent>
+                )}
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    href={`/projects/${projectId}/dashboard`}
+                    className={cn(
+                      "flex items-center gap-2 py-2 text-[13px] transition-colors",
+                      collapsed ? "justify-center px-2" : "px-3",
+                      pathname.includes("/dashboard") ? "bg-muted" : "hover:bg-muted/50",
+                    )}
+                  >
+                    <LayoutDashboard className="h-3.5 w-3.5 shrink-0" />
+                    {!collapsed && "Dashboard"}
+                  </Link>
+                </TooltipTrigger>
+                {collapsed && (
+                  <TooltipContent side="right" sideOffset={16}>
+                    Dashboard
                   </TooltipContent>
                 )}
               </Tooltip>


### PR DESCRIPTION
## Summary

Adds a **Dashboard** button to the project-scoped left navigation sidebar, positioned directly below the existing **Tracing** and **Detectors** buttons. The full dashboard feature will be built later; for now the button routes to a simple **"Coming soon"** placeholder page.

## Changes

- **`frontend/ui/src/components/layout/sidebar.tsx`** — added a Dashboard nav item (Link + Tooltip pair) immediately after Detectors, using the `LayoutDashboard` icon. It mirrors the existing items exactly: same classes, icon sizing, collapsed-state tooltip, and active-state highlight (`pathname.includes("/dashboard")`).
- **`frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx`** (new) — a "Coming soon" placeholder page reusing the `ProjectBreadcrumb` and the same page-header/empty-state styling as the Detectors page.

## Acceptance criteria

- [x] A "Dashboard" button appears below Tracing and Detectors in the sidebar when inside a project.
- [x] Clicking it navigates to a coming-soon placeholder page.
- [x] Styling/spacing matches the existing nav buttons.

## Verification

- ESLint: clean on both changed files.
- `tsc --noEmit`: 0 errors.

## Video

https://github.com/user-attachments/assets/9ed509ad-302c-4f98-a6ef-567b3321f622



Closes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Dashboard button to the project sidebar that links to a new /projects/[projectId]/dashboard “Coming soon” page. Satisfies #1113 by adding a placeholder nav target and route.

- **New Features**
  - Sidebar: new Dashboard item below Tracing and Detectors with matching styling, tooltip, and active state.
  - Route: new /projects/[projectId]/dashboard page with breadcrumb, header, and “Coming soon” placeholder.

<sup>Written for commit 2bb7b1ee36d2bb634142fea25fbf087649c367e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

