### PR TITLE
feat(ui): show a workspace settings nav button when inside a workspace

### DIFF
--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { useParams, usePathname } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 import { useTheme } from "next-themes";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -24,17 +24,6 @@ import { Logo } from "@/components/Logo";
 import { cn } from "@/lib/utils";
 import { GitHubStarWidget } from "@/components/layout/GitHubStarWidget";
 import { clientEnv } from "@/env.client";
-
-// Check if we're in a project context by looking at the path structure
-function getProjectContext(pathname: string): { isProject: boolean; projectId: string | null } {
-  // Check if path starts with /projects/[projectId]
-  const projectMatch = pathname.match(/^\/projects\/([^/]+)/);
-  if (projectMatch) {
-    return { isProject: true, projectId: projectMatch[1] };
-  }
-
-  return { isProject: false, projectId: null };
-}
 
 function getInitials(name?: string | null, email?: string | null): string {
   if (name) {
@@ -59,6 +48,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   const { data: sessionData } = authClient.useSession();
   const isImpersonating = !!sessionData?.session?.impersonatedBy;
   const { theme, setTheme } = useTheme();
+  const params = useParams<{ projectId?: string; workspaceId?: string }>();
 
   // Don't show sidebar on auth pages
   if (pathname.startsWith("/auth/")) {
@@ -69,8 +59,17 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   const initials = getInitials(user?.name, user?.email);
   const displayName = user?.name || user?.email?.split("@")[0] || "User";
 
-  // Get project context
-  const { isProject, projectId } = getProjectContext(pathname);
+  // Project/workspace context from the matched dynamic route params
+  const projectId = params?.projectId ?? null;
+  const workspaceId = params?.workspaceId ?? null;
+
+  // Settings target depends on context: project settings inside a project,
+  // workspace settings inside a workspace, hidden elsewhere
+  const settingsHref = projectId
+    ? `/projects/${projectId}/settings`
+    : workspaceId
+      ? `/workspaces/${workspaceId}/settings`
+      : null;
 
   return (
     <TooltipProvider delayDuration={0}>
@@ -131,7 +130,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
 
         {/* Navigation */}
         <nav className="flex-1">
-          {isProject && projectId ? (
+          {projectId ? (
             // Project context navigation
             <>
               <Tooltip>
@@ -204,7 +203,8 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                   className={cn(
                     "flex items-center gap-2 py-2 text-[13px] transition-colors",
                     collapsed ? "justify-center px-2" : "px-3",
-                    pathname === "/workspaces" || pathname.startsWith("/workspaces/")
+                    (pathname === "/workspaces" || pathname.startsWith("/workspaces/")) &&
+                      !pathname.includes("/settings")
                       ? "bg-muted"
                       : "hover:bg-muted/50",
                   )}
@@ -250,12 +250,12 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
             )}
           </Tooltip>
 
-          {/* Settings - only show when in project context */}
-          {isProject && projectId && (
+          {/* Settings - only show when in a project or workspace context */}
+          {settingsHref && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Link
-                  href={`/projects/${projectId}/settings`}
+                  href={settingsHref}
                   className={cn(
                     "flex w-full items-center gap-2 py-2 text-[13px] transition-colors",
                     collapsed ? "justify-center px-2" : "px-3",

--- a/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
+++ b/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
@@ -33,7 +33,7 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
       { label: "Workspaces", href: "/workspaces" },
       {
         label: workspace?.name || "...",
-        href: `/workspaces/${project?.workspace_id}/projects`,
+        href: project?.workspace_id ? `/workspaces/${project.workspace_id}/projects` : undefined,
       },
       {
         label: project?.name || "...",


### PR DESCRIPTION
## Summary

The bottom-of-sidebar **Settings** button previously rendered only in project context (`/projects/[projectId]/...`). Inside a workspace there was no way to reach the existing workspace settings pages from the navbar. The button now also renders in workspace context, linking to `/workspaces/[workspaceId]/settings` (which redirects to `/settings/general`).

## Changes

- `sidebar.tsx`: compute a single `settingsHref` — project settings inside a project, workspace settings inside a workspace, hidden elsewhere — and render the existing bottom Settings item whenever it is non-null. Same styling, tooltip-when-collapsed, and active-state behavior as before.

Follow-ups from a multi-angle code review of the change:

- Derive `projectId`/`workspaceId` from `useParams()` (the idiom used across the app's pages) instead of adding another hand-rolled pathname regex; this also removes the pre-existing `getProjectContext` regex helper in the sidebar.
- Keep the **Workspaces** nav item from highlighting at the same time as **Settings** on `/workspaces/[id]/settings/*` pages, matching project-context behavior where only one item is active.
- `ProjectBreadcrumb`: don't emit an `href` of `/workspaces/undefined/projects` while the project is still loading — the workspace crumb is now unlinked until `workspace_id` is available.

## Test plan

- `tsc --noEmit`, `eslint`, and `prettier --check` pass on the changed files.
- Manually verify: Settings appears at the bottom of the sidebar on `/workspaces/<id>/projects` and `/workspaces/<id>/settings/*`, is hidden on the bare `/workspaces` list and `/support`, and still appears on `/projects/<id>/*` linking to project settings.

## Video

https://github.com/user-attachments/assets/7635edf6-c923-4ed5-a426-69e09a0e5ab4



🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the sidebar Settings button when inside a workspace to make workspace settings easy to find. It links to `/workspaces/[workspaceId]/settings` and mirrors project behavior.

- **New Features**
  - Render the bottom Settings button in workspace context with the same styling, tooltip, and active-state; hidden on `/workspaces` list and `/support`.

- **Bug Fixes**
  - Workspaces nav no longer highlights on `/workspaces/[id]/settings/*` pages.
  - Project breadcrumb no longer links to `/workspaces/undefined/projects` while loading.

<sup>Written for commit a5b4021a1bc72b8ce0a1149d2ff8c84a9dace930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

