### PR TITLE
fix(ui): move sidebar Upgrade button below the GitHub star widget

### DIFF
--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -227,13 +227,13 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
 
         {/* Bottom section */}
         <div>
+          {/* Star widget */}
+          {!collapsed && <GitHubStarWidget />}
+
           {/* Upgrade button - only show when in project context */}
           {isProject && projectId && (
             <SidebarUpgradeButton projectId={projectId} collapsed={collapsed} />
           )}
-
-          {/* Star widget */}
-          {!collapsed && <GitHubStarWidget />}
 
           {/* GitHub link */}
           <Tooltip>


### PR DESCRIPTION
Fixes #1133

## Change

In the sidebar bottom section, the Upgrade button rendered above the "Star TraceRoot" widget. This swaps the two blocks so the order is now:

1. Star TraceRoot widget
2. Upgrade
3. GitHub / Settings / Support

Each block keeps its own visibility condition (Upgrade: project context only; star widget: expanded sidebar and not dismissed), so all visibility combinations remain correct. No styling changes were needed — the widget's existing `mb-1` now separates it from the Upgrade button, and the widget sitting at the top of the bottom section matches the existing non-project layout.

## Verification

- `eslint` and `tsc --noEmit` pass.
- Verified live on the local stack in a project context: the star widget renders above Upgrade, followed by GitHub/Settings/Support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the sidebar Upgrade button below the GitHub Star widget to match the intended order and improve layout consistency. Visibility rules are unchanged (star only when expanded and not dismissed; Upgrade only in project context), and no styling changes were needed.

<sup>Written for commit 1d0dd05a3d52f66b0fce5724bcabb297711c28a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

