### PR TITLE
fix(traces): stabilize sibling span ordering

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -393,6 +393,8 @@ async def get_spans_jsonl(trace_id: str, project_id: str):
     from fastapi.responses import PlainTextResponse
 
     ch = get_clickhouse_client()
+    # span_start_time is ms-precision, so sub-ms parallel siblings tie; the
+    # span_end_time + span_id tie-breakers keep the jsonl export deterministic.
     result = ch.query(
         """SELECT * FROM spans FINAL
            WHERE trace_id = {trace_id:String} AND project_id = {project_id:String}

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -469,7 +469,7 @@ async def get_spans_jsonl(trace_id: str, project_id: str):
                ORDER BY ch_update_time DESC
                LIMIT 1 BY span_id
            )
-           ORDER BY span_start_time""",
+           ORDER BY span_start_time ASC, span_end_time ASC, span_id ASC""",
         parameters={"trace_id": trace_id, "project_id": project_id},
     )
 

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -461,7 +461,9 @@ async def get_spans_jsonl(trace_id: str, project_id: str):
     ch = get_clickhouse_client()
     # Dedup ReplacingMergeTree rows without FINAL (FINAL scans all parts and
     # defeats the trace_id-first sort key / no-IO projection): keep the latest
-    # version per span_id, then order for output.
+    # version per span_id, then order for output. span_start_time is only
+    # ms-precision, so sub-ms parallel siblings need span_end_time + span_id as
+    # stable tie-breakers for deterministic export ordering.
     result = ch.query(
         """SELECT * FROM (
                SELECT * FROM spans

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -396,7 +396,7 @@ async def get_spans_jsonl(trace_id: str, project_id: str):
     result = ch.query(
         """SELECT * FROM spans FINAL
            WHERE trace_id = {trace_id:String} AND project_id = {project_id:String}
-           ORDER BY span_start_time""",
+           ORDER BY span_start_time ASC, span_end_time ASC, span_id ASC""",
         parameters={"trace_id": trace_id, "project_id": project_id},
     )
 

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -433,6 +433,9 @@ class TraceReaderService:
         # usage_details is kept (small map) to derive cost_details. Duration is
         # derived on the client from start/end so in-progress spans can grow
         # against `now()` for live traces.
+        # span_start_time is DateTime64(3) (ms), so sub-ms parallel siblings tie;
+        # the span_end_time + span_id tie-breakers give a stable, deterministic
+        # order (clients sort the same way — keep these columns in sync).
         spans_query = f"""
             SELECT
                 span_id, trace_id, parent_span_id, name, span_kind,

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -242,6 +242,9 @@ class TraceReaderService:
         # usage_details is kept (small map) to derive cost_details. Duration is
         # derived on the client from start/end so in-progress spans can grow
         # against `now()` for live traces.
+        # span_start_time is DateTime64(3) (ms), so sub-ms parallel siblings tie;
+        # the span_end_time + span_id tie-breakers give a stable, deterministic
+        # order (clients sort the same way — keep these columns in sync).
         spans_query = """
             SELECT
                 span_id, trace_id, parent_span_id, name, span_kind,

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -452,7 +452,7 @@ class TraceReaderService:
                 ORDER BY ch_update_time DESC
                 LIMIT 1 BY span_id
             )
-            ORDER BY span_start_time ASC
+            ORDER BY span_start_time ASC, span_end_time ASC, span_id ASC
         """
         spans_result = self._client.query(
             spans_query,

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -251,7 +251,7 @@ class TraceReaderService:
                 git_source_file, git_source_line, git_source_function
             FROM spans FINAL
             WHERE project_id = {project_id:String} AND trace_id = {trace_id:String}
-            ORDER BY span_start_time ASC
+            ORDER BY span_start_time ASC, span_end_time ASC, span_id ASC
         """
         spans_result = self._client.query(
             spans_query,

--- a/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
@@ -152,4 +152,40 @@ describe("buildTreeRows ↔ flattenTreeWithMetrics ordering parity", () => {
     expect(treeIds).toEqual(timelineIds);
     expect(treeIds).toEqual(["root", "a", "b"]);
   });
+
+  it("stabilizes sibling order when spans share the same start time", () => {
+    const spans = [
+      makeSpan({ span_id: "root" }),
+      makeSpan({
+        span_id: "b-child",
+        parent_span_id: "root",
+        span_start_time: "2024-01-01T00:00:00.100Z",
+        span_end_time: "2024-01-01T00:00:00.400Z",
+      }),
+      makeSpan({
+        span_id: "a-child",
+        parent_span_id: "root",
+        span_start_time: "2024-01-01T00:00:00.100Z",
+        span_end_time: "2024-01-01T00:00:00.300Z",
+      }),
+      makeSpan({
+        span_id: "c-child",
+        parent_span_id: "root",
+        span_start_time: "2024-01-01T00:00:00.100Z",
+        span_end_time: null,
+      }),
+    ];
+
+    const spanById = new Map(spans.map((s) => [s.span_id, s]));
+    const rows = buildSpanTree(spans);
+    const treeIds = buildTreeRows(rows, spanById, new Set()).flatMap((r) =>
+      r.type === "span" ? [r.row.span.span_id] : [],
+    );
+    const timelineIds = flattenTreeWithMetrics(spans, new Set(), 1000, 800).map(
+      (item) => item.span.span_id,
+    );
+
+    expect(treeIds).toEqual(["root", "a-child", "b-child", "c-child"]);
+    expect(timelineIds).toEqual(treeIds);
+  });
 });

--- a/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
@@ -191,4 +191,43 @@ describe("buildTreeRows ↔ flattenTreeWithMetrics ordering parity", () => {
     expect(treeIds).toEqual(["root", "a-child", "b-child", "c-child"]);
     expect(timelineIds).toEqual(treeIds);
   });
+
+  it("stabilizes sibling order when several spans are all in-progress", () => {
+    // Same start time and no end time on every child: the end-time comparison
+    // is Infinity vs Infinity, so ordering must come from the span_id
+    // tie-break regardless of arrival order.
+    const spans = [
+      makeSpan({ span_id: "root" }),
+      makeSpan({
+        span_id: "c-live",
+        parent_span_id: "root",
+        span_start_time: "2024-01-01T00:00:00.100Z",
+        span_end_time: null,
+      }),
+      makeSpan({
+        span_id: "a-live",
+        parent_span_id: "root",
+        span_start_time: "2024-01-01T00:00:00.100Z",
+        span_end_time: null,
+      }),
+      makeSpan({
+        span_id: "b-live",
+        parent_span_id: "root",
+        span_start_time: "2024-01-01T00:00:00.100Z",
+        span_end_time: null,
+      }),
+    ];
+
+    const spanById = new Map(spans.map((s) => [s.span_id, s]));
+    const rows = buildSpanTree(spans);
+    const treeIds = buildTreeRows(rows, spanById, new Set()).flatMap((r) =>
+      r.type === "span" ? [r.row.span.span_id] : [],
+    );
+    const timelineIds = flattenTreeWithMetrics(spans, new Set(), 1000, 800).map(
+      (item) => item.span.span_id,
+    );
+
+    expect(treeIds).toEqual(["root", "a-live", "b-live", "c-live"]);
+    expect(timelineIds).toEqual(treeIds);
+  });
 });

--- a/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
@@ -154,6 +154,9 @@ describe("buildTreeRows ↔ flattenTreeWithMetrics ordering parity", () => {
   });
 
   it("stabilizes sibling order when spans share the same start time", () => {
+    // All three children share a start time, so the tie-break is end_time then
+    // span_id: a-child (.300) < b-child (.400) < c-child (in-progress → +Inf).
+    // Input is deliberately not in that order, and both views must agree.
     const spans = [
       makeSpan({ span_id: "root" }),
       makeSpan({

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -10,6 +10,18 @@ export function parseTimestamp(ts: string): number {
   return parseAsUTC(ts.trim()).getTime();
 }
 
+export function compareSpansForStableDisplay(a: Span, b: Span): number {
+  const startDelta = parseTimestamp(a.span_start_time) - parseTimestamp(b.span_start_time);
+  if (startDelta !== 0) return startDelta;
+
+  const aEnd = a.span_end_time ? parseTimestamp(a.span_end_time) : Number.POSITIVE_INFINITY;
+  const bEnd = b.span_end_time ? parseTimestamp(b.span_end_time) : Number.POSITIVE_INFINITY;
+  const endDelta = aEnd - bEnd;
+  if (endDelta !== 0) return endDelta;
+
+  return a.span_id.localeCompare(b.span_id);
+}
+
 function parseMetadata(metadata: string | null): Record<string, unknown> {
   if (!metadata) return {};
   try {
@@ -169,7 +181,7 @@ export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
   // Sort children within each parent by start_time so connector lines
   // (isTerminal / parentLevels) are stable regardless of SSE arrival order.
   for (const children of childrenByParent.values()) {
-    children.sort((a, b) => parseTimestamp(a.span_start_time) - parseTimestamp(b.span_start_time));
+    children.sort(compareSpansForStableDisplay);
   }
 
   const rows: SpanTreeRow[] = [];
@@ -189,9 +201,7 @@ export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
   // 1. Connector lines are correct across all top-level items.
   // 2. Orphans are always visible, not silently dropped when root exists.
   const orphans = spans.filter((s) => s.parent_span_id !== null && !spanIds.has(s.parent_span_id));
-  const topLevel = [...(childrenByParent.get(null) ?? []), ...orphans].sort(
-    (a, b) => parseTimestamp(a.span_start_time) - parseTimestamp(b.span_start_time),
-  );
+  const topLevel = [...(childrenByParent.get(null) ?? []), ...orphans].sort(compareSpansForStableDisplay);
   topLevel.forEach((span, idx) => {
     traverse(span, 0, idx === topLevel.length - 1, []);
   });

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -201,7 +201,9 @@ export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
   // 1. Connector lines are correct across all top-level items.
   // 2. Orphans are always visible, not silently dropped when root exists.
   const orphans = spans.filter((s) => s.parent_span_id !== null && !spanIds.has(s.parent_span_id));
-  const topLevel = [...(childrenByParent.get(null) ?? []), ...orphans].sort(compareSpansForStableDisplay);
+  const topLevel = [...(childrenByParent.get(null) ?? []), ...orphans].sort(
+    compareSpansForStableDisplay,
+  );
   topLevel.forEach((span, idx) => {
     traverse(span, 0, idx === topLevel.length - 1, []);
   });

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -29,8 +29,9 @@ export function compareSpansForStableDisplay(a: Span, b: Span): number {
 
   const aEnd = a.span_end_time ? parseTimestamp(a.span_end_time) : Number.POSITIVE_INFINITY;
   const bEnd = b.span_end_time ? parseTimestamp(b.span_end_time) : Number.POSITIVE_INFINITY;
-  const endDelta = aEnd - bEnd;
-  if (endDelta !== 0) return endDelta;
+  // Strict inequality (not delta !== 0) so two in-progress spans — both
+  // +Infinity, whose subtraction is NaN — fall through to the span_id tie-break.
+  if (aEnd !== bEnd) return aEnd - bEnd;
 
   return a.span_id.localeCompare(b.span_id);
 }

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -10,6 +10,19 @@ export function parseTimestamp(ts: string): number {
   return parseAsUTC(ts.trim()).getTime();
 }
 
+/**
+ * Total ordering for sibling spans that is stable across fetches/streams of the
+ * same trace. `span_start_time` is stored at millisecond precision (ClickHouse
+ * DateTime64(3)), so sub-millisecond-fast parallel siblings (e.g. parallel tool
+ * calls) collapse to an identical start and would otherwise order arbitrarily.
+ *
+ * Tie-break start → end → span_id, mirroring the backend
+ * `ORDER BY span_start_time ASC, span_end_time ASC, span_id ASC` so the tree and
+ * timeline views agree with each other and with the server. In-progress spans
+ * have no end time; sorting them as +Infinity places them after completed
+ * siblings that share a start, and keeps two end-less siblings equal so the
+ * span_id tie-break decides. span_id is the final, always-present discriminator.
+ */
 export function compareSpansForStableDisplay(a: Span, b: Span): number {
   const startDelta = parseTimestamp(a.span_start_time) - parseTimestamp(b.span_start_time);
   if (startDelta !== 0) return startDelta;
@@ -178,8 +191,10 @@ export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
     childrenByParent.get(pid)!.push(span);
   });
 
-  // Sort children within each parent by start_time so connector lines
-  // (isTerminal / parentLevels) are stable regardless of SSE arrival order.
+  // Sort children within each parent so connector lines (isTerminal /
+  // parentLevels) are stable regardless of SSE arrival order. start_time alone
+  // ties for sub-ms parallel spans, so compareSpansForStableDisplay falls back
+  // to end_time then span_id.
   for (const children of childrenByParent.values()) {
     children.sort(compareSpansForStableDisplay);
   }
@@ -197,7 +212,7 @@ export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
   }
 
   // Combine true roots with orphan spans (parent not yet arrived) into a single
-  // top-level list sorted by start_time. This ensures:
+  // top-level list, stably sorted (start → end → span_id). This ensures:
   // 1. Connector lines are correct across all top-level items.
   // 2. Orphans are always visible, not silently dropped when root exists.
   const orphans = spans.filter((s) => s.parent_span_id !== null && !spanIds.has(s.parent_span_id));

--- a/frontend/ui/src/features/traces/utils/timeline.ts
+++ b/frontend/ui/src/features/traces/utils/timeline.ts
@@ -1,5 +1,5 @@
 import type { Span } from "@/types/api";
-import { buildChildrenMap, getSpanDuration, parseTimestamp } from "../utils";
+import { buildChildrenMap, compareSpansForStableDisplay, getSpanDuration, parseTimestamp } from "../utils";
 
 export interface TimelineMetrics {
   startOffsetPx: number;
@@ -54,15 +54,13 @@ export function flattenTreeWithMetrics(
   const spanIds = new Set(spans.map((s) => s.span_id));
 
   for (const children of childrenMap.values()) {
-    children.sort((a, b) => startTimes.get(a.span_id)! - startTimes.get(b.span_id)!);
+    children.sort(compareSpansForStableDisplay);
   }
 
   // True roots + orphan spans (parent not yet arrived), sorted by time
   const trueRoots = childrenMap.get(null) ?? [];
   const orphans = spans.filter((s) => s.parent_span_id !== null && !spanIds.has(s.parent_span_id));
-  const topLevel = [...trueRoots, ...orphans].sort(
-    (a, b) => startTimes.get(a.span_id)! - startTimes.get(b.span_id)!,
-  );
+  const topLevel = [...trueRoots, ...orphans].sort(compareSpansForStableDisplay);
 
   const flatList: FlatTimelineItem[] = [];
   const safeTraceDuration = Math.max(1, traceDurationMs);

--- a/frontend/ui/src/features/traces/utils/timeline.ts
+++ b/frontend/ui/src/features/traces/utils/timeline.ts
@@ -58,11 +58,13 @@ export function flattenTreeWithMetrics(
   const childrenMap = buildChildrenMap(spans);
   const spanIds = new Set(spans.map((s) => s.span_id));
 
+  // Stable sibling order (start → end → span_id) — must match SpanTreeView's
+  // buildSpanTree so the scroll-synced timeline and tree panels stay row-aligned.
   for (const children of childrenMap.values()) {
     children.sort(compareSpansForStableDisplay);
   }
 
-  // True roots + orphan spans (parent not yet arrived), sorted by time
+  // True roots + orphan spans (parent not yet arrived), same stable order.
   const trueRoots = childrenMap.get(null) ?? [];
   const orphans = spans.filter((s) => s.parent_span_id !== null && !spanIds.has(s.parent_span_id));
   const topLevel = [...trueRoots, ...orphans].sort(compareSpansForStableDisplay);

--- a/frontend/ui/src/features/traces/utils/timeline.ts
+++ b/frontend/ui/src/features/traces/utils/timeline.ts
@@ -1,5 +1,10 @@
 import type { Span } from "@/types/api";
-import { buildChildrenMap, compareSpansForStableDisplay, getSpanDuration, parseTimestamp } from "../utils";
+import {
+  buildChildrenMap,
+  compareSpansForStableDisplay,
+  getSpanDuration,
+  parseTimestamp,
+} from "../utils";
 
 export interface TimelineMetrics {
   startOffsetPx: number;

--- a/tests/test_trace_span_ordering.py
+++ b/tests/test_trace_span_ordering.py
@@ -14,19 +14,23 @@ class _StubClient:
         self.calls.append((query, parameters))
         normalized = " ".join(query.split())
         if "FROM traces FINAL" in normalized:
-            return _StubResult([[
-                "trace-1",
-                "project-1",
-                "Trace Name",
-                "2024-01-01T00:00:00.000Z",
-                "user-1",
-                "session-1",
-                "main",
-                "repo",
-                None,
-                None,
-                None,
-            ]])
+            return _StubResult(
+                [
+                    [
+                        "trace-1",
+                        "project-1",
+                        "Trace Name",
+                        "2024-01-01T00:00:00.000Z",
+                        "user-1",
+                        "session-1",
+                        "main",
+                        "repo",
+                        None,
+                        None,
+                        None,
+                    ]
+                ]
+            )
         if "FROM spans FINAL" in normalized:
             return _StubResult([])
         raise AssertionError(f"Unexpected query: {query}")

--- a/tests/test_trace_span_ordering.py
+++ b/tests/test_trace_span_ordering.py
@@ -1,0 +1,44 @@
+from rest.services.trace_reader import TraceReaderService
+
+
+class _StubResult:
+    def __init__(self, rows):
+        self.result_rows = rows
+
+
+class _StubClient:
+    def __init__(self):
+        self.calls = []
+
+    def query(self, query, parameters=None):
+        self.calls.append((query, parameters))
+        normalized = " ".join(query.split())
+        if "FROM traces FINAL" in normalized:
+            return _StubResult([[
+                "trace-1",
+                "project-1",
+                "Trace Name",
+                "2024-01-01T00:00:00.000Z",
+                "user-1",
+                "session-1",
+                "main",
+                "repo",
+                None,
+                None,
+                None,
+            ]])
+        if "FROM spans FINAL" in normalized:
+            return _StubResult([])
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+def test_get_trace_uses_stable_span_ordering(monkeypatch):
+    stub = _StubClient()
+    monkeypatch.setattr("rest.services.trace_reader.get_clickhouse_client", lambda: stub)
+
+    service = TraceReaderService()
+    trace = service.get_trace("project-1", "trace-1")
+
+    assert trace is not None
+    span_query = next(query for query, _ in stub.calls if "FROM spans FINAL" in query)
+    assert "ORDER BY span_start_time ASC, span_end_time ASC, span_id ASC" in span_query

--- a/tests/test_trace_span_ordering.py
+++ b/tests/test_trace_span_ordering.py
@@ -1,3 +1,11 @@
+"""Regression guard for deterministic sibling span ordering (issue #1161).
+
+span_start_time is stored at millisecond precision, so sub-ms parallel siblings
+tie. The span query must carry span_end_time + span_id tie-breakers so two reads
+of the same trace return identical order. The ClickHouse client is stubbed, so
+this asserts the ORDER BY clause directly rather than exercising a live DB.
+"""
+
 from rest.services.trace_reader import TraceReaderService
 
 

--- a/tests/test_trace_span_ordering.py
+++ b/tests/test_trace_span_ordering.py
@@ -6,6 +6,8 @@ of the same trace return identical order. The ClickHouse client is stubbed, so
 this asserts the ORDER BY clause directly rather than exercising a live DB.
 """
 
+from datetime import UTC, datetime
+
 from rest.services.trace_reader import TraceReaderService
 
 
@@ -21,14 +23,14 @@ class _StubClient:
     def query(self, query, parameters=None):
         self.calls.append((query, parameters))
         normalized = " ".join(query.split())
-        if "FROM traces FINAL" in normalized:
+        if "FROM traces" in normalized:
             return _StubResult(
                 [
                     [
                         "trace-1",
                         "project-1",
                         "Trace Name",
-                        "2024-01-01T00:00:00.000Z",
+                        datetime(2024, 1, 1, tzinfo=UTC),
                         "user-1",
                         "session-1",
                         "main",
@@ -39,7 +41,7 @@ class _StubClient:
                     ]
                 ]
             )
-        if "FROM spans FINAL" in normalized:
+        if "FROM spans" in normalized:
             return _StubResult([])
         raise AssertionError(f"Unexpected query: {query}")
 
@@ -52,5 +54,5 @@ def test_get_trace_uses_stable_span_ordering(monkeypatch):
     trace = service.get_trace("project-1", "trace-1")
 
     assert trace is not None
-    span_query = next(query for query, _ in stub.calls if "FROM spans FINAL" in query)
+    span_query = next(query for query, _ in stub.calls if "FROM spans" in query)
     assert "ORDER BY span_start_time ASC, span_end_time ASC, span_id ASC" in span_query


### PR DESCRIPTION
## Summary

Fixes #1161.

This makes sibling span ordering deterministic when multiple spans share the same `span_start_time` by applying the same stable tie-breakers in both backend queries and frontend traversal.

## Changes

- add `span_end_time ASC, span_id ASC` tie-breakers to trace detail span queries
- add the same stable comparator to frontend tree and timeline ordering
- cover the regression with focused backend and frontend tests

## Verification

- `.venv/bin/pytest tests/test_trace_span_ordering.py -q`
- `cd frontend/packages/core && pnpm run db:generate`
- `cd frontend/ui && pnpm exec vitest run src/features/traces/components/SpanTreeView.test.ts src/features/traces/utils/index.test.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes sibling span ordering when spans share the same start time by adding deterministic tie-breakers on backend and frontend. Prevents flicker, keeps tree/timeline rows aligned, and makes JSONL export stable.

- **Bug Fixes**
  - Backend: enforce `ORDER BY span_start_time ASC, span_end_time ASC, span_id ASC` in span queries and JSONL export.
  - Frontend: add `compareSpansForStableDisplay` (start → end → `span_id`) and use it in tree, timeline, and top-level roots/orphans; compare end times with strict inequality so in-progress siblings fall through to the `span_id` tie-break.
  - Tests: backend regression asserting the exact ORDER BY; frontend tests for same-start siblings, all-in-progress cases, and tree/timeline parity.

<sup>Written for commit cb4b33eb882b13b5b5a0c3c31c6f71a35475d83c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

