### PR TITLE
fix(ui): align row ordering between token and cost breakdowns

### DIFF
--- a/frontend/ui/src/features/traces/components/CostBreakdown.tsx
+++ b/frontend/ui/src/features/traces/components/CostBreakdown.tsx
@@ -33,7 +33,7 @@ export function CostBreakdown({ details }: CostBreakdownProps) {
         <span className="tabular-nums">{formatCost(c.inputCost)}</span>
       </div>
       <div className="mt-1 space-y-0.5">
-        <Row label="uncached input" value={c.inputUncachedCost} />
+        <Row label="uncached" value={c.inputUncachedCost} />
         <Row label="cache read" value={c.cacheReadCost} />
         <Row label="cache write" value={c.cacheWriteCost} />
       </div>

--- a/frontend/ui/src/features/traces/components/TokenUsageBreakdown.tsx
+++ b/frontend/ui/src/features/traces/components/TokenUsageBreakdown.tsx
@@ -21,8 +21,8 @@ function Row({ label, value }: { label: string; value: number }) {
 /**
  * Hierarchical "Usage breakdown" panel for a span's token counts (issue #958).
  *
- * Input usage (gross input_tokens) splits into its cache components and the
- * remaining uncached input; output usage splits into reasoning and plain
+ * Input usage (gross input_tokens) splits into uncached input and its cache
+ * components (same row order as CostBreakdown); output usage splits into reasoning and plain
  * output. The cache sub-rows always render — even at zero — so it's clear we
  * track cache tokens; reasoning renders only when non-zero (it's specific to
  * reasoning models). The uncached `input`/`output` leaf rows always render so
@@ -56,10 +56,11 @@ export function TokenUsageBreakdown({
         <span className="tabular-nums">{formatExactTokens(input)}</span>
       </div>
       <div className="mt-1 space-y-0.5">
-        {/* Always shown (even at zero) so it's clear cache tokens are tracked. */}
+        {/* Always shown (even at zero) so it's clear cache tokens are tracked.
+            Same row order as CostBreakdown so the two panels read in parallel. */}
+        <Row label="uncached" value={uncachedInput} />
         <Row label="cache read" value={cacheRead} />
         <Row label="cache write" value={cacheWrite} />
-        <Row label="uncached" value={uncachedInput} />
       </div>
 
       <div className="mt-2 flex justify-between gap-8 border-b border-border/60 pb-1 font-medium">

--- a/frontend/ui/src/features/traces/components/breakdown-ordering.test.ts
+++ b/frontend/ui/src/features/traces/components/breakdown-ordering.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { TokenUsageBreakdown } from "./TokenUsageBreakdown";
+import { CostBreakdown } from "./CostBreakdown";
+
+// Both panels split input into the same three categories; they must render
+// them in the same order (uncached, then cache read, then cache write) so the
+// token and dollar views line up when read side by side.
+function labelOrder(markup: string, labels: string[]): number[] {
+  return labels.map((label) => markup.indexOf(`>${label}<`));
+}
+
+describe("breakdown row ordering", () => {
+  it("orders token input rows uncached, cache read, cache write", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TokenUsageBreakdown, {
+        inputTokens: 1000,
+        outputTokens: 200,
+        totalTokens: 1200,
+        cacheReadTokens: 300,
+        cacheWriteTokens: 100,
+      }),
+    );
+    const [uncached, read, write] = labelOrder(markup, ["uncached", "cache read", "cache write"]);
+    expect(uncached).toBeGreaterThan(-1);
+    expect(read).toBeGreaterThan(uncached);
+    expect(write).toBeGreaterThan(read);
+  });
+
+  it("orders cost input rows uncached, cache read, cache write", () => {
+    const markup = renderToStaticMarkup(
+      createElement(CostBreakdown, {
+        details: {
+          input_uncached_cost: 0.01,
+          cache_read_cost: 0.002,
+          cache_write_cost: 0.003,
+          output_cost: 0.05,
+        },
+      }),
+    );
+    const [uncached, read, write] = labelOrder(markup, [
+      "uncached input",
+      "cache read",
+      "cache write",
+    ]);
+    expect(uncached).toBeGreaterThan(-1);
+    expect(read).toBeGreaterThan(uncached);
+    expect(write).toBeGreaterThan(read);
+  });
+});

--- a/frontend/ui/src/features/traces/components/breakdown-ordering.test.ts
+++ b/frontend/ui/src/features/traces/components/breakdown-ordering.test.ts
@@ -5,8 +5,9 @@ import { TokenUsageBreakdown } from "./TokenUsageBreakdown";
 import { CostBreakdown } from "./CostBreakdown";
 
 // Both panels split input into the same three categories; they must render
-// them in the same order (uncached, then cache read, then cache write) so the
-// token and dollar views line up when read side by side.
+// them with the same labels in the same order (uncached, then cache read,
+// then cache write) so the token and dollar views line up when read side by
+// side.
 function labelOrder(markup: string, labels: string[]): number[] {
   return labels.map((label) => markup.indexOf(`>${label}<`));
 }
@@ -39,11 +40,7 @@ describe("breakdown row ordering", () => {
         },
       }),
     );
-    const [uncached, read, write] = labelOrder(markup, [
-      "uncached input",
-      "cache read",
-      "cache write",
-    ]);
+    const [uncached, read, write] = labelOrder(markup, ["uncached", "cache read", "cache write"]);
     expect(uncached).toBeGreaterThan(-1);
     expect(read).toBeGreaterThan(uncached);
     expect(write).toBeGreaterThan(read);


### PR DESCRIPTION
## Summary
- Reorder the token usage breakdown's input rows to uncached → cache read → cache write, matching the cost breakdown
- Normalize the row label too: the cost panel called the row "uncached input" while the token panel says "uncached"; both now use "uncached" (the section header already says Input)
- Add a server-render vitest test pinning the shared row order and label in both panels so they can't drift apart again

## Test plan
- `pnpm exec vitest run` in `frontend/ui` (new ordering test + existing suites; unrelated pre-existing flakes aside, all green)
- `pnpm lint` and `pnpm exec tsc --noEmit` clean
- Verified visually against a seeded trace on the local stack with distinct uncached / cache read / cache write values on both panels

## Video

https://github.com/user-attachments/assets/f2ea7388-1a5c-4dbd-a23d-11d21e54fdef



closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)