### PR TITLE
fix: restrict auth redirect targets

### DIFF
--- a/frontend/ui/src/app/api/github/callback/route.ts
+++ b/frontend/ui/src/app/api/github/callback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 import { prisma } from "@traceroot/core";
 import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import { sanitizeRedirectPath } from "@/lib/safe-redirect";
 import {
   GITHUB_AUTH_STATE_COOKIE,
   GITHUB_INSTALL_STATE_COOKIE,
@@ -153,9 +154,7 @@ async function processGitHubCallback(
 
   // 7. Build the redirect.
   const rawReturnTo = request.cookies.get(GITHUB_RETURN_TO_COOKIE)?.value || "/";
-  // Guard against open redirect: only accept relative paths. new URL(absolute, base)
-  // ignores the base entirely, so an absolute URL in the cookie would escape the origin.
-  const returnTo = rawReturnTo.startsWith("/") && !rawReturnTo.startsWith("//") ? rawReturnTo : "/";
+  const returnTo = sanitizeRedirectPath(rawReturnTo);
   // Use BETTER_AUTH_URL as base — request.url inside Docker resolves to 0.0.0.0
   // which loses the session cookie (set on localhost).
   // Mirror the persistence condition (chosen && workspaceId): if either is

--- a/frontend/ui/src/app/api/github/install-callback/route.test.ts
+++ b/frontend/ui/src/app/api/github/install-callback/route.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/env", () => ({
+  env: {
+    BETTER_AUTH_URL: "http://localhost:3000",
+    GITHUB_APP_ID: "123456",
+    GITHUB_APP_PRIVATE_KEY: "fake-key",
+  },
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: vi.fn((data, init) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+      cookies: { set: vi.fn() },
+    })),
+    redirect: vi.fn((url) => ({
+      status: 307,
+      headers: new Headers({ location: url.toString() }),
+      url: url.toString(),
+      cookies: { set: vi.fn() },
+    })),
+  },
+}));
+
+const upsertMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    gitHubInstallation: {
+      upsert: (...args: unknown[]) => upsertMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireWorkspaceMembershipMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireWorkspaceMembership: (...args: unknown[]) => requireWorkspaceMembershipMock(...args),
+}));
+
+const getInstallationMock = vi.fn();
+vi.mock("@traceroot/github", () => ({
+  GITHUB_INSTALL_STATE_COOKIE: "github_install_state",
+  GITHUB_INSTALLATION_ID_COOKIE: "github_installation_id",
+  GITHUB_RETURN_TO_COOKIE: "github_return_to",
+  GITHUB_WORKSPACE_ID_COOKIE: "github_workspace_id",
+  getInstallation: (...args: unknown[]) => getInstallationMock(...args),
+}));
+
+import { GET } from "./route";
+
+function makeRequest(returnTo: string) {
+  const searchParams = new URLSearchParams({
+    installation_id: "789",
+    state: "state_1",
+  });
+  const cookies: Record<string, string> = {
+    github_install_state: "state_1",
+    github_return_to: returnTo,
+    github_workspace_id: "ws_1",
+  };
+
+  return {
+    nextUrl: { searchParams },
+    cookies: {
+      get: (key: string) => (cookies[key] ? { value: cookies[key] } : undefined),
+    },
+  } as unknown as Parameters<typeof GET>[0];
+}
+
+describe("GET /api/github/install-callback", () => {
+  beforeEach(() => {
+    upsertMock.mockReset();
+    requireAuthMock.mockReset();
+    requireWorkspaceMembershipMock.mockReset();
+    getInstallationMock.mockReset();
+
+    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
+    requireWorkspaceMembershipMock.mockResolvedValue({ membership: { workspaceId: "ws_1" } });
+    getInstallationMock.mockResolvedValue({ account: { login: "octocat" } });
+    upsertMock.mockResolvedValue({});
+  });
+
+  it("redirects to a same-origin return path", async () => {
+    const res = await GET(makeRequest("/projects/proj_1/settings/github"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe(
+      "http://localhost:3000/projects/proj_1/settings/github",
+    );
+  });
+
+  it("falls back to root when returnTo is external", async () => {
+    const res = await GET(makeRequest("https://evil.example/phish"));
+
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("http://localhost:3000/");
+  });
+});

--- a/frontend/ui/src/app/api/github/install-callback/route.test.ts
+++ b/frontend/ui/src/app/api/github/install-callback/route.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+// All vi.mock() calls are hoisted by Vitest before imports — keep them at the
+// top and self-contained (no out-of-scope variable references).
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/env", () => ({
   env: {
@@ -8,6 +10,8 @@ vi.mock("@/env", () => ({
   },
 }));
 
+// NextResponse mock mirrors callback/route.test.ts: redirect() exposes the
+// resolved absolute URL via .url, and cookies.set() is a no-op spy.
 vi.mock("next/server", () => ({
   NextResponse: {
     json: vi.fn((data, init) => ({
@@ -17,40 +21,34 @@ vi.mock("next/server", () => ({
     })),
     redirect: vi.fn((url) => ({
       status: 307,
-      headers: new Headers({ location: url.toString() }),
       url: url.toString(),
       cookies: { set: vi.fn() },
     })),
   },
 }));
 
-const upsertMock = vi.fn();
 vi.mock("@traceroot/core", () => ({
   prisma: {
-    gitHubInstallation: {
-      upsert: (...args: unknown[]) => upsertMock(...args),
-    },
+    gitHubInstallation: { upsert: vi.fn(async () => ({})) },
   },
 }));
 
-const requireAuthMock = vi.fn();
-const requireWorkspaceMembershipMock = vi.fn();
 vi.mock("@/lib/auth-helpers", () => ({
-  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
-  requireWorkspaceMembership: (...args: unknown[]) => requireWorkspaceMembershipMock(...args),
+  requireAuth: vi.fn(async () => ({ user: { id: "u_1" } })),
+  requireWorkspaceMembership: vi.fn(async () => ({ membership: { workspaceId: "ws_1" } })),
 }));
 
-const getInstallationMock = vi.fn();
 vi.mock("@traceroot/github", () => ({
   GITHUB_INSTALL_STATE_COOKIE: "github_install_state",
   GITHUB_INSTALLATION_ID_COOKIE: "github_installation_id",
   GITHUB_RETURN_TO_COOKIE: "github_return_to",
   GITHUB_WORKSPACE_ID_COOKIE: "github_workspace_id",
-  getInstallation: (...args: unknown[]) => getInstallationMock(...args),
+  getInstallation: vi.fn(async () => ({ account: { login: "octocat" } })),
 }));
 
 import { GET } from "./route";
 
+// Minimal request shape the handler consumes: nextUrl.searchParams + cookies.get
 function makeRequest(returnTo: string) {
   const searchParams = new URLSearchParams({
     installation_id: "789",
@@ -71,31 +69,17 @@ function makeRequest(returnTo: string) {
 }
 
 describe("GET /api/github/install-callback", () => {
-  beforeEach(() => {
-    upsertMock.mockReset();
-    requireAuthMock.mockReset();
-    requireWorkspaceMembershipMock.mockReset();
-    getInstallationMock.mockReset();
-
-    requireAuthMock.mockResolvedValue({ user: { id: "u_1" } });
-    requireWorkspaceMembershipMock.mockResolvedValue({ membership: { workspaceId: "ws_1" } });
-    getInstallationMock.mockResolvedValue({ account: { login: "octocat" } });
-    upsertMock.mockResolvedValue({});
-  });
-
   it("redirects to a same-origin return path", async () => {
     const res = await GET(makeRequest("/projects/proj_1/settings/github"));
 
     expect(res.status).toBe(307);
-    expect(res.headers.get("location")).toBe(
-      "http://localhost:3000/projects/proj_1/settings/github",
-    );
+    expect(res.url).toBe("http://localhost:3000/projects/proj_1/settings/github");
   });
 
   it("falls back to root when returnTo is external", async () => {
     const res = await GET(makeRequest("https://evil.example/phish"));
 
     expect(res.status).toBe(307);
-    expect(res.headers.get("location")).toBe("http://localhost:3000/");
+    expect(res.url).toBe("http://localhost:3000/");
   });
 });

--- a/frontend/ui/src/app/api/github/install-callback/route.ts
+++ b/frontend/ui/src/app/api/github/install-callback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 import { prisma } from "@traceroot/core";
 import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import { sanitizeRedirectPath } from "@/lib/safe-redirect";
 import {
   GITHUB_INSTALL_STATE_COOKIE,
   GITHUB_INSTALLATION_ID_COOKIE,
@@ -88,7 +89,7 @@ export async function GET(request: NextRequest) {
     });
 
     // Redirect to return URL
-    const returnTo = request.cookies.get(GITHUB_RETURN_TO_COOKIE)?.value || "/";
+    const returnTo = sanitizeRedirectPath(request.cookies.get(GITHUB_RETURN_TO_COOKIE)?.value);
     const response = NextResponse.redirect(new URL(returnTo, env.BETTER_AUTH_URL));
 
     // Clear state cookies

--- a/frontend/ui/src/app/api/github/install/route.ts
+++ b/frontend/ui/src/app/api/github/install/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import { sanitizeRedirectPath } from "@/lib/safe-redirect";
 import {
   GITHUB_INSTALL_STATE_COOKIE,
   GITHUB_RETURN_TO_COOKIE,
@@ -13,7 +14,7 @@ export async function GET(request: NextRequest) {
     if (authResult.error) return authResult.error;
 
     const state = crypto.randomUUID();
-    const returnTo = request.nextUrl.searchParams.get("returnTo") || "/";
+    const returnTo = sanitizeRedirectPath(request.nextUrl.searchParams.get("returnTo"));
     // Allow workspaceId to come from either the query (button click) or the
     // cookie set by /api/github/login earlier in the flow — callback redirects
     // here without re-passing the param when no install exists yet.

--- a/frontend/ui/src/app/api/github/login/route.ts
+++ b/frontend/ui/src/app/api/github/login/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { env } from "@/env";
 import { requireAuth, requireWorkspaceMembership } from "@/lib/auth-helpers";
+import { sanitizeRedirectPath } from "@/lib/safe-redirect";
 import {
   GITHUB_AUTH_STATE_COOKIE,
   GITHUB_RETURN_TO_COOKIE,
@@ -13,7 +14,7 @@ export async function GET(request: NextRequest) {
     if (authResult.error) return authResult.error;
 
     const state = crypto.randomUUID();
-    const returnTo = request.nextUrl.searchParams.get("returnTo") || "/";
+    const returnTo = sanitizeRedirectPath(request.nextUrl.searchParams.get("returnTo"));
     const workspaceId = request.nextUrl.searchParams.get("workspaceId");
 
     // Connecting GitHub mutates a workspace-shared resource — admin only.

--- a/frontend/ui/src/app/auth/sign-in/sign-in-client.tsx
+++ b/frontend/ui/src/app/auth/sign-in/sign-in-client.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Logo } from "@/components/Logo";
+import { sanitizeRedirectPath } from "@/lib/safe-redirect";
 
 const signInSchema = z.object({
   email: z.string().email("Invalid email"),
@@ -27,7 +28,7 @@ type SignInContentProps = {
 function SignInContent({ googleAuthConfigured }: SignInContentProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const callbackUrl = searchParams.get("callbackUrl") || "/";
+  const callbackUrl = sanitizeRedirectPath(searchParams.get("callbackUrl"));
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [showPassword, setShowPassword] = useState(false);

--- a/frontend/ui/src/lib/safe-redirect.test.ts
+++ b/frontend/ui/src/lib/safe-redirect.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { sanitizeRedirectPath } from "./safe-redirect";
+
+describe("sanitizeRedirectPath", () => {
+  it("keeps same-origin absolute paths", () => {
+    expect(sanitizeRedirectPath("/")).toBe("/");
+    expect(sanitizeRedirectPath("/projects/proj_123/settings?tab=github#install")).toBe(
+      "/projects/proj_123/settings?tab=github#install",
+    );
+  });
+
+  it("falls back for external and protocol-relative URLs", () => {
+    expect(sanitizeRedirectPath("https://evil.example/phish")).toBe("/");
+    expect(sanitizeRedirectPath("http://evil.example/phish")).toBe("/");
+    expect(sanitizeRedirectPath("//evil.example/phish")).toBe("/");
+  });
+
+  it("falls back for non-path inputs and dangerous schemes", () => {
+    expect(sanitizeRedirectPath("dashboard")).toBe("/");
+    expect(sanitizeRedirectPath("javascript:alert(1)")).toBe("/");
+    expect(sanitizeRedirectPath("data:text/html,hello")).toBe("/");
+  });
+
+  it("falls back for ambiguous or malformed paths", () => {
+    expect(sanitizeRedirectPath("/\\evil.example")).toBe("/");
+    expect(sanitizeRedirectPath(" /dashboard")).toBe("/");
+    expect(sanitizeRedirectPath("/dashboard\nLocation: https://evil.example")).toBe("/");
+    expect(sanitizeRedirectPath(null)).toBe("/");
+    expect(sanitizeRedirectPath(undefined)).toBe("/");
+  });
+});

--- a/frontend/ui/src/lib/safe-redirect.ts
+++ b/frontend/ui/src/lib/safe-redirect.ts
@@ -1,0 +1,23 @@
+const FALLBACK_REDIRECT_PATH = "/";
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001F\u007F]/;
+
+/**
+ * Keep post-auth redirects on the current origin.
+ *
+ * Accept only path-absolute URLs like "/projects/123?tab=settings".
+ * Reject absolute, protocol-relative, malformed, and control-character inputs.
+ */
+export function sanitizeRedirectPath(value: string | null | undefined): string {
+  if (!value) return FALLBACK_REDIRECT_PATH;
+
+  if (
+    !value.startsWith("/") ||
+    value.startsWith("//") ||
+    value.startsWith("/\\") ||
+    CONTROL_CHAR_PATTERN.test(value)
+  ) {
+    return FALLBACK_REDIRECT_PATH;
+  }
+
+  return value;
+}


### PR DESCRIPTION
## Summary
- Add a shared redirect sanitizer for post-auth return paths.
- Apply it to sign-in callback URLs and GitHub login/install callback flows.
- Prevent external, protocol-relative, and malformed redirect targets from escaping the app origin.

## Test plan
- IDE diagnostics: no errors
- Not run: dependencies are not installed locally; frozen pnpm install is blocked by lockfile/overrides mismatch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared redirect sanitizer across sign-in and GitHub auth to block open redirects and keep users on our origin.

- **Bug Fixes**
  - Add `sanitizeRedirectPath` (accepts only path-absolute "/..."; else falls back to "/"); apply to sign-in `callbackUrl` and GitHub `returnTo` in `api/github/{login,install,install-callback,callback}`.
  - Add unit tests for the helper and the install-callback route; make the install-callback test self-contained to avoid `vi.mock` hoisting issues.

<sup>Written for commit 3352c3784a53698ef05a94942e42dbbf0c0f7c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

