### PR TITLE
feat(onboarding): prompt to add detectors during first-time setup

### DIFF
--- a/frontend/ui/src/app/onboarding/page.test.tsx
+++ b/frontend/ui/src/app/onboarding/page.test.tsx
@@ -36,11 +36,11 @@ vi.mock("@/features/detectors/components/add-detectors-step", () => ({
   }: {
     projectId: string;
     projectName: string;
-    onDone: (n: number) => void;
+    onDone: () => void;
   }) => (
     <div data-testid="add-detectors-step" data-project-id={projectId}>
       <span>{projectName}</span>
-      <button onClick={() => onDone(0)}>mock-done</button>
+      <button onClick={onDone}>mock-done</button>
     </div>
   ),
 }));

--- a/frontend/ui/src/app/onboarding/page.test.tsx
+++ b/frontend/ui/src/app/onboarding/page.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  createWorkspace: vi.fn(),
+  createProject: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: { user: { email: "kai@example.com" } },
+      isPending: false,
+    }),
+  },
+}));
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({ setHeaderContent: vi.fn() }),
+}));
+vi.mock("@/lib/api", () => ({
+  createWorkspace: mocks.createWorkspace,
+  createProject: mocks.createProject,
+}));
+vi.mock("@/features/detectors/components/add-detectors-step", () => ({
+  AddDetectorsStep: ({
+    projectId,
+    projectName,
+    onDone,
+  }: {
+    projectId: string;
+    projectName: string;
+    onDone: (n: number) => void;
+  }) => (
+    <div data-testid="add-detectors-step" data-project-id={projectId}>
+      <span>{projectName}</span>
+      <button onClick={() => onDone(0)}>mock-done</button>
+    </div>
+  ),
+}));
+
+import OnboardingPage from "./page";
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <OnboardingPage />
+    </QueryClientProvider>,
+  );
+}
+
+async function completeStepOne() {
+  fireEvent.click(screen.getByRole("button", { name: "Create" }));
+  await waitFor(() => expect(screen.getByTestId("add-detectors-step")).toBeDefined());
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.push.mockReset();
+  mocks.createWorkspace.mockReset();
+  mocks.createProject.mockReset();
+});
+
+describe("OnboardingPage", () => {
+  it("shows the detectors step after workspace + project creation instead of redirecting", async () => {
+    mocks.createWorkspace.mockResolvedValue({ id: "ws-1" });
+    mocks.createProject.mockResolvedValue({ id: "proj-1", name: "my-llm-project" });
+    renderPage();
+    await completeStepOne();
+
+    expect(mocks.createWorkspace).toHaveBeenCalledWith("Example");
+    expect(mocks.createProject).toHaveBeenCalledWith("ws-1", "my-llm-project");
+    expect(screen.getByTestId("add-detectors-step").dataset.projectId).toBe("proj-1");
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  it("navigates to traces when the detectors step finishes", async () => {
+    mocks.createWorkspace.mockResolvedValue({ id: "ws-1" });
+    mocks.createProject.mockResolvedValue({ id: "proj-1", name: "my-llm-project" });
+    renderPage();
+    await completeStepOne();
+
+    fireEvent.click(screen.getByRole("button", { name: "mock-done" }));
+    expect(mocks.push).toHaveBeenCalledWith("/projects/proj-1/traces");
+  });
+
+  it("still surfaces creation errors on step one", async () => {
+    mocks.createWorkspace.mockRejectedValue(new Error("workspace boom"));
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(screen.getByText("workspace boom")).toBeDefined());
+    expect(screen.queryByTestId("add-detectors-step")).toBeNull();
+  });
+});

--- a/frontend/ui/src/app/onboarding/page.tsx
+++ b/frontend/ui/src/app/onboarding/page.tsx
@@ -13,6 +13,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { useLayout } from "@/components/layout/app-layout";
 import { createWorkspace, createProject } from "@/lib/api";
 import { LayoutGrid, Layers, Check } from "lucide-react";
+import { AddDetectorsStep } from "@/features/detectors/components/add-detectors-step";
 
 const onboardingSchema = z.object({
   workspaceName: z.string().min(1, "Workspace name is required"),
@@ -52,6 +53,7 @@ function OnboardingContent() {
   const { setHeaderContent } = useLayout();
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [createdProject, setCreatedProject] = useState<{ id: string; name: string } | null>(null);
 
   // Set header content
   useEffect(() => {
@@ -119,7 +121,8 @@ function OnboardingContent() {
 
       queryClient.invalidateQueries({ queryKey: ["workspaces"] });
 
-      router.push(`/projects/${project.id}/traces`);
+      setCreatedProject({ id: project.id, name: projectName });
+      setIsLoading(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
       setIsLoading(false);
@@ -150,7 +153,9 @@ function OnboardingContent() {
         <div className="mb-6">
           <h1 className="text-lg font-semibold">Setup</h1>
           <p className="text-[13px] text-muted-foreground">
-            Set up your workspace and first project
+            {createdProject
+              ? "Workspace and project created — one more thing"
+              : "Set up your workspace and first project"}
           </p>
         </div>
 
@@ -164,86 +169,103 @@ function OnboardingContent() {
         {/* Tree Form */}
         <Card>
           <CardContent className="p-4">
-            <div className="space-y-0">
-              {/* Workspace Section */}
-              <div className="flex items-start gap-3">
-                <div className="flex flex-col items-center">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-primary/10">
-                    {isProjectOnlyMode ? (
-                      <Check className="h-4 w-4 text-primary" />
-                    ) : (
-                      <LayoutGrid className="h-4 w-4 text-primary" />
-                    )}
-                  </div>
-                  {/* Vertical connector line */}
-                  <div className="my-1.5 h-12 w-px bg-border" />
-                </div>
-                <div className="flex-1 pb-2 pt-0.5">
-                  <label className="text-[13px] font-medium">Workspace</label>
-                  <p className="mb-2 text-[11px] text-muted-foreground">
-                    Your team's home for billing and members
-                  </p>
-                  {isProjectOnlyMode ? (
-                    <div className="flex max-w-xs items-center gap-2 border bg-muted/50 px-2.5 py-1.5 text-[13px]">
-                      <span>{existingWorkspaceName || "Selected workspace"}</span>
-                      <Check className="ml-auto h-3.5 w-3.5 text-green-600" />
+            {createdProject ? (
+              <div>
+                <p className="mb-2 text-[13px] font-medium">Add detectors</p>
+                <AddDetectorsStep
+                  projectId={createdProject.id}
+                  projectName={createdProject.name}
+                  onDone={() => router.push(`/projects/${createdProject.id}/traces`)}
+                />
+              </div>
+            ) : (
+              <>
+                <div className="space-y-0">
+                  {/* Workspace Section */}
+                  <div className="flex items-start gap-3">
+                    <div className="flex flex-col items-center">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-primary/10">
+                        {isProjectOnlyMode ? (
+                          <Check className="h-4 w-4 text-primary" />
+                        ) : (
+                          <LayoutGrid className="h-4 w-4 text-primary" />
+                        )}
+                      </div>
+                      {/* Vertical connector line */}
+                      <div className="my-1.5 h-12 w-px bg-border" />
                     </div>
-                  ) : (
-                    <Input
-                      placeholder="Acme Inc"
-                      {...register("workspaceName")}
-                      className="h-8 max-w-xs text-[13px]"
-                    />
-                  )}
-                  {errors.workspaceName && (
-                    <p className="mt-1 text-[11px] text-red-500">{errors.workspaceName.message}</p>
-                  )}
-                </div>
-              </div>
+                    <div className="flex-1 pb-2 pt-0.5">
+                      <label className="text-[13px] font-medium">Workspace</label>
+                      <p className="mb-2 text-[11px] text-muted-foreground">
+                        Your team's home for billing and members
+                      </p>
+                      {isProjectOnlyMode ? (
+                        <div className="flex max-w-xs items-center gap-2 border bg-muted/50 px-2.5 py-1.5 text-[13px]">
+                          <span>{existingWorkspaceName || "Selected workspace"}</span>
+                          <Check className="ml-auto h-3.5 w-3.5 text-green-600" />
+                        </div>
+                      ) : (
+                        <Input
+                          placeholder="Acme Inc"
+                          {...register("workspaceName")}
+                          className="h-8 max-w-xs text-[13px]"
+                        />
+                      )}
+                      {errors.workspaceName && (
+                        <p className="mt-1 text-[11px] text-red-500">
+                          {errors.workspaceName.message}
+                        </p>
+                      )}
+                    </div>
+                  </div>
 
-              {/* Project Section */}
-              <div className="flex items-start gap-3">
-                <div className="flex flex-col items-center">
-                  <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-muted">
-                    <Layers className="h-4 w-4 text-muted-foreground" />
+                  {/* Project Section */}
+                  <div className="flex items-start gap-3">
+                    <div className="flex flex-col items-center">
+                      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-muted">
+                        <Layers className="h-4 w-4 text-muted-foreground" />
+                      </div>
+                    </div>
+                    <div className="flex-1 pb-2 pt-0.5">
+                      <label className="text-[13px] font-medium">Project</label>
+                      <p className="mb-2 text-[11px] text-muted-foreground">
+                        Where your traces and experiments live
+                      </p>
+                      <Input
+                        placeholder="my-llm-project"
+                        {...register("projectName")}
+                        className="h-8 max-w-xs text-[13px]"
+                      />
+                      {errors.projectName && (
+                        <p className="mt-1 text-[11px] text-red-500">
+                          {errors.projectName.message}
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </div>
-                <div className="flex-1 pb-2 pt-0.5">
-                  <label className="text-[13px] font-medium">Project</label>
-                  <p className="mb-2 text-[11px] text-muted-foreground">
-                    Where your traces and experiments live
-                  </p>
-                  <Input
-                    placeholder="my-llm-project"
-                    {...register("projectName")}
-                    className="h-8 max-w-xs text-[13px]"
-                  />
-                  {errors.projectName && (
-                    <p className="mt-1 text-[11px] text-red-500">{errors.projectName.message}</p>
-                  )}
-                </div>
-              </div>
-            </div>
 
-            {/* Actions */}
-            <div className="mt-6 flex items-center justify-center gap-2">
-              <Button
-                size="sm"
-                className="h-7 px-4 text-[12px]"
-                onClick={handleSubmit}
-                disabled={isLoading}
-              >
-                {isLoading ? "Creating..." : "Create"}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-7 px-4 text-[12px]"
-                onClick={() => router.push("/workspaces")}
-              >
-                Cancel
-              </Button>
-            </div>
+                {/* Actions */}
+                <div className="mt-6 flex items-center justify-center gap-2">
+                  <Button
+                    size="sm"
+                    className="h-7 px-4 text-[12px]"
+                    onClick={handleSubmit}
+                    disabled={isLoading}
+                  >
+                    {isLoading ? "Creating..." : "Create"}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 px-4 text-[12px]"
+                    onClick={() => router.push("/workspaces")}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </>
+            )}
           </CardContent>
         </Card>
       </div>

--- a/frontend/ui/src/app/onboarding/page.tsx
+++ b/frontend/ui/src/app/onboarding/page.tsx
@@ -154,7 +154,7 @@ function OnboardingContent() {
           <h1 className="text-lg font-semibold">Setup</h1>
           <p className="text-[13px] text-muted-foreground">
             {createdProject
-              ? "Workspace and project created — one more thing"
+              ? `${isProjectOnlyMode ? "Project" : "Workspace and project"} created — one more thing`
               : "Set up your workspace and first project"}
           </p>
         </div>

--- a/frontend/ui/src/app/onboarding/page.tsx
+++ b/frontend/ui/src/app/onboarding/page.tsx
@@ -121,7 +121,7 @@ function OnboardingContent() {
 
       queryClient.invalidateQueries({ queryKey: ["workspaces"] });
 
-      setCreatedProject({ id: project.id, name: projectName });
+      setCreatedProject({ id: project.id, name: project.name });
       setIsLoading(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { getTemplate } from "@/features/detectors/templates";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  mutateAsync: vi.fn().mockResolvedValue({ id: "det-1" }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "proj-1" }),
+  useRouter: () => ({ push: mocks.push }),
+}));
+vi.mock("@/features/detectors/hooks/use-detectors", () => ({
+  useCreateDetector: () => ({ mutateAsync: mocks.mutateAsync, isPending: false }),
+}));
+vi.mock("@/features/projects/hooks", () => ({
+  useProject: () => ({ data: undefined }),
+}));
+vi.mock("@/features/projects/components", () => ({
+  ProjectBreadcrumb: () => null,
+}));
+vi.mock("@/features/ai-assistant/components/model-selector", () => ({
+  ModelSelector: () => null,
+}));
+vi.mock("@/features/detectors/components/trigger-editor", () => ({
+  TriggerEditor: () => null,
+}));
+vi.mock("@/features/detectors/components/agent-model-link", () => ({
+  AgentModelLink: () => null,
+}));
+vi.mock("@/features/detectors/components/rca-toggle", () => ({
+  RcaToggle: () => null,
+}));
+
+import NewDetectorPage from "./page";
+
+afterEach(() => {
+  cleanup();
+  mocks.mutateAsync.mockClear();
+  mocks.push.mockClear();
+});
+
+describe("NewDetectorPage", () => {
+  it("submits the selected template's defaults", async () => {
+    render(<NewDetectorPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Create Detector" }));
+
+    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
+    const failure = getTemplate("failure")!;
+    expect(mocks.mutateAsync).toHaveBeenCalledWith({
+      name: "Failure Detector",
+      template: "failure",
+      prompt: failure.prompt,
+      outputSchema: failure.outputSchema,
+      triggerConditions: failure.defaultConditions,
+      sampleRate: 100,
+      enableRca: true,
+      detectionModel: undefined,
+      detectionProvider: undefined,
+      detectionSource: "system",
+    });
+    expect(mocks.push).toHaveBeenCalledWith("/projects/proj-1/detectors");
+  });
+
+  it("submits user-edited name and prompt over the template defaults", async () => {
+    render(<NewDetectorPage />);
+    fireEvent.change(screen.getByDisplayValue("Failure Detector"), {
+      target: { value: "My detector" },
+    });
+    fireEvent.change(document.querySelector("textarea")!, {
+      target: { value: "my prompt" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Detector" }));
+
+    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
+    expect(mocks.mutateAsync.mock.calls[0][0]).toMatchObject({
+      name: "My detector",
+      prompt: "my prompt",
+      template: "failure",
+    });
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -8,7 +8,7 @@ import {
   ModelSelector,
   type ModelSelection,
 } from "@/features/ai-assistant/components/model-selector";
-import { DETECTOR_TEMPLATES } from "@/features/detectors/templates";
+import { DETECTOR_TEMPLATES, buildTemplateDetectorInput } from "@/features/detectors/templates";
 import { useCreateDetector } from "@/features/detectors/hooks/use-detectors";
 import type { CreateDetectorInput } from "@/features/detectors/hooks/use-detectors";
 import { TriggerEditor } from "@/features/detectors/components/trigger-editor";
@@ -61,10 +61,9 @@ export default function NewDetectorPage() {
     e.preventDefault();
     const template = DETECTOR_TEMPLATES.find((t) => t.id === selectedTemplate)!;
     const input: CreateDetectorInput = {
+      ...buildTemplateDetectorInput(template),
       name,
-      template: selectedTemplate,
       prompt,
-      outputSchema: template.outputSchema,
       sampleRate,
       enableRca,
       triggerConditions,

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { getTemplate } from "../templates";
+
+const mocks = vi.hoisted(() => ({
+  mutateAsync: vi.fn(),
+}));
+
+vi.mock("../hooks/use-detectors", () => ({
+  useCreateDetector: () => ({ mutateAsync: mocks.mutateAsync }),
+}));
+
+import { AddDetectorsStep } from "./add-detectors-step";
+
+function renderStep() {
+  const onDone = vi.fn();
+  render(<AddDetectorsStep projectId="proj-1" projectName="checkout-agent" onDone={onDone} />);
+  return { onDone };
+}
+
+const pill = (label: string) => screen.getByRole("button", { name: label });
+const continueButton = () => screen.getByRole("button", { name: "Continue" });
+
+afterEach(() => {
+  cleanup();
+  mocks.mutateAsync.mockReset();
+});
+
+describe("AddDetectorsStep", () => {
+  it("renders the five quick-add templates and no Blank pill", () => {
+    renderStep();
+    for (const label of ["Failure", "Hallucination", "Logic Error", "Task Completion", "Safety"]) {
+      expect(pill(label)).toBeDefined();
+    }
+    expect(screen.queryByRole("button", { name: "Blank" })).toBeNull();
+    expect(screen.getByText("checkout-agent")).toBeDefined();
+  });
+
+  it("shows the description of the last-toggled template", () => {
+    renderStep();
+    fireEvent.click(pill("Safety"));
+    expect(screen.getByText(getTemplate("safety")!.description)).toBeDefined();
+    fireEvent.click(pill("Failure"));
+    expect(screen.getByText(getTemplate("failure")!.description)).toBeDefined();
+  });
+
+  it("calls onDone(0) without posting when continuing with nothing selected", () => {
+    const { onDone } = renderStep();
+    fireEvent.click(continueButton());
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledWith(0);
+  });
+
+  it("calls onDone(0) on skip", () => {
+    const { onDone } = renderStep();
+    fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledWith(0);
+  });
+
+  it("creates one detector per selected template with the shared defaults", async () => {
+    mocks.mutateAsync.mockResolvedValue({ id: "det-1" });
+    const { onDone } = renderStep();
+    fireEvent.click(pill("Failure"));
+    fireEvent.click(pill("Safety"));
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith(2));
+    expect(mocks.mutateAsync).toHaveBeenCalledTimes(2);
+    const payloads = mocks.mutateAsync.mock.calls.map((c) => c[0]);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        template: "failure",
+        name: "Failure Detector",
+        sampleRate: 100,
+        enableRca: true,
+        detectionSource: "system",
+      }),
+    );
+    expect(payloads).toContainEqual(expect.objectContaining({ template: "safety" }));
+  });
+
+  it("deselecting a pill removes it from the submission", async () => {
+    mocks.mutateAsync.mockResolvedValue({ id: "det-1" });
+    const { onDone } = renderStep();
+    fireEvent.click(pill("Failure"));
+    fireEvent.click(pill("Safety"));
+    fireEvent.click(pill("Failure")); // toggle back off
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith(1));
+    expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mocks.mutateAsync.mock.calls[0][0]).toMatchObject({ template: "safety" });
+  });
+
+  it("keeps failed templates selected with an inline error, and retries only those", async () => {
+    mocks.mutateAsync.mockImplementation((input: { template: string }) =>
+      input.template === "safety"
+        ? Promise.reject(new Error("Failed to create detector: 500"))
+        : Promise.resolve({ id: "det-1" }),
+    );
+    const { onDone } = renderStep();
+    fireEvent.click(pill("Failure"));
+    fireEvent.click(pill("Safety"));
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(screen.getByText(/Couldn't create: Safety/)).toBeDefined());
+    expect(onDone).not.toHaveBeenCalled();
+
+    // Retry: only the failed template is re-posted
+    mocks.mutateAsync.mockClear();
+    mocks.mutateAsync.mockResolvedValue({ id: "det-2" });
+    fireEvent.click(continueButton());
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith(2));
+    expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mocks.mutateAsync.mock.calls[0][0]).toMatchObject({ template: "safety" });
+  });
+});

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
@@ -37,11 +37,14 @@ describe("AddDetectorsStep", () => {
     expect(screen.getByText("checkout-agent")).toBeDefined();
   });
 
-  it("shows the description of the last-toggled template", () => {
+  it("shows the description of the hovered template", () => {
     renderStep();
-    fireEvent.click(pill("Safety"));
+    fireEvent.mouseEnter(pill("Safety"));
     expect(screen.getByText(getTemplate("safety")!.description)).toBeDefined();
-    fireEvent.click(pill("Failure"));
+    fireEvent.mouseEnter(pill("Failure"));
+    expect(screen.getByText(getTemplate("failure")!.description)).toBeDefined();
+    // clicking selects but does not move the description
+    fireEvent.click(pill("Safety"));
     expect(screen.getByText(getTemplate("failure")!.description)).toBeDefined();
   });
 

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
@@ -45,18 +45,18 @@ describe("AddDetectorsStep", () => {
     expect(screen.getByText(getTemplate("failure")!.description)).toBeDefined();
   });
 
-  it("calls onDone(0) without posting when continuing with nothing selected", () => {
+  it("calls onDone without posting when continuing with nothing selected", () => {
     const { onDone } = renderStep();
     fireEvent.click(continueButton());
     expect(mocks.mutateAsync).not.toHaveBeenCalled();
-    expect(onDone).toHaveBeenCalledWith(0);
+    expect(onDone).toHaveBeenCalledTimes(1);
   });
 
-  it("calls onDone(0) on skip", () => {
+  it("calls onDone on skip", () => {
     const { onDone } = renderStep();
     fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
     expect(mocks.mutateAsync).not.toHaveBeenCalled();
-    expect(onDone).toHaveBeenCalledWith(0);
+    expect(onDone).toHaveBeenCalledTimes(1);
   });
 
   it("creates one detector per selected template with the shared defaults", async () => {
@@ -66,7 +66,7 @@ describe("AddDetectorsStep", () => {
     fireEvent.click(pill("Safety"));
     fireEvent.click(continueButton());
 
-    await waitFor(() => expect(onDone).toHaveBeenCalledWith(2));
+    await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1));
     expect(mocks.mutateAsync).toHaveBeenCalledTimes(2);
     const payloads = mocks.mutateAsync.mock.calls.map((c) => c[0]);
     expect(payloads).toContainEqual(
@@ -89,7 +89,7 @@ describe("AddDetectorsStep", () => {
     fireEvent.click(pill("Failure")); // toggle back off
     fireEvent.click(continueButton());
 
-    await waitFor(() => expect(onDone).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1));
     expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
     expect(mocks.mutateAsync.mock.calls[0][0]).toMatchObject({ template: "safety" });
   });
@@ -113,7 +113,7 @@ describe("AddDetectorsStep", () => {
     mocks.mutateAsync.mockResolvedValue({ id: "det-2" });
     fireEvent.click(continueButton());
 
-    await waitFor(() => expect(onDone).toHaveBeenCalledWith(2));
+    await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1));
     expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
     expect(mocks.mutateAsync.mock.calls[0][0]).toMatchObject({ template: "safety" });
   });

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  QUICK_ADD_TEMPLATES,
+  buildTemplateDetectorInput,
+  getTemplate,
+} from "@/features/detectors/templates";
+import { useCreateDetector } from "@/features/detectors/hooks/use-detectors";
+
+interface AddDetectorsStepProps {
+  projectId: string;
+  projectName: string;
+  /** Called when the step is finished: number of detectors created (0 on skip). */
+  onDone: (createdCount: number) => void;
+}
+
+/**
+ * Skippable multi-select template picker shown right after a project is
+ * created. Creates one detector per selected template through the same
+ * endpoint as the new-detector form; the project is never affected.
+ */
+export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetectorsStepProps) {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [lastToggledId, setLastToggledId] = useState(QUICK_ADD_TEMPLATES[0].id);
+  const [failedLabels, setFailedLabels] = useState<string[]>([]);
+  const [createdCount, setCreatedCount] = useState(0);
+  const [submitting, setSubmitting] = useState(false);
+  const createMutation = useCreateDetector(projectId);
+
+  const toggle = (templateId: string) => {
+    setLastToggledId(templateId);
+    setSelected((prev) =>
+      prev.includes(templateId) ? prev.filter((id) => id !== templateId) : [...prev, templateId],
+    );
+  };
+
+  const handleContinue = async () => {
+    if (selected.length === 0) {
+      onDone(createdCount);
+      return;
+    }
+    setSubmitting(true);
+    setFailedLabels([]);
+    const results = await Promise.allSettled(
+      selected.map((id) =>
+        createMutation.mutateAsync(buildTemplateDetectorInput(getTemplate(id)!)),
+      ),
+    );
+    const failed = selected.filter((_, i) => results[i].status === "rejected");
+    const total = createdCount + selected.length - failed.length;
+    if (failed.length === 0) {
+      onDone(total);
+      return;
+    }
+    setCreatedCount(total);
+    setSelected(failed);
+    setFailedLabels(failed.map((id) => getTemplate(id)?.label ?? id));
+    setSubmitting(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-[13px] text-muted-foreground">
+        Detectors automatically scan traces in{" "}
+        <span className="font-medium text-foreground">{projectName}</span> for issues. Select any to
+        start with.
+      </p>
+      <div className="border border-border">
+        <div className="border-b border-border bg-muted/50 px-3 py-1.5">
+          <span className="text-[12px] font-medium text-muted-foreground">Templates</span>
+        </div>
+        <div className="p-3">
+          <div className="flex flex-wrap gap-1.5">
+            {QUICK_ADD_TEMPLATES.map((t) => (
+              <Button
+                key={t.id}
+                type="button"
+                size="sm"
+                variant={selected.includes(t.id) ? "default" : "outline"}
+                onClick={() => toggle(t.id)}
+                disabled={submitting}
+                className="h-7 text-[12px]"
+              >
+                {t.label}
+              </Button>
+            ))}
+          </div>
+          <p className="mt-2 min-h-[1rem] text-[12px] text-muted-foreground">
+            {getTemplate(lastToggledId)?.description ?? ""}
+          </p>
+        </div>
+      </div>
+      {failedLabels.length > 0 && (
+        <p className="text-[12px] text-destructive">
+          Couldn&apos;t create: {failedLabels.join(", ")}. Try again or skip.
+        </p>
+      )}
+      <div className="flex items-center justify-between pt-1">
+        <button
+          type="button"
+          onClick={() => onDone(createdCount)}
+          disabled={submitting}
+          className="text-[12px] text-muted-foreground underline-offset-2 hover:underline disabled:opacity-50"
+        >
+          Skip for now
+        </button>
+        <Button
+          type="button"
+          size="sm"
+          className="h-7 text-[12px]"
+          onClick={handleContinue}
+          disabled={submitting}
+        >
+          {submitting ? "Adding..." : "Continue"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
@@ -23,13 +23,12 @@ interface AddDetectorsStepProps {
  */
 export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetectorsStepProps) {
   const [selected, setSelected] = useState<string[]>([]);
-  const [lastToggledId, setLastToggledId] = useState(QUICK_ADD_TEMPLATES[0].id);
+  const [previewedId, setPreviewedId] = useState(QUICK_ADD_TEMPLATES[0].id);
   const [failedLabels, setFailedLabels] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const createMutation = useCreateDetector(projectId);
 
   const toggle = (templateId: string) => {
-    setLastToggledId(templateId);
     setSelected((prev) =>
       prev.includes(templateId) ? prev.filter((id) => id !== templateId) : [...prev, templateId],
     );
@@ -77,6 +76,8 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
                 size="sm"
                 variant={selected.includes(t.id) ? "default" : "outline"}
                 onClick={() => toggle(t.id)}
+                onMouseEnter={() => setPreviewedId(t.id)}
+                onFocus={() => setPreviewedId(t.id)}
                 disabled={submitting}
                 className="h-7 text-[12px]"
               >
@@ -85,7 +86,7 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
             ))}
           </div>
           <p className="mt-2 min-h-[1rem] text-[12px] text-muted-foreground">
-            {getTemplate(lastToggledId)?.description ?? ""}
+            {getTemplate(previewedId)?.description ?? ""}
           </p>
         </div>
       </div>

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
-  QUICK_ADD_TEMPLATES,
+  DETECTOR_QUICK_ADD_TEMPLATES,
   buildTemplateDetectorInput,
   getTemplate,
 } from "@/features/detectors/templates";
@@ -23,7 +23,7 @@ interface AddDetectorsStepProps {
  */
 export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetectorsStepProps) {
   const [selected, setSelected] = useState<string[]>([]);
-  const [previewedId, setPreviewedId] = useState(QUICK_ADD_TEMPLATES[0].id);
+  const [previewedId, setPreviewedId] = useState(DETECTOR_QUICK_ADD_TEMPLATES[0].id);
   const [failedLabels, setFailedLabels] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const createMutation = useCreateDetector(projectId);
@@ -69,7 +69,7 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
         </div>
         <div className="p-3">
           <div className="flex flex-wrap gap-1.5">
-            {QUICK_ADD_TEMPLATES.map((t) => (
+            {DETECTOR_QUICK_ADD_TEMPLATES.map((t) => (
               <Button
                 key={t.id}
                 type="button"

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
@@ -12,8 +12,8 @@ import { useCreateDetector } from "@/features/detectors/hooks/use-detectors";
 interface AddDetectorsStepProps {
   projectId: string;
   projectName: string;
-  /** Called when the step is finished: number of detectors created (0 on skip). */
-  onDone: (createdCount: number) => void;
+  /** Called when the step is finished, whether detectors were created or it was skipped. */
+  onDone: () => void;
 }
 
 /**
@@ -25,7 +25,6 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
   const [selected, setSelected] = useState<string[]>([]);
   const [lastToggledId, setLastToggledId] = useState(QUICK_ADD_TEMPLATES[0].id);
   const [failedLabels, setFailedLabels] = useState<string[]>([]);
-  const [createdCount, setCreatedCount] = useState(0);
   const [submitting, setSubmitting] = useState(false);
   const createMutation = useCreateDetector(projectId);
 
@@ -38,7 +37,7 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
 
   const handleContinue = async () => {
     if (selected.length === 0) {
-      onDone(createdCount);
+      onDone();
       return;
     }
     setSubmitting(true);
@@ -49,12 +48,10 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
       ),
     );
     const failed = selected.filter((_, i) => results[i].status === "rejected");
-    const total = createdCount + selected.length - failed.length;
     if (failed.length === 0) {
-      onDone(total);
+      onDone();
       return;
     }
-    setCreatedCount(total);
     setSelected(failed);
     setFailedLabels(failed.map((id) => getTemplate(id)?.label ?? id));
     setSubmitting(false);
@@ -100,7 +97,7 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
       <div className="flex items-center justify-between pt-1">
         <button
           type="button"
-          onClick={() => onDone(createdCount)}
+          onClick={onDone}
           disabled={submitting}
           className="text-[12px] text-muted-foreground underline-offset-2 hover:underline disabled:opacity-50"
         >

--- a/frontend/ui/src/features/detectors/templates.test.ts
+++ b/frontend/ui/src/features/detectors/templates.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { QUICK_ADD_TEMPLATES, buildTemplateDetectorInput, getTemplate } from "./templates";
+
+describe("QUICK_ADD_TEMPLATES", () => {
+  it("excludes the blank template and keeps the rest in order", () => {
+    expect(QUICK_ADD_TEMPLATES.map((t) => t.id)).toEqual([
+      "failure",
+      "hallucination",
+      "logic",
+      "task",
+      "safety",
+    ]);
+  });
+});
+
+describe("buildTemplateDetectorInput", () => {
+  it("builds the defaults the new-detector form starts from", () => {
+    const failure = getTemplate("failure")!;
+    expect(buildTemplateDetectorInput(failure)).toEqual({
+      name: "Failure Detector",
+      template: "failure",
+      prompt: failure.prompt,
+      outputSchema: failure.outputSchema,
+      triggerConditions: failure.defaultConditions,
+      sampleRate: 100,
+      enableRca: true,
+      detectionSource: "system",
+    });
+  });
+
+  it("derives the name from the template label", () => {
+    const safety = getTemplate("safety")!;
+    expect(buildTemplateDetectorInput(safety).name).toBe("Safety Detector");
+  });
+});

--- a/frontend/ui/src/features/detectors/templates.test.ts
+++ b/frontend/ui/src/features/detectors/templates.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { QUICK_ADD_TEMPLATES, buildTemplateDetectorInput, getTemplate } from "./templates";
+import { DETECTOR_QUICK_ADD_TEMPLATES, buildTemplateDetectorInput, getTemplate } from "./templates";
 
-describe("QUICK_ADD_TEMPLATES", () => {
+describe("DETECTOR_QUICK_ADD_TEMPLATES", () => {
   it("excludes the blank template and keeps the rest in order", () => {
-    expect(QUICK_ADD_TEMPLATES.map((t) => t.id)).toEqual([
+    expect(DETECTOR_QUICK_ADD_TEMPLATES.map((t) => t.id)).toEqual([
       "failure",
       "hallucination",
       "logic",

--- a/frontend/ui/src/features/detectors/templates.ts
+++ b/frontend/ui/src/features/detectors/templates.ts
@@ -1,3 +1,5 @@
+import type { CreateDetectorInput } from "@/features/detectors/hooks/use-detectors";
+
 export interface DetectorTemplate {
   id: string;
   label: string;
@@ -104,4 +106,23 @@ Report identified=true only for clear, concrete safety violations.`,
 
 export function getTemplate(id: string): DetectorTemplate | undefined {
   return DETECTOR_TEMPLATES.find((t) => t.id === id);
+}
+
+// Templates offered for one-click creation in the project-creation flow.
+// Blank needs a custom prompt, so it is only available on the full new-detector form.
+export const QUICK_ADD_TEMPLATES = DETECTOR_TEMPLATES.filter((t) => t.id !== "blank");
+
+// Default create payload for a template — shared by the new-detector form and the
+// project-creation quick-add step so the two creation paths cannot drift.
+export function buildTemplateDetectorInput(template: DetectorTemplate): CreateDetectorInput {
+  return {
+    name: `${template.label} Detector`,
+    template: template.id,
+    prompt: template.prompt,
+    outputSchema: template.outputSchema,
+    triggerConditions: template.defaultConditions,
+    sampleRate: 100,
+    enableRca: true,
+    detectionSource: "system",
+  };
 }

--- a/frontend/ui/src/features/detectors/templates.ts
+++ b/frontend/ui/src/features/detectors/templates.ts
@@ -110,7 +110,7 @@ export function getTemplate(id: string): DetectorTemplate | undefined {
 
 // Templates offered for one-click creation in the project-creation flow.
 // Blank needs a custom prompt, so it is only available on the full new-detector form.
-export const QUICK_ADD_TEMPLATES = DETECTOR_TEMPLATES.filter((t) => t.id !== "blank");
+export const DETECTOR_QUICK_ADD_TEMPLATES = DETECTOR_TEMPLATES.filter((t) => t.id !== "blank");
 
 // Default create payload for a template — shared by the new-detector form and the
 // project-creation quick-add step so the two creation paths cannot drift.


### PR DESCRIPTION
## Summary

Detectors are a core part of the product, but new users finish onboarding without ever seeing them. After the workspace and project are created on `/onboarding`, the Setup card now swaps to a skippable **Add detectors** step: a multi-select picker over the detector templates (Failure, Hallucination, Logic Error, Task Completion, Safety) where Continue creates one detector per selected template, and Skip/Continue both land on the project's traces page as before.

## How it works

- New shared `AddDetectorsStep` component (`features/detectors/components/add-detectors-step.tsx`): multi-select template pills (descriptions preview on hover/focus), Skip for now / Continue footer. The Blank template is intentionally omitted — it requires a custom prompt, which is what the full new-detector form is for.
- Reuses the existing creation path end to end: one `POST /api/projects/{projectId}/detectors` per selected template via the existing `useCreateDetector` hook (no new endpoints, cache invalidation for free).
- Template defaults are extracted from the new-detector page into a shared `buildTemplateDetectorInput()` helper in `templates.ts`; the new-detector form was refactored onto it (behavior-preserving, pinned by a regression test) so the two creation paths cannot drift.
- The step is purely additive: detector-creation failures show an inline error with retry of only the failed templates, and skipping/closing never affects the already-created project. Project-only onboarding (`?workspaceId=`) is supported with corrected header copy.

## Testing

- New RTL/jsdom tests for `AddDetectorsStep` (template rendering, hover preview, multi-create payloads, empty-continue/skip, partial-failure retry), the onboarding step transition, and a regression test pinning the new-detector form's submission payload.
- `tsc` and `eslint` clean; diff coverage 94% against the 80% CI gate.

## Video

https://github.com/user-attachments/assets/4b0d71a5-0305-4f38-9386-edc55a8e51dc



Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a skippable “Add detectors” step to onboarding so new projects can quickly create detectors from templates before landing on traces. This improves first-time exposure to detectors without adding new APIs.

- **New Features**
  - Added `AddDetectorsStep`: multi-select template pills (Failure, Hallucination, Logic Error, Task Completion, Safety) with hover/focus description preview.
  - Creates one detector per selected template using the existing `useCreateDetector` path; skipping or finishing navigates to the project’s traces.
  - Handles partial failures: keeps failed selections with an inline error and retries only those.
  - Supports project-only onboarding with corrected header copy.

- **Refactors**
  - Extracted `buildTemplateDetectorInput()` in `features/detectors/templates.ts` to centralize template defaults.
  - Updated the new-detector form to build its submission from the shared helper to keep creation paths aligned.
  - Introduced and standardized on `DETECTOR_QUICK_ADD_TEMPLATES` for the quick-add list.

<sup>Written for commit afb9806d39a8becdaf0acbb9d58de178baf9ca65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



