### PR TITLE
Fix frontend ci tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,15 +105,22 @@ jobs:
           # Run test:coverage in each package
           cd frontend
 
+          FAIL=0
           for pkg in ui worker packages/core packages/agent packages/slack packages/github; do
             echo "::group::test:coverage — $pkg"
             cd "$pkg"
-            pnpm test:coverage || true
+            pnpm test:coverage || FAIL=1
             cd -
             echo "::endgroup::"
           done
 
+          if [ "$FAIL" -eq 1 ]; then
+            echo "::error::One or more frontend test suites failed."
+            exit 1
+          fi
+
       - name: Fix lcov source paths and merge
+        if: always()
         run: |
           set -euo pipefail
 
@@ -147,6 +154,7 @@ jobs:
           echo "Merged frontend lcov lines: $(wc -l < coverage-frontend.lcov)"
 
       - name: Upload coverage artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-frontend
@@ -199,7 +207,7 @@ jobs:
     # queue. On merge_group events github.base_ref is empty, so the compare-ref
     # logic below would have no base to diff against -- supporting it would need
     # github.event.merge_group.base_ref instead.
-    if: github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v4

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "dotenv-cli": "^11.0.0",
     "eslint": "^9.39.2",
     "eslint-plugin-react-hooks": "^7.0.1",
+    "jsdom": "^29.1.1",
     "lint-staged": "^16.2.7",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",

--- a/frontend/packages/agent/src/executors/__tests__/daytona.test.ts
+++ b/frontend/packages/agent/src/executors/__tests__/daytona.test.ts
@@ -174,7 +174,7 @@ describe("DaytonaExecutor", () => {
       await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
         ref: "main",
         username: "x-access-token",
-        password: "ghp_secret",
+        password: "dummy_token",
       });
 
       // askpass script uploaded
@@ -191,13 +191,13 @@ describe("DaytonaExecutor", () => {
       expect(cmd).toContain('"$GIT_DEST"');
       expect(cmd).not.toContain("https://github.com/foo/bar.git");
       // token is NEVER in the command string
-      expect(cmd).not.toContain("ghp_secret");
+      expect(cmd).not.toContain("dummy_token");
       // creds + structured args flow through env
       expect(env).toMatchObject({
         GIT_ASKPASS: "/tmp/git-askpass.sh",
         GIT_TERMINAL_PROMPT: "0",
         GIT_USERNAME: "x-access-token",
-        GIT_PASSWORD: "ghp_secret",
+        GIT_PASSWORD: "dummy_token",
         GIT_URL: "https://github.com/foo/bar.git",
         GIT_DEST: "/repos/bar",
         GIT_REF: "main",
@@ -212,7 +212,7 @@ describe("DaytonaExecutor", () => {
       const hostile = 'main"; rm -rf / #';
       await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
         ref: hostile,
-        password: "ghp_xxx",
+        password: "dummy_token",
       });
 
       const [cmd, , env] = cloneCall();
@@ -224,7 +224,7 @@ describe("DaytonaExecutor", () => {
     it("defaults username to x-access-token", async () => {
       await executor.init();
       await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
-        password: "ghp_xxx",
+        password: "dummy_token",
       });
       const [, , env] = cloneCall();
       expect(env.GIT_USERNAME).toBe("x-access-token");
@@ -234,7 +234,7 @@ describe("DaytonaExecutor", () => {
       await executor.init();
       await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
         ref: "main",
-        password: "ghp_xxx",
+        password: "dummy_token",
       });
       const [cmd, , env] = cloneCall();
       expect(cmd).toContain('--branch "$GIT_REF"');
@@ -247,7 +247,7 @@ describe("DaytonaExecutor", () => {
       const sha = "29b242d1b96aab9ac17e37350e6c7dc54033f61b";
       await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
         ref: sha,
-        password: "ghp_xxx",
+        password: "dummy_token",
       });
       const [cmd, , env] = cloneCall();
       expect(cmd).not.toContain("--branch");
@@ -259,7 +259,7 @@ describe("DaytonaExecutor", () => {
       await executor.init();
       await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
         ref: "29b242d",
-        password: "ghp_xxx",
+        password: "dummy_token",
       });
       const [cmd, , env] = cloneCall();
       expect(cmd).not.toContain("--branch");
@@ -270,7 +270,7 @@ describe("DaytonaExecutor", () => {
     it("shallow-clones the default branch when no ref is given", async () => {
       await executor.init();
       await executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
-        password: "ghp_xxx",
+        password: "dummy_token",
       });
       const [cmd] = cloneCall();
       expect(cmd).toContain("--depth 1");
@@ -284,12 +284,12 @@ describe("DaytonaExecutor", () => {
       // chmod + clone both return non-zero; only the clone's exit is checked.
       mockSandbox.process.executeCommand.mockResolvedValue({
         exitCode: 128,
-        result: "fatal: could not read Password ghp_secret",
+        result: "fatal: could not read Password dummy_token",
       });
 
       await expect(
         executor.cloneRepo("https://github.com/foo/bar.git", "/repos/bar", {
-          password: "ghp_secret",
+          password: "dummy_token",
         }),
       ).rejects.toThrow(/git clone failed.*\[REDACTED\]/s);
     });

--- a/frontend/packages/github/src/__tests__/callback-validation.test.ts
+++ b/frontend/packages/github/src/__tests__/callback-validation.test.ts
@@ -79,7 +79,7 @@ describe("validateCallbackParams", () => {
     it("accepts when setup_action=install, has installation_id, and no stored state", () => {
       const params: CallbackParams = {
         code: "somecode",
-        state: "github-generated-state",
+        state: null,
         installationId: "12345",
         setupAction: "install",
         storedState: null,
@@ -180,9 +180,8 @@ describe("verifyInstallationId", () => {
     const installations = [{ id: 999, app_id: 123456 }];
     const result = verifyInstallationId("fake-id", installations, appId);
     expect(result.verified).toBe(false);
-    expect(result.error).toContain("Installation ID mismatch");
+    expect(result.error).toContain("does not belong to authenticated user");
     expect(result.error).toContain("fake-id");
-    expect(result.error).toContain("999");
   });
 
   it("handles string IDs from GitHub API", () => {
@@ -192,9 +191,9 @@ describe("verifyInstallationId", () => {
     expect(result.installationId).toBe("999");
   });
 
-  it("handles empty installations array", () => {
+  it("handles empty installations array and rejects claimed ID", () => {
     const result = verifyInstallationId("999", [], appId);
-    expect(result.verified).toBe(true);
-    expect(result.installationId).toBeUndefined();
+    expect(result.verified).toBe(false);
+    expect(result.error).toContain("does not belong to authenticated user");
   });
 });

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.6.1))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       lint-staged:
         specifier: ^16.2.7
         version: 16.4.0

--- a/frontend/ui/src/app/api/slack/oauth/callback/route.test.ts
+++ b/frontend/ui/src/app/api/slack/oauth/callback/route.test.ts
@@ -15,7 +15,12 @@ vi.mock("@traceroot/slack", async (importOriginal) => {
   };
 });
 vi.mock("@/env", () => ({
-  env: { SLACK_CLIENT_ID: "cid", SLACK_CLIENT_SECRET: "csec", SLACK_REDIRECT_URI: "http://x/cb" },
+  env: {
+    SLACK_CLIENT_ID: "cid",
+    SLACK_CLIENT_SECRET: "csec",
+    SLACK_REDIRECT_URI: "http://x/cb",
+    BETTER_AUTH_URL: "http://localhost:3000",
+  },
 }));
 
 global.fetch = fetchMock as any;
@@ -25,6 +30,7 @@ describe("GET /api/slack/oauth/callback", () => {
     verifyStateParam.mockReset();
     storeInstallation.mockReset();
     fetchMock.mockReset();
+    vi.stubEnv("BETTER_AUTH_URL", "http://localhost:3000");
   });
 
   it("redirects with error on missing code/state", async () => {


### PR DESCRIPTION
Fixes #1145

## Summary
This PR addresses the 7 pre-existing frontend test failures and updates the frontend test pipeline to make future failures correctly block CI. It also resolves a minor false-positive triggered by GitGuardian in the agent tests.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [x] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [x] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
1. **UI Tests**: Fixed 4 failing Slack OAuth callback tests (`frontend/ui`) that were crashing due to an undefined `BETTER_AUTH_URL` environment variable by properly mocking it using `vi.stubEnv`.
2. **GitHub Validation Tests**: Fixed 3 failing tests in `frontend/packages/github` that were incorrectly testing insecure behaviors or using stale assumptions (e.g. assuming direct installs contain a state parameter).
3. **CI Pipeline**: Replaced the `pnpm test:coverage || true` mask in `.github/workflows/test.yml` with a `FAIL` state-tracking loop. The workflow now tests all packages and successfully uploads the coverage artifact even if tests fail, but properly exits with `exit 1` at the end to gate PRs on test correctness.
4. **Agent Tests**: Scrubbed `ghp_xxx` and `ghp_secret` dummy strings from `frontend/packages/agent/src/executors/__tests__/daytona.test.ts` to prevent false-positives in secret-scanning tools like GitGuardian.

## Screenshots / Recordings (if applicable)
N/A

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seven failing frontend tests and makes the frontend CI fail when any package tests fail, while still uploading coverage. Also removes dummy PAT strings in agent tests to avoid secret-scanning false positives.

- **Bug Fixes**
  - `frontend/ui`: Slack OAuth callback tests now mock `BETTER_AUTH_URL` via `vi.stubEnv` to prevent crashes.
  - `frontend/packages/github`: Updated callback validation tests to allow null state for direct installs and to enforce stricter installation ID checks.
  - `frontend/packages/agent`: Replaced `ghp_*` placeholders with `dummy_token` in tests to avoid secret-scan alerts.

- **Dependencies**
  - Added `jsdom` for frontend tests.

<sup>Written for commit 7729f3879eb68b60b4f096ebd5c19d8fe2513f5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

