### PR TITLE
docs(detectors): document the per-detector "Run root cause analysis" toggle

### DIFF
--- a/docs/detectors/get-started.mdx
+++ b/docs/detectors/get-started.mdx
@@ -18,6 +18,12 @@ Open your project in [TraceRoot Cloud](https://app.traceroot.ai), select **Detec
 
 The create sheet offers a handful of templates covering common failure modes — things like tool errors, hallucinations, logic mistakes, incomplete tasks, and safety issues — plus a blank slate if none of them fit. Pick whichever maps to a problem you've seen in production. The template fills in a prompt you can edit; save, and the detector starts running on the next incoming trace.
 
+### Choose whether to run root cause analysis
+
+The create sheet — and the edit panel for an existing detector — includes a **Run root cause analysis on findings** toggle, on by default. Leave it on and the AI agent investigates each finding; turn it off for a noisy or low-stakes detector where you want findings recorded without paying agent-model cost on every one. Detection is unaffected either way: the detector still fires and records findings.
+
+RCA is shared per trace, so a finding from an RCA-off detector can still be analyzed when an RCA-on detector fires on the same trace. See [Root cause analysis](/detectors/introduction#root-cause-analysis) for the exact rule.
+
 ## How it works
 
 The pipeline that runs on every trace:
@@ -25,7 +31,7 @@ The pipeline that runs on every trace:
 1. **Ingest.** A trace lands in the project.
 2. **Match.** TraceRoot decides which detectors apply (default: all enabled detectors in the project).
 3. **Evaluate.** The LLM-as-a-judge (Claude Haiku by default) reads the trace and returns `identified` plus a short summary.
-4. **Diagnose.** When `identified` is true, the trace becomes a **finding** and the TraceRoot AI agent investigates: it downloads the trace, reads your production source code at the failure point, checks recent commits and PRs touching that file, and produces a root cause analysis.
+4. **Diagnose.** When `identified` is true, the trace becomes a **finding** and — provided at least one detector that fired on the trace has **Run root cause analysis on findings** enabled — the TraceRoot AI agent investigates: it downloads the trace, reads your production source code at the failure point, checks recent commits and PRs touching that file, and produces a root cause analysis.
 5. **Alert.** The combined finding plus RCA is sent to your configured channels (email, Slack).
 
 

--- a/docs/detectors/introduction.mdx
+++ b/docs/detectors/introduction.mdx
@@ -23,13 +23,23 @@ Each step's model is configurable. For the judge we can choose a cheaper model a
 
 ## Anatomy of a detector
 
-A detector has three parts:
+A detector has four parts:
 
 - **A prompt** — what to look for, in natural language ("does this trace contain a hallucination?").
 - **A target** — which traces it runs on (every trace in the project, by default).
 - **An outcome** — a boolean `identified` — was the problem present in this trace?
+- **An RCA toggle** — whether the AI agent investigates this detector's findings (on by default).
 
-When `identified` is true, the detector emits a **finding**, the AI agent investigates, and the combined alert — finding plus analysis — lands in your inbox.
+When `identified` is true, the detector emits a **finding**, the AI agent investigates (when RCA is enabled — see below), and the combined alert — finding plus analysis — lands in your inbox.
+
+## Root cause analysis
+
+Every detector has a **Run root cause analysis on findings** toggle, available in the create sheet and the edit panel. It controls whether the AI agent (step 2) investigates the detector's findings — turn it off for a noisy detector that would otherwise incur agent-model cost on every finding. It defaults to on, and detection itself is unaffected either way: a detector with the toggle off still fires and records findings; only the downstream analysis is skipped.
+
+RCA is decided **per trace, not per detector**. When several detectors fire on the same trace they share a single finding and a single RCA agent, and that analysis runs if **at least one detector that fired** on the trace has the toggle on. Two consequences:
+
+- Turning a detector's toggle off only suppresses RCA when it fires alone (or only alongside other RCA-off detectors).
+- When an RCA-off detector shares a trace with a firing RCA-on detector, its finding still rides along into the one shared analysis — at no extra cost, since there is only ever one agent per trace.
 
 ## Where to start
 


### PR DESCRIPTION
## Summary

Documents the per-detector **"Run root cause analysis on findings"** toggle in the detector docs, which previously didn't mention RCA gating at all.

- `docs/detectors/introduction.mdx` — adds the RCA toggle to the "Anatomy of a detector" list and a new **Root cause analysis** section covering: default-on, detection unaffected by the toggle, the per-trace decision (one shared finding and one shared RCA agent per trace), and the gating rule — RCA runs if at least one detector that fired on the trace has the toggle on, so an off detector only suppresses RCA when it fires alone.
- `docs/detectors/get-started.mdx` — adds a "Choose whether to run root cause analysis" step to the create flow explaining when to turn the toggle off, and qualifies the "Diagnose" pipeline step with the gating condition.

Behavior documented matches the gating rules pinned in `frontend/worker/src/processors/__tests__/rca-gating.test.ts`, and the toggle wording matches the UI label in `rca-toggle.tsx`.

Closes #1103

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update detector docs to cover the per-detector "Run root cause analysis on findings" toggle and how it affects the pipeline.
Adds the toggle to the detector anatomy and create/edit flow, documents default-on, detection unaffected, and the per-trace gating rule (one shared analysis per trace; runs if any fired detector has RCA on; off only suppresses RCA when it fires alone).

<sup>Written for commit e5e8350426778b9db7b63573b09cb9e712726a75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1150?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

