### PR TITLE
feat(ui): add sidebar Upgrade button that opens the pricing dialog in place

### DIFF
--- a/frontend/ui/src/components/layout/SidebarUpgradeButton.tsx
+++ b/frontend/ui/src/components/layout/SidebarUpgradeButton.tsx
@@ -28,9 +28,13 @@ export function SidebarUpgradeButton({ projectId, collapsed }: SidebarUpgradeBut
         <TooltipTrigger asChild>
           <button
             className={cn(
-              "flex w-full items-center gap-2 py-2 text-[13px] transition-colors hover:bg-muted/50",
+              "flex w-full items-center gap-2 py-2 text-[13px] transition-colors hover:bg-muted/50 disabled:opacity-50",
               collapsed ? "justify-center px-2" : "px-3",
             )}
+            // Wait for the workspace record so the dialog acts on the real plan;
+            // opening it with the FREE fallback could route a subscribed
+            // workspace to checkout instead of change-plan.
+            disabled={!workspace}
             onClick={() => setShowPricingDialog(true)}
           >
             <Sparkles className="h-3.5 w-3.5 shrink-0" />

--- a/frontend/ui/src/components/layout/SidebarUpgradeButton.tsx
+++ b/frontend/ui/src/components/layout/SidebarUpgradeButton.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { Sparkles } from "lucide-react";
+import { PlanType } from "@traceroot/core";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useProject } from "@/features/projects/hooks";
+import { useWorkspace } from "@/features/workspaces/hooks";
+import { PricingDialog } from "@/ee/features/billing/PricingDialog";
+
+interface SidebarUpgradeButtonProps {
+  projectId: string;
+  collapsed: boolean;
+}
+
+export function SidebarUpgradeButton({ projectId, collapsed }: SidebarUpgradeButtonProps) {
+  const [showPricingDialog, setShowPricingDialog] = useState(false);
+
+  // Resolve the project's workspace so the pricing dialog can act on its plan
+  const { data: project } = useProject(projectId);
+  const workspaceId = project?.workspace_id ?? "";
+  const { data: workspace } = useWorkspace(workspaceId);
+
+  return (
+    <>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            className={cn(
+              "flex w-full items-center gap-2 py-2 text-[13px] transition-colors hover:bg-muted/50",
+              collapsed ? "justify-center px-2" : "px-3",
+            )}
+            onClick={() => setShowPricingDialog(true)}
+          >
+            <Sparkles className="h-3.5 w-3.5 shrink-0" />
+            {!collapsed && "Upgrade"}
+          </button>
+        </TooltipTrigger>
+        {collapsed && (
+          <TooltipContent side="right" sideOffset={16}>
+            Upgrade
+          </TooltipContent>
+        )}
+      </Tooltip>
+
+      <PricingDialog
+        open={showPricingDialog}
+        onOpenChange={setShowPricingDialog}
+        workspaceId={workspaceId}
+        currentPlan={(workspace?.billingPlan as PlanType) || PlanType.FREE}
+        hasSubscription={!!workspace?.billingSubscriptionId}
+      />
+    </>
+  );
+}

--- a/frontend/ui/src/components/layout/project-context.test.ts
+++ b/frontend/ui/src/components/layout/project-context.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { getProjectContext } from "./project-context";
+
+// The sidebar uses this to gate project-only items (Settings, the Upgrade button).
+describe("getProjectContext", () => {
+  it("detects a project route and extracts the project id", () => {
+    expect(getProjectContext("/projects/abc123/traces")).toEqual({
+      isProject: true,
+      projectId: "abc123",
+    });
+    expect(getProjectContext("/projects/abc123")).toEqual({
+      isProject: true,
+      projectId: "abc123",
+    });
+    expect(getProjectContext("/projects/abc123/settings")).toEqual({
+      isProject: true,
+      projectId: "abc123",
+    });
+  });
+
+  it("is not a project context on non-project routes", () => {
+    expect(getProjectContext("/")).toEqual({ isProject: false, projectId: null });
+    expect(getProjectContext("/workspaces")).toEqual({ isProject: false, projectId: null });
+    expect(getProjectContext("/workspaces/ws1/settings/billing")).toEqual({
+      isProject: false,
+      projectId: null,
+    });
+    expect(getProjectContext("/support")).toEqual({ isProject: false, projectId: null });
+  });
+
+  it("is not a project context on the bare /projects path", () => {
+    expect(getProjectContext("/projects")).toEqual({ isProject: false, projectId: null });
+    expect(getProjectContext("/projects/")).toEqual({ isProject: false, projectId: null });
+  });
+});

--- a/frontend/ui/src/components/layout/project-context.ts
+++ b/frontend/ui/src/components/layout/project-context.ts
@@ -1,0 +1,14 @@
+// Check if we're in a project context by looking at the path structure.
+// Extracted from the sidebar so the route gating is unit-testable without rendering React.
+export function getProjectContext(pathname: string): {
+  isProject: boolean;
+  projectId: string | null;
+} {
+  // Check if path starts with /projects/[projectId]
+  const projectMatch = pathname.match(/^\/projects\/([^/]+)/);
+  if (projectMatch) {
+    return { isProject: true, projectId: projectMatch[1] };
+  }
+
+  return { isProject: false, projectId: null };
+}

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -22,18 +22,9 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import { Logo } from "@/components/Logo";
 import { cn } from "@/lib/utils";
 import { GitHubStarWidget } from "@/components/layout/GitHubStarWidget";
+import { SidebarUpgradeButton } from "@/components/layout/SidebarUpgradeButton";
+import { getProjectContext } from "@/components/layout/project-context";
 import { clientEnv } from "@/env.client";
-
-// Check if we're in a project context by looking at the path structure
-function getProjectContext(pathname: string): { isProject: boolean; projectId: string | null } {
-  // Check if path starts with /projects/[projectId]
-  const projectMatch = pathname.match(/^\/projects\/([^/]+)/);
-  if (projectMatch) {
-    return { isProject: true, projectId: projectMatch[1] };
-  }
-
-  return { isProject: false, projectId: null };
-}
 
 function getInitials(name?: string | null, email?: string | null): string {
   if (name) {
@@ -203,6 +194,11 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
 
         {/* Bottom section */}
         <div>
+          {/* Upgrade button - only show when in project context */}
+          {isProject && projectId && (
+            <SidebarUpgradeButton projectId={projectId} collapsed={collapsed} />
+          )}
+
           {/* Star widget */}
           {!collapsed && <GitHubStarWidget />}
 

--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -2,20 +2,11 @@
 
 import { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
-import { ArrowRight, ExternalLink, AlertCircle, CalendarClock } from "lucide-react";
+import { ExternalLink, AlertCircle, CalendarClock } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { cn } from "@/lib/utils";
 import {
   PLANS,
   PlanType,
-  isUpgrade,
   EVENT_QUOTAS,
   AI_RUN_QUOTAS,
   RCA_RUN_QUOTAS,
@@ -23,6 +14,7 @@ import {
 } from "@traceroot/core";
 import type { UsageStats, AIUsageByModel } from "@/types/api";
 import { formatRcaQuotaLabel, formatDetectorScanLabel } from "./usage-labels";
+import { PricingDialog } from "./PricingDialog";
 
 function formatCost(cost: number): string {
   if (cost < 0.01) return cost > 0 ? "< $0.01" : "$0.00";
@@ -107,13 +99,7 @@ function UsageSection({
     </div>
   );
 }
-import {
-  createCheckoutSession,
-  changePlan,
-  getPortalUrl,
-  getSubscriptionInfo,
-  type SubscriptionInfo,
-} from "./api";
+import { getPortalUrl, getSubscriptionInfo, type SubscriptionInfo } from "./api";
 
 interface BillingTabProps {
   workspaceId: string;
@@ -155,39 +141,6 @@ export function BillingTab({
       });
   }, [workspaceId, hasSubscription]);
 
-  async function handlePlanSelect(newPlan: PlanType) {
-    if (newPlan === currentPlan) return;
-
-    // Enterprise = contact sales
-    if (newPlan === PlanType.ENTERPRISE) {
-      window.open("https://cal.com/traceroot/30min", "_blank");
-      return;
-    }
-
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      if (!hasSubscription && newPlan !== PlanType.FREE) {
-        // No subscription yet, need to go through checkout
-        const { url } = await createCheckoutSession(workspaceId, newPlan);
-        window.location.href = url;
-      } else {
-        // Has subscription, use change-plan (upgrade, downgrade, or cancel to free)
-        const result = await changePlan(workspaceId, newPlan);
-        if (result.success) {
-          setShowPricingDialog(false);
-          // Reload to reflect new plan
-          window.location.reload();
-        }
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to change plan");
-    } finally {
-      setIsLoading(false);
-    }
-  }
-
   async function handleOpenPortal() {
     setIsLoading(true);
     try {
@@ -198,14 +151,6 @@ export function BillingTab({
     } finally {
       setIsLoading(false);
     }
-  }
-
-  function getButtonText(planId: PlanType): string {
-    if (planId === currentPlan) return "Current Plan";
-    if (planId === PlanType.ENTERPRISE) return "Contact Sales";
-    if (planId === PlanType.FREE) return "Downgrade";
-    if (isUpgrade(currentPlan, planId)) return "Upgrade";
-    return "Downgrade";
   }
 
   return (
@@ -398,86 +343,13 @@ export function BillingTab({
       />
 
       {/* Pricing Dialog */}
-      <Dialog open={showPricingDialog} onOpenChange={setShowPricingDialog}>
-        <DialogContent className="max-w-5xl">
-          <DialogHeader>
-            <DialogTitle>Choose a plan</DialogTitle>
-            <DialogDescription>Select a plan that best fits your needs.</DialogDescription>
-          </DialogHeader>
-          <div className="py-4">
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
-              {(Object.entries(PLANS) as [PlanType, (typeof PLANS)[PlanType]][]).map(
-                ([planId, plan]) => {
-                  const isCurrentPlan = planId === currentPlan;
-                  const isEnterprise = planId === PlanType.ENTERPRISE;
-
-                  return (
-                    <div
-                      key={planId}
-                      className={cn(
-                        "flex flex-col border",
-                        plan.highlighted && "border-foreground shadow-md",
-                      )}
-                    >
-                      {/* Plan header */}
-                      <div className="border-b px-4 pb-3 pt-4">
-                        <div className="flex items-center justify-between">
-                          <h3 className="text-lg font-semibold">{plan.name}</h3>
-                          {plan.badge && (
-                            <span className="rounded-full bg-muted px-2 py-1 text-xs">
-                              {plan.badge}
-                            </span>
-                          )}
-                        </div>
-                        <p className="mt-1 text-sm text-muted-foreground">{plan.description}</p>
-                      </div>
-
-                      {/* Price */}
-                      <div className="border-b px-4 py-3">
-                        <div>
-                          {plan.price !== null ? (
-                            <>
-                              <span className="text-2xl font-bold">${plan.price}</span>
-                              <span className="text-muted-foreground"> per month</span>
-                            </>
-                          ) : (
-                            <span className="text-2xl font-bold">Custom</span>
-                          )}
-                        </div>
-                        <p className="mt-1 text-xs text-muted-foreground">{plan.support} support</p>
-                      </div>
-
-                      {/* Features */}
-                      <div className="flex-1 px-4 py-3">
-                        <ul className="space-y-2">
-                          {plan.features.map((feature, index) => (
-                            <li key={index} className="text-sm">
-                              {feature}
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-
-                      {/* CTA Button */}
-                      <div className="px-4 pb-4">
-                        <Button
-                          variant={plan.highlighted ? "default" : "outline"}
-                          className="w-full justify-between"
-                          disabled={isCurrentPlan || (isLoading && !isEnterprise)}
-                          onClick={() => handlePlanSelect(planId)}
-                        >
-                          {getButtonText(planId)}
-                          {!isCurrentPlan && <ArrowRight className="h-4 w-4" />}
-                        </Button>
-                      </div>
-                    </div>
-                  );
-                },
-              )}
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
+      <PricingDialog
+        open={showPricingDialog}
+        onOpenChange={setShowPricingDialog}
+        workspaceId={workspaceId}
+        currentPlan={currentPlan}
+        hasSubscription={hasSubscription}
+      />
     </div>
   );
 }

--- a/frontend/ui/src/ee/features/billing/PricingDialog.tsx
+++ b/frontend/ui/src/ee/features/billing/PricingDialog.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import { ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+import { PLANS, PlanType } from "@traceroot/core";
+import { createCheckoutSession, changePlan } from "./api";
+import { getPlanButtonText, resolvePlanAction } from "./plan-actions";
+
+interface PricingDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string;
+  currentPlan?: PlanType;
+  hasSubscription?: boolean; // true if workspace has billingSubscriptionId
+}
+
+export function PricingDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+  currentPlan = PlanType.FREE,
+  hasSubscription = false,
+}: PricingDialogProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handlePlanSelect(newPlan: PlanType) {
+    const action = resolvePlanAction(currentPlan, newPlan, hasSubscription);
+
+    if (action.type === "none") return;
+
+    if (action.type === "contact-sales") {
+      window.open("https://cal.com/traceroot/30min", "_blank");
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      if (action.type === "checkout") {
+        const { url } = await createCheckoutSession(workspaceId, newPlan);
+        window.location.href = url;
+      } else {
+        const result = await changePlan(workspaceId, newPlan);
+        if (result.success) {
+          onOpenChange(false);
+          // Reload to reflect new plan
+          window.location.reload();
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to change plan");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-5xl">
+        <DialogHeader>
+          <DialogTitle>Choose a plan</DialogTitle>
+          <DialogDescription>Select a plan that best fits your needs.</DialogDescription>
+        </DialogHeader>
+        {error && (
+          <div className="border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
+        )}
+        <div className="py-4">
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+            {(Object.entries(PLANS) as [PlanType, (typeof PLANS)[PlanType]][]).map(
+              ([planId, plan]) => {
+                const isCurrentPlan = planId === currentPlan;
+                const isEnterprise = planId === PlanType.ENTERPRISE;
+
+                return (
+                  <div
+                    key={planId}
+                    className={cn(
+                      "flex flex-col border",
+                      plan.highlighted && "border-foreground shadow-md",
+                    )}
+                  >
+                    {/* Plan header */}
+                    <div className="border-b px-4 pb-3 pt-4">
+                      <div className="flex items-center justify-between">
+                        <h3 className="text-lg font-semibold">{plan.name}</h3>
+                        {plan.badge && (
+                          <span className="rounded-full bg-muted px-2 py-1 text-xs">
+                            {plan.badge}
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-1 text-sm text-muted-foreground">{plan.description}</p>
+                    </div>
+
+                    {/* Price */}
+                    <div className="border-b px-4 py-3">
+                      <div>
+                        {plan.price !== null ? (
+                          <>
+                            <span className="text-2xl font-bold">${plan.price}</span>
+                            <span className="text-muted-foreground"> per month</span>
+                          </>
+                        ) : (
+                          <span className="text-2xl font-bold">Custom</span>
+                        )}
+                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">{plan.support} support</p>
+                    </div>
+
+                    {/* Features */}
+                    <div className="flex-1 px-4 py-3">
+                      <ul className="space-y-2">
+                        {plan.features.map((feature, index) => (
+                          <li key={index} className="text-sm">
+                            {feature}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+
+                    {/* CTA Button */}
+                    <div className="px-4 pb-4">
+                      <Button
+                        variant={plan.highlighted ? "default" : "outline"}
+                        className="w-full justify-between"
+                        disabled={isCurrentPlan || (isLoading && !isEnterprise)}
+                        onClick={() => handlePlanSelect(planId)}
+                      >
+                        {getPlanButtonText(currentPlan, planId)}
+                        {!isCurrentPlan && <ArrowRight className="h-4 w-4" />}
+                      </Button>
+                    </div>
+                  </div>
+                );
+              },
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/ui/src/ee/features/billing/PricingDialog.tsx
+++ b/frontend/ui/src/ee/features/billing/PricingDialog.tsx
@@ -39,7 +39,7 @@ export function PricingDialog({
     if (action.type === "none") return;
 
     if (action.type === "contact-sales") {
-      window.open("https://cal.com/traceroot/30min", "_blank");
+      window.open("https://cal.com/traceroot/30min", "_blank", "noopener,noreferrer");
       return;
     }
 

--- a/frontend/ui/src/ee/features/billing/plan-actions.test.ts
+++ b/frontend/ui/src/ee/features/billing/plan-actions.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { PlanType } from "@traceroot/core";
+import { getPlanButtonText, resolvePlanAction } from "./plan-actions";
+
+describe("getPlanButtonText", () => {
+  it("labels the user's current plan", () => {
+    expect(getPlanButtonText(PlanType.FREE, PlanType.FREE)).toBe("Current Plan");
+    expect(getPlanButtonText(PlanType.PRO, PlanType.PRO)).toBe("Current Plan");
+  });
+
+  it("labels Enterprise as Contact Sales", () => {
+    expect(getPlanButtonText(PlanType.FREE, PlanType.ENTERPRISE)).toBe("Contact Sales");
+    expect(getPlanButtonText(PlanType.PRO, PlanType.ENTERPRISE)).toBe("Contact Sales");
+  });
+
+  it("labels Free as Downgrade when on a paid plan", () => {
+    expect(getPlanButtonText(PlanType.STARTER, PlanType.FREE)).toBe("Downgrade");
+    expect(getPlanButtonText(PlanType.PRO, PlanType.FREE)).toBe("Downgrade");
+  });
+
+  it("labels higher plans as Upgrade", () => {
+    expect(getPlanButtonText(PlanType.FREE, PlanType.STARTER)).toBe("Upgrade");
+    expect(getPlanButtonText(PlanType.FREE, PlanType.PRO)).toBe("Upgrade");
+    expect(getPlanButtonText(PlanType.STARTER, PlanType.PRO)).toBe("Upgrade");
+  });
+
+  it("labels lower paid plans as Downgrade", () => {
+    expect(getPlanButtonText(PlanType.PRO, PlanType.STARTER)).toBe("Downgrade");
+  });
+});
+
+describe("resolvePlanAction", () => {
+  it("does nothing when selecting the current plan", () => {
+    expect(resolvePlanAction(PlanType.PRO, PlanType.PRO, true)).toEqual({ type: "none" });
+    expect(resolvePlanAction(PlanType.FREE, PlanType.FREE, false)).toEqual({ type: "none" });
+  });
+
+  it("routes Enterprise to contact sales regardless of subscription state", () => {
+    expect(resolvePlanAction(PlanType.FREE, PlanType.ENTERPRISE, false)).toEqual({
+      type: "contact-sales",
+    });
+    expect(resolvePlanAction(PlanType.PRO, PlanType.ENTERPRISE, true)).toEqual({
+      type: "contact-sales",
+    });
+  });
+
+  it("routes first-time subscribers to Stripe checkout for paid plans", () => {
+    expect(resolvePlanAction(PlanType.FREE, PlanType.STARTER, false)).toEqual({
+      type: "checkout",
+    });
+    expect(resolvePlanAction(PlanType.FREE, PlanType.PRO, false)).toEqual({ type: "checkout" });
+  });
+
+  it("routes existing subscribers to change-plan (upgrade, downgrade, or cancel to free)", () => {
+    expect(resolvePlanAction(PlanType.FREE, PlanType.PRO, true)).toEqual({ type: "change-plan" });
+    expect(resolvePlanAction(PlanType.PRO, PlanType.STARTER, true)).toEqual({
+      type: "change-plan",
+    });
+    expect(resolvePlanAction(PlanType.PRO, PlanType.FREE, true)).toEqual({ type: "change-plan" });
+  });
+
+  it("routes a downgrade to Free without a subscription to change-plan, not checkout", () => {
+    expect(resolvePlanAction(PlanType.PRO, PlanType.FREE, false)).toEqual({
+      type: "change-plan",
+    });
+  });
+});

--- a/frontend/ui/src/ee/features/billing/plan-actions.ts
+++ b/frontend/ui/src/ee/features/billing/plan-actions.ts
@@ -1,0 +1,34 @@
+// Plan-selection decision logic for the pricing dialog.
+// Extracted from PricingDialog so the logic is unit-testable without rendering React.
+import { PlanType, isUpgrade } from "@traceroot/core";
+
+export type PlanAction =
+  | { type: "none" }
+  | { type: "contact-sales" }
+  | { type: "checkout" }
+  | { type: "change-plan" };
+
+export function getPlanButtonText(currentPlan: PlanType, planId: PlanType): string {
+  if (planId === currentPlan) return "Current Plan";
+  if (planId === PlanType.ENTERPRISE) return "Contact Sales";
+  if (planId === PlanType.FREE) return "Downgrade";
+  if (isUpgrade(currentPlan, planId)) return "Upgrade";
+  return "Downgrade";
+}
+
+export function resolvePlanAction(
+  currentPlan: PlanType,
+  newPlan: PlanType,
+  hasSubscription: boolean,
+): PlanAction {
+  if (newPlan === currentPlan) return { type: "none" };
+
+  // Enterprise = contact sales
+  if (newPlan === PlanType.ENTERPRISE) return { type: "contact-sales" };
+
+  // No subscription yet, need to go through checkout
+  if (!hasSubscription && newPlan !== PlanType.FREE) return { type: "checkout" };
+
+  // Has subscription, use change-plan (upgrade, downgrade, or cancel to free)
+  return { type: "change-plan" };
+}


### PR DESCRIPTION
## Summary

- Adds an **Upgrade** button to the bottom section of the left sidebar, visible only in project context. Clicking it opens the plan/pricing popup as a modal — no navigation to the billing page.
- The button resolves the project's workspace (`useProject` → `useWorkspace`) so the popup shows the correct current plan and the plan buttons act on the right workspace.
- Extracts the pricing dialog out of `BillingTab` into a reusable `PricingDialog` component so the billing page's "Change plan" and the sidebar button render the same popup. Plan-select errors now display inside the dialog (the sidebar has no page-level error banner).
- Extracts pure logic into unit-tested modules, following the existing `usage-labels` pattern:
  - `plan-actions.ts` — plan button labels and checkout-vs-change-plan routing (10 tests)
  - `project-context.ts` — the sidebar's project-route gating (3 tests)

Closes #1116

## Test plan

- [x] Unit tests: 13 new tests pass (`plan-actions.test.ts`, `project-context.test.ts`); full vitest suite green apart from pre-existing env-dependent Slack OAuth tests
- [x] tsc, eslint, prettier clean
- [x] Verified live against the local stack: button absent outside projects (onboarding, workspace settings), present inside a project (expanded and collapsed sidebar); dialog opens in place with no redirect, Esc closes it; Free plan shows disabled "Current Plan"; clicking Upgrade→Starter created a correct Stripe sandbox checkout session; billing page "Change plan" still opens the identical dialog

## Video 

https://github.com/user-attachments/assets/2a3bd97e-0754-4b56-90a1-a4f6ef00631c



🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a project-only Upgrade button in the left sidebar that opens the pricing dialog as a modal, so users can upgrade without leaving the page. Extracts a reusable PricingDialog and plan-selection logic with tests, and hardens the flow to always act on the correct workspace. Closes #1116.

- New Features
  - Sidebar Upgrade button appears only on project routes; tooltip shown when collapsed.
  - Opens a shared PricingDialog in place; Esc closes; plan-select errors render inside the dialog.
  - Resolves the project’s workspace so the dialog shows the right plan and routes checkout vs change-plan correctly.

- Bug Fixes
  - Disable the Upgrade button until the workspace record loads to avoid acting on a FREE fallback or empty workspace id.
  - Open the Contact Sales link with noopener,noreferrer to prevent opener navigation.

<sup>Written for commit 75a05a21a64510e8ee51229e5a76c4ec24122536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



