### PR TITLE
Keep claude-agent-sdk (python) traces sparse on ingest

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -41,6 +41,17 @@ from shared.enums import SpanKind, SpanStatus
 
 logger = logging.getLogger(__name__)
 
+# Scopes whose LLM spans intentionally leave per-turn token counts unset (usage is
+# aggregated onto a few result spans). Skip text-based estimation for them, else the
+# deliberately-empty spans get fabricated counts. Python only — the TypeScript scope
+# ("@traceroot-ai/claude-agent-sdk") reports real per-turn usage and is excluded.
+_SKIP_TEXT_TOKEN_ESTIMATION_SCOPES = frozenset({"traceroot.claude-agent-sdk"})
+
+
+def _scope_skips_text_token_estimation(scope_name: str | None) -> bool:
+    return scope_name in _SKIP_TEXT_TOKEN_ESTIMATION_SCOPES
+
+
 # Attributes that are already extracted into dedicated fields
 _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.input",
@@ -537,8 +548,9 @@ def transform_otel_to_clickhouse(
                         cost = cost_from_buckets(get_model_price(model_name), buckets)
                         if cost is not None:
                             span_record["cost"] = cost
-                    else:
-                        # Fall back to text-based estimation.
+                    elif not _scope_skips_text_token_estimation(scope_name):
+                        # Fall back to text-based estimation — unless this scope leaves
+                        # tokens deliberately unset (see _SKIP_TEXT_TOKEN_ESTIMATION_SCOPES).
                         from worker.tokens import calculate_cost
 
                         usage = calculate_cost(

--- a/backend/worker/tests/test_otel_transform_token_estimation_skip.py
+++ b/backend/worker/tests/test_otel_transform_token_estimation_skip.py
@@ -1,0 +1,94 @@
+"""Tests for skipping text-based token estimation in otel_transform.
+
+The in-house claude-agent-sdk (python) instrumentor deliberately leaves intermediate
+LLM spans without token counts (the authoritative usage is aggregated onto the
+result-bearing spans). The platform must NOT fabricate text-based token estimates for
+those spans, or the trace stops looking sparse and the per-trace tokens/cost inflate.
+The skip is python-only; the TypeScript instrumentor reports real per-turn usage and
+must be unaffected.
+"""
+
+import base64
+
+from worker.otel_transform import transform_otel_to_clickhouse
+
+CLAUDE_AGENT_SDK_SCOPE = "traceroot.claude-agent-sdk"  # python in-house instrumentor (skipped)
+CLAUDE_AGENT_SDK_TS_SCOPE = "@traceroot-ai/claude-agent-sdk"  # TypeScript (must NOT be skipped)
+OTHER_SCOPE = "openinference.instrumentation.anthropic"
+
+
+def _b64(byte: int, n: int) -> str:
+    return base64.b64encode(bytes([byte] * n)).decode()
+
+
+def _payload(scope_name: str) -> dict:
+    """One LLM span: has a model name + output text, but NO token-count attributes."""
+    return {
+        "resourceSpans": [
+            {
+                "scopeSpans": [
+                    {
+                        "scope": {"name": scope_name},
+                        "spans": [
+                            {
+                                "traceId": _b64(0x01, 16),
+                                "spanId": _b64(0x02, 8),
+                                "name": "anthropic.messages.create",
+                                "startTimeUnixNano": "1700000000000000000",
+                                "endTimeUnixNano": "1700000001000000000",
+                                "attributes": [
+                                    {
+                                        "key": "openinference.span.kind",
+                                        "value": {"stringValue": "LLM"},
+                                    },
+                                    {
+                                        "key": "llm.model_name",
+                                        "value": {"stringValue": "claude-sonnet-4-20250514"},
+                                    },
+                                    {
+                                        "key": "output.value",
+                                        "value": {
+                                            "stringValue": "This is a fairly long assistant turn "
+                                            * 20
+                                        },
+                                    },
+                                    # NOTE: intentionally NO llm.token_count.* attributes.
+                                ],
+                                "status": {"code": "STATUS_CODE_OK"},
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+
+
+def _llm_span(scope_name: str) -> dict:
+    _, spans = transform_otel_to_clickhouse(_payload(scope_name), project_id="proj-1")
+    llm = [s for s in spans if s["name"] == "anthropic.messages.create"]
+    assert len(llm) == 1
+    return llm[0]
+
+
+def test_claude_agent_sdk_python_llm_span_gets_no_estimated_tokens():
+    span = _llm_span(CLAUDE_AGENT_SDK_SCOPE)
+    assert span.get("output_tokens") in (None, 0), span.get("output_tokens")
+    assert span.get("input_tokens") in (None, 0), span.get("input_tokens")
+    assert span.get("cost") in (None, 0), span.get("cost")
+
+
+def test_other_scope_llm_span_still_gets_estimated_tokens():
+    """Control: a non-claude-agent-sdk scope with the same shape DOES get text-based
+    estimation, so the change is narrowly scoped."""
+    span = _llm_span(OTHER_SCOPE)
+    assert span.get("output_tokens"), "expected text-estimated output_tokens for other scopes"
+    assert span.get("cost"), "expected text-estimated cost for other scopes"
+
+
+def test_claude_agent_sdk_typescript_is_not_skipped():
+    """The skip is PYTHON ONLY. The TS integration uses a different scope and reports
+    real per-turn usage, so it must keep getting estimation when a count is missing."""
+    span = _llm_span(CLAUDE_AGENT_SDK_TS_SCOPE)
+    assert span.get("output_tokens"), "TS claude-agent-sdk must NOT be skipped (python-only)"
+    assert span.get("cost"), "TS claude-agent-sdk must NOT be skipped (python-only)"

--- a/examples/python/claude-agent-sdk/main.py
+++ b/examples/python/claude-agent-sdk/main.py
@@ -103,6 +103,7 @@ async def run_research(topic: str) -> str:
             f"Coordinate the agents and present the final report."
         ),
         options=ClaudeAgentOptions(
+            model="claude-sonnet-4-20250514",
             allowed_tools=["Agent"],
             max_turns=15,
             # WARNING: bypassPermissions auto-approves all tool calls (Bash, WebSearch)
@@ -128,6 +129,7 @@ async def run_research(topic: str) -> str:
 
 DEMO_TOPICS = [
     "What are the key features of OpenTelemetry for AI observability?",
+    "What is Model Context Protocol (MCP) and why does it matter?",
 ]
 
 

--- a/examples/python/claude-agent-sdk/requirements.txt
+++ b/examples/python/claude-agent-sdk/requirements.txt
@@ -1,4 +1,4 @@
 claude-agent-sdk>=0.1.72
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot>=0.1.8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ pythonpath = ["backend"]
 [tool.coverage.run]
 source = ["backend"]
 branch = true
-omit = ["tests/*"]
+omit = ["tests/*", "*/tests/*"]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
## What

The in-house claude-agent-sdk (python) instrumentor aggregates token usage onto a few result-bearing LLM spans and intentionally leaves the many intermediate LLM spans without per-turn token counts (SDK side: traceroot-ai/traceroot-py#125).

On ingest, `otel_transform`'s text-based token-estimation fallback was fabricating counts for those deliberately-empty spans — inflating per-trace token/cost totals and making the trace look denser than intended.

This PR skips text-based token estimation for the claude-agent-sdk (python) instrumentation scope (`traceroot.claude-agent-sdk`) so those spans stay empty.

- **Python only.** The TypeScript instrumentor uses a different scope (`@traceroot-ai/claude-agent-sdk`) and reports real per-turn usage, so it is explicitly excluded (and covered by a test).
- Scope-gated via `_SKIP_TEXT_TOKEN_ESTIMATION_SCOPES`, mirroring the existing scope-based handling in `tokens/buckets.py`.

Also refreshes the python example to the multi-topic pipeline used for validation and bumps its SDK pin.

## Changes
- `backend/worker/otel_transform.py` — skip estimation for the scope.
- `backend/worker/tests/test_otel_transform_token_estimation_skip.py` — python-skipped / TS-not-skipped / other-scope-still-estimated.
- `examples/python/claude-agent-sdk/{main.py,requirements.txt}` — example refresh + SDK pin.

## Screenshots
<img width="2303" height="1077" alt="Screenshot 2026-06-12 at 2 19 06 AM" src="https://github.com/user-attachments/assets/f0e05468-68f5-4778-9f64-bb35d044ca1e" />
<img width="2304" height="1082" alt="Screenshot 2026-06-12 at 2 18 56 AM" src="https://github.com/user-attachments/assets/a20cf02c-4a8a-456c-b236-c7eb33323dd8" />


## Test
`pytest backend/worker/tests/test_otel_transform_token_estimation_skip.py` (3) + existing transform tests pass. Verified e2e against a local platform: claude-agent-sdk traces ingest sparse instead of fully-tagged.

Closes #1154

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip text-based token estimation for the Python `traceroot.claude-agent-sdk` scope so intermediate LLM spans stay empty and per-trace token/cost totals remain accurate. Addresses Linear #1154.

- **Bug Fixes**
  - Skip estimation for `traceroot.claude-agent-sdk` in ingest (Python only).
  - Keep `@traceroot-ai/claude-agent-sdk` unchanged; other scopes still estimated.
  - Add tests covering python-skipped, TS-not-skipped, and control scope.

- **Dependencies**
  - Bump `traceroot` in the Python example to `>=0.1.8`.
  - Refresh Python example pipeline and set a default model.

<sup>Written for commit b89f0c7644e593ffe04919356f11ffdc618fd43a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

