### PR TITLE
fix(examples): migrate vercel-ai example to AI SDK v6

### DIFF
--- a/examples/typescript/vercel-ai/agent.ts
+++ b/examples/typescript/vercel-ai/agent.ts
@@ -15,7 +15,7 @@
 
 import 'dotenv/config';
 
-import { generateText, tool } from 'ai';
+import { generateText, tool, stepCountIs } from 'ai';
 import { openai } from '@ai-sdk/openai';
 import { z } from 'zod';
 import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
@@ -49,7 +49,7 @@ async function runAgent(query: string): Promise<string> {
   return observe({ name: 'vercel_ai_agent', type: 'agent' }, async () => {
     const result = await generateText({
       model: openai('gpt-4o-mini'),
-      maxSteps: 5,
+      stopWhen: stepCountIs(5),
       system:
         'You are a helpful AI assistant with access to weather and stock tools. ' +
         'Use the tools to answer user questions accurately.',
@@ -60,7 +60,7 @@ async function runAgent(query: string): Promise<string> {
       tools: {
         getWeather: tool({
           description: 'Get current weather for a city',
-          parameters: z.object({
+          inputSchema: z.object({
             city: z.string().describe('The city name'),
           }),
           execute: async ({ city }) => {
@@ -76,7 +76,7 @@ async function runAgent(query: string): Promise<string> {
         }),
         getStockPrice: tool({
           description: 'Get current stock price for a ticker symbol',
-          parameters: z.object({
+          inputSchema: z.object({
             symbol: z.string().describe('Stock ticker symbol e.g. AAPL'),
           }),
           execute: async ({ symbol }) => {
@@ -89,7 +89,7 @@ async function runAgent(query: string): Promise<string> {
         }),
         calculate: tool({
           description: 'Evaluate a mathematical expression',
-          parameters: z.object({
+          inputSchema: z.object({
             expression: z.string().describe("Math expression e.g. '2 + 2 * 3'"),
           }),
           execute: async ({ expression }) => {

--- a/examples/typescript/vercel-ai/package.json
+++ b/examples/typescript/vercel-ai/package.json
@@ -7,12 +7,12 @@
     "demo:streaming": "tsx agent-streaming.ts"
   },
   "dependencies": {
-    "@ai-sdk/openai": "^1.0.0",
+    "@ai-sdk/openai": "^3.0.0",
     "@traceroot-ai/traceroot": "^0.1.6",
-    "ai": "^4.0.0",
+    "ai": "^6.0.0",
     "dotenv": "^16.0.0",
     "openai": "^6.0.0",
-    "zod": "^3.0.0"
+    "zod": "^4.1.8"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
## What

Migrates the `examples/typescript/vercel-ai` example from Vercel AI SDK v4 to v6 (the line we test on). The example was pinned to `ai ^4` / `@ai-sdk/openai ^1` and no longer compiled against current stable (`ai 6.0.205`).

## Why it was broken

Two v4 APIs were removed/renamed in v5+:

1. **`generateText({ maxSteps })` → `stopWhen: stepCountIs(n)`.** Beyond the type error, the v6 default is `stepCountIs(1)` — so a v6 run would silently stop after one step and never invoke the tools, defeating the point of a multi-step tool-use demo.
2. **`tool({ parameters }) → tool({ inputSchema })`.** The renamed key collapses each tool's input type, breaking every `execute` callback.

Additionally, `ai@6` needs zod's **v4** type internals for tool input inference. Its runtime peer range (`^3.25.76 || ^4.1.8`) allows zod 3, but any zod 3 line degrades the inferred tool input to `{ [x: string]: unknown }` (`TS2589` / missing property). Verified the failure on both `zod@3.0.x` and `zod@3.25.76`; only `zod@4` typechecks clean.

## Changes

- `package.json`: `ai ^6.0.0`, `@ai-sdk/openai ^3.0.0`, `zod ^4.1.8`.
- `agent.ts`: import `stepCountIs`; `maxSteps: 5` → `stopWhen: stepCountIs(5)`; three `parameters:` → `inputSchema:`.

`agent-streaming.ts` was already v6-compatible (only `generateText`/`streamText` with `system`/`prompt`/`experimental_telemetry`, none of which changed) and is untouched. `experimental_telemetry` still exists in v6, so the "no `instrumentModules`" premise of the example holds.

## Verification

`agent.ts` typechecks clean (`tsc --noEmit`, exit 0) against `ai@6.0.205` + `@ai-sdk/openai@3.0.71` + `zod@4.4.3`. This is a standalone example outside the frontend/backend suites, so the diff-coverage gate does not apply.

closes #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate the `examples/typescript/vercel-ai` example to AI SDK v6 so it compiles and the multi-step tool demo works again. Updates APIs and deps; the streaming demo is unchanged.

- **Migration**
  - Replace `maxSteps: 5` with `stopWhen: stepCountIs(5)` to keep multi-step behavior.
  - Rename `tool({ parameters })` to `tool({ inputSchema })` for all tools.
  - Leave `agent-streaming.ts` as-is (already v6 compatible).

- **Dependencies**
  - Bump `ai` to `^6.0.0`, `@ai-sdk/openai` to `^3.0.0`, and `zod` to `^4.1.8`.
  - Use `zod@4` to restore correct tool input inference (v3 degrades types).

<sup>Written for commit 327c06f52d047257181ffd41b54f0ae0ee87e182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

