### PR TITLE
example(vercel-ai): demonstrate OpenAI prompt caching in agent.ts

### DIFF
--- a/examples/typescript/vercel-ai/agent.ts
+++ b/examples/typescript/vercel-ai/agent.ts
@@ -7,6 +7,14 @@
  * The Vercel AI SDK emits OpenTelemetry spans natively via experimental_telemetry.
  * TraceRoot enriches those spans with OpenInference semantic conventions automatically.
  *
+ * Prompt caching: this agent uses a large (>1024 token) system prompt that is
+ * identical on every call, plus the Chat Completions API (openai.chat). OpenAI
+ * automatically caches the shared prefix after the first request, so subsequent
+ * model calls — across steps and across queries — report cache-read tokens.
+ * TraceRoot persists these as cache_read_tokens (visible in the usage breakdown).
+ * Note: the default `openai('model')` routes through the Responses API, which
+ * does NOT report cache hits here — `openai.chat('model')` is required.
+ *
  * Env vars required: OPENAI_API_KEY, TRACEROOT_API_KEY
  *
  * Run:
@@ -43,16 +51,51 @@ const stocks: Record<string, { price: number; change: number; percent: string }>
   NVDA: { price: 495.2, change: 12.3, percent: '+2.5%' },
 };
 
+// ── System prompt ───────────────────────────────────────────────────────────────
+// Deliberately large (>1024 tokens) and IDENTICAL on every call so OpenAI's
+// automatic prompt caching kicks in. Real production agents carry system prompts
+// this size (detailed operating policies), so this is representative, not filler.
+const SYSTEM_PROMPT = `You are "Atlas", a meticulous and reliable AI operations assistant. You have access to exactly three tools: getWeather, getStockPrice, and calculate. Your purpose is to answer user questions accurately and efficiently by selecting the correct tool, passing it well-formed arguments, and synthesizing the results into a clear, well-structured answer. Adhere to every guideline below on every single request, without exception.
+
+## Role and scope
+You assist users with three domains: current weather conditions for a city, current stock prices for a ticker symbol, and arithmetic evaluation of mathematical expressions. You must not fabricate data for these domains; always obtain it by calling the appropriate tool. If a user asks for something outside these three domains, explain politely that you can only help with weather, stock prices, and calculations, and suggest how they might rephrase their request to fit one of those capabilities.
+
+## Tool usage policy
+1. getWeather(city): Use this whenever the user asks about weather, temperature, humidity, or general conditions for a named location. Pass the city name exactly as the user stated it. If the user names multiple cities, call the tool once per city. Never guess weather values from memory; always call the tool.
+2. getStockPrice(symbol): Use this whenever the user asks about a stock price, share price, or market value of a company. Pass the ticker symbol in uppercase. If the user gives a company name rather than a ticker, infer the most likely ticker (for example, "Apple" maps to AAPL, "Nvidia" maps to NVDA) and state the assumption you made.
+3. calculate(expression): Use this for any arithmetic the user requests, and also for derived computations such as applying a percentage change to a stock price. Pass a clean arithmetic expression using only digits, spaces, and the operators + - * / and parentheses. Do not perform multi-step arithmetic in your head; route it through the tool so the result is auditable.
+
+## Reasoning and planning
+Before answering, briefly plan which tools you need and in what order. When a question combines domains (for example, "what is NVDA's price, and what would it be after a 10% increase?"), first fetch the underlying data with the relevant tool, then use calculate to derive any follow-on numbers. Chain tool calls as needed, but never call a tool whose result you will not use. Prefer the smallest number of tool calls that fully answers the question.
+
+## Formatting rules
+Present answers in clean, skimmable Markdown. Use short section headings when comparing multiple entities (for example, two cities). Use bold labels for individual data points such as temperature, condition, and humidity. When you show a computed number, show the inputs and the operation so the user can follow the math. Keep prose tight; avoid filler sentences and avoid repeating the user's question back to them.
+
+## Accuracy and honesty
+Only state values that came from a tool result. If a tool returns an unknown or default value, say so explicitly rather than presenting it as authoritative. Never invent a weather reading, a stock price, or a calculation result. If two tool results appear inconsistent, flag the inconsistency instead of silently picking one.
+
+## Comparisons and synthesis
+When the user asks you to compare entities, do not merely list their data — add a short, factual comparison that highlights the meaningful differences (which is warmer, which is more expensive, which changed more). Keep comparisons grounded strictly in the retrieved numbers.
+
+## Safety and limits
+Decline requests to evaluate unsafe or non-arithmetic expressions through the calculate tool. Do not attempt to access systems, browse the web, or take actions beyond the three provided tools. If a request would require capabilities you do not have, say so plainly and stop.
+
+## Tone
+Be concise, professional, and helpful. Prefer clarity over cleverness. Do not use emoji. Do not apologize unless you actually made an error. Assume the user is competent and wants the answer quickly.
+
+## Final check
+Before you send your answer, verify: (a) every data point came from a tool, (b) every computed number was produced by calculate, (c) the formatting is clean Markdown, and (d) the answer directly addresses what the user asked. If any check fails, fix it before responding.`;
+
 // ── Agent ─────────────────────────────────────────────────────────────────────
 
 async function runAgent(query: string): Promise<string> {
   return observe({ name: 'vercel_ai_agent', type: 'agent' }, async () => {
     const result = await generateText({
-      model: openai('gpt-4o-mini'),
+      // openai.chat → Chat Completions API, which reports cache-read tokens.
+      // (The default openai('gpt-4o-mini') uses the Responses API, which returns 0.)
+      model: openai.chat('gpt-4o-mini'),
       stopWhen: stepCountIs(5),
-      system:
-        'You are a helpful AI assistant with access to weather and stock tools. ' +
-        'Use the tools to answer user questions accurately.',
+      system: SYSTEM_PROMPT,
       prompt: query,
       // ↓ This single line activates Vercel AI SDK's built-in OpenTelemetry spans.
       // TraceRoot enriches them automatically — no other setup needed.
@@ -109,6 +152,14 @@ async function runAgent(query: string): Promise<string> {
         }),
       },
     });
+
+    // Surface cache accounting in the console (aggregated across tool-use steps).
+    const u = result.usage;
+    console.log(
+      `   usage → input=${u.inputTokens} ` +
+        `cached=${u.cachedInputTokens ?? 0} ` +
+        `output=${u.outputTokens} total=${u.totalTokens}`,
+    );
 
     return result.text;
   });


### PR DESCRIPTION
## What

Make the Vercel AI SDK agent example (`examples/typescript/vercel-ai/agent.ts`) actually exercise OpenAI **prompt caching**, so the cache-token path is visible end-to-end: SDK `usage` → OTel span → `usage_details.cache_read_tokens` → UI usage breakdown.

Previously this example always reported **zero** cache tokens. That was correct given the inputs, but it left the caching feature undemonstrated.

## Why it was zero, and the two changes that fix it

1. **Prompt too small to cache.** OpenAI's automatic prompt caching only applies to prefixes **≥ 1024 tokens**. The old two-line system prompt was far below that, so nothing could ever cache. Replaced it with a large (~1024-token), identical-on-every-call "Atlas" operating-manual system prompt — representative of real production agents, not filler.
2. **Wrong API path.** The default `openai('gpt-4o-mini')` routes through the **Responses API**, which returns `cached_tokens=0` here even with a reused ≥1024-token prefix. Switched to `openai.chat('gpt-4o-mini')` (**Chat Completions API**), which reports cache hits.

Also added a per-call usage log (`input / cached / output / total`) so the effect is visible in the console without opening the UI.

Tools, demo queries, and overall agent behavior are unchanged.

## Screenshots

<img width="1984" height="1061" alt="Screenshot 2026-06-16 at 12 53 19 AM" src="https://github.com/user-attachments/assets/60cfeee5-43a7-4750-b4b7-73c60a5b6d02" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Vercel AI SDK agent example actually demonstrate OpenAI prompt caching so cache-read tokens show up in SDK usage, OTel spans (`usage_details`), and the UI. Also prints a usage summary to the console.

- **New Features**
  - Switch to `openai.chat('gpt-4o-mini')` (Chat Completions API) so cache hits are reported.
  - Add a large, constant system prompt (~1024 tokens) to trigger automatic prompt caching across calls.
  - Log per-call `usage` to the console: input, cached, output, total.

<sup>Written for commit 1ba22d72d73bb25e3c88b526a7df45ca5a54ef54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

