### PR TITLE
fix(ui): keyboard accessibility — Escape closes trace panel, autoFocus on dialogs

### DIFF
--- a/frontend/ui/src/features/projects/components/CreateProjectDialog.test.tsx
+++ b/frontend/ui/src/features/projects/components/CreateProjectDialog.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/lib/api", () => ({ createProject: vi.fn() }));
+
+import { CreateProjectDialog } from "./CreateProjectDialog";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreateProjectDialog focus", () => {
+  it("autofocuses the name input when opened", () => {
+    render(<CreateProjectDialog workspaceId="ws-1" open={true} onOpenChange={vi.fn()} />);
+    const input = document.querySelector('input[placeholder="Project name"]');
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/frontend/ui/src/features/projects/components/CreateProjectDialog.tsx
+++ b/frontend/ui/src/features/projects/components/CreateProjectDialog.tsx
@@ -76,6 +76,7 @@ export function CreateProjectDialog({
           </DialogHeader>
           <div className="py-4">
             <Input
+              autoFocus
               placeholder="Project name"
               value={name}
               onChange={(e) => setName(e.target.value)}

--- a/frontend/ui/src/features/traces/components/SessionDetailPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SessionDetailPanel.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({
+    aiPanelOpen: false,
+    setAiPanelOpen: vi.fn(),
+    setAiContext: vi.fn(),
+    registerAiHost: () => () => {},
+  }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ isPending: false }),
+}));
+
+vi.mock("@/features/traces/hooks", () => ({
+  useSession: () => ({ data: undefined, isPending: false, error: null }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/features/ai-assistant/components/ai-assistant-panel", () => ({
+  AiAssistantPanel: () => null,
+}));
+
+vi.mock("@/components/ui/resizable", () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => null,
+}));
+
+import { SessionDetailPanel } from "./SessionDetailPanel";
+
+afterEach(() => {
+  cleanup();
+});
+
+function renderPanel(onClose = vi.fn()) {
+  render(
+    <SessionDetailPanel
+      projectId="proj-1"
+      sessionId="session-1"
+      onClose={onClose}
+      onNavigate={vi.fn()}
+      canNavigateUp={false}
+      canNavigateDown={false}
+    />,
+  );
+  return onClose;
+}
+
+describe("SessionDetailPanel keyboard", () => {
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = renderPanel();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose when Escape's default was already prevented", () => {
+    const onClose = renderPanel();
+    const event = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+    event.preventDefault();
+    document.dispatchEvent(event);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
@@ -106,6 +106,19 @@ export function SessionDetailPanel({
     return registerAiHost();
   }, [registerAiHost]);
 
+  // Close the panel on Escape. A nested Radix overlay (dialog/select/popover/menu) that
+  // consumes the Escape calls preventDefault() in the capture phase, before this
+  // bubble-phase listener runs — so defaultPrevented means "already handled, leave the panel open".
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (e.defaultPrevented) return;
+      onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
   // Compute timestamps from date filter props
   const sessionQueryOptions = useMemo(() => {
     if (!dateFilter) return {};

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, fireEvent } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   sidebarCollapsed: false,
@@ -84,5 +84,46 @@ describe("TraceViewerPanel layout", () => {
     const panel = renderPanel({ initialFullscreen: false });
     expect(panel.className).toContain("w-[70%]");
     expect(panel.className).toContain("top-0");
+  });
+});
+
+
+describe("TraceViewerPanel keyboard", () => {
+  it("calls onClose when Escape is pressed", () => {
+    const onClose = vi.fn();
+    render(
+      <TraceViewerPanel
+        projectId="proj-1"
+        traceId="trace-1"
+        onClose={onClose}
+        onNavigate={vi.fn()}
+        canNavigateUp={false}
+        canNavigateDown={false}
+      />,
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onClose when Escape is pressed inside a dialog", () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <>
+        <TraceViewerPanel
+          projectId="proj-1"
+          traceId="trace-1"
+          onClose={onClose}
+          onNavigate={vi.fn()}
+          canNavigateUp={false}
+          canNavigateDown={false}
+        />
+        <div role="dialog">
+          <button id="nested-btn">inside dialog</button>
+        </div>
+      </>,
+    );
+    (container.querySelector("#nested-btn") as HTMLElement).focus();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -104,25 +104,21 @@ describe("TraceViewerPanel keyboard", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("does not call onClose when Escape is pressed inside a dialog", () => {
+  it("does not call onClose when Escape's default was already prevented", () => {
     const onClose = vi.fn();
-    const { container } = render(
-      <>
-        <TraceViewerPanel
-          projectId="proj-1"
-          traceId="trace-1"
-          onClose={onClose}
-          onNavigate={vi.fn()}
-          canNavigateUp={false}
-          canNavigateDown={false}
-        />
-        <div role="dialog">
-          <button id="nested-btn">inside dialog</button>
-        </div>
-      </>,
+    render(
+      <TraceViewerPanel
+        projectId="proj-1"
+        traceId="trace-1"
+        onClose={onClose}
+        onNavigate={vi.fn()}
+        canNavigateUp={false}
+        canNavigateDown={false}
+      />,
     );
-    (container.querySelector("#nested-btn") as HTMLElement).focus();
-    fireEvent.keyDown(document, { key: "Escape" });
+    const event = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
+    event.preventDefault();
+    document.dispatchEvent(event);
     expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -87,7 +87,6 @@ describe("TraceViewerPanel layout", () => {
   });
 });
 
-
 describe("TraceViewerPanel keyboard", () => {
   it("calls onClose when Escape is pressed", () => {
     const onClose = vi.fn();

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -161,6 +161,25 @@ export function TraceViewerPanel({
     });
   }, [viewMode]);
 
+
+// #1179 — close panel with Escape key
+useEffect(() => {
+  const handleKeyDown = (e: KeyboardEvent) => {
+    if (e.key !== "Escape") return;
+    // Let nested popovers/selects/dialogs handle Escape first
+    const activeEl = document.activeElement;
+    if (
+      activeEl instanceof HTMLElement &&
+      activeEl.closest('[role="dialog"], [role="listbox"], [data-radix-popper-content-wrapper]')
+    ) {
+      return;
+    }
+    onClose();
+  };
+  document.addEventListener("keydown", handleKeyDown);
+  return () => document.removeEventListener("keydown", handleKeyDown);
+}, [onClose]);
+
   const handleToggleCollapse = useCallback((id: string) => {
     setCollapsedIds((prev) => {
       const next = new Set(prev);

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -160,26 +160,25 @@ export function TraceViewerPanel({
       timelineScrollRef.current.scrollTop = treeScrollRef.current.scrollTop;
     });
   }, [viewMode]);
-
-
-// #1179 — close panel with Escape key
-useEffect(() => {
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key !== "Escape") return;
-    // Let nested popovers/selects/dialogs handle Escape first
-    const activeEl = document.activeElement;
-    if (
-      activeEl instanceof HTMLElement &&
-      activeEl.closest('[role="dialog"], [role="listbox"], [data-radix-popper-content-wrapper]')
-    ) {
-      return;
-    }
-    onClose();
-  };
-  document.addEventListener("keydown", handleKeyDown);
-  return () => document.removeEventListener("keydown", handleKeyDown);
-}, [onClose]);
-
+  // Close the panel on Escape, unless a nested overlay (dialog/select/popover) owns focus and should consume it first.
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      // Let nested popovers/selects/dialogs handle Escape first
+      const activeEl = document.activeElement;
+      if (
+        activeEl instanceof HTMLElement &&
+        activeEl.closest(
+          '[role="dialog"], [role="listbox"], [role="menu"], [data-radix-popper-content-wrapper]',
+        )
+      ) {
+        return;
+      }
+      onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
   const handleToggleCollapse = useCallback((id: string) => {
     setCollapsedIds((prev) => {
       const next = new Set(prev);

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -160,20 +160,13 @@ export function TraceViewerPanel({
       timelineScrollRef.current.scrollTop = treeScrollRef.current.scrollTop;
     });
   }, [viewMode]);
-  // Close the panel on Escape, unless a nested overlay (dialog/select/popover) owns focus and should consume it first.
+  // Close the panel on Escape. A nested Radix overlay (dialog/select/popover/menu) that
+  // consumes the Escape calls preventDefault() in the capture phase, before this
+  // bubble-phase listener runs — so defaultPrevented means "already handled, leave the panel open".
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
-      // Let nested popovers/selects/dialogs handle Escape first
-      const activeEl = document.activeElement;
-      if (
-        activeEl instanceof HTMLElement &&
-        activeEl.closest(
-          '[role="dialog"], [role="listbox"], [role="menu"], [data-radix-popper-content-wrapper]',
-        )
-      ) {
-        return;
-      }
+      if (e.defaultPrevented) return;
       onClose();
     };
     document.addEventListener("keydown", handleKeyDown);

--- a/frontend/ui/src/features/workspaces/components/CreateWorkspaceDialog.test.tsx
+++ b/frontend/ui/src/features/workspaces/components/CreateWorkspaceDialog.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => ({ mutate: vi.fn(), isPending: false, isError: false }),
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/lib/api", () => ({ createWorkspace: vi.fn() }));
+
+import { CreateWorkspaceDialog } from "./CreateWorkspaceDialog";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("CreateWorkspaceDialog focus", () => {
+  it("autofocuses the name input when opened", () => {
+    render(<CreateWorkspaceDialog open={true} onOpenChange={vi.fn()} />);
+    const input = document.querySelector('input[placeholder="Workspace name"]');
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/frontend/ui/src/features/workspaces/components/CreateWorkspaceDialog.tsx
+++ b/frontend/ui/src/features/workspaces/components/CreateWorkspaceDialog.tsx
@@ -72,6 +72,7 @@ export function CreateWorkspaceDialog({
           </DialogHeader>
           <div className="py-4">
             <Input
+              autoFocus
               placeholder="Workspace name"
               value={name}
               onChange={(e) => setName(e.target.value)}


### PR DESCRIPTION
Fixes #1179

Changes:
- `TraceViewerPanel`: adds `keydown` listener that calls `onClose` on Escape, yields to nested dialogs/popovers/selects first
- `CreateProjectDialog` + `CreateWorkspaceDialog`: adds `autoFocus` to name input so Enter-to-submit works on open
- `TraceViewerPanel.test.tsx`: two new tests covering Escape closes panel and Escape inside dialog does not close panel

Tested manually. CI will verify tests.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves keyboard accessibility: Escape now closes the trace and session detail panels, and create dialogs auto-focus the name field so Enter submits (addresses #1179).

- **Bug Fixes**
  - Escape closes TraceViewerPanel and SessionDetailPanel; ignored when `defaultPrevented` (e.g., inside dialogs/popovers/menus).
  - Create Project/Workspace dialogs: `autoFocus` the name input for immediate typing and Enter-to-submit.
  - Tests cover Escape-to-close with `defaultPrevented` guard and autofocus on create dialogs.

<sup>Written for commit 33a125f89023fb903a43ecd2b6425f1b607332fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

