### PR TITLE
chore: bump @traceroot-ai/traceroot to ^0.1.6 in TS examples

### DIFF
--- a/examples/typescript/deepseek/package.json
+++ b/examples/typescript/deepseek/package.json
@@ -6,7 +6,7 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "0.1.2",
+    "@traceroot-ai/traceroot": "^0.1.6",
     "dotenv": "^16.4.5",
     "openai": "^6.7.0"
   },

--- a/examples/typescript/langchain/package.json
+++ b/examples/typescript/langchain/package.json
@@ -7,7 +7,7 @@
     "demo": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "0.1.2",
+    "@traceroot-ai/traceroot": "^0.1.6",
     "@langchain/core": "^1.0.0",
     "@langchain/langgraph": "^1.0.0",
     "@langchain/openai": "^1.0.0",

--- a/examples/typescript/openai-agents/package.json
+++ b/examples/typescript/openai-agents/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@openai/agents": "^0.8.5",
-    "@traceroot-ai/traceroot": "0.1.3",
+    "@traceroot-ai/traceroot": "^0.1.6",
     "dotenv": "^16.4.5",
     "openai": "^6.34.0",
     "zod": "^4.0.0"

--- a/examples/typescript/openai/package.json
+++ b/examples/typescript/openai/package.json
@@ -9,7 +9,7 @@
     "streaming": "tsx streaming-pipeline.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "0.1.2",
+    "@traceroot-ai/traceroot": "^0.1.6",
     "dotenv": "^16.4.5",
     "openai": "^6.7.0"
   },

--- a/examples/typescript/openrouter/package.json
+++ b/examples/typescript/openrouter/package.json
@@ -7,7 +7,7 @@
     "start": "tsx agent.ts"
   },
   "dependencies": {
-    "@traceroot-ai/traceroot": "0.1.2",
+    "@traceroot-ai/traceroot": "^0.1.6",
     "dotenv": "^16.4.5",
     "openai": "^6.7.0"
   },


### PR DESCRIPTION
## Summary
Bumps the `@traceroot-ai/traceroot` dependency to `^0.1.6` in the five TypeScript examples still on older SDK versions, aligning them with the rest of `examples/typescript/`.

| Example | Before | After |
| --- | --- | --- |
| langchain | 0.1.2 | ^0.1.6 |
| deepseek | 0.1.2 | ^0.1.6 |
| openrouter | 0.1.2 | ^0.1.6 |
| openai | 0.1.2 | ^0.1.6 |
| openai-agents | 0.1.3 | ^0.1.6 |

The other six examples were already on `^0.1.6` and are untouched.

## Test plan
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `@traceroot-ai/traceroot` to `^0.1.6` in the remaining TypeScript examples (`langchain`, `deepseek`, `openrouter`, `openai`, `openai-agents`) to match the rest of `examples/typescript/`. Ensures consistent SDK behavior across examples; package.json only.

<sup>Written for commit 3f9081fa9956777cde97a0af7dfcb2333434bea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

