### PR TITLE
fix(traces): surface child span error signals when parent status_message is null

### DIFF
--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -1,0 +1,350 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { Span, TraceDetail } from "@/types/api";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up before any import of the module under test
+// ---------------------------------------------------------------------------
+
+const mockUseSpanIO = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+}));
+
+vi.mock("../hooks", () => ({
+  useSpanIO: (...args: unknown[]) => mockUseSpanIO(...args),
+}));
+
+vi.mock("@/components/ui/copy-button", () => ({
+  CopyButton: () => null,
+}));
+
+vi.mock("./TokenChip", () => ({
+  TokenChip: () => null,
+}));
+
+vi.mock("./CostChip", () => ({
+  CostChip: () => null,
+}));
+
+vi.mock("./SpanKindIcon", () => ({
+  SpanKindIcon: () => null,
+}));
+
+vi.mock("./ContentRenderer", () => ({
+  ContentRenderer: () => null,
+}));
+
+vi.mock("@/components/ui/expandable-section", () => ({
+  ExpandableSection: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { SpanInfoPanel, extractErrorSignal, findBestErrorDescendant } from "./SpanInfoPanel";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
+  return {
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: overrides.span_id,
+    span_kind: SpanKind.SPAN,
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:01.000Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...overrides,
+  };
+}
+
+function makeTrace(spans: Span[]): TraceDetail {
+  return {
+    trace_id: "trace-1",
+    project_id: "proj-1",
+    name: "test-trace",
+    trace_start_time: "2024-01-01T00:00:00.000Z",
+    user_id: null,
+    session_id: null,
+    git_ref: null,
+    git_repo: null,
+    environment: "test",
+    release: null,
+    input: null,
+    output: null,
+    metadata: null,
+    spans,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function unit tests (no DOM required, but jsdom env is fine)
+// ---------------------------------------------------------------------------
+
+describe("extractErrorSignal", () => {
+  it("returns null for null input", () => {
+    expect(extractErrorSignal(null)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(extractErrorSignal("")).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(extractErrorSignal("{not json}")).toBeNull();
+  });
+
+  it("returns null when no known error key is present", () => {
+    expect(extractErrorSignal(JSON.stringify({ someOtherKey: "value" }))).toBeNull();
+  });
+
+  it("picks up exception.message as a string", () => {
+    const metadata = JSON.stringify({ "exception.message": "something went wrong" });
+    expect(extractErrorSignal(metadata)).toEqual({
+      key: "exception.message",
+      value: "something went wrong",
+    });
+  });
+
+  it("picks up exception.type as a string", () => {
+    const metadata = JSON.stringify({ "exception.type": "ValueError" });
+    expect(extractErrorSignal(metadata)).toEqual({
+      key: "exception.type",
+      value: "ValueError",
+    });
+  });
+
+  it("picks up error.message", () => {
+    const metadata = JSON.stringify({ "error.message": "network timeout" });
+    expect(extractErrorSignal(metadata)).toEqual({
+      key: "error.message",
+      value: "network timeout",
+    });
+  });
+
+  it("picks up ai.response.finishReason", () => {
+    const metadata = JSON.stringify({ "ai.response.finishReason": "content-filter" });
+    expect(extractErrorSignal(metadata)).toEqual({
+      key: "ai.response.finishReason",
+      value: "content-filter",
+    });
+  });
+
+  it("picks up first element of gen_ai.response.finish_reasons array", () => {
+    const metadata = JSON.stringify({ "gen_ai.response.finish_reasons": ["content_filter"] });
+    expect(extractErrorSignal(metadata)).toEqual({
+      key: "gen_ai.response.finish_reasons",
+      value: "content_filter",
+    });
+  });
+
+  it("skips empty string values and returns null when all keys are empty", () => {
+    const metadata = JSON.stringify({ "exception.message": "" });
+    expect(extractErrorSignal(metadata)).toBeNull();
+  });
+
+  it("skips empty arrays", () => {
+    const metadata = JSON.stringify({ "gen_ai.response.finish_reasons": [] });
+    expect(extractErrorSignal(metadata)).toBeNull();
+  });
+
+  it("returns the first matching key in priority order", () => {
+    const metadata = JSON.stringify({
+      "ai.response.finishReason": "stop",
+      "exception.message": "first wins",
+    });
+    expect(extractErrorSignal(metadata)).toEqual({
+      key: "exception.message",
+      value: "first wins",
+    });
+  });
+});
+
+describe("findBestErrorDescendant", () => {
+  it("returns null when there are no spans at all", () => {
+    expect(findBestErrorDescendant([], "root")).toBeNull();
+  });
+
+  it("returns null when root has no children", () => {
+    const root = makeSpan({ span_id: "root" });
+    expect(findBestErrorDescendant([root], "root")).toBeNull();
+  });
+
+  it("returns the only child when it exists", () => {
+    const root = makeSpan({ span_id: "root" });
+    const child = makeSpan({ span_id: "child", parent_span_id: "root" });
+    expect(findBestErrorDescendant([root, child], "root")).toBe(child);
+  });
+
+  it("prefers a descendant with status_message over one without", () => {
+    const root = makeSpan({ span_id: "root" });
+    const plain = makeSpan({ span_id: "plain", parent_span_id: "root" });
+    const withMsg = makeSpan({
+      span_id: "with-msg",
+      parent_span_id: "root",
+      status_message: "boom",
+    });
+    const result = findBestErrorDescendant([root, plain, withMsg], "root");
+    expect(result?.span_id).toBe("with-msg");
+  });
+
+  it("falls back to first descendant when none have status_message", () => {
+    const root = makeSpan({ span_id: "root" });
+    const a = makeSpan({ span_id: "a", parent_span_id: "root" });
+    const b = makeSpan({ span_id: "b", parent_span_id: "root" });
+    const result = findBestErrorDescendant([root, a, b], "root");
+    expect(result?.span_id).toBe("a");
+  });
+
+  it("searches grandchildren (multi-level BFS)", () => {
+    const root = makeSpan({ span_id: "root" });
+    const child = makeSpan({ span_id: "child", parent_span_id: "root" });
+    const grandchild = makeSpan({
+      span_id: "grandchild",
+      parent_span_id: "child",
+      status_message: "deep error",
+    });
+    const result = findBestErrorDescendant([root, child, grandchild], "root");
+    expect(result?.span_id).toBe("grandchild");
+  });
+
+  it("handles a cycle in parent_span_id without looping forever", () => {
+    const a = makeSpan({ span_id: "a", parent_span_id: "b" });
+    const b = makeSpan({ span_id: "b", parent_span_id: "a" });
+    expect(() => findBestErrorDescendant([a, b], "a")).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component render tests — verify the fallback error panel rendering
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockUseSpanIO.mockReset();
+  vi.stubGlobal("navigator", { clipboard: { writeText: vi.fn() } });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("SpanInfoPanel — fallback error signal", () => {
+  it("shows nothing in the error panel when span has no error", () => {
+    const span = makeSpan({ span_id: "s1" });
+    const trace = makeTrace([span]);
+    mockUseSpanIO.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SpanInfoPanel projectId="proj-1" trace={trace} selection={{ type: "span", span }} />);
+
+    expect(screen.queryByText(/error/i)).toBeNull();
+  });
+
+  it("shows status_message directly when present", () => {
+    const span = makeSpan({
+      span_id: "s1",
+      status: SpanStatus.ERROR,
+      status_message: "direct error message",
+    });
+    const trace = makeTrace([span]);
+    mockUseSpanIO.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SpanInfoPanel projectId="proj-1" trace={trace} selection={{ type: "span", span }} />);
+
+    expect(screen.getByText("direct error message")).toBeDefined();
+  });
+
+  it("surfaces fallback signal from child metadata when status_message is null", () => {
+    const parent = makeSpan({ span_id: "parent", status: SpanStatus.ERROR });
+    const child = makeSpan({ span_id: "child-1", name: "child-span", parent_span_id: "parent" });
+    const trace = makeTrace([parent, child]);
+
+    mockUseSpanIO.mockImplementation(
+      (_projectId: string, _traceId: string, spanId: string | null) => {
+        if (spanId === "child-1") {
+          return {
+            data: {
+              span_id: "child-1",
+              trace_id: "trace-1",
+              input: null,
+              output: null,
+              metadata: JSON.stringify({ "exception.message": "content-filter blocked request" }),
+            },
+            isLoading: false,
+          };
+        }
+        return { data: undefined, isLoading: false };
+      },
+    );
+
+    render(
+      <SpanInfoPanel projectId="proj-1" trace={trace} selection={{ type: "span", span: parent }} />,
+    );
+
+    expect(screen.getByText("content-filter blocked request")).toBeDefined();
+    expect(screen.getByText(/from "child-span"/)).toBeDefined();
+    expect(screen.getByText(/exception\.message/)).toBeDefined();
+  });
+
+  it("surfaces status_message from child span when child has one", () => {
+    const parent = makeSpan({ span_id: "parent", status: SpanStatus.ERROR });
+    const child = makeSpan({
+      span_id: "child-1",
+      name: "inner",
+      parent_span_id: "parent",
+      status_message: "inner failure",
+    });
+    const trace = makeTrace([parent, child]);
+
+    mockUseSpanIO.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(
+      <SpanInfoPanel projectId="proj-1" trace={trace} selection={{ type: "span", span: parent }} />,
+    );
+
+    expect(screen.getByText("inner failure")).toBeDefined();
+    expect(screen.getByText(/from "inner"/)).toBeDefined();
+  });
+
+  it("shows the 'descendant span' note only for fallback signals", () => {
+    const parent = makeSpan({ span_id: "parent", status: SpanStatus.ERROR });
+    const child = makeSpan({ span_id: "child-1", parent_span_id: "parent" });
+    const trace = makeTrace([parent, child]);
+
+    mockUseSpanIO.mockImplementation(
+      (_projectId: string, _traceId: string, spanId: string | null) => {
+        if (spanId === "child-1") {
+          return {
+            data: {
+              span_id: "child-1",
+              trace_id: "trace-1",
+              input: null,
+              output: null,
+              metadata: JSON.stringify({ "error.type": "RuntimeError" }),
+            },
+            isLoading: false,
+          };
+        }
+        return { data: undefined, isLoading: false };
+      },
+    );
+
+    render(
+      <SpanInfoPanel projectId="proj-1" trace={trace} selection={{ type: "span", span: parent }} />,
+    );
+
+    expect(screen.getByText(/closest failure signal from a descendant/)).toBeDefined();
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -156,9 +156,9 @@ export function SpanInfoPanel({
   );
   const fallbackSignal =
     hasError && !statusMessage
-      ? (fallbackChildSpan?.status_message
-          ? { key: "status_message", value: fallbackChildSpan.status_message }
-          : extractErrorSignal(fallbackChildIO?.metadata ?? null))
+      ? fallbackChildSpan?.status_message
+        ? { key: "status_message", value: fallbackChildSpan.status_message }
+        : extractErrorSignal(fallbackChildIO?.metadata ?? null)
       : null;
   const fallbackError = fallbackSignal?.value ?? null;
 
@@ -346,7 +346,8 @@ export function SpanInfoPanel({
             </div>
             {!statusMessage && fallbackError && (
               <p className="mb-2 text-xs italic text-red-500 dark:text-red-500">
-                No error message on this span — showing the closest failure signal from a descendant span.
+                No error message on this span — showing the closest failure signal from a descendant
+                span.
               </p>
             )}
             {!statusMessage && fallbackSignal && (

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -17,7 +17,7 @@ import { formatDuration, formatDate, buildUrlWithFilters } from "@/lib/utils";
 import { TokenChip } from "./TokenChip";
 import { CostChip } from "./CostChip";
 import { SpanStatus } from "@traceroot/core";
-import type { TraceDetail } from "@/types/api";
+import type { TraceDetail, Span } from "@/types/api";
 import type { TraceSelection } from "../types";
 import {
   getSpanDuration,
@@ -39,6 +39,48 @@ interface SpanInfoPanelProps {
   dateFilter?: { id: string; isCustom?: boolean };
   customStartDate?: Date | null;
   customEndDate?: Date | null;
+}
+
+const ERROR_ATTRIBUTE_KEYS = [
+  "exception.message",
+  "exception.type",
+  "error.message",
+  "error.type",
+  "ai.response.finishReason",
+  "gen_ai.response.finish_reasons",
+];
+
+function extractErrorSignal(metadata: string | null): { key: string; value: string } | null {
+  if (!metadata) return null;
+  try {
+    const parsed = JSON.parse(metadata) as Record<string, unknown>;
+    for (const key of ERROR_ATTRIBUTE_KEYS) {
+      const val = parsed[key];
+      if (typeof val === "string" && val) return { key, value: val };
+      if (Array.isArray(val) && val.length > 0) return { key, value: String(val[0]) };
+    }
+  } catch {
+    // ignore malformed metadata
+  }
+  return null;
+}
+
+// BFS through all descendants to find the best span with error context.
+// Prefers any descendant with a status_message, otherwise returns the first
+// descendant so its metadata can be fetched and inspected.
+function findBestErrorDescendant(spans: Span[], rootSpanId: string): Span | null {
+  const descendants: Span[] = [];
+  const queue = [rootSpanId];
+  const visited = new Set<string>();
+  while (queue.length > 0) {
+    const parentId = queue.shift()!;
+    if (visited.has(parentId)) continue;
+    visited.add(parentId);
+    const children = spans.filter((s) => s.parent_span_id === parentId);
+    descendants.push(...children);
+    queue.push(...children.map((c) => c.span_id));
+  }
+  return descendants.find((s) => !!s.status_message) ?? descendants[0] ?? null;
 }
 
 /**
@@ -100,6 +142,25 @@ export function SpanInfoPanel({
   // Error status
   const hasError = isTrace ? false : selection.span.status === SpanStatus.ERROR;
   const statusMessage = !isTrace ? selection.span.status_message : null;
+
+  // Fallback error signal: when status=ERROR but status_message is null,
+  // walk all descendants (BFS) and surface the first useful error attribute.
+  const fallbackChildSpan =
+    !isTrace && hasError && !statusMessage
+      ? findBestErrorDescendant(trace.spans, selection.span.span_id)
+      : null;
+  const { data: fallbackChildIO } = useSpanIO(
+    projectId,
+    trace.trace_id,
+    fallbackChildSpan?.span_id ?? null,
+  );
+  const fallbackSignal =
+    hasError && !statusMessage
+      ? (fallbackChildSpan?.status_message
+          ? { key: "status_message", value: fallbackChildSpan.status_message }
+          : extractErrorSignal(fallbackChildIO?.metadata ?? null))
+      : null;
+  const fallbackError = fallbackSignal?.value ?? null;
 
   const copyToClipboard = (text: string) => {
     navigator.clipboard.writeText(text);
@@ -272,12 +333,28 @@ export function SpanInfoPanel({
       {/* Content */}
       <div className="space-y-3 p-4">
         {/* Error message */}
-        {statusMessage && (
+        {(statusMessage || fallbackError) && (
           <div className="rounded-md border border-red-200 bg-red-50 p-3 dark:border-red-900 dark:bg-red-950/50">
             <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-red-700 dark:text-red-400">
               <AlertCircle className="h-3 w-3" />
               Error
+              {!statusMessage && fallbackChildSpan && (
+                <span className="ml-1 font-normal opacity-75">
+                  (from &quot;{fallbackChildSpan.name}&quot;)
+                </span>
+              )}
             </div>
+            {!statusMessage && fallbackError && (
+              <p className="mb-2 text-xs italic text-red-500 dark:text-red-500">
+                No error message on this span — showing the closest failure signal from a descendant span.
+              </p>
+            )}
+            {!statusMessage && fallbackSignal && (
+              <p className="mb-1 text-xs text-red-500 dark:text-red-500">
+                <span className="font-medium">Source:</span>{" "}
+                <span className="font-mono">{fallbackSignal.key}</span>
+              </p>
+            )}
             {/* Source location info */}
             {!isTrace && (trace.git_repo || trace.git_ref || selection.span.git_source_file) && (
               <div className="mb-2 flex flex-wrap items-center gap-2">
@@ -309,7 +386,7 @@ export function SpanInfoPanel({
               </div>
             )}
             <p className="whitespace-pre-wrap break-all font-mono text-xs text-red-600 dark:text-red-400">
-              {statusMessage}
+              {statusMessage ?? fallbackError}
             </p>
           </div>
         )}

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -50,7 +50,7 @@ const ERROR_ATTRIBUTE_KEYS = [
   "gen_ai.response.finish_reasons",
 ];
 
-function extractErrorSignal(metadata: string | null): { key: string; value: string } | null {
+export function extractErrorSignal(metadata: string | null): { key: string; value: string } | null {
   if (!metadata) return null;
   try {
     const parsed = JSON.parse(metadata) as Record<string, unknown>;
@@ -68,7 +68,7 @@ function extractErrorSignal(metadata: string | null): { key: string; value: stri
 // BFS through all descendants to find the best span with error context.
 // Prefers any descendant with a status_message, otherwise returns the first
 // descendant so its metadata can be fetched and inspected.
-function findBestErrorDescendant(spans: Span[], rootSpanId: string): Span | null {
+export function findBestErrorDescendant(spans: Span[], rootSpanId: string): Span | null {
   const descendants: Span[] = [];
   const queue = [rootSpanId];
   const visited = new Set<string>();


### PR DESCRIPTION
## Summary

- When a span has `status=ERROR` but `status_message` is null, the error panel showed nothing — blank despite a red ERROR badge
- Now walks all descendants via BFS to find the best error signal from child spans
- Renders with full attribution: span name and source attribute key (e.g. `Source: ai.response.finishReason`)
- Checks in priority order: `exception.message`, `exception.type`, `error.message`, `error.type`, `ai.response.finishReason`, `gen_ai.response.finish_reasons`, child `status_message`

## What changed

`frontend/ui/src/features/traces/components/SpanInfoPanel.tsx`
- Added `extractErrorSignal()` — returns `{ key, value }` for first matching error attribute
- Added `findBestErrorDescendant()` — BFS through all descendants, prefers span with `status_message`
- Added second `useSpanIO` call (no-op when not needed) to fetch fallback child metadata
- Updated error panel to show fallback with source span name and attribute key

## Test plan

- [ ] Span with `status=ERROR` and null `status_message` — panel now shows child signal
- [ ] Spans with existing `status_message` — unaffected
- [ ] Attribution and source key render correctly
- [ ] No child spans + no `status_message` — shows nothing (no false positives)

Fixes #1182

<img width="1076" height="540" alt="image" src="https://github.com/user-attachments/assets/2be9d6f3-e052-4c89-baec-55c298410221" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty error panels when a span is ERROR but has no `status_message` by surfacing the closest child error signal with clear attribution. Users now see the most relevant error detail and which span/attribute it came from.

- **Bug Fixes**
  - Walk descendants via BFS to find the best error span; prefer a child with `status_message`.
  - Added `extractErrorSignal()` to pull the first match from: `exception.message`, `exception.type`, `error.message`, `error.type`, `ai.response.finishReason`, `gen_ai.response.finish_reasons`.
  - Error panel shows the fallback value with the child span name and source attribute key.
  - Fetches child IO only when needed; no change when the parent has `status_message`; remains empty if no signal exists.
  - Added tests in `SpanInfoPanel.test.tsx` covering `extractErrorSignal`, `findBestErrorDescendant`, and fallback rendering.

- **Refactors**
  - Applied Prettier formatting to `SpanInfoPanel.tsx`; no logic changes.

<sup>Written for commit e6d8f6e2d99ba7d59e90cc4b842c3fc142db19bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

