### PR TITLE
feat(ui): make top-bar workspace/project breadcrumb a dropdown selector

### DIFF
--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -130,7 +130,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-auto w-10 shrink-0 self-stretch rounded-none"
+                  className="h-8 w-8 shrink-0"
                   onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
                 >
                   <PanelLeft className="h-4 w-4" />

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -130,7 +130,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="h-8 w-8 shrink-0"
+                  className="h-auto w-10 shrink-0 self-stretch rounded-none"
                   onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
                 >
                   <PanelLeft className="h-4 w-4" />

--- a/frontend/ui/src/components/layout/breadcrumb.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { Check, ChevronDown, ChevronRight, Plus } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ChevronDown, Plus, Settings, Slash } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -14,6 +15,8 @@ export interface BreadcrumbDropdownOption {
   id: string;
   label: string;
   href: string;
+  /** Optional settings page for the entity, shown as a gear on the row. */
+  settingsHref?: string;
 }
 
 export interface BreadcrumbItem {
@@ -21,8 +24,8 @@ export interface BreadcrumbItem {
   href?: string;
   /** When provided (and non-empty), the segment renders as a dropdown selector. */
   options?: BreadcrumbDropdownOption[];
-  /** Option id shown as the current selection at the top of the dropdown. */
-  selectedId?: string;
+  /** Bold first menu item linking to the entity list page (e.g. "Workspaces"). */
+  menuHeader?: { label: string; href: string };
   /** Optional create action at the bottom of the dropdown (e.g. "New workspace"). */
   createNew?: { label: string; onSelect: () => void };
 }
@@ -44,27 +47,26 @@ interface BreadcrumbProps {
  * ```
  *
  * Items with `options` render as a dropdown selector instead of a plain
- * link; selecting an option navigates to its href. Dropdown segments
- * stretch to the full header height so the panel opens flush with the
- * top bar, with the current selection pinned at the top of the panel.
+ * link: a bold header link, a scrollable entity list with per-entity
+ * settings shortcuts, and an optional create action.
  */
 export function Breadcrumb({ items }: BreadcrumbProps) {
   return (
-    <div className="flex h-full min-w-0 items-stretch gap-0.5 text-[13px]">
+    <div className="flex min-w-0 items-center gap-1.5 text-[13px]">
       {items.map((item, index) => (
-        <span key={index} className="flex min-w-0 items-center gap-0.5">
-          {index > 0 && <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />}
+        <span key={index} className="flex min-w-0 items-center gap-1.5">
+          {index > 0 && <Slash className="h-3 w-3 shrink-0 text-muted-foreground/50" />}
           {item.options && item.options.length > 0 ? (
             <BreadcrumbDropdown item={item} />
           ) : item.href ? (
             <Link
               href={item.href}
-              className="flex h-full items-center px-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="text-muted-foreground transition-colors hover:text-foreground"
             >
               {item.label}
             </Link>
           ) : (
-            <span className="truncate px-1.5 py-1 font-medium">{item.label}</span>
+            <span className="truncate font-medium">{item.label}</span>
           )}
         </span>
       ))}
@@ -73,38 +75,61 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
 }
 
 function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
-  const selected = item.options?.find((option) => option.id === item.selectedId);
-  const others = item.options?.filter((option) => option.id !== item.selectedId);
+  const router = useRouter();
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="group flex h-full min-w-0 items-center gap-1 px-2 font-medium outline-none transition-colors hover:bg-accent focus-visible:bg-accent data-[state=open]:bg-accent">
+      <DropdownMenuTrigger className="flex min-w-0 items-center gap-1 font-medium outline-none focus-visible:ring-1 focus-visible:ring-ring">
         <span className="truncate">{item.label}</span>
-        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-150 group-data-[state=open]:rotate-180" />
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" sideOffset={0} className="w-64 rounded-none p-0 shadow-lg">
-        {selected && (
+      <DropdownMenuContent align="start" className="rounded-none">
+        {item.menuHeader && (
           <>
-            <div className="flex items-center gap-2 bg-accent/50 px-3 py-2.5 text-[13px] font-medium">
-              <span className="flex-1 truncate">{selected.label}</span>
-              <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            </div>
-            <DropdownMenuSeparator className="m-0" />
+            <DropdownMenuItem asChild className="rounded-none text-[13px] font-semibold">
+              <Link href={item.menuHeader.href}>{item.menuHeader.label}</Link>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
           </>
         )}
-        {others?.map((option) => (
-          <DropdownMenuItem key={option.id} asChild className="rounded-none px-3 py-2 text-[13px]">
-            <Link href={option.href}>
-              <span className="flex-1 truncate">{option.label}</span>
-            </Link>
-          </DropdownMenuItem>
-        ))}
+        <div className="max-h-36 overflow-y-auto">
+          {item.options?.map((option) => (
+            <DropdownMenuItem key={option.id} asChild className="rounded-none text-[13px]">
+              <Link href={option.href} className="flex justify-between">
+                <span className="max-w-36 truncate" title={option.label}>
+                  {option.label}
+                </span>
+                {option.settingsHref && (
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      router.push(option.settingsHref!);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        router.push(option.settingsHref!);
+                      }
+                    }}
+                    className="-my-0.5 ml-4 flex h-6 w-6 items-center justify-center text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+                  >
+                    <Settings size={12} />
+                  </span>
+                )}
+              </Link>
+            </DropdownMenuItem>
+          ))}
+        </div>
         {item.createNew && (
           <>
-            <DropdownMenuSeparator className="m-0" />
+            <DropdownMenuSeparator />
             <DropdownMenuItem
               onSelect={item.createNew.onSelect}
-              className="rounded-none px-3 py-2 text-[13px] text-muted-foreground"
+              className="rounded-none text-[13px]"
             >
               <Plus className="h-3.5 w-3.5 shrink-0" />
               {item.createNew.label}

--- a/frontend/ui/src/components/layout/breadcrumb.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { Check, ChevronDown, ChevronRight } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Plus } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 
 export interface BreadcrumbDropdownOption {
@@ -20,8 +21,10 @@ export interface BreadcrumbItem {
   href?: string;
   /** When provided (and non-empty), the segment renders as a dropdown selector. */
   options?: BreadcrumbDropdownOption[];
-  /** Option id to mark as current in the dropdown. */
+  /** Option id shown as the current selection at the top of the dropdown. */
   selectedId?: string;
+  /** Optional create action at the bottom of the dropdown (e.g. "New workspace"). */
+  createNew?: { label: string; onSelect: () => void };
 }
 
 interface BreadcrumbProps {
@@ -41,22 +44,27 @@ interface BreadcrumbProps {
  * ```
  *
  * Items with `options` render as a dropdown selector instead of a plain
- * link; selecting an option navigates to its href.
+ * link; selecting an option navigates to its href. Dropdown segments
+ * stretch to the full header height so the panel opens flush with the
+ * top bar, with the current selection pinned at the top of the panel.
  */
 export function Breadcrumb({ items }: BreadcrumbProps) {
   return (
-    <div className="flex items-center gap-1.5 text-[13px]">
+    <div className="flex h-full min-w-0 items-stretch gap-0.5 text-[13px]">
       {items.map((item, index) => (
-        <span key={index} className="flex items-center gap-1.5">
-          {index > 0 && <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
+        <span key={index} className="flex min-w-0 items-center gap-0.5">
+          {index > 0 && <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60" />}
           {item.options && item.options.length > 0 ? (
             <BreadcrumbDropdown item={item} />
           ) : item.href ? (
-            <Link href={item.href} className="hover:underline">
+            <Link
+              href={item.href}
+              className="px-1.5 py-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
               {item.label}
             </Link>
           ) : (
-            <span className="font-medium">{item.label}</span>
+            <span className="truncate px-1.5 py-1 font-medium">{item.label}</span>
           )}
         </span>
       ))}
@@ -65,21 +73,44 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
 }
 
 function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
+  const selected = item.options?.find((option) => option.id === item.selectedId);
+  const others = item.options?.filter((option) => option.id !== item.selectedId);
+
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className="flex items-center gap-0.5 rounded-sm hover:underline focus:outline-none focus-visible:ring-1 focus-visible:ring-ring">
-        {item.label}
-        <ChevronDown className="h-3 w-3 text-muted-foreground" />
+      <DropdownMenuTrigger className="group flex h-full min-w-0 items-center gap-1 px-2 font-medium outline-none transition-colors hover:bg-accent focus-visible:bg-accent data-[state=open]:bg-accent">
+        <span className="truncate">{item.label}</span>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-150 group-data-[state=open]:rotate-180" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        {item.options?.map((option) => (
-          <DropdownMenuItem key={option.id} asChild>
+      <DropdownMenuContent align="start" sideOffset={0} className="w-64 rounded-none p-0 shadow-lg">
+        {selected && (
+          <>
+            <div className="flex items-center gap-2 bg-accent/50 px-3 py-2.5 text-[13px] font-medium">
+              <span className="flex-1 truncate">{selected.label}</span>
+              <Check className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            </div>
+            <DropdownMenuSeparator className="m-0" />
+          </>
+        )}
+        {others?.map((option) => (
+          <DropdownMenuItem key={option.id} asChild className="rounded-none px-3 py-2 text-[13px]">
             <Link href={option.href}>
               <span className="flex-1 truncate">{option.label}</span>
-              {option.id === item.selectedId && <Check className="h-3.5 w-3.5 shrink-0" />}
             </Link>
           </DropdownMenuItem>
         ))}
+        {item.createNew && (
+          <>
+            <DropdownMenuSeparator className="m-0" />
+            <DropdownMenuItem
+              onSelect={item.createNew.onSelect}
+              className="rounded-none px-3 py-2 text-[13px] text-muted-foreground"
+            >
+              <Plus className="h-3.5 w-3.5 shrink-0" />
+              {item.createNew.label}
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/frontend/ui/src/components/layout/breadcrumb.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.tsx
@@ -59,7 +59,7 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
           ) : item.href ? (
             <Link
               href={item.href}
-              className="px-1.5 py-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="flex h-full items-center px-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
               {item.label}
             </Link>

--- a/frontend/ui/src/components/layout/breadcrumb.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.tsx
@@ -1,11 +1,27 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronRight } from "lucide-react";
+import { Check, ChevronDown, ChevronRight } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
+
+export interface BreadcrumbDropdownOption {
+  id: string;
+  label: string;
+  href: string;
+}
 
 export interface BreadcrumbItem {
   label: string;
   href?: string;
+  /** When provided (and non-empty), the segment renders as a dropdown selector. */
+  options?: BreadcrumbDropdownOption[];
+  /** Option id to mark as current in the dropdown. */
+  selectedId?: string;
 }
 
 interface BreadcrumbProps {
@@ -23,6 +39,9 @@ interface BreadcrumbProps {
  *   { label: 'Current Page' }  // no href = not a link
  * ]} />
  * ```
+ *
+ * Items with `options` render as a dropdown selector instead of a plain
+ * link; selecting an option navigates to its href.
  */
 export function Breadcrumb({ items }: BreadcrumbProps) {
   return (
@@ -30,7 +49,9 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
       {items.map((item, index) => (
         <span key={index} className="flex items-center gap-1.5">
           {index > 0 && <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />}
-          {item.href ? (
+          {item.options && item.options.length > 0 ? (
+            <BreadcrumbDropdown item={item} />
+          ) : item.href ? (
             <Link href={item.href} className="hover:underline">
               {item.label}
             </Link>
@@ -40,5 +61,26 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
         </span>
       ))}
     </div>
+  );
+}
+
+function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex items-center gap-0.5 rounded-sm hover:underline focus:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+        {item.label}
+        <ChevronDown className="h-3 w-3 text-muted-foreground" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {item.options?.map((option) => (
+          <DropdownMenuItem key={option.id} asChild>
+            <Link href={option.href}>
+              <span className="flex-1 truncate">{option.label}</span>
+              {option.id === item.selectedId && <Check className="h-3.5 w-3.5 shrink-0" />}
+            </Link>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/ui/src/components/ui/dropdown-menu.tsx
+++ b/frontend/ui/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-96 min-w-[8rem] overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-xs font-medium text-muted-foreground", className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+};

--- a/frontend/ui/src/features/projects/components/CreateProjectDialog.tsx
+++ b/frontend/ui/src/features/projects/components/CreateProjectDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createProject } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -39,15 +40,17 @@ export function CreateProjectDialog({
   };
   const [name, setName] = useState("");
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   const createMutation = useMutation({
     mutationFn: (name: string) => createProject(workspaceId, name),
-    onSuccess: () => {
+    onSuccess: (project) => {
       queryClient.invalidateQueries({ queryKey: ["workspace", workspaceId] });
       queryClient.invalidateQueries({ queryKey: ["workspaces"] });
       queryClient.invalidateQueries({ queryKey: ["projects", workspaceId] });
       setOpen(false);
       setName("");
+      router.push(`/projects/${project.id}/traces`);
     },
   });
 

--- a/frontend/ui/src/features/projects/components/CreateProjectDialog.tsx
+++ b/frontend/ui/src/features/projects/components/CreateProjectDialog.tsx
@@ -19,10 +19,24 @@ import {
 interface CreateProjectDialogProps {
   workspaceId: string;
   trigger?: React.ReactNode;
+  /** Controlled mode: when provided, no trigger is rendered. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function CreateProjectDialog({ workspaceId, trigger }: CreateProjectDialogProps) {
-  const [open, setOpen] = useState(false);
+export function CreateProjectDialog({
+  workspaceId,
+  trigger,
+  open: controlledOpen,
+  onOpenChange,
+}: CreateProjectDialogProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const setOpen = (next: boolean) => {
+    if (!isControlled) setUncontrolledOpen(next);
+    onOpenChange?.(next);
+  };
   const [name, setName] = useState("");
   const queryClient = useQueryClient();
 
@@ -46,7 +60,9 @@ export function CreateProjectDialog({ workspaceId, trigger }: CreateProjectDialo
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{trigger || <AddButton>New Project</AddButton>}</DialogTrigger>
+      {!isControlled && (
+        <DialogTrigger asChild>{trigger || <AddButton>New Project</AddButton>}</DialogTrigger>
+      )}
       <DialogContent>
         <form onSubmit={handleSubmit}>
           <DialogHeader>

--- a/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
+++ b/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
 import { Breadcrumb, BreadcrumbItem } from "@/components/layout/breadcrumb";
 import { useProject } from "../hooks";
-import { useWorkspace } from "@/features/workspaces/hooks";
+import { projectSwitchHref } from "../utils";
+import { useWorkspace, useWorkspaces } from "@/features/workspaces/hooks";
+import { workspaceSwitchHref } from "@/features/workspaces/utils";
 
 interface ProjectBreadcrumbProps {
   projectId: string;
@@ -15,6 +18,8 @@ interface ProjectBreadcrumbProps {
 /**
  * Breadcrumb component for project context pages.
  * Automatically fetches project and workspace data and sets the header.
+ * The workspace and project segments are dropdown selectors for quick
+ * switching; selecting a project keeps the current sub-page where sensible.
  *
  * Usage:
  * ```tsx
@@ -25,7 +30,9 @@ interface ProjectBreadcrumbProps {
  */
 export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps) {
   const { setHeaderContent } = useLayout();
+  const pathname = usePathname();
   const { data: project } = useProject(projectId);
+  const { data: workspaces } = useWorkspaces();
   const { data: workspace } = useWorkspace(project?.workspace_id || "", !!project?.workspace_id);
 
   useEffect(() => {
@@ -34,10 +41,22 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
       {
         label: workspace?.name || "...",
         href: `/workspaces/${project?.workspace_id}/projects`,
+        options: workspaces?.map((ws) => ({
+          id: ws.id,
+          label: ws.name,
+          href: workspaceSwitchHref(pathname, ws.id),
+        })),
+        selectedId: project?.workspace_id,
       },
       {
         label: project?.name || "...",
         href: current ? `/projects/${projectId}/traces` : undefined,
+        options: workspace?.projects?.map((p) => ({
+          id: p.id,
+          label: p.name,
+          href: projectSwitchHref(pathname, p.id),
+        })),
+        selectedId: projectId,
       },
     ];
 
@@ -47,7 +66,7 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
 
     setHeaderContent(<Breadcrumb items={breadcrumbItems} />);
     return () => setHeaderContent(null);
-  }, [setHeaderContent, project, workspace, projectId, current]);
+  }, [setHeaderContent, project, workspace, workspaces, projectId, current, pathname]);
 
   return null;
 }

--- a/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
+++ b/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
 import { Breadcrumb, BreadcrumbItem } from "@/components/layout/breadcrumb";
 import { useProject } from "../hooks";
 import { projectSwitchHref } from "../utils";
+import { CreateProjectDialog } from "./CreateProjectDialog";
+import { CreateWorkspaceDialog } from "@/features/workspaces/components";
 import { useWorkspace, useWorkspaces } from "@/features/workspaces/hooks";
 import { workspaceSwitchHref } from "@/features/workspaces/utils";
 
@@ -19,7 +21,8 @@ interface ProjectBreadcrumbProps {
  * Breadcrumb component for project context pages.
  * Automatically fetches project and workspace data and sets the header.
  * The workspace and project segments are dropdown selectors for quick
- * switching; selecting a project keeps the current sub-page where sensible.
+ * switching and creation; selecting a project keeps the current sub-page
+ * where sensible.
  *
  * Usage:
  * ```tsx
@@ -34,6 +37,8 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
   const { data: project } = useProject(projectId);
   const { data: workspaces } = useWorkspaces();
   const { data: workspace } = useWorkspace(project?.workspace_id || "", !!project?.workspace_id);
+  const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false);
+  const [createProjectOpen, setCreateProjectOpen] = useState(false);
 
   useEffect(() => {
     const breadcrumbItems: BreadcrumbItem[] = [
@@ -47,6 +52,7 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
           href: workspaceSwitchHref(pathname, ws.id),
         })),
         selectedId: project?.workspace_id,
+        createNew: { label: "New workspace", onSelect: () => setCreateWorkspaceOpen(true) },
       },
       {
         label: project?.name || "...",
@@ -57,6 +63,7 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
           href: projectSwitchHref(pathname, p.id),
         })),
         selectedId: projectId,
+        createNew: { label: "New project", onSelect: () => setCreateProjectOpen(true) },
       },
     ];
 
@@ -68,5 +75,16 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
     return () => setHeaderContent(null);
   }, [setHeaderContent, project, workspace, workspaces, projectId, current, pathname]);
 
-  return null;
+  return (
+    <>
+      <CreateWorkspaceDialog open={createWorkspaceOpen} onOpenChange={setCreateWorkspaceOpen} />
+      {project?.workspace_id && (
+        <CreateProjectDialog
+          workspaceId={project.workspace_id}
+          open={createProjectOpen}
+          onOpenChange={setCreateProjectOpen}
+        />
+      )}
+    </>
+  );
 }

--- a/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
+++ b/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
@@ -42,7 +42,6 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
 
   useEffect(() => {
     const breadcrumbItems: BreadcrumbItem[] = [
-      { label: "Workspaces", href: "/workspaces" },
       {
         label: workspace?.name || "...",
         href: `/workspaces/${project?.workspace_id}/projects`,
@@ -50,8 +49,9 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
           id: ws.id,
           label: ws.name,
           href: workspaceSwitchHref(pathname, ws.id),
+          settingsHref: `/workspaces/${ws.id}/settings`,
         })),
-        selectedId: project?.workspace_id,
+        menuHeader: { label: "Workspaces", href: "/workspaces" },
         createNew: { label: "New workspace", onSelect: () => setCreateWorkspaceOpen(true) },
       },
       {
@@ -61,8 +61,12 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
           id: p.id,
           label: p.name,
           href: projectSwitchHref(pathname, p.id),
+          settingsHref: `/projects/${p.id}/settings`,
         })),
-        selectedId: projectId,
+        menuHeader: {
+          label: "Projects",
+          href: `/workspaces/${project?.workspace_id}/projects`,
+        },
         createNew: { label: "New project", onSelect: () => setCreateProjectOpen(true) },
       },
     ];

--- a/frontend/ui/src/features/projects/utils/index.test.ts
+++ b/frontend/ui/src/features/projects/utils/index.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { projectSwitchHref } from "./index";
+
+describe("projectSwitchHref", () => {
+  it("preserves a top-level sub-page when switching projects", () => {
+    expect(projectSwitchHref("/projects/abc/traces", "xyz")).toBe("/projects/xyz/traces");
+    expect(projectSwitchHref("/projects/abc/sessions", "xyz")).toBe("/projects/xyz/sessions");
+    expect(projectSwitchHref("/projects/abc/dashboard", "xyz")).toBe("/projects/xyz/dashboard");
+  });
+
+  it("preserves settings sub-pages (they exist for every project)", () => {
+    expect(projectSwitchHref("/projects/abc/settings/general", "xyz")).toBe(
+      "/projects/xyz/settings/general",
+    );
+    expect(projectSwitchHref("/projects/abc/settings/accessKeys", "xyz")).toBe(
+      "/projects/xyz/settings/accessKeys",
+    );
+  });
+
+  it("drops entity-specific segments below the sub-page", () => {
+    expect(projectSwitchHref("/projects/abc/detectors/det-123", "xyz")).toBe(
+      "/projects/xyz/detectors",
+    );
+    expect(projectSwitchHref("/projects/abc/detectors/new", "xyz")).toBe("/projects/xyz/detectors");
+  });
+
+  it("falls back to traces when not on a project sub-page", () => {
+    expect(projectSwitchHref("/projects/abc", "xyz")).toBe("/projects/xyz/traces");
+    expect(projectSwitchHref("/workspaces/ws-1/projects", "xyz")).toBe("/projects/xyz/traces");
+    expect(projectSwitchHref("", "xyz")).toBe("/projects/xyz/traces");
+  });
+});

--- a/frontend/ui/src/features/projects/utils/index.ts
+++ b/frontend/ui/src/features/projects/utils/index.ts
@@ -14,6 +14,21 @@ export function formatProjectDate(dateString: string): string {
 }
 
 /**
+ * Build the destination URL for switching to another project, preserving the
+ * current sub-page where sensible. Settings sub-pages exist for every project
+ * so they are kept; entity-specific segments (e.g. a detector id) are dropped.
+ */
+export function projectSwitchHref(pathname: string, targetProjectId: string): string {
+  const match = pathname.match(/^\/projects\/[^/]+\/([^/]+)(?:\/([^/]+))?/);
+  if (!match) return `/projects/${targetProjectId}/traces`;
+  const [, subPage, nested] = match;
+  if (subPage === "settings" && nested) {
+    return `/projects/${targetProjectId}/settings/${nested}`;
+  }
+  return `/projects/${targetProjectId}/${subPage}`;
+}
+
+/**
  * Get display text for trace TTL
  */
 export function formatTraceTtl(days: number | null): string {

--- a/frontend/ui/src/features/workspaces/components/CreateWorkspaceDialog.tsx
+++ b/frontend/ui/src/features/workspaces/components/CreateWorkspaceDialog.tsx
@@ -18,10 +18,23 @@ import {
 
 interface CreateWorkspaceDialogProps {
   trigger?: React.ReactNode;
+  /** Controlled mode: when provided, no trigger is rendered. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
-export function CreateWorkspaceDialog({ trigger }: CreateWorkspaceDialogProps) {
-  const [open, setOpen] = useState(false);
+export function CreateWorkspaceDialog({
+  trigger,
+  open: controlledOpen,
+  onOpenChange,
+}: CreateWorkspaceDialogProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : uncontrolledOpen;
+  const setOpen = (next: boolean) => {
+    if (!isControlled) setUncontrolledOpen(next);
+    onOpenChange?.(next);
+  };
   const [name, setName] = useState("");
   const queryClient = useQueryClient();
 
@@ -43,7 +56,9 @@ export function CreateWorkspaceDialog({ trigger }: CreateWorkspaceDialogProps) {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{trigger || <AddButton>New Workspace</AddButton>}</DialogTrigger>
+      {!isControlled && (
+        <DialogTrigger asChild>{trigger || <AddButton>New Workspace</AddButton>}</DialogTrigger>
+      )}
       <DialogContent>
         <form onSubmit={handleSubmit}>
           <DialogHeader>

--- a/frontend/ui/src/features/workspaces/components/CreateWorkspaceDialog.tsx
+++ b/frontend/ui/src/features/workspaces/components/CreateWorkspaceDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createWorkspace } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -37,13 +38,15 @@ export function CreateWorkspaceDialog({
   };
   const [name, setName] = useState("");
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   const createMutation = useMutation({
     mutationFn: (name: string) => createWorkspace(name),
-    onSuccess: () => {
+    onSuccess: (workspace) => {
       queryClient.invalidateQueries({ queryKey: ["workspaces"] });
       setOpen(false);
       setName("");
+      router.push(`/workspaces/${workspace.id}/projects`);
     },
   });
 

--- a/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.tsx
+++ b/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.tsx
@@ -35,7 +35,6 @@ export function WorkspaceBreadcrumb({ workspaceId, current }: WorkspaceBreadcrum
 
   useEffect(() => {
     const breadcrumbItems: BreadcrumbItem[] = [
-      { label: "Workspaces", href: "/workspaces" },
       {
         label: workspace?.name || "...",
         href: current ? `/workspaces/${workspaceId}/projects` : undefined,
@@ -43,8 +42,9 @@ export function WorkspaceBreadcrumb({ workspaceId, current }: WorkspaceBreadcrum
           id: ws.id,
           label: ws.name,
           href: workspaceSwitchHref(pathname, ws.id),
+          settingsHref: `/workspaces/${ws.id}/settings`,
         })),
-        selectedId: workspaceId,
+        menuHeader: { label: "Workspaces", href: "/workspaces" },
         createNew: { label: "New workspace", onSelect: () => setCreateWorkspaceOpen(true) },
       },
     ];

--- a/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.tsx
+++ b/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { usePathname } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
 import { Breadcrumb, BreadcrumbItem } from "@/components/layout/breadcrumb";
 import { useWorkspace, useWorkspaces } from "../hooks";
 import { workspaceSwitchHref } from "../utils";
+import { CreateWorkspaceDialog } from "./CreateWorkspaceDialog";
 
 interface WorkspaceBreadcrumbProps {
   workspaceId: string;
@@ -16,8 +17,8 @@ interface WorkspaceBreadcrumbProps {
 /**
  * Breadcrumb component for workspace context pages.
  * Automatically fetches workspace data and sets the header.
- * The workspace segment is a dropdown selector for quick switching;
- * selecting a workspace keeps the current sub-page.
+ * The workspace segment is a dropdown selector for quick switching and
+ * creation; selecting a workspace keeps the current sub-page.
  *
  * Usage:
  * ```tsx
@@ -30,6 +31,7 @@ export function WorkspaceBreadcrumb({ workspaceId, current }: WorkspaceBreadcrum
   const pathname = usePathname();
   const { data: workspace } = useWorkspace(workspaceId);
   const { data: workspaces } = useWorkspaces();
+  const [createWorkspaceOpen, setCreateWorkspaceOpen] = useState(false);
 
   useEffect(() => {
     const breadcrumbItems: BreadcrumbItem[] = [
@@ -43,6 +45,7 @@ export function WorkspaceBreadcrumb({ workspaceId, current }: WorkspaceBreadcrum
           href: workspaceSwitchHref(pathname, ws.id),
         })),
         selectedId: workspaceId,
+        createNew: { label: "New workspace", onSelect: () => setCreateWorkspaceOpen(true) },
       },
     ];
 
@@ -54,5 +57,5 @@ export function WorkspaceBreadcrumb({ workspaceId, current }: WorkspaceBreadcrum
     return () => setHeaderContent(null);
   }, [setHeaderContent, workspace, workspaces, workspaceId, current, pathname]);
 
-  return null;
+  return <CreateWorkspaceDialog open={createWorkspaceOpen} onOpenChange={setCreateWorkspaceOpen} />;
 }

--- a/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.tsx
+++ b/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
 import { Breadcrumb, BreadcrumbItem } from "@/components/layout/breadcrumb";
-import { useWorkspace } from "../hooks";
+import { useWorkspace, useWorkspaces } from "../hooks";
+import { workspaceSwitchHref } from "../utils";
 
 interface WorkspaceBreadcrumbProps {
   workspaceId: string;
@@ -14,6 +16,8 @@ interface WorkspaceBreadcrumbProps {
 /**
  * Breadcrumb component for workspace context pages.
  * Automatically fetches workspace data and sets the header.
+ * The workspace segment is a dropdown selector for quick switching;
+ * selecting a workspace keeps the current sub-page.
  *
  * Usage:
  * ```tsx
@@ -23,7 +27,9 @@ interface WorkspaceBreadcrumbProps {
  */
 export function WorkspaceBreadcrumb({ workspaceId, current }: WorkspaceBreadcrumbProps) {
   const { setHeaderContent } = useLayout();
+  const pathname = usePathname();
   const { data: workspace } = useWorkspace(workspaceId);
+  const { data: workspaces } = useWorkspaces();
 
   useEffect(() => {
     const breadcrumbItems: BreadcrumbItem[] = [
@@ -31,6 +37,12 @@ export function WorkspaceBreadcrumb({ workspaceId, current }: WorkspaceBreadcrum
       {
         label: workspace?.name || "...",
         href: current ? `/workspaces/${workspaceId}/projects` : undefined,
+        options: workspaces?.map((ws) => ({
+          id: ws.id,
+          label: ws.name,
+          href: workspaceSwitchHref(pathname, ws.id),
+        })),
+        selectedId: workspaceId,
       },
     ];
 
@@ -40,7 +52,7 @@ export function WorkspaceBreadcrumb({ workspaceId, current }: WorkspaceBreadcrum
 
     setHeaderContent(<Breadcrumb items={breadcrumbItems} />);
     return () => setHeaderContent(null);
-  }, [setHeaderContent, workspace, workspaceId, current]);
+  }, [setHeaderContent, workspace, workspaces, workspaceId, current, pathname]);
 
   return null;
 }

--- a/frontend/ui/src/features/workspaces/utils/index.ts
+++ b/frontend/ui/src/features/workspaces/utils/index.ts
@@ -32,3 +32,13 @@ export function getRoleLabel(role: Role): string {
 export function isAdminRole(role: Role): boolean {
   return role === Role.ADMIN;
 }
+
+/**
+ * Build the destination URL for switching to another workspace, preserving
+ * the current workspace sub-page (e.g. settings) where possible.
+ */
+export function workspaceSwitchHref(pathname: string, targetWorkspaceId: string): string {
+  const match = pathname.match(/^\/workspaces\/[^/]+\/(.+)/);
+  if (!match) return `/workspaces/${targetWorkspaceId}/projects`;
+  return `/workspaces/${targetWorkspaceId}/${match[1]}`;
+}

--- a/frontend/ui/src/features/workspaces/utils/workspace-switch-href.test.ts
+++ b/frontend/ui/src/features/workspaces/utils/workspace-switch-href.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { workspaceSwitchHref } from "./index";
+
+describe("workspaceSwitchHref", () => {
+  it("preserves the current sub-page when switching workspaces", () => {
+    expect(workspaceSwitchHref("/workspaces/abc/projects", "xyz")).toBe("/workspaces/xyz/projects");
+    expect(workspaceSwitchHref("/workspaces/abc/settings/general", "xyz")).toBe(
+      "/workspaces/xyz/settings/general",
+    );
+    expect(workspaceSwitchHref("/workspaces/abc/settings/integrations", "xyz")).toBe(
+      "/workspaces/xyz/settings/integrations",
+    );
+  });
+
+  it("falls back to the projects page when not on a workspace sub-page", () => {
+    expect(workspaceSwitchHref("/workspaces/abc", "xyz")).toBe("/workspaces/xyz/projects");
+    expect(workspaceSwitchHref("/projects/p-1/traces", "xyz")).toBe("/workspaces/xyz/projects");
+    expect(workspaceSwitchHref("", "xyz")).toBe("/workspaces/xyz/projects");
+  });
+});


### PR DESCRIPTION
## Summary

Turns the top-bar breadcrumb segments into dropdown selectors so users can switch workspace and project without navigating away (closes #1117).

- New `dropdown-menu` UI primitive wrapping `@radix-ui/react-dropdown-menu` (the dependency already existed but had no wrapper).
- Breadcrumb reads `<workspace> ▾ / <project> ▾ [/ page]` with slash separators; triggers are plain label + chevron with no hover highlight, and all menu surfaces use square corners.
- Each dropdown contains: a bold header link (**Workspaces** → `/workspaces`, **Projects** → the workspace's projects page), a scrollable entity list (`max-h-36`) where each row navigates on click and has a settings-gear shortcut to that entity's settings, and a **+ New workspace / + New project** action that opens the existing create dialogs (extended with a controlled `open`/`onOpenChange` mode, backwards compatible).
- Creating a workspace/project now navigates to the new entity (workspace → its projects page, project → its traces page) from anywhere the dialogs are used.
- Switching a project preserves the current sub-page where sensible (`traces`/`sessions`/`users`/`dashboard`/`detectors`, and `settings/<tab>`); entity-specific segments fall back to the list page. Switching a workspace lands on that workspace's projects page (or keeps the settings tab on workspace settings pages).

## Testing

- Unit tests for the URL-preservation helpers (`projectSwitchHref`, `workspaceSwitchHref`); `tsc --noEmit`, eslint, prettier, and the vitest suite clean.
- Live-verified against the local stack: switching workspace/project from the dropdowns (including sub-page preservation), the settings gear navigating to entity settings without selecting the row, the bold header links, and the create flows landing on the newly created workspace/project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Video

https://github.com/user-attachments/assets/9330dc28-b2a8-4002-af22-8c20ce0686f9

