### PR TITLE
fix(worker): recognize Vercel AI SDK token attributes so cache breakdown persists

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -448,6 +448,12 @@ def transform_otel_to_clickhouse(
                             "llm.token_count.prompt",
                             "gen_ai.usage.input_tokens",
                             "gen_ai.usage.prompt_tokens",
+                            # Vercel AI SDK raw attrs (its OpenInference span
+                            # processor normalizes totals only on LLM-kind
+                            # spans, so outer agent spans keep the raw keys):
+                            "ai.usage.inputTokens",
+                            # generateObject still emits only this spelling:
+                            "ai.usage.promptTokens",
                         ],
                     )
                     api_output_tokens = first_present_number(
@@ -456,6 +462,10 @@ def transform_otel_to_clickhouse(
                             "llm.token_count.completion",
                             "gen_ai.usage.output_tokens",
                             "gen_ai.usage.completion_tokens",
+                            # Vercel AI SDK raw attrs:
+                            "ai.usage.outputTokens",
+                            # generateObject still emits only this spelling:
+                            "ai.usage.completionTokens",
                         ],
                     )
                     # Cache buckets. The OpenInference keys (prompt_details.*) are the
@@ -472,6 +482,10 @@ def transform_otel_to_clickhouse(
                             # pydantic-ai version variants (names differ by release):
                             "gen_ai.usage.cache_read_tokens",
                             "gen_ai.usage.details.cache_read_input_tokens",
+                            # Vercel AI SDK: cache detail is NEVER normalized to
+                            # llm.*/gen_ai.* — it exists only under ai.usage.*:
+                            "ai.usage.cachedInputTokens",
+                            "ai.usage.inputTokenDetails.cacheReadTokens",
                         ],
                     )
                     api_cache_write_tokens = first_present_number(
@@ -483,6 +497,8 @@ def transform_otel_to_clickhouse(
                             "gen_ai.usage.details.cache_write_tokens",
                             # pydantic-ai version variant:
                             "gen_ai.usage.details.cache_creation_input_tokens",
+                            # Vercel AI SDK raw attr (never normalized upstream):
+                            "ai.usage.inputTokenDetails.cacheWriteTokens",
                         ],
                     )
                     # Reasoning tokens (o-series / GPT-5): a SUBSET of output
@@ -495,6 +511,9 @@ def transform_otel_to_clickhouse(
                             "gen_ai.usage.reasoning_tokens",
                             "gen_ai.usage.output_details.reasoning_tokens",
                             "gen_ai.usage.details.reasoning_tokens",
+                            # Vercel AI SDK raw attrs (aliases of the same value):
+                            "ai.usage.outputTokenDetails.reasoningTokens",
+                            "ai.usage.reasoningTokens",
                         ],
                     )
 

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -442,32 +442,30 @@ def transform_otel_to_clickhouse(
 
                     # Try API-provided token counts first (from instrumentors).
                     # OpenInference: llm.token_count.*  ·  GenAI semconv: gen_ai.usage.*
-                    api_input_tokens = first_present_number(
-                        span_attrs,
-                        [
-                            "llm.token_count.prompt",
-                            "gen_ai.usage.input_tokens",
-                            "gen_ai.usage.prompt_tokens",
-                            # Vercel AI SDK raw attrs (its OpenInference span
-                            # processor normalizes totals only on LLM-kind
-                            # spans, so outer agent spans keep the raw keys):
-                            "ai.usage.inputTokens",
-                            # generateObject still emits only this spelling:
-                            "ai.usage.promptTokens",
-                        ],
-                    )
-                    api_output_tokens = first_present_number(
-                        span_attrs,
-                        [
-                            "llm.token_count.completion",
-                            "gen_ai.usage.output_tokens",
-                            "gen_ai.usage.completion_tokens",
-                            # Vercel AI SDK raw attrs:
-                            "ai.usage.outputTokens",
-                            # generateObject still emits only this spelling:
-                            "ai.usage.completionTokens",
-                        ],
-                    )
+                    input_token_keys = [
+                        "llm.token_count.prompt",
+                        "gen_ai.usage.input_tokens",
+                        "gen_ai.usage.prompt_tokens",
+                    ]
+                    output_token_keys = [
+                        "llm.token_count.completion",
+                        "gen_ai.usage.output_tokens",
+                        "gen_ai.usage.completion_tokens",
+                    ]
+                    if span_kind == SpanKind.LLM:
+                        # Vercel AI SDK raw GROSS totals are the only token source it
+                        # normalizes to neither llm.* nor gen_ai.*, so we read them as
+                        # a fallback. But they sit on BOTH the LLM doGenerate span AND
+                        # its AGENT/CHAIN wrapper (ai.generateText/ai.generateObject),
+                        # where they restate the SUM of the wrapper's LLM children.
+                        # Trust them only on the LLM span itself — otherwise the
+                        # wrapper is priced on top of its children (double count).
+                        # generateObject emits only the legacy *Tokens spelling; its
+                        # real usage still lands on an LLM .doGenerate child.
+                        input_token_keys += ["ai.usage.inputTokens", "ai.usage.promptTokens"]
+                        output_token_keys += ["ai.usage.outputTokens", "ai.usage.completionTokens"]
+                    api_input_tokens = first_present_number(span_attrs, input_token_keys)
+                    api_output_tokens = first_present_number(span_attrs, output_token_keys)
                     # Cache buckets. The OpenInference keys (prompt_details.*) are the
                     # verified path for Anthropic/OpenAI and MUST be listed first —
                     # they are the same family as llm.token_count.prompt (read above).

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -49,6 +49,14 @@ _KNOWN_SCOPE_PREFIXES: tuple[str, ...] = (
     "traceroot",
 )
 
+# Scopes recognized by EXACT name — too short to prefix-match safely (a bare
+# "ai" prefix would also swallow unrelated ai*-named scopes).
+_KNOWN_SCOPE_EXACT: frozenset[str] = frozenset(
+    {
+        "ai",  # Vercel AI SDK tracer; GROSS input with cache detail under ai.usage.*
+    }
+)
+
 # Bound the dedup set so a high-cardinality (or adversarial) stream of unknown
 # scope names cannot grow it without limit. Real emitters are few; this ceiling
 # is far above any legitimate count.
@@ -62,14 +70,16 @@ def _warn_once_if_unknown_scope(scope_name: str | None) -> None:
     ``scope_name`` is typed ``str | None`` but comes from untrusted OTLP, so a
     malformed (non-string) value is guarded — it must never crash ingestion.
     """
-    if isinstance(scope_name, str) and scope_name.lower().startswith(_KNOWN_SCOPE_PREFIXES):
-        return
+    if isinstance(scope_name, str):
+        lowered = scope_name.lower()
+        if lowered in _KNOWN_SCOPE_EXACT or lowered.startswith(_KNOWN_SCOPE_PREFIXES):
+            return
     key = scope_name if isinstance(scope_name, str) and scope_name else "<missing>"
     if key not in _warned_scopes and len(_warned_scopes) < _MAX_WARNED_SCOPES:
         _warned_scopes.add(key)
         logger.warning(
             "Pricing tokens from unknown instrumentation scope %r; verify its "
-            "token convention and add it to _KNOWN_SCOPE_PREFIXES.",
+            "token convention and add it to _KNOWN_SCOPE_PREFIXES or _KNOWN_SCOPE_EXACT.",
             key,
         )
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -574,25 +574,91 @@ class TestTransformOtelToClickhouse:
         )
         assert spans[0]["cost"] == pytest.approx(expected)
 
-    def test_vercel_outer_span_raw_totals_used_as_api_counts(self):
-        """Outer ai.generateText spans carry llm.model_name (set by the
-        OpenInference vercel processor) but token totals only under raw
-        ai.usage.* — those must be picked up as API-provided counts."""
+    def test_vercel_agent_wrapper_raw_totals_not_double_counted(self):
+        """The ai.generateText AGENT wrapper carries ai.usage.* GROSS totals that
+        restate the SUM of its LLM doGenerate children (the SDK aggregates them
+        onto the wrapper). The wrapper must NOT be priced from those totals, or
+        the trace is charged twice. Only the LLM children — which carry the
+        normalized llm.*/gen_ai.* keys — count.
+
+        Span shapes are taken verbatim from a live ai@6 +
+        @arizeai/openinference-vercel run: wrapper in/out = 203/178 = sum of the
+        two children (67/46 + 136/132)."""
         from unittest.mock import patch
 
-        prices = {
-            "input": 0.000003,
-            "output": 0.000015,
-            "cacheRead": 0.0000003,
-            "cacheWrite": 0.00000375,
-        }
+        prices = {"input": 0.000003, "output": 0.000015, "cacheRead": 0.0, "cacheWrite": 0.0}
+
+        def llm_child(span_id_hex, prompt, completion):
+            return make_span(
+                "aa" * 16,
+                span_id_hex,
+                name="ai.generateText.doGenerate",
+                parent_span_id_hex="bb" * 8,
+                attributes=[
+                    make_attr("openinference.span.kind", "LLM"),
+                    make_attr("llm.model_name", "gpt-4o-mini"),
+                    make_attr("llm.token_count.prompt", prompt),
+                    make_attr("llm.token_count.completion", completion),
+                    # Vercel stamps its raw totals on the LLM span too; the
+                    # normalized keys above take priority, so these are redundant.
+                    make_attr("ai.usage.inputTokens", prompt),
+                    make_attr("ai.usage.outputTokens", completion),
+                ],
+            )
+
         payload = make_otel_payload(
             [
+                # AGENT wrapper: openinference.span.kind=AGENT (set by the vercel
+                # processor by function name) and ONLY raw ai.usage.* aggregates.
                 make_span(
                     "aa" * 16,
                     "bb" * 8,
                     name="ai.generateText",
                     attributes=[
+                        make_attr("openinference.span.kind", "AGENT"),
+                        make_attr("llm.model_name", "gpt-4o-mini"),
+                        make_attr("ai.usage.inputTokens", 203),
+                        make_attr("ai.usage.outputTokens", 178),
+                    ],
+                ),
+                llm_child("cc" * 8, 67, 46),
+                llm_child("dd" * 8, 136, 132),
+            ],
+            scope_name="ai",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        by_id = {s["span_id"]: s for s in spans}
+        wrapper = next(s for s in spans if s["name"] == "ai.generateText")
+        children = [s for s in spans if s["name"] == "ai.generateText.doGenerate"]
+
+        # Wrapper contributes nothing — its ai.usage.* aggregate is ignored.
+        assert (wrapper.get("input_tokens") or 0) == 0
+        assert (wrapper.get("output_tokens") or 0) == 0
+        assert (wrapper.get("cost") or 0) == 0
+        # Each LLM child is priced from its own (normalized) counts.
+        assert sorted(c["input_tokens"] for c in children) == [67, 136]
+        # Trace totals equal the children alone (203 in / 178 out), not 2x.
+        assert sum((s.get("input_tokens") or 0) for s in spans) == 203
+        assert sum((s.get("output_tokens") or 0) for s in spans) == 178
+        assert by_id  # spans were keyed by id without collision
+
+    def test_vercel_do_generate_raw_totals_used_when_normalized_absent(self):
+        """On an LLM doGenerate span that exposes ONLY the raw ai.usage.* totals
+        (no normalized llm.*/gen_ai.* keys), those totals are still adopted —
+        the LLM-kind gate keeps the fallback alive where it is the sole source."""
+        from unittest.mock import patch
+
+        prices = {"input": 0.000003, "output": 0.000015, "cacheRead": 0.0, "cacheWrite": 0.0}
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    name="ai.generateText.doGenerate",
+                    attributes=[
+                        make_attr("openinference.span.kind", "LLM"),
                         make_attr("llm.model_name", "claude-sonnet-4-5"),
                         make_attr("ai.usage.inputTokens", 28466),
                         make_attr("ai.usage.outputTokens", 120),
@@ -611,10 +677,45 @@ class TestTransformOtelToClickhouse:
         assert spans[0]["usage_details"]["cache_read_tokens"] == 22041
         assert spans[0]["usage_details"]["cache_write_tokens"] == 6422
 
-    def test_vercel_generate_object_legacy_token_spellings_used(self):
-        """ai.generateObject spans emit only the legacy ai.usage.promptTokens /
-        completionTokens spellings (no inputTokens, no cache detail); totals
-        must still resolve as API counts."""
+    def test_vercel_gross_totals_dropped_on_non_llm_span(self):
+        """A non-LLM span (AGENT or CHAIN→SPAN) that carries ONLY the Vercel raw
+        ai.usage.* gross totals must contribute nothing. The gross-total keys are
+        consulted on LLM spans only, so api_input/output stay None → the
+        API-count branch is skipped, and the estimation branch is LLM-only too."""
+        from unittest.mock import patch
+
+        prices = {"input": 0.000003, "output": 0.000015, "cacheRead": 0.0, "cacheWrite": 0.0}
+        for oi_kind in ("AGENT", "CHAIN"):
+            payload = make_otel_payload(
+                [
+                    make_span(
+                        "aa" * 16,
+                        "bb" * 8,
+                        name="ai.someWrapper",
+                        attributes=[
+                            make_attr("openinference.span.kind", oi_kind),
+                            make_attr("llm.model_name", "gpt-4o-mini"),
+                            make_attr("ai.usage.inputTokens", 1234),
+                            make_attr("ai.usage.outputTokens", 567),
+                            make_attr("ai.usage.promptTokens", 1234),
+                            make_attr("ai.usage.completionTokens", 567),
+                        ],
+                    )
+                ],
+                scope_name="ai",
+            )
+            with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+                _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+            s = spans[0]
+            assert (s.get("input_tokens") or 0) == 0, f"oi_kind={oi_kind}"
+            assert (s.get("output_tokens") or 0) == 0, f"oi_kind={oi_kind}"
+            assert (s.get("cost") or 0) == 0, f"oi_kind={oi_kind}"
+
+    def test_vercel_generate_object_legacy_spellings_priced_on_llm_child_only(self):
+        """generateObject emits only the legacy ai.usage.promptTokens /
+        completionTokens spellings. The AGENT wrapper (ai.generateObject) and its
+        LLM child (ai.generateObject.doGenerate) both carry them, but only the
+        LLM child may be priced — the wrapper would double-count."""
         from unittest.mock import patch
 
         prices = {"input": 0.000003, "output": 0.000015, "cacheRead": 0.0, "cacheWrite": 0.0}
@@ -625,19 +726,38 @@ class TestTransformOtelToClickhouse:
                     "bb" * 8,
                     name="ai.generateObject",
                     attributes=[
+                        make_attr("openinference.span.kind", "AGENT"),
                         make_attr("llm.model_name", "gpt-4o"),
                         make_attr("ai.usage.promptTokens", 500),
                         make_attr("ai.usage.completionTokens", 80),
                     ],
-                )
+                ),
+                make_span(
+                    "aa" * 16,
+                    "cc" * 8,
+                    name="ai.generateObject.doGenerate",
+                    parent_span_id_hex="bb" * 8,
+                    attributes=[
+                        make_attr("openinference.span.kind", "LLM"),
+                        make_attr("llm.model_name", "gpt-4o"),
+                        make_attr("ai.usage.promptTokens", 500),
+                        make_attr("ai.usage.completionTokens", 80),
+                    ],
+                ),
             ],
             scope_name="ai",
         )
         with patch("worker.tokens.pricing.get_model_price", return_value=prices):
             _, spans = transform_otel_to_clickhouse(payload, "proj-1")
 
-        assert spans[0]["input_tokens"] == 500
-        assert spans[0]["output_tokens"] == 80
+        wrapper = next(s for s in spans if s["name"] == "ai.generateObject")
+        child = next(s for s in spans if s["name"] == "ai.generateObject.doGenerate")
+        # Legacy spellings adopted on the LLM child.
+        assert child["input_tokens"] == 500
+        assert child["output_tokens"] == 80
+        # AGENT wrapper not priced from the same totals.
+        assert (wrapper.get("input_tokens") or 0) == 0
+        assert sum((s.get("input_tokens") or 0) for s in spans) == 500
 
     def test_malformed_high_priority_token_attr_falls_through_to_valid_key(self):
         """A present-but-malformed high-priority token attr must not suppress a

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -464,6 +464,20 @@ class TestTransformOtelToClickhouse:
                 "gen_ai.usage.details.cache_read_input_tokens",
                 "gen_ai.usage.details.cache_write_tokens",
             ),
+            # Vercel AI SDK: gen_ai totals are emitted natively on doGenerate
+            # spans, but cache detail exists only under the raw ai.* namespace.
+            (
+                "ai",
+                "gen_ai.usage.input_tokens",
+                "ai.usage.cachedInputTokens",
+                "ai.usage.inputTokenDetails.cacheWriteTokens",
+            ),
+            (
+                "ai",
+                "gen_ai.usage.input_tokens",
+                "ai.usage.inputTokenDetails.cacheReadTokens",
+                "ai.usage.inputTokenDetails.cacheWriteTokens",
+            ),
         ],
     )
     def test_cache_heavy_span_subtracts_before_pricing(
@@ -509,6 +523,121 @@ class TestTransformOtelToClickhouse:
         assert spans[0]["cost"] == pytest.approx(expected)
         # Stored input_tokens stays GROSS (display continuity; PR B revisits).
         assert spans[0]["input_tokens"] == 1000
+
+    def test_vercel_do_generate_cache_details_persist_to_usage_details(self):
+        """Vercel AI SDK doGenerate spans emit gen_ai.* totals but expose the
+        cache and reasoning split only under the raw ai.usage.* namespace; the
+        split must land in usage_details rather than zero out."""
+        from unittest.mock import patch
+
+        prices = {
+            "input": 0.000003,
+            "output": 0.000015,
+            "cacheRead": 0.0000003,
+            "cacheWrite": 0.00000375,
+        }
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    name="ai.generateText.doGenerate",
+                    attributes=[
+                        make_attr("gen_ai.request.model", "claude-sonnet-4-5"),
+                        make_attr("gen_ai.usage.input_tokens", 28466),
+                        make_attr("gen_ai.usage.output_tokens", 120),
+                        make_attr("ai.usage.cachedInputTokens", 22041),
+                        make_attr("ai.usage.inputTokenDetails.cacheReadTokens", 22041),
+                        make_attr("ai.usage.inputTokenDetails.cacheWriteTokens", 6422),
+                        make_attr("ai.usage.inputTokenDetails.noCacheTokens", 3),
+                        make_attr("ai.usage.outputTokenDetails.reasoningTokens", 64),
+                    ],
+                )
+            ],
+            scope_name="ai",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert spans[0]["usage_details"]["cache_read_tokens"] == 22041
+        assert spans[0]["usage_details"]["cache_write_tokens"] == 6422
+        assert spans[0]["usage_details"]["reasoning_tokens"] == 64
+        # Gross input reconciles with the breakdown: 3 + 22041 + 6422.
+        assert spans[0]["input_tokens"] == 28466
+        assert spans[0]["output_tokens"] == 120
+        # Cache-discounted cost, not the whole input at the uncached rate.
+        expected = (
+            3 * prices["input"]
+            + 120 * prices["output"]
+            + 22041 * prices["cacheRead"]
+            + 6422 * prices["cacheWrite"]
+        )
+        assert spans[0]["cost"] == pytest.approx(expected)
+
+    def test_vercel_outer_span_raw_totals_used_as_api_counts(self):
+        """Outer ai.generateText spans carry llm.model_name (set by the
+        OpenInference vercel processor) but token totals only under raw
+        ai.usage.* — those must be picked up as API-provided counts."""
+        from unittest.mock import patch
+
+        prices = {
+            "input": 0.000003,
+            "output": 0.000015,
+            "cacheRead": 0.0000003,
+            "cacheWrite": 0.00000375,
+        }
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    name="ai.generateText",
+                    attributes=[
+                        make_attr("llm.model_name", "claude-sonnet-4-5"),
+                        make_attr("ai.usage.inputTokens", 28466),
+                        make_attr("ai.usage.outputTokens", 120),
+                        make_attr("ai.usage.cachedInputTokens", 22041),
+                        make_attr("ai.usage.inputTokenDetails.cacheWriteTokens", 6422),
+                    ],
+                )
+            ],
+            scope_name="ai",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert spans[0]["input_tokens"] == 28466
+        assert spans[0]["output_tokens"] == 120
+        assert spans[0]["usage_details"]["cache_read_tokens"] == 22041
+        assert spans[0]["usage_details"]["cache_write_tokens"] == 6422
+
+    def test_vercel_generate_object_legacy_token_spellings_used(self):
+        """ai.generateObject spans emit only the legacy ai.usage.promptTokens /
+        completionTokens spellings (no inputTokens, no cache detail); totals
+        must still resolve as API counts."""
+        from unittest.mock import patch
+
+        prices = {"input": 0.000003, "output": 0.000015, "cacheRead": 0.0, "cacheWrite": 0.0}
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    name="ai.generateObject",
+                    attributes=[
+                        make_attr("llm.model_name", "gpt-4o"),
+                        make_attr("ai.usage.promptTokens", 500),
+                        make_attr("ai.usage.completionTokens", 80),
+                    ],
+                )
+            ],
+            scope_name="ai",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert spans[0]["input_tokens"] == 500
+        assert spans[0]["output_tokens"] == 80
 
     def test_malformed_high_priority_token_attr_falls_through_to_valid_key(self):
         """A present-but-malformed high-priority token attr must not suppress a

--- a/tests/worker/tokens/test_buckets.py
+++ b/tests/worker/tokens/test_buckets.py
@@ -148,6 +148,36 @@ def test_js_openinference_scope_is_known_inclusive_no_warning(caplog):
     assert not any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
 
 
+def test_vercel_ai_scope_is_known_inclusive_no_warning(caplog):
+    # The Vercel AI SDK tracer scope is exactly "ai"; its inputTokens total is
+    # GROSS (noCache + cacheRead + cacheWrite components), so the standard
+    # subtraction applies and no unknown-scope warning should fire.
+    with caplog.at_level(logging.WARNING):
+        b = normalize_token_usage(
+            "ai",
+            input_tokens=28466,
+            output_tokens=120,
+            cache_read_tokens=22041,
+            cache_write_tokens=6422,
+        )
+    assert b == TokenBuckets(input_uncached=3, output=120, cache_read=22041, cache_write=6422)
+    assert not any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
+
+
+def test_ai_prefixed_scope_still_warns(caplog):
+    # "ai" is matched exactly, not as a prefix — an unrelated ai*-named scope
+    # must still surface the unknown-emitter warning.
+    with caplog.at_level(logging.WARNING):
+        normalize_token_usage(
+            "aiohttp.client",
+            input_tokens=10,
+            output_tokens=1,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+        )
+    assert any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
+
+
 def test_token_buckets_fields_default_to_zero():
     # Defaults make future token categories (reasoning/audio) purely additive.
     assert TokenBuckets() == TokenBuckets(input_uncached=0, output=0, cache_read=0, cache_write=0)


### PR DESCRIPTION
## Summary

Vercel AI SDK spans (`ai.generateText`, `ai.generateText.doGenerate`, `ai.generateObject`) were landing in ClickHouse with `usage_details` cache/reasoning tokens zeroed out, so the trace viewer's usage breakdown showed the entire input as uncached and cost was overcharged. Reported against Vercel AI SDK **v6.x** (`ai/6.x`).

**Root cause:** the SDK exposes cache and reasoning token detail *only* under its raw `ai.usage.*` attribute namespace. The OpenInference vercel span processor normalizes input/output **totals** to `llm.*`/`gen_ai.*` but never the cache or reasoning split (verified through the latest upstream release), and the ingest transform's lookup lists didn't cover the raw keys — so they resolved to `None` → `0`.

## Changes

- **`backend/worker/otel_transform.py`** — append `ai.usage.*` keys as lowest-priority fallbacks to all five token lookup lists (input, output, cache-read, cache-write, reasoning). Normalized `llm.*`/`gen_ai.*` keys keep priority, so existing SDK paths are unaffected. Includes the legacy `ai.usage.promptTokens`/`completionTokens` spellings that current `ai.generateObject` spans still emit.
- **`backend/worker/tokens/buckets.py`** — register the SDK's exact `"ai"` tracer scope as a known gross (cache-inclusive) emitter via a new exact-match set. A bare `"ai"` prefix was avoided deliberately — it would swallow unrelated `ai*`-named scopes (e.g. `aiohttp.client`).
- Tests in `tests/worker/test_otel_transform.py` and `tests/worker/tokens/test_buckets.py`.

All attribute shapes were verified against the published `ai@6.0.204` source: tracer scope is exactly `"ai"`, `inputTokens` totals are gross (noCache + cacheRead + cacheWrite), and `generateObject` emits only the legacy total spellings.

## Caveat — Vercel AI SDK version coverage

The cache-token telemetry attributes are **version-dependent**, which is why the issue specifies v6.x:

| SDK major | Emits | Cache breakdown captured by this fix |
|-----------|-------|--------------------------------------|
| **v4** | `ai.usage.promptTokens` / `completionTokens` only | Totals only — the SDK emits **no** cache attributes, so there is no cache data to capture |
| **v5** | adds `ai.usage.cachedInputTokens` (cache **read**) | Cache **read** + totals; v5 emits no cache-**write** attribute |
| **v6+** | adds `ai.usage.inputTokenDetails.{cacheReadTokens,cacheWriteTokens,noCacheTokens}` | Full breakdown — read **and** write; this is the version the issue reports |

The fix carries keys for all of these spellings, so it degrades gracefully across versions: v6+ gets the complete read/write split (the reported case), v5 gets cache-read, and v4 has no cache data to lose. Verified end-to-end with a live v6 + Anthropic prompt-caching run against the local stack: a real `ai.generateText.doGenerate` span landed in ClickHouse with non-zero `cache_read_tokens`/`cache_write_tokens` in `usage_details`.

## Cost impact

For `doGenerate` spans the prior behavior was not cost-neutral: they had API totals, so cost *was* computed but priced the entire input at the uncached rate — roughly a 2.7× overcharge on a cache-heavy span. Newly-ingested spans are now priced correctly. No backfill: existing rows already persisted zeros.

## Testing

- Full backend suite: 355 passed; worker suite 236 passed.
- Diff-coverage vs `main`: 100% on changed lines.
- New tests reproduce the exact production span shape (3 uncached + 22041 cache-read + 6422 cache-write = 28466 gross) and assert the cache-discounted cost by hand; red phase confirmed by reverting only the source change.

## Screenshots
<img width="1725" height="991" alt="Screenshot 2026-06-15 at 9 30 08 AM" src="https://github.com/user-attachments/assets/795d5c7b-370e-4dd4-8ce0-9f377defe37b" />
<img width="1728" height="986" alt="Screenshot 2026-06-15 at 9 30 17 AM" src="https://github.com/user-attachments/assets/f88f89ed-73ca-499b-b456-6f79d2e060aa" />


closes #1181


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect pricing for Vercel AI SDK spans: we now read `ai.usage.*` token attributes so cache read/write and reasoning tokens persist to `usage_details`, and we only use raw `ai.usage` gross totals on LLM spans to prevent wrapper double-counting. Also registers the SDK’s `ai` scope as a known gross emitter. Closes #1181.

- **Bug Fixes**
  - Added `ai.usage.*` fallbacks for input/output totals on LLM spans only (includes legacy `promptTokens`/`completionTokens`); kept `llm.*`/`gen_ai.*` as higher priority.
  - Added `ai.usage.*` fallbacks for cache-read, cache-write, and reasoning tokens so the full breakdown persists.
  - Registered exact `ai` tracer scope as a known gross emitter; avoids prefix matching.
  - Tests cover `ai.generateText`, `ai.generateText.doGenerate`, and `ai.generateObject`, including no double-count on AGENT wrappers and legacy spellings.

<sup>Written for commit b73917c072dd740993ba27a4f4daf76bcf65ca05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




