### PR TITLE
fix(agent): clone repos via git CLI in Daytona sandbox to fix x509 failures

### DIFF
--- a/frontend/packages/agent/src/executors/__tests__/daytona.test.ts
+++ b/frontend/packages/agent/src/executors/__tests__/daytona.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the Daytona SDK
+const mockSandbox = {
+  process: {
+    executeCommand: vi.fn(),
+  },
+  fs: {
+    uploadFile: vi.fn(),
+    downloadFile: vi.fn(),
+  },
+  git: {
+    clone: vi.fn(),
+  },
+  getWorkDir: vi.fn(),
+  delete: vi.fn(),
+};
+
+const mockDaytona = {
+  create: vi.fn().mockResolvedValue(mockSandbox),
+};
+
+vi.mock("@daytonaio/sdk", () => ({
+  Daytona: vi.fn().mockImplementation(() => mockDaytona),
+}));
+
+import { DaytonaExecutor } from "../daytona.js";
+
+describe("DaytonaExecutor", () => {
+  let executor: DaytonaExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new DaytonaExecutor();
+
+    // Default mock returns
+    mockSandbox.getWorkDir.mockResolvedValue("/home/daytona");
+    mockSandbox.process.executeCommand.mockResolvedValue({
+      exitCode: 0,
+      result: "",
+    });
+  });
+
+  describe("init()", () => {
+    it("creates ephemeral sandbox from ubuntu:24.04 and caches workDir", async () => {
+      await executor.init();
+
+      expect(mockDaytona.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          image: "ubuntu:24.04",
+          ephemeral: true,
+          autoStopInterval: 15,
+        }),
+        expect.objectContaining({ timeout: 60 }),
+      );
+      // workDir is always /workspace regardless of what getWorkDir() returns
+      expect(executor.getWorkspacePath()).toBe("/workspace");
+      expect(executor.isReady()).toBe(true);
+    });
+
+    it("installs ca-certificates and git tooling at runtime", async () => {
+      await executor.init();
+
+      // ca-certificates must be present before any HTTPS clone (CLI git reads
+      // the on-disk trust store), alongside git/jq/curl.
+      const runtimeCmds = mockSandbox.process.executeCommand.mock.calls.map((c: [string]) => c[0]);
+      const apt = runtimeCmds.find((c: string) => c.includes("apt-get"));
+      expect(apt).toBeTruthy();
+      expect(apt).toContain("ca-certificates");
+      expect(apt).toContain("git");
+    });
+  });
+
+  describe("exec()", () => {
+    it("maps Daytona response to ExecResult", async () => {
+      await executor.init();
+      mockSandbox.process.executeCommand.mockResolvedValueOnce({
+        exitCode: 0,
+        result: "hello world",
+      });
+
+      const result = await executor.exec("echo hello world");
+
+      expect(result).toEqual({
+        stdout: "hello world",
+        stderr: "",
+        code: 0,
+      });
+    });
+
+    it("passes timeout to executeCommand", async () => {
+      await executor.init();
+      mockSandbox.process.executeCommand.mockResolvedValueOnce({
+        exitCode: 0,
+        result: "",
+      });
+
+      await executor.exec("sleep 1", { timeout: 10 });
+
+      expect(mockSandbox.process.executeCommand).toHaveBeenCalledWith(
+        "sleep 1",
+        undefined,
+        undefined,
+        10,
+      );
+    });
+
+    it("throws if not initialized", async () => {
+      await expect(executor.exec("ls")).rejects.toThrow("not initialized");
+    });
+
+    it("handles null result gracefully", async () => {
+      await executor.init();
+      mockSandbox.process.executeCommand.mockResolvedValueOnce({
+        exitCode: 1,
+        result: null,
+      });
+
+      const result = await executor.exec("false");
+
+      expect(result).toEqual({ stdout: "", stderr: "", code: 1 });
+    });
+  });
+
+  describe("writeFile()", () => {
+    it("uploads content via fs.uploadFile", async () => {
+      await executor.init();
+      vi.clearAllMocks();
+
+      await executor.writeFile("/tmp/test.txt", "hello");
+
+      expect(mockSandbox.fs.uploadFile).toHaveBeenCalledWith(Buffer.from("hello"), "/tmp/test.txt");
+    });
+
+    it("throws if not initialized", async () => {
+      await expect(executor.writeFile("/tmp/x", "y")).rejects.toThrow("not initialized");
+    });
+  });
+
+  describe("readFile()", () => {
+    it("delegates to sandbox.fs.downloadFile()", async () => {
+      await executor.init();
+      mockSandbox.fs.downloadFile.mockResolvedValueOnce(Buffer.from("file contents"));
+
+      const result = await executor.readFile("/tmp/test.txt");
+
+      expect(result).toBe("file contents");
+      expect(mockSandbox.fs.downloadFile).toHaveBeenCalledWith("/tmp/test.txt");
+    });
+
+    it("throws if not initialized", async () => {
+      await expect(executor.readFile("/tmp/x")).rejects.toThrow("not initialized");
+    });
+  });
+
+  describe("cloneRepo()", () => {
+    // Deliberately uses the system `git` CLI (not go-git) with GIT_ASKPASS, so it
+    // handles LFS/large repos and the token never lands in argv / URL / .git/config.
+
+    /** Find the executeCommand call that runs `git ... clone` and return [cmd, cwd, env, timeout]. */
+    function cloneCall() {
+      const call = mockSandbox.process.executeCommand.mock.calls.find((c: [string]) =>
+        c[0].includes("clone"),
+      );
+      expect(call).toBeTruthy();
+      return call as [string, undefined, Record<string, string>, number];
+    }
+
+    it("writes an askpass helper and passes the token via env, never in argv", async () => {
+      await executor.init();
+      vi.clearAllMocks();
+      mockSandbox.process.executeCommand.mockResolvedValue({ exitCode: 0, result: "" });
+
+      await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
+        ref: "main",
+        username: "x-access-token",
+        password: "ghp_secret",
+      });
+
+      // askpass script uploaded
+      const askpassUpload = mockSandbox.fs.uploadFile.mock.calls.find(
+        (c: [Buffer, string]) => c[1] === "/tmp/git-askpass.sh",
+      );
+      expect(askpassUpload).toBeTruthy();
+      expect((askpassUpload![0] as Buffer).toString()).toContain("GIT_PASSWORD");
+
+      const [cmd, , env] = cloneCall();
+      // url/dest/ref are referenced as quoted $VARS, never interpolated — so the
+      // literal url is NOT in the command string; it flows through env instead.
+      expect(cmd).toContain('"$GIT_URL"');
+      expect(cmd).toContain('"$GIT_DEST"');
+      expect(cmd).not.toContain("https://github.com/foo/bar.git");
+      // token is NEVER in the command string
+      expect(cmd).not.toContain("ghp_secret");
+      // creds + structured args flow through env
+      expect(env).toMatchObject({
+        GIT_ASKPASS: "/tmp/git-askpass.sh",
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_USERNAME: "x-access-token",
+        GIT_PASSWORD: "ghp_secret",
+        GIT_URL: "https://github.com/foo/bar.git",
+        GIT_DEST: "/repos/bar",
+        GIT_REF: "main",
+      });
+    });
+
+    it("does not inject shell from a hostile ref", async () => {
+      await executor.init();
+      vi.clearAllMocks();
+      mockSandbox.process.executeCommand.mockResolvedValue({ exitCode: 0, result: "" });
+
+      const hostile = 'main"; rm -rf / #';
+      await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
+        ref: hostile,
+        password: "ghp_xxx",
+      });
+
+      const [cmd, , env] = cloneCall();
+      // hostile value never appears in the command string; only as an env value
+      expect(cmd).not.toContain("rm -rf");
+      expect(env.GIT_REF).toBe(hostile);
+    });
+
+    it("defaults username to x-access-token", async () => {
+      await executor.init();
+      await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
+        password: "ghp_xxx",
+      });
+      const [, , env] = cloneCall();
+      expect(env.GIT_USERNAME).toBe("x-access-token");
+    });
+
+    it("clones a branch with --branch (no checkout step)", async () => {
+      await executor.init();
+      await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
+        ref: "main",
+        password: "ghp_xxx",
+      });
+      const [cmd, , env] = cloneCall();
+      expect(cmd).toContain('--branch "$GIT_REF"');
+      expect(cmd).not.toContain("checkout");
+      expect(env.GIT_REF).toBe("main");
+    });
+
+    it("clones then checks out a full commit SHA (not --branch)", async () => {
+      await executor.init();
+      const sha = "29b242d1b96aab9ac17e37350e6c7dc54033f61b";
+      await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
+        ref: sha,
+        password: "ghp_xxx",
+      });
+      const [cmd, , env] = cloneCall();
+      expect(cmd).not.toContain("--branch");
+      expect(cmd).toContain('checkout "$GIT_REF"');
+      expect(env.GIT_REF).toBe(sha);
+    });
+
+    it("treats a short hex ref as a SHA (checkout, not --branch)", async () => {
+      await executor.init();
+      await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
+        ref: "29b242d",
+        password: "ghp_xxx",
+      });
+      const [cmd, , env] = cloneCall();
+      expect(cmd).not.toContain("--branch");
+      expect(cmd).toContain('checkout "$GIT_REF"');
+      expect(env.GIT_REF).toBe("29b242d");
+    });
+
+    it("shallow-clones the default branch when no ref is given", async () => {
+      await executor.init();
+      await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
+        password: "ghp_xxx",
+      });
+      const [cmd] = cloneCall();
+      expect(cmd).toContain("--depth 1");
+      expect(cmd).not.toContain("--branch");
+      expect(cmd).not.toContain("checkout");
+    });
+
+    it("throws a redacted error when the clone fails", async () => {
+      await executor.init();
+      vi.clearAllMocks();
+      // chmod + clone both return non-zero; only the clone's exit is checked.
+      mockSandbox.process.executeCommand.mockResolvedValue({
+        exitCode: 128,
+        result: "fatal: could not read Password ghp_secret",
+      });
+
+      await expect(
+        executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
+          password: "ghp_secret",
+        }),
+      ).rejects.toThrow(/git clone failed.*\[REDACTED\]/s);
+    });
+  });
+
+  describe("hasNativeGit()", () => {
+    it("returns true", () => {
+      expect(executor.hasNativeGit()).toBe(true);
+    });
+  });
+
+  describe("destroy()", () => {
+    it("deletes sandbox and resets state", async () => {
+      await executor.init();
+      expect(executor.isReady()).toBe(true);
+
+      await executor.destroy();
+
+      expect(mockSandbox.delete).toHaveBeenCalled();
+      expect(executor.isReady()).toBe(false);
+    });
+
+    it("no-ops if not initialized", async () => {
+      await executor.destroy(); // should not throw
+      expect(mockSandbox.delete).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors during delete", async () => {
+      await executor.init();
+      mockSandbox.delete.mockRejectedValueOnce(new Error("network error"));
+
+      await executor.destroy(); // should not throw
+      expect(executor.isReady()).toBe(false);
+    });
+  });
+});

--- a/frontend/packages/agent/src/executors/daytona.ts
+++ b/frontend/packages/agent/src/executors/daytona.ts
@@ -16,6 +16,9 @@ export class DaytonaExecutor implements Executor {
       target: "us",
     });
 
+    // Plain ubuntu:24.04 — a tiny, near-always-warm base (no custom snapshot to
+    // build or cold-pull). We install tools at runtime below; the cost lands once
+    // per session (init is cached per session, guarded by isReady()).
     this.sandbox = await this.daytona.create(
       {
         image: "ubuntu:24.04",
@@ -32,9 +35,13 @@ export class DaytonaExecutor implements Executor {
       "mkdir -p /workspace/repos /workspace/traces /workspace/notes",
     );
 
-    // Install required tools
+    // Install required tools. ca-certificates is essential: cloneRepo uses the
+    // system `git` CLI (a fresh process that reads the on-disk trust store), so
+    // certs must be present before any HTTPS clone. We intentionally do NOT rely
+    // on Daytona's native go-git here — its daemon caches an empty cert pool at
+    // boot on this image, so its in-process TLS can't be fixed by a later apt.
     await this.sandbox.process.executeCommand(
-      "apt-get update -qq && apt-get install -y -qq git jq curl > /dev/null 2>&1 || true",
+      "apt-get update -qq && apt-get install -y -qq ca-certificates git jq curl > /dev/null 2>&1 || true",
     );
 
     console.log(`[DaytonaExecutor] Sandbox ready, workDir: ${this.workDir}`);
@@ -46,7 +53,7 @@ export class DaytonaExecutor implements Executor {
     const result = await this.sandbox.process.executeCommand(
       command,
       undefined,
-      undefined,
+      options?.env,
       options?.timeout,
     );
 
@@ -87,7 +94,17 @@ export class DaytonaExecutor implements Executor {
     this.sandbox = null;
   }
 
-  // Native Git Support
+  // Git Support
+  //
+  // The executor owns cloning (hasNativeGit=true), but deliberately uses the
+  // system `git` CLI rather than Daytona's native `sandbox.git.clone()` (go-git):
+  //   - go-git is a pure-Go reimplementation with no Git LFS support, weak
+  //     submodule handling, and worse behavior on large repos / protocol v2 —
+  //     bad properties for cloning arbitrary customer repos.
+  //   - the CLI is a fresh process that reads the on-disk CA store, sidestepping
+  //     the daemon's boot-cached trust store entirely.
+  // The token is passed via GIT_ASKPASS + env (base64 out-of-band), so it never
+  // lands in argv, the clone URL, or .git/config.
 
   hasNativeGit(): boolean {
     return true;
@@ -100,18 +117,66 @@ export class DaytonaExecutor implements Executor {
   ): Promise<void> {
     if (!this.sandbox) throw new Error("Sandbox not initialized");
 
-    // Daytona distinguishes branch/tag (3rd arg) from commit SHA (4th arg).
-    // Passing a SHA as branch causes a 400 error from the API.
-    const isCommitSha = options?.ref !== undefined && /^[0-9a-f]{7,40}$/i.test(options.ref);
+    const username = options?.username || "x-access-token";
+    const password = options?.password ?? "";
+    const ref = options?.ref;
 
-    await this.sandbox.git.clone(
-      url,
-      path,
-      isCommitSha ? undefined : options?.ref, // branch or tag
-      isCommitSha ? options?.ref : undefined, // commit SHA
-      options?.username || "x-access-token",
-      options?.password,
+    // Askpass helper: git calls this for credential prompts; it echoes the
+    // creds we hand it via env. Keeps secrets out of argv and the URL.
+    const askpassPath = "/tmp/git-askpass.sh";
+    await this.writeFile(
+      askpassPath,
+      [
+        "#!/bin/sh",
+        'case "$1" in',
+        '  Username*) printf "%s" "$GIT_USERNAME" ;;',
+        '  Password*) printf "%s" "$GIT_PASSWORD" ;;',
+        "esac",
+        "",
+      ].join("\n"),
     );
+    await this.exec(`chmod +x ${askpassPath}`);
+
+    // URL/ref/path flow through env and are referenced as quoted "$VARS", never
+    // interpolated into the command string — so a hostile branch name or ref
+    // (e.g. from a trace's git_ref) can't break quoting or inject shell. This is
+    // the structured-arg safety go-git gave us, kept on the CLI path.
+    // credential.helper= and core.hooksPath=/dev/null neutralize any inherited
+    // credential helper / repo hooks (defense-in-depth, mirrors Daytona's daemon).
+    const base = `git -c credential.helper= -c core.hooksPath=/dev/null`;
+    const isCommitSha = ref !== undefined && /^[0-9a-f]{7,40}$/i.test(ref);
+
+    let inner: string;
+    if (!ref) {
+      inner = `${base} clone --depth 1 -- "$GIT_URL" "$GIT_DEST"`;
+    } else if (isCommitSha) {
+      // A SHA isn't a fetchable ref name — full clone, then checkout.
+      inner = `${base} clone -- "$GIT_URL" "$GIT_DEST" && ${base} -C "$GIT_DEST" checkout "$GIT_REF"`;
+    } else {
+      // Branch or tag.
+      inner = `${base} clone --depth 1 --branch "$GIT_REF" -- "$GIT_URL" "$GIT_DEST"`;
+    }
+
+    // Merge stderr→stdout: Daytona's exec only surfaces stdout, and git writes
+    // progress + errors to stderr.
+    const result = await this.exec(`( ${inner} ) 2>&1`, {
+      timeout: 180,
+      env: {
+        GIT_ASKPASS: askpassPath,
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_USERNAME: username,
+        GIT_PASSWORD: password,
+        GIT_URL: url,
+        GIT_DEST: path,
+        ...(ref ? { GIT_REF: ref } : {}),
+      },
+    });
+
+    if (result.code !== 0) {
+      const output = result.stderr || result.stdout || "";
+      const sanitized = password ? output.replaceAll(password, "[REDACTED]") : output;
+      throw new Error(`git clone failed (exit ${result.code}): ${sanitized.trim()}`);
+    }
   }
 }
 

--- a/frontend/packages/agent/src/executors/interface.ts
+++ b/frontend/packages/agent/src/executors/interface.ts
@@ -13,6 +13,11 @@ export interface ExecResult {
 export interface ExecOptions {
   timeout?: number;
   signal?: AbortSignal;
+  /**
+   * Extra environment variables for the command. Daytona's SDK passes these
+   * out-of-band (base64-encoded) so secrets never appear in argv/`ps`.
+   */
+  env?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
## Problem

Agent git clones in Daytona sandboxes fail with `tls: failed to verify certificate: x509: certificate signed by unknown authority` — even though the same `git clone` run manually inside the sandbox works fine.

## Root cause

This is **not** a Daytona bug — it's the interaction of two things:

1. Daytona's daemon clones via in-process TLS (go-git), which loads the Go system cert pool **once at boot**.
2. The `ubuntu:24.04` sandbox image ships **without `ca-certificates`**, so the daemon caches an empty trust store. Installing certs later via `apt` doesn't help — the daemon never re-reads them. A manual `git clone` works only because it's a fresh process reading the now-populated on-disk store.

Verified live: the native clone fails with x509 even after certs are on disk, while a CLI `git clone` in the same sandbox succeeds.

## Screenshots
<img width="2207" height="977" alt="Screenshot 2026-06-11 at 11 59 32 PM" src="https://github.com/user-attachments/assets/aa11d077-3d30-420f-87f6-f14b776433b3" />

## Fix

- `cloneRepo` now runs the system `git` CLI inside the sandbox (a fresh process that reads the on-disk CA store) instead of native `sandbox.git.clone()`.
- Install `ca-certificates` at runtime alongside git/jq/curl.
- Bonus: the CLI brings Git LFS, submodules, and better large-repo / protocol-v2 behavior that go-git lacks — important when cloning arbitrary customer repos.

### Security / robustness
- Token flows via `GIT_ASKPASS` + env — never in the clone URL, argv, or `.git/config`.
- `url`/`ref`/`dest` are passed as env and referenced as quoted `$VARS`, so a hostile `ref` (e.g. from a trace's `git_ref`) can't break quoting or inject shell.
- `credential.helper=` and `core.hooksPath=/dev/null` neutralize inherited helpers/hooks.

## Why CLI over baking a custom snapshot

We evaluated baking certs into a custom Daytona snapshot (certs at boot, keeps native go-git) vs runtime certs + CLI. Measured: a baked snapshot adds a one-time ~3 min build **plus** a ~37s cold-pull tail after idle eviction, whereas runtime-apt + CLI is predictable (~9–12s cold init, once per session) with no build and no tail. Chose CLI.

## Testing

- **Live-verified against real Daytona:** default + branch clones succeed, the token is never written to `.git/config`, and a hostile-ref canary file survives (injection blocked).
- **e2e in the local platform:** a real agent "git clone the repo and …" session created the sandbox, cloned successfully (no x509), and completed a multi-turn analysis.
- Unit tests covering the CLI command shape, branch/tag vs SHA handling, token-not-in-argv, hostile-ref safety, and redacted errors exist locally and can be added to this PR on request.

## Deploy

No deployment changes needed — pure app-code change; the clone runs inside the sandbox (not the agent container), and image/secrets/env/CI are already in place.

Fixes #1170

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes x509 clone failures in Daytona sandboxes by switching repo cloning to the system `git` CLI and installing `ca-certificates` at runtime. Improves clone reliability for arbitrary repos while keeping credentials secure.

- Bug Fixes
  - Replace Daytona native clone with system `git` inside the sandbox to read the on-disk CA store and avoid the daemon’s cached empty pool.
  - Install `ca-certificates` with `git`/`jq`/`curl` on `ubuntu:24.04` before any HTTPS clone.
  - Add `env` support to `exec()` so secrets can be passed out-of-band.
  - Harden cloning: use `GIT_ASKPASS`, avoid tokens in argv/URL/config, disable credential helpers/hooks, handle branch/tag vs SHA safely, and redact secrets in errors.
  - Add unit tests for the CLI clone path (branch vs SHA, token via env, injection safety, redacted errors).

<sup>Written for commit 9d4dfe3d2a274f05d59f0a808f1698368434e149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



