### PR TITLE
fix: harden git clone shell execution

### DIFF
--- a/frontend/packages/agent/src/executors/docker.ts
+++ b/frontend/packages/agent/src/executors/docker.ts
@@ -49,7 +49,11 @@ export class DockerExecutor implements Executor {
     if (!this.containerId) throw new Error("Container not initialized");
 
     return new Promise((resolve) => {
-      const child = spawn("docker", ["exec", this.containerId!, "sh", "-c", command], {
+      const envArgs = Object.entries(options?.env ?? {}).flatMap(([key, value]) => [
+        "-e",
+        `${key}=${value}`,
+      ]);
+      const child = spawn("docker", ["exec", ...envArgs, this.containerId!, "sh", "-c", command], {
         stdio: ["ignore", "pipe", "pipe"],
       });
 

--- a/frontend/packages/agent/src/tools/__tests__/git-clone.test.ts
+++ b/frontend/packages/agent/src/tools/__tests__/git-clone.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Executor } from "../../executors/interface.js";
+
+vi.mock("../../executors/docker.js", () => ({
+  setupGhCli: vi.fn(async () => {}),
+}));
+
+vi.mock("../../executors/daytona.js", () => ({
+  setupGhCliDaytona: vi.fn(async () => {}),
+}));
+
+import { createGitCloneTool } from "../git-clone.js";
+
+function textFrom(result: Awaited<ReturnType<ReturnType<typeof createGitCloneTool>["execute"]>>) {
+  return result.content.map((part) => (part.type === "text" ? part.text : "")).join("\n");
+}
+
+function createExecutor(): Executor & { exec: ReturnType<typeof vi.fn>; writeFile: ReturnType<typeof vi.fn> } {
+  return {
+    init: vi.fn(async () => {}),
+    exec: vi.fn(async (command: string) => {
+      if (command.includes("git log")) return { stdout: "abc123 commit subject\n", stderr: "", code: 0 };
+      return { stdout: "", stderr: "", code: 0 };
+    }),
+    getWorkspacePath: () => "/workspace",
+    writeFile: vi.fn(async () => {}),
+    readFile: vi.fn(async () => ""),
+    isReady: () => true,
+    destroy: vi.fn(async () => {}),
+    hasNativeGit: () => false,
+  };
+}
+
+describe("git_clone tool", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ token: "ghs_secret_token", github_username: "octocat" }),
+      })),
+    );
+  });
+
+  it("rejects repositories outside owner/repo format before fetching a token", async () => {
+    const executor = createExecutor();
+    const tool = createGitCloneTool("ws_1", "http://ui.test", executor);
+
+    const result = await tool.execute("call_1", {
+      label: "clone hostile repo",
+      repo: 'owner/repo"; touch /tmp/pwned #',
+    });
+
+    expect(textFrom(result)).toContain("Invalid repository");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(executor.exec).not.toHaveBeenCalled();
+  });
+
+  it("rejects refs containing shell metacharacters before executing git", async () => {
+    const executor = createExecutor();
+    const tool = createGitCloneTool("ws_1", "http://ui.test", executor);
+
+    const result = await tool.execute("call_1", {
+      label: "clone hostile ref",
+      repo: "owner/repo",
+      ref: 'main"; touch /tmp/pwned #',
+    });
+
+    expect(textFrom(result)).toContain("Invalid git ref");
+    expect(fetch).not.toHaveBeenCalled();
+    expect(executor.exec).not.toHaveBeenCalled();
+  });
+
+  it("passes repo, ref, and token through env in the Docker fallback", async () => {
+    const executor = createExecutor();
+    const tool = createGitCloneTool("ws_1", "http://ui.test", executor);
+
+    const result = await tool.execute("call_1", {
+      label: "clone safe ref",
+      repo: "owner/repo",
+      ref: "feature/safe-ref_1",
+    });
+
+    expect(textFrom(result)).toContain("Cloned owner/repo");
+    const cloneCall = executor.exec.mock.calls.find(([command]) => command.includes("clone"));
+    expect(cloneCall).toBeTruthy();
+
+    const [cloneCommand, cloneOptions] = cloneCall!;
+    expect(cloneCommand).toContain('"$GIT_URL"');
+    expect(cloneCommand).toContain('"$GIT_DEST"');
+    expect(cloneCommand).toContain('"$GIT_REF"');
+    expect(cloneCommand).not.toContain("feature/safe-ref_1");
+    expect(cloneCommand).not.toContain("ghs_secret_token");
+    expect(cloneOptions?.env).toMatchObject({
+      GIT_ASKPASS: "/tmp/git-askpass.sh",
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_USERNAME: "x-access-token",
+      GIT_PASSWORD: "ghs_secret_token",
+      GIT_URL: "https://github.com/owner/repo.git",
+      GIT_DEST: "/workspace/repos/owner_repo",
+      GIT_REF: "feature/safe-ref_1",
+    });
+  });
+
+  it("uses checkout for commit-like refs without interpolating the SHA", async () => {
+    const executor = createExecutor();
+    const tool = createGitCloneTool("ws_1", "http://ui.test", executor);
+
+    await tool.execute("call_1", {
+      label: "clone commit",
+      repo: "owner/repo",
+      ref: "29b242d",
+    });
+
+    const cloneCall = executor.exec.mock.calls.find(([command]) => command.includes("clone"));
+    const [cloneCommand, cloneOptions] = cloneCall!;
+    expect(cloneCommand).toContain('checkout "$GIT_REF"');
+    expect(cloneCommand).not.toContain("29b242d");
+    expect(cloneOptions?.env?.GIT_REF).toBe("29b242d");
+  });
+});

--- a/frontend/packages/agent/src/tools/git-clone.ts
+++ b/frontend/packages/agent/src/tools/git-clone.ts
@@ -12,6 +12,33 @@ const schema = Type.Object({
   ),
 });
 
+const GITHUB_REPO_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?\/[A-Za-z0-9._-]+$/;
+const GIT_REF_PATTERN = /^[A-Za-z0-9._/-]+$/;
+const FULL_OR_SHORT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
+
+function validationError(text: string): AgentToolResult<undefined> {
+  return { content: [{ type: "text", text }], details: undefined };
+}
+
+function validateCloneParams(repo: string, ref?: string): string | null {
+  if (!GITHUB_REPO_PATTERN.test(repo)) {
+    return "Invalid repository. Use GitHub 'owner/repo' format.";
+  }
+
+  if (
+    ref !== undefined &&
+    (!GIT_REF_PATTERN.test(ref) ||
+      ref.includes("..") ||
+      ref.startsWith("/") ||
+      ref.endsWith("/") ||
+      ref.includes("//"))
+  ) {
+    return "Invalid git ref. Use a branch, tag, or commit SHA containing only letters, numbers, '.', '_', '-', and '/'.";
+  }
+
+  return null;
+}
+
 export function createGitCloneTool(
   workspaceId: string,
   uiBaseUrl: string,
@@ -24,6 +51,9 @@ export function createGitCloneTool(
       "Clone a GitHub repository into the sandbox. Uses the user's GitHub App installation for authentication. After cloning, use bash/read to explore the code.",
     parameters: schema,
     execute: async (_, params): Promise<AgentToolResult<undefined>> => {
+      const invalid = validateCloneParams(params.repo, params.ref);
+      if (invalid) return validationError(invalid);
+
       // Ensure sandbox is ready
       if (!executor.isReady()) {
         await executor.init();
@@ -83,21 +113,47 @@ export function createGitCloneTool(
           };
         }
       } else {
-        const cloneUrl = `https://x-access-token:${token}@github.com/${params.repo}.git`;
+        const cloneUrl = `https://github.com/${params.repo}.git`;
+        const askpassPath = "/tmp/git-askpass.sh";
+        await executor.writeFile(
+          askpassPath,
+          [
+            "#!/bin/sh",
+            'case "$1" in',
+            '  Username*) printf "%s" "$GIT_USERNAME" ;;',
+            '  Password*) printf "%s" "$GIT_PASSWORD" ;;',
+            "esac",
+            "",
+          ].join("\n"),
+        );
+        await executor.exec(`chmod +x ${askpassPath}`);
 
         let cloneCmd: string;
-        if (params.ref) {
-          // Try as branch/tag first, fall back to fetch+checkout for commit SHAs
-          cloneCmd = `git clone --depth 1 --branch "${params.ref}" "${cloneUrl}" "${clonePath}" 2>/dev/null || (git clone "${cloneUrl}" "${clonePath}" && cd "${clonePath}" && git checkout "${params.ref}")`;
+        if (!params.ref) {
+          cloneCmd = `git -c credential.helper= -c core.hooksPath=/dev/null clone --depth 1 -- "$GIT_URL" "$GIT_DEST"`;
+        } else if (FULL_OR_SHORT_SHA_PATTERN.test(params.ref)) {
+          cloneCmd = `git -c credential.helper= -c core.hooksPath=/dev/null clone -- "$GIT_URL" "$GIT_DEST" && git -c credential.helper= -c core.hooksPath=/dev/null -C "$GIT_DEST" checkout "$GIT_REF"`;
         } else {
-          cloneCmd = `git clone --depth 1 "${cloneUrl}" "${clonePath}"`;
+          cloneCmd = `git -c credential.helper= -c core.hooksPath=/dev/null clone --depth 1 --branch "$GIT_REF" -- "$GIT_URL" "$GIT_DEST"`;
         }
 
-        const result = await executor.exec(cloneCmd, { timeout: 120 });
+        const result = await executor.exec(`( ${cloneCmd} ) 2>&1`, {
+          timeout: 120,
+          env: {
+            GIT_ASKPASS: askpassPath,
+            GIT_TERMINAL_PROMPT: "0",
+            GIT_USERNAME: "x-access-token",
+            GIT_PASSWORD: token,
+            GIT_URL: cloneUrl,
+            GIT_DEST: clonePath,
+            ...(params.ref ? { GIT_REF: params.ref } : {}),
+          },
+        });
 
         if (result.code !== 0) {
           // Sanitize error (remove token from output)
-          const sanitizedErr = result.stderr.replace(token, "[REDACTED]");
+          const output = result.stderr || result.stdout || "";
+          const sanitizedErr = output.replaceAll(token, "[REDACTED]");
           return {
             content: [
               {


### PR DESCRIPTION
## Summary
- Validate git_clone repo and ref inputs before fetching GitHub credentials.
- Pass clone URL, ref, destination, and token through environment variables in the Docker fallback instead of interpolating them into shell commands.
- Add agent tests covering rejected malicious inputs and safe Docker fallback command construction.

## Test plan
- IDE diagnostics: no errors
- `git diff --check`
- Attempted: `corepack pnpm test src/tools/__tests__/git-clone.test.ts`
- Blocked: local `node_modules` are missing, and `corepack pnpm install --frozen-lockfile` fails because current overrides do not match the lockfile.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened git clone execution to prevent shell injection and secret leakage in the agent’s Docker fallback. Validates inputs, moves credentials to env, and adds tests.

- **Bug Fixes**
  - Validate `owner/repo` and ref before fetching tokens or running git.
  - Pass clone URL, ref, dest, and credentials via env with `GIT_ASKPASS`; no secrets in command strings.
  - Handle branch/tag clones and SHA checkouts without interpolating the ref; redact tokens from output.
  - Forward env vars in `docker exec`; add tests for malicious inputs and safe command construction.

<sup>Written for commit df915552f52aee41ea215b764b81cb0ff0116065. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

