### PR TITLE
docs(examples): add minimal Claude Agent SDK Python demo

### DIFF
--- a/examples/python/claude-agent-sdk/README.md
+++ b/examples/python/claude-agent-sdk/README.md
@@ -13,7 +13,16 @@ With `uv` (recommended):
 uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
 ```
 
+For a fast end-to-end check (~1-2 min), run the minimal variant instead:
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python minimal.py
+```
+
 ## What it does
 
 Runs demo queries using the Claude Agent SDK's built-in tools (Read, Glob, Grep, Bash).
 Claude autonomously decides which tools to use and executes them.
+
+- `main.py` — full demo: 2 topics, WebSearch researcher, higher turn budget.
+- `minimal.py` — trimmed version of `main.py`: 1 topic, no WebSearch, low `max_turns`,
+  "be brief" prompts. Same trace shape, finishes in ~1-2 min.

--- a/examples/python/claude-agent-sdk/minimal.py
+++ b/examples/python/claude-agent-sdk/minimal.py
@@ -1,0 +1,100 @@
+"""Minimal multi-agent demo with TraceRoot observability.
+
+A trimmed-down version of main.py for quick end-to-end SDK testing:
+- ONE topic (not 2)
+- No WebSearch (the slow part) — researcher answers from knowledge
+- Low max_turns and "be brief" instructions so the run finishes in ~1-2 min
+
+Still exercises the full trace shape: orchestrator + researcher/analyst/writer
+subagents + LLM spans + a Bash tool span + the final ResultMessage.
+
+Usage:
+    cp .env.example .env
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python minimal.py
+"""
+
+import asyncio
+import logging
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found. Using process environment variables.")
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.CLAUDE_AGENT_SDK])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+from claude_agent_sdk import AgentDefinition, ClaudeAgentOptions, query
+
+# No-WebSearch researcher → fast. Analyst uses Bash (quick). Writer has no tools.
+RESEARCHER = AgentDefinition(
+    description="Research specialist. Gives key facts about a topic from its own knowledge.",
+    prompt="You are a research specialist. Give 3 key facts about the topic from your own knowledge. No web search. Under 80 words.",
+    tools=[],
+    model="haiku",
+)
+ANALYST = AgentDefinition(
+    description="Data analyst. Performs a quick calculation.",
+    prompt="You are a data analyst. Use Bash with python3 for ONE short calculation. Report the number. Under 40 words.",
+    tools=["Bash"],
+    model="haiku",
+)
+WRITER = AgentDefinition(
+    description="Report writer. Synthesizes findings into a short summary.",
+    prompt="You are a report writer. Write a 3-bullet summary. Under 80 words.",
+    tools=[],
+    model="haiku",
+)
+
+TOPIC = "What are the key features of OpenTelemetry for AI observability?"
+
+
+@observe(name="research_pipeline", type="agent")
+async def run_research(topic: str) -> str:
+    result_text = ""
+    async for message in query(
+        prompt=(
+            f"Topic: {topic}\n\n"
+            f"Do exactly 3 steps, calling each agent EXACTLY ONCE, and be very brief:\n"
+            f"1. researcher agent: 3 key facts (no web search)\n"
+            f"2. analyst agent: one quick python3 calculation\n"
+            f"3. writer agent: a 3-bullet summary\n"
+            f"Then present the final summary."
+        ),
+        options=ClaudeAgentOptions(
+            model="claude-sonnet-4-20250514",
+            allowed_tools=["Agent"],
+            max_turns=8,
+            permission_mode="bypassPermissions",
+            agents={"researcher": RESEARCHER, "analyst": ANALYST, "writer": WRITER},
+        ),
+    ):
+        if hasattr(message, "result"):
+            result_text = message.result
+    return result_text
+
+
+@observe(name="demo_session", type="agent")
+async def run_demo():
+    print("=" * 60)
+    print(f"Research: {TOPIC}")
+    print("=" * 60)
+    result = await run_research(TOPIC)
+    if result:
+        print(f"\n{result}")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="claude-agent-sdk-minimal-session"):
+        try:
+            asyncio.run(run_demo())
+        finally:
+            traceroot.flush()


### PR DESCRIPTION
## What

Adds `minimal.py` to the Claude Agent SDK Python example — a trimmed-down variant of `main.py` for fast end-to-end SDK testing.

Differences from `main.py`:
- **One** topic instead of two
- **No WebSearch** (the slow part) — researcher answers from its own knowledge
- Lower `max_turns` and "be brief" prompts

It finishes in ~1-2 min while still producing the full trace shape: orchestrator + researcher/analyst/writer subagents + LLM spans + a Bash tool span + the final ResultMessage.

## Changes
- `examples/python/claude-agent-sdk/minimal.py` (new)
- `examples/python/claude-agent-sdk/README.md` — document `main.py` (full) vs `minimal.py` (fast)

## Test
Ran locally via `uv run --no-project --python 3.13 --with-requirements requirements.txt python minimal.py` — pipeline completes and traces export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a minimal Python demo for `claude_agent_sdk` to enable fast end-to-end testing. It runs one topic with no WebSearch and a low turn budget, finishing in ~1–2 minutes while keeping the full trace shape.

- **New Features**
  - Added `examples/python/claude-agent-sdk/minimal.py` with researcher/analyst/writer agents, LLM spans, a Bash tool span, and a final result.
  - Removed WebSearch; researcher answers from knowledge; `max_turns=8`; concise prompts.
  - Updated README with run command and a brief `main.py` (full) vs `minimal.py` (fast) comparison.

<sup>Written for commit f84df236f594b8d32b7b049732c2b3af183749b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

