### PR TITLE
feat(detectors): default the sampling rate to 25% instead of 100%

### DIFF
--- a/frontend/packages/core/prisma/migrations/20260611000000_default_detector_sample_rate_25/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260611000000_default_detector_sample_rate_25/migration.sql
@@ -1,0 +1,4 @@
+-- New detectors default to 25% sampling so the out-of-the-box cost profile
+-- stays light. Existing rows keep their configured sample_rate; only the
+-- column default changes.
+ALTER TABLE "detectors" ALTER COLUMN "sample_rate" SET DEFAULT 25;

--- a/frontend/packages/core/prisma/migrations/20260611000000_default_detector_sample_rate_25/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260611000000_default_detector_sample_rate_25/migration.sql
@@ -1,4 +1,0 @@
--- New detectors default to 25% sampling so the out-of-the-box cost profile
--- stays light. Existing rows keep their configured sample_rate; only the
--- column default changes.
-ALTER TABLE "detectors" ALTER COLUMN "sample_rate" SET DEFAULT 25;

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -350,7 +350,7 @@ model Detector {
   template     String   @db.VarChar  // "failure"|"hallucination"|"logic"|"task"|"safety"|"intent"|"blank"
   prompt       String   @db.Text
   outputSchema       Json     @map("output_schema") @db.JsonB
-  sampleRate         Int      @default(100) @map("sample_rate")  // 1–100
+  sampleRate         Int      @default(25) @map("sample_rate")  // 1–100
   enabled            Boolean  @default(true)
   enableRca          Boolean  @default(true) @map("enable_rca")  // run agent-model RCA on this detector's findings
   detectionModel     String?  @map("detection_model") @db.VarChar    // model id; null = worker picks default

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({ NextRequest: class {} }));
+
+const detectorCreateMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    detector: {
+      create: (...args: unknown[]) => detectorCreateMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({
+    status,
+    json: async () => data,
+  }),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: unknown) {
+  return { json: async () => body } as unknown as Parameters<typeof POST>[0];
+}
+
+function makeParams() {
+  return { params: Promise.resolve({ projectId: "proj-1" }) };
+}
+
+/** Minimal valid create payload — sampleRate intentionally omitted. */
+function validBody(extra: Record<string, unknown> = {}) {
+  return { name: "My detector", template: "failure", prompt: "Find failures", ...extra };
+}
+
+beforeEach(() => {
+  detectorCreateMock.mockReset();
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+  detectorCreateMock.mockResolvedValue({ id: "det-1" });
+});
+
+describe("POST .../detectors — sampleRate default", () => {
+  it("defaults sampleRate to 25 when omitted", async () => {
+    const res = await POST(makeRequest(validBody()), makeParams());
+
+    expect(res.status).toBe(201);
+    expect(detectorCreateMock).toHaveBeenCalledTimes(1);
+    expect(detectorCreateMock.mock.calls[0][0].data.sampleRate).toBe(25);
+  });
+
+  it("keeps an explicit sampleRate (100) instead of the default", async () => {
+    const res = await POST(makeRequest(validBody({ sampleRate: 100 })), makeParams());
+
+    expect(res.status).toBe(201);
+    expect(detectorCreateMock.mock.calls[0][0].data.sampleRate).toBe(100);
+  });
+
+  it("rejects an out-of-range sampleRate", async () => {
+    const res = await POST(makeRequest(validBody({ sampleRate: 101 })), makeParams());
+
+    expect(res.status).toBe(400);
+    expect(detectorCreateMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -80,7 +80,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     template,
     prompt,
     outputSchema,
-    sampleRate = 100,
+    sampleRate,
     triggerConditions,
     detectionModel,
     detectionProvider,
@@ -99,8 +99,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     return errorResponse("prompt must be a non-empty string", 400);
   }
 
-  // Validate sampleRate (integer 0-100). Fall back to 100 only when omitted.
-  let resolvedSampleRate = 100;
+  // Validate sampleRate (integer 0-100). Fall back to 25 only when omitted —
+  // a lighter default so new detectors don't run an LLM call on every trace.
+  let resolvedSampleRate = 25;
   if (sampleRate !== undefined) {
     if (
       typeof sampleRate !== "number" ||

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from "next/server";
 import { prisma } from "@traceroot/core";
+import { DEFAULT_DETECTOR_SAMPLE_RATE } from "@/features/detectors/templates";
 import {
   requireAuth,
   requireProjectAccess,
@@ -99,9 +100,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     return errorResponse("prompt must be a non-empty string", 400);
   }
 
-  // Validate sampleRate (integer 0-100). Fall back to 25 only when omitted —
-  // a lighter default so new detectors don't run an LLM call on every trace.
-  let resolvedSampleRate = 25;
+  // Validate sampleRate (integer 0-100). Fall back to the default only when
+  // omitted — kept light so new detectors don't run an LLM call on every trace.
+  let resolvedSampleRate: number = DEFAULT_DETECTOR_SAMPLE_RATE;
   if (sampleRate !== undefined) {
     if (
       typeof sampleRate !== "number" ||

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -55,7 +55,7 @@ describe("NewDetectorPage", () => {
       prompt: failure.prompt,
       outputSchema: failure.outputSchema,
       triggerConditions: failure.defaultConditions,
-      sampleRate: 100,
+      sampleRate: 25,
       enableRca: true,
       detectionModel: undefined,
       detectionProvider: undefined,

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -8,7 +8,11 @@ import {
   ModelSelector,
   type ModelSelection,
 } from "@/features/ai-assistant/components/model-selector";
-import { DETECTOR_TEMPLATES, buildTemplateDetectorInput } from "@/features/detectors/templates";
+import {
+  DEFAULT_DETECTOR_SAMPLE_RATE,
+  DETECTOR_TEMPLATES,
+  buildTemplateDetectorInput,
+} from "@/features/detectors/templates";
 import { useCreateDetector } from "@/features/detectors/hooks/use-detectors";
 import type { CreateDetectorInput } from "@/features/detectors/hooks/use-detectors";
 import { TriggerEditor } from "@/features/detectors/components/trigger-editor";
@@ -32,7 +36,7 @@ export default function NewDetectorPage() {
   const [name, setName] = useState(INITIAL_TEMPLATE.label + " Detector");
   const [nameEdited, setNameEdited] = useState(false);
   const [prompt, setPrompt] = useState(INITIAL_TEMPLATE.prompt);
-  const [sampleRate, setSampleRate] = useState(25);
+  const [sampleRate, setSampleRate] = useState(DEFAULT_DETECTOR_SAMPLE_RATE);
   // Seeded from the template's defaultConditions so a user who picks
   // "Failure" and clicks Create gets the trigger filters the template
   // intends, not an unfiltered detector that fires on every trace.

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -32,7 +32,7 @@ export default function NewDetectorPage() {
   const [name, setName] = useState(INITIAL_TEMPLATE.label + " Detector");
   const [nameEdited, setNameEdited] = useState(false);
   const [prompt, setPrompt] = useState(INITIAL_TEMPLATE.prompt);
-  const [sampleRate, setSampleRate] = useState(100);
+  const [sampleRate, setSampleRate] = useState(25);
   // Seeded from the template's defaultConditions so a user who picks
   // "Failure" and clicks Create gets the trigger filters the template
   // intends, not an unfiltered detector that fires on every trace.

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
@@ -76,7 +76,7 @@ describe("AddDetectorsStep", () => {
       expect.objectContaining({
         template: "failure",
         name: "Failure Detector",
-        sampleRate: 100,
+        sampleRate: 25,
         enableRca: true,
         detectionSource: "system",
       }),

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Eye, X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
 import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
+import { DEFAULT_DETECTOR_SAMPLE_RATE } from "../templates";
 import { useProject } from "@/features/projects/hooks";
 import { TriggerEditor } from "./trigger-editor";
 import type { TriggerCondition } from "./trigger-editor";
@@ -45,7 +46,7 @@ export function DetectorPanel({
 
   const [editName, setEditName] = useState("");
   const [editPrompt, setEditPrompt] = useState("");
-  const [editSampleRate, setEditSampleRate] = useState(100);
+  const [editSampleRate, setEditSampleRate] = useState(DEFAULT_DETECTOR_SAMPLE_RATE);
   const [editModelSelection, setEditModelSelection] = useState<ModelSelection>({
     model: "",
     provider: "",
@@ -58,7 +59,7 @@ export function DetectorPanel({
   const emptyForm: DetectorFormValues = {
     name: "",
     prompt: "",
-    sampleRate: 100,
+    sampleRate: DEFAULT_DETECTOR_SAMPLE_RATE,
     enableRca: true,
     detectionModel: "",
     detectionProvider: "",

--- a/frontend/ui/src/features/detectors/templates.test.ts
+++ b/frontend/ui/src/features/detectors/templates.test.ts
@@ -22,7 +22,7 @@ describe("buildTemplateDetectorInput", () => {
       prompt: failure.prompt,
       outputSchema: failure.outputSchema,
       triggerConditions: failure.defaultConditions,
-      sampleRate: 100,
+      sampleRate: 25,
       enableRca: true,
       detectionSource: "system",
     });

--- a/frontend/ui/src/features/detectors/templates.test.ts
+++ b/frontend/ui/src/features/detectors/templates.test.ts
@@ -1,5 +1,25 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { DETECTOR_QUICK_ADD_TEMPLATES, buildTemplateDetectorInput, getTemplate } from "./templates";
+import {
+  DEFAULT_DETECTOR_SAMPLE_RATE,
+  DETECTOR_QUICK_ADD_TEMPLATES,
+  buildTemplateDetectorInput,
+  getTemplate,
+} from "./templates";
+
+describe("DEFAULT_DETECTOR_SAMPLE_RATE", () => {
+  it("matches the Prisma column default, which cannot import the constant", () => {
+    const schemaPath = path.resolve(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "../../../../packages/core/prisma/schema.prisma",
+    );
+    const match = readFileSync(schemaPath, "utf8").match(/sampleRate\s+Int\s+@default\((\d+)\)/);
+    expect(match).not.toBeNull();
+    expect(Number(match![1])).toBe(DEFAULT_DETECTOR_SAMPLE_RATE);
+  });
+});
 
 describe("DETECTOR_QUICK_ADD_TEMPLATES", () => {
   it("excludes the blank template and keeps the rest in order", () => {

--- a/frontend/ui/src/features/detectors/templates.ts
+++ b/frontend/ui/src/features/detectors/templates.ts
@@ -121,7 +121,7 @@ export function buildTemplateDetectorInput(template: DetectorTemplate): CreateDe
     prompt: template.prompt,
     outputSchema: template.outputSchema,
     triggerConditions: template.defaultConditions,
-    sampleRate: 100,
+    sampleRate: 25,
     enableRca: true,
     detectionSource: "system",
   };

--- a/frontend/ui/src/features/detectors/templates.ts
+++ b/frontend/ui/src/features/detectors/templates.ts
@@ -112,6 +112,12 @@ export function getTemplate(id: string): DetectorTemplate | undefined {
 // Blank needs a custom prompt, so it is only available on the full new-detector form.
 export const DETECTOR_QUICK_ADD_TEMPLATES = DETECTOR_TEMPLATES.filter((t) => t.id !== "blank");
 
+// Single source of truth for the default detector sampling rate. The Prisma
+// column default (packages/core/prisma/schema.prisma) cannot import this —
+// schema files only take literals — so a drift-guard test in templates.test.ts
+// asserts the two stay equal.
+export const DEFAULT_DETECTOR_SAMPLE_RATE = 25;
+
 // Default create payload for a template — shared by the new-detector form and the
 // project-creation quick-add step so the two creation paths cannot drift.
 export function buildTemplateDetectorInput(template: DetectorTemplate): CreateDetectorInput {
@@ -121,7 +127,7 @@ export function buildTemplateDetectorInput(template: DetectorTemplate): CreateDe
     prompt: template.prompt,
     outputSchema: template.outputSchema,
     triggerConditions: template.defaultConditions,
-    sampleRate: 25,
+    sampleRate: DEFAULT_DETECTOR_SAMPLE_RATE,
     enableRca: true,
     detectionSource: "system",
   };


### PR DESCRIPTION
Closes #1151

## What

New detectors now default to a 25% sampling rate instead of 100%, so the out-of-the-box cost profile is lighter. Users can still raise it to 100% explicitly when full coverage matters.

The 100% default lived in four places, all changed together:

- **New-detector form** — the sampling slider now starts at 25.
- **API route** — `POST /api/projects/[projectId]/detectors` falls back to 25 when `sampleRate` is omitted from the payload. The previously duplicated default (destructuring default + validation-block fallback, where the latter was dead code) is collapsed into a single fallback.
- **Shared template builder** — `buildTemplateDetectorInput` (used by both the new-detector form and the onboarding quick-add step, added on main after this branch was cut) now emits 25 instead of a hardcoded 100. Without this, detectors created from the onboarding flow would have kept the old default.
- **Prisma schema** — `Detector.sampleRate` is now `@default(25)`. No migration: the API route is the only path that inserts detectors and always supplies `sampleRate` explicitly, so the database-level column default is never exercised — it intentionally stays at 100 in existing databases, and the 25 default is carried app-side.

The first three share a single exported constant, `DEFAULT_DETECTOR_SAMPLE_RATE`. The Prisma schema cannot import it, so a drift-guard test reads `schema.prisma` and asserts the `@default` value matches the constant — future drift fails CI instead of shipping silently.

## Tests

- New `route.test.ts` for the detector create route, covering the 25 default when `sampleRate` is omitted, explicit-override preservation, and out-of-range rejection. The default test failed (got 100) before the route change and passes after.
- New drift-guard test pinning the Prisma column default to the shared constant.
- Updated assertions in `templates.test.ts`, `add-detectors-step.test.tsx`, and `page.test.tsx` from 100 to 25.

## Verification

- 56/56 detector tests pass across 9 files; `tsc --noEmit`, eslint, and `prisma validate`/`generate` all clean.
- Live-verified on the local stack, both creation paths: a detector created from the new-detector form and one created through the onboarding quick-add step each landed with `sample_rate = 25` in Postgres.

## Video

https://github.com/user-attachments/assets/9cc66ef1-cd8e-4854-9dfb-5c3c9d5f78ed



🤖 Generated with [Claude Code](https://claude.com/claude-code)
