### PR TITLE
fix(ui): hide the navbar AI assistant button while a trace viewer is open

### DIFF
--- a/frontend/ui/src/components/layout/app-layout.test.tsx
+++ b/frontend/ui/src/components/layout/app-layout.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { useEffect, useLayoutEffect } from "react";
+
+// AppLayout renders the navbar button itself; everything heavy around it is
+// irrelevant to the visibility logic under test.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/projects/p1/traces",
+}));
+vi.mock("./sidebar", () => ({ Sidebar: () => null }));
+vi.mock("@/features/ai-assistant/components/ai-assistant-panel", () => ({
+  AiAssistantPanel: () => null,
+}));
+vi.mock("@/features/ai-assistant/components/ai-chat-context", () => ({
+  AiChatProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => null,
+}));
+
+import { AppLayout, useLayout } from "./app-layout";
+
+// Observability pages flip hideAiButton off in a layout effect (see
+// src/app/projects/[projectId]/traces/page.tsx); mirror that here so the
+// navbar button's baseline state is "shown".
+function ObservabilityPageStub({ children }: { children?: React.ReactNode }) {
+  const { setHideAiButton } = useLayout();
+  useLayoutEffect(() => {
+    setHideAiButton(false);
+    return () => setHideAiButton(true);
+  }, [setHideAiButton]);
+  return <>{children}</>;
+}
+
+// Stand-in for TraceViewerPanel/SessionDetailPanel: claims the AI slot on
+// mount, releases it on unmount.
+function AiHostStub() {
+  const { registerAiHost } = useLayout();
+  useEffect(() => registerAiHost(), [registerAiHost]);
+  return null;
+}
+
+function renderLayout(withHost: boolean) {
+  return render(
+    <AppLayout>
+      <ObservabilityPageStub>{withHost && <AiHostStub />}</ObservabilityPageStub>
+    </AppLayout>,
+  );
+}
+
+afterEach(cleanup);
+
+describe("AppLayout navbar AI button", () => {
+  it("shows the AI button on an observability page with no viewer open", () => {
+    renderLayout(false);
+    expect(screen.queryByTitle("AI Assistant")).not.toBeNull();
+  });
+
+  it("hides the AI button while a viewer panel owns the AI slot", () => {
+    renderLayout(true);
+    expect(screen.queryByTitle("AI Assistant")).toBeNull();
+  });
+
+  it("restores the AI button when the viewer panel unmounts", () => {
+    const { rerender } = renderLayout(true);
+    expect(screen.queryByTitle("AI Assistant")).toBeNull();
+    rerender(
+      <AppLayout>
+        <ObservabilityPageStub />
+      </AppLayout>,
+    );
+    expect(screen.queryByTitle("AI Assistant")).not.toBeNull();
+  });
+});

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -81,7 +81,11 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const viewerOwnsAiSlot = aiHostRefCount > 0;
 
   const isObservabilityPage = /^\/projects\/[^/]+\/(traces|users|sessions)(\/|$)/.test(pathname);
-  const showAiButton = isObservabilityPage && !hideAiButton;
+  // Viewer panels (trace / session detail) carry their own AI Assistant
+  // button, so the navbar copy would duplicate it — visibly so in fullscreen,
+  // where the panel sits below the header instead of covering it. Step aside
+  // while any viewer owns the AI slot; the button returns when it unmounts.
+  const showAiButton = isObservabilityPage && !hideAiButton && !viewerOwnsAiSlot;
   const projectIdMatch = pathname.match(/^\/projects\/([^/]+)/);
   const projectId = projectIdMatch?.[1];
 


### PR DESCRIPTION
## Summary

- The trace and session viewer panels render their own AI assistant button, so the top-navbar copy duplicates it. The duplication is visible when the panel is expanded to fullscreen, since fullscreen positions the panel below the header (`top-14`) instead of over it.
- Gate the navbar button on `!viewerOwnsAiSlot` — the existing layout-context signal set while `TraceViewerPanel`/`SessionDetailPanel` are mounted (the same signal that already makes the app-rail AI panel step aside). The button reappears when the viewer closes.
- Add `app-layout.test.tsx` covering the button shown on an observability page, hidden while a viewer owns the AI slot, and restored when the viewer unmounts.

Closes #1163
Closes #1162

## Test plan

- [x] `pnpm vitest run src/components/layout/app-layout.test.tsx` — 3/3 pass (red→green TDD: the hidden/restored cases failed before the fix)
- [x] Full frontend suite — only pre-existing, unrelated Slack OAuth callback failures (also fail on a clean origin/main checkout)
- [x] `tsc --noEmit` and `eslint` clean on changed files; diff coverage 100% on changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the navbar AI Assistant button on observability pages while a trace or session viewer is open to remove the duplicate button in fullscreen, fixing #1163. Visibility is gated by `viewerOwnsAiSlot`; tests in `app-layout.test.tsx` cover show/hide/restore states.

<sup>Written for commit 1e5c338a158b9a0600df17ee030fd00b5ec6e2be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


