### PR TITLE
fix(ui): Preserve saved detector agent model

### DIFF
--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  models: undefined as
+    | {
+        systemModels: Array<{
+          provider: string;
+          adapter: string;
+          source: "system";
+          models: Array<{ id: string; label: string; supported?: boolean }>;
+        }>;
+        byokProviders: Array<{
+          provider: string;
+          adapter: string;
+          source: "byok";
+          models: Array<{ id: string; label: string; supported?: boolean }>;
+        }>;
+      }
+    | undefined,
+  onChange: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: mocks.models }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getAvailableLLMModels: vi.fn(),
+}));
+
+import { ModelSelector } from "./model-selector";
+
+afterEach(() => {
+  cleanup();
+  mocks.models = undefined;
+  mocks.onChange.mockReset();
+});
+
+describe("ModelSelector", () => {
+  it("preserves a saved but unmatched selection instead of auto-picking a default", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "local-llm", provider: "local", source: "byok", adapter: "openai" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    expect(screen.getByRole("button").textContent).toContain("local-llm");
+    expect(mocks.onChange).not.toHaveBeenCalled();
+  });
+
+  it("auto-picks a default only when the model is empty", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: "claude-4",
+      provider: "anthropic",
+      source: "system",
+      adapter: "anthropic",
+    });
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -42,7 +42,8 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
   //   1. exact match on (model, provider, source) → check adapter; backfill if empty/wrong
   //   2. model-id-only match (legacy/hydrated state where the parent only has
   //      `model` saved, e.g. `project.rca_model: string`) → backfill the rest
-  //   3. no match → auto-pick a default
+  //   3. no match → preserve the current selection if the user already picked
+  //      one, and only auto-pick a default when the model is still empty.
   // Without case 2 the selector would silently auto-pick a default when a
   // partially-hydrated saved selection arrives, clobbering the user's choice.
   useEffect(() => {
@@ -56,14 +57,16 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
     const match = exact ?? modelOnly;
 
     if (!match) {
-      const pick = pickDefaultModel(models);
-      if (pick) {
-        onChange({
-          model: pick.id,
-          provider: pick.provider,
-          source: pick.source,
-          adapter: pick.adapter,
-        });
+      if (!value.model) {
+        const pick = pickDefaultModel(models);
+        if (pick) {
+          onChange({
+            model: pick.id,
+            provider: pick.provider,
+            source: pick.source,
+            adapter: pick.adapter,
+          });
+        }
       }
       return;
     }

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -132,5 +132,4 @@ describe("DetectorPanel", () => {
     expect(promptBox().value).toBe("");
     expect((saveButton() as HTMLButtonElement).disabled).toBe(true);
   });
-
 });

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -132,4 +132,5 @@ describe("DetectorPanel", () => {
     expect(promptBox().value).toBe("");
     expect((saveButton() as HTMLButtonElement).disabled).toBe(true);
   });
+
 });


### PR DESCRIPTION
## Summary
- Preserve a detector's saved agent model when it is not an exact live-catalog match.
- Auto-pick a default only when the model is empty.
- Add regression coverage for the model-selector reconciliation logic.

## Testing
- `npm test -- --run src/features/ai-assistant/components/model-selector.test.tsx src/__tests__/next-config.test.ts src/components/layout/sidebar.test.tsx`
- `npm run lint`

## Related
- Fixes #1218

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves a detector’s saved agent model and no longer auto-replaces it unless the model is empty (fixes #1218). Adds tests for the selector’s reconciliation and defaulting logic.

<sup>Written for commit bc35d226ec984b7d45b39eda9f5aac8878a687b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

