### PR TITLE
feat(ui): widen the expanded left sidebar slightly

### DIFF
--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -79,7 +79,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
       <div
         className={cn(
           "flex h-screen shrink-0 flex-col border-r bg-background transition-all duration-200",
-          collapsed ? "w-14" : "w-40",
+          collapsed ? "w-14" : "w-48",
         )}
       >
         {isImpersonating && (


### PR DESCRIPTION
## Summary

Widens the expanded left navigation sidebar from `w-40` (160px) to `w-48` (192px) so nav labels and the workspace/upgrade rows have more breathing room. The collapsed width (`w-14`, 56px) is unchanged.

Closes #1125

## Changes

- `frontend/ui/src/components/layout/sidebar.tsx`: `collapsed ? "w-14" : "w-40"` → `collapsed ? "w-14" : "w-48"` (one line). The sidebar's existing `transition-all duration-200` picks up the new width; the main content is a `min-w-0 flex-1` panel next to a `shrink-0` sidebar, so no other layout offsets needed updating.

## Verification

- Live-checked in the browser: expanded sidebar measures exactly 192px with all labels uncramped; collapsed state still measures 56px; toggling animates smoothly and the main content edge tracks the sidebar in both states.
- `pnpm lint` and `tsc --noEmit` pass (no new issues).

Note: stacked on #1126, which carries the `isProject` sidebar fix this branch needs to build and render — merge #1126 first.

## Screenshots

# Before
<img width="1728" height="986" alt="Screenshot 2026-06-09 at 10 22 36 PM" src="https://github.com/user-attachments/assets/8e1fa43a-31e1-4af3-ad31-77ee17c58f83" />

# After
<img width="1728" height="990" alt="Screenshot 2026-06-09 at 10 22 30 PM" src="https://github.com/user-attachments/assets/36e7086b-73a2-4a4e-8c2b-c76562961283" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widened the expanded left sidebar from 160px (`w-40`) to 192px (`w-48`) for clearer labels (closes #1125). Reworked breadcrumbs so workspace/project segments are dropdown selectors with per-item settings and “New” actions; switching preserves sub-pages, create dialogs route to the new item, and a crash is fixed by deriving `isProject` from project context.

<sup>Written for commit ac34ccbb599c4a440a9a33c6564490f05c74e0d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




