### PR TITLE
feat(traces): smooth traces-list pagination (keep previous rows + hover prefetch)

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 
 const prefetch = vi.fn();
 let fetching = false;
+let autoRefresh = false;
 vi.mock("@/features/traces/hooks", () => ({
   useTraces: () => ({
     data: {
@@ -38,7 +39,7 @@ vi.mock("@/lib/hooks/use-list-page-state", () => ({
     queryOptions: { page: 3, limit: 50, start_after: "S" },
   }),
 }));
-vi.mock("@/lib/hooks/use-local-storage", () => ({ useLocalStorage: () => [false, vi.fn()] }));
+vi.mock("@/lib/hooks/use-local-storage", () => ({ useLocalStorage: () => [autoRefresh, vi.fn()] }));
 vi.mock("@/lib/auth-client", () => ({
   useSession: () => ({ data: { user: { id: "u1", email: "e" } }, isPending: false }),
 }));
@@ -76,6 +77,7 @@ afterEach(() => {
   cleanup();
   prefetch.mockReset();
   fetching = false;
+  autoRefresh = false;
 });
 
 describe("TracesPage prefetch wiring", () => {
@@ -91,5 +93,12 @@ describe("TracesPage prefetch wiring", () => {
     fetching = true;
     const { container } = render(<TracesPage />, { wrapper: Wrapper });
     expect(container.querySelector(".opacity-50")).not.toBeNull();
+  });
+
+  it("does not prefetch on hover when auto-refresh is enabled", () => {
+    autoRefresh = true;
+    render(<TracesPage />, { wrapper: Wrapper });
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /next page/i }));
+    expect(prefetch).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
@@ -5,7 +5,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 
 const prefetch = vi.fn();
-let fetching = false;
 let autoRefresh = false;
 vi.mock("@/features/traces/hooks", () => ({
   useTraces: () => ({
@@ -14,7 +13,6 @@ vi.mock("@/features/traces/hooks", () => ({
       meta: { page: 3, limit: 50, total: 500 },
     },
     isLoading: false,
-    isFetching: fetching,
     error: null,
   }),
   usePrefetchTraces: () => prefetch,
@@ -76,7 +74,6 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 afterEach(() => {
   cleanup();
   prefetch.mockReset();
-  fetching = false;
   autoRefresh = false;
 });
 
@@ -87,12 +84,6 @@ describe("TracesPage prefetch wiring", () => {
     expect(prefetch).toHaveBeenCalledWith(
       expect.objectContaining({ page: 4, limit: 50, start_after: "S" }),
     );
-  });
-
-  it("dims the results while fetching", () => {
-    fetching = true;
-    const { container } = render(<TracesPage />, { wrapper: Wrapper });
-    expect(container.querySelector(".opacity-50")).not.toBeNull();
   });
 
   it("does not prefetch on hover when auto-refresh is enabled", () => {

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.prefetch.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+const prefetch = vi.fn();
+let fetching = false;
+vi.mock("@/features/traces/hooks", () => ({
+  useTraces: () => ({
+    data: {
+      data: [{ trace_id: "a", name: "n", trace_start_time: 0, error_count: 0, span_count: 1 }],
+      meta: { page: 3, limit: 50, total: 500 },
+    },
+    isLoading: false,
+    isFetching: fetching,
+    error: null,
+  }),
+  usePrefetchTraces: () => prefetch,
+}));
+vi.mock("@/lib/hooks/use-list-page-state", () => ({
+  useListPageState: () => ({
+    state: {
+      page: 3,
+      limit: 50,
+      dateFilter: "all",
+      customStartDate: null,
+      customEndDate: null,
+      keyword: "",
+    },
+    page: 3,
+    limit: 50,
+    goToPage: vi.fn(),
+    updateLimit: vi.fn(),
+    updateDateFilter: vi.fn(),
+    updateCustomRange: vi.fn(),
+    updateKeyword: vi.fn(),
+    queryOptions: { page: 3, limit: 50, start_after: "S" },
+  }),
+}));
+vi.mock("@/lib/hooks/use-local-storage", () => ({ useLocalStorage: () => [false, vi.fn()] }));
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "u1", email: "e" } }, isPending: false }),
+}));
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1" }),
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({ setHideAiButton: vi.fn() }),
+}));
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+vi.mock("@/features/traces/components", () => ({
+  TraceViewerPanel: () => null,
+  GettingStarted: () => null,
+}));
+vi.mock("@/components/search-filter-bar", () => ({
+  SearchFilterBar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/features/traces/utils", () => ({ formatContentPreview: () => "" }));
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+import TracesPage from "./page";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+afterEach(() => {
+  cleanup();
+  prefetch.mockReset();
+  fetching = false;
+});
+
+describe("TracesPage prefetch wiring", () => {
+  it("prefetches the next page on hover, carrying current query options", () => {
+    render(<TracesPage />, { wrapper: Wrapper });
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /next page/i }));
+    expect(prefetch).toHaveBeenCalledWith(
+      expect.objectContaining({ page: 4, limit: 50, start_after: "S" }),
+    );
+  });
+
+  it("dims the results while fetching", () => {
+    fetching = true;
+    const { container } = render(<TracesPage />, { wrapper: Wrapper });
+    expect(container.querySelector(".opacity-50")).not.toBeNull();
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -19,7 +19,7 @@ import {
   buildUrlWithFilters,
 } from "@/lib/utils";
 import type { TraceListItem } from "@/types/api";
-import { useTraces } from "@/features/traces/hooks";
+import { useTraces, usePrefetchTraces } from "@/features/traces/hooks";
 import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { useLocalStorage } from "@/lib/hooks/use-local-storage";
 import { TraceViewerPanel, GettingStarted } from "@/features/traces/components";
@@ -70,7 +70,7 @@ export default function TracesPage() {
   );
 
   // Fetch traces with combined query options + user filter from URL
-  const { data, isLoading, error } = useTraces(
+  const { data, isLoading, isFetching, error } = useTraces(
     projectId,
     {
       ...queryOptions,
@@ -78,6 +78,8 @@ export default function TracesPage() {
     },
     { refetchInterval: autoRefresh ? 5000 : false },
   );
+
+  const prefetchTraces = usePrefetchTraces(projectId);
 
   // Check if project has EVER sent traces (no date filter) — controls onboarding visibility.
   // staleTime: Infinity because once a project has traces it always will (immutable fact).
@@ -236,7 +238,7 @@ export default function TracesPage() {
             </div>
           ) : (
             <div className="flex h-full flex-col">
-              <div className="flex-1 overflow-auto">
+              <div className={cn("flex-1 overflow-auto", isFetching && "opacity-50")}>
                 <table className="w-full">
                   <thead className="sticky top-0 bg-background">
                     <tr className="border-b border-border bg-muted/50">
@@ -349,6 +351,12 @@ export default function TracesPage() {
                 total={total}
                 onPageChange={goToPage}
                 onLimitChange={updateLimit}
+                onPrefetchPage={
+                  autoRefresh
+                    ? undefined
+                    : (p) =>
+                        prefetchTraces({ ...queryOptions, user_id: userId || undefined, page: p })
+                }
               />
             </div>
           )}

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -70,7 +70,7 @@ export default function TracesPage() {
   );
 
   // Fetch traces with combined query options + user filter from URL
-  const { data, isLoading, isFetching, error } = useTraces(
+  const { data, isLoading, error } = useTraces(
     projectId,
     {
       ...queryOptions,
@@ -238,7 +238,7 @@ export default function TracesPage() {
             </div>
           ) : (
             <div className="flex h-full flex-col">
-              <div className={cn("flex-1 overflow-auto", isFetching && "opacity-50")}>
+              <div className="flex-1 overflow-auto">
                 <table className="w-full">
                   <thead className="sticky top-0 bg-background">
                     <tr className="border-b border-border bg-muted/50">

--- a/frontend/ui/src/components/list-pagination.test.tsx
+++ b/frontend/ui/src/components/list-pagination.test.tsx
@@ -76,4 +76,44 @@ describe("ListPagination", () => {
     expect(onPageChange).toHaveBeenCalledWith(9); // clamped to last page (0-indexed: page 10 → index 9)
     expect(input.value).toBe("10"); // input reflects the clamped value, not 9999
   });
+
+  it("prefetches prev and next pages on hover, respecting bounds", () => {
+    const onPrefetchPage = vi.fn();
+    render(
+      <ListPagination
+        page={3}
+        limit={50}
+        total={500} // 10 pages
+        onPageChange={vi.fn()}
+        onLimitChange={vi.fn()}
+        onPrefetchPage={onPrefetchPage}
+      />,
+    );
+
+    const prev = screen.getByRole("button", { name: /previous page/i });
+    const next = screen.getByRole("button", { name: /next page/i });
+
+    fireEvent.mouseEnter(next);
+    expect(onPrefetchPage).toHaveBeenCalledWith(4);
+
+    fireEvent.mouseEnter(prev);
+    expect(onPrefetchPage).toHaveBeenCalledWith(2);
+  });
+
+  it("does not prefetch past the first or last page", () => {
+    const onPrefetchPage = vi.fn();
+    render(
+      <ListPagination
+        page={0}
+        limit={50}
+        total={50} // 1 page → both disabled
+        onPageChange={vi.fn()}
+        onLimitChange={vi.fn()}
+        onPrefetchPage={onPrefetchPage}
+      />,
+    );
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /previous page/i }));
+    fireEvent.mouseEnter(screen.getByRole("button", { name: /next page/i }));
+    expect(onPrefetchPage).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/ui/src/components/list-pagination.tsx
+++ b/frontend/ui/src/components/list-pagination.tsx
@@ -13,6 +13,8 @@ interface ListPaginationProps {
   onPageChange: (page: number) => void;
   onLimitChange: (limit: number) => void;
   itemsPerPageOptions?: number[];
+  /** Warm an adjacent page on hover/focus of the prev/next buttons. */
+  onPrefetchPage?: (page: number) => void;
 }
 
 const DEFAULT_OPTIONS = [50, 100, 200];
@@ -29,6 +31,7 @@ export function ListPagination({
   onPageChange,
   onLimitChange,
   itemsPerPageOptions = DEFAULT_OPTIONS,
+  onPrefetchPage,
 }: ListPaginationProps) {
   const [itemsPerPageOpen, setItemsPerPageOpen] = useState(false);
 
@@ -60,6 +63,12 @@ export function ListPagination({
     } else {
       setPageState(String(page + 1)); // Reset to current page if invalid input
     }
+  };
+
+  const prefetchPage = (target: number) => {
+    if (!onPrefetchPage) return;
+    if (target < 0 || target > totalPages - 1 || target === page) return;
+    onPrefetchPage(target);
   };
 
   return (
@@ -128,7 +137,10 @@ export function ListPagination({
         <Button
           variant="outline"
           size="sm"
+          aria-label="Previous page"
           onClick={() => onPageChange(Math.max(0, page - 1))}
+          onMouseEnter={() => prefetchPage(page - 1)}
+          onFocus={() => prefetchPage(page - 1)}
           disabled={page === 0}
           className="h-7 w-7 p-0"
         >
@@ -137,7 +149,10 @@ export function ListPagination({
         <Button
           variant="outline"
           size="sm"
+          aria-label="Next page"
           onClick={() => onPageChange(page + 1)}
+          onMouseEnter={() => prefetchPage(page + 1)}
+          onFocus={() => prefetchPage(page + 1)}
           disabled={page >= totalPages - 1}
           className="h-7 w-7 p-0"
         >

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -16,6 +16,25 @@ export { useTraceListState } from "./use-trace-list-state";
 export { useTraceStream } from "./use-trace-stream";
 
 /**
+ * Canonical React Query key for the paginated traces list. Exported so the
+ * hover-prefetch and the useTraces hook key identically — a drift here would
+ * silently cache prefetched pages under a key the hook never reads.
+ */
+export function tracesQueryKey(projectId: string, options: TraceQueryOptions = {}) {
+  return [
+    "traces",
+    projectId,
+    options.page,
+    options.limit,
+    options.search_query,
+    options.start_after,
+    options.end_before,
+    options.user_id,
+    options.session_id,
+  ] as const;
+}
+
+/**
  * Hook for fetching paginated traces list
  */
 export function useTraces(
@@ -32,17 +51,7 @@ export function useTraces(
     ? { id: authSession.user.id, email: authSession.user.email }
     : undefined;
   return useQuery({
-    queryKey: [
-      "traces",
-      projectId,
-      options.page,
-      options.limit,
-      options.search_query,
-      options.start_after,
-      options.end_before,
-      options.user_id,
-      options.session_id,
-    ],
+    queryKey: tracesQueryKey(projectId, options),
     queryFn: () => getTraces(projectId, "", options, user),
     enabled: sessionReady && !!projectId,
     ...queryOptions,

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -1,7 +1,7 @@
 /**
  * Trace feature hooks
  */
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
 import { useSession as useAuthSession } from "@/lib/auth-client";
 import { getTraces, getTrace, getSpanIO } from "@/lib/api";
 import { getSessions, getSession, type SessionDetailOptions } from "@/lib/api/sessions";
@@ -34,6 +34,10 @@ export function tracesQueryKey(projectId: string, options: TraceQueryOptions = {
   ] as const;
 }
 
+/** Traces are mostly append-only; a short stale window stops redundant refetches
+ *  on revisit and lets a hover-prefetched page actually "stick" before navigation. */
+export const TRACES_LIST_STALE_TIME_MS = 30_000;
+
 /**
  * Hook for fetching paginated traces list
  */
@@ -54,6 +58,8 @@ export function useTraces(
     queryKey: tracesQueryKey(projectId, options),
     queryFn: () => getTraces(projectId, "", options, user),
     enabled: sessionReady && !!projectId,
+    placeholderData: keepPreviousData,
+    staleTime: TRACES_LIST_STALE_TIME_MS,
     ...queryOptions,
   });
 }

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -182,7 +182,9 @@ export function usePrefetchTraces(projectId: string) {
         staleTime: TRACES_LIST_STALE_TIME_MS,
       });
     },
-    [queryClient, projectId, user?.id, user?.email],
+    // `user` is a fresh object literal each render; key off its stable id/email
+    // so the callback isn't rebuilt every render.
+    [queryClient, projectId, user?.id, user?.email], // eslint-disable-line react-hooks/exhaustive-deps
   );
 }
 

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -1,7 +1,8 @@
 /**
  * Trace feature hooks
  */
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { useQuery, keepPreviousData, useQueryClient } from "@tanstack/react-query";
 import { useSession as useAuthSession } from "@/lib/auth-client";
 import { getTraces, getTrace, getSpanIO } from "@/lib/api";
 import { getSessions, getSession, type SessionDetailOptions } from "@/lib/api/sessions";
@@ -158,6 +159,31 @@ export function useSessions(projectId: string, options: SessionQueryOptions = {}
     queryFn: () => getSessions(projectId, options, user),
     enabled: sessionReady && !!projectId,
   });
+}
+
+/**
+ * Returns a function that warms an adjacent traces page into the React Query
+ * cache. Wire to hover/focus of the pagination prev/next buttons so the click
+ * lands on a cache hit. No-op until auth + projectId are ready.
+ */
+export function usePrefetchTraces(projectId: string) {
+  const queryClient = useQueryClient();
+  const { data: authSession } = useAuthSession();
+  const user: TraceApiUser | undefined = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
+
+  return useCallback(
+    (options: TraceQueryOptions = {}) => {
+      if (!projectId || !user) return;
+      queryClient.prefetchQuery({
+        queryKey: tracesQueryKey(projectId, options),
+        queryFn: () => getTraces(projectId, "", options, user),
+        staleTime: TRACES_LIST_STALE_TIME_MS,
+      });
+    },
+    [queryClient, projectId, user?.id, user?.email],
+  );
 }
 
 /**

--- a/frontend/ui/src/features/traces/hooks/traces-query-key.test.ts
+++ b/frontend/ui/src/features/traces/hooks/traces-query-key.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { tracesQueryKey } from "./index";
+
+describe("tracesQueryKey", () => {
+  it("includes project id and all paging/filter fields in a stable order", () => {
+    expect(
+      tracesQueryKey("p1", {
+        page: 2,
+        limit: 50,
+        search_query: "x",
+        start_after: "S",
+        end_before: "E",
+        user_id: "u",
+        session_id: "s",
+      }),
+    ).toEqual(["traces", "p1", 2, 50, "x", "S", "E", "u", "s"]);
+  });
+
+  it("fills undefined for omitted options so keys stay positionally stable", () => {
+    expect(tracesQueryKey("p1", { page: 0, limit: 50 })).toEqual([
+      "traces",
+      "p1",
+      0,
+      50,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ]);
+  });
+});

--- a/frontend/ui/src/features/traces/hooks/use-traces.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-traces.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "u1", email: "e@x.dev" } }, isPending: false }),
+}));
+const getTraces = vi.fn();
+vi.mock("@/lib/api", () => ({
+  getTraces: (...a: unknown[]) => getTraces(...a),
+  getTrace: vi.fn(),
+  getSpanIO: vi.fn(),
+}));
+vi.mock("@/lib/api/sessions", () => ({ getSessions: vi.fn(), getSession: vi.fn() }));
+vi.mock("@/lib/api/users", () => ({ getUsers: vi.fn() }));
+vi.mock("./use-trace-list-state", () => ({ useTraceListState: vi.fn() }));
+vi.mock("./use-trace-stream", () => ({ useTraceStream: vi.fn() }));
+
+import { useTraces } from "./index";
+
+afterEach(() => {
+  cleanup();
+  getTraces.mockReset();
+});
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useTraces", () => {
+  it("keeps previous page data on screen while the next page is fetching", async () => {
+    getTraces.mockResolvedValueOnce({ data: [{ trace_id: "a" }], total: 100 });
+    const { result, rerender } = renderHook(({ page }) => useTraces("p1", { page, limit: 50 }), {
+      wrapper: wrapper(),
+      initialProps: { page: 0 },
+    });
+    await waitFor(() => expect(result.current.data?.data?.[0]?.trace_id).toBe("a"));
+
+    let resolveNext: (v: unknown) => void = () => {};
+    getTraces.mockReturnValueOnce(
+      new Promise((r) => {
+        resolveNext = r;
+      }),
+    );
+    rerender({ page: 1 });
+
+    // While page 1 is in flight, previous page's rows remain (no flash to empty).
+    expect(result.current.data?.data?.[0]?.trace_id).toBe("a");
+    expect(result.current.isFetching).toBe(true);
+
+    resolveNext({ data: [{ trace_id: "b" }], total: 100 });
+    await waitFor(() => expect(result.current.data?.data?.[0]?.trace_id).toBe("b"));
+  });
+});

--- a/frontend/ui/src/features/traces/hooks/use-traces.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-traces.test.tsx
@@ -17,7 +17,7 @@ vi.mock("@/lib/api/users", () => ({ getUsers: vi.fn() }));
 vi.mock("./use-trace-list-state", () => ({ useTraceListState: vi.fn() }));
 vi.mock("./use-trace-stream", () => ({ useTraceStream: vi.fn() }));
 
-import { useTraces } from "./index";
+import { useTraces, usePrefetchTraces } from "./index";
 
 afterEach(() => {
   cleanup();
@@ -54,5 +54,28 @@ describe("useTraces", () => {
 
     resolveNext({ data: [{ trace_id: "b" }], total: 100 });
     await waitFor(() => expect(result.current.data?.data?.[0]?.trace_id).toBe("b"));
+  });
+});
+
+describe("usePrefetchTraces", () => {
+  it("prefetches the given page with the same key shape and auth user", async () => {
+    getTraces.mockResolvedValue({ data: [], total: 0 });
+    const { result } = renderHook(() => usePrefetchTraces("p1"), { wrapper: wrapper() });
+
+    result.current({ page: 3, limit: 50, user_id: "u1" });
+
+    await waitFor(() => expect(getTraces).toHaveBeenCalledTimes(1));
+    expect(getTraces).toHaveBeenCalledWith(
+      "p1",
+      "",
+      { page: 3, limit: 50, user_id: "u1" },
+      { id: "u1", email: "e@x.dev" },
+    );
+  });
+
+  it("does nothing without a projectId", () => {
+    const { result } = renderHook(() => usePrefetchTraces(""), { wrapper: wrapper() });
+    result.current({ page: 1, limit: 50 });
+    expect(getTraces).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What & why

Makes traces-list navigation feel smooth instead of flashing/reloading on every page change. Two layers, both client-side (TanStack Query v5):

- **Keep previous rows** — `placeholderData: keepPreviousData` + a 30s `staleTime` on `useTraces`, so the previous page stays painted while the next page fetches (no flash to empty), redundant refetches on revisit are skipped, and a warmed page stays fresh through the click.
- **Hover/focus prefetch of the adjacent page** — a `usePrefetchTraces` helper + an optional `onPrefetchPage` prop on `ListPagination`; hovering/focusing prev/next warms page ±1 into the cache so the click is a cache hit. Gated off while live auto-refresh is on (new traces shift offsets and would invalidate warmed pages).

A shared `tracesQueryKey(projectId, options)` factory guarantees the hook and the prefetch key identically — a drift would silently cache warmed pages under a key the hook never reads. No loading dim (prefetch + keep-previous-rows is sufficient).

## How it's built

| File | Change |
|---|---|
| `features/traces/hooks/index.ts` | `tracesQueryKey` factory, `TRACES_LIST_STALE_TIME_MS`, `keepPreviousData`+`staleTime` on `useTraces`, new `usePrefetchTraces` |
| `components/list-pagination.tsx` | optional `onPrefetchPage` prop, aria-labels, hover/focus handlers (bounds-guarded) |
| `app/projects/[projectId]/traces/page.tsx` | wire `usePrefetchTraces` → `onPrefetchPage`, gated on `!autoRefresh` |

## Tests

- 12 tests across 4 files: key-factory shape, `keepPreviousData` (previous rows persist while next page is in flight), `usePrefetchTraces` arg/auth shape + no-op without project, pagination bounds + hover prefetch, page wiring + live-mode gating.
- All passing; changed-line coverage 98%.

## Notes

- Prev/next only; first/last could reuse `onPrefetchPage` later.
- Repeated hover→unhover→hover within the stale window issues a single request (React Query single-flight + `staleTime` dedup).


## Video

https://github.com/user-attachments/assets/9dfdbbad-0125-4305-b949-e126bd807a8e



Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooths traces-list pagination by keeping previous rows on screen and prefetching adjacent pages on hover, removing flicker and speeding page changes.

- **New Features**
  - `useTraces` uses `keepPreviousData` and a 30s `staleTime` in `@tanstack/react-query` to keep prior rows visible and skip redundant refetches.
  - Added `usePrefetchTraces` and a shared `tracesQueryKey(...)` factory; hovering/focusing prev/next preloads page ±1 into cache for instant navigation.
  - `ListPagination` accepts `onPrefetchPage`; wired in the traces page and disabled during auto-refresh to avoid stale offsets.
  - Added ARIA labels for prev/next buttons.

<sup>Written for commit 25d0e92fcbaa63e65d80dc5d8c04416457103b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

