### PR TITLE
fix(frontend): allow clearing pagination page input

### DIFF
--- a/frontend/ui/src/components/list-pagination.test.tsx
+++ b/frontend/ui/src/components/list-pagination.test.tsx
@@ -56,4 +56,24 @@ describe("ListPagination", () => {
     expect(onPageChange).not.toHaveBeenCalled();
     expect(input.value).toBe("8");
   });
+
+  it("clamps an out-of-range page number on blur", () => {
+    const onPageChange = vi.fn();
+    render(
+      <ListPagination
+        page={0}
+        limit={50}
+        total={500}
+        onPageChange={onPageChange}
+        onLimitChange={vi.fn()}
+      />,
+    ); // 500 / 50 = 10 total pages
+
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "9999" } });
+    fireEvent.blur(input);
+
+    expect(onPageChange).toHaveBeenCalledWith(9); // clamped to last page (0-indexed: page 10 → index 9)
+    expect(input.value).toBe("10"); // input reflects the clamped value, not 9999
+  });
 });

--- a/frontend/ui/src/components/list-pagination.test.tsx
+++ b/frontend/ui/src/components/list-pagination.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { ListPagination } from "./list-pagination";
+
+afterEach(cleanup);
+
+describe("ListPagination", () => {
+  it("allows the page input to be cleared while editing", () => {
+    const onPageChange = vi.fn();
+    const onLimitChange = vi.fn();
+
+    render(
+      <ListPagination
+        page={7}
+        limit={50}
+        total={12450}
+        onPageChange={onPageChange}
+        onLimitChange={onLimitChange}
+      />,
+    );
+
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+
+    expect(input.value).toBe("8");
+
+    fireEvent.change(input, { target: { value: "" } });
+    expect(input.value).toBe("");
+
+    fireEvent.change(input, { target: { value: "150" } });
+    fireEvent.blur(input);
+
+    expect(onPageChange).toHaveBeenCalledWith(149);
+    expect(input.value).toBe("150");
+  });
+
+  it("restores the current page when an empty input is blurred", () => {
+    const onPageChange = vi.fn();
+    const onLimitChange = vi.fn();
+
+    render(
+      <ListPagination
+        page={7}
+        limit={50}
+        total={12450}
+        onPageChange={onPageChange}
+        onLimitChange={onLimitChange}
+      />,
+    );
+
+    const input = screen.getByRole("spinbutton") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+
+    expect(onPageChange).not.toHaveBeenCalled();
+    expect(input.value).toBe("8");
+  });
+});

--- a/frontend/ui/src/components/list-pagination.tsx
+++ b/frontend/ui/src/components/list-pagination.tsx
@@ -53,7 +53,7 @@ export function ListPagination({
 
   const handlePageInputChange = () => {
     const val = parseInt(pageState, 10);
-    if (!isNaN(val) && val >= 1 && val <= totalPages) {
+    if (!isNaN(val)) {
       const clamped = Math.min(Math.max(1, val), totalPages);
       onPageChange(clamped - 1);
       setPageState(String(clamped));

--- a/frontend/ui/src/components/list-pagination.tsx
+++ b/frontend/ui/src/components/list-pagination.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { ChevronLeft, ChevronRight, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -32,14 +32,35 @@ export function ListPagination({
 }: ListPaginationProps) {
   const [itemsPerPageOpen, setItemsPerPageOpen] = useState(false);
 
-  if (total <= 0) return null;
-
   // Defend against invalid `limit` propagating from URL/state (0, negative,
   // NaN, Infinity) — without this, `Math.ceil(total / 0)` is Infinity and
   // negative limits give negative `totalPages`, breaking nav controls.
   const safeLimit =
     Number.isFinite(limit) && limit >= 1 ? Math.floor(limit) : itemsPerPageOptions[0];
   const totalPages = Math.max(1, Math.ceil(total / safeLimit));
+
+  // Transient string for the input. Lets the field be emptied mid-edit
+  // without React snapping it back to the last valid page number.
+  const [pageState, setPageState] = useState(String(page + 1));
+
+  // Keep the input in sync when the page changes externally
+  // Example: (prev/next/first/last buttons, or parent-driven updates).
+  useEffect(() => {
+    setPageState(String(page + 1));
+  }, [page]);
+
+  if (total <= 0) return null;
+
+  const handlePageInputChange = () => {
+    const val = parseInt(pageState, 10);
+    if (!isNaN(val) && val >= 1 && val <= totalPages) {
+      const clamped = Math.min(Math.max(1, val), totalPages);
+      onPageChange(clamped - 1);
+      setPageState(String(clamped));
+    } else {
+      setPageState(String(page + 1)); // Reset to current page if invalid input
+    }
+  };
 
   return (
     <div className="flex items-center justify-end gap-6 border-t border-border bg-background px-4 py-2.5">
@@ -81,11 +102,12 @@ export function ListPagination({
           type="number"
           min={1}
           max={totalPages}
-          value={page + 1}
-          onChange={(e) => {
-            const val = parseInt(e.target.value, 10);
-            if (!isNaN(val) && val >= 1 && val <= totalPages) {
-              onPageChange(val - 1);
+          value={pageState}
+          onChange={(e) => setPageState(e.target.value)}
+          onBlur={handlePageInputChange}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.currentTarget.blur();
             }
           }}
           className="h-7 w-12 rounded border border-border bg-background px-2 py-1 text-center text-[12px] [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"


### PR DESCRIPTION
# fix(frontend): allow clearing the pagination page input

Fixes #1198

## Summary

This PR fixes the pagination page-number input so it can be fully cleared while editing. The input no longer forces a digit to remain in the field on every keystroke. Instead, it allows transient empty/string states during typing and only validates/clamps the value on blur or Enter.

## Type of Change

- [x] bug fix

## Approach

The input was fully controlled by `page`, with validation running on every keystroke - any empty/invalid value was dropped, snapping the field back. Fixed by adding local string state for the input's displayed value (decoupled from `page`), so it can be freely cleared/edited. Validation and clamping `(1–totalPages)` now happen only on blur or Enter, with the field resyncing to `page` after commit or on external page changes (nav buttons).

## Details

The change is made in the shared pagination component, `frontend/ui/src/components/list-pagination.tsx`, which is the universal pagination control used wherever list pagination is rendered in the UI.

This component is used by:

- `frontend/ui/src/app/projects/[projectId]/traces/page.tsx`
- `frontend/ui/src/app/projects/[projectId]/users/page.tsx`
- `frontend/ui/src/app/projects/[projectId]/sessions/page.tsx`
- `frontend/ui/src/app/projects/[projectId]/detectors/page.tsx`
- `frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx`
- `frontend/ui/src/app/dev/pagination/page.tsx` for local UI verification

## Changes

- The Page input can now be fully cleared.
- Users can type a new page number after clearing the field.
- Invalid or out-of-range values are handled on blur or when pressing Enter.
- The component remains the shared pagination implementation for all applicable paginated list views.

## Verification and Screenshot

- Added a development-only mock pagination page for reproducing the issue without backend data.

**Empty Page State**
<img width="1920" height="968" alt="Screenshot from 2026-06-16 01-31-46" src="https://github.com/user-attachments/assets/0b0726e8-7340-4122-b2c0-d2c9426e1ebb" />

**New Entered Page State**
<img width="1920" height="968" alt="Screenshot from 2026-06-16 01-32-11" src="https://github.com/user-attachments/assets/f7545a44-e12d-4cf1-a198-fef643b97679" />



## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have added screenshots or recordings for UI changes, if applicable

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the pagination page input so it can be fully cleared while typing. The field accepts empty text and only commits a clamped page on blur or Enter, staying in sync with nav buttons and parent-driven changes.

- **Bug Fixes**
  - Keep page text in local state and sync from external `page`.
  - On blur/Enter, clamp to 1–totalPages; if empty/invalid, restore the current page. The input reflects the clamped value. Added tests for clearing, empty-blur restore, and out-of-range clamping.

<sup>Written for commit 13b2ccf9b8854d95cc0878b4ccc09f0f901fe236. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

