### PR TITLE
fix(worker): time out detector LLM eval to prevent worker slot exhaustion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,11 @@ AGENT_SERVICE_URL=http://localhost:8100
 # ANTHROPIC_API_KEY=sk-ant-...  # CHANGEME - required for Claude models (default)
 # OPENAI_API_KEY=sk-...         # CHANGEME - required if using GPT models
 
+# --- Detectors ----------------------------------------------------------------
+# Per-attempt wall-clock timeout (ms) for the detector LLM-as-judge eval. Bounds
+# a hung or unreachable provider so it can't stall the detector worker.
+# DETECTOR_EVAL_TIMEOUT_MS=60000
+
 # ── Sandbox Provider ──────────────────────────────────────────────────────────
 # Choose: "docker" (dev/self-hosted) or "daytona" (production/SaaS)
 SANDBOX_PROVIDER=docker

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -324,6 +324,10 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+      # --- Detector config ---
+      # Per-attempt wall-clock timeout (ms) for the LLM-as-judge eval call so a
+      # hung or unreachable provider can't pin a worker slot indefinitely.
+      DETECTOR_EVAL_TIMEOUT_MS: ${DETECTOR_EVAL_TIMEOUT_MS:-60000}
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
+++ b/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
@@ -232,6 +232,63 @@ describe("runDetectionForTrace", () => {
     expect(result.error).toBe("API rate limit");
   });
 
+  it("passes an AbortSignal to complete() so the call is cancellable", async () => {
+    mockComplete.mockResolvedValueOnce({
+      content: [
+        {
+          type: "toolCall",
+          name: "submit_result",
+          arguments: { identified: false, summary: "ok", data: {} },
+        },
+      ],
+      usage: ZERO_USAGE,
+      stopReason: "toolUse",
+    });
+
+    await runDetectionForTrace({
+      traceId: "t",
+      spansJsonl: "{}",
+      detector: { ...DETECTOR, detectionSource: "system" },
+      workspaceId: "ws-1",
+    });
+
+    const opts = mockComplete.mock.calls[0][2] as { signal?: AbortSignal };
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("aborts and returns a timeout error when the provider never responds", async () => {
+    vi.useFakeTimers();
+    try {
+      // Simulate a hung provider: the promise only settles if its signal aborts.
+      mockComplete.mockImplementationOnce((_model, _ctx, opts) => {
+        const { signal } = opts as { signal: AbortSignal };
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => {
+            const err = new Error("The operation was aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+        });
+      });
+
+      const promise = runDetectionForTrace({
+        traceId: "t",
+        spansJsonl: "{}",
+        detector: { ...DETECTOR, detectionSource: "system" },
+        workspaceId: "ws-1",
+      });
+
+      // Advance past the eval timeout; the AbortController fires and the call rejects.
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await promise;
+
+      expect(result.identified).toBe(false);
+      expect(result.error).toMatch(/timed out/i);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   describe("inference cost + source attribution", () => {
     it("captures system source cost on happy path", async () => {
       mockComplete.mockResolvedValueOnce({

--- a/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
+++ b/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
@@ -284,6 +284,7 @@ describe("runDetectionForTrace", () => {
 
       expect(result.identified).toBe(false);
       expect(result.error).toMatch(/timed out/i);
+      expect(mockComplete).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
+++ b/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
@@ -289,6 +289,40 @@ describe("runDetectionForTrace", () => {
     }
   });
 
+  it("classifies an aborted response (stopReason=aborted) as a timeout without retrying", async () => {
+    vi.useFakeTimers();
+    try {
+      // pi-ai may RESOLVE (not throw) with an aborted response once the signal
+      // fires: stopReason "aborted" + empty content. This must be treated as a
+      // timeout, not as a missing submit_result (which would retry).
+      mockComplete.mockImplementationOnce((_model, _ctx, opts) => {
+        const { signal } = opts as { signal: AbortSignal };
+        return new Promise((resolve) => {
+          signal.addEventListener("abort", () => {
+            resolve({ stopReason: "aborted", content: [], usage: ZERO_USAGE });
+          });
+        });
+      });
+
+      const promise = runDetectionForTrace({
+        traceId: "t",
+        spansJsonl: "{}",
+        detector: { ...DETECTOR, detectionSource: "system" },
+        workspaceId: "ws-1",
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      const result = await promise;
+
+      expect(result.identified).toBe(false);
+      expect(result.error).toMatch(/timed out/i);
+      expect(result.error).not.toMatch(/did not call submit_result/i);
+      expect(mockComplete).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   describe("inference cost + source attribution", () => {
     it("captures system source cost on happy path", async () => {
       mockComplete.mockResolvedValueOnce({

--- a/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
+++ b/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
@@ -25,7 +25,12 @@ vi.mock("@traceroot/core/model-resolver", () => ({
   findByokKeyForPiProvider: mockFindByokKey,
 }));
 
-import { runDetectionForTrace } from "../sandbox-eval.js";
+import {
+  runDetectionForTrace,
+  parseDetectorEvalTimeoutMs,
+  DEFAULT_DETECTOR_EVAL_TIMEOUT_MS,
+  MAX_DETECTOR_EVAL_TIMEOUT_MS,
+} from "../sandbox-eval.js";
 
 const DETECTOR = {
   id: "det-1",
@@ -257,6 +262,9 @@ describe("runDetectionForTrace", () => {
   });
 
   it("aborts and returns a timeout error when the provider never responds", async () => {
+    // Pin the timeout so the test is deterministic regardless of any ambient
+    // DETECTOR_EVAL_TIMEOUT_MS, and advance to exactly the configured bound.
+    vi.stubEnv("DETECTOR_EVAL_TIMEOUT_MS", "5000");
     vi.useFakeTimers();
     try {
       // Simulate a hung provider: the promise only settles if its signal aborts.
@@ -279,18 +287,20 @@ describe("runDetectionForTrace", () => {
       });
 
       // Advance past the eval timeout; the AbortController fires and the call rejects.
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(5_000);
       const result = await promise;
 
       expect(result.identified).toBe(false);
-      expect(result.error).toMatch(/timed out/i);
+      expect(result.error).toMatch(/timed out after 5000ms/i);
       expect(mockComplete).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
+      vi.unstubAllEnvs();
     }
   });
 
   it("classifies an aborted response (stopReason=aborted) as a timeout without retrying", async () => {
+    vi.stubEnv("DETECTOR_EVAL_TIMEOUT_MS", "5000");
     vi.useFakeTimers();
     try {
       // pi-ai may RESOLVE (not throw) with an aborted response once the signal
@@ -312,7 +322,7 @@ describe("runDetectionForTrace", () => {
         workspaceId: "ws-1",
       });
 
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(5_000);
       const result = await promise;
 
       expect(result.identified).toBe(false);
@@ -321,7 +331,32 @@ describe("runDetectionForTrace", () => {
       expect(mockComplete).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
+      vi.unstubAllEnvs();
     }
+  });
+
+  describe("parseDetectorEvalTimeoutMs", () => {
+    it("accepts valid positive values up to the Node timer max", () => {
+      expect(parseDetectorEvalTimeoutMs("30000")).toBe(30000);
+      expect(parseDetectorEvalTimeoutMs(String(MAX_DETECTOR_EVAL_TIMEOUT_MS))).toBe(
+        MAX_DETECTOR_EVAL_TIMEOUT_MS,
+      );
+    });
+
+    it.each([
+      ["undefined", undefined],
+      ["empty string", ""],
+      ["whitespace", "   "],
+      ["zero", "0"],
+      ["negative", "-1000"],
+      ["Infinity", "Infinity"],
+      ["non-numeric", "abc"],
+      ["over the Node timer max", String(MAX_DETECTOR_EVAL_TIMEOUT_MS + 1)],
+    ])("falls back to the default for %s", (_label, raw) => {
+      expect(parseDetectorEvalTimeoutMs(raw as string | undefined)).toBe(
+        DEFAULT_DETECTOR_EVAL_TIMEOUT_MS,
+      );
+    });
   });
 
   describe("inference cost + source attribution", () => {

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -201,6 +201,16 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
         signal: controller.signal,
       } as Record<string, unknown>);
 
+      // A timed-out call may RESOLVE with an aborted response (stopReason
+      // "aborted", empty content) rather than throwing. Treat that exactly like
+      // the thrown-abort case in catch: record a timeout and stop — do NOT fall
+      // through to the "no submit_result" retry, which would burn a second
+      // provider call and mislabel the failure.
+      if (controller.signal.aborted || response.stopReason === "aborted") {
+        lastError = `detector eval timed out after ${DETECTOR_EVAL_TIMEOUT_MS}ms (model=${model.id}, api=${model.api})`;
+        break;
+      }
+
       inferenceCost += response.usage?.cost?.total ?? 0;
       inferenceInputTokens += response.usage?.input ?? 0;
       inferenceOutputTokens += response.usage?.output ?? 0;

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -189,14 +189,17 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
   let inferenceProvider: string | null = null;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    // Per-attempt timeout: pi-ai forwards this signal to the provider fetch,
+    // which otherwise has no upper bound. Declared outside the try so the catch
+    // can distinguish a timeout (controller.signal.aborted) from a real error.
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DETECTOR_EVAL_TIMEOUT_MS);
     try {
-      const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), DETECTOR_EVAL_TIMEOUT_MS);
       const response = await complete(model, { systemPrompt, messages, tools: [submitTool] }, {
         apiKey,
         toolChoice: TOOL_CHOICE,
         signal: controller.signal,
-      } as Record<string, unknown>).finally(() => clearTimeout(timeout));
+      } as Record<string, unknown>);
 
       inferenceCost += response.usage?.cost?.total ?? 0;
       inferenceInputTokens += response.usage?.input ?? 0;
@@ -247,13 +250,14 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
         timestamp: Date.now(),
       });
     } catch (err) {
-      const isTimeout = err instanceof Error && err.name === "AbortError";
-      lastError = isTimeout
+      lastError = controller.signal.aborted
         ? `detector eval timed out after ${DETECTOR_EVAL_TIMEOUT_MS}ms (model=${model.id}, api=${model.api})`
         : err instanceof Error
           ? err.message
           : String(err);
       break;
+    } finally {
+      clearTimeout(timeout);
     }
   }
 

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -57,8 +57,14 @@ const SYSTEM_DEFAULT_MODEL = "claude-haiku-4-5";
  * Such a call would pin a BullMQ worker slot indefinitely (an I/O-bound handler
  * is never marked stalled, never retried), and enough of them drain the pool and
  * halt the whole detector-run queue. Override with DETECTOR_EVAL_TIMEOUT_MS.
+ * Ignore non-positive / non-finite overrides: 0 or a negative value would make
+ * setTimeout fire immediately and abort every eval, so fall back to the default.
  */
-const DETECTOR_EVAL_TIMEOUT_MS = Number(process.env.DETECTOR_EVAL_TIMEOUT_MS) || 60_000;
+const DETECTOR_EVAL_TIMEOUT_MS_OVERRIDE = Number(process.env.DETECTOR_EVAL_TIMEOUT_MS);
+const DETECTOR_EVAL_TIMEOUT_MS =
+  Number.isFinite(DETECTOR_EVAL_TIMEOUT_MS_OVERRIDE) && DETECTOR_EVAL_TIMEOUT_MS_OVERRIDE > 0
+    ? DETECTOR_EVAL_TIMEOUT_MS_OVERRIDE
+    : 60_000;
 
 /**
  * `tool_choice` value sent to every provider for detector eval.

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -1,5 +1,5 @@
 import { complete, getEnvApiKey } from "@earendil-works/pi-ai";
-import type { Message, ToolCall } from "@earendil-works/pi-ai";
+import type { Message, ToolCall, ProviderStreamOptions } from "@earendil-works/pi-ai";
 import {
   findByokKeyForPiProvider,
   fetchProviderConfig,
@@ -49,22 +49,24 @@ const MAX_ATTEMPTS = 2;
 const SAFETY_TRUNCATE_CHARS = 150_000;
 /** Default screening model for system source — cheap-and-fast, not the agent default. */
 const SYSTEM_DEFAULT_MODEL = "claude-haiku-4-5";
+/** Fallback per-attempt timeout when DETECTOR_EVAL_TIMEOUT_MS is unset or invalid. */
+export const DEFAULT_DETECTOR_EVAL_TIMEOUT_MS = 60_000;
+/** Node's setTimeout max delay; larger values clamp to 1ms (an instant abort). */
+export const MAX_DETECTOR_EVAL_TIMEOUT_MS = 2_147_483_647;
+
 /**
- * Per-attempt wall-clock cap on the judge LLM call. pi-ai forwards an
- * AbortSignal to the provider fetch but imposes no default timeout, and Node's
- * fetch has none either — so a provider that accepts the connection but never
- * responds (stalled socket / hung stream) leaves `complete()` pending forever.
- * Such a call would pin a BullMQ worker slot indefinitely (an I/O-bound handler
- * is never marked stalled, never retried), and enough of them drain the pool and
- * halt the whole detector-run queue. Override with DETECTOR_EVAL_TIMEOUT_MS.
- * Ignore non-positive / non-finite overrides: 0 or a negative value would make
- * setTimeout fire immediately and abort every eval, so fall back to the default.
+ * Parse DETECTOR_EVAL_TIMEOUT_MS into a per-attempt cap (ms) on one complete() call.
+ * Falls back to the default for anything that would break the watchdog — unset/empty,
+ * non-numeric, non-finite, non-positive, or above the Node timer max — since each of
+ * those would otherwise abort every eval immediately. Read at call time so the
+ * deployed value is honored and tests can vary it.
  */
-const DETECTOR_EVAL_TIMEOUT_MS_OVERRIDE = Number(process.env.DETECTOR_EVAL_TIMEOUT_MS);
-const DETECTOR_EVAL_TIMEOUT_MS =
-  Number.isFinite(DETECTOR_EVAL_TIMEOUT_MS_OVERRIDE) && DETECTOR_EVAL_TIMEOUT_MS_OVERRIDE > 0
-    ? DETECTOR_EVAL_TIMEOUT_MS_OVERRIDE
-    : 60_000;
+export function parseDetectorEvalTimeoutMs(raw: string | undefined): number {
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 && parsed <= MAX_DETECTOR_EVAL_TIMEOUT_MS
+    ? parsed
+    : DEFAULT_DETECTOR_EVAL_TIMEOUT_MS;
+}
 
 /**
  * `tool_choice` value sent to every provider for detector eval.
@@ -194,26 +196,34 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
   let inferenceModel: string | null = null;
   let inferenceProvider: string | null = null;
 
+  // Per-attempt cap, read at call time so the deployed value is honored.
+  const timeoutMs = parseDetectorEvalTimeoutMs(process.env.DETECTOR_EVAL_TIMEOUT_MS);
+  const timeoutMessage = `detector eval timed out after ${timeoutMs}ms (model=${model.id}, api=${model.api})`;
+
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    // Per-attempt timeout: pi-ai forwards this signal to the provider fetch,
-    // which otherwise has no upper bound. Declared outside the try so the catch
-    // can distinguish a timeout (controller.signal.aborted) from a real error.
+    // Fresh controller per attempt. The signal is what cancels the underlying
+    // provider fetch (pi-ai forwards it); a timer alone can't. Declared outside the
+    // try so the catch can tell a timeout (signal.aborted) from a real error. A
+    // timeout is TERMINAL — every abort branch breaks, so a hung provider is hit once.
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), DETECTOR_EVAL_TIMEOUT_MS);
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    timeout.unref?.();
     try {
-      const response = await complete(model, { systemPrompt, messages, tools: [submitTool] }, {
+      const options: ProviderStreamOptions = {
         apiKey,
         toolChoice: TOOL_CHOICE,
         signal: controller.signal,
-      } as Record<string, unknown>);
+      };
+      const response = await complete(
+        model,
+        { systemPrompt, messages, tools: [submitTool] },
+        options,
+      );
 
-      // A timed-out call may RESOLVE with an aborted response (stopReason
-      // "aborted", empty content) rather than throwing. Treat that exactly like
-      // the thrown-abort case in catch: record a timeout and stop — do NOT fall
-      // through to the "no submit_result" retry, which would burn a second
-      // provider call and mislabel the failure.
+      // pi-ai may RESOLVE an aborted call with stopReason "aborted" rather than
+      // throwing. Treat it as a terminal timeout — not a missing-submit_result retry.
       if (controller.signal.aborted || response.stopReason === "aborted") {
-        lastError = `detector eval timed out after ${DETECTOR_EVAL_TIMEOUT_MS}ms (model=${model.id}, api=${model.api})`;
+        lastError = timeoutMessage;
         break;
       }
 
@@ -266,8 +276,10 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
         timestamp: Date.now(),
       });
     } catch (err) {
+      // A thrown AbortError (transports that reject rather than resolve) is the
+      // same terminal timeout; anything else is a genuine error. Either way, stop.
       lastError = controller.signal.aborted
-        ? `detector eval timed out after ${DETECTOR_EVAL_TIMEOUT_MS}ms (model=${model.id}, api=${model.api})`
+        ? timeoutMessage
         : err instanceof Error
           ? err.message
           : String(err);

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -49,6 +49,16 @@ const MAX_ATTEMPTS = 2;
 const SAFETY_TRUNCATE_CHARS = 150_000;
 /** Default screening model for system source — cheap-and-fast, not the agent default. */
 const SYSTEM_DEFAULT_MODEL = "claude-haiku-4-5";
+/**
+ * Per-attempt wall-clock cap on the judge LLM call. pi-ai forwards an
+ * AbortSignal to the provider fetch but imposes no default timeout, and Node's
+ * fetch has none either — so a provider that accepts the connection but never
+ * responds (stalled socket / hung stream) leaves `complete()` pending forever.
+ * Such a call would pin a BullMQ worker slot indefinitely (an I/O-bound handler
+ * is never marked stalled, never retried), and enough of them drain the pool and
+ * halt the whole detector-run queue. Override with DETECTOR_EVAL_TIMEOUT_MS.
+ */
+const DETECTOR_EVAL_TIMEOUT_MS = Number(process.env.DETECTOR_EVAL_TIMEOUT_MS) || 60_000;
 
 /**
  * `tool_choice` value sent to every provider for detector eval.
@@ -180,10 +190,13 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), DETECTOR_EVAL_TIMEOUT_MS);
       const response = await complete(model, { systemPrompt, messages, tools: [submitTool] }, {
         apiKey,
         toolChoice: TOOL_CHOICE,
-      } as Record<string, unknown>);
+        signal: controller.signal,
+      } as Record<string, unknown>).finally(() => clearTimeout(timeout));
 
       inferenceCost += response.usage?.cost?.total ?? 0;
       inferenceInputTokens += response.usage?.input ?? 0;
@@ -234,7 +247,12 @@ ${spansJsonl.slice(0, SAFETY_TRUNCATE_CHARS)}`;
         timestamp: Date.now(),
       });
     } catch (err) {
-      lastError = err instanceof Error ? err.message : String(err);
+      const isTimeout = err instanceof Error && err.name === "AbortError";
+      lastError = isTimeout
+        ? `detector eval timed out after ${DETECTOR_EVAL_TIMEOUT_MS}ms (model=${model.id}, api=${model.api})`
+        : err instanceof Error
+          ? err.message
+          : String(err);
       break;
     }
   }


### PR DESCRIPTION
## Summary

Fixes #1193 

Detector evals had no upper bound on the LLM judge call: the worker passed no `AbortSignal`, pi-ai's providers impose no default timeout, and Node's `fetch` has no total-request timeout. A provider — or a user-supplied BYOK `baseUrl` — that accepts the connection but never responds left `complete()` pending forever, permanently pinning a BullMQ worker slot (an I/O-bound handler is never marked stalled, never retried). Enough hung calls drain the pool and silently halt all detection until the worker restarts.

This PR bounds each eval attempt with a configurable timeout and classifies aborted evals as timeouts instead of "missing tool call" retries.

## How it works

```
detector eval (per attempt)
  → create AbortController + setTimeout(abort, DETECTOR_EVAL_TIMEOUT_MS)
    → complete(model, …, { signal })          // pi-ai forwards signal → provider fetch
      → timer fires → controller.abort()
        → cancellation surfaces two ways (transport-dependent):
            • complete() THROWS an AbortError                → caught
            • complete() RESOLVES { stopReason: "aborted" }  → detected inline  ← pi-ai's real behavior
        → record "detector eval timed out after <ms>ms", break (NO retry)
          → run written with status = failed
  finally → clearTimeout
```

**Why an `AbortSignal`, not just a timer:** a timer can't cancel an in-flight `fetch` — without a signal the hung call keeps pending. The signal is the cancellation handle; pi-ai forwards it to the provider request, so `abort()` actually stops the call. Because pi-ai catches its own abort and **resolves** with `stopReason: "aborted"` (rather than rejecting), the loop checks both `controller.signal.aborted` and `response.stopReason === "aborted"`; the thrown-`AbortError` branch stays as defensive coverage for transports that do reject.

Key invariant: **a timed-out eval fails fast and never retries** — one provider hit, not two.

## What's included

### Worker
- `frontend/worker/src/detection/sandbox-eval.ts` — per-attempt `AbortController` timeout passed into `complete()`; aborted evals (thrown `AbortError` **or** resolved `stopReason: "aborted"`) classified as timeouts and short-circuited; `clearTimeout` in `finally`; non-positive / non-finite `DETECTOR_EVAL_TIMEOUT_MS` overrides ignored.
- `frontend/worker/src/detection/__tests__/sandbox-eval.test.ts` — three new tests: signal forwarded to `complete()`, abort-via-throw, abort-via-resolved-`stopReason` (asserts timeout error + no retry).

### Infrastructure & config
- `docker-compose.prod.yml` — `DETECTOR_EVAL_TIMEOUT_MS: ${DETECTOR_EVAL_TIMEOUT_MS:-60000}` added to the `detector` service (the only one that runs the eval). Without it the container fell back to the code default regardless of root `.env`.
- `.env.example` — documents the variable.

## Configuration

`DETECTOR_EVAL_TIMEOUT_MS` — per-attempt wall-clock bound on the judge call.
- **Default `60000` (60s).** Generous for the default Haiku screening path (capped prompt, tiny tool-call output). Kept at 60s deliberately — a larger default doubles the slot-hold on a genuine hang.
- **Override** plumbed through Docker and documented; non-positive / non-finite values fall back to the default.
- **Guidance:** slow BYOK / local / reasoning models, or very large near-cap traces, may want `120000`–`180000`.

## Test plan
- [x] Hung provider (blackhole) → eval aborts at the bound, one provider request, no retry
- [x] `detector_runs` row written `status=failed` for the timed-out eval
- [x] Unit: signal forwarded; abort-via-throw; abort-via-resolved-`stopReason` (no retry)
- [x] Normal plain-text response still retries once (existing test)
- [x] `DETECTOR_EVAL_TIMEOUT_MS` override reaches the detector container in `dev-lite` / `prod-lite`
- [x] Healthy provider/key still produces a normal finding/clean run (no false timeout)
- [x] Non-positive override (`0` / negative) falls back to 60s (no instant abort)