### PR TITLE
fix(ui): derive isProject in sidebar from project context

### DIFF
--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -64,6 +64,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   // Project/workspace context from the matched dynamic route params
   const projectId = params?.projectId ?? null;
   const workspaceId = params?.workspaceId ?? null;
+  const { isProject } = getProjectContext(pathname);
 
   // Settings target depends on context: project settings inside a project,
   // workspace settings inside a workspace, hidden elsewhere


### PR DESCRIPTION
## Summary

`main` currently crashes the layout on every page with `Uncaught ReferenceError: isProject is not defined` at `sidebar.tsx`. The sidebar-upgrade and workspace-settings-nav branches merged with a semantic conflict: the upgrade-button gating references `isProject`, while the hardening pass moved that logic into `getProjectContext()` (imported but never called), leaving the variable undefined.

One-line fix: derive `const { isProject } = getProjectContext(pathname)` alongside the existing route-param context.

## Testing

- `tsc --noEmit` goes from `error TS2304: Cannot find name 'isProject'` to clean.
- Verified on the local stack that pages render again (the layout previously crashed with the dev overlay's "This page couldn't load").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a layout crash by deriving `isProject` from project context in the sidebar. The sidebar now calls `getProjectContext(pathname)` and uses its `isProject` flag to gate the upgrade button, removing the undefined variable that broke every page.

<sup>Written for commit fc9bd870b66940bbf2aa2a0396635b56e8fa79dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

