### PR TITLE
fix(vercel-ai): preserve user request during synthesis

### DIFF
--- a/examples/typescript/vercel-ai/agent-streaming.ts
+++ b/examples/typescript/vercel-ai/agent-streaming.ts
@@ -137,7 +137,10 @@ async function runChatTurn(query: string): Promise<string> {
       model: openai('gpt-4o-mini'),
       experimental_telemetry: { isEnabled: true, functionId: 'synthesis' },
       system: 'You are a principal engineer writing a crisp executive summary.',
-      prompt: `Synthesize these analyses into a 2-paragraph brief:\n\n${analyses.join('\n\n')}`,
+      prompt:
+        `User request: ${query}\n\n` +
+        `Using these analyses, write a 2-paragraph brief and then recommend where to invest first with a clear ranking.\n\n` +
+        analyses.join('\n\n'),
     });
 
     return `${intro}\n\n${analyses.join('\n\n')}\n\n# Summary\n${synthesis.trim()}`;
@@ -196,9 +199,9 @@ async function main() {
     console.log('\n[Traces exported]');
     console.log(
       'Open the trace in the UI: the root POST /api/chat span ends ~' +
-        STREAM_OPEN_MS +
-        'ms in (the streamed response), while chat.turn and the whole research ' +
-        'fan-out keep running well after — all under the same trace.',
+      STREAM_OPEN_MS +
+      'ms in (the streamed response), while chat.turn and the whole research ' +
+      'fan-out keep running well after — all under the same trace.',
     );
   }
 }


### PR DESCRIPTION
Closes #1207

## Summary

The Vercel AI streaming example was not completing the full user request.

The original query asks the agent to both:

1. Research common reliability problems in modern AI inference platforms.
2. Recommend where to invest first.

However, the synthesis step only received the generated analyses and was instructed to create a 2-paragraph brief. Since the original request was not passed into the synthesis prompt, the model never received the recommendation requirement and could return a summary without any prioritization.

This change passes the original user request into the synthesis step and explicitly instructs the model to provide a ranked recommendation.

## Changes

* Pass the original `query` into the synthesis prompt.
* Update synthesis instructions to:

  * Generate a 2-paragraph brief.
  * Recommend where to invest first.
  * Provide a clear ranking.

## Validation

* Verified that the synthesis phase previously received only the generated analyses.
* Confirmed that the recommendation requirement was not propagated to the final synthesis prompt.
* Updated the synthesis prompt to preserve the original user intent.
* Attempted local execution of `demo:streaming`.
* Runtime validation was blocked by OpenAI API quota exhaustion (`insufficient_quota`) and a missing `TRACEROOT_API_KEY`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the user's request in the `vercel-ai` streaming example so the synthesis step returns both the 2-paragraph brief and a ranked recommendation, not just a summary.

- **Bug Fixes**
  - Pass the original `query` into the synthesis prompt to preserve intent.
  - Update synthesis instructions to write a 2-paragraph brief and then provide a ranked recommendation.

<sup>Written for commit 14a7d07903041a21a864639dfe66b02bbb68f0d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

