### PR TITLE
feat(ui): submit onboarding workspace/project step on Enter

### DIFF
--- a/frontend/ui/src/app/onboarding/page.test.tsx
+++ b/frontend/ui/src/app/onboarding/page.test.tsx
@@ -101,4 +101,89 @@ describe("OnboardingPage", () => {
     await waitFor(() => expect(screen.getByText("workspace boom")).toBeDefined());
     expect(screen.queryByTestId("add-detectors-step")).toBeNull();
   });
+
+  it("submits successfully when pressing Enter in the workspace input", async () => {
+    mocks.createWorkspace.mockResolvedValue({ id: "ws-1" });
+    mocks.createProject.mockResolvedValue({ id: "proj-1", name: "my-llm-project" });
+    renderPage();
+
+    const workspaceInput = screen.getByPlaceholderText("Acme Inc");
+    fireEvent.change(workspaceInput, { target: { value: "My Company" } });
+    fireEvent.submit(workspaceInput);
+
+    await waitFor(() => expect(screen.getByTestId("add-detectors-step")).toBeDefined());
+    expect(mocks.createWorkspace).toHaveBeenCalledWith("My Company");
+    expect(mocks.createProject).toHaveBeenCalledWith("ws-1", "my-llm-project");
+  });
+
+  it("submits successfully when pressing Enter in the project input", async () => {
+    mocks.createWorkspace.mockResolvedValue({ id: "ws-1" });
+    mocks.createProject.mockResolvedValue({ id: "proj-1", name: "custom-project" });
+    renderPage();
+
+    const projectInput = screen.getByPlaceholderText("my-llm-project");
+    fireEvent.change(projectInput, { target: { value: "custom-project" } });
+    fireEvent.submit(projectInput);
+
+    await waitFor(() => expect(screen.getByTestId("add-detectors-step")).toBeDefined());
+    expect(mocks.createWorkspace).toHaveBeenCalledWith("Example");
+    expect(mocks.createProject).toHaveBeenCalledWith("ws-1", "custom-project");
+  });
+
+  it("displays validation errors when pressing Enter with invalid values", async () => {
+    renderPage();
+
+    const workspaceInput = screen.getByPlaceholderText("Acme Inc");
+    fireEvent.change(workspaceInput, { target: { value: "" } });
+    fireEvent.submit(workspaceInput);
+
+    await waitFor(() => {
+      expect(screen.getByText("Workspace name is required")).toBeDefined();
+    });
+
+    expect(mocks.createWorkspace).not.toHaveBeenCalled();
+    expect(mocks.createProject).not.toHaveBeenCalled();
+  });
+
+  it("displays validation errors when project name is empty and Enter is pressed", async () => {
+    renderPage();
+
+    const projectInput = screen.getByPlaceholderText("my-llm-project");
+    fireEvent.change(projectInput, { target: { value: "" } });
+    fireEvent.submit(projectInput);
+
+    await waitFor(() => {
+      expect(screen.getByText("Project name is required")).toBeDefined();
+    });
+
+    expect(mocks.createWorkspace).not.toHaveBeenCalled();
+    expect(mocks.createProject).not.toHaveBeenCalled();
+  });
+
+  it("does not trigger another submission when pressing Enter while loading", async () => {
+    let resolveWorkspacePromise: (value: any) => void = () => {};
+    const workspacePromise = new Promise((resolve) => {
+      resolveWorkspacePromise = resolve;
+    });
+    mocks.createWorkspace.mockReturnValue(workspacePromise);
+
+    renderPage();
+
+    const workspaceInput = screen.getByPlaceholderText("Acme Inc");
+    fireEvent.submit(workspaceInput);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Creating..." })).toBeDefined();
+    });
+
+    fireEvent.submit(workspaceInput);
+
+    resolveWorkspacePromise({ id: "ws-1" });
+    mocks.createProject.mockResolvedValue({ id: "proj-1", name: "my-llm-project" });
+
+    await waitFor(() => expect(screen.getByTestId("add-detectors-step")).toBeDefined());
+
+    expect(mocks.createWorkspace).toHaveBeenCalledTimes(1);
+    expect(mocks.createProject).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/ui/src/app/onboarding/page.tsx
+++ b/frontend/ui/src/app/onboarding/page.tsx
@@ -70,6 +70,7 @@ function OnboardingContent() {
 
   const {
     register,
+    handleSubmit: handleFormSubmit,
     formState: { errors },
     getValues,
   } = useForm<OnboardingForm>({
@@ -84,7 +85,8 @@ function OnboardingContent() {
     },
   });
 
-  async function handleSubmit() {
+  async function onSubmit(data: OnboardingForm) {
+    if (isLoading) return;
     setIsLoading(true);
     setError(null);
 
@@ -93,12 +95,7 @@ function OnboardingContent() {
 
       // Create workspace if not in project-only mode
       if (!isProjectOnlyMode) {
-        const workspaceName = getValues("workspaceName");
-        if (!workspaceName) {
-          setError("Workspace name is required");
-          setIsLoading(false);
-          return;
-        }
+        const workspaceName = data.workspaceName;
         const workspace = await createWorkspace(workspaceName);
         workspaceId = workspace.id;
       }
@@ -110,13 +107,7 @@ function OnboardingContent() {
       }
 
       // Create project
-      const projectName = getValues("projectName");
-      if (!projectName) {
-        setError("Project name is required");
-        setIsLoading(false);
-        return;
-      }
-
+      const projectName = data.projectName;
       const project = await createProject(workspaceId, projectName);
 
       queryClient.invalidateQueries({ queryKey: ["workspaces"] });
@@ -179,7 +170,7 @@ function OnboardingContent() {
                 />
               </div>
             ) : (
-              <>
+              <form onSubmit={handleFormSubmit(onSubmit)}>
                 <div className="space-y-0">
                   {/* Workspace Section */}
                   <div className="flex items-start gap-3">
@@ -250,7 +241,7 @@ function OnboardingContent() {
                   <Button
                     size="sm"
                     className="h-7 px-4 text-[12px]"
-                    onClick={handleSubmit}
+                    type="submit"
                     disabled={isLoading}
                   >
                     {isLoading ? "Creating..." : "Create"}
@@ -259,12 +250,13 @@ function OnboardingContent() {
                     variant="outline"
                     size="sm"
                     className="h-7 px-4 text-[12px]"
+                    type="button"
                     onClick={() => router.push("/workspaces")}
                   >
                     Cancel
                   </Button>
                 </div>
-              </>
+              </form>
             )}
           </CardContent>
         </Card>

--- a/frontend/ui/src/app/onboarding/page.tsx
+++ b/frontend/ui/src/app/onboarding/page.tsx
@@ -72,7 +72,6 @@ function OnboardingContent() {
     register,
     handleSubmit: handleFormSubmit,
     formState: { errors },
-    getValues,
   } = useForm<OnboardingForm>({
     resolver: zodResolver(onboardingSchema),
     defaultValues: {


### PR DESCRIPTION
Wrap the onboarding form fields in a `<form>` element with an `onSubmit` handler wired through react-hook-form's `handleSubmit`. This lets users press Enter in either input to advance, preserving the existing validation and loading guard.

## Changes

- Extract form data from `onSubmit` callback instead of `getValues()`
- Replace `getValues()` validation with react-hook-form field rules
- Add `isLoading` guard at the top of `onSubmit` to prevent double submits while a workspace/project create is in flight
- Add 5 new tests covering Enter-to-submit, validation errors on Enter, and no-op while loading

## Tests Added

| Test | What it verifies |
|------|-----------------|
| Submit on Enter in workspace input | Workspace + project created successfully |
| Submit on Enter in project input | Respects workspace default, creates custom project |
| Validation errors on Enter (empty workspace) | Shows error, no API calls fire |
| Validation errors on Enter (empty project) | Shows error, no API calls fire |
| Enter while loading is a no-op | Guard prevents double submit, createWorkspace called once |

Closes #1211

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable pressing Enter in the onboarding workspace/project step to submit and advance, improving keyboard flow. Keeps validation and prevents double submits.

- **New Features**
  - Wrapped inputs in a form with onSubmit via `react-hook-form`’s `handleSubmit`; Enter in either field submits.
  - Switched to onSubmit data and field-level rules; shows errors for empty names; added isLoading guard; set button types correctly.
  - Added 5 tests for Enter-to-submit, validation on Enter, and no-op during loading.

- **Bug Fixes**
  - Removed unused `getValues` from form destructuring.

Closes #1211.

<sup>Written for commit 841c4ac9c92dbd049fe348a79d527dabac086b45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

