### PR TITLE
feat(pricing): price Anthropic 1-hour cache-write tokens

### DIFF
--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from db.clickhouse import get_clickhouse_client
 from rest.sql_utils import escape_ilike, to_utc_naive
-from worker.tokens.buckets import TokenBuckets
+from worker.tokens.buckets import TokenBuckets, reconcile_cache_write_1h
 from worker.tokens.pricing import cost_breakdown_from_buckets, get_model_price
 
 
@@ -25,11 +25,19 @@ def span_cost_details(
         return {}
     cache_read = int(usage_details.get("cache_read_tokens", 0) or 0)
     cache_write = int(usage_details.get("cache_write_tokens", 0) or 0)
+    # Optional 1-hour cache-write portion (absent for spans with no 1-hour writes and
+    # for any emitter that doesn't report it). Reconciled against the write total with
+    # the same rule used at ingest, so a stored breakdown can't over-count.
+    cache_write_1h = reconcile_cache_write_1h(
+        cache_write,
+        int(usage_details.get("cache_write_1h_tokens", 0) or 0),
+    )
     buckets = TokenBuckets(
         input_uncached=max((input_tokens or 0) - cache_read - cache_write, 0),
         output=output_tokens or 0,
         cache_read=cache_read,
         cache_write=cache_write,
+        cache_write_1h=cache_write_1h,
     )
     return cost_breakdown_from_buckets(get_model_price(model_name), buckets) or {}
 

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -507,6 +507,19 @@ def transform_otel_to_clickhouse(
                             "ai.usage.inputTokenDetails.cacheWriteTokens",
                         ],
                     )
+                    # Optional Anthropic 1-hour cache-write portion (1h write = 2.0x
+                    # input, versus 1.25x for the default 5-minute write). A SUBSET of
+                    # cache_write, priced at its own rate when present; absent for every
+                    # emitter today (the split is dropped at the instrumentation layer),
+                    # so this defaults to None -> 0 and leaves pricing unchanged.
+                    api_cache_write_1h_tokens = first_present_number(
+                        span_attrs,
+                        [
+                            "llm.token_count.prompt_details.cache_write_1h",
+                            "gen_ai.usage.cache_creation.ephemeral_1h_input_tokens",
+                            "gen_ai.usage.cache_creation_ephemeral_1h_input_tokens",
+                        ],
+                    )
                     # Reasoning tokens (o-series / GPT-5): a SUBSET of output
                     # tokens, already priced at the output rate, so this is
                     # display-only and must NOT feed the cost buckets.
@@ -545,6 +558,7 @@ def transform_otel_to_clickhouse(
                             output_tokens=output_tokens,
                             cache_read_tokens=int_or_zero(api_cache_read_tokens),
                             cache_write_tokens=int_or_zero(api_cache_write_tokens),
+                            cache_write_1h_tokens=int_or_zero(api_cache_write_1h_tokens),
                         )
                         # Store a GROSS (cache-inclusive) input reconstructed from the
                         # disjoint buckets, so the input column always reconciles with
@@ -571,6 +585,14 @@ def transform_otel_to_clickhouse(
                                 int_or_zero(api_reasoning_tokens), output_tokens
                             ),
                         }
+                        # Persist the 1-hour cache-write portion only when an emitter
+                        # actually reports it, so spans with no 1-hour portion (every
+                        # span today) keep an identical usage_details map. The read path
+                        # defaults the missing key to 0.
+                        if buckets.cache_write_1h:
+                            span_record["usage_details"]["cache_write_1h_tokens"] = (
+                                buckets.cache_write_1h
+                            )
                         cost = cost_from_buckets(get_model_price(model_name), buckets)
                         if cost is not None:
                             span_record["cost"] = cost

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -13,6 +13,20 @@ the cache is a subset that subtracts cleanly; for net emitters the cache simply
 exceeds the input, so the uncached bucket floors to zero while the additive cache
 is still priced in full. Each physical token is therefore priced exactly once
 without a per-emitter convention branch.
+
+Cache WRITES can additionally carry a TTL split: Anthropic prices a 1-hour write at
+2.0x base input, versus 1.25x for the default 5-minute write (reads are 0.1x
+regardless of TTL). Since the existing ``cacheWrite`` rate already IS the 5-minute
+rate, only the 1-hour portion needs its own rate; it is modeled as a SUB-PARTITION
+of the ``cache_write`` total, never as a new disjoint bucket::
+
+    cache_write  =  cache_write_1h  +  remainder
+                    \\_ priced at _/    \\__ priced at the combined cacheWrite rate
+                       cacheWrite1h          (the 5-minute / default write rate)
+
+Keeping ``cache_write`` as the single total means the gross-input reconstruction
+(uncached + cache_read + cache_write) is unchanged, and any emitter that does not
+report the 1-hour portion (every emitter today) is priced exactly as before.
 """
 
 from __future__ import annotations
@@ -29,12 +43,18 @@ class TokenBuckets:
 
     Fields default to ``0`` so new token categories (e.g. reasoning, audio) can be
     added as purely additive changes without touching existing call sites.
+
+    ``cache_write_1h`` is NOT an additional disjoint bucket: it is a sub-partition of
+    ``cache_write`` (``cache_write_1h <= cache_write``), used only to price the 1-hour
+    write rate. It defaults to ``0``, so an emitter that does not report the 1-hour
+    portion prices identically to before.
     """
 
     input_uncached: int = 0
     output: int = 0
     cache_read: int = 0
     cache_write: int = 0
+    cache_write_1h: int = 0
 
 
 # Instrumentation scopes traceroot recognizes today. Used only to surface an
@@ -84,6 +104,18 @@ def _warn_once_if_unknown_scope(scope_name: str | None) -> None:
         )
 
 
+def reconcile_cache_write_1h(cache_write: int, cache_write_1h: int) -> int:
+    """Clamp the 1-hour cache-write portion to a valid sub-partition of the write total.
+
+    Returns ``cache_write_1h`` clamped non-negative and capped at ``cache_write`` (also
+    floored at 0), so the portion can never over-count the write total (the leftover
+    ``cache_write - cache_write_1h`` is the remainder priced at the combined cache-write
+    rate). Deterministic for any input. Shared by the ingest path (normalize_token_usage)
+    and the read path (span_cost_details).
+    """
+    return min(max(cache_write_1h, 0), max(cache_write, 0))
+
+
 def normalize_token_usage(
     scope_name: str | None,
     *,
@@ -91,6 +123,7 @@ def normalize_token_usage(
     output_tokens: int,
     cache_read_tokens: int,
     cache_write_tokens: int,
+    cache_write_1h_tokens: int = 0,
 ) -> TokenBuckets:
     """Convert an instrumentor's token counts into disjoint priced buckets.
 
@@ -99,13 +132,22 @@ def normalize_token_usage(
     input, so it subtracts out) and for NET emitters such as claude-agent-sdk
     (cache exceeds the input, so the uncached bucket floors to zero while the
     additive cache is still priced in full). All buckets are clamped non-negative.
+
+    ``cache_write_1h_tokens`` is an OPTIONAL 1-hour portion of the cache-write total.
+    It is reconciled against ``cache_write`` so the sub-partition invariant always
+    holds even for malformed input: clamped non-negative and capped so
+    ``cache_write_1h <= cache_write`` (the remainder is priced at the combined
+    cache-write rate). Defaults to ``0``, so an emitter that does not report the
+    1-hour portion (every emitter today) is unaffected.
     """
     _warn_once_if_unknown_scope(scope_name)
     cache_read = max(cache_read_tokens, 0)
     cache_write = max(cache_write_tokens, 0)
+    cache_write_1h = reconcile_cache_write_1h(cache_write, cache_write_1h_tokens)
     return TokenBuckets(
         input_uncached=max(max(input_tokens, 0) - cache_read - cache_write, 0),
         output=max(output_tokens, 0),
         cache_read=cache_read,
         cache_write=cache_write,
+        cache_write_1h=cache_write_1h,
     )

--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -16,7 +16,7 @@ import psycopg2
 
 from shared.config import settings
 
-from .buckets import TokenBuckets
+from .buckets import TokenBuckets, reconcile_cache_write_1h
 from .usage import count_tokens
 
 logger = logging.getLogger(__name__)
@@ -105,6 +105,20 @@ def get_model_price(model: str) -> dict[str, float] | None:
     return None
 
 
+def _rate(prices: dict[str, float], key: str, *fallbacks: str) -> Decimal:
+    """Resolve a per-token rate as an exact Decimal, trying ``key`` then fallbacks.
+
+    A missing/null/zero rate falls through to the next key, and an absent rate is 0
+    (e.g. OpenAI has no cache-write rate). Lets the per-TTL cache-write rates fall
+    back to the combined ``cacheWrite`` rate when a model doesn't distinguish TTLs.
+    """
+    for name in (key, *fallbacks):
+        value = prices.get(name)
+        if value:
+            return Decimal(str(value))
+    return Decimal(0)
+
+
 def _bucket_cost_terms(
     prices: dict[str, float] | None, buckets: TokenBuckets
 ) -> dict[str, Decimal] | None:
@@ -114,17 +128,41 @@ def _bucket_cost_terms(
     Missing cacheRead / cacheWrite rates are treated as 0 (e.g. OpenAI has no
     cache-write rate). Both the total (cost_from_buckets) and the display-side
     breakdown (cost_breakdown_from_buckets) derive from this, so they cannot diverge.
+
+    Every count is clamped non-negative before pricing, so the cost can never go
+    negative and the formula matches the TS helper (calculateCostFromPricing) for any
+    input. For real traffic (all counts already >= 0) the clamps are no-ops, so the
+    result is identical to the unclamped formula.
+
+    The cache-write term prices the optional 1-hour portion as a sub-partition of the
+    write total: the 1-hour portion at its own rate (falling back to ``cacheWrite``
+    when a model doesn't distinguish TTLs) and the remainder at the combined
+    ``cacheWrite`` rate (which already IS the 5-minute / default write rate). When no
+    1-hour portion is reported the remainder equals the whole write total, so the term
+    is identical to ``cache_write * cacheWrite``. ``cache_write_cost`` stays a single
+    canonical term, so the total never double-counts.
     """
     if not prices:
         return None
 
+    # Reconcile the 1-hour portion here too — this is the single source of truth for
+    # the cost formula, so it must price each write token once for ANY TokenBuckets,
+    # not only ones built through normalize_token_usage. The total is clamped
+    # non-negative first (mirrors the TS helper) so a malformed negative total can
+    # never produce a negative cost; remainder = the cache-write tokens with no 1-hour
+    # attribution, priced at the combined cacheWrite rate.
+    cache_write_total = max(buckets.cache_write, 0)
+    cache_write_1h = reconcile_cache_write_1h(cache_write_total, buckets.cache_write_1h)
+    cache_write_remainder = cache_write_total - cache_write_1h
+    cache_write_cost = Decimal(cache_write_remainder) * _rate(prices, "cacheWrite") + Decimal(
+        cache_write_1h
+    ) * _rate(prices, "cacheWrite1h", "cacheWrite")
+
     return {
-        "input_uncached_cost": Decimal(buckets.input_uncached)
-        * Decimal(str(prices.get("input", 0))),
-        "cache_read_cost": Decimal(buckets.cache_read) * Decimal(str(prices.get("cacheRead") or 0)),
-        "cache_write_cost": Decimal(buckets.cache_write)
-        * Decimal(str(prices.get("cacheWrite") or 0)),
-        "output_cost": Decimal(buckets.output) * Decimal(str(prices.get("output", 0))),
+        "input_uncached_cost": Decimal(max(buckets.input_uncached, 0)) * _rate(prices, "input"),
+        "cache_read_cost": Decimal(max(buckets.cache_read, 0)) * _rate(prices, "cacheRead"),
+        "cache_write_cost": cache_write_cost,
+        "output_cost": Decimal(max(buckets.output, 0)) * _rate(prices, "output"),
     }
 
 

--- a/frontend/packages/core/src/__tests__/model-pricing.test.ts
+++ b/frontend/packages/core/src/__tests__/model-pricing.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// lookup.ts imports prisma at module load (registerCacheClear); mock it so the
+// pricing path is testable without a generated client or DB.
+vi.mock("../lib/prisma", () => ({
+  prisma: { standardModel: { findMany: vi.fn() } },
+}));
+
+// Import via the package index so the public re-exports are covered too.
+import {
+  calculateCost,
+  calculateCostFromPricing,
+  getModelPricing,
+  type ModelPricing,
+} from "../model-pricing/index.ts";
+import { prisma } from "../lib/prisma.ts";
+
+// opus-4.x-shaped rates: cacheWrite is the 5-minute / default rate (1.25x input);
+// cacheWrite1h = 2x input.
+const CLAUDE: ModelPricing = {
+  input: 0.000005,
+  output: 0.000025,
+  cacheRead: 0.0000005,
+  cacheWrite: 0.00000625,
+  cacheWrite1h: 0.00001,
+};
+
+describe("calculateCostFromPricing — cache-write 1-hour portion", () => {
+  it("prices the 1-hour portion at its own rate", () => {
+    // 900 write: 600 @1h, 300 remainder.
+    const cost = calculateCostFromPricing(CLAUDE, 100, 0, 0, 900, 600);
+    const expected = 100 * CLAUDE.input + 300 * 0.00000625 + 600 * 0.00001;
+    expect(cost).toBeCloseTo(expected, 12);
+  });
+
+  it("prices the remainder at the combined cacheWrite rate", () => {
+    // 1000 write: 200 @1h, 800 remainder.
+    const cost = calculateCostFromPricing(CLAUDE, 0, 0, 0, 1000, 200);
+    const expected = 200 * 0.00001 + 800 * 0.00000625;
+    expect(cost).toBeCloseTo(expected, 12);
+  });
+
+  it("is identical to the combined rate when no 1-hour portion is supplied", () => {
+    const cost = calculateCostFromPricing(CLAUDE, 100, 0, 0, 900);
+    const expected = 100 * CLAUDE.input + 900 * 0.00000625;
+    expect(cost).toBeCloseTo(expected, 12);
+  });
+
+  it("falls back to cacheWrite when the 1-hour rate is null", () => {
+    const noTtl: ModelPricing = { ...CLAUDE, cacheWrite1h: null };
+    const cost = calculateCostFromPricing(noTtl, 0, 0, 0, 500, 150);
+    expect(cost).toBeCloseTo(500 * 0.00000625, 12); // whole write total at cacheWrite
+  });
+
+  it("falls back to cacheWrite when the 1-hour rate is 0 (|| parity with the worker)", () => {
+    const zeroRate: ModelPricing = { ...CLAUDE, cacheWrite1h: 0 };
+    const cost = calculateCostFromPricing(zeroRate, 0, 0, 0, 100, 40);
+    expect(cost).toBeCloseTo(100 * 0.00000625, 12); // 40 @1h -> cacheWrite, 60 remainder
+  });
+
+  it("caps an over-reported 1-hour portion to the write total", () => {
+    // 1h=180 > 100 -> capped to 100 @1h, 0 remainder.
+    const cost = calculateCostFromPricing(CLAUDE, 0, 0, 0, 100, 180);
+    const expected = 100 * 0.00001;
+    expect(cost).toBeCloseTo(expected, 12);
+  });
+
+  it("matches the original formula for a plain (no-cache) span", () => {
+    const cost = calculateCostFromPricing(CLAUDE, 1000, 500);
+    expect(cost).toBeCloseTo(1000 * CLAUDE.input + 500 * CLAUDE.output, 12);
+  });
+
+  it("clamps negative counts to zero (mirrors the worker)", () => {
+    const cost = calculateCostFromPricing(CLAUDE, -100, -50, -10, -900, -1);
+    expect(cost).toBe(0);
+  });
+});
+
+describe("getModelPricing + calculateCost (prisma-backed)", () => {
+  beforeEach(() => {
+    (prisma.standardModel.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        modelName: "claude-opus-4-7",
+        matchPattern: "^claude-opus-4-7$",
+        prices: [
+          { usageType: "input", price: 0.000005 },
+          { usageType: "output", price: 0.000025 },
+          { usageType: "cacheRead", price: 0.0000005 },
+          { usageType: "cacheWrite", price: 0.00000625 },
+          { usageType: "cacheWrite1h", price: 0.00001 },
+        ],
+      },
+    ]);
+  });
+
+  it("loads the 1h cache rate from the price table", async () => {
+    const pricing = await getModelPricing("claude-opus-4-7");
+    expect(pricing).not.toBeNull();
+    expect(pricing!.cacheWrite).toBe(0.00000625);
+    expect(pricing!.cacheWrite1h).toBe(0.00001);
+  });
+
+  it("prices the 1-hour portion end-to-end via the async calculateCost", async () => {
+    // 900 write: 600 @1h (-> cacheWrite1h), 300 remainder (-> cacheWrite).
+    const cost = await calculateCost("claude-opus-4-7", 100, 0, 0, 900, 600);
+    const expected = 100 * 0.000005 + 300 * 0.00000625 + 600 * 0.00001;
+    expect(cost).toBeCloseTo(expected, 12);
+  });
+
+  it("returns 0 when the model is not in the pricing table", async () => {
+    const cost = await calculateCost("totally-unknown-model-2099", 100, 50);
+    expect(cost).toBe(0);
+  });
+});

--- a/frontend/packages/core/src/model-pricing/index.ts
+++ b/frontend/packages/core/src/model-pricing/index.ts
@@ -1,3 +1,3 @@
 export { syncStandardPrices } from "./sync-standard-prices.ts";
-export { getModelPricing, calculateCost } from "./lookup.ts";
+export { getModelPricing, calculateCost, calculateCostFromPricing } from "./lookup.ts";
 export type { ModelPricing } from "./lookup.ts";

--- a/frontend/packages/core/src/model-pricing/lookup.ts
+++ b/frontend/packages/core/src/model-pricing/lookup.ts
@@ -6,6 +6,11 @@ export interface ModelPricing {
   output: number;
   cacheRead: number | null;
   cacheWrite: number | null;
+  // Optional Anthropic 1-hour cache-write rate (2.0x input, versus 1.25x for the
+  // default 5-minute write). null when a model doesn't distinguish TTLs, in which
+  // case the combined `cacheWrite` rate (which already equals the 5-minute rate) is
+  // used. Only `cacheWrite1h` is populated in the price table today.
+  cacheWrite1h: number | null;
 }
 
 interface CachedModel {
@@ -43,6 +48,7 @@ async function loadCache(): Promise<CachedModel[]> {
         output: priceMap["output"] ?? 0,
         cacheRead: priceMap["cacheRead"] ?? null,
         cacheWrite: priceMap["cacheWrite"] ?? null,
+        cacheWrite1h: priceMap["cacheWrite1h"] ?? null,
       },
     };
   });
@@ -76,6 +82,47 @@ export async function getModelPricing(modelId: string): Promise<ModelPricing | n
 }
 
 /**
+ * Price token counts against a known ModelPricing. Pure (no DB lookup), so it is
+ * unit-testable without mocking Prisma, and mirrors the Python worker's cost formula.
+ *
+ * The 1-hour cache-write portion (cacheWrite1hTokens) is a sub-partition of
+ * cacheWriteTokens: clamped non-negative and capped so `1h <= total`, with the
+ * remainder priced at the combined `cacheWrite` rate (which already equals the
+ * 5-minute / default rate) and the 1-hour portion at its own rate (falling back to
+ * `cacheWrite`). When no 1-hour portion is supplied the remainder is the whole write
+ * total, so the result is identical to the pre-split formula.
+ */
+export function calculateCostFromPricing(
+  pricing: ModelPricing,
+  inputTokens: number,
+  outputTokens: number,
+  cacheReadTokens: number = 0,
+  cacheWriteTokens: number = 0,
+  cacheWrite1hTokens: number = 0,
+): number {
+  // Clamp every count non-negative so malformed input can't produce a negative
+  // cost, mirroring the worker's normalize_token_usage.
+  const input = Math.max(inputTokens, 0);
+  const output = Math.max(outputTokens, 0);
+  const cacheRead = Math.max(cacheReadTokens, 0);
+  const cacheWrite = Math.max(cacheWriteTokens, 0);
+  const cacheWrite1h = Math.min(Math.max(cacheWrite1hTokens, 0), cacheWrite);
+  const remainder = cacheWrite - cacheWrite1h;
+  const cacheWriteRate = pricing.cacheWrite ?? 0;
+
+  // `|| cacheWriteRate` (not `??`): a 0 rate is treated as unset and falls back to the
+  // base cache-write rate, matching the Python worker's truthy `_rate` fallback so the
+  // two cost formulas agree for every input (incl. an explicit cacheWrite1h of 0).
+  return (
+    input * pricing.input +
+    output * pricing.output +
+    cacheRead * (pricing.cacheRead ?? 0) +
+    remainder * cacheWriteRate +
+    cacheWrite1h * (pricing.cacheWrite1h || cacheWriteRate)
+  );
+}
+
+/**
  * Calculate cost in USD given model ID and token counts.
  * Returns 0 if the model is not found in the pricing table.
  */
@@ -85,14 +132,17 @@ export async function calculateCost(
   outputTokens: number,
   cacheReadTokens: number = 0,
   cacheWriteTokens: number = 0,
+  cacheWrite1hTokens: number = 0,
 ): Promise<number> {
   const pricing = await getModelPricing(modelId);
   if (!pricing) return 0;
 
-  return (
-    inputTokens * pricing.input +
-    outputTokens * pricing.output +
-    cacheReadTokens * (pricing.cacheRead ?? 0) +
-    cacheWriteTokens * (pricing.cacheWrite ?? 0)
+  return calculateCostFromPricing(
+    pricing,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    cacheWrite1hTokens,
   );
 }

--- a/frontend/packages/core/src/model-pricing/sync-standard-prices.ts
+++ b/frontend/packages/core/src/model-pricing/sync-standard-prices.ts
@@ -11,6 +11,8 @@ interface StandardModelEntry {
     output: number;
     cacheRead: number | null;
     cacheWrite: number | null;
+    // Optional 1-hour cache-write rate; synced generically via Object.entries.
+    cacheWrite1h?: number | null;
   };
 }
 

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -8,7 +8,8 @@
       "input": 0.000005,
       "output": 0.000025,
       "cacheRead": 0.0000005,
-      "cacheWrite": 0.00000625
+      "cacheWrite": 0.00000625,
+      "cacheWrite1h": 0.00001
     }
   },
   {
@@ -20,7 +21,8 @@
       "input": 0.000005,
       "output": 0.000025,
       "cacheRead": 0.0000005,
-      "cacheWrite": 0.00000625
+      "cacheWrite": 0.00000625,
+      "cacheWrite1h": 0.00001
     }
   },
   {
@@ -32,7 +34,8 @@
       "input": 0.000005,
       "output": 0.000025,
       "cacheRead": 0.0000005,
-      "cacheWrite": 0.00000625
+      "cacheWrite": 0.00000625,
+      "cacheWrite1h": 0.00001
     }
   },
   {
@@ -44,7 +47,8 @@
       "input": 0.000003,
       "output": 0.000015,
       "cacheRead": 0.0000003,
-      "cacheWrite": 0.00000375
+      "cacheWrite": 0.00000375,
+      "cacheWrite1h": 0.000006
     }
   },
   {
@@ -56,7 +60,8 @@
       "input": 0.000005,
       "output": 0.000025,
       "cacheRead": 0.0000005,
-      "cacheWrite": 0.00000625
+      "cacheWrite": 0.00000625,
+      "cacheWrite1h": 0.00001
     }
   },
   {
@@ -68,7 +73,8 @@
       "input": 0.000003,
       "output": 0.000015,
       "cacheRead": 0.0000003,
-      "cacheWrite": 0.00000375
+      "cacheWrite": 0.00000375,
+      "cacheWrite1h": 0.000006
     }
   },
   {
@@ -80,7 +86,8 @@
       "input": 0.000001,
       "output": 0.000005,
       "cacheRead": 0.0000001,
-      "cacheWrite": 0.00000125
+      "cacheWrite": 0.00000125,
+      "cacheWrite1h": 0.000002
     }
   },
   {
@@ -596,7 +603,8 @@
       "input": 0.000003,
       "output": 0.000015,
       "cacheRead": 0.0000003,
-      "cacheWrite": 0.00000375
+      "cacheWrite": 0.00000375,
+      "cacheWrite1h": 0.000006
     }
   },
   {
@@ -608,7 +616,8 @@
       "input": 0.0000008,
       "output": 0.000004,
       "cacheRead": 0.00000008,
-      "cacheWrite": 0.000001
+      "cacheWrite": 0.000001,
+      "cacheWrite1h": 0.0000016
     }
   },
   {
@@ -620,7 +629,8 @@
       "input": 0.000005,
       "output": 0.000025,
       "cacheRead": 0.0000005,
-      "cacheWrite": 0.00000625
+      "cacheWrite": 0.00000625,
+      "cacheWrite1h": 0.00001
     }
   },
   {
@@ -632,7 +642,8 @@
       "input": 0.000003,
       "output": 0.000015,
       "cacheRead": 0.0000003,
-      "cacheWrite": 0.00000375
+      "cacheWrite": 0.00000375,
+      "cacheWrite1h": 0.000006
     }
   },
   {
@@ -644,7 +655,8 @@
       "input": 0.00000025,
       "output": 0.00000125,
       "cacheRead": 0.00000003,
-      "cacheWrite": 0.0000003
+      "cacheWrite": 0.0000003,
+      "cacheWrite1h": 0.0000005
     }
   },
   {
@@ -656,7 +668,8 @@
       "input": 0.000003,
       "output": 0.000015,
       "cacheRead": 0.0000003,
-      "cacheWrite": 0.00000375
+      "cacheWrite": 0.00000375,
+      "cacheWrite1h": 0.000006
     }
   },
   {

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -43,6 +43,56 @@ def test_span_cost_details_reconciles_to_cost():
     assert details["input_uncached_cost"] == pytest.approx(2000 * 0.000003)
 
 
+def test_span_cost_details_rebuilds_1h_portion():
+    from rest.services.trace_reader import span_cost_details
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    # input 1000 = 100 uncached + 0 read + 900 write; of the 900: 600 @1h, 300 remainder.
+    prices = {**CLAUDE_PRICES, "cacheWrite1h": 0.000006}  # 2x the 0.000003 input rate
+    with patch("rest.services.trace_reader.get_model_price", return_value=prices):
+        details = span_cost_details(
+            "claude-opus-4-7",
+            input_tokens=1000,
+            output_tokens=0,
+            usage_details={
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 900,
+                "cache_write_1h_tokens": 600,
+            },
+        )
+
+    expected = cost_from_buckets(
+        prices,
+        TokenBuckets(
+            input_uncached=100,
+            output=0,
+            cache_read=0,
+            cache_write=900,
+            cache_write_1h=600,
+        ),
+    )
+    assert sum(details.values()) == pytest.approx(expected)
+    # Independent ground truth: 300 remainder @cacheWrite + 600 @cacheWrite1h.
+    assert details["cache_write_cost"] == pytest.approx(300 * 0.00000375 + 600 * 0.000006)
+
+
+def test_span_cost_details_without_1h_key_matches_combined_rate():
+    # A stored span with no 1-hour key (every span today) prices its whole write total
+    # at the combined cacheWrite rate.
+    from rest.services.trace_reader import span_cost_details
+
+    prices = {**CLAUDE_PRICES, "cacheWrite1h": 0.000006}
+    with patch("rest.services.trace_reader.get_model_price", return_value=prices):
+        details = span_cost_details(
+            "claude-opus-4-7",
+            input_tokens=1000,
+            output_tokens=0,
+            usage_details={"cache_read_tokens": 0, "cache_write_tokens": 900},
+        )
+    assert details["cache_write_cost"] == pytest.approx(900 * 0.00000375)
+
+
 def test_span_cost_details_empty_without_model():
     from rest.services.trace_reader import span_cost_details
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -841,6 +841,80 @@ class TestTransformOtelToClickhouse:
         ]
         assert cost_for(cached) < cost_for(base)
 
+    def test_cache_write_1h_portion_is_extracted_and_priced(self):
+        """When an emitter reports the 1-hour write portion, it is priced at its own
+        rate (1h = 2x input), the remainder at cacheWrite, and the breakdown persists."""
+        from unittest.mock import patch
+
+        prices = {
+            "input": 0.000005,
+            "output": 0.000025,
+            "cacheRead": 0.0000005,
+            "cacheWrite": 0.00000625,  # 5-minute / default rate
+            "cacheWrite1h": 0.00001,  # 1h rate (2x input)
+        }
+        # gross input 1000 = 100 uncached + 900 write; of the 900: 600 @1h, 300 remainder.
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=[
+                        make_attr("gen_ai.request.model", "claude-opus-4-7"),
+                        make_attr("llm.token_count.prompt", 1000),
+                        make_attr("llm.token_count.completion", 0),
+                        make_attr("llm.token_count.prompt_details.cache_write", 900),
+                        make_attr("gen_ai.usage.cache_creation.ephemeral_1h_input_tokens", 600),
+                    ],
+                )
+            ],
+            scope_name="openinference.instrumentation.anthropic",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        ud = spans[0]["usage_details"]
+        assert ud["cache_write_tokens"] == 900
+        assert ud["cache_write_1h_tokens"] == 600
+        expected = 100 * prices["input"] + 300 * prices["cacheWrite"] + 600 * prices["cacheWrite1h"]
+        assert spans[0]["cost"] == pytest.approx(expected)
+
+    def test_no_1h_portion_omits_key_and_prices_at_combined_rate(self):
+        """Regression guard: a span with no 1-hour portion keeps an identical
+        usage_details map (key absent, not zero) and the whole write total prices at
+        cacheWrite."""
+        from unittest.mock import patch
+
+        prices = {
+            "input": 0.000005,
+            "output": 0.000025,
+            "cacheRead": 0.0000005,
+            "cacheWrite": 0.00000625,
+            "cacheWrite1h": 0.00001,
+        }
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=[
+                        make_attr("gen_ai.request.model", "claude-opus-4-7"),
+                        make_attr("llm.token_count.prompt", 1000),
+                        make_attr("llm.token_count.completion", 0),
+                        make_attr("llm.token_count.prompt_details.cache_write", 900),
+                    ],
+                )
+            ],
+            scope_name="openinference.instrumentation.anthropic",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        ud = spans[0]["usage_details"]
+        assert "cache_write_1h_tokens" not in ud
+        expected = 100 * prices["input"] + 900 * prices["cacheWrite"]
+        assert spans[0]["cost"] == pytest.approx(expected)
+
     def test_text_estimation_fallback(self):
         """Falls back to text-based token estimation when no API counts."""
         from unittest.mock import patch
@@ -1291,3 +1365,41 @@ class TestCacheTokenMetadata:
         assert spans[0]["usage_details"]["cache_write_tokens"] == 64
         assert isinstance(spans[0]["usage_details"]["cache_read_tokens"], int)
         assert isinstance(spans[0]["usage_details"]["cache_write_tokens"], int)
+
+    def test_cache_write_1h_portion_promoted_to_usage_details(self):
+        # The optional 1-hour write portion lands in the usage_details map when present.
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=self._llm_attrs(
+                        make_attr("llm.token_count.prompt_details.cache_write", 500),
+                        make_attr("gen_ai.usage.cache_creation.ephemeral_1h_input_tokens", 300),
+                    ),
+                )
+            ]
+        )
+        _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+        ud = spans[0]["usage_details"]
+        assert ud["cache_write_tokens"] == 500
+        assert ud["cache_write_1h_tokens"] == 300
+
+    def test_absent_1h_portion_keeps_usage_details_keys_unchanged(self):
+        # No 1-hour portion reported (every span today) -> no extra key is added, so the
+        # stored map is identical to before this change.
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=self._llm_attrs(
+                        make_attr("llm.token_count.prompt_details.cache_write", 500),
+                    ),
+                )
+            ]
+        )
+        _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+        ud = spans[0]["usage_details"]
+        assert "cache_write_1h_tokens" not in ud
+        assert set(ud) == {"cache_read_tokens", "cache_write_tokens", "reasoning_tokens"}

--- a/tests/worker/tokens/test_buckets.py
+++ b/tests/worker/tokens/test_buckets.py
@@ -182,3 +182,81 @@ def test_token_buckets_fields_default_to_zero():
     # Defaults make future token categories (reasoning/audio) purely additive.
     assert TokenBuckets() == TokenBuckets(input_uncached=0, output=0, cache_read=0, cache_write=0)
     assert TokenBuckets(output=5).cache_read == 0
+
+
+# ---------------------------------------------------------------------------
+# Cache-write 1-hour portion: a SUB-PARTITION of the cache_write total, not a new
+# disjoint bucket. cache_write_1h <= cache_write; the remainder prices at cacheWrite.
+# ---------------------------------------------------------------------------
+
+
+def test_cache_write_1h_portion_is_carried_through():
+    b = normalize_token_usage(
+        "openinference.instrumentation.anthropic",
+        input_tokens=1000,
+        output_tokens=10,
+        cache_read_tokens=200,
+        cache_write_tokens=300,
+        cache_write_1h_tokens=180,
+    )
+    # The portion is carried; the cache_write TOTAL and the uncached reconstruction
+    # are unaffected by it.
+    assert b.cache_write == 300
+    assert b.cache_write_1h == 180
+    assert b.input_uncached == 500  # 1000 - 200 (read) - 300 (write)
+
+
+def test_cache_write_1h_caps_to_total():
+    # An emitter over-reporting the 1-hour portion must never exceed the write total.
+    b = normalize_token_usage(
+        "pydantic-ai",
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=100,
+        cache_write_1h_tokens=180,  # > 100
+    )
+    assert b.cache_write_1h == 100  # capped to the write total
+    assert b.cache_write_1h <= b.cache_write
+
+
+def test_cache_write_1h_clamps_negative():
+    b = normalize_token_usage(
+        "pydantic-ai",
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_write_tokens=100,
+        cache_write_1h_tokens=-50,
+    )
+    assert b.cache_write_1h == 0
+
+
+def test_cache_write_1h_absent_defaults_to_zero():
+    # The dominant path today: no 1-hour portion reported -> it is zero and the write
+    # total is intact, so pricing is unchanged.
+    b = normalize_token_usage(
+        "openinference.instrumentation.anthropic",
+        input_tokens=1000,
+        output_tokens=10,
+        cache_read_tokens=200,
+        cache_write_tokens=300,
+    )
+    assert b.cache_write_1h == 0
+    assert b.cache_write == 300
+
+
+def test_reconcile_cache_write_1h_is_a_valid_partition():
+    from worker.tokens.buckets import reconcile_cache_write_1h
+
+    assert reconcile_cache_write_1h(100, 30) == 30
+    assert reconcile_cache_write_1h(100, 180) == 100  # capped to total
+    assert reconcile_cache_write_1h(100, -5) == 0  # clamped non-negative
+    assert reconcile_cache_write_1h(0, 10) == 0  # no writes
+    assert reconcile_cache_write_1h(-50, 10) == 0  # negative total clamped
+    assert reconcile_cache_write_1h(50, 999) <= 50
+
+
+def test_token_buckets_1h_field_defaults_to_zero():
+    assert TokenBuckets().cache_write_1h == 0
+    assert TokenBuckets(cache_write=5).cache_write_1h == 0

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -401,3 +401,153 @@ def test_cost_breakdown_from_buckets_returns_none_without_prices():
     buckets = TokenBuckets(input_uncached=100, output=50)
     assert cost_breakdown_from_buckets(None, buckets) is None
     assert cost_breakdown_from_buckets({}, buckets) is None
+
+
+# ---------------------------------------------------------------------------
+# Cache-write 1-hour portion pricing. The portion is a sub-partition of the
+# cache_write total: the 1-hour portion at its own rate, remainder at cacheWrite.
+# ---------------------------------------------------------------------------
+
+# opus-4.x-shaped rates: cacheWrite is the 5-minute / default rate (1.25x input);
+# cacheWrite1h = 2x input.
+TTL_PRICES = {
+    "input": 0.000005,
+    "output": 0.000025,
+    "cacheRead": 0.0000005,
+    "cacheWrite": 0.00000625,
+    "cacheWrite1h": 0.00001,
+}
+
+
+def test_cache_write_1h_portion_prices_at_its_own_rate():
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    # 900 write tokens: 600 @1h, 300 remainder (priced at cacheWrite).
+    buckets = TokenBuckets(cache_write=900, cache_write_1h=600)
+    expected = 300 * 0.00000625 + 600 * 0.00001
+    assert cost_from_buckets(TTL_PRICES, buckets) == pytest.approx(expected)
+
+
+def test_cache_write_remainder_prices_at_combined_rate():
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    # 1000 write: 200 @1h, 800 remainder (priced at cacheWrite).
+    buckets = TokenBuckets(cache_write=1000, cache_write_1h=200)
+    expected = 200 * 0.00001 + 800 * 0.00000625
+    assert cost_from_buckets(TTL_PRICES, buckets) == pytest.approx(expected)
+
+
+def test_cost_from_buckets_caps_unreconciled_1h():
+    # Defense-in-depth: _bucket_cost_terms is the single source of truth, so a
+    # hand-built bucket that over-reports the 1-hour portion (1h > cache_write) must
+    # still price at most the write total — never double-count.
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    over = TokenBuckets(cache_write=100, cache_write_1h=180)
+    capped = TokenBuckets(cache_write=100, cache_write_1h=100)
+    assert cost_from_buckets(TTL_PRICES, over) == pytest.approx(
+        cost_from_buckets(TTL_PRICES, capped)
+    )
+    # Never exceeds pricing the whole write total at the 1h rate.
+    assert cost_from_buckets(TTL_PRICES, over) <= 100 * TTL_PRICES["cacheWrite1h"]
+
+
+def test_negative_cache_write_total_never_prices_negative():
+    # A malformed negative total must clamp to 0, never produce a negative cost
+    # (the total is clamped non-negative before the split math, matching the TS helper).
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    buckets = TokenBuckets(cache_write=-500, cache_write_1h=-200)
+    assert cost_from_buckets(TTL_PRICES, buckets) == pytest.approx(0.0)
+
+
+def test_negative_counts_never_price_negative_matches_ts():
+    # Every count is clamped non-negative before pricing, so a fully-malformed bucket
+    # prices to exactly 0 — identical to the TS helper's all-negative case. Guards the
+    # Python<->TS parity invariant for negative inputs.
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    buckets = TokenBuckets(
+        input_uncached=-100,
+        output=-50,
+        cache_read=-10,
+        cache_write=-900,
+        cache_write_1h=-1,
+    )
+    assert cost_from_buckets(TTL_PRICES, buckets) == pytest.approx(0.0)
+
+
+def test_cache_write_1h_rate_of_zero_falls_back_to_combined_rate():
+    # An explicit cacheWrite1h of 0 is treated as unset and falls back to cacheWrite,
+    # matching the TS `|| cacheWriteRate` fallback so the two cost formulas agree.
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    prices = {"input": 0.000005, "output": 0.0, "cacheWrite": 0.00000625, "cacheWrite1h": 0.0}
+    buckets = TokenBuckets(cache_write=100, cache_write_1h=40)
+    # 40 @1h (-> cacheWrite, since cacheWrite1h is 0) + 60 remainder @cacheWrite.
+    expected = 100 * 0.00000625
+    assert cost_from_buckets(prices, buckets) == pytest.approx(expected)
+
+
+def test_cache_write_1h_without_ttl_rate_matches_combined():
+    # A 1-hour portion present but the model has no 1h rate (e.g. non-Anthropic): it
+    # falls back to cacheWrite, so cost == the pre-split formula.
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_from_buckets
+
+    prices = {"input": 0.000003, "output": 0.0, "cacheWrite": 0.00000375}
+    split = TokenBuckets(cache_write=500, cache_write_1h=150)
+    combined = TokenBuckets(cache_write=500)
+    assert cost_from_buckets(prices, split) == pytest.approx(cost_from_buckets(prices, combined))
+
+
+def test_cache_write_1h_absent_is_byte_identical_to_today():
+    # Regression guard: with no 1-hour portion, cache_write_cost == cache_write * cacheWrite.
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_breakdown_from_buckets
+
+    buckets = TokenBuckets(input_uncached=10, output=5, cache_read=20, cache_write=300)
+    breakdown = cost_breakdown_from_buckets(TTL_PRICES, buckets)
+    assert breakdown["cache_write_cost"] == pytest.approx(300 * 0.00000625)
+
+
+def test_cache_write_1h_breakdown_still_sums_to_total():
+    from worker.tokens.buckets import TokenBuckets
+    from worker.tokens.pricing import cost_breakdown_from_buckets, cost_from_buckets
+
+    buckets = TokenBuckets(
+        input_uncached=100,
+        output=50,
+        cache_read=200,
+        cache_write=300,
+        cache_write_1h=180,
+    )
+    breakdown = cost_breakdown_from_buckets(TTL_PRICES, buckets)
+    assert sum(breakdown.values()) == pytest.approx(cost_from_buckets(TTL_PRICES, buckets))
+    # cache_write_cost stays one canonical term: the 1-hour portion is priced inside it,
+    # never added as extra keys, so the total can't double-count.
+    assert set(breakdown) == {
+        "input_uncached_cost",
+        "cache_read_cost",
+        "cache_write_cost",
+        "output_cost",
+    }
+
+
+def test_anthropic_entries_have_2x_input_1h_cache_rate():
+    # Every Anthropic entry that has a cache-write rate must carry a 1h rate equal
+    # to 2x its input rate (Anthropic's platform pricing for 1-hour cache writes).
+    anthropic = [e for e in _standard_price_entries() if e.get("provider") == "anthropic"]
+    assert anthropic, "expected anthropic entries in the price table"
+    for entry in anthropic:
+        prices = entry["prices"]
+        if prices.get("cacheWrite") is None:
+            continue
+        assert "cacheWrite1h" in prices, f"{entry['modelName']} missing cacheWrite1h"
+        assert prices["cacheWrite1h"] == pytest.approx(prices["input"] * 2), entry["modelName"]


### PR DESCRIPTION
## what

prices anthropic 1-hour cache writes. a 1-hour write is 2.0x base input; the default 5-minute write is 1.25x, which is already today's single `cacheWrite` rate. reads stay 0.1x and are unchanged. today every write is priced at the 5m rate, so a 1h write is under-counted by 37.5% on that line item.

part of #1070.

## why this is the downstream half

no instrumentation source we ingest from propagates the 5m/1h distinction today. openinference (py + js), pydantic-ai/logfire and openllmetry all collapse cache writes into one cache_creation total, and the agent path (pi-ai) does too. the traceroot sdks that could emit it are separate repos. so this PR builds the receiving end: purely additive, byte-identical to today's behavior until an emitter reports a 1-hour portion, then prices it correctly.

an earlier revision also tracked a separate 5m bucket. per review it was dropped, since the 5m rate is identical to the base `cacheWrite` rate so a separate bucket never changed any cost. 5m and untagged tokens fold into the remainder, priced at `cacheWrite`.

## how

the 1-hour portion is modeled as a sub-partition of the existing cache_write total, not a new disjoint bucket:

```
cache_write = cache_write_1h + remainder
```

keeping cache_write as the single total means the gross-input reconstruction (uncached + read + write) is untouched, and the cost formula stays one canonical cache_write_cost term so the total can't double-count:

```
cache_write_cost = remainder*cacheWrite + cache_write_1h*(cacheWrite1h || cacheWrite)
```

- `backend/worker/otel_transform.py` extracts cache_write_1h from new lowest-priority attribute fallbacks (e.g. `gen_ai.usage.cache_creation.ephemeral_1h_input_tokens`); stores it in usage_details only when present, so spans with no 1h portion keep an identical map
- `backend/worker/tokens/buckets.py`: TokenBuckets gains cache_write_1h (default 0); `reconcile_cache_write_1h` clamps non-negative and caps so 1h <= cache_write (shared by the ingest and read paths)
- `backend/worker/tokens/pricing.py`: the single cost formula prices the 1h portion, reconciling internally so it's correct for any TokenBuckets; cacheWrite1h falls back to cacheWrite
- `backend/rest/services/trace_reader.py`: read-path rebuild of the 1h portion from usage_details
- `frontend/packages/core/src/model-pricing/lookup.ts` mirrors the worker: pure `calculateCostFromPricing` helper (extracted so it's unit-testable without prisma) plus the 1h portion
- `standard-model-prices.json` adds cacheWrite1h = 2x input to the anthropic entries. cacheWrite already is the 5m rate so it's the only new key. usage_type is generic, no schema/migration change

## cost impact

zero change for existing data and current traffic. with no 1-hour portion present (all traffic today) every cost is identical to before, proven by regression tests on the ingest and read paths. when an emitter does report a 1-hour portion, that portion is priced at 2x input instead of 1.25x.

## testing

- backend: full suite passes. new tests for the reconcile/cap, 1h pricing (remainder + rate fallback + a defensive cap on unreconciled buckets), the byte-identical-when-absent invariant, ingest extraction + conditional storage, the read-path rebuild, and a real-json check that every anthropic entry's cacheWrite1h == 2x input
- frontend: core vitest passes; new tests for the 1h math, the cap, rate fallback and negative clamping. tsc clean
- ruff clean

## not in this PR (on purpose)

- sdk emission of the split: separate repos (python `traceroot`, npm `@traceroot-ai/traceroot`)
- the per-ttl breakout in the cost popup: the combined cache-write row keeps working unchanged; tracking with #1069
