### PR TITLE
examples(claude-agent-sdk): add ClaudeSDKClient + MCP examples

### DIFF
--- a/examples/python/claude-agent-sdk/README.md
+++ b/examples/python/claude-agent-sdk/README.md
@@ -20,9 +20,16 @@ uv run --no-project --python 3.13 --with-requirements requirements.txt python mi
 
 ## What it does
 
-Runs demo queries using the Claude Agent SDK's built-in tools (Read, Glob, Grep, Bash).
-Claude autonomously decides which tools to use and executes them.
+Runs demo queries using the Claude Agent SDK. Claude autonomously decides which
+tools to use and executes them. Each variant exercises a distinct part of the SDK
+surface, so they double as instrumentation smoke tests:
 
-- `main.py` — full demo: 2 topics, WebSearch researcher, higher turn budget.
-- `minimal.py` — trimmed version of `main.py`: 1 topic, no WebSearch, low `max_turns`,
+- `main.py` — full demo via `query()`: 2 topics, WebSearch researcher, higher turn budget.
+- `minimal.py` — trimmed `query()` version: 1 topic, no WebSearch, low `max_turns`,
   "be brief" prompts. Same trace shape, finishes in ~1-2 min.
+- `client.py` — the **persistent `ClaudeSDKClient`** API (a two-turn streaming
+  session) rather than the one-shot `query()` helper. This is the API most
+  production agents use.
+- `client-mcp.py` — `ClaudeSDKClient` driving **MCP tools** (a self-contained
+  in-process SDK MCP server). Covers the `mcp__<server>__<tool>` tool-span path
+  production agents lean on; external stdio MCP servers produce the same span shape.

--- a/examples/python/claude-agent-sdk/client-mcp.py
+++ b/examples/python/claude-agent-sdk/client-mcp.py
@@ -1,0 +1,104 @@
+"""MCP-tool demo with TraceRoot observability.
+
+Shows how MCP tool calls appear in traces. Production agents are often
+MCP-heavy, with traces full of `mcp__<server>__<tool>` spans.
+
+This uses an *in-process* SDK MCP server (`create_sdk_mcp_server`) so it runs
+self-contained with just an Anthropic key — no external MCP server process to
+install. An external stdio MCP server (the typical production setup) produces
+the **same** span shape through the same code path: each MCP call arrives as a
+`ToolUseBlock` named `mcp__<server>__<tool>` and gets a TOOL span, exactly like
+a built-in tool.
+
+Driven through the persistent `ClaudeSDKClient` (see client.py), since that
+is the API real agents use.
+
+Usage:
+    cp .env.example .env
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python client-mcp.py
+"""
+
+import asyncio
+import logging
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found. Using process environment variables.")
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.CLAUDE_AGENT_SDK])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ClaudeSDKClient,
+    create_sdk_mcp_server,
+    tool,
+)
+
+# --- A tiny in-process MCP server with two tools ----------------------------
+
+
+@tool("multiply", "Multiply two numbers", {"a": float, "b": float})
+async def multiply(args):
+    result = args["a"] * args["b"]
+    return {"content": [{"type": "text", "text": str(result)}]}
+
+
+@tool("add", "Add two numbers", {"a": float, "b": float})
+async def add(args):
+    result = args["a"] + args["b"]
+    return {"content": [{"type": "text", "text": str(result)}]}
+
+
+calc_server = create_sdk_mcp_server(name="calc", version="1.0.0", tools=[multiply, add])
+
+OPTIONS = ClaudeAgentOptions(
+    model="haiku",
+    mcp_servers={"calc": calc_server},
+    # MCP tools are addressed as mcp__<server>__<tool>.
+    allowed_tools=["mcp__calc__multiply", "mcp__calc__add"],
+    max_turns=5,
+    permission_mode="bypassPermissions",
+)
+
+TURN_1 = "Use the multiply tool to compute 17 * 23. Reply with only the number."
+TURN_2 = "Now use the add tool to add 100 to that number. Reply with only the result."
+
+
+@observe(name="mcp_pipeline", type="agent")
+async def run_session() -> str:
+    final = ""
+    async with ClaudeSDKClient(options=OPTIONS) as client:
+        for turn in (TURN_1, TURN_2):
+            await client.query(turn)
+            async for message in client.receive_response():
+                if hasattr(message, "result"):
+                    final = message.result
+    return final
+
+
+@observe(name="demo_session", type="agent")
+async def run_demo():
+    print("=" * 60)
+    print("ClaudeSDKClient + MCP tools — Demo (TraceRoot)")
+    print("=" * 60)
+    result = await run_session()
+    if result:
+        print(f"\n{result}")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="claude-agent-sdk-mcp-session"):
+        try:
+            asyncio.run(run_demo())
+        finally:
+            traceroot.flush()

--- a/examples/python/claude-agent-sdk/client.py
+++ b/examples/python/claude-agent-sdk/client.py
@@ -1,0 +1,80 @@
+"""ClaudeSDKClient demo with TraceRoot observability.
+
+Counterpart to minimal.py, but uses the *persistent streaming* client
+(`ClaudeSDKClient`) instead of the one-shot `query()` helper. This is the API
+real production agents tend to use — a long-lived session driven across multiple
+turns (here, two turns where the second builds on the first).
+
+TraceRoot instruments the full `ClaudeSDKClient` path (connect / query /
+receive_response), so the session below produces the same rich spans as the
+`query()` examples: a per-turn root, nested `anthropic.messages.create` LLM
+spans, and tool spans — on top of the manual `@observe` spans.
+
+Usage:
+    cp .env.example .env
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python client.py
+"""
+
+import asyncio
+import logging
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found. Using process environment variables.")
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.CLAUDE_AGENT_SDK])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+# Shared workload — a two-turn persistent session. Turn 2 references turn 1,
+# which only works because ClaudeSDKClient keeps the conversation alive.
+TURN_1 = "Use the Bash tool to compute 17 * 23 with python3. Reply with only the number."
+TURN_2 = "Now use the Bash tool to add 100 to that number. Reply with only the result."
+
+OPTIONS = ClaudeAgentOptions(
+    model="haiku",
+    allowed_tools=["Bash"],
+    max_turns=4,
+    permission_mode="bypassPermissions",
+)
+
+
+@observe(name="research_pipeline", type="agent")
+async def run_session() -> str:
+    """Drive a persistent ClaudeSDKClient session across two turns."""
+    final = ""
+    async with ClaudeSDKClient(options=OPTIONS) as client:
+        for turn in (TURN_1, TURN_2):
+            await client.query(turn)
+            async for message in client.receive_response():
+                if hasattr(message, "result"):
+                    final = message.result
+    return final
+
+
+@observe(name="demo_session", type="agent")
+async def run_demo():
+    print("=" * 60)
+    print("ClaudeSDKClient persistent session — Demo (TraceRoot)")
+    print("=" * 60)
+    result = await run_session()
+    if result:
+        print(f"\n{result}")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="claude-agent-sdk-client-session"):
+        try:
+            asyncio.run(run_demo())
+        finally:
+            traceroot.flush()

--- a/examples/python/claude-agent-sdk/main.py
+++ b/examples/python/claude-agent-sdk/main.py
@@ -103,7 +103,7 @@ async def run_research(topic: str) -> str:
             f"Coordinate the agents and present the final report."
         ),
         options=ClaudeAgentOptions(
-            model="claude-sonnet-4-20250514",
+            model="sonnet",
             allowed_tools=["Agent"],
             max_turns=15,
             # WARNING: bypassPermissions auto-approves all tool calls (Bash, WebSearch)

--- a/examples/python/claude-agent-sdk/minimal.py
+++ b/examples/python/claude-agent-sdk/minimal.py
@@ -70,7 +70,7 @@ async def run_research(topic: str) -> str:
             f"Then present the final summary."
         ),
         options=ClaudeAgentOptions(
-            model="claude-sonnet-4-20250514",
+            model="sonnet",
             allowed_tools=["Agent"],
             max_turns=8,
             permission_mode="bypassPermissions",

--- a/examples/python/claude-agent-sdk/requirements.txt
+++ b/examples/python/claude-agent-sdk/requirements.txt
@@ -1,4 +1,4 @@
 claude-agent-sdk>=0.1.72
 python-dotenv>=1.0.0
 
-traceroot>=0.1.8
+traceroot>=0.1.9


### PR DESCRIPTION
## What

Adds two new Claude Agent SDK examples (covering the `ClaudeSDKClient` API) and fixes the orchestrator model id in the existing ones.

- **`client.py`** — a persistent `ClaudeSDKClient` streaming session (two turns, where the second builds on the first). This is the API most production agents use, distinct from the one-shot `query()` helper that `main.py` / `minimal.py` already demonstrate.
- **`client-mcp.py`** — `ClaudeSDKClient` driving an in-process SDK MCP server, so MCP tool calls (`mcp__<server>__<tool>`) show up in traces. Self-contained — needs only an Anthropic key — and an external stdio MCP server produces the same span shape.
- **`main.py` / `minimal.py`** — switch the orchestrator model from the pinned dated id `claude-sonnet-4-20250514` (no longer available) to the `sonnet` alias, which resolves to the current Sonnet and won't deprecate out.
- **`requirements.txt`** — require `traceroot>=0.1.9` (the version that instruments the `ClaudeSDKClient` path).

Each variant exercises a distinct part of the SDK surface, so they double as instrumentation smoke tests.

## Note

`client.py` / `client-mcp.py` rely on the `ClaudeSDKClient` instrumentation shipping in `traceroot` 0.1.9 — merge once that release is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two new Python examples showcasing the persistent `ClaudeSDKClient` and MCP tools in the `claude-agent-sdk`, and switch existing examples to the `sonnet` model alias to avoid deprecations. Requires `traceroot>=0.1.9` for `ClaudeSDKClient` instrumentation.

- **New Features**
  - `client.py`: two-turn streaming session using `ClaudeSDKClient`.
  - `client-mcp.py`: in-process MCP server with `mcp__<server>__<tool>` spans.
  - README: clarifies demo variants and their trace coverage.

- **Bug Fixes**
  - Replace `claude-sonnet-4-20250514` with `sonnet` in `main.py` and `minimal.py`.

<sup>Written for commit d1480655ddf09dde8a89bceb1e497d7a7c68ed7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

