### PR TITLE
chore(examples): bump Python traceroot SDK pin to 0.1.7

### DIFF
--- a/examples/python/agno-tool-agent/requirements.txt
+++ b/examples/python/agno-tool-agent/requirements.txt
@@ -4,4 +4,4 @@ yfinance>=0.2.0
 duckduckgo-search>=8.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/anthropic-tool-agent/requirements.txt
+++ b/examples/python/anthropic-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 anthropic>=0.40.0
 python-dotenv>=1.0.0
-traceroot==0.1.4
+traceroot==0.1.7
 openinference-instrumentation-anthropic>=1.0.0

--- a/examples/python/autogen-tool-agent/requirements.txt
+++ b/examples/python/autogen-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 ag2[Gemini]>=0.11.5
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/claude-agent-sdk/requirements.txt
+++ b/examples/python/claude-agent-sdk/requirements.txt
@@ -1,4 +1,4 @@
 claude-agent-sdk>=0.1.72
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/crewai-agent/requirements.txt
+++ b/examples/python/crewai-agent/requirements.txt
@@ -1,4 +1,4 @@
 crewai>=1.10.1
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/deepagents/requirements.txt
+++ b/examples/python/deepagents/requirements.txt
@@ -2,4 +2,4 @@ deepagents>=0.4.0
 langchain>=0.3.0
 langchain-anthropic>=0.3.0
 python-dotenv>=1.0.0
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/deepseek-tool-agent/requirements.txt
+++ b/examples/python/deepseek-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/dspy-agent/requirements.txt
+++ b/examples/python/dspy-agent/requirements.txt
@@ -2,4 +2,4 @@ dspy>=2.6.22,<4.0
 openinference-instrumentation-dspy>=0.1.34,<1.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.5
+traceroot==0.1.7

--- a/examples/python/gemini-tool-agent/requirements.txt
+++ b/examples/python/gemini-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 google-genai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/google-adk-agent/requirements.txt
+++ b/examples/python/google-adk-agent/requirements.txt
@@ -1,4 +1,4 @@
 google-adk>=1.31.1
 python-dotenv>=1.0.0
 
-traceroot==0.1.5
+traceroot==0.1.7

--- a/examples/python/groq-tool-agent/requirements.txt
+++ b/examples/python/groq-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 groq>=0.9.0
 python-dotenv>=1.0.0
 
-traceroot>=0.1.3
+traceroot==0.1.7

--- a/examples/python/langgraph-code-agent/requirements.txt
+++ b/examples/python/langgraph-code-agent/requirements.txt
@@ -6,4 +6,4 @@ python-dotenv>=1.0.0
 fastapi==0.115.12
 uvicorn==0.34.3
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/llamaindex-rag/requirements.txt
+++ b/examples/python/llamaindex-rag/requirements.txt
@@ -3,4 +3,4 @@ llama-index-llms-openai>=0.1.0
 llama-index-embeddings-openai>=0.1.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/mistral-tool-agent/requirements.txt
+++ b/examples/python/mistral-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 mistralai>=2.0.0
 python-dotenv>=1.0.0
 
-traceroot>=0.1.5
+traceroot==0.1.7

--- a/examples/python/openai-agents-sdk/requirements.txt
+++ b/examples/python/openai-agents-sdk/requirements.txt
@@ -1,4 +1,4 @@
 openai-agents>=0.0.3
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/openai-tool-agent/requirements.txt
+++ b/examples/python/openai-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/openrouter-tool-agent/requirements.txt
+++ b/examples/python/openrouter-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.4
+traceroot==0.1.7

--- a/examples/python/pydantic-ai-tool-agent/requirements.txt
+++ b/examples/python/pydantic-ai-tool-agent/requirements.txt
@@ -2,4 +2,4 @@ pydantic-ai>=0.2.0
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot>=0.1.6
+traceroot==0.1.7


### PR DESCRIPTION
## What

Bumps the pinned `traceroot` SDK version in all 18 Python example `requirements.txt` files to **0.1.7** (latest on PyPI).

## Why

The examples were pinned to a mix of stale versions and inconsistent operators:
- Most pinned `traceroot==0.1.4`
- A few at `0.1.5`
- Mixed range pins: `>=0.1.3`, `>=0.1.5`, `>=0.1.6`

This standardizes every example on `traceroot==0.1.7` so users following the examples get the current SDK.

## Test plan

- [x] `grep` confirms all 18 example requirements now pin `traceroot==0.1.7`
- [ ] Examples install cleanly against the new pin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized all Python example requirements to pin `traceroot==0.1.7` so users run the examples with a consistent, current SDK. Replaces mixed stale versions and range pins with a single exact version.

- **Dependencies**
  - Updated `traceroot` to `0.1.7` across 18 example `requirements.txt` files.

<sup>Written for commit 5b00b5a59c09fd0c4684eebd49221b2283366074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

