### PR TITLE
Fix/open in new tab preserves ai chat

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.test.tsx
@@ -17,6 +17,14 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => ({ get: (key: string) => mocks.searchParam(key) }),
 }));
 
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({
+    setAiPanelOpen: mocks.setAiPanelOpen,
+    setAiContext: mocks.setAiContext,
+    setAiInitialSessionId: mocks.setAiInitialSessionId,
+  }),
+}));
+
 // Controlled list state so the test asserts the exact range carried back to the list.
 vi.mock("@/lib/hooks/use-list-page-state", () => ({
   useListPageState: () => ({
@@ -32,14 +40,6 @@ vi.mock("@/lib/hooks/use-list-page-state", () => ({
 
 vi.mock("@/features/detectors/hooks/use-detectors", () => ({
   useDetector: () => ({ data: { name: "My Detector" } }),
-}));
-
-vi.mock("@/components/layout/app-layout", () => ({
-  useLayout: () => ({
-    setAiPanelOpen: mocks.setAiPanelOpen,
-    setAiContext: mocks.setAiContext,
-    setAiInitialSessionId: mocks.setAiInitialSessionId,
-  }),
 }));
 
 // Both tabs are the same table: the page calls useRuns twice — once with
@@ -139,15 +139,16 @@ afterEach(() => {
   mocks.useRuns.mockImplementation(defaultUseRuns);
   mocks.searchParam.mockReset();
   mocks.searchParam.mockReturnValue(null);
+  mocks.setAiPanelOpen.mockClear();
+  mocks.setAiContext.mockClear();
+  mocks.setAiInitialSessionId.mockClear();
 });
 
 describe("DetectorDetailPage", () => {
   it("carries the selected time range back to the list via the Detectors link", () => {
     mocks.useRuns.mockImplementation(defaultUseRuns);
     render(<DetectorDetailPage />);
-
     fireEvent.click(screen.getByRole("button", { name: "Detectors" }));
-
     expect(mocks.push).toHaveBeenCalledWith("/projects/proj-1/detectors?date_filter=7d");
   });
 

--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.test.tsx
@@ -1,11 +1,14 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent, within, waitFor } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   useRuns: vi.fn(),
   searchParam: vi.fn((_key: string): string | null => null),
+  setAiPanelOpen: vi.fn(),
+  setAiContext: vi.fn(),
+  setAiInitialSessionId: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -29,6 +32,14 @@ vi.mock("@/lib/hooks/use-list-page-state", () => ({
 
 vi.mock("@/features/detectors/hooks/use-detectors", () => ({
   useDetector: () => ({ data: { name: "My Detector" } }),
+}));
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({
+    setAiPanelOpen: mocks.setAiPanelOpen,
+    setAiContext: mocks.setAiContext,
+    setAiInitialSessionId: mocks.setAiInitialSessionId,
+  }),
 }));
 
 // Both tabs are the same table: the page calls useRuns twice — once with
@@ -273,5 +284,38 @@ describe("DetectorDetailPage", () => {
     render(<DetectorDetailPage />);
 
     expect(screen.getByText("No findings found")).toBeTruthy();
+  });
+});
+
+describe("DetectorDetailPage AI panel restoration", () => {
+  it("does not open AI panel when ai param is absent", async () => {
+    mocks.useRuns.mockImplementation(defaultUseRuns);
+    render(<DetectorDetailPage />);
+    await waitFor(() => {});
+    expect(mocks.setAiPanelOpen).not.toHaveBeenCalledWith(true);
+  });
+
+  it("opens AI panel and sets context when ai=1 and traceId are in the URL", async () => {
+    mocks.useRuns.mockImplementation(defaultUseRuns);
+    mocks.searchParam.mockImplementation((key: string) => {
+      if (key === "ai") return "1";
+      if (key === "traceId") return "trace-1";
+      return null;
+    });
+    render(<DetectorDetailPage />);
+    await waitFor(() => expect(mocks.setAiPanelOpen).toHaveBeenCalledWith(true));
+    expect(mocks.setAiContext).toHaveBeenCalledWith({ traceId: "trace-1" });
+  });
+
+  it("restores the chat session when sessionId is also in the URL", async () => {
+    mocks.useRuns.mockImplementation(defaultUseRuns);
+    mocks.searchParam.mockImplementation((key: string) => {
+      if (key === "ai") return "1";
+      if (key === "traceId") return "trace-1";
+      if (key === "sessionId") return "sess-42";
+      return null;
+    });
+    render(<DetectorDetailPage />);
+    await waitFor(() => expect(mocks.setAiInitialSessionId).toHaveBeenCalledWith("sess-42"));
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
@@ -13,6 +13,7 @@ import { DetectorRunsTable } from "@/features/detectors/components/detector-runs
 import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { DETECTORS_DEFAULT_DATE_FILTER_ID } from "@/lib/date-filter";
 import { TraceViewerPanel } from "@/features/traces/components/TraceViewerPanel";
+import { useLayout } from "@/components/layout/app-layout";
 
 /**
  * Which trace the consolidated panel shows. `kind` selects RCA auto-open:
@@ -34,9 +35,13 @@ export default function DetectorDetailPage() {
   const projectId = params.projectId as string;
   const detectorId = params.detectorId as string;
 
+  const { setAiPanelOpen, setAiContext, setAiInitialSessionId } = useLayout();
+
   // Deep-link params: set when a trace is popped out into a new tab from the
   // panel's "open in new tab" button, so it reopens here in the detector tab.
   const traceIdFromUrl = searchParams.get("traceId");
+  const aiParam = searchParams.get("ai");
+  const sessionIdParam = searchParams.get("sessionId");
   const [startFullscreen, setStartFullscreen] = useState(searchParams.get("fullscreen") === "1");
   const [didAutoOpen, setDidAutoOpen] = useState(false);
 
@@ -127,6 +132,20 @@ export default function DetectorDetailPage() {
     }
   }, [didAutoOpen, traceIdFromUrl, activeRows]);
 
+  useEffect(() => {
+    if (aiParam !== "1" || !traceIdFromUrl) return;
+    setAiContext({ traceId: traceIdFromUrl });
+    if (sessionIdParam) setAiInitialSessionId(sessionIdParam);
+    setAiPanelOpen(true);
+  }, [
+    aiParam,
+    sessionIdParam,
+    traceIdFromUrl,
+    setAiContext,
+    setAiInitialSessionId,
+    setAiPanelOpen,
+  ]);
+
   const selectedIndex = selectedTrace
     ? activeRows.findIndex((r) => r.trace_id === selectedTrace.traceId)
     : -1;
@@ -145,7 +164,7 @@ export default function DetectorDetailPage() {
 
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Page header */}
-        <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+        <div className="gap-2 border-border px-4 py-3 flex items-center border-b">
           <button
             type="button"
             onClick={() => router.push(buildUrl(`/projects/${projectId}/detectors`))}
@@ -154,11 +173,11 @@ export default function DetectorDetailPage() {
             Detectors
           </button>
           <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="text-[13px] font-medium">{detector?.name ?? detectorId}</span>
+          <span className="font-medium text-[13px]">{detector?.name ?? detectorId}</span>
         </div>
 
         {/* Tabs */}
-        <div className="border-b border-border bg-background">
+        <div className="border-border bg-background border-b">
           <div className="flex">
             {tabs.map((tab) => {
               const Icon = tab.icon;
@@ -169,10 +188,10 @@ export default function DetectorDetailPage() {
                   type="button"
                   onClick={() => setActiveTab(tab.id)}
                   className={cn(
-                    "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
+                    "gap-1.5 px-3 py-1.5 font-medium flex items-center border-b-2 text-[13px] transition-colors",
                     isActive
                       ? "border-foreground bg-muted text-foreground"
-                      : "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                      : "text-muted-foreground hover:bg-muted/50 hover:text-foreground border-transparent",
                   )}
                 >
                   <Icon className="h-3.5 w-3.5" />

--- a/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/[detectorId]/page.tsx
@@ -164,7 +164,7 @@ export default function DetectorDetailPage() {
 
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Page header */}
-        <div className="gap-2 border-border px-4 py-3 flex items-center border-b">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-3">
           <button
             type="button"
             onClick={() => router.push(buildUrl(`/projects/${projectId}/detectors`))}
@@ -173,11 +173,11 @@ export default function DetectorDetailPage() {
             Detectors
           </button>
           <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="font-medium text-[13px]">{detector?.name ?? detectorId}</span>
+          <span className="text-[13px] font-medium">{detector?.name ?? detectorId}</span>
         </div>
 
         {/* Tabs */}
-        <div className="border-border bg-background border-b">
+        <div className="border-b border-border bg-background">
           <div className="flex">
             {tabs.map((tab) => {
               const Icon = tab.icon;
@@ -188,10 +188,10 @@ export default function DetectorDetailPage() {
                   type="button"
                   onClick={() => setActiveTab(tab.id)}
                   className={cn(
-                    "gap-1.5 px-3 py-1.5 font-medium flex items-center border-b-2 text-[13px] transition-colors",
+                    "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
                     isActive
                       ? "border-foreground bg-muted text-foreground"
-                      : "text-muted-foreground hover:bg-muted/50 hover:text-foreground border-transparent",
+                      : "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
                   )}
                 >
                   <Icon className="h-3.5 w-3.5" />

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.test.tsx
@@ -39,6 +39,7 @@ vi.mock("@/features/traces/hooks", () => ({
     isPending: false,
     error: null,
   }),
+  usePrefetchTraces: () => vi.fn(),
 }));
 
 vi.mock("@/lib/hooks/use-list-page-state", () => ({

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  setAiPanelOpen: vi.fn(),
+  setAiContext: vi.fn(),
+  setAiInitialSessionId: vi.fn(),
+  params: {} as Record<string, string>,
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "proj-1" }),
+  useSearchParams: () => ({ get: (k: string) => mocks.params[k] ?? null }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({
+    setHideAiButton: vi.fn(),
+    setAiPanelOpen: mocks.setAiPanelOpen,
+    setAiContext: mocks.setAiContext,
+    setAiInitialSessionId: mocks.setAiInitialSessionId,
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ isPending: false }),
+}));
+
+vi.mock("@/features/traces/hooks", () => ({
+  useTraces: () => ({
+    data: { data: [], meta: { total: 0 } },
+    isLoading: false,
+    isPending: false,
+    error: null,
+  }),
+}));
+
+vi.mock("@/lib/hooks/use-list-page-state", () => ({
+  useListPageState: () => ({
+    state: {
+      dateFilter: { id: "1d" },
+      customStartDate: null,
+      customEndDate: null,
+      keyword: "",
+      page: 1,
+      limit: 20,
+    },
+    updateDateFilter: vi.fn(),
+    updateCustomRange: vi.fn(),
+    updateKeyword: vi.fn(),
+    updateLimit: vi.fn(),
+    goToPage: vi.fn(),
+    queryOptions: {},
+  }),
+}));
+
+vi.mock("@/lib/hooks/use-local-storage", () => ({
+  useLocalStorage: () => [false, vi.fn()],
+}));
+
+vi.mock("@/features/traces/components", () => ({
+  TraceViewerPanel: () => null,
+  GettingStarted: () => null,
+}));
+
+vi.mock("@/features/projects/components", () => ({
+  ProjectBreadcrumb: () => null,
+}));
+
+vi.mock("@/components/search-filter-bar", () => ({
+  SearchFilterBar: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/list-pagination", () => ({
+  ListPagination: () => null,
+}));
+
+vi.mock("@/features/traces/utils", () => ({
+  formatContentPreview: (v: unknown) => String(v),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  formatDuration: vi.fn(),
+  formatDate: vi.fn(),
+  formatCost: vi.fn(),
+  formatTokenFlow: vi.fn(),
+  formatExactTokens: vi.fn(),
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+  buildUrlWithFilters: (path: string) => path,
+}));
+
+import TracesPage from "./page";
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  mocks.params = {};
+});
+
+describe("TracesPage AI panel restoration", () => {
+  it("does not open AI panel when ai param is absent", async () => {
+    render(<TracesPage />);
+    await waitFor(() => {});
+    expect(mocks.setAiPanelOpen).not.toHaveBeenCalledWith(true);
+  });
+
+  it("opens AI panel and sets context when ai=1 and traceId are in the URL", async () => {
+    mocks.params = { ai: "1", traceId: "trace-1" };
+    render(<TracesPage />);
+    await waitFor(() => expect(mocks.setAiPanelOpen).toHaveBeenCalledWith(true));
+    expect(mocks.setAiContext).toHaveBeenCalledWith({ traceId: "trace-1" });
+  });
+
+  it("restores the chat session when sessionId is also in the URL", async () => {
+    mocks.params = { ai: "1", traceId: "trace-1", sessionId: "sess-42" };
+    render(<TracesPage />);
+    await waitFor(() => expect(mocks.setAiInitialSessionId).toHaveBeenCalledWith("sess-42"));
+  });
+
+  it("does not call setAiInitialSessionId when sessionId is absent", async () => {
+    mocks.params = { ai: "1", traceId: "trace-1" };
+    render(<TracesPage />);
+    await waitFor(() => expect(mocks.setAiPanelOpen).toHaveBeenCalledWith(true));
+    expect(mocks.setAiInitialSessionId).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -39,10 +39,12 @@ export default function TracesPage() {
   const router = useRouter();
   const projectId = params.projectId as string;
   const queryClient = useQueryClient();
-  const { setHideAiButton } = useLayout();
+  const { setHideAiButton, setAiPanelOpen, setAiContext, setAiInitialSessionId } = useLayout();
   const { isPending: authPending } = useAuthSession();
   const userId = searchParams.get("user_id");
   const traceIdFromUrl = searchParams.get("traceId");
+  const aiParam = searchParams.get("ai");
+  const sessionIdParam = searchParams.get("sessionId");
   // Set when a trace is opened in a new tab via the panel's "open in new tab"
   // button, so the panel mounts already expanded to full width. Held as state
   // (not a derived value) so it only seeds the first trace opened from the URL:
@@ -117,6 +119,20 @@ export default function TracesPage() {
     setHideAiButton(shouldHideAiButton);
   }, [shouldHideAiButton, setHideAiButton]);
 
+  useEffect(() => {
+    if (aiParam !== "1" || !traceIdFromUrl) return;
+    setAiContext({ traceId: traceIdFromUrl });
+    if (sessionIdParam) setAiInitialSessionId(sessionIdParam);
+    setAiPanelOpen(true);
+  }, [
+    aiParam,
+    sessionIdParam,
+    traceIdFromUrl,
+    setAiContext,
+    setAiInitialSessionId,
+    setAiPanelOpen,
+  ]);
+
   const buildUrl = (path: string, extraParams?: Record<string, string>) =>
     buildUrlWithFilters(path, {
       dateFilter: state.dateFilter,
@@ -133,7 +149,7 @@ export default function TracesPage() {
       <div className="flex min-w-0 flex-1 flex-col">
         {/* Tab navigation — hidden during onboarding or while checking */}
         {!checking && !showGettingStarted && (
-          <div className="border-b border-border bg-background">
+          <div className="border-border bg-background border-b">
             <div className="flex">
               {tabs.map((tab) => {
                 const Icon = tab.icon;
@@ -143,10 +159,10 @@ export default function TracesPage() {
                     key={tab.id}
                     href={buildUrl(`/projects/${projectId}/${tab.href}`)}
                     className={cn(
-                      "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
+                      "gap-1.5 px-3 py-1.5 font-medium flex items-center border-b-2 text-[13px] transition-colors",
                       isActive
                         ? "border-foreground bg-muted text-foreground"
-                        : "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+                        : "text-muted-foreground hover:bg-muted/50 hover:text-foreground border-transparent",
                     )}
                   >
                     <Icon className="h-3.5 w-3.5" />
@@ -180,32 +196,32 @@ export default function TracesPage() {
                   ? "Live list refresh on (every 5s) — click to disable"
                   : "Enable live list refresh"
               }
-              className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1 text-[12px] text-foreground transition-colors hover:border-foreground/40 hover:bg-muted"
+              className="gap-2 rounded-md border-border px-2.5 py-1 text-foreground hover:border-foreground/40 hover:bg-muted flex items-center border text-[12px] transition-colors"
             >
               Live
               <span
                 className={cn(
-                  "relative inline-flex h-4 w-7 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200",
+                  "h-4 w-7 relative inline-flex shrink-0 rounded-full border-2 border-transparent transition-colors duration-200",
                   autoRefresh ? "bg-foreground" : "bg-input",
                 )}
               >
                 <span
                   className={cn(
-                    "block h-3 w-3 rounded-full bg-background shadow-sm transition-transform duration-200",
+                    "h-3 w-3 bg-background shadow-sm block rounded-full transition-transform duration-200",
                     autoRefresh ? "translate-x-3" : "translate-x-0",
                   )}
                 />
               </span>
             </button>
             {userId && (
-              <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 py-1 pl-2.5 pr-1.5">
+              <div className="gap-1.5 rounded-md border-border bg-muted/50 py-1 pl-2.5 pr-1.5 flex items-center border">
                 <Users className="h-3 w-3 text-muted-foreground" />
-                <span className="text-[12px] text-muted-foreground">User:</span>
-                <span className="text-[12px] font-medium text-foreground">{userId}</span>
+                <span className="text-muted-foreground text-[12px]">User:</span>
+                <span className="font-medium text-foreground text-[12px]">{userId}</span>
                 <button
                   type="button"
                   onClick={() => router.push(buildUrl(`/projects/${projectId}/traces`))}
-                  className="ml-1 rounded p-0.5 transition-colors hover:bg-muted"
+                  className="ml-1 rounded p-0.5 hover:bg-muted transition-colors"
                 >
                   <X className="h-3 w-3 text-muted-foreground" />
                 </button>
@@ -215,24 +231,24 @@ export default function TracesPage() {
         )}
 
         {/* Content */}
-        <div className="flex-1 overflow-auto bg-background">
+        <div className="bg-background flex-1 overflow-auto">
           {isLoading || checking ? (
-            <div className="flex h-64 items-center justify-center">
-              <p className="text-[13px] text-muted-foreground">Loading traces...</p>
+            <div className="h-64 flex items-center justify-center">
+              <p className="text-muted-foreground text-[13px]">Loading traces...</p>
             </div>
           ) : error && !data ? (
-            <div className="flex h-64 flex-col items-center justify-center gap-3">
-              <p className="text-[13px] text-destructive">Error loading traces</p>
-              <p className="text-[12px] text-muted-foreground">
+            <div className="h-64 gap-3 flex flex-col items-center justify-center">
+              <p className="text-destructive text-[13px]">Error loading traces</p>
+              <p className="text-muted-foreground text-[12px]">
                 Make sure the API server is running and you have API keys configured.
               </p>
             </div>
           ) : showGettingStarted ? (
             <GettingStarted projectId={projectId} />
           ) : traces.length === 0 ? (
-            <div className="flex h-64 flex-col items-center justify-center gap-3">
-              <p className="text-[13px] text-muted-foreground">No traces found</p>
-              <p className="text-[12px] text-muted-foreground">
+            <div className="h-64 gap-3 flex flex-col items-center justify-center">
+              <p className="text-muted-foreground text-[13px]">No traces found</p>
+              <p className="text-muted-foreground text-[12px]">
                 Try adjusting your filters or date range.
               </p>
             </div>
@@ -240,36 +256,36 @@ export default function TracesPage() {
             <div className="flex h-full flex-col">
               <div className="flex-1 overflow-auto">
                 <table className="w-full">
-                  <thead className="sticky top-0 bg-background">
-                    <tr className="border-b border-border bg-muted/50">
-                      <th className="w-[140px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  <thead className="top-0 bg-background sticky">
+                    <tr className="border-border bg-muted/50 border-b">
+                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[140px] border-r text-left text-[12px]">
                         Timestamp
                       </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground border-r text-left text-[12px]">
                         Name
                       </th>
-                      <th className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground max-w-[400px] min-w-[280px] border-r text-left text-[12px]">
                         Trace ID
                       </th>
-                      <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[60px] border-r text-left text-[12px]">
                         Errors
                       </th>
-                      <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[60px] border-r text-left text-[12px]">
                         Spans
                       </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground border-r text-left text-[12px]">
                         Input
                       </th>
-                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground border-r text-left text-[12px]">
                         Output
                       </th>
-                      <th className="w-[100px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[100px] border-r text-left text-[12px]">
                         Tokens
                       </th>
-                      <th className="w-[80px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[80px] border-r text-left text-[12px]">
                         Cost
                       </th>
-                      <th className="px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                      <th className="px-3 py-1.5 font-medium text-muted-foreground text-left text-[12px]">
                         Latency
                       </th>
                     </tr>
@@ -282,44 +298,44 @@ export default function TracesPage() {
                           setSelectedTraceId(trace.trace_id);
                         }}
                         className={cn(
-                          "cursor-pointer border-b border-border/50 transition-colors last:border-0",
+                          "border-border/50 cursor-pointer border-b transition-colors last:border-0",
                           selectedTraceId === trace.trace_id ? "bg-muted" : "hover:bg-muted/50",
                         )}
                       >
-                        <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                        <td className="border-border/50 px-3 py-1.5 text-muted-foreground border-r text-[12px] whitespace-nowrap">
                           {formatDate(trace.trace_start_time)}
                         </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
+                        <td className="border-border/50 px-3 py-1.5 text-foreground border-r text-[12px]">
                           {trace.name}
                         </td>
-                        <td className="min-w-[280px] max-w-[400px] whitespace-nowrap border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
+                        <td className="border-border/50 px-3 py-1.5 font-mono text-muted-foreground max-w-[400px] min-w-[280px] border-r text-[11px] whitespace-nowrap">
                           <span className="block truncate" title={trace.trace_id}>
                             {trace.trace_id}
                           </span>
                         </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 text-center">
+                        <td className="border-border/50 px-3 py-1.5 border-r text-center">
                           {trace.error_count > 0 ? (
-                            <span className="inline-flex min-w-5 justify-center rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
+                            <span className="min-w-5 rounded bg-red-100 px-1.5 py-0.5 font-medium text-red-700 dark:bg-red-950 dark:text-red-400 inline-flex justify-center text-[10px]">
                               {trace.error_count}
                             </span>
                           ) : (
-                            <span className="text-[12px] text-muted-foreground">0</span>
+                            <span className="text-muted-foreground text-[12px]">0</span>
                           )}
                         </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 text-center text-[12px] text-muted-foreground">
+                        <td className="border-border/50 px-3 py-1.5 text-muted-foreground border-r text-center text-[12px]">
                           {trace.span_count}
                         </td>
-                        <td className="max-w-[180px] border-r border-border/50 px-3 py-1.5">
-                          <span className="block truncate font-mono text-[11px] text-muted-foreground">
+                        <td className="border-border/50 px-3 py-1.5 max-w-[180px] border-r">
+                          <span className="font-mono text-muted-foreground block truncate text-[11px]">
                             {formatContentPreview(trace.input)}
                           </span>
                         </td>
-                        <td className="max-w-[180px] border-r border-border/50 px-3 py-1.5">
-                          <span className="block truncate font-mono text-[11px] text-muted-foreground">
+                        <td className="border-border/50 px-3 py-1.5 max-w-[180px] border-r">
+                          <span className="font-mono text-muted-foreground block truncate text-[11px]">
                             {formatContentPreview(trace.output)}
                           </span>
                         </td>
-                        <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                        <td className="border-border/50 px-3 py-1.5 text-muted-foreground border-r text-[12px] whitespace-nowrap">
                           {(trace.total_input_tokens ?? 0) + (trace.total_output_tokens ?? 0) >
                           0 ? (
                             <span
@@ -331,12 +347,12 @@ export default function TracesPage() {
                             "-"
                           )}
                         </td>
-                        <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
+                        <td className="border-border/50 px-3 py-1.5 text-foreground border-r text-[12px]">
                           {trace.total_cost && trace.total_cost > 0
                             ? formatCost(trace.total_cost)
                             : "-"}
                         </td>
-                        <td className="whitespace-nowrap px-3 py-1.5 text-[12px] text-foreground">
+                        <td className="px-3 py-1.5 text-foreground text-[12px] whitespace-nowrap">
                           {formatDuration(trace.duration_ms)}
                         </td>
                       </tr>

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -149,7 +149,7 @@ export default function TracesPage() {
       <div className="flex min-w-0 flex-1 flex-col">
         {/* Tab navigation — hidden during onboarding or while checking */}
         {!checking && !showGettingStarted && (
-          <div className="border-border bg-background border-b">
+          <div className="border-b border-border bg-background">
             <div className="flex">
               {tabs.map((tab) => {
                 const Icon = tab.icon;
@@ -159,10 +159,10 @@ export default function TracesPage() {
                     key={tab.id}
                     href={buildUrl(`/projects/${projectId}/${tab.href}`)}
                     className={cn(
-                      "gap-1.5 px-3 py-1.5 font-medium flex items-center border-b-2 text-[13px] transition-colors",
+                      "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
                       isActive
                         ? "border-foreground bg-muted text-foreground"
-                        : "text-muted-foreground hover:bg-muted/50 hover:text-foreground border-transparent",
+                        : "border-transparent text-muted-foreground hover:bg-muted/50 hover:text-foreground",
                     )}
                   >
                     <Icon className="h-3.5 w-3.5" />
@@ -196,32 +196,32 @@ export default function TracesPage() {
                   ? "Live list refresh on (every 5s) — click to disable"
                   : "Enable live list refresh"
               }
-              className="gap-2 rounded-md border-border px-2.5 py-1 text-foreground hover:border-foreground/40 hover:bg-muted flex items-center border text-[12px] transition-colors"
+              className="flex items-center gap-2 rounded-md border border-border px-2.5 py-1 text-[12px] text-foreground transition-colors hover:border-foreground/40 hover:bg-muted"
             >
               Live
               <span
                 className={cn(
-                  "h-4 w-7 relative inline-flex shrink-0 rounded-full border-2 border-transparent transition-colors duration-200",
+                  "relative inline-flex h-4 w-7 shrink-0 rounded-full border-2 border-transparent transition-colors duration-200",
                   autoRefresh ? "bg-foreground" : "bg-input",
                 )}
               >
                 <span
                   className={cn(
-                    "h-3 w-3 bg-background shadow-sm block rounded-full transition-transform duration-200",
+                    "block h-3 w-3 rounded-full bg-background shadow-sm transition-transform duration-200",
                     autoRefresh ? "translate-x-3" : "translate-x-0",
                   )}
                 />
               </span>
             </button>
             {userId && (
-              <div className="gap-1.5 rounded-md border-border bg-muted/50 py-1 pl-2.5 pr-1.5 flex items-center border">
+              <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 py-1 pl-2.5 pr-1.5">
                 <Users className="h-3 w-3 text-muted-foreground" />
-                <span className="text-muted-foreground text-[12px]">User:</span>
-                <span className="font-medium text-foreground text-[12px]">{userId}</span>
+                <span className="text-[12px] text-muted-foreground">User:</span>
+                <span className="text-[12px] font-medium text-foreground">{userId}</span>
                 <button
                   type="button"
                   onClick={() => router.push(buildUrl(`/projects/${projectId}/traces`))}
-                  className="ml-1 rounded p-0.5 hover:bg-muted transition-colors"
+                  className="ml-1 rounded p-0.5 transition-colors hover:bg-muted"
                 >
                   <X className="h-3 w-3 text-muted-foreground" />
                 </button>
@@ -231,24 +231,24 @@ export default function TracesPage() {
         )}
 
         {/* Content */}
-        <div className="bg-background flex-1 overflow-auto">
+        <div className="flex-1 overflow-auto bg-background">
           {isLoading || checking ? (
-            <div className="h-64 flex items-center justify-center">
-              <p className="text-muted-foreground text-[13px]">Loading traces...</p>
+            <div className="flex h-64 items-center justify-center">
+              <p className="text-[13px] text-muted-foreground">Loading traces...</p>
             </div>
           ) : error && !data ? (
-            <div className="h-64 gap-3 flex flex-col items-center justify-center">
-              <p className="text-destructive text-[13px]">Error loading traces</p>
-              <p className="text-muted-foreground text-[12px]">
+            <div className="flex h-64 flex-col items-center justify-center gap-3">
+              <p className="text-[13px] text-destructive">Error loading traces</p>
+              <p className="text-[12px] text-muted-foreground">
                 Make sure the API server is running and you have API keys configured.
               </p>
             </div>
           ) : showGettingStarted ? (
             <GettingStarted projectId={projectId} />
           ) : traces.length === 0 ? (
-            <div className="h-64 gap-3 flex flex-col items-center justify-center">
-              <p className="text-muted-foreground text-[13px]">No traces found</p>
-              <p className="text-muted-foreground text-[12px]">
+            <div className="flex h-64 flex-col items-center justify-center gap-3">
+              <p className="text-[13px] text-muted-foreground">No traces found</p>
+              <p className="text-[12px] text-muted-foreground">
                 Try adjusting your filters or date range.
               </p>
             </div>
@@ -256,36 +256,36 @@ export default function TracesPage() {
             <div className="flex h-full flex-col">
               <div className="flex-1 overflow-auto">
                 <table className="w-full">
-                  <thead className="top-0 bg-background sticky">
-                    <tr className="border-border bg-muted/50 border-b">
-                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[140px] border-r text-left text-[12px]">
+                  <thead className="sticky top-0 bg-background">
+                    <tr className="border-b border-border bg-muted/50">
+                      <th className="w-[140px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Timestamp
                       </th>
-                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground border-r text-left text-[12px]">
+                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Name
                       </th>
-                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground max-w-[400px] min-w-[280px] border-r text-left text-[12px]">
+                      <th className="min-w-[280px] max-w-[400px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Trace ID
                       </th>
-                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[60px] border-r text-left text-[12px]">
+                      <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Errors
                       </th>
-                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[60px] border-r text-left text-[12px]">
+                      <th className="w-[60px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Spans
                       </th>
-                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground border-r text-left text-[12px]">
+                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Input
                       </th>
-                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground border-r text-left text-[12px]">
+                      <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Output
                       </th>
-                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[100px] border-r text-left text-[12px]">
+                      <th className="w-[100px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Tokens
                       </th>
-                      <th className="border-border/50 px-3 py-1.5 font-medium text-muted-foreground w-[80px] border-r text-left text-[12px]">
+                      <th className="w-[80px] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Cost
                       </th>
-                      <th className="px-3 py-1.5 font-medium text-muted-foreground text-left text-[12px]">
+                      <th className="px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                         Latency
                       </th>
                     </tr>
@@ -298,44 +298,44 @@ export default function TracesPage() {
                           setSelectedTraceId(trace.trace_id);
                         }}
                         className={cn(
-                          "border-border/50 cursor-pointer border-b transition-colors last:border-0",
+                          "cursor-pointer border-b border-border/50 transition-colors last:border-0",
                           selectedTraceId === trace.trace_id ? "bg-muted" : "hover:bg-muted/50",
                         )}
                       >
-                        <td className="border-border/50 px-3 py-1.5 text-muted-foreground border-r text-[12px] whitespace-nowrap">
+                        <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                           {formatDate(trace.trace_start_time)}
                         </td>
-                        <td className="border-border/50 px-3 py-1.5 text-foreground border-r text-[12px]">
+                        <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
                           {trace.name}
                         </td>
-                        <td className="border-border/50 px-3 py-1.5 font-mono text-muted-foreground max-w-[400px] min-w-[280px] border-r text-[11px] whitespace-nowrap">
+                        <td className="min-w-[280px] max-w-[400px] whitespace-nowrap border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
                           <span className="block truncate" title={trace.trace_id}>
                             {trace.trace_id}
                           </span>
                         </td>
-                        <td className="border-border/50 px-3 py-1.5 border-r text-center">
+                        <td className="border-r border-border/50 px-3 py-1.5 text-center">
                           {trace.error_count > 0 ? (
-                            <span className="min-w-5 rounded bg-red-100 px-1.5 py-0.5 font-medium text-red-700 dark:bg-red-950 dark:text-red-400 inline-flex justify-center text-[10px]">
+                            <span className="inline-flex min-w-5 justify-center rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
                               {trace.error_count}
                             </span>
                           ) : (
-                            <span className="text-muted-foreground text-[12px]">0</span>
+                            <span className="text-[12px] text-muted-foreground">0</span>
                           )}
                         </td>
-                        <td className="border-border/50 px-3 py-1.5 text-muted-foreground border-r text-center text-[12px]">
+                        <td className="border-r border-border/50 px-3 py-1.5 text-center text-[12px] text-muted-foreground">
                           {trace.span_count}
                         </td>
-                        <td className="border-border/50 px-3 py-1.5 max-w-[180px] border-r">
-                          <span className="font-mono text-muted-foreground block truncate text-[11px]">
+                        <td className="max-w-[180px] border-r border-border/50 px-3 py-1.5">
+                          <span className="block truncate font-mono text-[11px] text-muted-foreground">
                             {formatContentPreview(trace.input)}
                           </span>
                         </td>
-                        <td className="border-border/50 px-3 py-1.5 max-w-[180px] border-r">
-                          <span className="font-mono text-muted-foreground block truncate text-[11px]">
+                        <td className="max-w-[180px] border-r border-border/50 px-3 py-1.5">
+                          <span className="block truncate font-mono text-[11px] text-muted-foreground">
                             {formatContentPreview(trace.output)}
                           </span>
                         </td>
-                        <td className="border-border/50 px-3 py-1.5 text-muted-foreground border-r text-[12px] whitespace-nowrap">
+                        <td className="whitespace-nowrap border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                           {(trace.total_input_tokens ?? 0) + (trace.total_output_tokens ?? 0) >
                           0 ? (
                             <span
@@ -347,12 +347,12 @@ export default function TracesPage() {
                             "-"
                           )}
                         </td>
-                        <td className="border-border/50 px-3 py-1.5 text-foreground border-r text-[12px]">
+                        <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
                           {trace.total_cost && trace.total_cost > 0
                             ? formatCost(trace.total_cost)
                             : "-"}
                         </td>
-                        <td className="px-3 py-1.5 text-foreground text-[12px] whitespace-nowrap">
+                        <td className="whitespace-nowrap px-3 py-1.5 text-[12px] text-foreground">
                           {formatDuration(trace.duration_ms)}
                         </td>
                       </tr>

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-import {
-  useState,
-  useEffect,
-  useRef,
-  useCallback,
-  createContext,
-  useContext,
-  ReactNode,
-} from "react";
+import { useState, useEffect, useCallback, useRef, createContext, useContext, ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { Button } from "@/components/ui/button";
@@ -72,12 +64,11 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [hideAiButton, setHideAiButton] = useState(true);
   const [aiHostRefCount, setAiHostRefCount] = useState(0);
   const pathname = usePathname();
-  // Skip the AI-panel reset on the very first render so that pages can
-  // restore AI state from URL params (e.g. ai=1&sessionId=...) without
-  // AppLayout immediately clearing what they set.
   const isMountedRef = useRef(false);
 
   // Close the global AI panel whenever the user navigates.
+  // Skip the first render so page-level AI restoration (e.g. open-in-new-tab)
+  // is not overwritten before the child page's useEffect has a chance to run.
   // NOTE: do NOT reset hideAiButton here. Observability pages own that flag.
   useEffect(() => {
     if (!isMountedRef.current) {
@@ -143,10 +134,10 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             <ResizablePanel
               id="main-content"
               minSize="0px"
-              className="min-w-0 flex flex-col overflow-hidden"
+              className="flex min-w-0 flex-col overflow-hidden"
             >
               {/* Top header bar */}
-              <header className="h-14 gap-2 bg-background px-3 flex shrink-0 items-center border-b">
+              <header className="flex h-14 shrink-0 items-center gap-2 border-b bg-background px-3">
                 <Button
                   variant="ghost"
                   size="icon"

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useState, useEffect, useCallback, createContext, useContext, ReactNode } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  createContext,
+  useContext,
+  ReactNode,
+} from "react";
 import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { Button } from "@/components/ui/button";
@@ -64,10 +72,18 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [hideAiButton, setHideAiButton] = useState(true);
   const [aiHostRefCount, setAiHostRefCount] = useState(0);
   const pathname = usePathname();
+  // Skip the AI-panel reset on the very first render so that pages can
+  // restore AI state from URL params (e.g. ai=1&sessionId=...) without
+  // AppLayout immediately clearing what they set.
+  const isMountedRef = useRef(false);
 
   // Close the global AI panel whenever the user navigates.
   // NOTE: do NOT reset hideAiButton here. Observability pages own that flag.
   useEffect(() => {
+    if (!isMountedRef.current) {
+      isMountedRef.current = true;
+      return;
+    }
     setAiPanelOpen(false);
     setAiContext(null);
     setAiInitialSessionId(undefined);
@@ -127,10 +143,10 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
             <ResizablePanel
               id="main-content"
               minSize="0px"
-              className="flex min-w-0 flex-col overflow-hidden"
+              className="min-w-0 flex flex-col overflow-hidden"
             >
               {/* Top header bar */}
-              <header className="flex h-14 shrink-0 items-center gap-2 border-b bg-background px-3">
+              <header className="h-14 gap-2 bg-background px-3 flex shrink-0 items-center border-b">
                 <Button
                   variant="ghost"
                   size="icon"

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, createContext, useContext, ReactNode } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  createContext,
+  useContext,
+  ReactNode,
+} from "react";
 import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { Button } from "@/components/ui/button";

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+
+vi.mock("./use-ai-stream", () => ({
+  useAIStream: () => ({
+    messages: [],
+    isStreaming: false,
+    sendMessage: vi.fn(),
+    abort: vi.fn(),
+    setMessages: vi.fn(),
+  }),
+}));
+
+import { useAiChat } from "./use-ai-chat";
+
+describe("useAiChat.getCurrentSessionId", () => {
+  it("returns null before any session is created", () => {
+    const { result } = renderHook(() => useAiChat({ projectId: "proj-1" }));
+    expect(result.current.getCurrentSessionId()).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -205,6 +205,10 @@ export function useAiChat({
     sessions,
     historyOpen,
     currentSessionId: sessionIdRef.current,
+    // Reads the live ref value at call time — use this in event handlers where
+    // the rendered snapshot of currentSessionId would be stale (refs don't
+    // trigger re-renders when mutated).
+    getCurrentSessionId: () => sessionIdRef.current,
 
     // Setters
     setHistoryOpen,

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   traceError: null as unknown,
   traceLoading: false,
   aiPanelOpen: false,
+  getCurrentSessionId: (): string | null => null,
 }));
 
 // Layout context drives the fullscreen width math (sidebar width).
@@ -20,6 +21,10 @@ vi.mock("@/components/layout/app-layout", () => ({
     registerAiHost: () => () => {},
     sidebarCollapsed: mocks.sidebarCollapsed,
   }),
+}));
+
+vi.mock("@/features/ai-assistant/components/ai-chat-context", () => ({
+  useAiChatContext: () => ({ getCurrentSessionId: mocks.getCurrentSessionId }),
 }));
 
 // Trace fetch + stream — irrelevant to layout, stub them out.
@@ -76,6 +81,53 @@ afterEach(() => {
   mocks.traceError = null;
   mocks.traceLoading = false;
   mocks.aiPanelOpen = false;
+  mocks.getCurrentSessionId = () => null;
+});
+
+describe("TraceViewerPanel open in new tab", () => {
+  it("opens URL without AI params when panel is closed", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    mocks.aiPanelOpen = false;
+    renderPanel();
+    fireEvent.click(screen.getByTitle("Open in new tab"));
+    const url = openSpy.mock.calls[0][0] as string;
+    expect(url).not.toContain("ai=1");
+    expect(url).not.toContain("sessionId");
+    openSpy.mockRestore();
+  });
+
+  it("includes ai=1 in URL when panel is open", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    mocks.aiPanelOpen = true;
+    renderPanel();
+    fireEvent.click(screen.getByTitle("Open in new tab"));
+    const url = openSpy.mock.calls[0][0] as string;
+    expect(url).toContain("ai=1");
+    openSpy.mockRestore();
+  });
+
+  it("includes sessionId in URL when panel is open with an active session", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    mocks.aiPanelOpen = true;
+    mocks.getCurrentSessionId = () => "sess-abc";
+    renderPanel();
+    fireEvent.click(screen.getByTitle("Open in new tab"));
+    const url = openSpy.mock.calls[0][0] as string;
+    expect(url).toContain("sessionId=sess-abc");
+    openSpy.mockRestore();
+  });
+
+  it("omits sessionId when panel is open but no session exists yet", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    mocks.aiPanelOpen = true;
+    mocks.getCurrentSessionId = () => null;
+    renderPanel();
+    fireEvent.click(screen.getByTitle("Open in new tab"));
+    const url = openSpy.mock.calls[0][0] as string;
+    expect(url).toContain("ai=1");
+    expect(url).not.toContain("sessionId");
+    openSpy.mockRestore();
+  });
 });
 
 describe("TraceViewerPanel layout", () => {

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -97,7 +97,7 @@ export function TraceViewerPanel({
     registerAiHost,
     sidebarCollapsed,
   } = useLayout();
-  const { currentSessionId } = useAiChatContext();
+  const { getCurrentSessionId } = useAiChatContext();
 
   // Claim the AI slot for this viewer so AppLayout's project rail steps aside.
   // `registerAiHost()` returns its own cleanup, which we return from the effect
@@ -297,7 +297,8 @@ export function TraceViewerPanel({
                 const extraParams: Record<string, string> = { traceId, fullscreen: "1" };
                 if (aiPanelOpen) {
                   extraParams.ai = "1";
-                  if (currentSessionId) extraParams.sessionId = currentSessionId;
+                  const sessionId = getCurrentSessionId();
+                  if (sessionId) extraParams.sessionId = sessionId;
                 }
                 window.open(
                   buildUrlWithFilters(newTabPath ?? `/projects/${projectId}/traces`, {

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -24,6 +24,7 @@ import { SpanTreeView, type SpanTreeViewHandle } from "./SpanTreeView";
 import { SpanInfoPanel } from "./SpanInfoPanel";
 import { useLayout } from "@/components/layout/app-layout";
 import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
+import { useAiChatContext } from "@/features/ai-assistant/components/ai-chat-context";
 import { useTraceStream } from "../hooks/use-trace-stream";
 import { SpanTimelineView } from "./SpanTimelineView";
 import { TREE_LAYOUT } from "../utils";
@@ -96,6 +97,7 @@ export function TraceViewerPanel({
     registerAiHost,
     sidebarCollapsed,
   } = useLayout();
+  const { currentSessionId } = useAiChatContext();
 
   // Claim the AI slot for this viewer so AppLayout's project rail steps aside.
   // `registerAiHost()` returns its own cleanup, which we return from the effect
@@ -224,7 +226,7 @@ export function TraceViewerPanel({
   return (
     <div
       className={cn(
-        "animate-slide-in-right fixed bottom-0 right-0 z-50 border-l border-border bg-background shadow-xl transition-[width,top] duration-200",
+        "animate-slide-in-right bottom-0 right-0 border-border bg-background shadow-xl fixed z-50 border-l transition-[width,top] duration-200",
         // Fullscreen stays clear of the chrome it would otherwise cover: it
         // starts below the top breadcrumb/header bar (h-14) and to the right of
         // the left navbar. Width = 100% minus the sidebar's width, which differs
@@ -236,15 +238,15 @@ export function TraceViewerPanel({
           : "top-0 w-[70%]",
       )}
     >
-      <div className="flex h-full flex-col bg-background">
+      <div className="bg-background flex h-full flex-col">
         {/* ── MAIN HEADER ── */}
-        <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
-          <div className="flex min-w-0 items-center gap-2">
+        <div className="h-12 border-border bg-muted/30 px-4 flex items-center justify-between border-b">
+          <div className="min-w-0 gap-2 flex items-center">
             <Workflow className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Trace</span>
-            <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
+            <span className="font-mono text-xs text-muted-foreground truncate">{traceId}</span>
           </div>
-          <div className="flex items-center gap-1">
+          <div className="gap-1 flex items-center">
             {hasRca && (
               <button
                 type="button"
@@ -253,7 +255,7 @@ export function TraceViewerPanel({
                   setAiInitialSessionId(rcaSessionId);
                   setAiPanelOpen(true);
                 }}
-                className="rounded-md border border-red-300 bg-red-50 px-2 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60"
+                className="rounded-md border-red-300 bg-red-50 px-2 py-1 font-medium text-red-700 hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60 border text-[11px] transition-colors"
                 title="Findings detected — open root cause analysis"
               >
                 Alert
@@ -291,17 +293,22 @@ export function TraceViewerPanel({
             <Button
               variant="outline"
               size="sm"
-              onClick={() =>
+              onClick={() => {
+                const extraParams: Record<string, string> = { traceId, fullscreen: "1" };
+                if (aiPanelOpen) {
+                  extraParams.ai = "1";
+                  if (currentSessionId) extraParams.sessionId = currentSessionId;
+                }
                 window.open(
                   buildUrlWithFilters(newTabPath ?? `/projects/${projectId}/traces`, {
                     dateFilter,
                     customStartDate,
                     customEndDate,
-                    extraParams: { traceId, fullscreen: "1" },
+                    extraParams,
                   }),
                   "_blank",
-                )
-              }
+                );
+              }}
               className="h-7 w-7 p-0"
               title="Open in new tab"
             >
@@ -334,12 +341,12 @@ export function TraceViewerPanel({
         </div>
 
         {/* ── VIEW TOGGLE SUB-HEADER ── */}
-        <div className="flex h-10 items-center border-b border-border">
-          <div className="flex items-center rounded-lg px-2 py-1">
+        <div className="h-10 border-border flex items-center border-b">
+          <div className="rounded-lg px-2 py-1 flex items-center">
             <button
               onClick={() => setViewMode("tree")}
               className={cn(
-                "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+                "gap-2 rounded-md px-3 py-1 text-xs font-medium flex items-center transition-all",
                 viewMode === "tree"
                   ? "bg-muted text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground",
@@ -350,7 +357,7 @@ export function TraceViewerPanel({
             <button
               onClick={() => setViewMode("timeline")}
               className={cn(
-                "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+                "gap-2 rounded-md px-3 py-1 text-xs font-medium flex items-center transition-all",
                 viewMode === "timeline"
                   ? "bg-muted text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground",

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -23,8 +23,8 @@ import type { TraceSelection } from "../types";
 import { SpanTreeView, type SpanTreeViewHandle } from "./SpanTreeView";
 import { SpanInfoPanel } from "./SpanInfoPanel";
 import { useLayout } from "@/components/layout/app-layout";
-import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
 import { useAiChatContext } from "@/features/ai-assistant/components/ai-chat-context";
+import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
 import { useTraceStream } from "../hooks/use-trace-stream";
 import { SpanTimelineView } from "./SpanTimelineView";
 import { TREE_LAYOUT } from "../utils";
@@ -226,7 +226,7 @@ export function TraceViewerPanel({
   return (
     <div
       className={cn(
-        "animate-slide-in-right bottom-0 right-0 border-border bg-background shadow-xl fixed z-50 border-l transition-[width,top] duration-200",
+        "animate-slide-in-right fixed bottom-0 right-0 z-50 border-l border-border bg-background shadow-xl transition-[width,top] duration-200",
         // Fullscreen stays clear of the chrome it would otherwise cover: it
         // starts below the top breadcrumb/header bar (h-14) and to the right of
         // the left navbar. Width = 100% minus the sidebar's width, which differs
@@ -238,15 +238,15 @@ export function TraceViewerPanel({
           : "top-0 w-[70%]",
       )}
     >
-      <div className="bg-background flex h-full flex-col">
+      <div className="flex h-full flex-col bg-background">
         {/* ── MAIN HEADER ── */}
-        <div className="h-12 border-border bg-muted/30 px-4 flex items-center justify-between border-b">
-          <div className="min-w-0 gap-2 flex items-center">
+        <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
+          <div className="flex min-w-0 items-center gap-2">
             <Workflow className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Trace</span>
-            <span className="font-mono text-xs text-muted-foreground truncate">{traceId}</span>
+            <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
           </div>
-          <div className="gap-1 flex items-center">
+          <div className="flex items-center gap-1">
             {hasRca && (
               <button
                 type="button"
@@ -255,7 +255,7 @@ export function TraceViewerPanel({
                   setAiInitialSessionId(rcaSessionId);
                   setAiPanelOpen(true);
                 }}
-                className="rounded-md border-red-300 bg-red-50 px-2 py-1 font-medium text-red-700 hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60 border text-[11px] transition-colors"
+                className="rounded-md border border-red-300 bg-red-50 px-2 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60"
                 title="Findings detected — open root cause analysis"
               >
                 Alert
@@ -342,12 +342,12 @@ export function TraceViewerPanel({
         </div>
 
         {/* ── VIEW TOGGLE SUB-HEADER ── */}
-        <div className="h-10 border-border flex items-center border-b">
-          <div className="rounded-lg px-2 py-1 flex items-center">
+        <div className="flex h-10 items-center border-b border-border">
+          <div className="flex items-center rounded-lg px-2 py-1">
             <button
               onClick={() => setViewMode("tree")}
               className={cn(
-                "gap-2 rounded-md px-3 py-1 text-xs font-medium flex items-center transition-all",
+                "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
                 viewMode === "tree"
                   ? "bg-muted text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground",
@@ -358,7 +358,7 @@ export function TraceViewerPanel({
             <button
               onClick={() => setViewMode("timeline")}
               className={cn(
-                "gap-2 rounded-md px-3 py-1 text-xs font-medium flex items-center transition-all",
+                "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
                 viewMode === "timeline"
                   ? "bg-muted text-foreground shadow-sm"
                   : "text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
## Problem

When a trace detail is open alongside the AI chatbot with an active conversation, clicking "Open in new tab" only opens the trace — the chatbot panel and the current chat session are lost.

## Root Cause

Three issues combined to cause this:

1. The "open in new tab" button only passed `traceId` and `fullscreen=1` in the URL — no information about the AI panel state or active session
2. `currentSessionId` from `useAiChatContext` was read at render time, but it's backed by a `useRef` which doesn't trigger re-renders, so the value was always stale (`null`) at click time
3. `AppLayout` has a `useEffect` that resets `aiPanelOpen` and `aiInitialSessionId` on every pathname change — including the initial mount of a new tab — which clobbered any state the destination page tried to restore

## Fix

- **`use-ai-chat.ts`** — expose `getCurrentSessionId()` function so event handlers can read the live ref value at click time instead of the stale rendered value
- **`TraceViewerPanel.tsx`** — updated the "open in new tab" onClick to call `getCurrentSessionId()` and append `ai=1` + `sessionId` to the URL when the panel is open
- **`traces/page.tsx`** and **`detectors/[detectorId]/page.tsx`** — added a `useEffect` that reads `ai` and `sessionId` URL params on load and calls `setAiContext` + `setAiInitialSessionId` + `setAiPanelOpen(true)` to restore the session
- **`app-layout.tsx`** — skip the AI panel reset on the very first mount using a ref, so the destination page's restore logic isn't immediately overwritten

## Testing

1. Open a trace, start a chat in the AI panel
2. Click "Open in new tab"
3. The new tab should open with the AI panel visible and the same conversation loaded

## Screenshots / Recordings (if applicable)

https://github.com/user-attachments/assets/4ca2b41f-d05c-40a6-86b0-ef42023c01f1

Fix: #1168


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the chat panel and current conversation when opening a trace in a new tab. The new tab restores the same session and context.

- **Bug Fixes**
  - TraceViewerPanel: adds `ai=1` and `sessionId` in the "Open in new tab" URL when the panel is open, reading the live ID via `getCurrentSessionId()`.
  - use-ai-chat: exposes `getCurrentSessionId()` for click handlers to avoid stale `currentSessionId`.
  - Traces and Detector pages: on mount, read `ai`, `traceId`, and `sessionId` params and call `setAiContext`, `setAiInitialSessionId` (if present), and `setAiPanelOpen(true)` to restore.
  - AppLayout: skips the initial AI panel reset so page-level restore runs first.
  - Tests: add coverage for URL param propagation and restoration on both pages; verify `getCurrentSessionId()` default; fix traces/page test by mocking `usePrefetchTraces`.

<sup>Written for commit 015d47faa0c40df5c63b6b7e29e1619479749518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



