### PR TITLE
fix(ui): keep expanded trace panel clear of the sidebar

### DIFF
--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  sidebarCollapsed: false,
+}));
+
+// Layout context drives the fullscreen width math (sidebar width).
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({
+    aiPanelOpen: false,
+    setAiPanelOpen: vi.fn(),
+    setAiContext: vi.fn(),
+    setAiInitialSessionId: vi.fn(),
+    registerAiHost: () => () => {},
+    sidebarCollapsed: mocks.sidebarCollapsed,
+  }),
+}));
+
+// Trace fetch + stream — irrelevant to layout, stub them out.
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: {}, isLoading: false, error: null }),
+}));
+vi.mock("@/lib/api", () => ({ getTrace: vi.fn() }));
+vi.mock("../hooks/use-trace-stream", () => ({ useTraceStream: vi.fn() }));
+vi.mock("@/features/detectors/hooks/use-findings", () => ({
+  useTraceFindings: () => ({ data: undefined }),
+  useRca: () => ({ data: undefined }),
+}));
+
+// Heavy children + resizable layout — replace with passthroughs so only the
+// panel's own root wrapper (which carries the width class) matters.
+vi.mock("./SpanTreeView", () => ({ SpanTreeView: () => null }));
+vi.mock("./SpanInfoPanel", () => ({ SpanInfoPanel: () => null }));
+vi.mock("./SpanTimelineView", () => ({ SpanTimelineView: () => null }));
+vi.mock("@/features/ai-assistant/components/ai-assistant-panel", () => ({
+  AiAssistantPanel: () => null,
+}));
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => null,
+}));
+
+import { TraceViewerPanel } from "./TraceViewerPanel";
+
+function renderPanel(props: { initialFullscreen?: boolean } = {}) {
+  const { container } = render(
+    <TraceViewerPanel
+      projectId="proj-1"
+      traceId="trace-1"
+      onClose={vi.fn()}
+      onNavigate={vi.fn()}
+      canNavigateUp={false}
+      canNavigateDown={false}
+      {...props}
+    />,
+  );
+  // The slide-in wrapper is the outermost element and carries the width class.
+  return container.firstElementChild as HTMLElement;
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.sidebarCollapsed = false;
+});
+
+describe("TraceViewerPanel layout", () => {
+  it("clears the expanded sidebar (w-48 / 12rem) when fullscreen", () => {
+    mocks.sidebarCollapsed = false;
+    const panel = renderPanel({ initialFullscreen: true });
+    expect(panel.className).toContain("w-[calc(100%-12rem)]");
+    expect(panel.className).toContain("top-14");
+  });
+
+  it("clears the collapsed sidebar (w-14 / 3.5rem) when fullscreen", () => {
+    mocks.sidebarCollapsed = true;
+    const panel = renderPanel({ initialFullscreen: true });
+    expect(panel.className).toContain("w-[calc(100%-3.5rem)]");
+  });
+
+  it("uses the default 70% width when not fullscreen", () => {
+    const panel = renderPanel({ initialFullscreen: false });
+    expect(panel.className).toContain("w-[70%]");
+    expect(panel.className).toContain("top-0");
+  });
+});

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -218,7 +218,7 @@ export function TraceViewerPanel({
         isFullscreen
           ? sidebarCollapsed
             ? "top-14 w-[calc(100%-3.5rem)]"
-            : "top-14 w-[calc(100%-10rem)]"
+            : "top-14 w-[calc(100%-12rem)]"
           : "top-0 w-[70%]",
       )}
     >


### PR DESCRIPTION
## What

The fullscreen ("Expand") trace detail panel slid 2rem too far left and covered part of the left navigation sidebar.

## Why

The expanded panel width is `100% − sidebar width`. The expanded sidebar is `w-48` (12rem), but the panel subtracted `10rem` — a stale value from when the sidebar was `w-40`. The collapsed branch (`3.5rem` = `w-14`) was already correct.

## Fix

Subtract `12rem` so the panel's left edge sits flush with the sidebar.

```diff
-            : "top-14 w-[calc(100%-10rem)]"
+            : "top-14 w-[calc(100%-12rem)]"
```

One-line change in `frontend/ui/src/features/traces/components/TraceViewerPanel.tsx`.



## Before

See https://github.com/traceroot-ai/traceroot/issues/1159
After 

<img width="1964" height="912" alt="Screenshot 2026-06-11 at 12 58 54 PM" src="https://github.com/user-attachments/assets/0e2c15e7-f0ac-4a7e-9df8-a89ccb99883b" />



Fixes #1159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the fullscreen trace detail panel aligned with the left sidebar by changing its width to w-[calc(100%-12rem)] (was 10rem); this prevents a 2rem overhang and fixes #1159. Add render tests to verify widths: 12rem when sidebar is expanded, 3.5rem when collapsed, and 70% when not fullscreen.

<sup>Written for commit aa9951391eb42026973cdc93128aca1e4bbd930a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

