### PR TITLE
fix(worker): surface git metadata during live traces

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -306,6 +306,7 @@ def transform_otel_to_clickhouse(
     # Shortest ids_path = closest to root. Used to correct eager trace names
     # when the first span in a batch isn't the closest-to-root span for that trace.
     _trace_name_candidates: dict[str, tuple[int, str]] = {}
+    trace_git_attrs: dict[str, dict[str, str | None]] = {}
 
     # camelCase: resourceSpans
     resource_spans = otel_data.get("resourceSpans", [])
@@ -587,9 +588,13 @@ def transform_otel_to_clickhouse(
                 # Priority: root span values overwrite, child span values only set if empty
                 span_user_id = _extract_user_id(span_attrs)
                 span_session_id = _extract_session_id(span_attrs)
+                span_git_ref = span_attrs.get("traceroot.git.ref")
+                span_git_repo = span_attrs.get("traceroot.git.repo")
 
                 if trace_id not in trace_attrs:
                     trace_attrs[trace_id] = {"user_id": None, "session_id": None}
+                if trace_id not in trace_git_attrs:
+                    trace_git_attrs[trace_id] = {"git_ref": None, "git_repo": None}
 
                 if not parent_span_id:
                     # Root span: always use its values if present (overwrites child values)
@@ -599,6 +604,12 @@ def transform_otel_to_clickhouse(
                     trace_attrs[trace_id]["session_id"] = (
                         span_session_id or trace_attrs[trace_id]["session_id"]
                     )
+                    trace_git_attrs[trace_id]["git_ref"] = (
+                        span_git_ref or trace_git_attrs[trace_id]["git_ref"]
+                    )
+                    trace_git_attrs[trace_id]["git_repo"] = (
+                        span_git_repo or trace_git_attrs[trace_id]["git_repo"]
+                    )
                 else:
                     # Child span: only set if not already set (first child wins)
                     trace_attrs[trace_id]["user_id"] = (
@@ -606,6 +617,12 @@ def transform_otel_to_clickhouse(
                     )
                     trace_attrs[trace_id]["session_id"] = (
                         trace_attrs[trace_id]["session_id"] or span_session_id
+                    )
+                    trace_git_attrs[trace_id]["git_ref"] = (
+                        trace_git_attrs[trace_id]["git_ref"] or span_git_ref
+                    )
+                    trace_git_attrs[trace_id]["git_repo"] = (
+                        trace_git_attrs[trace_id]["git_repo"] or span_git_repo
                     )
 
                 # Eager trace creation:
@@ -625,6 +642,10 @@ def transform_otel_to_clickhouse(
                         "user_id": trace_attrs[trace_id]["user_id"],
                         "session_id": trace_attrs[trace_id]["session_id"],
                     }
+                    if trace_git_attrs[trace_id]["git_ref"] is not None:
+                        traces[trace_id]["git_ref"] = trace_git_attrs[trace_id]["git_ref"]
+                    if trace_git_attrs[trace_id]["git_repo"] is not None:
+                        traces[trace_id]["git_repo"] = trace_git_attrs[trace_id]["git_repo"]
 
                 # Track the best-known root name for this trace using the span
                 # closest to the root (shortest ids_path). Batches may contain
@@ -648,9 +669,6 @@ def transform_otel_to_clickhouse(
 
                 if not parent_span_id:
                     # Root span arrived — upgrade to full trace with rich metadata
-                    git_ref = span_attrs.get("traceroot.git.ref")
-                    git_repo = span_attrs.get("traceroot.git.repo")
-
                     traces[trace_id].update(
                         {
                             "trace_start_time": start_time,
@@ -662,10 +680,10 @@ def transform_otel_to_clickhouse(
 
                     if environment is not None:
                         traces[trace_id]["environment"] = environment
-                    if git_ref is not None:
-                        traces[trace_id]["git_ref"] = git_ref
-                    if git_repo is not None:
-                        traces[trace_id]["git_repo"] = git_repo
+                    if trace_git_attrs[trace_id]["git_ref"] is not None:
+                        traces[trace_id]["git_ref"] = trace_git_attrs[trace_id]["git_ref"]
+                    if trace_git_attrs[trace_id]["git_repo"] is not None:
+                        traces[trace_id]["git_repo"] = trace_git_attrs[trace_id]["git_repo"]
 
                     # Extract trace-level metadata
                     trace_metadata = span_attrs.get("traceroot.trace.metadata")
@@ -704,5 +722,15 @@ def transform_otel_to_clickhouse(
                 traces[trace_id]["user_id"] = attrs["user_id"]
             if attrs["session_id"] and not traces[trace_id].get("session_id"):
                 traces[trace_id]["session_id"] = attrs["session_id"]
+
+    # Git repo/ref are stamped on every SDK span, but the root span often arrives
+    # last in live streaming. Promote the first child values so repo/ref are visible
+    # while the trace is still running, then let root values overwrite when present.
+    for trace_id, attrs in trace_git_attrs.items():
+        if trace_id in traces:
+            if attrs["git_ref"] is not None:
+                traces[trace_id]["git_ref"] = attrs["git_ref"]
+            if attrs["git_repo"] is not None:
+                traces[trace_id]["git_repo"] = attrs["git_repo"]
 
     return list(traces.values()), spans

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -303,6 +303,94 @@ class TestTransformOtelToClickhouse:
 
         assert traces[0]["user_id"] == "child-user"
 
+    def test_git_metadata_from_child_before_root_arrives(self):
+        """Repo/ref should be available during live streaming, not only at trace end."""
+        trace_hex = "aa" * 16
+        root_hex = "bb" * 8
+        child_hex = "cc" * 8
+        payload = make_otel_payload(
+            [
+                make_span(
+                    trace_hex,
+                    child_hex,
+                    name="llm-call",
+                    parent_span_id_hex=root_hex,
+                    attributes=[
+                        make_attr("traceroot.git.repo", "https://github.com/acme/agent"),
+                        make_attr("traceroot.git.ref", "feature/live-debug"),
+                    ],
+                )
+            ]
+        )
+
+        traces, _ = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert len(traces) == 1
+        assert traces[0]["git_repo"] == "https://github.com/acme/agent"
+        assert traces[0]["git_ref"] == "feature/live-debug"
+
+    def test_root_git_metadata_overrides_child_candidate(self):
+        """If root and child disagree, root remains the authoritative trace value."""
+        trace_hex = "aa" * 16
+        root_hex = "bb" * 8
+        child_hex = "cc" * 8
+        payload = make_otel_payload(
+            [
+                make_span(
+                    trace_hex,
+                    child_hex,
+                    name="tool-call",
+                    parent_span_id_hex=root_hex,
+                    attributes=[
+                        make_attr("traceroot.git.repo", "https://github.com/acme/stale-agent"),
+                        make_attr("traceroot.git.ref", "stale-ref"),
+                    ],
+                ),
+                make_span(
+                    trace_hex,
+                    root_hex,
+                    name="agent-run",
+                    attributes=[
+                        make_attr("traceroot.git.repo", "https://github.com/acme/agent"),
+                        make_attr("traceroot.git.ref", "main"),
+                    ],
+                ),
+            ]
+        )
+
+        traces, _ = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert len(traces) == 1
+        assert traces[0]["git_repo"] == "https://github.com/acme/agent"
+        assert traces[0]["git_ref"] == "main"
+
+    def test_child_git_metadata_survives_when_root_has_none(self):
+        """Older or partial root spans should not clear git metadata from child spans."""
+        trace_hex = "aa" * 16
+        root_hex = "bb" * 8
+        child_hex = "cc" * 8
+        payload = make_otel_payload(
+            [
+                make_span(
+                    trace_hex,
+                    child_hex,
+                    name="tool-call",
+                    parent_span_id_hex=root_hex,
+                    attributes=[
+                        make_attr("traceroot.git.repo", "https://github.com/acme/agent"),
+                        make_attr("traceroot.git.ref", "main"),
+                    ],
+                ),
+                make_span(trace_hex, root_hex, name="agent-run"),
+            ]
+        )
+
+        traces, _ = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert len(traces) == 1
+        assert traces[0]["git_repo"] == "https://github.com/acme/agent"
+        assert traces[0]["git_ref"] == "main"
+
     def test_skip_span_with_missing_ids(self):
         """Spans without traceId/spanId are skipped."""
         payload = {


### PR DESCRIPTION
Fixes #1099.

## What changed
- Promote `traceroot.git.repo` and `traceroot.git.ref` from the first span that carries them, so live trace records have GitHub context before the root span finishes.
- Keep root span values authoritative when they arrive, while preserving child values if an older or partial root span does not include git context.
- Add regression coverage for child-before-root live batches, root override, and missing-root-git cases.

## Why
The SDK already stamps git repo/ref on every span. The backend only copied those fields from the root span, which usually arrives last in live streaming. That made repo/ref appear only at the end of a run even though the data was already present in child spans.

## Validation
- `/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/worker/test_otel_transform.py tests/worker/test_otel_transform_metadata.py`
- `/Users/ritwij/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m ruff check backend/worker/otel_transform.py tests/worker/test_otel_transform.py`
- `git diff --check`