### PR TITLE
fix(detector): sync cross tab detector sync

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^3.2.6
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       dotenv-cli:
         specifier: ^11.0.0
         version: 11.0.0
@@ -85,7 +85,7 @@ importers:
         version: 6.0.0(@types/node@22.19.15)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core:
     dependencies:
@@ -104,7 +104,7 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^3.2.6
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       prisma:
         specifier: ^5.22.0
         version: 5.22.0
@@ -116,7 +116,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/github:
     dependencies:
@@ -132,13 +132,13 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^3.2.6
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/slack:
     dependencies:
@@ -160,13 +160,13 @@ importers:
         version: 22.19.15
       '@vitest/coverage-v8':
         specifier: ^3.2.6
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   ui:
     dependencies:
@@ -208,7 +208,7 @@ importers:
         version: 3.0.3
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mongodb@7.1.0(socks@2.8.7))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(prisma@5.22.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.6.11(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mongodb@7.1.0(socks@2.8.7))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(prisma@5.22.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -267,6 +267,12 @@ importers:
       '@tailwindcss/typography':
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@types/bcryptjs':
         specifier: ^3.0.0
         version: 3.0.0
@@ -284,10 +290,13 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/coverage-v8':
         specifier: ^3.2.6
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.5.0
         version: 10.5.0(postcss@8.5.15)
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       postcss:
         specifier: ^8.5.15
         version: 8.5.15
@@ -299,7 +308,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
   worker:
     dependencies:
@@ -339,7 +348,7 @@ importers:
         version: 6.4.23
       '@vitest/coverage-v8':
         specifier: ^3.2.6
-        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -348,7 +357,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -368,6 +377,21 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -808,6 +832,46 @@ packages:
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.3':
+    resolution: {integrity: sha512-DOgvIPkikIOixQRlD4YF31VN6fLLUTdrzhfRbis8vm0kMTgIbEPX0Ip/YX9fOeV9iywAS4sUUbTclpan7yYP8Q==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@daytonaio/api-client@0.148.0':
     resolution: {integrity: sha512-5/1fvSF69SEaKluddVB6QxVAyRI6LEsUim7m4oSJCtB5UfIuq1b/k5svTkFbi1dag1UJEypr8xw7eTaVFvnBMA==}
 
@@ -1184,6 +1248,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -2824,11 +2897,33 @@ packages:
   '@tanstack/virtual-core@3.14.0':
     resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/bcryptjs@3.0.0':
     resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
@@ -3044,6 +3139,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -3064,6 +3163,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -3184,6 +3286,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
@@ -3376,6 +3481,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -3392,6 +3501,10 @@ packages:
     resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
     engines: {node: '>= 14'}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
@@ -3403,6 +3516,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -3449,6 +3565,9 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
   dompurify@3.3.3:
     resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
@@ -3492,6 +3611,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -3827,6 +3950,10 @@ packages:
     resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3924,6 +4051,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -3978,6 +4108,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -4169,6 +4308,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -4184,6 +4327,10 @@ packages:
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -4246,6 +4393,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   memory-pager@1.5.0:
     resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
@@ -4582,6 +4732,9 @@ packages:
     resolution: {integrity: sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==}
     engines: {node: '>=0.10.0'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
@@ -4759,6 +4912,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prisma@5.22.0:
     resolution: {integrity: sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==}
     engines: {node: '>=16.13'}
@@ -4811,6 +4968,9 @@ packages:
     resolution: {integrity: sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==}
     peerDependencies:
       react: '*'
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
@@ -4893,6 +5053,10 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
@@ -4942,6 +5106,10 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.25.0:
     resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
@@ -5132,6 +5300,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
@@ -5181,13 +5352,28 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.2:
+    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+
+  tldts@7.4.2:
+    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -5427,6 +5613,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
@@ -5438,9 +5628,21 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
   whatwg-url@14.2.0:
     resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
     engines: {node: '>=18'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -5479,6 +5681,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -5548,6 +5757,26 @@ snapshots:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
       zod: 4.4.3
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.3(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -6545,6 +6774,34 @@ snapshots:
 
   '@better-fetch/fetch@1.1.21': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.3(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@daytonaio/api-client@0.148.0':
     dependencies:
       axios: 1.15.2
@@ -6862,6 +7119,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -8619,12 +8880,35 @@ snapshots:
 
   '@tanstack/virtual-core@3.14.0': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/bcryptjs@3.0.0':
     dependencies:
@@ -8798,7 +9082,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -8813,11 +9097,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -8832,7 +9116,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -8917,6 +9201,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -8933,6 +9219,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -8979,7 +9269,7 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
-  better-auth@1.6.11(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mongodb@7.1.0(socks@2.8.7))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(prisma@5.22.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)):
+  better-auth@1.6.11(@opentelemetry/api@1.9.0)(@prisma/client@5.22.0(prisma@5.22.0))(mongodb@7.1.0(socks@2.8.7))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(prisma@5.22.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)
@@ -9005,7 +9295,7 @@ snapshots:
       prisma: 5.22.0
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
-      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -9018,6 +9308,10 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 4.4.3
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bignumber.js@9.3.1: {}
 
@@ -9208,6 +9502,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -9216,11 +9515,20 @@ snapshots:
 
   data-uri-to-buffer@6.0.2: {}
 
+  data-urls@7.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   date-fns@4.1.0: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -9255,6 +9563,8 @@ snapshots:
   didyoumean@1.2.2: {}
 
   dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dompurify@3.3.3:
     optionalDependencies:
@@ -9296,6 +9606,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  entities@8.0.0: {}
 
   environment@1.1.0: {}
 
@@ -9717,6 +10029,12 @@ snapshots:
 
   hono@4.12.21: {}
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
@@ -9812,6 +10130,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-stream@2.0.1: {}
 
   isexe@2.0.0: {}
@@ -9863,6 +10183,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -10031,6 +10377,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.1: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -10042,6 +10390,8 @@ snapshots:
       react: 19.0.0
 
   luxon@3.7.2: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -10213,6 +10563,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   memory-pager@1.5.0:
     optional: true
@@ -10640,6 +10992,10 @@ snapshots:
 
   parse-passwd@1.0.0: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   partial-json@0.1.7: {}
 
   path-exists@4.0.0: {}
@@ -10747,6 +11103,12 @@ snapshots:
 
   prettier@3.8.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prisma@5.22.0:
     dependencies:
       '@prisma/engines': 5.22.0
@@ -10809,6 +11171,8 @@ snapshots:
   react-icons@5.6.0(react@19.0.0):
     dependencies:
       react: 19.0.0
+
+  react-is@17.0.2: {}
 
   react-markdown@10.1.0(@types/react@19.2.14)(react@19.0.0):
     dependencies:
@@ -10918,6 +11282,8 @@ snapshots:
 
   require-directory@2.1.1: {}
 
+  require-from-string@2.0.2: {}
+
   require-in-the-middle@8.0.1:
     dependencies:
       debug: 4.4.3
@@ -11005,6 +11371,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   safe-buffer@5.2.1: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.25.0: {}
 
@@ -11224,6 +11594,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@2.6.1: {}
 
   tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2):
@@ -11293,14 +11665,28 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.4.2: {}
+
+  tldts@7.4.2:
+    dependencies:
+      tldts-core: 7.4.2
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.2
 
   tr46@5.1.1:
     dependencies:
       punycode: 2.3.1
     optional: true
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -11537,7 +11923,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@1.21.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -11565,6 +11951,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.19.15
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -11579,7 +11966,7 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@22.19.15)(jiti@2.6.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -11607,6 +11994,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.19.15
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -11621,6 +12009,10 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-streams-polyfill@3.3.3: {}
 
   web-vitals@5.1.0: {}
@@ -11628,11 +12020,23 @@ snapshots:
   webidl-conversions@7.0.0:
     optional: true
 
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
   whatwg-url@14.2.0:
     dependencies:
       tr46: 5.1.1
       webidl-conversions: 7.0.0
     optional: true
+
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -11664,6 +12068,10 @@ snapshots:
       strip-ansi: 7.2.0
 
   ws@8.19.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 

--- a/frontend/ui/package.json
+++ b/frontend/ui/package.json
@@ -48,6 +48,8 @@
   "devDependencies": {
     "@tailwindcss/container-queries": "^0.1.1",
     "@tailwindcss/typography": "^0.5.19",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/bcryptjs": "^3.0.0",
     "@types/node": "^22.0.0",
     "@types/nodemailer": "^7.0.9",
@@ -55,6 +57,7 @@
     "@types/react-dom": "^19.0.0",
     "@vitest/coverage-v8": "^3.2.6",
     "autoprefixer": "^10.5.0",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.0",

--- a/frontend/ui/src/app/providers.test.tsx
+++ b/frontend/ui/src/app/providers.test.tsx
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { Providers } from "./providers";
+
+beforeEach(() => {
+  // jsdom has no matchMedia; next-themes' ThemeProvider needs it.
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn().mockReturnValue({
+      matches: false,
+      media: "",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("Providers", () => {
+  it("renders children inside the provider tree", () => {
+    render(
+      <Providers>
+        <div data-testid="child">hello</div>
+      </Providers>,
+    );
+    expect(screen.getByTestId("child")).toBeDefined();
+  });
+});

--- a/frontend/ui/src/app/providers.tsx
+++ b/frontend/ui/src/app/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { useState, type ReactNode } from "react";
+import { CrossTabQuerySync } from "@/components/cross-tab-query-sync";
 
 interface ProvidersProps {
   children: ReactNode;
@@ -24,6 +25,7 @@ export function Providers({ children }: ProvidersProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
+      <CrossTabQuerySync />
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
         {children}
       </ThemeProvider>

--- a/frontend/ui/src/components/cross-tab-query-sync.test.tsx
+++ b/frontend/ui/src/components/cross-tab-query-sync.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { CrossTabQuerySync } from "./cross-tab-query-sync";
+
+class FakeBroadcastChannel {
+  static instances: FakeBroadcastChannel[] = [];
+  name: string;
+  closed = false;
+  private listeners: Array<(e: MessageEvent) => void> = [];
+
+  constructor(name: string) {
+    this.name = name;
+    FakeBroadcastChannel.instances.push(this);
+  }
+  postMessage() {}
+  addEventListener(_type: string, listener: (e: MessageEvent) => void) {
+    this.listeners.push(listener);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(data: unknown) {
+    for (const listener of this.listeners) listener({ data } as MessageEvent);
+  }
+}
+
+afterEach(() => {
+  cleanup();
+  FakeBroadcastChannel.instances = [];
+  vi.unstubAllGlobals();
+});
+
+function renderSync() {
+  vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+  const queryClient = new QueryClient();
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <CrossTabQuerySync />
+    </QueryClientProvider>,
+  );
+  return { invalidateSpy, view };
+}
+
+describe("CrossTabQuerySync", () => {
+  it("invalidates the query key received from another tab", () => {
+    const { invalidateSpy } = renderSync();
+    const channel = FakeBroadcastChannel.instances.at(-1)!;
+    channel.emit({ type: "invalidate", queryKey: ["detectors"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["detectors"] });
+  });
+
+  it("ignores malformed messages", () => {
+    const { invalidateSpy } = renderSync();
+    const channel = FakeBroadcastChannel.instances.at(-1)!;
+    channel.emit({ type: "other" });
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it("closes the channel on unmount", () => {
+    const { view } = renderSync();
+    const channel = FakeBroadcastChannel.instances.at(-1)!;
+    view.unmount();
+    expect(channel.closed).toBe(true);
+  });
+});

--- a/frontend/ui/src/components/cross-tab-query-sync.tsx
+++ b/frontend/ui/src/components/cross-tab-query-sync.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { subscribeToQueryInvalidations } from "@/lib/cross-tab-sync";
+
+/**
+ * Bridges query invalidations across browser tabs: when another tab reports
+ * it wrote data, refetch the matching queries here so every tab converges
+ * without a manual refresh. Renders nothing.
+ */
+export function CrossTabQuerySync() {
+  const queryClient = useQueryClient();
+
+  useEffect(
+    () =>
+      subscribeToQueryInvalidations((queryKey) => {
+        void queryClient.invalidateQueries({ queryKey });
+      }),
+    [queryClient],
+  );
+
+  return null;
+}

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import type { Detector } from "../hooks/use-detectors";
+
+const mocks = vi.hoisted(() => ({
+  detector: undefined as Detector | undefined,
+  mutate: vi.fn(),
+}));
+
+vi.mock("../hooks/use-detectors", () => ({
+  useDetector: () => ({ data: mocks.detector }),
+  useUpdateDetector: () => ({ mutate: mocks.mutate, isPending: false }),
+}));
+vi.mock("@/features/projects/hooks", () => ({
+  useProject: () => ({ data: undefined }),
+}));
+vi.mock("./trigger-editor", () => ({
+  TriggerEditor: () => null,
+}));
+vi.mock("./agent-model-link", () => ({
+  AgentModelLink: () => null,
+}));
+vi.mock("@/features/ai-assistant/components/model-selector", () => ({
+  ModelSelector: () => null,
+}));
+vi.mock("./rca-toggle", () => ({
+  RcaToggle: ({
+    id,
+    checked,
+    onCheckedChange,
+  }: {
+    id: string;
+    checked: boolean;
+    onCheckedChange: (checked: boolean) => void;
+  }) => (
+    <input
+      type="checkbox"
+      data-testid="rca-toggle"
+      id={id}
+      checked={checked}
+      onChange={(e) => onCheckedChange(e.target.checked)}
+    />
+  ),
+}));
+
+import { DetectorPanel } from "./detector-panel";
+
+const baseDetector: Detector = {
+  id: "det-1",
+  projectId: "proj-1",
+  name: "Latency spikes",
+  template: "custom",
+  prompt: "Find slow spans",
+  outputSchema: [],
+  sampleRate: 50,
+  enableRca: true,
+  detectionModel: "model-a",
+  detectionProvider: "provider-a",
+  detectionSource: "system",
+  createTime: "2026-06-01T00:00:00Z",
+  updateTime: "2026-06-01T00:00:00Z",
+  trigger: { conditions: [] },
+};
+
+function renderPanel(detectorId = "det-1") {
+  const onClose = vi.fn();
+  const view = render(
+    <DetectorPanel detectorId={detectorId} projectId="proj-1" onClose={onClose} />,
+  );
+  const rerender = () =>
+    view.rerender(<DetectorPanel detectorId={detectorId} projectId="proj-1" onClose={onClose} />);
+  return { onClose, rerender };
+}
+
+const rcaToggle = () => screen.getByTestId("rca-toggle") as HTMLInputElement;
+const promptBox = () => document.querySelector("textarea") as HTMLTextAreaElement;
+const saveButton = () => screen.getByRole("button", { name: "Save" });
+
+afterEach(() => {
+  cleanup();
+  mocks.detector = undefined;
+  mocks.mutate.mockReset();
+});
+
+describe("DetectorPanel", () => {
+  it("populates the form from the loaded detector", () => {
+    mocks.detector = baseDetector;
+    renderPanel();
+    expect(screen.getByDisplayValue("Latency spikes")).toBeDefined();
+    expect(promptBox().value).toBe("Find slow spans");
+    expect(rcaToggle().checked).toBe(true);
+  });
+
+  it("adopts a remote toggle change while preserving an in-progress prompt edit", () => {
+    mocks.detector = baseDetector;
+    const { rerender } = renderPanel();
+    fireEvent.change(promptBox(), { target: { value: "my draft" } });
+
+    mocks.detector = { ...baseDetector, enableRca: false };
+    rerender();
+
+    expect(rcaToggle().checked).toBe(false);
+    expect(promptBox().value).toBe("my draft");
+  });
+
+  it("saves only the fields the user changed", () => {
+    mocks.detector = baseDetector;
+    const { onClose } = renderPanel();
+    fireEvent.change(promptBox(), { target: { value: "new prompt" } });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ prompt: "new prompt" });
+
+    const options = mocks.mutate.mock.calls[0][1] as { onSuccess: () => void };
+    options.onSuccess();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("closes without a network call when nothing changed", () => {
+    mocks.detector = baseDetector;
+    const { onClose } = renderPanel();
+    fireEvent.click(saveButton());
+    expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("clears the form and disables Save while the loaded detector does not match the id", () => {
+    mocks.detector = baseDetector;
+    renderPanel("det-2");
+    expect(promptBox().value).toBe("");
+    expect((saveButton() as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -91,11 +91,12 @@ export function DetectorPanel({
     setEditConditions(values.conditions as TriggerCondition[]);
   };
 
-  // Snapshot of the server state the form was last populated from. Save
-  // diffs against it so only user-changed fields are PATCHed, and refetches
-  // merge against it so untouched fields update live (e.g. another tab
-  // toggling RCA) without clobbering in-progress edits.
-  const loadedRef = useRef<DetectorFormValues | null>(null);
+  // Snapshot of the server state the form was last populated from, tagged
+  // with the detector id it belongs to. Save diffs against it so only
+  // user-changed fields are PATCHed, and refetches merge against it so
+  // untouched fields update live (e.g. another tab toggling RCA) without
+  // clobbering in-progress edits.
+  const loadedRef = useRef<{ id: string; values: DetectorFormValues } | null>(null);
 
   // When the loaded detector matches the requested id, populate or merge.
   // Otherwise clear: the panel's Next/Prev arrow can change `detectorId`
@@ -106,8 +107,22 @@ export function DetectorPanel({
     if (detector && detector.id === detectorId) {
       const next = detectorToFormValues(detector);
       const previous = loadedRef.current;
-      applyForm(previous ? mergeDetectorIntoForm(previous, next, readForm()) : next);
-      loadedRef.current = next;
+      if (previous && previous.id === detector.id) {
+        // Skip when the payload is unchanged. This also covers StrictMode's
+        // dev double-invoke: the re-run sees identical data while the form
+        // state from the first run hasn't committed yet, and merging then
+        // would read empty initial values and blank the form.
+        if (JSON.stringify(next) !== JSON.stringify(previous.values)) {
+          applyForm(mergeDetectorIntoForm(previous.values, next, readForm()));
+          loadedRef.current = { id: detector.id, values: next };
+        }
+      } else {
+        // First load, or navigation to a different detector (possibly served
+        // instantly from the query cache): populate fresh. Merging across
+        // detectors would leak one detector's edits into another.
+        applyForm(next);
+        loadedRef.current = { id: detector.id, values: next };
+      }
     } else {
       applyForm(emptyForm);
       loadedRef.current = null;
@@ -127,10 +142,13 @@ export function DetectorPanel({
     // Guard against saving while the new detector's data is still loading.
     // Edit state would be the previous detector's, but the mutation targets
     // the current detectorId; without this guard, stale values would
-    // overwrite the new detector. The Save button is also disabled in this
-    // state — this is defense-in-depth.
-    if (!detector || detector.id !== detectorId || !loadedRef.current) return;
-    const patch = buildDetectorPatch(loadedRef.current, readForm());
+    // overwrite the new detector. The Save button is also disabled for the
+    // detector check — this is defense-in-depth. The snapshot check below
+    // handles the one-frame window before the populate effect has run.
+    if (!detector || detector.id !== detectorId) return;
+    const loaded = loadedRef.current;
+    if (!loaded || loaded.id !== detectorId) return;
+    const patch = buildDetectorPatch(loaded.values, readForm());
     if (Object.keys(patch).length === 0) {
       onClose();
       return;

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Eye, X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
 import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
 import { useProject } from "@/features/projects/hooks";
@@ -8,6 +8,12 @@ import { TriggerEditor } from "./trigger-editor";
 import type { TriggerCondition } from "./trigger-editor";
 import { AgentModelLink } from "./agent-model-link";
 import { RcaToggle } from "./rca-toggle";
+import {
+  detectorToFormValues,
+  buildDetectorPatch,
+  mergeDetectorIntoForm,
+  type DetectorFormValues,
+} from "../utils";
 import {
   ModelSelector,
   type ModelSelection,
@@ -49,36 +55,62 @@ export function DetectorPanel({
   const [editConditions, setEditConditions] = useState<TriggerCondition[]>([]);
   const [editEnableRca, setEditEnableRca] = useState(true);
 
-  const populate = (d: typeof detector) => {
-    if (!d) return;
-    setEditName(d.name);
-    setEditPrompt(d.prompt);
-    setEditSampleRate(d.sampleRate);
-    setEditModelSelection({
-      model: d.detectionModel ?? "",
-      provider: d.detectionProvider ?? "",
-      source: d.detectionSource ?? "system",
-      adapter: "",
-    });
-    setEditConditions((d.trigger?.conditions ?? []) as TriggerCondition[]);
-    setEditEnableRca(d.enableRca ?? true);
+  const emptyForm: DetectorFormValues = {
+    name: "",
+    prompt: "",
+    sampleRate: 100,
+    enableRca: true,
+    detectionModel: "",
+    detectionProvider: "",
+    detectionSource: "system",
+    conditions: [],
   };
 
-  // When the loaded detector matches the requested id, populate edit state.
-  // Otherwise clear it: the panel's Next/Prev arrow can change `detectorId`
+  const readForm = (): DetectorFormValues => ({
+    name: editName,
+    prompt: editPrompt,
+    sampleRate: editSampleRate,
+    enableRca: editEnableRca,
+    detectionModel: editModelSelection.model,
+    detectionProvider: editModelSelection.provider,
+    detectionSource: editModelSelection.source === "byok" ? "byok" : "system",
+    conditions: editConditions as DetectorFormValues["conditions"],
+  });
+
+  const applyForm = (values: DetectorFormValues) => {
+    setEditName(values.name);
+    setEditPrompt(values.prompt);
+    setEditSampleRate(values.sampleRate);
+    setEditEnableRca(values.enableRca);
+    setEditModelSelection({
+      model: values.detectionModel,
+      provider: values.detectionProvider,
+      source: values.detectionSource,
+      adapter: "",
+    });
+    setEditConditions(values.conditions as TriggerCondition[]);
+  };
+
+  // Snapshot of the server state the form was last populated from. Save
+  // diffs against it so only user-changed fields are PATCHed, and refetches
+  // merge against it so untouched fields update live (e.g. another tab
+  // toggling RCA) without clobbering in-progress edits.
+  const loadedRef = useRef<DetectorFormValues | null>(null);
+
+  // When the loaded detector matches the requested id, populate or merge.
+  // Otherwise clear: the panel's Next/Prev arrow can change `detectorId`
   // before `useDetector` resolves the new fetch, and without this clear the
   // form would briefly hold the previous detector's values — a Save during
   // that gap would write them to the new detector.
   useEffect(() => {
     if (detector && detector.id === detectorId) {
-      populate(detector);
+      const next = detectorToFormValues(detector);
+      const previous = loadedRef.current;
+      applyForm(previous ? mergeDetectorIntoForm(previous, next, readForm()) : next);
+      loadedRef.current = next;
     } else {
-      setEditName("");
-      setEditPrompt("");
-      setEditSampleRate(100);
-      setEditModelSelection({ model: "", provider: "", source: "system", adapter: "" });
-      setEditConditions([]);
-      setEditEnableRca(true);
+      applyForm(emptyForm);
+      loadedRef.current = null;
     }
   }, [detectorId, detector]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -97,20 +129,13 @@ export function DetectorPanel({
     // the current detectorId; without this guard, stale values would
     // overwrite the new detector. The Save button is also disabled in this
     // state — this is defense-in-depth.
-    if (!detector || detector.id !== detectorId) return;
-    updateMutation.mutate(
-      {
-        name: editName,
-        prompt: editPrompt,
-        sampleRate: editSampleRate,
-        enableRca: editEnableRca,
-        triggerConditions: editConditions,
-        detectionModel: editModelSelection.model || undefined,
-        detectionProvider: editModelSelection.provider || undefined,
-        detectionSource: editModelSelection.source === "byok" ? "byok" : "system",
-      },
-      { onSuccess: () => onClose() },
-    );
+    if (!detector || detector.id !== detectorId || !loadedRef.current) return;
+    const patch = buildDetectorPatch(loadedRef.current, readForm());
+    if (Object.keys(patch).length === 0) {
+      onClose();
+      return;
+    }
+    updateMutation.mutate(patch, { onSuccess: () => onClose() });
   };
 
   return (

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.test.tsx
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useCreateDetector, useUpdateDetector, useDeleteDetector } from "./use-detectors";
+
+class FakeBroadcastChannel {
+  static posted: unknown[] = [];
+  constructor(public name: string) {}
+  postMessage(data: unknown) {
+    FakeBroadcastChannel.posted.push(data);
+  }
+  addEventListener() {}
+  close() {}
+}
+
+afterEach(() => {
+  FakeBroadcastChannel.posted = [];
+  vi.unstubAllGlobals();
+});
+
+function setup() {
+  vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ detector: { id: "det-1" } }),
+    }),
+  );
+  const queryClient = new QueryClient();
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, invalidateSpy };
+}
+
+const expectNotified = (invalidateSpy: MockInstance) => {
+  expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["detectors"] });
+  expect(FakeBroadcastChannel.posted).toEqual([{ type: "invalidate", queryKey: ["detectors"] }]);
+};
+
+describe("detector mutations notify other tabs on success", () => {
+  it("update: invalidates locally and broadcasts", async () => {
+    const { wrapper, invalidateSpy } = setup();
+    const { result } = renderHook(() => useUpdateDetector("proj-1", "det-1"), { wrapper });
+    result.current.mutate({ enableRca: false });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expectNotified(invalidateSpy);
+  });
+
+  it("create: invalidates locally and broadcasts", async () => {
+    const { wrapper, invalidateSpy } = setup();
+    const { result } = renderHook(() => useCreateDetector("proj-1"), { wrapper });
+    result.current.mutate({ name: "n", template: "t", prompt: "p", outputSchema: [] });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expectNotified(invalidateSpy);
+  });
+
+  it("delete: invalidates locally and broadcasts", async () => {
+    const { wrapper, invalidateSpy } = setup();
+    const { result } = renderHook(() => useDeleteDetector("proj-1"), { wrapper });
+    result.current.mutate("det-1");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expectNotified(invalidateSpy);
+  });
+});

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { broadcastQueryInvalidation } from "@/lib/cross-tab-sync";
 
 export interface Detector {
   id: string;
@@ -177,6 +178,7 @@ export function useCreateDetector(projectId: string) {
     mutationFn: (input: CreateDetectorInput) => createDetector(projectId, input),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["detectors"] });
+      broadcastQueryInvalidation(["detectors"]);
     },
   });
 }
@@ -187,6 +189,7 @@ export function useUpdateDetector(projectId: string, detectorId: string) {
     mutationFn: (input: UpdateDetectorInput) => updateDetector(projectId, detectorId, input),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["detectors"] });
+      broadcastQueryInvalidation(["detectors"]);
     },
   });
 }
@@ -197,6 +200,7 @@ export function useDeleteDetector(projectId: string) {
     mutationFn: (detectorId: string) => deleteDetector(projectId, detectorId),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["detectors"] });
+      broadcastQueryInvalidation(["detectors"]);
     },
   });
 }

--- a/frontend/ui/src/features/detectors/utils/index.test.ts
+++ b/frontend/ui/src/features/detectors/utils/index.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectorToFormValues,
+  buildDetectorPatch,
+  mergeDetectorIntoForm,
+  type DetectorFormValues,
+} from "./index";
+import type { Detector } from "../hooks/use-detectors";
+
+const baseDetector: Detector = {
+  id: "det-1",
+  projectId: "proj-1",
+  name: "Latency spikes",
+  template: "custom",
+  prompt: "Find slow spans",
+  outputSchema: [],
+  sampleRate: 50,
+  enableRca: true,
+  detectionModel: "model-a",
+  detectionProvider: "provider-a",
+  detectionSource: "system",
+  createTime: "2026-06-01T00:00:00Z",
+  updateTime: "2026-06-01T00:00:00Z",
+  trigger: { conditions: [{ field: "duration", op: "gt", value: 1000 }] },
+};
+
+const baseForm: DetectorFormValues = detectorToFormValues(baseDetector);
+
+describe("detectorToFormValues", () => {
+  it("maps detector fields onto form values", () => {
+    expect(baseForm).toEqual({
+      name: "Latency spikes",
+      prompt: "Find slow spans",
+      sampleRate: 50,
+      enableRca: true,
+      detectionModel: "model-a",
+      detectionProvider: "provider-a",
+      detectionSource: "system",
+      conditions: [{ field: "duration", op: "gt", value: 1000 }],
+    });
+  });
+
+  it("defaults null model/provider/source and missing trigger", () => {
+    const values = detectorToFormValues({
+      ...baseDetector,
+      detectionModel: null,
+      detectionProvider: null,
+      detectionSource: null,
+      trigger: null,
+    });
+    expect(values.detectionModel).toBe("");
+    expect(values.detectionProvider).toBe("");
+    expect(values.detectionSource).toBe("system");
+    expect(values.conditions).toEqual([]);
+  });
+});
+
+describe("buildDetectorPatch", () => {
+  it("returns an empty patch when nothing changed", () => {
+    expect(buildDetectorPatch(baseForm, { ...baseForm })).toEqual({});
+  });
+
+  it("includes only the toggled field", () => {
+    const patch = buildDetectorPatch(baseForm, { ...baseForm, enableRca: false });
+    expect(patch).toEqual({ enableRca: false });
+  });
+
+  it("includes only the edited prompt, leaving enableRca untouched", () => {
+    const patch = buildDetectorPatch(baseForm, { ...baseForm, prompt: "New prompt" });
+    expect(patch).toEqual({ prompt: "New prompt" });
+  });
+
+  it("omits a model cleared to empty (omission means leave unchanged)", () => {
+    const patch = buildDetectorPatch(baseForm, { ...baseForm, detectionModel: "" });
+    expect(patch).toEqual({});
+  });
+
+  it("sends changed trigger conditions as triggerConditions", () => {
+    const conditions = [{ field: "status", op: "eq", value: "error" }];
+    const patch = buildDetectorPatch(baseForm, { ...baseForm, conditions });
+    expect(patch).toEqual({ triggerConditions: conditions });
+  });
+});
+
+describe("mergeDetectorIntoForm", () => {
+  const next: DetectorFormValues = { ...baseForm, enableRca: false, name: "Renamed" };
+
+  it("takes all server values when the form is untouched", () => {
+    expect(mergeDetectorIntoForm(baseForm, next, { ...baseForm })).toEqual(next);
+  });
+
+  it("keeps the user's prompt edit while applying the server's toggle", () => {
+    const form = { ...baseForm, prompt: "user draft" };
+    const merged = mergeDetectorIntoForm(baseForm, next, form);
+    expect(merged.prompt).toBe("user draft");
+    expect(merged.enableRca).toBe(false);
+    expect(merged.name).toBe("Renamed");
+  });
+
+  it("keeps all three detection fields when the user touched the model selector", () => {
+    const form = { ...baseForm, detectionModel: "model-b" };
+    const serverNext = {
+      ...baseForm,
+      detectionModel: "model-c",
+      detectionProvider: "provider-c",
+      detectionSource: "byok" as const,
+    };
+    const merged = mergeDetectorIntoForm(baseForm, serverNext, form);
+    expect(merged.detectionModel).toBe("model-b");
+    expect(merged.detectionProvider).toBe("provider-a");
+    expect(merged.detectionSource).toBe("system");
+  });
+});

--- a/frontend/ui/src/features/detectors/utils/index.test.ts
+++ b/frontend/ui/src/features/detectors/utils/index.test.ts
@@ -75,6 +75,20 @@ describe("buildDetectorPatch", () => {
     expect(patch).toEqual({});
   });
 
+  it("includes a changed detection model, provider, and source", () => {
+    const patch = buildDetectorPatch(baseForm, {
+      ...baseForm,
+      detectionModel: "model-b",
+      detectionProvider: "provider-b",
+      detectionSource: "byok",
+    });
+    expect(patch).toEqual({
+      detectionModel: "model-b",
+      detectionProvider: "provider-b",
+      detectionSource: "byok",
+    });
+  });
+
   it("sends changed trigger conditions as triggerConditions", () => {
     const conditions = [{ field: "status", op: "eq", value: "error" }];
     const patch = buildDetectorPatch(baseForm, { ...baseForm, conditions });

--- a/frontend/ui/src/features/detectors/utils/index.test.ts
+++ b/frontend/ui/src/features/detectors/utils/index.test.ts
@@ -97,6 +97,21 @@ describe("mergeDetectorIntoForm", () => {
     expect(merged.name).toBe("Renamed");
   });
 
+  it("keeps the user's edited conditions while applying server values elsewhere", () => {
+    const userConditions = [{ field: "status", op: "eq", value: "error" }];
+    const form = { ...baseForm, conditions: userConditions };
+    const merged = mergeDetectorIntoForm(baseForm, next, form);
+    expect(merged.conditions).toEqual(userConditions);
+    expect(merged.enableRca).toBe(false);
+  });
+
+  it("takes the server's conditions when the form left them untouched", () => {
+    const serverConditions = [{ field: "latency", op: "gt", value: 5000 }];
+    const serverNext = { ...baseForm, conditions: serverConditions };
+    const merged = mergeDetectorIntoForm(baseForm, serverNext, { ...baseForm });
+    expect(merged.conditions).toEqual(serverConditions);
+  });
+
   it("keeps all three detection fields when the user touched the model selector", () => {
     const form = { ...baseForm, detectionModel: "model-b" };
     const serverNext = {

--- a/frontend/ui/src/features/detectors/utils/index.ts
+++ b/frontend/ui/src/features/detectors/utils/index.ts
@@ -1,0 +1,99 @@
+import type { Detector, UpdateDetectorInput } from "../hooks/use-detectors";
+
+/**
+ * The detector edit panel's form as plain data, so dirty-checking and merge
+ * logic stay pure and unit-testable. Empty string means "unset" for the
+ * detection model/provider; conditions mirror the trigger editor's rows.
+ */
+export interface DetectorFormValues {
+  name: string;
+  prompt: string;
+  sampleRate: number;
+  enableRca: boolean;
+  detectionModel: string;
+  detectionProvider: string;
+  detectionSource: "system" | "byok";
+  conditions: Array<{ field: string; op: string; value: unknown }>;
+}
+
+export function detectorToFormValues(d: Detector): DetectorFormValues {
+  return {
+    name: d.name,
+    prompt: d.prompt,
+    sampleRate: d.sampleRate,
+    enableRca: d.enableRca ?? true,
+    detectionModel: d.detectionModel ?? "",
+    detectionProvider: d.detectionProvider ?? "",
+    detectionSource: d.detectionSource === "byok" ? "byok" : "system",
+    conditions: (d.trigger?.conditions ?? []) as DetectorFormValues["conditions"],
+  };
+}
+
+function conditionsEqual(
+  a: DetectorFormValues["conditions"],
+  b: DetectorFormValues["conditions"],
+): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Diff the form against the last-loaded server snapshot and return only the
+ * fields the user actually changed. Saving a partial body means a stale tab
+ * can no longer silently revert fields it never touched (the PATCH route
+ * leaves omitted fields unchanged). A model/provider cleared to "" is omitted
+ * rather than sent, matching the previous save behavior.
+ */
+export function buildDetectorPatch(
+  loaded: DetectorFormValues,
+  form: DetectorFormValues,
+): UpdateDetectorInput {
+  const patch: UpdateDetectorInput = {};
+  if (form.name !== loaded.name) patch.name = form.name;
+  if (form.prompt !== loaded.prompt) patch.prompt = form.prompt;
+  if (form.sampleRate !== loaded.sampleRate) patch.sampleRate = form.sampleRate;
+  if (form.enableRca !== loaded.enableRca) patch.enableRca = form.enableRca;
+  if (!conditionsEqual(form.conditions, loaded.conditions)) {
+    patch.triggerConditions = form.conditions;
+  }
+  if (form.detectionModel !== loaded.detectionModel && form.detectionModel !== "") {
+    patch.detectionModel = form.detectionModel;
+  }
+  if (form.detectionProvider !== loaded.detectionProvider && form.detectionProvider !== "") {
+    patch.detectionProvider = form.detectionProvider;
+  }
+  if (form.detectionSource !== loaded.detectionSource) {
+    patch.detectionSource = form.detectionSource;
+  }
+  return patch;
+}
+
+/**
+ * Fold freshly fetched detector values into the form without clobbering
+ * in-progress edits: a field the user hasn't touched (form === previous
+ * snapshot) takes the server's new value; a touched field keeps the user's.
+ * The three detection fields move as a group because the model selector sets
+ * them together — merging them independently could pair a model with a
+ * provider nobody chose.
+ */
+export function mergeDetectorIntoForm(
+  previous: DetectorFormValues,
+  next: DetectorFormValues,
+  form: DetectorFormValues,
+): DetectorFormValues {
+  const touchedSelector =
+    form.detectionModel !== previous.detectionModel ||
+    form.detectionProvider !== previous.detectionProvider ||
+    form.detectionSource !== previous.detectionSource;
+  return {
+    name: form.name === previous.name ? next.name : form.name,
+    prompt: form.prompt === previous.prompt ? next.prompt : form.prompt,
+    sampleRate: form.sampleRate === previous.sampleRate ? next.sampleRate : form.sampleRate,
+    enableRca: form.enableRca === previous.enableRca ? next.enableRca : form.enableRca,
+    detectionModel: touchedSelector ? form.detectionModel : next.detectionModel,
+    detectionProvider: touchedSelector ? form.detectionProvider : next.detectionProvider,
+    detectionSource: touchedSelector ? form.detectionSource : next.detectionSource,
+    conditions: conditionsEqual(form.conditions, previous.conditions)
+      ? next.conditions
+      : form.conditions,
+  };
+}

--- a/frontend/ui/src/features/detectors/utils/index.ts
+++ b/frontend/ui/src/features/detectors/utils/index.ts
@@ -73,7 +73,9 @@ export function buildDetectorPatch(
  * snapshot) takes the server's new value; a touched field keeps the user's.
  * The three detection fields move as a group because the model selector sets
  * them together — merging them independently could pair a model with a
- * provider nobody chose.
+ * provider nobody chose. Known tradeoff: a field edited back to its original
+ * value is indistinguishable from untouched, so a concurrent remote change
+ * to that field will be adopted rather than preserved as-was.
  */
 export function mergeDetectorIntoForm(
   previous: DetectorFormValues,

--- a/frontend/ui/src/features/detectors/utils/index.ts
+++ b/frontend/ui/src/features/detectors/utils/index.ts
@@ -25,7 +25,7 @@ export function detectorToFormValues(d: Detector): DetectorFormValues {
     detectionModel: d.detectionModel ?? "",
     detectionProvider: d.detectionProvider ?? "",
     detectionSource: d.detectionSource === "byok" ? "byok" : "system",
-    conditions: (d.trigger?.conditions ?? []) as DetectorFormValues["conditions"],
+    conditions: d.trigger?.conditions ?? [],
   };
 }
 

--- a/frontend/ui/src/lib/cross-tab-sync.test.ts
+++ b/frontend/ui/src/lib/cross-tab-sync.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  QUERY_SYNC_CHANNEL,
+  isQueryInvalidationMessage,
+  broadcastQueryInvalidation,
+  subscribeToQueryInvalidations,
+} from "./cross-tab-sync";
+
+class FakeBroadcastChannel {
+  static instances: FakeBroadcastChannel[] = [];
+  name: string;
+  posted: unknown[] = [];
+  closed = false;
+  private listeners: Array<(e: MessageEvent) => void> = [];
+
+  constructor(name: string) {
+    this.name = name;
+    FakeBroadcastChannel.instances.push(this);
+  }
+  postMessage(data: unknown) {
+    this.posted.push(data);
+  }
+  addEventListener(_type: string, listener: (e: MessageEvent) => void) {
+    this.listeners.push(listener);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(data: unknown) {
+    for (const listener of this.listeners) listener({ data } as MessageEvent);
+  }
+}
+
+afterEach(() => {
+  FakeBroadcastChannel.instances = [];
+  vi.unstubAllGlobals();
+});
+
+describe("isQueryInvalidationMessage", () => {
+  it("accepts a well-formed message", () => {
+    expect(isQueryInvalidationMessage({ type: "invalidate", queryKey: ["detectors"] })).toBe(true);
+  });
+
+  it.each([null, "invalidate", { type: "invalidate" }, { type: "other", queryKey: [] }])(
+    "rejects malformed data: %j",
+    (data) => {
+      expect(isQueryInvalidationMessage(data)).toBe(false);
+    },
+  );
+});
+
+describe("broadcastQueryInvalidation", () => {
+  it("posts the message on the shared channel and closes it", () => {
+    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+    broadcastQueryInvalidation(["detectors"]);
+    const channel = FakeBroadcastChannel.instances[0];
+    expect(channel.name).toBe(QUERY_SYNC_CHANNEL);
+    expect(channel.posted).toEqual([{ type: "invalidate", queryKey: ["detectors"] }]);
+    expect(channel.closed).toBe(true);
+  });
+
+  it("is a no-op when BroadcastChannel is unavailable", () => {
+    vi.stubGlobal("BroadcastChannel", undefined);
+    expect(() => broadcastQueryInvalidation(["detectors"])).not.toThrow();
+  });
+});
+
+describe("subscribeToQueryInvalidations", () => {
+  it("invokes the callback for valid messages and ignores junk", () => {
+    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+    const received: unknown[] = [];
+    subscribeToQueryInvalidations((queryKey) => received.push(queryKey));
+    const channel = FakeBroadcastChannel.instances[0];
+    channel.emit({ type: "invalidate", queryKey: ["detectors"] });
+    channel.emit({ unrelated: true });
+    expect(received).toEqual([["detectors"]]);
+  });
+
+  it("returns an unsubscribe function that closes the channel", () => {
+    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+    const unsubscribe = subscribeToQueryInvalidations(() => {});
+    unsubscribe();
+    expect(FakeBroadcastChannel.instances[0].closed).toBe(true);
+  });
+
+  it("returns a no-op unsubscribe when BroadcastChannel is unavailable", () => {
+    vi.stubGlobal("BroadcastChannel", undefined);
+    expect(() => subscribeToQueryInvalidations(() => {})()).not.toThrow();
+  });
+});

--- a/frontend/ui/src/lib/cross-tab-sync.test.ts
+++ b/frontend/ui/src/lib/cross-tab-sync.test.ts
@@ -81,6 +81,19 @@ describe("broadcastQueryInvalidation", () => {
     broadcastQueryInvalidation(["detectors"]);
     expect(FakeBroadcastChannel.instances).toHaveLength(0);
   });
+
+  it("swallows a throwing channel constructor", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal(
+      "BroadcastChannel",
+      class {
+        constructor() {
+          throw new Error("denied");
+        }
+      },
+    );
+    expect(() => broadcastQueryInvalidation(["detectors"])).not.toThrow();
+  });
 });
 
 describe("subscribeToQueryInvalidations", () => {
@@ -104,6 +117,19 @@ describe("subscribeToQueryInvalidations", () => {
   it("returns a no-op unsubscribe when BroadcastChannel is unavailable", () => {
     vi.stubGlobal("window", {});
     vi.stubGlobal("BroadcastChannel", undefined);
+    expect(() => subscribeToQueryInvalidations(() => {})()).not.toThrow();
+  });
+
+  it("returns a no-op unsubscribe when the channel constructor throws", () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal(
+      "BroadcastChannel",
+      class {
+        constructor() {
+          throw new Error("denied");
+        }
+      },
+    );
     expect(() => subscribeToQueryInvalidations(() => {})()).not.toThrow();
   });
 });

--- a/frontend/ui/src/lib/cross-tab-sync.test.ts
+++ b/frontend/ui/src/lib/cross-tab-sync.test.ts
@@ -49,12 +49,15 @@ describe("isQueryInvalidationMessage", () => {
     expect(isQueryInvalidationMessage({ type: "invalidate", queryKey: ["detectors"] })).toBe(true);
   });
 
-  it.each([null, "invalidate", { type: "invalidate" }, { type: "other", queryKey: [] }])(
-    "rejects malformed data: %j",
-    (data) => {
-      expect(isQueryInvalidationMessage(data)).toBe(false);
-    },
-  );
+  it.each([
+    null,
+    "invalidate",
+    { type: "invalidate" },
+    { type: "other", queryKey: ["detectors"] },
+    { type: "invalidate", queryKey: [] },
+  ])("rejects malformed data: %j", (data) => {
+    expect(isQueryInvalidationMessage(data)).toBe(false);
+  });
 });
 
 describe("broadcastQueryInvalidation", () => {

--- a/frontend/ui/src/lib/cross-tab-sync.test.ts
+++ b/frontend/ui/src/lib/cross-tab-sync.test.ts
@@ -31,6 +31,14 @@ class FakeBroadcastChannel {
   }
 }
 
+// The implementation no-ops outside the browser (Node also has a global
+// BroadcastChannel), so active-path tests must stub `window` alongside the
+// fake channel.
+function stubBrowserEnvironment() {
+  vi.stubGlobal("window", {});
+  vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+}
+
 afterEach(() => {
   FakeBroadcastChannel.instances = [];
   vi.unstubAllGlobals();
@@ -51,7 +59,7 @@ describe("isQueryInvalidationMessage", () => {
 
 describe("broadcastQueryInvalidation", () => {
   it("posts the message on the shared channel and closes it", () => {
-    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+    stubBrowserEnvironment();
     broadcastQueryInvalidation(["detectors"]);
     const channel = FakeBroadcastChannel.instances[0];
     expect(channel.name).toBe(QUERY_SYNC_CHANNEL);
@@ -60,14 +68,21 @@ describe("broadcastQueryInvalidation", () => {
   });
 
   it("is a no-op when BroadcastChannel is unavailable", () => {
+    vi.stubGlobal("window", {});
     vi.stubGlobal("BroadcastChannel", undefined);
     expect(() => broadcastQueryInvalidation(["detectors"])).not.toThrow();
+  });
+
+  it("does not open a channel outside the browser even when BroadcastChannel exists", () => {
+    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+    broadcastQueryInvalidation(["detectors"]);
+    expect(FakeBroadcastChannel.instances).toHaveLength(0);
   });
 });
 
 describe("subscribeToQueryInvalidations", () => {
   it("invokes the callback for valid messages and ignores junk", () => {
-    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+    stubBrowserEnvironment();
     const received: unknown[] = [];
     subscribeToQueryInvalidations((queryKey) => received.push(queryKey));
     const channel = FakeBroadcastChannel.instances[0];
@@ -77,13 +92,14 @@ describe("subscribeToQueryInvalidations", () => {
   });
 
   it("returns an unsubscribe function that closes the channel", () => {
-    vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
+    stubBrowserEnvironment();
     const unsubscribe = subscribeToQueryInvalidations(() => {});
     unsubscribe();
     expect(FakeBroadcastChannel.instances[0].closed).toBe(true);
   });
 
   it("returns a no-op unsubscribe when BroadcastChannel is unavailable", () => {
+    vi.stubGlobal("window", {});
     vi.stubGlobal("BroadcastChannel", undefined);
     expect(() => subscribeToQueryInvalidations(() => {})()).not.toThrow();
   });

--- a/frontend/ui/src/lib/cross-tab-sync.ts
+++ b/frontend/ui/src/lib/cross-tab-sync.ts
@@ -25,7 +25,10 @@ export function isQueryInvalidationMessage(data: unknown): data is QueryInvalida
  * silently does nothing.
  */
 export function broadcastQueryInvalidation(queryKey: QueryKey): void {
-  if (typeof BroadcastChannel === "undefined") return;
+  // The window check matters: Node also has a global BroadcastChannel, so
+  // without it a server-side call would open a real worker_threads channel
+  // instead of the documented no-op.
+  if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") return;
   try {
     const channel = new BroadcastChannel(QUERY_SYNC_CHANNEL);
     const message: QueryInvalidationMessage = { type: "invalidate", queryKey };
@@ -43,7 +46,7 @@ export function broadcastQueryInvalidation(queryKey: QueryKey): void {
 export function subscribeToQueryInvalidations(
   onInvalidate: (queryKey: QueryKey) => void,
 ): () => void {
-  if (typeof BroadcastChannel === "undefined") return () => {};
+  if (typeof window === "undefined" || typeof BroadcastChannel === "undefined") return () => {};
   let channel: BroadcastChannel;
   try {
     channel = new BroadcastChannel(QUERY_SYNC_CHANNEL);

--- a/frontend/ui/src/lib/cross-tab-sync.ts
+++ b/frontend/ui/src/lib/cross-tab-sync.ts
@@ -13,7 +13,10 @@ export function isQueryInvalidationMessage(data: unknown): data is QueryInvalida
     typeof data === "object" &&
     data !== null &&
     (data as { type?: unknown }).type === "invalidate" &&
-    Array.isArray((data as { queryKey?: unknown }).queryKey)
+    Array.isArray((data as { queryKey?: unknown }).queryKey) &&
+    // An empty key would prefix-match every query and refetch the whole
+    // cache; no legitimate broadcaster sends it.
+    (data as { queryKey: unknown[] }).queryKey.length > 0
   );
 }
 

--- a/frontend/ui/src/lib/cross-tab-sync.ts
+++ b/frontend/ui/src/lib/cross-tab-sync.ts
@@ -1,0 +1,57 @@
+import type { QueryKey } from "@tanstack/react-query";
+
+/** One channel shared by all tabs of the app on this origin. */
+export const QUERY_SYNC_CHANNEL = "traceroot-query-sync";
+
+export interface QueryInvalidationMessage {
+  type: "invalidate";
+  queryKey: QueryKey;
+}
+
+export function isQueryInvalidationMessage(data: unknown): data is QueryInvalidationMessage {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    (data as { type?: unknown }).type === "invalidate" &&
+    Array.isArray((data as { queryKey?: unknown }).queryKey)
+  );
+}
+
+/**
+ * Tell other tabs that queries under `queryKey` are stale so they refetch.
+ * The posting tab is not notified (BroadcastChannel never echoes to its
+ * sender) — callers rely on their own local invalidation for that. Cross-tab
+ * sync is best-effort: where BroadcastChannel is unavailable or throws, this
+ * silently does nothing.
+ */
+export function broadcastQueryInvalidation(queryKey: QueryKey): void {
+  if (typeof BroadcastChannel === "undefined") return;
+  try {
+    const channel = new BroadcastChannel(QUERY_SYNC_CHANNEL);
+    const message: QueryInvalidationMessage = { type: "invalidate", queryKey };
+    channel.postMessage(message);
+    channel.close();
+  } catch {
+    // Best-effort only; the local cache was already invalidated by the caller.
+  }
+}
+
+/**
+ * Listen for invalidation messages from other tabs. Returns an unsubscribe
+ * function (a no-op where BroadcastChannel is unavailable).
+ */
+export function subscribeToQueryInvalidations(
+  onInvalidate: (queryKey: QueryKey) => void,
+): () => void {
+  if (typeof BroadcastChannel === "undefined") return () => {};
+  let channel: BroadcastChannel;
+  try {
+    channel = new BroadcastChannel(QUERY_SYNC_CHANNEL);
+  } catch {
+    return () => {};
+  }
+  channel.addEventListener("message", (event: MessageEvent) => {
+    if (isQueryInvalidationMessage(event.data)) onInvalidate(event.data.queryKey);
+  });
+  return () => channel.close();
+}

--- a/frontend/ui/vitest.config.ts
+++ b/frontend/ui/vitest.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
 export default defineConfig({
+  // Next.js sets tsconfig "jsx": "preserve", which esbuild would pass through
+  // untransformed; component tests need the automatic runtime instead.
+  esbuild: { jsx: "automatic" },
   test: {
     environment: "node",
     coverage: {
@@ -8,7 +11,7 @@ export default defineConfig({
       reporter: ["lcov"],
       reportsDirectory: "./coverage",
       reportOnFailure: true,
-      exclude: ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts", "**/types.ts"],
+      exclude: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.d.ts", "**/types.ts"],
     },
   },
   resolve: {


### PR DESCRIPTION
## Problem

With the same detector's edit panel open in two browser tabs, each tab has its own React Query cache and there is no cross-tab signal, so:

1. **No live updates** — toggling "Run root cause analysis" in one tab leaves the other tab stale until a window refocus (after the 60s staleTime) or a manual refresh.
2. **Silent lost update** — the panel PATCHed *every* form field on save, so a stale tab saving an unrelated change would silently revert the RCA toggle (a direct cost impact, since the toggle gates agent-model spend).
3. **Edit clobbering** — any refetch unconditionally repopulated the form, discarding in-progress edits.

## Solution

- **Cross-tab invalidation channel** (`lib/cross-tab-sync.ts`): a thin wrapper over the native `BroadcastChannel` API posting `{type: "invalidate", queryKey}` messages. Guarded to no-op outside the browser (Node also has a global `BroadcastChannel`) and to reject empty query keys (an empty key prefix-matches the entire cache). No new dependency, no server changes.
- **App-wide listener** (`components/cross-tab-query-sync.tsx`, mounted in `Providers`): invalidates whatever key arrives, so active queries in other tabs refetch immediately.
- **Detector mutations broadcast** `["detectors"]` after their local invalidation (create/update/delete).
- **Dirty-field saves**: the edit panel diffs its form against an id-tagged snapshot of the last-loaded server state (`features/detectors/utils/`) and PATCHes only changed fields — the route already supports partial bodies. A no-change save closes without a network call.
- **Edit-preserving merge**: fresh server data merges field-wise into the form — untouched fields update live (the toggle flips in real time), edited fields keep the user's values; the detection model/provider/source trio moves as one group.

BroadcastChannel was chosen over an SSE/Redis pipeline because the failure mode is same-browser multi-tab; the message module is transport-agnostic, so a server-pushed feed could drive the same invalidation path later if cross-user liveness is ever needed.

## Hardening found during review

- Snapshot is tagged with its detector id, so panel navigation to an already-cached detector populates fresh instead of merging one detector's edits into another.
- A no-op payload skip makes React StrictMode's dev double-effect harmless (it previously could blank the form and enable destructive empty PATCHes).

## Testing

- 24 new unit tests (form diff/merge helpers, broadcast channel wrapper) — `pnpm test` in `frontend/ui`: 215 passed; the only failures are 4 pre-existing Slack OAuth tests that need `BETTER_AUTH_URL` set locally.
- `tsc --noEmit` and eslint clean on all touched files.

## Video

# Before

https://github.com/user-attachments/assets/5c6ffa4d-503b-43d7-9090-5c87b988c149



# Fixed

https://github.com/user-attachments/assets/2db0c149-1d54-4b68-86bd-61848cd985c4





closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs detector edits across browser tabs and makes saves safe and incremental. RCA toggles and other changes now propagate instantly, and in‑progress edits aren’t clobbered.

- **New Features**
  - App-wide cross‑tab query invalidation via `BroadcastChannel`; listener mounted in Providers.
  - Detector mutations broadcast `["detectors"]` after local invalidation so other tabs refetch immediately.
  - Edit panel saves only changed fields; no‑change save closes without a request. Refetches merge into the form, preserving touched fields (model/provider/source move together).

- **Bug Fixes**
  - Live updates across tabs (e.g., RCA toggle) without refresh or refocus.
  - Prevents silent RCA toggle reverts from stale saves by sending partial PATCH bodies only.
  - Stops refetches from wiping in‑progress edits; snapshot is scoped per detector and no‑op merges avoid StrictMode double-invoke issues.

<sup>Written for commit 3624c716381a5818c4f330623711046ccc4d09dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

