### PR TITLE
fix: mark current breadcrumb dropdown option

### DIFF
--- a/frontend/ui/src/components/layout/breadcrumb.test.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, cleanup, within } from "@testing-library/react";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -20,10 +20,17 @@ afterEach(() => cleanup());
 const workspaceItem: BreadcrumbItem = {
   label: "Workspace One",
   options: [
-    { id: "ws-1", label: "Workspace One", href: "/workspaces/ws-1/projects" },
+    {
+      id: "ws-1",
+      label: "Workspace One",
+      href: "/workspaces/ws-1/projects",
+      isCurrent: true,
+      settingsHref: "/workspaces/ws-1/settings",
+    },
     { id: "ws-2", label: "Workspace Two", href: "/workspaces/ws-2/projects" },
   ],
   menuHeader: { label: "Workspaces", href: "/workspaces" },
+  createNew: { label: "New workspace", onSelect: vi.fn() },
 };
 
 function renderAndOpen() {
@@ -73,5 +80,28 @@ describe("BreadcrumbDropdown focus return", () => {
     fireEvent.keyDown(menu, { key: "Escape" });
     await waitFor(() => expect(screen.queryByRole("menu")).toBeNull());
     expect(document.activeElement).toBe(trigger);
+  });
+});
+
+describe("BreadcrumbDropdown current option", () => {
+  it("marks the current option and keeps it from being a self-link", async () => {
+    renderAndOpen();
+
+    const menu = await screen.findByRole("menu");
+    const current = within(menu).getByText("Workspace One");
+    expect(current.previousElementSibling?.textContent).toBe("✓");
+    expect(current.closest("a")).toBeNull();
+
+    const other = within(menu).getByText("Workspace Two").closest("a");
+    expect(other?.getAttribute("href")).toBe("/workspaces/ws-2/projects");
+  });
+
+  it("keeps header, settings, and create actions available", async () => {
+    renderAndOpen();
+
+    const menu = await screen.findByRole("menu");
+    expect(within(menu).getByText("Workspaces")).toBeTruthy();
+    expect(within(menu).getByText("New workspace")).toBeTruthy();
+    expect(within(menu).getAllByRole("button").length).toBeGreaterThan(0);
   });
 });

--- a/frontend/ui/src/components/layout/breadcrumb.test.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.test.tsx
@@ -94,7 +94,7 @@ describe("BreadcrumbDropdown current option", () => {
 
     const menu = await screen.findByRole("menu");
     const current = within(menu).getByText("Workspace One");
-    expect(current.previousElementSibling?.textContent).toBe("✓");
+    expect(current.previousElementSibling?.querySelector("svg")).not.toBeNull();
     expect(current.closest("a")).toBeNull();
 
     const other = within(menu).getByText("Workspace Two").closest("a");

--- a/frontend/ui/src/components/layout/breadcrumb.test.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.test.tsx
@@ -2,8 +2,10 @@
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, cleanup, within } from "@testing-library/react";
 
+const mockPush = vi.fn();
+
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 import { Breadcrumb, type BreadcrumbItem } from "@/components/layout/breadcrumb";
@@ -15,7 +17,10 @@ beforeAll(() => {
   window.HTMLElement.prototype.releasePointerCapture = vi.fn();
 });
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  mockPush.mockClear();
+});
 
 const workspaceItem: BreadcrumbItem = {
   label: "Workspace One",
@@ -103,5 +108,21 @@ describe("BreadcrumbDropdown current option", () => {
     expect(within(menu).getByText("Workspaces")).toBeTruthy();
     expect(within(menu).getByText("New workspace")).toBeTruthy();
     expect(within(menu).getAllByRole("button").length).toBeGreaterThan(0);
+  });
+
+  it("opens settings from the current option by mouse or keyboard", async () => {
+    renderAndOpen();
+
+    let menu = await screen.findByRole("menu");
+    const settingsButton = within(menu).getByRole("button");
+    fireEvent.click(settingsButton);
+    expect(mockPush).toHaveBeenCalledWith("/workspaces/ws-1/settings");
+
+    cleanup();
+    renderAndOpen();
+    menu = await screen.findByRole("menu");
+    fireEvent.keyDown(within(menu).getByRole("button"), { key: "Enter" });
+    expect(mockPush).toHaveBeenCalledTimes(2);
+    expect(mockPush).toHaveBeenLastCalledWith("/workspaces/ws-1/settings");
   });
 });

--- a/frontend/ui/src/components/layout/breadcrumb.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { ChevronDown, Plus, Settings, Slash } from "lucide-react";
+import { Check, ChevronDown, Plus, Settings, Slash } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -172,12 +172,10 @@ function BreadcrumbOptionContent({
 }) {
   return (
     <span className="flex w-full items-center justify-between">
-      <span className="flex min-w-0 items-center gap-1.5">
-        {option.isCurrent && (
-          <span aria-hidden="true" className="shrink-0 text-[11px]">
-            &#10003;
-          </span>
-        )}
+      <span className="flex min-w-0 items-center pl-6">
+        <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+          {option.isCurrent && <Check aria-hidden="true" className="h-4 w-4" />}
+        </span>
         <span className="max-w-36 truncate" title={option.label}>
           {option.label}
         </span>

--- a/frontend/ui/src/components/layout/breadcrumb.tsx
+++ b/frontend/ui/src/components/layout/breadcrumb.tsx
@@ -16,6 +16,8 @@ export interface BreadcrumbDropdownOption {
   id: string;
   label: string;
   href: string;
+  /** True when this option represents the entity currently in view. */
+  isCurrent?: boolean;
   /** Optional settings page for the entity, shown as a gear on the row. */
   settingsHref?: string;
 }
@@ -126,36 +128,23 @@ function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
           </>
         )}
         <div className="max-h-36 overflow-y-auto">
-          {item.options?.map((option) => (
-            <DropdownMenuItem key={option.id} asChild className="rounded-none text-[13px]">
-              <Link href={option.href} className="flex justify-between">
-                <span className="max-w-36 truncate" title={option.label}>
-                  {option.label}
-                </span>
-                {option.settingsHref && (
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      openSettings(option.settingsHref!);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        openSettings(option.settingsHref!);
-                      }
-                    }}
-                    className="-my-0.5 ml-4 flex h-6 w-6 items-center justify-center text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
-                  >
-                    <Settings size={12} />
-                  </span>
-                )}
-              </Link>
-            </DropdownMenuItem>
-          ))}
+          {item.options?.map((option) =>
+            option.isCurrent ? (
+              <DropdownMenuItem
+                key={option.id}
+                className="rounded-none text-[13px] font-medium text-foreground"
+                onSelect={(event) => event.preventDefault()}
+              >
+                <BreadcrumbOptionContent option={option} onOpenSettings={openSettings} />
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem key={option.id} asChild className="rounded-none text-[13px]">
+                <Link href={option.href}>
+                  <BreadcrumbOptionContent option={option} onOpenSettings={openSettings} />
+                </Link>
+              </DropdownMenuItem>
+            ),
+          )}
         </div>
         {item.createNew && (
           <>
@@ -171,5 +160,49 @@ function BreadcrumbDropdown({ item }: { item: BreadcrumbItem }) {
         )}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+function BreadcrumbOptionContent({
+  option,
+  onOpenSettings,
+}: {
+  option: BreadcrumbDropdownOption;
+  onOpenSettings: (href: string) => void;
+}) {
+  return (
+    <span className="flex w-full items-center justify-between">
+      <span className="flex min-w-0 items-center gap-1.5">
+        {option.isCurrent && (
+          <span aria-hidden="true" className="shrink-0 text-[11px]">
+            &#10003;
+          </span>
+        )}
+        <span className="max-w-36 truncate" title={option.label}>
+          {option.label}
+        </span>
+      </span>
+      {option.settingsHref && (
+        <span
+          role="button"
+          tabIndex={0}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onOpenSettings(option.settingsHref!);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              e.stopPropagation();
+              onOpenSettings(option.settingsHref!);
+            }
+          }}
+          className="-my-0.5 ml-4 flex h-6 w-6 items-center justify-center text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+        >
+          <Settings size={12} />
+        </span>
+      )}
+    </span>
   );
 }

--- a/frontend/ui/src/features/projects/components/ProjectBreadcrumb.test.tsx
+++ b/frontend/ui/src/features/projects/components/ProjectBreadcrumb.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+
+const mocks = vi.hoisted(() => ({
+  setHeaderContent: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/projects/p-1/traces",
+}));
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({
+    setHeaderContent: mocks.setHeaderContent,
+  }),
+}));
+
+vi.mock("@/features/workspaces/components", () => ({
+  CreateWorkspaceDialog: () => null,
+}));
+
+vi.mock("./CreateProjectDialog", () => ({
+  CreateProjectDialog: () => null,
+}));
+
+vi.mock("../hooks", () => ({
+  useProject: () => ({
+    data: {
+      id: "p-1",
+      name: "Project One",
+      workspace_id: "w-1",
+    },
+  }),
+}));
+
+vi.mock("@/features/workspaces/hooks", () => ({
+  useWorkspaces: () => ({
+    data: [
+      { id: "w-1", name: "Workspace One" },
+      { id: "w-2", name: "Workspace Two" },
+    ],
+  }),
+  useWorkspace: () => ({
+    data: {
+      id: "w-1",
+      name: "Workspace One",
+      projects: [
+        { id: "p-1", name: "Project One" },
+        { id: "p-2", name: "Project Two" },
+      ],
+    },
+  }),
+}));
+
+import { ProjectBreadcrumb } from "./ProjectBreadcrumb";
+
+afterEach(() => {
+  cleanup();
+  mocks.setHeaderContent.mockClear();
+});
+
+function latestBreadcrumbItems() {
+  const call = mocks.setHeaderContent.mock.calls.find(([content]) => content !== null);
+  return (
+    call?.[0] as ReactElement<{
+      items: Array<{ options?: Array<{ id: string; isCurrent?: boolean }> }>;
+    }>
+  ).props.items;
+}
+
+describe("ProjectBreadcrumb", () => {
+  it("marks the current workspace and project options", async () => {
+    render(<ProjectBreadcrumb projectId="p-1" />);
+
+    await waitFor(() => expect(mocks.setHeaderContent).toHaveBeenCalled());
+    const [workspaceItem, projectItem] = latestBreadcrumbItems();
+
+    expect(workspaceItem.options?.find((option) => option.id === "w-1")?.isCurrent).toBe(true);
+    expect(workspaceItem.options?.find((option) => option.id === "w-2")?.isCurrent).toBe(false);
+    expect(projectItem.options?.find((option) => option.id === "p-1")?.isCurrent).toBe(true);
+    expect(projectItem.options?.find((option) => option.id === "p-2")?.isCurrent).toBe(false);
+  });
+});

--- a/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
+++ b/frontend/ui/src/features/projects/components/ProjectBreadcrumb.tsx
@@ -49,6 +49,7 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
           id: ws.id,
           label: ws.name,
           href: workspaceSwitchHref(pathname, ws.id),
+          isCurrent: ws.id === project?.workspace_id,
           settingsHref: `/workspaces/${ws.id}/settings`,
         })),
         menuHeader: { label: "Workspaces", href: "/workspaces" },
@@ -61,6 +62,7 @@ export function ProjectBreadcrumb({ projectId, current }: ProjectBreadcrumbProps
           id: p.id,
           label: p.name,
           href: projectSwitchHref(pathname, p.id),
+          isCurrent: p.id === projectId,
           settingsHref: `/projects/${p.id}/settings`,
         })),
         menuHeader: {

--- a/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.test.tsx
+++ b/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+
+const mocks = vi.hoisted(() => ({
+  setHeaderContent: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/workspaces/w-1/projects",
+}));
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({
+    setHeaderContent: mocks.setHeaderContent,
+  }),
+}));
+
+vi.mock("./CreateWorkspaceDialog", () => ({
+  CreateWorkspaceDialog: () => null,
+}));
+
+vi.mock("../hooks", () => ({
+  useWorkspace: () => ({
+    data: {
+      id: "w-1",
+      name: "Workspace One",
+    },
+  }),
+  useWorkspaces: () => ({
+    data: [
+      { id: "w-1", name: "Workspace One" },
+      { id: "w-2", name: "Workspace Two" },
+    ],
+  }),
+}));
+
+import { WorkspaceBreadcrumb } from "./WorkspaceBreadcrumb";
+
+afterEach(() => {
+  cleanup();
+  mocks.setHeaderContent.mockClear();
+});
+
+function latestBreadcrumbItems() {
+  const call = mocks.setHeaderContent.mock.calls.find(([content]) => content !== null);
+  return (
+    call?.[0] as ReactElement<{
+      items: Array<{ options?: Array<{ id: string; isCurrent?: boolean }> }>;
+    }>
+  ).props.items;
+}
+
+describe("WorkspaceBreadcrumb", () => {
+  it("marks the current workspace option", async () => {
+    render(<WorkspaceBreadcrumb workspaceId="w-1" />);
+
+    await waitFor(() => expect(mocks.setHeaderContent).toHaveBeenCalled());
+    const [workspaceItem] = latestBreadcrumbItems();
+
+    expect(workspaceItem.options?.find((option) => option.id === "w-1")?.isCurrent).toBe(true);
+    expect(workspaceItem.options?.find((option) => option.id === "w-2")?.isCurrent).toBe(false);
+  });
+});

--- a/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.tsx
+++ b/frontend/ui/src/features/workspaces/components/WorkspaceBreadcrumb.tsx
@@ -42,6 +42,7 @@ export function WorkspaceBreadcrumb({ workspaceId, current }: WorkspaceBreadcrum
           id: ws.id,
           label: ws.name,
           href: workspaceSwitchHref(pathname, ws.id),
+          isCurrent: ws.id === workspaceId,
           settingsHref: `/workspaces/${ws.id}/settings`,
         })),
         menuHeader: { label: "Workspaces", href: "/workspaces" },


### PR DESCRIPTION
Fixes #1225

## Summary

Marks the current workspace or project in breadcrumb dropdowns.

The current row now shows a checkmark and is not clickable.

## Type of Change

- [x] fix - A bug fix
- [x] test - Adding missing tests or correcting existing tests

## Details

Uses explicit `isCurrent` state from the project and workspace breadcrumb wrappers.

Keeps other rows as links, and keeps the settings gear, menu header, and create actions working.

Validated by:

- `pnpm --dir frontend/ui test src/components/layout/breadcrumb.test.tsx` - proves current rows are marked and other rows still link.
- Local repro with `make dev-lite` - confirms the dropdown shows the current row clearly.

## Screenshots / Recordings (if applicable)

Before:
<p float="left">
  <img src="https://github.com/user-attachments/assets/1193f56d-02fa-44f6-ac6d-ae51034cb7fd" width="214" />
  <img src="https://github.com/user-attachments/assets/25a5b64b-4bc4-4470-a670-9f67786b0607" width="218" />
</p>

After:
<p float="left">
  <img src="https://github.com/user-attachments/assets/c9275f6c-d863-49a3-939e-9bb0d80117e7" width="222" />
  <img width="211" height="180" alt="image" src="https://github.com/user-attachments/assets/b8268385-9c19-4b4d-b706-1d29bf5a81aa" />
</p>







## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the current workspace/project in breadcrumb dropdowns with a select-style checkmark and disables self-links to prevent accidental reloads. Fixes #1225.

- **Bug Fixes**
  - Added `isCurrent` to dropdown options and updated rendering to match our select design: shows a checkmark, emphasizes the row, and blocks selecting the active item.
  - Kept menu header, create actions, and settings gear working; settings open via click or Enter/Space. Added tests for current markers, link behavior, and settings access across `Breadcrumb`, `WorkspaceBreadcrumb`, and `ProjectBreadcrumb`.

<sup>Written for commit 427cbf299640a7f23fafe6abe70005828145c9d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

