### PR TITLE
feat(models): add Opus 4.8 and hosted OpenAI models to the model catalog

### DIFF
--- a/docs/integrations/internal-models.mdx
+++ b/docs/integrations/internal-models.mdx
@@ -9,8 +9,9 @@ TraceRoot Cloud provides the following models out of the box — no API key requ
 
 | Model               | Description                                            |
 | ------------------- | ------------------------------------------------------ |
-| `claude-opus-4-7`   | Most capable model for complex reasoning and debugging |
-| `claude-opus-4-6`   | Previous Opus generation                               |
+| `claude-opus-4-8`   | Most capable model for complex reasoning and debugging |
+| `claude-opus-4-7`   | Previous Opus generation                               |
+| `claude-opus-4-6`   | Earlier Opus generation                                |
 | `claude-sonnet-4-6` | Balanced performance and speed                         |
 | `claude-opus-4-5`   | Earlier Opus generation                                |
 | `claude-sonnet-4-5` | Previous Sonnet generation                             |
@@ -20,7 +21,11 @@ TraceRoot Cloud provides the following models out of the box — no API key requ
 
 | Model           | Description                            |
 | --------------- | -------------------------------------- |
-| `gpt-5`         | OpenAI's most capable model            |
+| `gpt-5.5`       | OpenAI's most capable model            |
+| `gpt-5.4`       | Balanced GPT-5.4 model                 |
+| `gpt-5.4-mini`  | Fast and cost-efficient GPT-5.4 variant |
+| `gpt-5.4-nano`  | Smallest, lowest-cost GPT-5.4 variant  |
+| `gpt-5`         | Previous flagship model                |
 | `gpt-5-mini`    | Fast and cost-efficient GPT-5 variant  |
 | `gpt-5.3-codex` | Code-optimized model via Responses API |
 | `o3`            | Advanced reasoning model               |

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -90,6 +90,7 @@ export const SYSTEM_MODELS: {
     piAIProvider: "anthropic",
     apiProtocol: "anthropic-messages",
     models: [
+      { id: "claude-opus-4-8", label: "claude-opus-4-8" },
       { id: "claude-opus-4-7", label: "claude-opus-4-7" },
       { id: "claude-opus-4-6", label: "claude-opus-4-6" },
       { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
@@ -104,6 +105,10 @@ export const SYSTEM_MODELS: {
     piAIProvider: "openai",
     apiProtocol: "openai-completions",
     models: [
+      { id: "gpt-5.5", label: "gpt-5.5" },
+      { id: "gpt-5.4", label: "gpt-5.4" },
+      { id: "gpt-5.4-mini", label: "gpt-5.4-mini" },
+      { id: "gpt-5.4-nano", label: "gpt-5.4-nano" },
       { id: "gpt-5", label: "gpt-5" },
       { id: "gpt-5-mini", label: "gpt-5-mini" },
       { id: "o3", label: "o3" },
@@ -149,6 +154,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "o4-mini", label: "o4-mini" },
   ],
   anthropic: [
+    { id: "claude-opus-4-8", label: "claude-opus-4-8" },
     { id: "claude-opus-4-7", label: "claude-opus-4-7" },
     { id: "claude-opus-4-6", label: "claude-opus-4-6" },
     { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },


### PR DESCRIPTION
Fixes #978 

## Summary

Adds the **model catalog / selectable** layer for the latest models.

> ⚠️ **Depends on #987 landing first.** A model that is selectable here but unpriced would silently bill $0, so it should merge before this.

## Changes

`frontend/packages/core/src/llm-providers.ts`:
- Add `claude-opus-4-8` to `SYSTEM_MODELS.anthropic` (hosted) and `ADAPTER_MODELS.anthropic` (BYOK dropdown).
- Add the already-priced, already-BYOK OpenAI models that were lagging in the hosted catalog to `SYSTEM_MODELS.openai`: `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`.

`docs/integrations/internal-models.mdx`:
- Update the hosted Anthropic and OpenAI model tables to match.

## Out of scope

- Pricing data (`standard-model-prices.json`) and pricing tests — owned by #987.
- Hosted support for Gemini / Grok / Kimi / GLM / DeepSeek — BYOK-only by design (#978).

## Verification

- `pnpm exec vitest run src/__tests__/llm-providers.test.ts` — 8/8 pass (SYSTEM_MODELS / ADAPTER_MODELS consistency, incl. shared-ID apiProtocol agreement).
- All newly-hosted OpenAI models already have pricing entries on `main`, so plain IDs resolve to non-zero cost.