### PR TITLE
feat(cli): scaffold standalone traceroot-cli package

### DIFF
--- a/.github/workflows/traceroot-cli-ci.yml
+++ b/.github/workflows/traceroot-cli-ci.yml
@@ -1,0 +1,43 @@
+name: traceroot-cli CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "traceroot-cli/**"
+      - ".github/workflows/traceroot-cli-ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "traceroot-cli/**"
+      - ".github/workflows/traceroot-cli-ci.yml"
+
+jobs:
+  build:
+    name: Build, Lint & Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: traceroot-cli
+    strategy:
+      matrix:
+        node-version: ["20", "22"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: traceroot-cli/package-lock.json
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm run lint
+
+      - run: npm run format:check
+
+      - run: npm test

--- a/.github/workflows/traceroot-cli-ci.yml
+++ b/.github/workflows/traceroot-cli-ci.yml
@@ -36,6 +36,10 @@ jobs:
 
       - run: npm run build
 
+      - run: npm run typecheck
+
+      - run: npm run typecheck:test
+
       - run: npm run lint
 
       - run: npm run format:check

--- a/traceroot-cli/.gitignore
+++ b/traceroot-cli/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+*.tsbuildinfo
+.DS_Store

--- a/traceroot-cli/.prettierrc
+++ b/traceroot-cli/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/traceroot-cli/README.md
+++ b/traceroot-cli/README.md
@@ -87,10 +87,10 @@ traceroot-cli/
 
 | Issue                      | Topic                                    |
 | -------------------------- | ---------------------------------------- |
-| [#1082](../../issues/1082) | This scaffold                            |
-| [#1083](../../issues/1083) | Config, auth resolution, output contract |
-| [#1084](../../issues/1084) | OpenAPI codegen                          |
-| [#1089](../../issues/1089) | Epic                                     |
+| [#1082](https://github.com/traceroot-ai/traceroot/issues/1082) | This scaffold                            |
+| [#1083](https://github.com/traceroot-ai/traceroot/issues/1083) | Config, auth resolution, output contract |
+| [#1084](https://github.com/traceroot-ai/traceroot/issues/1084) | OpenAPI codegen                          |
+| [#1089](https://github.com/traceroot-ai/traceroot/issues/1089) | Epic                                     |
 
 ## License
 

--- a/traceroot-cli/README.md
+++ b/traceroot-cli/README.md
@@ -1,0 +1,97 @@
+# traceroot-cli
+
+> **Status: scaffold** — command implementations are stubs; real behaviour lands in follow-on issues.
+
+Read-only CLI for [TraceRoot](https://traceroot.ai) — inspect traces, spans, and service health from your terminal.
+
+## Requirements
+
+- Node ≥ 20
+- A TraceRoot workspace and a personal access token
+
+## Installation
+
+```sh
+npm install -g traceroot-cli
+# or, without installing:
+npx traceroot-cli --help
+```
+
+## Usage
+
+```sh
+traceroot --help
+traceroot --version
+
+traceroot login token <TOKEN>      # save PAT to ~/.traceroot/config.json
+traceroot status                   # show auth status and active workspace
+
+traceroot traces list              # list recent traces (table)
+traceroot traces list --json       # newline-delimited JSON
+traceroot traces get <traceId>     # render a single trace as a span tree
+traceroot traces get <traceId> --json
+```
+
+### Environment variables
+
+| Variable              | Purpose                                            |
+| --------------------- | -------------------------------------------------- |
+| `TRACEROOT_TOKEN`     | Auth token (overrides `~/.traceroot/config.json`)  |
+| `TRACEROOT_API_URL`   | API base URL (default: `https://api.traceroot.ai`) |
+| `TRACEROOT_WORKSPACE` | Active workspace slug                              |
+| `NO_COLOR`            | Suppress all ANSI colour output                    |
+
+## Development
+
+```sh
+npm install
+npm run build        # compile TypeScript → dist/
+npm run typecheck    # type-check without emitting
+npm run lint         # ESLint
+npm run format       # Prettier (write)
+npm run format:check # Prettier (check only)
+npm test             # Vitest (requires build for bin integration tests)
+npm run test:watch   # Vitest in watch mode
+```
+
+## Architecture
+
+```
+traceroot-cli/
+  bin/traceroot.mjs          # thin ESM entry → dist/cli.js
+  src/
+    cli.ts                   # commander program; registers subcommands
+    output.ts                # stdout/stderr/exit-code/NO_COLOR contract
+    commands/
+      login.ts               # traceroot login [token]
+      status.ts              # traceroot status
+      traces.ts              # traceroot traces list / get
+    config/
+      schema.ts              # config shape + type guard
+      manager.ts             # ~/.traceroot/config.json read/write
+      resolve.ts             # auth resolution (env → config fallback)
+    api/
+      client.ts              # fetch-based HTTP client
+      generated/             # typed stubs (replaced by codegen in #1084)
+    render/
+      table.ts               # padded column table renderer
+      tree.ts                # span-tree renderer
+    util/
+      index.ts               # shared helpers (truncate, plural, …)
+  test/                      # Vitest, mirrors src/
+  scripts/                   # codegen + release helpers (see #1084)
+  openapi.json               # vendored public schema snapshot
+```
+
+## Related issues
+
+| Issue                      | Topic                                    |
+| -------------------------- | ---------------------------------------- |
+| [#1082](../../issues/1082) | This scaffold                            |
+| [#1083](../../issues/1083) | Config, auth resolution, output contract |
+| [#1084](../../issues/1084) | OpenAPI codegen                          |
+| [#1089](../../issues/1089) | Epic                                     |
+
+## License
+
+MIT

--- a/traceroot-cli/README.md
+++ b/traceroot-cli/README.md
@@ -85,8 +85,8 @@ traceroot-cli/
 
 ## Related issues
 
-| Issue                      | Topic                                    |
-| -------------------------- | ---------------------------------------- |
+| Issue                                                          | Topic                                    |
+| -------------------------------------------------------------- | ---------------------------------------- |
 | [#1082](https://github.com/traceroot-ai/traceroot/issues/1082) | This scaffold                            |
 | [#1083](https://github.com/traceroot-ai/traceroot/issues/1083) | Config, auth resolution, output contract |
 | [#1084](https://github.com/traceroot-ai/traceroot/issues/1084) | OpenAPI codegen                          |

--- a/traceroot-cli/bin/traceroot.mjs
+++ b/traceroot-cli/bin/traceroot.mjs
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+// Thin ESM entry-point — delegates to compiled TypeScript output.
+// Node >= 20 required (native fetch, structuredClone, etc.)
+import "../dist/cli.js";

--- a/traceroot-cli/eslint.config.mjs
+++ b/traceroot-cli/eslint.config.mjs
@@ -1,0 +1,22 @@
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
+      "@typescript-eslint/no-explicit-any": "warn",
+    },
+  },
+  {
+    ignores: ["node_modules/**", "dist/**", "coverage/**", "*.config.js"],
+  },
+];

--- a/traceroot-cli/openapi.json
+++ b/traceroot-cli/openapi.json
@@ -1,0 +1,24 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "TraceRoot Public API",
+    "version": "0.1.0",
+    "description": "Vendored snapshot of the TraceRoot public OpenAPI schema.\nThis file is updated by scripts/update-openapi.sh (see #1084)."
+  },
+  "paths": {},
+  "components": {
+    "schemas": {},
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "PAT"
+      }
+    }
+  },
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ]
+}

--- a/traceroot-cli/package-lock.json
+++ b/traceroot-cli/package-lock.json
@@ -1,0 +1,2805 @@
+{
+  "name": "traceroot-cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "traceroot-cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "chalk": "^5.4.1",
+        "commander": "^12.1.0"
+      },
+      "bin": {
+        "traceroot": "bin/traceroot.mjs"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.0.0",
+        "@types/node": "^22.0.0",
+        "eslint": "^9.0.0",
+        "prettier": "^3.5.0",
+        "typescript": "^5.8.0",
+        "typescript-eslint": "^8.0.0",
+        "vitest": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.61.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.61.1",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.60.1",
+        "@typescript-eslint/types": "^8.60.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.60.1",
+        "@typescript-eslint/tsconfig-utils": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "12.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.61.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.61.1",
+        "@rollup/rollup-android-arm64": "4.61.1",
+        "@rollup/rollup-darwin-arm64": "4.61.1",
+        "@rollup/rollup-darwin-x64": "4.61.1",
+        "@rollup/rollup-freebsd-arm64": "4.61.1",
+        "@rollup/rollup-freebsd-x64": "4.61.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
+        "@rollup/rollup-linux-arm64-musl": "4.61.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
+        "@rollup/rollup-linux-loong64-musl": "4.61.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-gnu": "4.61.1",
+        "@rollup/rollup-linux-x64-musl": "4.61.1",
+        "@rollup/rollup-openbsd-x64": "4.61.1",
+        "@rollup/rollup-openharmony-arm64": "4.61.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
+        "@rollup/rollup-win32-x64-gnu": "4.61.1",
+        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
+      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
+      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
+      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
+      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
+      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
+      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
+      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
+      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
+      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
+      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
+      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
+      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
+      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
+      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
+      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
+      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
+      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
+      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
+      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
+      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
+      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
+      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.61.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
+      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/rollup/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.60.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.60.1",
+        "@typescript-eslint/parser": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
+      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/type-utils": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.60.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/traceroot-cli/package.json
+++ b/traceroot-cli/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "traceroot-cli",
+  "version": "0.1.0",
+  "description": "TraceRoot CLI — read-only CLI for inspecting traces, spans, and service health",
+  "type": "module",
+  "engines": {
+    "node": ">=20"
+  },
+  "bin": {
+    "traceroot": "./bin/traceroot.mjs"
+  },
+  "files": [
+    "dist",
+    "bin",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src test",
+    "lint:fix": "eslint src test --fix",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "npm run build",
+    "pretest": "npm run build"
+  },
+  "dependencies": {
+    "chalk": "^5.4.1",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "@types/node": "^22.0.0",
+    "eslint": "^9.0.0",
+    "prettier": "^3.5.0",
+    "typescript": "^5.8.0",
+    "typescript-eslint": "^8.0.0",
+    "vitest": "^3.2.0"
+  }
+}

--- a/traceroot-cli/package.json
+++ b/traceroot-cli/package.json
@@ -18,6 +18,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "typecheck": "tsc --noEmit",
+    "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
     "lint": "eslint src test",
     "lint:fix": "eslint src test --fix",
     "format": "prettier --write .",

--- a/traceroot-cli/scripts/README.md
+++ b/traceroot-cli/scripts/README.md
@@ -1,0 +1,8 @@
+# scripts/
+
+Utility scripts for the `traceroot-cli` package.
+
+| Script              | Status                      | Purpose                                                                       |
+| ------------------- | --------------------------- | ----------------------------------------------------------------------------- |
+| `update-openapi.sh` | Not yet implemented (#1084) | Fetch the latest public OpenAPI schema into `openapi.json`                    |
+| `codegen.ts`        | Not yet implemented (#1084) | Generate typed API client types from `openapi.json` into `src/api/generated/` |

--- a/traceroot-cli/src/api/client.ts
+++ b/traceroot-cli/src/api/client.ts
@@ -69,9 +69,17 @@ export class ApiClient {
     if (!response.ok) {
       let errBody: unknown;
       try {
-        errBody = await response.json();
+        // Read as text first — response.json() consumes the body stream,
+        // making a subsequent .text() call throw.  Non-JSON bodies (HTML
+        // error pages, plain text) are common from proxies and gateways.
+        const raw = await response.text();
+        try {
+          errBody = JSON.parse(raw);
+        } catch {
+          errBody = raw;
+        }
       } catch {
-        errBody = await response.text();
+        // Body already consumed or network error — leave as undefined.
       }
       throw new ApiError(response.status, response.statusText, errBody);
     }

--- a/traceroot-cli/src/api/client.ts
+++ b/traceroot-cli/src/api/client.ts
@@ -1,0 +1,93 @@
+/**
+ * Thin HTTP client built on native fetch (Node >= 20).
+ *
+ * Design decisions:
+ *  - No axios or node-fetch — Node 20 global fetch is sufficient.
+ *  - ApiError carries status code and raw body for callers to handle.
+ *  - Timeout is implemented with AbortController so it works with any fetch.
+ *  - All methods are generic so callers can type the response against
+ *    the generated types in src/api/generated/.
+ */
+
+export class ApiError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    public readonly body?: unknown,
+  ) {
+    super(`HTTP ${statusCode}: ${message}`);
+    this.name = "ApiError";
+  }
+}
+
+export interface ApiClientOptions {
+  apiUrl: string;
+  token: string;
+  /** Request timeout in milliseconds. Default: 30 000. */
+  timeoutMs?: number;
+}
+
+export class ApiClient {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+
+  constructor({ apiUrl, token, timeoutMs = 30_000 }: ApiClientOptions) {
+    // Strip trailing slash so path concatenation is consistent.
+    this.baseUrl = apiUrl.replace(/\/$/, "");
+    this.token = token;
+    this.timeoutMs = timeoutMs;
+  }
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+
+    let response: Response;
+    try {
+      response = await fetch(url, {
+        method,
+        signal: controller.signal,
+        headers: {
+          Authorization: `Bearer ${this.token}`,
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "User-Agent": "traceroot-cli/0.1.0",
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new ApiError(0, `Request timed out after ${this.timeoutMs}ms`);
+      }
+      throw new ApiError(0, err instanceof Error ? err.message : String(err));
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      let errBody: unknown;
+      try {
+        errBody = await response.json();
+      } catch {
+        errBody = await response.text();
+      }
+      throw new ApiError(response.status, response.statusText, errBody);
+    }
+
+    if (response.status === 204 || response.headers.get("content-length") === "0") {
+      return undefined as T;
+    }
+
+    return response.json() as Promise<T>;
+  }
+
+  get<T>(path: string): Promise<T> {
+    return this.request<T>("GET", path);
+  }
+
+  post<T>(path: string, body: unknown): Promise<T> {
+    return this.request<T>("POST", path, body);
+  }
+}

--- a/traceroot-cli/src/api/generated/index.ts
+++ b/traceroot-cli/src/api/generated/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Typed stubs for the TraceRoot public API.
+ *
+ * NOT YET GENERATED — these are hand-written placeholders that will be
+ * replaced by codegen output in #1084 (Vendor public OpenAPI schema and
+ * generate typed client). Run `npm run codegen` once that lands.
+ */
+
+export interface Trace {
+  traceId: string;
+  rootSpanId: string;
+  startTime: string;
+  endTime: string;
+  durationMs: number;
+  rootServiceName: string;
+  rootName: string;
+  status: "ok" | "error" | "unset";
+}
+
+export interface Span {
+  spanId: string;
+  parentSpanId?: string;
+  traceId: string;
+  name: string;
+  serviceName: string;
+  startTime: string;
+  endTime: string;
+  durationMs: number;
+  status: "ok" | "error" | "unset";
+  attributes?: Record<string, string | number | boolean>;
+}
+
+export interface ListTracesResponse {
+  traces: Trace[];
+  nextCursor?: string;
+}
+
+export interface GetTraceResponse {
+  trace: Trace;
+  spans: Span[];
+}

--- a/traceroot-cli/src/cli.ts
+++ b/traceroot-cli/src/cli.ts
@@ -1,0 +1,26 @@
+import { Command } from "commander";
+import { createRequire } from "module";
+import { registerLogin } from "./commands/login.js";
+import { registerStatus } from "./commands/status.js";
+import { registerTraces } from "./commands/traces.js";
+import { fatal } from "./output.js";
+
+// Read version from package.json without top-level await or JSON import assertions.
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
+
+const program = new Command();
+
+program
+  .name("traceroot")
+  .description("TraceRoot CLI — inspect traces, spans, and service health")
+  .version(version, "-V, --version", "Print version and exit")
+  .helpOption("-h, --help", "Display help for command");
+
+registerLogin(program);
+registerStatus(program);
+registerTraces(program);
+
+program.parseAsync(process.argv).catch((err: unknown) => {
+  fatal(err instanceof Error ? err.message : String(err));
+});

--- a/traceroot-cli/src/commands/login.ts
+++ b/traceroot-cli/src/commands/login.ts
@@ -1,0 +1,18 @@
+import type { Command } from "commander";
+import { notImplemented } from "../output.js";
+
+/**
+ * Registers the `traceroot login` command group.
+ *
+ * Subcommands:
+ *   traceroot login   — read a personal access token from stdin and persist
+ *                       it to ~/.traceroot/config.json
+ *
+ * Real implementation lands in #1083.
+ */
+export function registerLogin(program: Command): void {
+  program
+    .command("login")
+    .description("Authenticate with a TraceRoot workspace (reads token from stdin)")
+    .action(() => notImplemented("login"));
+}

--- a/traceroot-cli/src/commands/status.ts
+++ b/traceroot-cli/src/commands/status.ts
@@ -1,0 +1,15 @@
+import type { Command } from "commander";
+import { notImplemented } from "../output.js";
+
+/**
+ * Registers the `traceroot status` command.
+ * Shows current auth status and the active workspace.
+ *
+ * Real implementation lands in #1083.
+ */
+export function registerStatus(program: Command): void {
+  program
+    .command("status")
+    .description("Show current auth status and active workspace")
+    .action(() => notImplemented("status"));
+}

--- a/traceroot-cli/src/commands/traces.ts
+++ b/traceroot-cli/src/commands/traces.ts
@@ -1,0 +1,33 @@
+import type { Command } from "commander";
+import { notImplemented } from "../output.js";
+
+/**
+ * Registers the `traceroot traces` command group.
+ *
+ * Subcommands:
+ *   traceroot traces list              — list recent traces as a table
+ *   traceroot traces list --json       — newline-delimited JSON
+ *   traceroot traces get <traceId>     — render span tree
+ *   traceroot traces get <traceId> --json
+ *
+ * Real implementation lands in a follow-on issue.
+ */
+export function registerTraces(program: Command): void {
+  const traces = program.command("traces").description("Inspect distributed traces");
+
+  traces
+    .command("list")
+    .description("List recent traces")
+    .option("-n, --limit <n>", "Maximum number of traces to return", (v) => parseInt(v, 10), 20)
+    .option("--service <name>", "Filter by service name")
+    .option("--from <iso>", "Start of time range (ISO 8601)")
+    .option("--to <iso>", "End of time range (ISO 8601)")
+    .option("--json", "Emit newline-delimited JSON instead of a table")
+    .action(() => notImplemented("traces list"));
+
+  traces
+    .command("get <traceId>")
+    .description("Fetch a single trace and render its span tree")
+    .option("--json", "Emit raw JSON instead of a tree")
+    .action(() => notImplemented("traces get"));
+}

--- a/traceroot-cli/src/config/manager.ts
+++ b/traceroot-cli/src/config/manager.ts
@@ -1,0 +1,58 @@
+import { homedir } from "os";
+import { join } from "path";
+import { readFileSync, mkdirSync, existsSync, openSync, writeSync, closeSync } from "fs";
+import { type TraceRootConfig, DEFAULT_API_URL, isValidConfig } from "./schema.js";
+
+export const CONFIG_DIR = join(homedir(), ".traceroot");
+export const CONFIG_FILE = join(CONFIG_DIR, "config.json");
+
+let dirEnsured = false;
+
+/**
+ * Read config from disk.
+ * Returns sensible defaults if the file is absent or contains malformed JSON.
+ */
+export function readConfig(): TraceRootConfig {
+  if (!existsSync(CONFIG_FILE)) {
+    return { apiUrl: DEFAULT_API_URL };
+  }
+  try {
+    const raw = readFileSync(CONFIG_FILE, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (isValidConfig(parsed)) return parsed;
+  } catch {
+    // Malformed JSON — fall back to defaults silently.
+  }
+  return { apiUrl: DEFAULT_API_URL };
+}
+
+/**
+ * Persist config to disk.
+ * Creates ~/.traceroot/ if it does not already exist.
+ */
+export function writeConfig(config: TraceRootConfig): void {
+  if (!dirEnsured) {
+    mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
+    dirEnsured = true;
+  }
+  // Write with restrictive permissions from the start so the file is never
+  // world-readable, even briefly.  mode 0o600 = owner read+write only.
+  const data = JSON.stringify(config, null, 2) + "\n";
+  const fd = openSync(CONFIG_FILE, "w", 0o600);
+  try {
+    writeSync(fd, data, 0, "utf8");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * Merge a partial update into the existing config and persist.
+ * Returns the merged config.
+ */
+export function updateConfig(patch: Partial<TraceRootConfig>): TraceRootConfig {
+  const current = readConfig();
+  const next: TraceRootConfig = { ...current, ...patch };
+  writeConfig(next);
+  return next;
+}

--- a/traceroot-cli/src/config/manager.ts
+++ b/traceroot-cli/src/config/manager.ts
@@ -50,7 +50,7 @@ export function writeConfig(config: TraceRootConfig): void {
   // Write atomically via a temp file so an interrupted write never leaves
   // a truncated config.  renameSync is atomic on the same filesystem.
   const data = JSON.stringify(config, null, 2) + "\n";
-  const tmp = CONFIG_FILE + ".tmp";
+  const tmp = CONFIG_FILE + ".tmp." + Date.now() + "." + process.pid;
   const fd = openSync(tmp, "w", 0o600);
   try {
     writeSync(fd, data, 0, "utf8");

--- a/traceroot-cli/src/config/manager.ts
+++ b/traceroot-cli/src/config/manager.ts
@@ -1,6 +1,15 @@
 import { homedir } from "os";
 import { join } from "path";
-import { readFileSync, mkdirSync, existsSync, openSync, writeSync, closeSync } from "fs";
+import {
+  readFileSync,
+  mkdirSync,
+  existsSync,
+  openSync,
+  writeSync,
+  closeSync,
+  renameSync,
+  chmodSync,
+} from "fs";
 import { type TraceRootConfig, DEFAULT_API_URL, isValidConfig } from "./schema.js";
 
 export const CONFIG_DIR = join(homedir(), ".traceroot");
@@ -20,8 +29,11 @@ export function readConfig(): TraceRootConfig {
     const raw = readFileSync(CONFIG_FILE, "utf8");
     const parsed: unknown = JSON.parse(raw);
     if (isValidConfig(parsed)) return parsed;
-  } catch {
-    // Malformed JSON — fall back to defaults silently.
+  } catch (err) {
+    // Re-throw filesystem errors (permission denied, etc.). Only swallow
+    // JSON syntax errors and shape mismatches — those are recoverable by
+    // falling back to defaults.
+    if (!(err instanceof SyntaxError)) throw err;
   }
   return { apiUrl: DEFAULT_API_URL };
 }
@@ -35,15 +47,21 @@ export function writeConfig(config: TraceRootConfig): void {
     mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
     dirEnsured = true;
   }
-  // Write with restrictive permissions from the start so the file is never
-  // world-readable, even briefly.  mode 0o600 = owner read+write only.
+  // Write atomically via a temp file so an interrupted write never leaves
+  // a truncated config.  renameSync is atomic on the same filesystem.
   const data = JSON.stringify(config, null, 2) + "\n";
-  const fd = openSync(CONFIG_FILE, "w", 0o600);
+  const tmp = CONFIG_FILE + ".tmp";
+  const fd = openSync(tmp, "w", 0o600);
   try {
     writeSync(fd, data, 0, "utf8");
   } finally {
     closeSync(fd);
   }
+  renameSync(tmp, CONFIG_FILE);
+  // Enforce restrictive permissions on every write.  openSync mode only
+  // applies when the file is created; an existing file keeps its old mode,
+  // which may have been relaxed by another tool or a prior version.
+  chmodSync(CONFIG_FILE, 0o600);
 }
 
 /**

--- a/traceroot-cli/src/config/resolve.ts
+++ b/traceroot-cli/src/config/resolve.ts
@@ -11,6 +11,8 @@
  */
 
 import { readConfig } from "./manager.js";
+import { DEFAULT_API_URL } from "./schema.js";
+import type { TraceRootConfig } from "./schema.js";
 import { fatal } from "../output.js";
 
 export interface ResolvedAuth {
@@ -26,7 +28,15 @@ export interface ResolvedAuth {
  * Returns null when no token is available (user is unauthenticated).
  */
 export function resolveAuth(): ResolvedAuth | null {
-  const config = readConfig();
+  // Try to read config but never let a broken config file block env-auth.
+  // TRACEROOT_TOKEN has highest precedence and must work even when
+  // ~/.traceroot/config.json is missing or unreadable.
+  let config: TraceRootConfig;
+  try {
+    config = readConfig();
+  } catch {
+    config = { apiUrl: DEFAULT_API_URL };
+  }
   const apiUrl = process.env["TRACEROOT_API_URL"] || config.apiUrl;
   const workspace = process.env["TRACEROOT_WORKSPACE"] || config.workspace;
 

--- a/traceroot-cli/src/config/resolve.ts
+++ b/traceroot-cli/src/config/resolve.ts
@@ -1,0 +1,55 @@
+/**
+ * Auth resolution for the CLI.
+ *
+ * Priority (highest first):
+ *   1. TRACEROOT_TOKEN environment variable
+ *   2. token field in ~/.traceroot/config.json
+ *
+ * API URL and workspace follow the same precedence:
+ *   1. TRACEROOT_API_URL / TRACEROOT_WORKSPACE env vars
+ *   2. apiUrl / workspace fields in config
+ */
+
+import { readConfig } from "./manager.js";
+import { fatal } from "../output.js";
+
+export interface ResolvedAuth {
+  apiUrl: string;
+  token: string;
+  workspace?: string;
+  /** Where the token was found — useful for `traceroot status` output. */
+  source: "env" | "config";
+}
+
+/**
+ * Attempt to resolve auth credentials.
+ * Returns null when no token is available (user is unauthenticated).
+ */
+export function resolveAuth(): ResolvedAuth | null {
+  const config = readConfig();
+  const apiUrl = process.env["TRACEROOT_API_URL"] || config.apiUrl;
+  const workspace = process.env["TRACEROOT_WORKSPACE"] || config.workspace;
+
+  const envToken = process.env["TRACEROOT_TOKEN"];
+  if (envToken) {
+    return { apiUrl, token: envToken, workspace, source: "env" };
+  }
+
+  if (config.token) {
+    return { apiUrl, token: config.token, workspace, source: "config" };
+  }
+
+  return null;
+}
+
+/**
+ * Like resolveAuth() but exits with a helpful message when no token is found.
+ * Use this in command actions that require authentication.
+ */
+export function requireAuth(): ResolvedAuth {
+  const auth = resolveAuth();
+  if (!auth) {
+    fatal("not authenticated — run `traceroot login token <TOKEN>` or set TRACEROOT_TOKEN");
+  }
+  return auth;
+}

--- a/traceroot-cli/src/config/schema.ts
+++ b/traceroot-cli/src/config/schema.ts
@@ -1,0 +1,27 @@
+/**
+ * Shape and validation for ~/.traceroot/config.json.
+ *
+ * Intentionally dependency-free — no Zod or ajv — to keep the package lean.
+ * A hand-written type guard is sufficient for a flat config with two fields.
+ */
+
+export interface TraceRootConfig {
+  /** Base URL of the TraceRoot API, e.g. https://api.traceroot.ai */
+  apiUrl: string;
+  /** Active workspace slug */
+  workspace?: string;
+  /** Personal access token (written by `traceroot login token`) */
+  token?: string;
+}
+
+export const DEFAULT_API_URL = "https://api.traceroot.ai";
+
+/** Type guard — validates that an unknown value is a well-formed TraceRootConfig. */
+export function isValidConfig(value: unknown): value is TraceRootConfig {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj["apiUrl"] !== "string") return false;
+  if ("workspace" in obj && typeof obj["workspace"] !== "string") return false;
+  if ("token" in obj && typeof obj["token"] !== "string") return false;
+  return true;
+}

--- a/traceroot-cli/src/output.ts
+++ b/traceroot-cli/src/output.ts
@@ -1,0 +1,58 @@
+/**
+ * Canonical stdout / stderr / exit-code contract for the CLI.
+ *
+ * Rules:
+ *  - All user-facing output goes through these helpers — never bare console.log.
+ *  - Colour is suppressed when the NO_COLOR env var is set or TERM is "dumb".
+ *  - stderr is reserved for diagnostics (errors, warnings, progress).
+ *  - stdout carries only machine-readable or table output so it can be piped.
+ */
+
+import chalk from "chalk";
+
+const NO_COLOR =
+  "NO_COLOR" in process.env || process.env["TERM"] === "dumb" || !process.stdout.isTTY;
+
+if (NO_COLOR) {
+  chalk.level = 0;
+}
+
+/** Write a line to stdout. */
+export function println(line: string): void {
+  process.stdout.write(line + "\n");
+}
+
+/** Write a line to stderr. */
+export function eprintln(line: string): void {
+  process.stderr.write(line + "\n");
+}
+
+/** Write a red "error: <message>" line to stderr. */
+export function printError(message: string): void {
+  eprintln(chalk.red(`error: ${message}`));
+}
+
+/** Write a yellow "warn: <message>" line to stderr. */
+export function printWarn(message: string): void {
+  eprintln(chalk.yellow(`warn: ${message}`));
+}
+
+function _exit(code: number): never {
+  process.exitCode = code;
+  process.exit(code);
+}
+
+/**
+ * Write a "<command>: not yet implemented" message to stderr and exit 1.
+ * Used by stub command actions until their issues land.
+ */
+export function notImplemented(command: string): never {
+  eprintln(`${command}: not yet implemented`);
+  _exit(1);
+}
+
+/** Write an error message to stderr and exit with the given code (default 1). */
+export function fatal(message: string, exitCode = 1): never {
+  printError(message);
+  _exit(exitCode);
+}

--- a/traceroot-cli/src/render/table.ts
+++ b/traceroot-cli/src/render/table.ts
@@ -1,0 +1,43 @@
+/**
+ * Minimal dependency-free table renderer for terminal output.
+ *
+ * Deliberately avoids cli-table3 / columnify to keep the dependency surface
+ * small. Sufficient for listing traces in V1.
+ */
+
+export interface Column<T> {
+  header: string;
+  /** Extract the display string for a cell from a row object. */
+  accessor: (row: T) => string;
+  /** Minimum column width (characters). Defaults to header length. */
+  minWidth?: number;
+}
+
+function pad(s: string, w: number): string {
+  return s.padEnd(w, " ");
+}
+
+/**
+ * Render an array of objects as a padded plain-text table.
+ *
+ * @returns A string ending with "\n", ready for process.stdout.write().
+ */
+export function renderTable<T>(rows: T[], columns: Column<T>[]): string {
+  if (rows.length === 0) {
+    return "(no results)\n";
+  }
+
+  // Compute column widths — maximum of header length, minWidth, and data lengths.
+  const widths = columns.map((col) => {
+    const base = Math.max(col.minWidth ?? 0, col.header.length);
+    return rows.reduce((max, row) => Math.max(max, col.accessor(row).length), base);
+  });
+
+  const sep = widths.map((w) => "-".repeat(w)).join("  ");
+  const header = columns.map((col, i) => pad(col.header, widths[i]!)).join("  ");
+  const dataRows = rows.map((row) =>
+    columns.map((col, i) => pad(col.accessor(row), widths[i]!)).join("  "),
+  );
+
+  return [header, sep, ...dataRows].join("\n") + "\n";
+}

--- a/traceroot-cli/src/render/tree.ts
+++ b/traceroot-cli/src/render/tree.ts
@@ -1,0 +1,66 @@
+/**
+ * Span-tree renderer for `traceroot traces get`.
+ *
+ * Renders a depth-first tree of spans using box-drawing characters.
+ * Output is a plain string so callers can write it to stdout or capture it
+ * in tests without mocking any I/O.
+ */
+
+export interface SpanNode {
+  spanId: string;
+  name: string;
+  service?: string;
+  durationMs?: number;
+  status?: "ok" | "error" | "unset";
+  children: SpanNode[];
+}
+
+const BRANCH = "├── ";
+const LAST = "└── ";
+const PIPE = "│   ";
+const SPACE = "    ";
+const MAX_DEPTH = 200;
+
+/**
+ * Render a span tree to a multi-line string ending with "\n".
+ */
+export function renderTree(root: SpanNode): string {
+  const lines: string[] = [];
+  renderNode(root, "", true, lines, true);
+  return lines.join("\n") + "\n";
+}
+
+function renderNode(
+  node: SpanNode,
+  prefix: string,
+  isLast: boolean,
+  lines: string[],
+  isRoot: boolean,
+  depth = 0,
+): void {
+  if (depth > MAX_DEPTH) {
+    lines.push(`${prefix}... (truncated, max depth ${MAX_DEPTH})`);
+    return;
+  }
+
+  const label = formatLabel(node);
+
+  if (isRoot) {
+    lines.push(label);
+  } else {
+    lines.push(`${prefix}${isLast ? LAST : BRANCH}${label}`);
+  }
+
+  const childPrefix = isRoot ? "" : prefix + (isLast ? SPACE : PIPE);
+  node.children.forEach((child, idx) => {
+    renderNode(child, childPrefix, idx === node.children.length - 1, lines, false, depth + 1);
+  });
+}
+
+function formatLabel(node: SpanNode): string {
+  const parts: string[] = [node.name];
+  if (node.service) parts.push(`[${node.service}]`);
+  if (node.durationMs !== undefined) parts.push(`${node.durationMs}ms`);
+  if (node.status === "error") parts.push("ERROR");
+  return parts.join(" ");
+}

--- a/traceroot-cli/src/render/tree.ts
+++ b/traceroot-cli/src/render/tree.ts
@@ -57,9 +57,16 @@ function renderNode(
   });
 }
 
+/** Strip control characters that could break terminal layout or inject
+ * ANSI escape sequences.  Keeps printable Unicode, tabs, and spaces. */
+function sanitize(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+}
+
 function formatLabel(node: SpanNode): string {
-  const parts: string[] = [node.name];
-  if (node.service) parts.push(`[${node.service}]`);
+  const parts: string[] = [sanitize(node.name)];
+  if (node.service) parts.push(`[${sanitize(node.service)}]`);
   if (node.durationMs !== undefined) parts.push(`${node.durationMs}ms`);
   if (node.status === "error") parts.push("ERROR");
   return parts.join(" ");

--- a/traceroot-cli/src/render/tree.ts
+++ b/traceroot-cli/src/render/tree.ts
@@ -61,7 +61,7 @@ function renderNode(
  * ANSI escape sequences.  Keeps printable Unicode, tabs, and spaces. */
 function sanitize(s: string): string {
   // eslint-disable-next-line no-control-regex
-  return s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "");
+  return s.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F\n\r]/g, "");
 }
 
 function formatLabel(node: SpanNode): string {

--- a/traceroot-cli/src/util/index.ts
+++ b/traceroot-cli/src/util/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared utility helpers.
+ * Keep this module lean — add utilities here as the codebase grows.
+ */
+
+/** Format an ISO 8601 timestamp to a short locale-aware string. */
+export function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
+/** Truncate a string to maxLen, appending "…" if it was longer. */
+export function truncate(s: string, maxLen: number): string {
+  return s.length <= maxLen ? s : s.slice(0, maxLen - 1) + "…";
+}
+
+/** Return the correct singular or plural form based on count. */
+export function plural(count: number, singular: string, pluralForm?: string): string {
+  return count === 1 ? singular : (pluralForm ?? `${singular}s`);
+}
+
+/** Convert milliseconds to a human-readable duration string, e.g. "1.23s", "45ms". */
+export function formatDuration(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${ms}ms`;
+}

--- a/traceroot-cli/test/cli.test.ts
+++ b/traceroot-cli/test/cli.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Integration tests for the compiled binary.
+ *
+ * These tests run the actual `bin/traceroot.mjs` via Node so they exercise
+ * the real commander wiring.  They require `npm run build` to have been run
+ * first (dist/ must exist).  In CI, the build step always precedes this suite.
+ * Locally, `npm test` triggers a build via the pretest hook.
+ */
+
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "child_process";
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BIN = join(__dirname, "..", "bin", "traceroot.mjs");
+const DIST = join(__dirname, "..", "dist", "cli.js");
+const PKG_VERSION = (
+  JSON.parse(readFileSync(join(__dirname, "..", "package.json"), "utf8")) as {
+    version: string;
+  }
+).version;
+
+/** Run the binary with the given args, returning stdout, stderr, and exit code. */
+function run(args: string[]): { stdout: string; stderr: string; code: number } {
+  const result = spawnSync(process.execPath, [BIN, ...args], { encoding: "utf8" });
+  return {
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    code: result.status ?? 1,
+  };
+}
+
+const distExists = existsSync(DIST);
+
+describe.skipIf(!distExists)("traceroot --help", () => {
+  it("exits 0 and includes 'Usage:'", () => {
+    const { stdout, code } = run(["--help"]);
+    expect(code).toBe(0);
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("traceroot");
+  });
+
+  it("lists all registered subcommands", () => {
+    const { stdout } = run(["--help"]);
+    expect(stdout).toContain("login");
+    expect(stdout).toContain("status");
+    expect(stdout).toContain("traces");
+  });
+});
+
+describe.skipIf(!distExists)("traceroot --version", () => {
+  it("prints the package.json version and exits 0", () => {
+    const { stdout, code } = run(["--version"]);
+    expect(code).toBe(0);
+    expect(stdout.trim()).toBe(PKG_VERSION);
+  });
+});
+
+describe.skipIf(!distExists)("stub commands", () => {
+  it("traceroot status exits 1 with 'not yet implemented'", () => {
+    const { stderr, code } = run(["status"]);
+    expect(code).toBe(1);
+    expect(stderr).toContain("not yet implemented");
+  });
+
+  it("traceroot traces list exits 1 with 'not yet implemented'", () => {
+    const { stderr, code } = run(["traces", "list"]);
+    expect(code).toBe(1);
+    expect(stderr).toContain("not yet implemented");
+  });
+});

--- a/traceroot-cli/test/output.test.ts
+++ b/traceroot-cli/test/output.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { println, eprintln, printError, printWarn, notImplemented, fatal } from "../src/output.js";
+
+describe("output helpers", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(process, "exit").mockImplementation((_code?: number) => {
+      throw new Error(`process.exit(${_code ?? "undefined"})`);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("println writes to stdout with trailing newline", () => {
+    println("hello");
+    expect(stdoutSpy).toHaveBeenCalledWith("hello\n");
+  });
+
+  it("eprintln writes to stderr with trailing newline", () => {
+    eprintln("oops");
+    expect(stderrSpy).toHaveBeenCalledWith("oops\n");
+  });
+
+  it("printError prefixes message with 'error:'", () => {
+    printError("something broke");
+    expect(stderrSpy).toHaveBeenCalledWith("error: something broke\n");
+  });
+
+  it("printWarn prefixes message with 'warn:'", () => {
+    printWarn("watch out");
+    expect(stderrSpy).toHaveBeenCalledWith("warn: watch out\n");
+  });
+
+  it("notImplemented writes to stderr and calls process.exit(1)", () => {
+    expect(() => notImplemented("foo bar")).toThrow("process.exit(1)");
+    expect(stderrSpy).toHaveBeenCalledWith("foo bar: not yet implemented\n");
+  });
+
+  it("fatal writes an error message and exits with the given code", () => {
+    expect(() => fatal("critical failure", 2)).toThrow("process.exit(2)");
+    expect(stderrSpy).toHaveBeenCalledWith("error: critical failure\n");
+  });
+
+  it("fatal defaults to exit code 1", () => {
+    expect(() => fatal("boom")).toThrow("process.exit(1)");
+  });
+});

--- a/traceroot-cli/test/output.test.ts
+++ b/traceroot-cli/test/output.test.ts
@@ -2,14 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { println, eprintln, printError, printWarn, notImplemented, fatal } from "../src/output.js";
 
 describe("output helpers", () => {
-  let stdoutSpy: ReturnType<typeof vi.spyOn>;
-  let stderrSpy: ReturnType<typeof vi.spyOn>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stdoutSpy: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let stderrSpy: any;
 
   beforeEach(() => {
     stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    vi.spyOn(process, "exit").mockImplementation((_code?: number) => {
-      throw new Error(`process.exit(${_code ?? "undefined"})`);
+    vi.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
+      throw new Error(`process.exit(${code ?? "undefined"})`);
     });
   });
 

--- a/traceroot-cli/test/render/table.test.ts
+++ b/traceroot-cli/test/render/table.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { renderTable, type Column } from "../../src/render/table.js";
+
+interface Row {
+  id: string;
+  name: string;
+}
+
+const COLUMNS: Column<Row>[] = [
+  { header: "ID", accessor: (r) => r.id },
+  { header: "NAME", accessor: (r) => r.name },
+];
+
+describe("renderTable", () => {
+  it("returns a no-results message for an empty array", () => {
+    expect(renderTable([], COLUMNS)).toBe("(no results)\n");
+  });
+
+  it("includes headers in the output", () => {
+    const result = renderTable([{ id: "1", name: "span-a" }], COLUMNS);
+    expect(result).toContain("ID");
+    expect(result).toContain("NAME");
+  });
+
+  it("includes a separator row between header and data", () => {
+    const result = renderTable([{ id: "1", name: "span-a" }], COLUMNS);
+    expect(result).toMatch(/[-]+/);
+  });
+
+  it("includes row data in the output", () => {
+    const result = renderTable([{ id: "abc123", name: "my-span" }], COLUMNS);
+    expect(result).toContain("abc123");
+    expect(result).toContain("my-span");
+  });
+
+  it("pads all lines to the same length", () => {
+    const rows: Row[] = [
+      { id: "short", name: "x" },
+      { id: "much-longer-id", name: "y" },
+    ];
+    const result = renderTable(rows, COLUMNS);
+    const lines = result.split("\n").filter(Boolean);
+    const lengths = new Set(lines.map((l) => l.length));
+    expect(lengths.size).toBe(1);
+  });
+
+  it("renders multiple rows", () => {
+    const rows: Row[] = [
+      { id: "1", name: "alpha" },
+      { id: "2", name: "beta" },
+      { id: "3", name: "gamma" },
+    ];
+    const result = renderTable(rows, COLUMNS);
+    expect(result).toContain("alpha");
+    expect(result).toContain("beta");
+    expect(result).toContain("gamma");
+  });
+});

--- a/traceroot-cli/test/render/table.test.ts
+++ b/traceroot-cli/test/render/table.test.ts
@@ -24,7 +24,7 @@ describe("renderTable", () => {
 
   it("includes a separator row between header and data", () => {
     const result = renderTable([{ id: "1", name: "span-a" }], COLUMNS);
-    expect(result).toMatch(/[-]+/);
+    expect(result).toMatch(/^[ -]+$/m);
   });
 
   it("includes row data in the output", () => {

--- a/traceroot-cli/test/render/tree.test.ts
+++ b/traceroot-cli/test/render/tree.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { renderTree, type SpanNode } from "../../src/render/tree.js";
+
+const leaf = (name: string, extra?: Partial<SpanNode>): SpanNode => ({
+  spanId: name,
+  name,
+  children: [],
+  ...extra,
+});
+
+describe("renderTree", () => {
+  it("renders a single root node", () => {
+    const result = renderTree(leaf("root"));
+    expect(result).toContain("root");
+    expect(result.endsWith("\n")).toBe(true);
+  });
+
+  it("renders child nodes with tree connector characters", () => {
+    const root: SpanNode = {
+      spanId: "root",
+      name: "root",
+      children: [leaf("child-a"), leaf("child-b")],
+    };
+    const result = renderTree(root);
+    expect(result).toContain("child-a");
+    expect(result).toContain("child-b");
+    // Last child gets └──, non-last gets ├──
+    expect(result).toContain("└──");
+    expect(result).toContain("├──");
+  });
+
+  it("renders deeply nested spans", () => {
+    const root: SpanNode = {
+      spanId: "root",
+      name: "root",
+      children: [
+        {
+          spanId: "child",
+          name: "child",
+          children: [leaf("grandchild")],
+        },
+      ],
+    };
+    const result = renderTree(root);
+    expect(result).toContain("grandchild");
+  });
+
+  it("appends service name in brackets when provided", () => {
+    const result = renderTree(leaf("http.request", { service: "api-gateway" }));
+    expect(result).toContain("[api-gateway]");
+  });
+
+  it("appends duration when provided", () => {
+    const result = renderTree(leaf("db.query", { durationMs: 42 }));
+    expect(result).toContain("42ms");
+  });
+
+  it("appends ERROR marker for error-status spans", () => {
+    const result = renderTree(leaf("broken", { status: "error" }));
+    expect(result).toContain("ERROR");
+  });
+
+  it("does not append ERROR for ok or unset spans", () => {
+    expect(renderTree(leaf("ok-span", { status: "ok" }))).not.toContain("ERROR");
+    expect(renderTree(leaf("unset-span", { status: "unset" }))).not.toContain("ERROR");
+  });
+});

--- a/traceroot-cli/test/util/index.test.ts
+++ b/traceroot-cli/test/util/index.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { formatTimestamp, truncate, plural, formatDuration } from "../../src/util/index.js";
+
+describe("truncate", () => {
+  it("returns the string unchanged when it fits within maxLen", () => {
+    expect(truncate("hello", 10)).toBe("hello");
+  });
+
+  it("returns the string unchanged when length equals maxLen", () => {
+    expect(truncate("hello", 5)).toBe("hello");
+  });
+
+  it("truncates long strings and appends an ellipsis character", () => {
+    const result = truncate("hello world", 8);
+    expect(result).toHaveLength(8);
+    expect(result.endsWith("…")).toBe(true);
+  });
+});
+
+describe("plural", () => {
+  it("returns the singular form for count = 1", () => {
+    expect(plural(1, "trace")).toBe("trace");
+  });
+
+  it("returns the auto-pluralised form for count != 1", () => {
+    expect(plural(0, "trace")).toBe("traces");
+    expect(plural(2, "trace")).toBe("traces");
+  });
+
+  it("uses the explicit plural form when provided", () => {
+    expect(plural(2, "query", "queries")).toBe("queries");
+    expect(plural(1, "query", "queries")).toBe("query");
+  });
+});
+
+describe("formatDuration", () => {
+  it("shows milliseconds for values < 1 000ms", () => {
+    expect(formatDuration(42)).toBe("42ms");
+    expect(formatDuration(999)).toBe("999ms");
+  });
+
+  it("shows seconds (2 decimal places) for values >= 1 000ms", () => {
+    expect(formatDuration(1000)).toBe("1.00s");
+    expect(formatDuration(1500)).toBe("1.50s");
+    expect(formatDuration(12345)).toBe("12.35s");
+  });
+});
+
+describe("formatTimestamp", () => {
+  it("returns the original string for an invalid date", () => {
+    expect(formatTimestamp("not-a-date")).toBe("not-a-date");
+  });
+
+  it("returns a non-empty, formatted string for a valid ISO date", () => {
+    const result = formatTimestamp("2024-01-15T10:30:00Z");
+    expect(result).toBeTruthy();
+    // Should not return the raw ISO string unchanged.
+    expect(result).not.toBe("2024-01-15T10:30:00Z");
+  });
+});

--- a/traceroot-cli/tsconfig.json
+++ b/traceroot-cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/traceroot-cli/tsconfig.json
+++ b/traceroot-cli/tsconfig.json
@@ -14,5 +14,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "test"]
+  "exclude": ["node_modules", "dist"]
 }

--- a/traceroot-cli/tsconfig.test.json
+++ b/traceroot-cli/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/traceroot-cli/vitest.config.ts
+++ b/traceroot-cli/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/api/generated/**"],
+    },
+  },
+});


### PR DESCRIPTION
# Scaffold standalone `traceroot-cli` package

Closes #1082

## Description

Scaffolds the `traceroot-cli` TypeScript package as specified in #1082. The package is a standalone, SDK-free CLI with zero imports from the backend monorepo. It ships as an npm package named `traceroot-cli` with the binary `traceroot`.

## What this scaffold includes

- ESM, Node 20+, TypeScript strict mode with NodeNext module resolution
- `commander` for CLI wiring with hand-written command modules
- Native `fetch` for HTTP (no axios or node-fetch)
- Vitest test runner with ESLint and Prettier
- CI workflow that runs build, lint, and test on Node 20 and 22
- Working `traceroot --help` and `traceroot --version`
- All commands are stubs that print `"not yet implemented"` and exit 1

## Directory layout

```
traceroot-cli/
  bin/traceroot.mjs          # thin ESM entry, delegates to dist/
  src/cli.ts                 # commander program, registers subcommands
  src/commands/              # login.ts, status.ts, traces.ts
  src/config/                # config file read/write, auth resolution
  src/api/                   # native fetch client, typed stubs
  src/render/                # table and tree renderers
  src/output.ts              # stdout/stderr/exit contract, NO_COLOR
  src/util/                  # shared helpers
  test/                      # Vitest, mirrors src/
  .github/workflows/ci.yml   # build, lint, test on Node 20 and 22
```

## Dependencies

Runtime dependencies are only `commander` and `chalk`.

## Out of scope

Deferred to follow-on issues:

- Real command behavior (#1083 and beyond)
- Config persistence (#1083)
- OpenAPI codegen (#1084)
- npm release and publishing

## Tests

35 tests pass. Typecheck and lint are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scaffolded a standalone `traceroot-cli` that ships the `traceroot` binary with working help/version, strict TypeScript, tests, and CI. Sets the foundation for #1082 with stubbed commands to be implemented next.

- New Features
  - Standalone ESM package for Node 20+ with strict TS and `commander` wiring; `traceroot --help` and `--version` work.
  - Commands scaffolded: `login`, `status`, and `traces (list|get)`; all currently print "not yet implemented" and exit 1.
  - Config management: reads/writes `~/.traceroot/config.json`, resolves env vars, uses atomic writes and tight permissions.
  - Native `fetch` API client with AbortController timeouts and rich `ApiError` (status + body).
  - Renderers: dependency-free table and span-tree output.
  - Output layer centralizes stdout/stderr and honors `NO_COLOR`.
  - Tests via `vitest` and a GitHub Actions workflow (Node 20/22) for build, typecheck, lint, format check, and tests.

- Bug Fixes
  - Safe config read when resolving env-based auth so a bad or missing config file does not block `TRACEROOT_*` env vars.
  - Stronger table separator assertion in tests to reduce false positives.

<sup>Written for commit d343995e394095ffc72fc6a8839e91192c81fe83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

