### PR TITLE
feat: implement error-leaf counting heuristic in trace_reader.py and …

### DIFF
--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -34,6 +34,32 @@ def span_cost_details(
     return cost_breakdown_from_buckets(get_model_price(model_name), buckets) or {}
 
 
+def _count_error_leaves(spans: list[tuple[str, str | None, str]]) -> int:
+    """Count ERROR spans that have no ERROR child (error-leaf heuristic).
+
+    Mirrors the SQL self-join in the ``span_agg`` CTE of ``list_traces()``.
+    If you change the logic here, change the SQL query too (and vice versa).
+
+    Known limitations (same as the SQL):
+    - Independent parent+child both ERROR collapses to 1 (child hides parent).
+    - Broken chain (ERROR -> OK -> ERROR) overcounts as 2 instead of 1.
+    """
+    parent_to_spans: dict[str | None, list[tuple[str, str | None, str]]] = {}
+    for sid, pid, status in spans:
+        parent_to_spans.setdefault(pid, []).append((sid, pid, status))
+
+    error_count = 0
+    for sid, pid, status in spans:
+        if status != "ERROR":
+            continue
+        # Check if any child of this span is also ERROR
+        children = parent_to_spans.get(sid, [])
+        has_error_child = any(child_status == "ERROR" for _, _, child_status in children)
+        if not has_error_child:
+            error_count += 1
+    return error_count
+
+
 class TraceReaderService:
     """Read traces and spans from ClickHouse."""
 
@@ -110,29 +136,48 @@ class TraceReaderService:
                 ORDER BY trace_start_time DESC
                 LIMIT {{limit:UInt32}} OFFSET {{offset:UInt32}}
             ),
+            deduped_spans AS (
+                -- Dedup ReplacingMergeTree: latest ch_update_time wins (see #963).
+                SELECT trace_id, span_id, parent_span_id, status,
+                       span_start_time, span_end_time,
+                       input_tokens, output_tokens, cost
+                FROM spans
+                WHERE project_id = {{project_id:String}}
+                  AND trace_id IN (SELECT trace_id FROM page)
+                ORDER BY ch_update_time DESC
+                LIMIT 1 BY project_id, trace_id, span_id
+            ),
+            error_children AS (
+                SELECT parent_span_id, trace_id, count() AS child_errors
+                FROM deduped_spans
+                WHERE status = 'ERROR' AND parent_span_id IS NOT NULL
+                GROUP BY parent_span_id, trace_id
+            ),
             span_agg AS (
                 SELECT
-                    trace_id,
-                    count(span_id) as span_count,
+                    d.trace_id,
+                    count(d.span_id) as span_count,
                     if(
-                        min(span_start_time) IS NOT NULL AND max(span_end_time) IS NOT NULL,
-                        dateDiff('millisecond', min(span_start_time), max(span_end_time)),
+                        min(d.span_start_time) IS NOT NULL AND max(d.span_end_time) IS NOT NULL,
+                        dateDiff('millisecond', min(d.span_start_time), max(d.span_end_time)),
                         NULL
                     ) as duration_ms,
-                    countIf(status = 'ERROR') as error_count,
-                    sum(input_tokens) as total_input_tokens,
-                    sum(output_tokens) as total_output_tokens,
-                    sum(cost) as total_cost
-                FROM (
-                    SELECT trace_id, span_id, status, span_start_time, span_end_time,
-                           input_tokens, output_tokens, cost
-                    FROM spans
-                    WHERE project_id = {{project_id:String}}
-                      AND trace_id IN (SELECT trace_id FROM page)
-                    ORDER BY ch_update_time DESC
-                    LIMIT 1 BY project_id, trace_id, span_id
-                )
-                GROUP BY trace_id
+                    -- Error leaf heuristic: count ERROR spans that have no ERROR child.
+                    -- Collapses a single exception unwinding through N ancestor context
+                    -- managers from N to 1. Mirrors _count_error_leaves() below — if you
+                    -- change the logic here, change it there too (and vice versa).
+                    -- Known limitations:
+                    --   (a) independent parent+child both ERROR counts as 1 (not 2);
+                    --   (b) broken chain (ERROR -> OK -> ERROR) overcounts as 2 (not 1).
+                    -- See PR #1204 for full discussion.
+                    countIf(d.status = 'ERROR' AND coalesce(ec.child_errors, 0) = 0) as error_count,
+                    sum(d.input_tokens) as total_input_tokens,
+                    sum(d.output_tokens) as total_output_tokens,
+                    sum(d.cost) as total_cost
+                FROM deduped_spans d
+                LEFT JOIN error_children ec
+                    ON d.span_id = ec.parent_span_id AND d.trace_id = ec.trace_id
+                GROUP BY d.trace_id
             )
             SELECT
                 p.trace_id,

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -49,7 +49,7 @@ def _count_error_leaves(spans: list[tuple[str, str | None, str]]) -> int:
         parent_to_spans.setdefault(pid, []).append((sid, pid, status))
 
     error_count = 0
-    for sid, pid, status in spans:
+    for sid, _pid, status in spans:
         if status != "ERROR":
             continue
         # Check if any child of this span is also ERROR

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -321,3 +321,55 @@ class TestGetSpanIO:
         assert len(spans) == 2
         assert spans[1]["model_name"] == "gpt-4o"
         assert spans[1]["cost"] == 0.005
+
+
+class TestErrorCountHeuristic:
+    """Pure-Python unit tests for _count_error_leaves.
+
+    Tests the error-leaf heuristic directly (no ClickHouse needed).
+    Mirrors the SQL self-join in trace_reader.py's span_agg CTE —
+    if the Python logic changes, the SQL must change too (and vice versa).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _import_impl(self):
+        from rest.services.trace_reader import _count_error_leaves
+
+        self._count_error_leaves = _count_error_leaves
+
+    def test_error_count_collapses_propagated_chain(self):
+        """A single exception propagating through 3 nested spans yields 1."""
+        spans = [
+            ("a", None, "ERROR"),
+            ("b", "a", "ERROR"),
+            ("c", "b", "ERROR"),
+        ]
+        assert self._count_error_leaves(spans) == 1
+
+    def test_error_count_preserves_independent_failures(self):
+        """Two unrelated ERROR spans in separate subtrees both counted."""
+        spans = [
+            ("root", None, "OK"),
+            ("left", "root", "ERROR"),
+            ("left-child", "left", "OK"),
+            ("right", "root", "ERROR"),
+            ("right-child", "right", "OK"),
+        ]
+        assert self._count_error_leaves(spans) == 2
+
+    def test_error_count_zero_when_no_errors(self):
+        """All spans OK yields 0 (regression guard)."""
+        spans = [
+            ("a", None, "OK"),
+            ("b", "a", "OK"),
+        ]
+        assert self._count_error_leaves(spans) == 0
+
+    def test_error_count_broken_chain_overcounts(self):
+        """Known limitation: ERROR -> OK -> ERROR counts as 2, not 1."""
+        spans = [
+            ("a", None, "ERROR"),
+            ("b", "a", "OK"),
+            ("c", "b", "ERROR"),
+        ]
+        assert self._count_error_leaves(spans) == 2


### PR DESCRIPTION
…add unit tests

Fixes <issue-id>
#1204 

## Summary
The trace list's `error_count` was counting every span in an ERROR state,
not the number of distinct errors. Since OTel context managers mark every
ancestor span ERROR as an exception unwinds, a single failure deep in a
trace (e.g. agent → LLM call → tool call) was reported as 3 errors instead
of 1. This PR changes the count to use an "error leaf" heuristic: only
ERROR spans with no ERROR children are counted, so propagated errors
collapse to their origin while genuinely independent failures still count
separately.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
**Root cause:** `trace_reader.py` used `countIf(status = 'ERROR')` over all
spans in a trace, which counts span-level error *states*, not error
*origins*. The trace-level status boolean (`countIf(status='ERROR') > 0`)
was already correct and is unchanged.

**Fix:** Restructured the `span_agg` CTE in `list_traces()`'s query to
self-join each trace's deduped spans against a per-parent count of ERROR
children (`error_children` CTE), then count only ERROR spans where
`coalesce(child_errors, 0) = 0`. This requires no schema change or
re-ingest — `parent_span_id` was already stored per span.

**Known limitations of the heuristic** (documented inline in the SQL and in
the Python mirror used for testing):
- A parent and child both genuinely failing for unrelated reasons collapses
  to a count of 1, not 2 (the child "hides" the parent in the heuristic).
- A broken error chain (`ERROR → OK → ERROR`, e.g. a `try/except` that
  suppresses the error at one level) overcounts as 2 instead of 1.

Both are edge cases, not regressions versus current behavior — the current
behavior is strictly worse (it overcounts every propagation chain). The
durable fix requires parsing OTel exception events at ingest, which
`otel_transform.py` currently discards entirely; that's scoped as a
follow-up (see #1204 discussion) since it needs an SDK-emission audit
across languages first, not implemented here.

**Testing note:** This repo has no ClickHouse test infrastructure (no
testcontainers, no service container in CI), so the error-leaf logic is
unit-tested via `_count_error_leaves`, a pure-Python function that mirrors
the SQL self-join exactly, rather than testing the SQL directly. Both
implementations are cross-referenced by comment ("CHANGE HERE REQUIRES A
CHANGE THERE") and live in the same file. **This means the SQL itself is
not executed by CI** — manual verification against a real ClickHouse
instance is recommended before merge.


## Screenshots / Recordings (if applicable)
<img width="645" height="510" alt="Screenshot 2026-06-18 170614" src="https://github.com/user-attachments/assets/30054be4-7cb3-4486-93f5-9a7b0ec8fe2f" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes error overcounting in trace lists by counting error “leaves” (distinct origins) instead of every ERROR span, so propagated exceptions count once. Fixes #1204.

- **Bug Fixes**
  - Updated `list_traces()` SQL: added `deduped_spans` and `error_children` CTEs and now count ERROR spans with no ERROR children to compute `error_count` (no schema change).
  - Added `_count_error_leaves()` helper that mirrors the SQL and unit tests to validate collapsing propagation chains and preserving independent failures.
  - Renamed a variable in `_count_error_leaves()` for clarity; no behavior change.

<sup>Written for commit 9dfd966e1442f269cead9698921510e0d5140c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

