### PR TITLE
fix(ui): stop the breadcrumb dropdown leaving a focus ring on its trigger after mouse interaction

### DIFF
--- a/frontend/ui/src/components/layout/breadcrumb.test.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import { Breadcrumb, type BreadcrumbItem } from "@/components/layout/breadcrumb";
+
+beforeAll(() => {
+  // jsdom lacks these; Radix menus call them on focus / pointer handling.
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+});
+
+afterEach(() => cleanup());
+
+const workspaceItem: BreadcrumbItem = {
+  label: "Workspace One",
+  options: [
+    { id: "ws-1", label: "Workspace One", href: "/workspaces/ws-1/projects" },
+    { id: "ws-2", label: "Workspace Two", href: "/workspaces/ws-2/projects" },
+  ],
+  menuHeader: { label: "Workspaces", href: "/workspaces" },
+};
+
+function renderAndOpen() {
+  render(<Breadcrumb items={[workspaceItem]} />);
+  const trigger = screen.getByRole("button");
+  // Radix triggers open on pointerdown, not click.
+  fireEvent.pointerDown(trigger, { button: 0, pointerType: "mouse" });
+  return trigger;
+}
+
+describe("BreadcrumbDropdown focus return", () => {
+  it("does not refocus the trigger when an entry is selected with the mouse", async () => {
+    const trigger = renderAndOpen();
+    const entry = await screen.findByText("Workspace Two");
+    fireEvent.pointerDown(entry, { button: 0, pointerType: "mouse" });
+    fireEvent.click(entry);
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(document.activeElement).not.toBe(trigger);
+  });
+
+  it("refocuses the trigger when the menu is closed with the keyboard", async () => {
+    const trigger = renderAndOpen();
+    const menu = await screen.findByRole("menu");
+    fireEvent.keyDown(menu, { key: "ArrowDown" });
+    fireEvent.keyDown(menu, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/frontend/ui/src/components/layout/breadcrumb.test.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.test.tsx
@@ -53,6 +53,17 @@ describe("BreadcrumbDropdown focus return", () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  it("does not refocus the trigger when a keyboard-opened menu is dismissed by clicking outside", async () => {
+    render(<Breadcrumb items={[workspaceItem]} />);
+    const trigger = screen.getByRole("button");
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    await screen.findByRole("menu");
+    fireEvent.pointerDown(document.body, { button: 0, pointerType: "mouse" });
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(document.activeElement).not.toBe(trigger);
+  });
+
   it("refocuses the trigger when the menu is opened and closed with the keyboard", async () => {
     render(<Breadcrumb items={[workspaceItem]} />);
     const trigger = screen.getByRole("button");

--- a/frontend/ui/src/components/layout/breadcrumb.test.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.test.tsx
@@ -52,4 +52,15 @@ describe("BreadcrumbDropdown focus return", () => {
     await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
     expect(document.activeElement).toBe(trigger);
   });
+
+  it("refocuses the trigger when the menu is opened and closed with the keyboard", async () => {
+    render(<Breadcrumb items={[workspaceItem]} />);
+    const trigger = screen.getByRole("button");
+    trigger.focus();
+    fireEvent.keyDown(trigger, { key: "Enter" });
+    const menu = await screen.findByRole("menu");
+    fireEvent.keyDown(menu, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
+    expect(document.activeElement).toBe(trigger);
+  });
 });

--- a/frontend/ui/src/components/layout/breadcrumb.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { ChevronDown, Plus, Settings, Slash } from "lucide-react";
@@ -78,6 +78,19 @@ export function Breadcrumb({ items }: BreadcrumbProps) {
 function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  // Radix refocuses the trigger when the menu closes, and browsers treat that
+  // programmatic focus as :focus-visible — a pure mouse interaction would
+  // leave a keyboard focus ring on the workspace/project breadcrumb trigger
+  // after pure mouse use. Track the last input modality and prevent the focus
+  // return for pointer-driven closes; keyboard closes keep the focus return
+  // and ring.
+  const usedKeyboard = useRef(false);
+  const trackKeyboard = () => {
+    usedKeyboard.current = true;
+  };
+  const trackPointer = () => {
+    usedKeyboard.current = false;
+  };
 
   // The gear stops propagation so the row's select (and its navigation)
   // doesn't fire, which also skips the menu's auto-close - close explicitly.
@@ -88,11 +101,23 @@ function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger className="flex min-w-0 items-center gap-1 font-medium outline-none focus-visible:ring-1 focus-visible:ring-ring">
+      <DropdownMenuTrigger
+        className="flex min-w-0 items-center gap-1 font-medium outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        onKeyDownCapture={trackKeyboard}
+        onPointerDownCapture={trackPointer}
+      >
         <span className="truncate">{item.label}</span>
         <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="rounded-none">
+      <DropdownMenuContent
+        align="start"
+        className="rounded-none"
+        onKeyDownCapture={trackKeyboard}
+        onPointerDownCapture={trackPointer}
+        onCloseAutoFocus={(event) => {
+          if (!usedKeyboard.current) event.preventDefault();
+        }}
+      >
         {item.menuHeader && (
           <>
             <DropdownMenuItem asChild className="rounded-none text-[13px] font-semibold">

--- a/frontend/ui/src/components/layout/breadcrumb.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.tsx
@@ -79,11 +79,9 @@ function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
   // Radix refocuses the trigger when the menu closes, and browsers treat that
-  // programmatic focus as :focus-visible — a pure mouse interaction would
-  // leave a keyboard focus ring on the workspace/project breadcrumb trigger
-  // after pure mouse use. Track the last input modality and prevent the focus
-  // return for pointer-driven closes; keyboard closes keep the focus return
-  // and ring.
+  // programmatic focus as :focus-visible, leaving a focus ring after mouse-only
+  // interaction. Track the last input modality and prevent focus return for
+  // pointer-driven closes; keyboard closes keep it.
   const usedKeyboard = useRef(false);
   const trackKeyboard = () => {
     usedKeyboard.current = true;
@@ -102,7 +100,7 @@ function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
   return (
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger
-        className="flex min-w-0 items-center gap-1 font-medium outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        className="-mx-1 -my-0.5 flex min-w-0 items-center gap-1 rounded px-1 py-0.5 font-medium outline-none focus-visible:ring-1 focus-visible:ring-ring"
         onKeyDownCapture={trackKeyboard}
         onPointerDownCapture={trackPointer}
       >

--- a/frontend/ui/src/components/layout/breadcrumb.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.tsx
@@ -112,6 +112,7 @@ function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
         className="rounded-none"
         onKeyDownCapture={trackKeyboard}
         onPointerDownCapture={trackPointer}
+        onPointerDownOutside={trackPointer}
         onCloseAutoFocus={(event) => {
           if (!usedKeyboard.current) event.preventDefault();
         }}


### PR DESCRIPTION
## Summary

Selecting a workspace/project from the top-header breadcrumb dropdown with the mouse — or dismissing the menu by clicking outside — left the trigger text wrapped in a sharp 1px near-black rectangle (`:focus-visible` ring) that persisted until the next click.

**Root cause:** Radix DropdownMenu programmatically refocuses the trigger when the menu closes (default `onCloseAutoFocus`, per the WAI-ARIA menu pattern). Browsers can treat that script-initiated focus as matching `:focus-visible` (the heuristic is sticky on recent keyboard input), so the keyboard-only ring showed after mouse use. The trigger also had no padding or radius, so the ring hugged the text as an ugly box. The breadcrumb lives in the persistent header, so client-side navigation never remounted it and the ring stuck around.

**Fix (`BreadcrumbDropdown`, covers both the workspace and project segments):**
- Track the last input modality with a ref via capture-phase `keydown`/`pointerdown` handlers on the trigger and menu content (plus `onPointerDownOutside` for click-away dismissal), and `preventDefault()` the focus return for pointer-driven closes. Keyboard closes keep the focus return and ring, so the WAI-ARIA behavior is preserved for keyboard users.
- Give the trigger a radius and padding (offset by negative margins, no layout shift) so the legitimate keyboard ring renders as a rounded pill instead of a text-hugging box.

## Testing

- New `breadcrumb.test.tsx` (jsdom) asserting the focus-return contract: mouse select → no refocus; click-outside after keyboard open → no refocus; keyboard close (mixed and pure-keyboard paths) → refocus. The mouse test failed on unfixed code.
- eslint and tsc clean; diff coverage on changed lines: 100% (gate is 80%).

Closes #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the header breadcrumb dropdown from leaving a visible focus ring on its trigger after mouse interactions. Preserves correct keyboard focus return and renders the ring as a rounded pill (fixes #1157).

- **Bug Fixes**
  - Track input modality; skip trigger refocus on pointer-driven closes (including click-outside); keep for keyboard.
  - Add padding and rounded styles to the trigger so the ring looks intentional.
  - Add tests covering mouse select, click-outside dismissal, and keyboard open/close focus behavior.

<sup>Written for commit 568ac6cfaf378b993650388254d928eebfb1f7e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

