### PR TITLE
fix(ui): keep star widget copy clear of the dismiss button column

### DIFF
--- a/frontend/ui/src/components/layout/GitHubStarWidget.tsx
+++ b/frontend/ui/src/components/layout/GitHubStarWidget.tsx
@@ -65,7 +65,7 @@ export function GitHubStarWidget() {
           <X className="h-3 w-3" />
         </button>
       </div>
-      <p className="mb-2 text-[11px] leading-snug text-muted-foreground">
+      <p className="mb-2 pr-6 text-[11px] leading-snug text-muted-foreground">
         Open source and shipping fast.
         <br />
         Made with ❤️ by contributors.


### PR DESCRIPTION
Fixes #1147

## Problem

The "Star TraceRoot" widget's description copy spans the card's full inner width, so its lines run underneath the ✕ dismiss button's column instead of ending left of it.

## Change

One class: `pr-6` on the description `<p>`. That bounds the copy's right edge 24px inside the card (16px ✕ button + ~8px gap), so the text is always left-aligned and ends a few pixels left of the dismiss button — at the current `w-40` sidebar, the upcoming `w-48` (#1132), or any future width. The link pill below is intentionally unchanged (see #1143: its full-width box with trailing whitespace is the desired design).

## Verification

- `eslint` and `tsc --noEmit` pass.
- Static Tailwind mock below (same markup/classes — not the live app; the dev stack was down). Red guide = a few px left of the ✕ button's left edge. Left: current, copy crosses the guide. Middle/right: with `pr-6` at 192px and 160px cards, copy stays left of the guide. Happy to re-verify live and attach real screenshots when the stack is up.

<img src="https://raw.githubusercontent.com/traceroot-ai/traceroot/assets-star-widget-text-demo/text-mock.png" width="900" alt="Mock: current vs pr-6 copy bounds at w-48 and w-40" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the Star TraceRoot widget’s description text from running under the ✕ dismiss button by adding `pr-6` right padding to the paragraph so the copy stops before the button column across sidebar widths. Fixes #1147.

<sup>Written for commit e3035f618ac3bd6c9d4e3d4f373de8b6747be51e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

