### PR TITLE
fix(ui): let the star widget link pill fill the sidebar width

### DIFF
--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -76,7 +76,7 @@ export function GitHubStarWidget() {
         rel="noopener noreferrer"
         className="flex w-full overflow-hidden rounded border border-border text-[11px] font-medium transition-colors hover:bg-muted/50"
       >
-        <span className="flex items-center gap-1 px-1.5 py-1">
+        <span className="flex flex-1 items-center gap-1 px-1.5 py-1">
           <Github className="h-3 w-3 shrink-0" />
           traceroot
         </span>


### PR DESCRIPTION
Fixes #1144

Related to #1132 / #1125 (sidebar widening from `w-40` to `w-48`).

## Problem

The "Star TraceRoot" widget's container already stretches with the sidebar (`mx-1.5` + full width), but the repo/star-count link pill inside it does not: the `traceroot` segment is sized to its content, and at the current 160px sidebar the pill's contents happen to fill the row almost exactly. Once the sidebar widens to 192px (#1132), the pill would show ~30px of dead space to the right of the star count, inside its own border.

## Change

One class: add `flex-1` to the repo-name segment of the link, so it grows to absorb extra width and the `★ count` segment stays flush against the pill's right edge. This makes the pill width-agnostic — it renders identically at today's 160px and keeps the same composition at 192px (or any future width). The rest of the widget (heading, copy, dismiss button) is already fluid and needs no changes.

## Verification

- `eslint` and `tsc --noEmit` pass.
- Live-verified on the local stack at the new `w-48` width (screenshots below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the GitHub star widget link pill expand to fill the sidebar width so the star count stays flush right, removing dead space after the sidebar widens to 192px. Adds `flex-1` to the repo-name span so the pill is width-agnostic and renders correctly at both 160px and 192px.

<sup>Written for commit cbaf133f8d13023e05388712ed5105e67550d05c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




## Screenshots

Captured live at the #1132 sidebar width (`w-48`, 192px), applied locally for the demo.

### Before (no `flex-1`) — divider sits mid-pill, dead space trails the star count

<img src="https://raw.githubusercontent.com/traceroot-ai/traceroot/assets-star-pill-w48-demo/before-closeup.png" width="220" alt="Pill before: dead space after star count" />

<img src="https://raw.githubusercontent.com/traceroot-ai/traceroot/assets-star-pill-w48-demo/before-full.png" width="700" alt="Sidebar before at w-48" />

### After (`flex-1`) — repo segment grows, star count flush against the right edge

<img src="https://raw.githubusercontent.com/traceroot-ai/traceroot/assets-star-pill-w48-demo/after-closeup.png" width="220" alt="Pill after: star count flush right" />

<img src="https://raw.githubusercontent.com/traceroot-ai/traceroot/assets-star-pill-w48-demo/after-full.png" width="700" alt="Sidebar after at w-48" />

