### PR TITLE
fix: add trace-start lower bound to span detail query

### DIFF
--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -242,7 +242,20 @@ class TraceReaderService:
         # usage_details is kept (small map) to derive cost_details. Duration is
         # derived on the client from start/end so in-progress spans can grow
         # against `now()` for live traces.
-        spans_query = """
+        spans_conditions = [
+            "project_id = {project_id:String}",
+            "trace_id = {trace_id:String}",
+        ]
+        spans_params = {"project_id": project_id, "trace_id": trace_id}
+        if trace["trace_start_time"] is not None:
+            spans_conditions.append(
+                "span_start_time >= {trace_start_time:DateTime64(3)} - INTERVAL 1 HOUR"
+            )
+            spans_params["trace_start_time"] = to_utc_naive(trace["trace_start_time"])
+
+        spans_where_clause = " AND ".join(spans_conditions)
+
+        spans_query = f"""
             SELECT
                 span_id, trace_id, parent_span_id, name, span_kind,
                 span_start_time, span_end_time, status, status_message,
@@ -250,12 +263,12 @@ class TraceReaderService:
                 usage_details,
                 git_source_file, git_source_line, git_source_function
             FROM spans FINAL
-            WHERE project_id = {project_id:String} AND trace_id = {trace_id:String}
+            WHERE {spans_where_clause}
             ORDER BY span_start_time ASC
         """
         spans_result = self._client.query(
             spans_query,
-            parameters={"project_id": project_id, "trace_id": trace_id},
+            parameters=spans_params,
         )
 
         spans = []

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -246,11 +246,8 @@ class TraceReaderService:
             "metadata": row[10],
         }
 
-        # Fetch span skeletons — omit the large input/output/metadata blobs to
-        # keep the payload lightweight (fetched per-span on demand instead).
-        # usage_details is kept (small map) to derive cost_details. Duration is
-        # derived on the client from start/end so in-progress spans can grow
-        # against `now()` for live traces.
+        # Build the span skeleton query. The optional trace_start_time lower
+        # bound lets ClickHouse prune old span partitions before the trace.
         spans_conditions = [
             "project_id = {project_id:String}",
             "trace_id = {trace_id:String}",
@@ -274,6 +271,11 @@ class TraceReaderService:
 
         spans_where_clause = " AND ".join(spans_conditions)
 
+        # Fetch span skeletons — omit the large input/output/metadata blobs to
+        # keep the payload lightweight (fetched per-span on demand instead).
+        # usage_details is kept (small map) to derive cost_details. Duration is
+        # derived on the client from start/end so in-progress spans can grow
+        # against `now()` for live traces.
         spans_query = f"""
             SELECT
                 span_id, trace_id, parent_span_id, name, span_kind,

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -7,6 +7,15 @@ from rest.sql_utils import escape_ilike, to_utc_naive
 from worker.tokens.buckets import TokenBuckets
 from worker.tokens.pricing import cost_breakdown_from_buckets, get_model_price
 
+# Lookback for the trace-detail spans query lower bound:
+# span_start_time >= trace_start_time - this value.
+# This gives room for clock skew and small differences between the stored
+# trace_start_time and the true earliest span start time. Increase it if spans
+# can validly start before the stored trace_start_time. Since spans are split by
+# month with toYYYYMM(span_start_time), values under about a month usually skip
+# the same old monthly partitions.
+TRACE_SPAN_LOOKBACK_HOURS = 1
+
 
 def span_cost_details(
     model_name: str | None,
@@ -248,8 +257,18 @@ class TraceReaderService:
         ]
         spans_params = {"project_id": project_id, "trace_id": trace_id}
         if trace["trace_start_time"] is not None:
+            # Lower-bound the spans scan by the trace start time so ClickHouse
+            # can skip old monthly span partitions. The spans table uses
+            # PARTITION BY toYYYYMM(span_start_time), and trace_id is not in the
+            # sort key, so without a time bound every trace open can scan all
+            # monthly partitions for the project. Keep this lower-bound only,
+            # with no upper bound, so late or streaming child spans are still
+            # returned. The lookback covers clock skew and trace start drift. If
+            # trace_start_time is null, skip the bound because correctness
+            # should not depend on it.
             spans_conditions.append(
-                "span_start_time >= {trace_start_time:DateTime64(3)} - INTERVAL 1 HOUR"
+                "span_start_time >= {trace_start_time:DateTime64(3)} "
+                f"- INTERVAL {TRACE_SPAN_LOOKBACK_HOURS} HOUR"
             )
             spans_params["trace_start_time"] = to_utc_naive(trace["trace_start_time"])
 

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -156,7 +156,13 @@ class TestGetTraceSkeleton:
         assert "FROM spans FINAL" in spans_sql
         # Bound by the already-read trace_start_time so ClickHouse can prune
         # monthly span partitions before the trace.
-        assert "span_start_time >= {trace_start_time:DateTime64(3)} - INTERVAL 1 HOUR" in spans_sql
+        from rest.services.trace_reader import TRACE_SPAN_LOOKBACK_HOURS
+
+        lower_bound_sql = (
+            "span_start_time >= {trace_start_time:DateTime64(3)} "
+            f"- INTERVAL {TRACE_SPAN_LOOKBACK_HOURS} HOUR"
+        )
+        assert lower_bound_sql in spans_sql
         assert captured["spans_parameters"] == {
             "project_id": "proj",
             "trace_id": "abc123",
@@ -261,7 +267,12 @@ class TestGetTraceSkeleton:
         result = service.get_trace("proj", "abc123")
 
         assert result["spans"] == []
-        lower_bound_sql = "span_start_time >= {trace_start_time:DateTime64(3)} - INTERVAL 1 HOUR"
+        from rest.services.trace_reader import TRACE_SPAN_LOOKBACK_HOURS
+
+        lower_bound_sql = (
+            "span_start_time >= {trace_start_time:DateTime64(3)} "
+            f"- INTERVAL {TRACE_SPAN_LOOKBACK_HOURS} HOUR"
+        )
         assert lower_bound_sql in captured["spans_query"]
         assert captured["spans_parameters"] == {
             "project_id": "proj",

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -111,6 +111,7 @@ class TestGetTraceSkeleton:
                 )
             # spans query
             captured["spans_query"] = query
+            captured["spans_parameters"] = parameters
             return _rows(
                 [
                     (
@@ -153,6 +154,14 @@ class TestGetTraceSkeleton:
         assert "output_tokens" in cols
         # Still selects via FINAL (correctness for ReplacingMergeTree).
         assert "FROM spans FINAL" in spans_sql
+        # Bound by the already-read trace_start_time so ClickHouse can prune
+        # monthly span partitions before the trace.
+        assert "span_start_time >= {trace_start_time:DateTime64(3)} - INTERVAL 1 HOUR" in spans_sql
+        assert captured["spans_parameters"] == {
+            "project_id": "proj",
+            "trace_id": "abc123",
+            "trace_start_time": datetime(2024, 1, 1),
+        }
 
         # Resulting span dict carries NO I/O keys, but keeps tree fields.
         span = result["spans"][0]
@@ -175,6 +184,43 @@ class TestGetTraceSkeleton:
 
         service, _ = _make_service(side_effect)
         assert service.get_trace("proj", "missing") is None
+
+    def test_spans_query_is_unbounded_when_trace_start_time_is_null(self):
+        captured = {}
+
+        def side_effect(query, parameters=None):
+            if "FROM traces FINAL" in query:
+                return _rows(
+                    [
+                        (
+                            "abc123",  # trace_id
+                            "proj",  # project_id
+                            "trace-name",  # name
+                            None,  # trace_start_time
+                            None,  # user_id
+                            None,  # session_id
+                            None,  # git_ref
+                            None,  # git_repo
+                            None,  # input
+                            None,  # output
+                            None,  # metadata
+                        )
+                    ]
+                )
+
+            captured["spans_query"] = query
+            captured["spans_parameters"] = parameters
+            return _rows([])
+
+        service, _ = _make_service(side_effect)
+        result = service.get_trace("proj", "abc123")
+
+        assert result["spans"] == []
+        assert "span_start_time >=" not in captured["spans_query"]
+        assert captured["spans_parameters"] == {
+            "project_id": "proj",
+            "trace_id": "abc123",
+        }
 
 
 class TestGetSpanIO:

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -3,7 +3,7 @@
 Pure logic — get_model_price is patched, so no DB/ClickHouse is needed.
 """
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -220,6 +220,53 @@ class TestGetTraceSkeleton:
         assert captured["spans_parameters"] == {
             "project_id": "proj",
             "trace_id": "abc123",
+        }
+
+    def test_spans_query_normalizes_aware_trace_start_time_to_utc(self):
+        captured = {}
+        trace_start_time = datetime(
+            2024,
+            1,
+            1,
+            12,
+            0,
+            tzinfo=timezone(timedelta(hours=-8)),
+        )
+
+        def side_effect(query, parameters=None):
+            if "FROM traces FINAL" in query:
+                return _rows(
+                    [
+                        (
+                            "abc123",  # trace_id
+                            "proj",  # project_id
+                            "trace-name",  # name
+                            trace_start_time,  # trace_start_time
+                            None,  # user_id
+                            None,  # session_id
+                            None,  # git_ref
+                            None,  # git_repo
+                            None,  # input
+                            None,  # output
+                            None,  # metadata
+                        )
+                    ]
+                )
+
+            captured["spans_query"] = query
+            captured["spans_parameters"] = parameters
+            return _rows([])
+
+        service, _ = _make_service(side_effect)
+        result = service.get_trace("proj", "abc123")
+
+        assert result["spans"] == []
+        lower_bound_sql = "span_start_time >= {trace_start_time:DateTime64(3)} - INTERVAL 1 HOUR"
+        assert lower_bound_sql in captured["spans_query"]
+        assert captured["spans_parameters"] == {
+            "project_id": "proj",
+            "trace_id": "abc123",
+            "trace_start_time": datetime(2024, 1, 1, 20, 0),
         }
 
 


### PR DESCRIPTION
Fixes #1230

## Summary

Adds a server-side lower-bound time filter when loading spans for a trace.

This lets ClickHouse skip old span partitions when opening trace detail pages. This keeps trace opens fast as a project grows.

## Type of Change

- [x] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests


## Details

Reproduced locally with `make dev-lite` by seeding ClickHouse with spans across old and current monthly partitions.

Before the fix, the trace span query did not include `span_start_time`, so ClickHouse could not prune old partitions.

After the fix, the backend uses the already-loaded `trace_start_time` and adds a lower-bound filter. It does not add an upper bound, so late child spans are still returned.

Validated by:

- `uv run pytest tests/rest/test_trace_reader.py -q` - proves the query adds the bound and keeps the null fallback.
- Local REST check against `make dev-lite` - proves the running backend returns the right spans.
- ClickHouse `EXPLAIN indexes = 1` - proves ClickHouse skips old partitions after the bound is added.


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a lower‑bound time filter to the trace detail spans query so ClickHouse skips old partitions and trace pages load fast. The bound is `trace_start_time` minus 1 hour (normalized to UTC if tz‑aware); it’s skipped when `trace_start_time` is null; there’s no upper bound to include late child spans; tests cover tz‑aware and null cases; comments clarify the `TRACE_SPAN_LOOKBACK_HOURS` rationale and partition pruning.

<sup>Written for commit d36789673119bed50a747abaaa4a91080ef62f36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

