### PR TITLE
fix(ui): Use truthful sidebar version labels

### DIFF
--- a/.github/workflows/_docker-images-custom.yml
+++ b/.github/workflows/_docker-images-custom.yml
@@ -54,6 +54,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch_ref }}
+          fetch-depth: 0
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -67,6 +68,10 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Resolve app version
+        id: app_version
+        run: echo "value=$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
 
       - name: Sanitize branch ref for Docker tag
         id: sanitize
@@ -93,6 +98,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
+            APP_VERSION=${{ steps.app_version.outputs.value }}
             NEXT_PUBLIC_APP_URL=${{ secrets.NEXT_PUBLIC_APP_URL }}
             NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
             NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -63,6 +63,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Resolve app version
+        id: app_version
+        run: echo "value=$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -82,7 +86,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            APP_VERSION=${{ github.ref_name }}
+            APP_VERSION=${{ steps.app_version.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 # =============================================================================
 
 PROD_COMPOSE := docker compose -f docker-compose.prod.yml
+APP_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 
 .PHONY: install-hooks dev dev-lite dev-autoreload dev-reset prod prod-lite prod-reset
 
@@ -24,7 +25,7 @@ dev-lite: install-hooks
 	@test -f .env || cp .env.example .env
 	@test -d frontend/node_modules || pnpm --dir frontend install
 	@echo "Starting TraceRoot at http://localhost:3000 - Ctrl+C to stop"
-	$(PROD_COMPOSE) up --build
+	APP_VERSION=$(APP_VERSION) $(PROD_COMPOSE) up --build
 
 ## Nuclear reset: kill tmux, destroy all containers/volumes/deps. Run `make dev` to start again.
 dev-reset:
@@ -40,7 +41,7 @@ prod:
 prod-lite:
 	@test -f .env || cp .env.example .env
 	@echo "Starting TraceRoot at http://localhost:3000 - Ctrl+C to stop"
-	$(PROD_COMPOSE) up --build
+	APP_VERSION=$(APP_VERSION) $(PROD_COMPOSE) up --build
 
 ## Nuclear reset: stop containers, remove volumes, built images, and orphaned sandboxes.
 prod-reset:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -126,7 +126,7 @@ services:
       context: .
       dockerfile: docker/Dockerfile.web
       args:
-        APP_VERSION: ${APP_VERSION:-}
+        APP_VERSION: ${APP_VERSION:-dev}
         BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-local-dev-secret-change-in-production}
         NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000/api/v1}

--- a/frontend/ui/next.config.js
+++ b/frontend/ui/next.config.js
@@ -1,11 +1,25 @@
+const { execSync } = require("child_process");
 const path = require("path");
+
+function resolveAppVersion() {
+  if (process.env.APP_VERSION) return process.env.APP_VERSION;
+  try {
+    return execSync("git describe --tags --always --dirty", {
+      cwd: path.join(__dirname, "../"),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "dev";
+  }
+}
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
   reactStrictMode: true,
   env: {
-    NEXT_PUBLIC_APP_VERSION: process.env.APP_VERSION || `v${require("./package.json").version}`,
+    NEXT_PUBLIC_APP_VERSION: resolveAppVersion(),
   },
   transpilePackages: ["@traceroot/core", "@traceroot/github", "@traceroot/slack"],
   // Include monorepo root so standalone output traces deps outside ui/

--- a/frontend/ui/src/__tests__/next-config.test.ts
+++ b/frontend/ui/src/__tests__/next-config.test.ts
@@ -1,3 +1,5 @@
+import { execSync } from "node:child_process";
+
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 describe("next.config.js env block", () => {
@@ -15,10 +17,20 @@ describe("next.config.js env block", () => {
     expect(config.default.env.NEXT_PUBLIC_APP_VERSION).toBe("v0.2.0");
   });
 
-  it("falls back to package.json version when APP_VERSION is unset", async () => {
+  it("falls back to git describe when APP_VERSION is unset", async () => {
     delete process.env.APP_VERSION;
     const config = await import("../../next.config.js");
-    const pkg = await import("../../package.json");
-    expect(config.default.env.NEXT_PUBLIC_APP_VERSION).toBe(`v${pkg.default.version}`);
+    const expected = execSync("git describe --tags --always --dirty", {
+      cwd: new URL("../../", import.meta.url),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    expect(config.default.env.NEXT_PUBLIC_APP_VERSION).toBe(expected);
+  });
+
+  it("falls back to dev when APP_VERSION is explicitly set to dev", async () => {
+    vi.stubEnv("APP_VERSION", "dev");
+    const config = await import("../../next.config.js?fallback-dev");
+    expect(config.default.env.NEXT_PUBLIC_APP_VERSION).toBe("dev");
   });
 });

--- a/frontend/ui/src/components/layout/sidebar.test.tsx
+++ b/frontend/ui/src/components/layout/sidebar.test.tsx
@@ -57,6 +57,7 @@ describe("Sidebar", () => {
   }
 
   it("renders expanded at w-48 with the star widget above the bottom links", () => {
+    process.env.NEXT_PUBLIC_APP_VERSION = "v1.2.3";
     render();
 
     const frame = container.querySelector("div.flex.h-screen");
@@ -67,6 +68,7 @@ describe("Sidebar", () => {
     expect(container.textContent).toContain("Workspaces");
     expect(container.textContent).toContain("GitHub");
     expect(container.textContent).toContain("Support");
+    expect(container.textContent).toContain("v1.2.3");
   });
 
   it("renders collapsed at w-14 and hides the star widget", () => {

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -131,7 +131,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
               <>
                 <span className="font-semibold">TraceRoot</span>
                 <span className="text-xs font-normal text-muted-foreground">
-                  {process.env.NEXT_PUBLIC_APP_VERSION}
+                  {process.env.NEXT_PUBLIC_APP_VERSION ?? "dev"}
                 </span>
               </>
             )}

--- a/tmux_tools/launcher.py
+++ b/tmux_tools/launcher.py
@@ -53,6 +53,13 @@ def _run(
     )
 
 
+def _default_app_version() -> str:
+    try:
+        return _run(["git", "describe", "--tags", "--always", "--dirty"], capture_output=True).stdout.strip() or "dev"
+    except Exception:
+        return "dev"
+
+
 # ---------------------------------------------------------------------------
 # Setup steps — these RUN the setup, not just check it
 # ---------------------------------------------------------------------------
@@ -478,6 +485,7 @@ def main() -> None:
     # Ensure the launcher process itself uses UTC, so inline steps like
     # run_goose() and Prisma migrations produce consistent timestamps.
     os.environ.setdefault("TZ", "UTC")
+    os.environ.setdefault("APP_VERSION", _default_app_version())
 
     os.chdir(ROOT)
 

--- a/tmux_tools/launcher.py
+++ b/tmux_tools/launcher.py
@@ -53,13 +53,6 @@ def _run(
     )
 
 
-def _default_app_version() -> str:
-    try:
-        return _run(["git", "describe", "--tags", "--always", "--dirty"], capture_output=True).stdout.strip() or "dev"
-    except Exception:
-        return "dev"
-
-
 # ---------------------------------------------------------------------------
 # Setup steps — these RUN the setup, not just check it
 # ---------------------------------------------------------------------------
@@ -485,7 +478,6 @@ def main() -> None:
     # Ensure the launcher process itself uses UTC, so inline steps like
     # run_goose() and Prisma migrations produce consistent timestamps.
     os.environ.setdefault("TZ", "UTC")
-    os.environ.setdefault("APP_VERSION", _default_app_version())
 
     os.chdir(ROOT)
 


### PR DESCRIPTION
## Summary
- Use a truthful app-version fallback for the sidebar instead of the stale package.json placeholder.
- Pass a real git-derived version into production Docker builds and local Docker entrypoints.
- Keep the sidebar version label visible and covered by tests.

## Testing
- `npm test -- --run src/__tests__/next-config.test.ts src/components/layout/sidebar.test.tsx`
- `npm run lint`

## Related
- Fixes #1221

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the actual app version in the sidebar by deriving it from git instead of package.json. Propagate a real `APP_VERSION` through local runs, Docker, and CI so the label is correct everywhere.

- **Bug Fixes**
  - Sidebar shows `NEXT_PUBLIC_APP_VERSION`, falling back to "dev".
  - `next.config.js`: version resolution order is `APP_VERSION` env → `git describe` → "dev".
  - Makefile/Docker: pass `APP_VERSION`; compose defaults to "dev"; Makefile derives from `git describe`.
  - CI: image workflows fetch full history, resolve version via `git describe`, and pass it as a build arg.
  - Tests cover config resolution (incl. explicit "dev") and the sidebar label.
  - Fixes #1221.

<sup>Written for commit 840eab44922ecad02bf6fb0745bd9c5c0c0502fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

