### PR TITLE
fix(traces): support projected trace io export

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -259,7 +259,7 @@
           },
           "spans": {
             "items": {
-              "$ref": "#/components/schemas/SpanSkeletonResponse"
+              "$ref": "#/components/schemas/SpanResponse"
             },
             "title": "Spans",
             "type": "array"
@@ -318,7 +318,7 @@
           },
           "spans": {
             "items": {
-              "$ref": "#/components/schemas/SpanSkeletonResponse"
+              "$ref": "#/components/schemas/SpanResponse"
             },
             "title": "Spans",
             "type": "array"
@@ -498,8 +498,8 @@
         "title": "PublicTraceListResponse",
         "type": "object"
       },
-      "SpanSkeletonResponse": {
-        "description": "Span skeleton \u2014 tree-building / display fields only, no I/O blobs.\n\nUsed by the trace-detail endpoint so the initial payload stays sub-MB\nregardless of trace size. Full I/O (input/output/metadata) is fetched\nper-span on demand via the dedicated ``/spans/{span_id}/io`` endpoint.\n\nNote: the token/cost breakdown maps (``usage_details``/``cost_details``)\nstay on the skeleton \u2014 they are small and drive the tree's token/cost\nchips. Only the large free-text I/O blobs are omitted.",
+      "SpanResponse": {
+        "description": "A span skeleton plus its per-span I/O blobs (``input``/``output``/``metadata``).\n\nThe projection-capable superset returned by the trace get/export endpoints.\nThe blobs default to ``None`` and are populated only when the caller requests\nthe matching field group (``io``/``metadata``; see\n``rest.projection``). The default ``skeleton`` projection leaves them ``None``\nand never runs the bulk span-I/O query, so there is no payload or query-cost\nregression for the dashboard. Keeping the fields present (as ``null``) rather\nthan omitting them is additive: a few bytes per span, and it matches the\nfields the shipped CLI's generated types already declare.",
         "properties": {
           "cost": {
             "anyOf": [
@@ -553,6 +553,17 @@
             ],
             "title": "Git Source Line"
           },
+          "input": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input"
+          },
           "input_tokens": {
             "anyOf": [
               {
@@ -563,6 +574,17 @@
               }
             ],
             "title": "Input Tokens"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
           },
           "model_name": {
             "anyOf": [
@@ -578,6 +600,17 @@
           "name": {
             "title": "Name",
             "type": "string"
+          },
+          "output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output"
           },
           "output_tokens": {
             "anyOf": [
@@ -681,7 +714,7 @@
           "output_tokens",
           "total_tokens"
         ],
-        "title": "SpanSkeletonResponse",
+        "title": "SpanResponse",
         "type": "object"
       },
       "ValidationError": {
@@ -1051,7 +1084,7 @@
     },
     "/api/v1/public/traces/{trace_id}": {
       "get": {
-        "description": "Get a single trace (full payload, including spans) for the key's project.",
+        "description": "Get a single trace for the key's project.\n\nDefaults to the lightweight `skeleton` projection (no per-span I/O); pass\n`fields=full` (or `fields=io,metadata`) for per-span input/output/metadata.",
         "operationId": "get_trace_api_v1_public_traces__trace_id__get",
         "parameters": [
           {
@@ -1061,6 +1094,24 @@
             "schema": {
               "title": "Trace Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated field groups to include: 'core' (tree/timing/status, always included), 'usage' (tokens/cost), 'io' (per-span input/output), 'metadata' (per-span metadata). Aliases: 'skeleton' (core,usage), 'full' (everything). Unknown groups return 400.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated field groups to include: 'core' (tree/timing/status, always included), 'usage' (tokens/cost), 'io' (per-span input/output), 'metadata' (per-span metadata). Aliases: 'skeleton' (core,usage), 'full' (everything). Unknown groups return 400.",
+              "title": "Fields"
             }
           }
         ],
@@ -1074,6 +1125,21 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Invalid fields parameter"
           },
           "401": {
             "content": {
@@ -1159,7 +1225,7 @@
     },
     "/api/v1/public/traces/{trace_id}/export": {
       "get": {
-        "description": "Export the V1 bundle (trace + spans + git_context + manifest) for the key's project.\n\n`bundle.trace` is identical to the `traces get` payload for the same trace.",
+        "description": "Export the V1 bundle (trace + spans + git_context + manifest) for the key's project.\n\nDefaults to the `full` projection \u2014 an export is explicit intent to take the\ncomplete trace, so per-span input/output/metadata are included unless the\ncaller narrows `fields`. `bundle.trace` equals the `traces get` payload at the\nsame projection.",
         "operationId": "export_trace_api_v1_public_traces__trace_id__export_get",
         "parameters": [
           {
@@ -1169,6 +1235,24 @@
             "schema": {
               "title": "Trace Id",
               "type": "string"
+            }
+          },
+          {
+            "description": "Comma-separated field groups to include: 'core' (tree/timing/status, always included), 'usage' (tokens/cost), 'io' (per-span input/output), 'metadata' (per-span metadata). Aliases: 'skeleton' (core,usage), 'full' (everything). Unknown groups return 400.",
+            "in": "query",
+            "name": "fields",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Comma-separated field groups to include: 'core' (tree/timing/status, always included), 'usage' (tokens/cost), 'io' (per-span input/output), 'metadata' (per-span metadata). Aliases: 'skeleton' (core,usage), 'full' (everything). Unknown groups return 400.",
+              "title": "Fields"
             }
           }
         ],
@@ -1182,6 +1266,21 @@
               }
             },
             "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Invalid fields parameter"
           },
           "401": {
             "content": {

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -80,6 +80,7 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
     for path in ("/api/v1/public/traces/{trace_id}", "/api/v1/public/traces/{trace_id}/export"):
         op = schema["paths"].get(path, {}).get("get")
         if op is not None:
+            op["responses"].setdefault("400", _error_response("Invalid fields parameter"))
             op["responses"].setdefault("404", _error_response("Trace not found"))
             op["responses"].setdefault("500", _error_response("Failed to get trace"))
 

--- a/backend/rest/projection.py
+++ b/backend/rest/projection.py
@@ -88,6 +88,11 @@ def resolve_span_fields(fields: str | None, *, default: frozenset[str]) -> froze
             f"Valid groups: {', '.join(_VALID_TOKENS)}."
         )
 
+    # Input with no usable tokens (e.g. "," or "  ,  ") is treated like an omitted
+    # param: return the default, consistent with the ""/None case above.
+    if not resolved:
+        return default
+
     resolved.add(CORE)
     return frozenset(resolved)
 

--- a/backend/rest/projection.py
+++ b/backend/rest/projection.py
@@ -1,0 +1,124 @@
+"""Field-group projection for trace reads (a ``fields`` query parameter).
+
+A single ``fields`` query parameter controls how much of a trace/span payload
+comes back, instead of a pile of orthogonal ``include_x`` booleans or a hard
+split into two differently-named endpoints. Named groups:
+
+  ``core``      span tree + timing + status — always included.
+  ``usage``     token counts + cost breakdown — small, included by default.
+  ``io``        per-span ``input``/``output`` blobs — heavy, opt-in.
+  ``metadata``  per-span ``metadata`` blob — heavy-ish, opt-in.
+
+The two convenience aliases ``skeleton`` (``core,usage``) and ``full``
+(everything) map to the obvious group sets. The dashboard/UI uses the
+``skeleton`` default (the #1040 lightweight read, kept for payload size); export
+and the agent request ``full`` for full fidelity.
+
+Only the ``io``/``metadata`` groups require the extra bulk span-I/O ClickHouse
+query, and only for the columns they name (``io_columns``) — ``core``/``usage``
+are served entirely by the cheap skeleton read, so the default projection has no
+query-cost regression for the dashboard.
+
+Finer-grained ``io.input`` / ``io.output`` projection is a deliberate follow-up
+(see the trace-read-projection epic); today ``io`` covers input+output together.
+"""
+
+CORE = "core"
+USAGE = "usage"
+IO = "io"
+METADATA = "metadata"
+
+# The canonical groups a *resolved* projection may contain.
+_CANONICAL = frozenset({CORE, USAGE, IO, METADATA})
+
+# Alias tokens a client may type, expanded into canonical group sets.
+SKELETON = frozenset({CORE, USAGE})
+FULL = frozenset({CORE, USAGE, IO, METADATA})
+_ALIASES = {"skeleton": SKELETON, "full": FULL}
+
+# Every token a `fields` value may legally contain (for the 400 message).
+_VALID_TOKENS = sorted(set(_CANONICAL) | set(_ALIASES))
+
+# Documentation string reused by every endpoint exposing ``fields``.
+FIELDS_PARAM_DESC = (
+    "Comma-separated field groups to include: 'core' (tree/timing/status, always "
+    "included), 'usage' (tokens/cost), 'io' (per-span input/output), 'metadata' "
+    "(per-span metadata). Aliases: 'skeleton' (core,usage), 'full' (everything). "
+    "Unknown groups return 400."
+)
+
+
+class InvalidFieldsError(ValueError):
+    """Raised when a ``fields`` value contains an unrecognized group token.
+
+    A ``ValueError`` subclass so callers can map it to ``400 Bad Request``
+    without importing FastAPI here.
+    """
+
+
+def resolve_span_fields(fields: str | None, *, default: frozenset[str]) -> frozenset[str]:
+    """Parse a ``fields`` query value into a validated, canonical group set.
+
+    ``None``/empty -> ``default``. Otherwise a comma-separated list of group
+    names (``core``/``usage``/``io``/``metadata``) or the ``skeleton``/``full``
+    aliases, case-insensitive. ``core`` is always implied so the span tree is
+    never empty. An unrecognized token raises ``InvalidFieldsError`` (mapped to
+    400) rather than being silently ignored — this catches client typos instead
+    of quietly returning a narrower payload.
+    """
+    if not fields or not fields.strip():
+        return default
+
+    resolved: set[str] = set()
+    unknown: list[str] = []
+    for raw in fields.split(","):
+        token = raw.strip().lower()
+        if not token:
+            continue
+        if token in _ALIASES:
+            resolved |= _ALIASES[token]
+        elif token in _CANONICAL:
+            resolved.add(token)
+        else:
+            unknown.append(raw.strip())
+
+    if unknown:
+        raise InvalidFieldsError(
+            f"Unknown fields group(s): {', '.join(unknown)}. "
+            f"Valid groups: {', '.join(_VALID_TOKENS)}."
+        )
+
+    resolved.add(CORE)
+    return frozenset(resolved)
+
+
+def io_columns(groups: frozenset[str]) -> frozenset[str]:
+    """The set of blob columns (``input``/``output``/``metadata``) a projection needs.
+
+    ``io`` -> input+output, ``metadata`` -> metadata. Empty when the projection
+    is ``core``/``usage`` only — the signal the routers use to skip the bulk
+    span-I/O query entirely (no dashboard regression).
+    """
+    columns: set[str] = set()
+    if IO in groups:
+        columns |= {"input", "output"}
+    if METADATA in groups:
+        columns.add("metadata")
+    return frozenset(columns)
+
+
+def merge_span_io(trace: dict, span_io: dict[str, dict]) -> None:
+    """Attach bulk per-span I/O onto a trace's skeleton spans, in place.
+
+    ``span_io`` is the ``{span_id: {column: value}}`` map from
+    ``TraceReaderService.get_trace_spans_io`` — it already contains only the
+    columns the projection requested, so each span is updated with exactly those
+    keys. Spans absent from the map are left untouched (their I/O stays ``None``),
+    so a partial/empty map never breaks serialization. Lives here (not in a router
+    module) so both the public and internal trace endpoints share it without
+    cross-importing.
+    """
+    for span in trace.get("spans", []):
+        io = span_io.get(span["span_id"])
+        if io:
+            span.update(io)

--- a/backend/rest/projection.py
+++ b/backend/rest/projection.py
@@ -122,3 +122,27 @@ def merge_span_io(trace: dict, span_io: dict[str, dict]) -> None:
         io = span_io.get(span["span_id"])
         if io:
             span.update(io)
+
+
+def hydrate_span_io(
+    service,
+    trace: dict,
+    *,
+    project_id: str,
+    trace_id: str,
+    groups: frozenset[str],
+) -> None:
+    """Attach per-span I/O to a skeleton ``trace`` for the resolved projection, in place.
+
+    The single gate for the bulk span-I/O query: it runs **only** when ``groups``
+    includes ``io``/``metadata`` (``io_columns`` non-empty). Centralizing it here —
+    rather than copy-pasting the gate into each router — means a new ``fields``
+    endpoint cannot forget the ``core``/``usage``-only fast path that keeps the
+    default skeleton read off the heavy query (the #1040 win). ``service`` is any
+    object exposing ``get_trace_spans_io(project_id, trace_id, columns)``.
+    """
+    columns = io_columns(groups)
+    if not columns:
+        return
+    span_io = service.get_trace_spans_io(project_id=project_id, trace_id=trace_id, columns=columns)
+    merge_span_io(trace, span_io)

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -15,8 +15,7 @@ from rest.projection import (
     FULL,
     SKELETON,
     InvalidFieldsError,
-    io_columns,
-    merge_span_io,
+    hydrate_span_io,
     resolve_span_fields,
 )
 from rest.routers.public.deps import Auth
@@ -113,12 +112,7 @@ def _require_trace(project_id: str, trace_id: str, groups: frozenset[str]) -> di
         service = get_trace_reader_service()
         trace = service.get_trace(project_id=project_id, trace_id=trace_id)
         if trace:
-            columns = io_columns(groups)
-            if columns:
-                span_io = service.get_trace_spans_io(
-                    project_id=project_id, trace_id=trace_id, columns=columns
-                )
-                merge_span_io(trace, span_io)
+            hydrate_span_io(service, trace, project_id=project_id, trace_id=trace_id, groups=groups)
     except Exception as e:
         logger.exception(f"Error getting trace: {e}")
         raise HTTPException(

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -10,6 +10,15 @@ import logging
 
 from fastapi import APIRouter, HTTPException, Query, status
 
+from rest.projection import (
+    FIELDS_PARAM_DESC,
+    FULL,
+    SKELETON,
+    InvalidFieldsError,
+    io_columns,
+    merge_span_io,
+    resolve_span_fields,
+)
 from rest.routers.public.deps import Auth
 from rest.routers.public.serialize import export_bundle, public_trace_detail
 from rest.schemas.public import (
@@ -50,32 +59,66 @@ async def list_traces(
 
 
 @router.get("/{trace_id}", response_model=PublicTraceDetailResponse)
-async def get_trace(auth: Auth, trace_id: str):
-    """Get a single trace (full payload, including spans) for the key's project."""
-    trace = _require_trace(auth.project_id, trace_id)
+async def get_trace(
+    auth: Auth,
+    trace_id: str,
+    fields: str | None = Query(None, description=FIELDS_PARAM_DESC),
+):
+    """Get a single trace for the key's project.
+
+    Defaults to the lightweight `skeleton` projection (no per-span I/O); pass
+    `fields=full` (or `fields=io,metadata`) for per-span input/output/metadata.
+    """
+    groups = _resolve_fields(fields, default=SKELETON)
+    trace = _require_trace(auth.project_id, trace_id, groups)
     return public_trace_detail(trace, auth.project_id)
 
 
 @router.get("/{trace_id}/export", response_model=PublicTraceExportResponse)
-async def export_trace(auth: Auth, trace_id: str):
+async def export_trace(
+    auth: Auth,
+    trace_id: str,
+    fields: str | None = Query(None, description=FIELDS_PARAM_DESC),
+):
     """Export the V1 bundle (trace + spans + git_context + manifest) for the key's project.
 
-    `bundle.trace` is identical to the `traces get` payload for the same trace.
+    Defaults to the `full` projection — an export is explicit intent to take the
+    complete trace, so per-span input/output/metadata are included unless the
+    caller narrows `fields`. `bundle.trace` equals the `traces get` payload at the
+    same projection.
     """
-    trace = _require_trace(auth.project_id, trace_id)
+    groups = _resolve_fields(fields, default=FULL)
+    trace = _require_trace(auth.project_id, trace_id, groups)
     return export_bundle(trace, auth.project_id)
 
 
-def _require_trace(project_id: str, trace_id: str) -> dict:
-    """Fetch a trace scoped to the project, or raise 404 (500 on reader failure).
+def _resolve_fields(fields: str | None, *, default: frozenset[str]) -> frozenset[str]:
+    """Resolve the `fields` projection, mapping a bad value to 400 Bad Request."""
+    try:
+        return resolve_span_fields(fields, default=default)
+    except InvalidFieldsError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+
+def _require_trace(project_id: str, trace_id: str, groups: frozenset[str]) -> dict:
+    """Fetch a trace scoped to the project at the requested projection.
 
     Centralizing the read here keeps `get` and `export` consistent: a reader
     failure is a controlled 500 (matching `list_traces`), a missing/cross-project
-    trace is a 404, and internal exception text is never leaked to clients.
+    trace is a 404, and internal exception text is never leaked to clients. The
+    bulk span-I/O query runs only when the projection requests `io`/`metadata`,
+    so the default skeleton read keeps the #1040 lightweight behavior.
     """
     try:
         service = get_trace_reader_service()
         trace = service.get_trace(project_id=project_id, trace_id=trace_id)
+        if trace:
+            columns = io_columns(groups)
+            if columns:
+                span_io = service.get_trace_spans_io(
+                    project_id=project_id, trace_id=trace_id, columns=columns
+                )
+                merge_span_io(trace, span_io)
     except Exception as e:
         logger.exception(f"Error getting trace: {e}")
         raise HTTPException(

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -67,6 +67,21 @@ async def get_trace(
 
     Defaults to the lightweight `skeleton` projection (no per-span I/O); pass
     `fields=full` (or `fields=io,metadata`) for per-span input/output/metadata.
+
+    Args:
+        auth (Auth): Resolved API-key context; scopes the read to its project.
+        trace_id (str): Trace to fetch.
+        fields (str | None): Comma-separated projection groups (e.g. ``io``,
+            ``metadata``) or an alias (``skeleton``/``full``). ``None`` selects
+            the default `skeleton` projection.
+
+    Returns:
+        PublicTraceDetailResponse: The trace with span skeletons, plus per-span
+            I/O when the projection requests it.
+
+    Raises:
+        HTTPException: 400 if `fields` is invalid, 404 if the trace is missing
+            or outside the key's project, 500 on a reader failure.
     """
     groups = _resolve_fields(fields, default=SKELETON)
     trace = _require_trace(auth.project_id, trace_id, groups)
@@ -85,6 +100,21 @@ async def export_trace(
     complete trace, so per-span input/output/metadata are included unless the
     caller narrows `fields`. `bundle.trace` equals the `traces get` payload at the
     same projection.
+
+    Args:
+        auth (Auth): Resolved API-key context; scopes the read to its project.
+        trace_id (str): Trace to export.
+        fields (str | None): Comma-separated projection groups or an alias
+            (``skeleton``/``full``). ``None`` selects the default `full`
+            projection.
+
+    Returns:
+        PublicTraceExportResponse: The V1 export bundle (manifest, trace, spans,
+            git_context) at the requested projection.
+
+    Raises:
+        HTTPException: 400 if `fields` is invalid, 404 if the trace is missing
+            or outside the key's project, 500 on a reader failure.
     """
     groups = _resolve_fields(fields, default=FULL)
     trace = _require_trace(auth.project_id, trace_id, groups)
@@ -92,7 +122,19 @@ async def export_trace(
 
 
 def _resolve_fields(fields: str | None, *, default: frozenset[str]) -> frozenset[str]:
-    """Resolve the `fields` projection, mapping a bad value to 400 Bad Request."""
+    """Resolve the `fields` projection, mapping a bad value to 400 Bad Request.
+
+    Args:
+        fields (str | None): Raw `fields` query value (comma-separated groups or
+            an alias). ``None``/empty resolves to ``default``.
+        default (frozenset[str]): Projection to use when `fields` is unset.
+
+    Returns:
+        frozenset[str]: The resolved set of projection groups.
+
+    Raises:
+        HTTPException: 400 Bad Request if `fields` names an unknown group.
+    """
     try:
         return resolve_span_fields(fields, default=default)
     except InvalidFieldsError as e:
@@ -107,6 +149,19 @@ def _require_trace(project_id: str, trace_id: str, groups: frozenset[str]) -> di
     trace is a 404, and internal exception text is never leaked to clients. The
     bulk span-I/O query runs only when the projection requests `io`/`metadata`,
     so the default skeleton read keeps the #1040 lightweight behavior.
+
+    Args:
+        project_id (str): Project that owns the trace; scopes the read.
+        trace_id (str): Trace to fetch.
+        groups (frozenset[str]): Resolved projection groups; per-span I/O is
+            hydrated only when ``io``/``metadata`` are present.
+
+    Returns:
+        dict: The trace detail dict, with per-span I/O merged in when requested.
+
+    Raises:
+        HTTPException: 404 if the trace is missing or outside the project, 500
+            on a reader failure.
     """
     try:
         service = get_trace_reader_service()

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -9,8 +9,7 @@ from rest.projection import (
     FIELDS_PARAM_DESC,
     SKELETON,
     InvalidFieldsError,
-    io_columns,
-    merge_span_io,
+    hydrate_span_io,
     resolve_span_fields,
 )
 from rest.routers.deps import ProjectAccess
@@ -86,14 +85,7 @@ async def get_trace(
             detail="Trace not found",
         )
 
-    # Only the io/metadata projections need the extra bulk query; skeleton skips it.
-    columns = io_columns(groups)
-    if columns:
-        span_io = service.get_trace_spans_io(
-            project_id=project_id, trace_id=trace_id, columns=columns
-        )
-        merge_span_io(trace, span_io)
-
+    hydrate_span_io(service, trace, project_id=project_id, trace_id=trace_id, groups=groups)
     return trace
 
 

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -70,6 +70,22 @@ async def get_trace(
     dashboard relies on this for sub-MB payloads. Non-interactive callers (e.g.
     the agent trace download) pass ``fields=full`` to regain per-span
     input/output/metadata in a single read.
+
+    Args:
+        project_id (str): Project that owns the trace; scopes the read.
+        trace_id (str): Trace to fetch.
+        _access (ProjectAccess): Dependency that validates the user's access to
+            the project; not used directly.
+        fields (str | None): Comma-separated projection groups (e.g. ``io``,
+            ``metadata``) or an alias (``skeleton``/``full``). ``None`` selects
+            the default `skeleton` projection.
+
+    Returns:
+        TraceDetailResponse: The trace with span skeletons, plus per-span I/O
+            when the projection requests it.
+
+    Raises:
+        HTTPException: 400 if `fields` is invalid, 404 if the trace is missing.
     """
     try:
         groups = resolve_span_fields(fields, default=SKELETON)

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -5,6 +5,14 @@ from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Query, status
 
+from rest.projection import (
+    FIELDS_PARAM_DESC,
+    SKELETON,
+    InvalidFieldsError,
+    io_columns,
+    merge_span_io,
+    resolve_span_fields,
+)
 from rest.routers.deps import ProjectAccess
 from rest.schemas.traces import SpanIOResponse, TraceDetailResponse, TraceListResponse
 from rest.services.trace_reader import get_trace_reader_service
@@ -55,8 +63,20 @@ async def get_trace(
     project_id: str,
     trace_id: str,
     _access: ProjectAccess,  # Validates user has access to project
+    fields: str | None = Query(None, description=FIELDS_PARAM_DESC),
 ):
-    """Get a single trace with span skeletons (no per-span I/O)."""
+    """Get a single trace for a project.
+
+    Defaults to the lightweight ``skeleton`` projection (no per-span I/O) — the
+    dashboard relies on this for sub-MB payloads. Non-interactive callers (e.g.
+    the agent trace download) pass ``fields=full`` to regain per-span
+    input/output/metadata in a single read.
+    """
+    try:
+        groups = resolve_span_fields(fields, default=SKELETON)
+    except InvalidFieldsError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
     service = get_trace_reader_service()
     trace = service.get_trace(project_id=project_id, trace_id=trace_id)
 
@@ -65,6 +85,14 @@ async def get_trace(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Trace not found",
         )
+
+    # Only the io/metadata projections need the extra bulk query; skeleton skips it.
+    columns = io_columns(groups)
+    if columns:
+        span_io = service.get_trace_spans_io(
+            project_id=project_id, trace_id=trace_id, columns=columns
+        )
+        merge_span_io(trace, span_io)
 
     return trace
 

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -3,7 +3,7 @@
 from pydantic import BaseModel
 
 from rest.schemas.common import PaginationMeta
-from rest.schemas.traces import SpanSkeletonResponse, TraceDetailResponse, TraceListItem
+from rest.schemas.traces import SpanResponse, TraceDetailResponse, TraceListItem
 
 
 class WhoamiResponse(BaseModel):
@@ -75,7 +75,8 @@ class PublicTraceExportResponse(BaseModel):
     manifest: ExportManifest
     trace: PublicTraceDetailResponse
     # Same span shape as `trace.spans` (the documented export.spans == detail.spans
-    # invariant). Skeletons omit per-span I/O blobs, matching what the reader's
-    # get_trace returns; full per-span I/O is fetched on demand via the span IO route.
-    spans: list[SpanSkeletonResponse]
+    # invariant). Export defaults to the `full` projection, so these carry per-span
+    # input/output/metadata; a narrowed `fields=skeleton` projection leaves them
+    # null. See rest.projection and the export endpoint's default `fields`.
+    spans: list[SpanResponse]
     git_context: GitContext

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -40,6 +40,24 @@ class SpanSkeletonResponse(BaseModel):
     git_source_function: str | None = None
 
 
+class SpanResponse(SpanSkeletonResponse):
+    """A span skeleton plus its per-span I/O blobs (``input``/``output``/``metadata``).
+
+    The projection-capable superset returned by the trace get/export endpoints.
+    The blobs default to ``None`` and are populated only when the caller requests
+    the matching field group (``io``/``metadata``; see
+    ``rest.projection``). The default ``skeleton`` projection leaves them ``None``
+    and never runs the bulk span-I/O query, so there is no payload or query-cost
+    regression for the dashboard. Keeping the fields present (as ``null``) rather
+    than omitting them is additive: a few bytes per span, and it matches the
+    fields the shipped CLI's generated types already declare.
+    """
+
+    input: str | None = None
+    output: str | None = None
+    metadata: str | None = None
+
+
 class SpanIOResponse(BaseModel):
     """Full I/O payload for a single span, fetched on demand."""
 
@@ -77,7 +95,15 @@ class TraceListResponse(BaseModel):
 
 
 class TraceDetailResponse(BaseModel):
-    """Single trace with span skeletons (no per-span I/O)."""
+    """Single trace with its spans.
+
+    Spans use ``SpanResponse`` (the skeleton superset): per-span ``input``/
+    ``output``/``metadata`` are present but default to ``None``. They are
+    populated only when the caller requests the matching ``io``/``metadata``
+    field group (see ``rest.projection``); the default ``skeleton`` projection
+    leaves them ``None`` and never runs the bulk span-I/O query, preserving the
+    #1040 lightweight behavior.
+    """
 
     trace_id: str
     project_id: str
@@ -90,4 +116,4 @@ class TraceDetailResponse(BaseModel):
     input: str | None
     output: str | None
     metadata: str | None
-    spans: list[SpanSkeletonResponse]
+    spans: list[SpanResponse]

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -292,6 +292,49 @@ class TraceReaderService:
         trace["spans"] = spans
         return trace
 
+    # Blob columns the bulk I/O reader may project, in a fixed order so the
+    # generated SELECT is deterministic. Whitelist guards the f-string below.
+    _IO_COLUMNS = ("input", "output", "metadata")
+
+    def get_trace_spans_io(
+        self, project_id: str, trace_id: str, columns: frozenset[str]
+    ) -> dict[str, dict]:
+        """Bulk-fetch the requested I/O columns for ALL spans in a trace, one query.
+
+        The trace-wide complement to ``get_span_io``: export and agent reads need
+        full per-span I/O without an N+1 fan-out of single-span calls. ``columns``
+        is the projection's blob columns (from ``rest.projection.io_columns`` —
+        any of ``input``/``output``/``metadata``); only those are SELECTed, so a
+        narrow projection (e.g. ``metadata`` alone) never reads the other heavy
+        blobs. Returns a ``{span_id: {column: value}}`` map. Callers merge it onto
+        the skeleton spans from ``get_trace``; spans absent from the map keep
+        whatever the skeleton carried, so a partial result never breaks
+        serialization.
+
+        Only invoked for ``io``/``metadata`` projections — the default skeleton
+        read never reaches here, so this adds no cost to the dashboard path.
+        """
+        # Preserve a fixed column order and reject anything outside the whitelist
+        # (the value is interpolated into the SQL, so never trust the caller).
+        selected = [c for c in self._IO_COLUMNS if c in columns]
+        if not selected:
+            return {}
+
+        select_clause = ", ".join(["span_id", *selected])
+        query = f"""
+            SELECT {select_clause}
+            FROM spans FINAL
+            WHERE project_id = {{project_id:String}} AND trace_id = {{trace_id:String}}
+        """
+        result = self._client.query(
+            query,
+            parameters={"project_id": project_id, "trace_id": trace_id},
+        )
+        return {
+            row[0]: {col: row[i + 1] for i, col in enumerate(selected)}
+            for row in result.result_rows
+        }
+
     def get_span_io(self, project_id: str, trace_id: str, span_id: str) -> dict | None:
         """Fetch full input/output/metadata for a single span on demand.
 

--- a/tests/rest/test_projection.py
+++ b/tests/rest/test_projection.py
@@ -15,10 +15,23 @@ from rest.projection import (
     SKELETON,
     USAGE,
     InvalidFieldsError,
+    hydrate_span_io,
     io_columns,
     merge_span_io,
     resolve_span_fields,
 )
+
+
+class _StubReader:
+    """Records get_trace_spans_io calls and returns a canned map."""
+
+    def __init__(self, span_io=None):
+        self._span_io = span_io or {}
+        self.calls = []
+
+    def get_trace_spans_io(self, *, project_id, trace_id, columns):
+        self.calls.append({"project_id": project_id, "trace_id": trace_id, "columns": columns})
+        return self._span_io
 
 
 class TestResolveSpanFields:
@@ -132,3 +145,35 @@ class TestMergeSpanIo:
 
     def test_no_spans_key_is_safe(self):
         merge_span_io({}, {"s1": {"input": "i"}})  # must not raise
+
+
+class TestHydrateSpanIo:
+    def _trace(self):
+        return {"spans": [{"span_id": "s1", "input": None, "output": None, "metadata": None}]}
+
+    def test_skeleton_skips_bulk_query(self):
+        """The #1040 gate: a skeleton projection must NOT touch the bulk reader."""
+        reader = _StubReader()
+        trace = self._trace()
+        hydrate_span_io(reader, trace, project_id="p", trace_id="t", groups=SKELETON)
+        assert reader.calls == []
+        assert trace["spans"][0]["input"] is None
+
+    def test_full_fetches_and_merges(self):
+        reader = _StubReader({"s1": {"input": "i", "output": "o", "metadata": "m"}})
+        trace = self._trace()
+        hydrate_span_io(reader, trace, project_id="p", trace_id="t", groups=FULL)
+        assert len(reader.calls) == 1
+        assert reader.calls[0]["columns"] == frozenset({"input", "output", "metadata"})
+        assert reader.calls[0]["project_id"] == "p"
+        assert reader.calls[0]["trace_id"] == "t"
+        assert trace["spans"][0]["input"] == "i"
+        assert trace["spans"][0]["metadata"] == "m"
+
+    def test_io_only_requests_input_output_columns(self):
+        reader = _StubReader({"s1": {"input": "i", "output": "o"}})
+        trace = self._trace()
+        hydrate_span_io(reader, trace, project_id="p", trace_id="t", groups=frozenset({CORE, IO}))
+        assert reader.calls[0]["columns"] == frozenset({"input", "output"})
+        assert trace["spans"][0]["input"] == "i"
+        assert trace["spans"][0]["metadata"] is None

--- a/tests/rest/test_projection.py
+++ b/tests/rest/test_projection.py
@@ -1,0 +1,134 @@
+"""Unit tests for the trace field-group projection vocabulary (`rest.projection`).
+
+Pure logic — no DB, no FastAPI. Covers the `fields` parsing, the alias/group
+expansion, the canonical-column mapping the bulk reader uses, and the in-place
+merge of bulk span I/O onto skeleton spans.
+"""
+
+import pytest
+
+from rest.projection import (
+    CORE,
+    FULL,
+    IO,
+    METADATA,
+    SKELETON,
+    USAGE,
+    InvalidFieldsError,
+    io_columns,
+    merge_span_io,
+    resolve_span_fields,
+)
+
+
+class TestResolveSpanFields:
+    def test_none_returns_default(self):
+        assert resolve_span_fields(None, default=SKELETON) == SKELETON
+        assert resolve_span_fields(None, default=FULL) == FULL
+
+    def test_blank_returns_default(self):
+        assert resolve_span_fields("   ", default=SKELETON) == SKELETON
+        assert resolve_span_fields("", default=FULL) == FULL
+
+    def test_skeleton_alias(self):
+        assert resolve_span_fields("skeleton", default=FULL) == frozenset({CORE, USAGE})
+
+    def test_full_alias(self):
+        assert resolve_span_fields("full", default=SKELETON) == frozenset(
+            {CORE, USAGE, IO, METADATA}
+        )
+
+    def test_io_group(self):
+        # core is always implied even when only io is asked for.
+        assert resolve_span_fields("io", default=SKELETON) == frozenset({CORE, IO})
+
+    def test_explicit_group_list_equals_full(self):
+        assert resolve_span_fields("core,usage,io,metadata", default=SKELETON) == FULL
+
+    def test_core_always_implied(self):
+        # Even asking for only metadata yields core (the span tree is never empty).
+        assert resolve_span_fields("metadata", default=SKELETON) == frozenset({CORE, METADATA})
+
+    def test_whitespace_and_case_insensitive(self):
+        assert resolve_span_fields(" IO , Metadata ", default=SKELETON) == frozenset(
+            {CORE, IO, METADATA}
+        )
+
+    def test_unknown_token_raises(self):
+        with pytest.raises(InvalidFieldsError):
+            resolve_span_fields("bogus", default=SKELETON)
+
+    def test_mixed_valid_and_unknown_raises(self):
+        with pytest.raises(InvalidFieldsError):
+            resolve_span_fields("io,bogus", default=SKELETON)
+
+    def test_error_message_names_the_bad_token(self):
+        with pytest.raises(InvalidFieldsError) as exc:
+            resolve_span_fields("scores", default=SKELETON)
+        assert "scores" in str(exc.value)
+
+    def test_fine_grained_io_input_not_yet_supported(self):
+        # io.input / io.output are a deliberate follow-up; today they 400.
+        with pytest.raises(InvalidFieldsError):
+            resolve_span_fields("io.input", default=SKELETON)
+
+
+class TestIoColumns:
+    def test_skeleton_needs_no_columns(self):
+        assert io_columns(SKELETON) == frozenset()
+
+    def test_full_needs_all_three(self):
+        assert io_columns(FULL) == frozenset({"input", "output", "metadata"})
+
+    def test_io_maps_to_input_and_output(self):
+        assert io_columns(frozenset({CORE, IO})) == frozenset({"input", "output"})
+
+    def test_metadata_only_maps_to_metadata_column(self):
+        assert io_columns(frozenset({CORE, METADATA})) == frozenset({"metadata"})
+
+
+class TestMergeSpanIo:
+    def _trace(self):
+        return {
+            "spans": [
+                {"span_id": "s1", "input": None, "output": None, "metadata": None},
+                {"span_id": "s2", "input": None, "output": None, "metadata": None},
+            ]
+        }
+
+    def test_attaches_only_present_columns(self):
+        trace = self._trace()
+        # Bulk reader returned only the metadata column (fields=metadata projection).
+        merge_span_io(trace, {"s1": {"metadata": "the-meta"}})
+        assert trace["spans"][0]["metadata"] == "the-meta"
+        # Untouched columns stay None.
+        assert trace["spans"][0]["input"] is None
+        assert trace["spans"][0]["output"] is None
+
+    def test_attaches_all_columns(self):
+        trace = self._trace()
+        merge_span_io(
+            trace,
+            {"s1": {"input": "i", "output": "o", "metadata": "m"}},
+        )
+        assert trace["spans"][0] == {
+            "span_id": "s1",
+            "input": "i",
+            "output": "o",
+            "metadata": "m",
+        }
+
+    def test_span_missing_from_map_left_untouched(self):
+        trace = self._trace()
+        merge_span_io(trace, {"s1": {"input": "i", "output": "o"}})
+        # s2 was absent from the bulk map — its I/O stays None, no KeyError.
+        assert trace["spans"][1]["input"] is None
+        assert trace["spans"][1]["output"] is None
+
+    def test_empty_map_is_safe(self):
+        trace = self._trace()
+        merge_span_io(trace, {})
+        assert all(s["input"] is None for s in trace["spans"])
+
+    def test_no_spans_key_is_safe(self):
+        merge_span_io({}, {"s1": {"input": "i"}})  # must not raise

--- a/tests/rest/test_projection.py
+++ b/tests/rest/test_projection.py
@@ -43,6 +43,12 @@ class TestResolveSpanFields:
         assert resolve_span_fields("   ", default=SKELETON) == SKELETON
         assert resolve_span_fields("", default=FULL) == FULL
 
+    def test_only_separators_returns_default(self):
+        # "," / "  ,  " have no usable tokens -> treated like an omitted param,
+        # NOT a narrowed {core} projection.
+        assert resolve_span_fields(",", default=SKELETON) == SKELETON
+        assert resolve_span_fields("  ,  ", default=FULL) == FULL
+
     def test_skeleton_alias(self):
         assert resolve_span_fields("skeleton", default=FULL) == frozenset({CORE, USAGE})
 

--- a/tests/rest/test_public_traces_export.py
+++ b/tests/rest/test_public_traces_export.py
@@ -5,6 +5,7 @@ git_context + manifest (no logs/metrics/related). Scoped to the API key's
 project. `bundle.trace` must equal the public `traces get` payload.
 """
 
+import copy
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -68,7 +69,12 @@ def make_auth(project_id: str = "proj-A") -> AuthResult:
 
 @pytest.fixture()
 def mock_reader():
-    return MagicMock()
+    reader = MagicMock()
+    # Export defaults to the `full` projection, so it always runs the bulk
+    # span-I/O reader. Default it to an empty map (no I/O) so tests that don't
+    # care about I/O keep their span shapes; tests that assert I/O override it.
+    reader.get_trace_spans_io.return_value = {}
+    return reader
 
 
 @pytest.fixture()
@@ -196,6 +202,59 @@ class TestExportBundle:
         url = body["trace"]["trace_url"]
         assert url == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
         assert "web:3000" not in url
+
+    def test_export_includes_span_io_by_default(self, client, mock_reader):
+        """The core regression fix: export defaults to full fidelity, so spans.json
+        carries real per-span input/output/metadata (not null)."""
+        mock_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
+        mock_reader.get_trace_spans_io.return_value = {
+            "span-1": {
+                "input": '{"prompt": "hi"}',
+                "output": '{"completion": "yo"}',
+                "metadata": '{"k": "v"}',
+            }
+        }
+        body = client.get("/api/v1/public/traces/abc123/export", headers=AUTH).json()
+        span = body["spans"][0]
+        assert span["input"] == '{"prompt": "hi"}'
+        assert span["output"] == '{"completion": "yo"}'
+        assert span["metadata"] == '{"k": "v"}'
+        # spans.json still mirrors trace.spans at the same (full) projection.
+        assert body["spans"] == body["trace"]["spans"]
+        mock_reader.get_trace_spans_io.assert_called_once()
+
+    def test_export_fields_skeleton_omits_io_and_skips_bulk(self, client, mock_reader):
+        """Narrowing export to skeleton avoids the bulk I/O query and returns null I/O."""
+        mock_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
+        body = client.get(
+            "/api/v1/public/traces/abc123/export?fields=skeleton", headers=AUTH
+        ).json()
+        span = body["spans"][0]
+        assert span["input"] is None
+        assert span["output"] is None
+        assert span["metadata"] is None
+        mock_reader.get_trace_spans_io.assert_not_called()
+
+    def test_export_trace_equals_get_at_equal_fields(self, client, mock_reader):
+        """The invariant holds at equal projection: export?fields=full == get?fields=full."""
+        io_map = {
+            "span-1": {"input": "i", "output": "o", "metadata": "m"},
+        }
+        mock_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
+        mock_reader.get_trace_spans_io.return_value = io_map
+        got = client.get("/api/v1/public/traces/abc123?fields=full", headers=AUTH).json()
+        mock_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
+        mock_reader.get_trace_spans_io.return_value = io_map
+        exported = client.get(
+            "/api/v1/public/traces/abc123/export?fields=full", headers=AUTH
+        ).json()
+        assert exported["trace"] == got
+
+    def test_unknown_fields_returns_400(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        resp = client.get("/api/v1/public/traces/abc123/export?fields=bogus", headers=AUTH)
+        assert resp.status_code == 400
+        mock_reader.get_trace_spans_io.assert_not_called()
 
     def test_404_when_missing(self, client, mock_reader):
         mock_reader.get_trace.return_value = None

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -209,6 +209,38 @@ class TestPublicGetTrace:
         assert url == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
         assert "web:3000" not in url
 
+    def test_default_is_skeleton_with_null_io_and_no_bulk_query(self, client, mock_reader):
+        """Public get defaults to skeleton: spans carry null I/O and the bulk
+        span-I/O query is never issued (no dashboard-class read)."""
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        resp = client.get("/api/v1/public/traces/abc123", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        span = resp.json()["spans"][0]
+        assert span["input"] is None
+        assert span["output"] is None
+        assert span["metadata"] is None
+        mock_reader.get_trace_spans_io.assert_not_called()
+
+    def test_fields_full_includes_span_io(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        mock_reader.get_trace_spans_io.return_value = {
+            "span-1": {"input": "the-in", "output": "the-out", "metadata": "the-meta"}
+        }
+        resp = client.get("/api/v1/public/traces/abc123?fields=full", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        span = resp.json()["spans"][0]
+        assert span["input"] == "the-in"
+        assert span["output"] == "the-out"
+        assert span["metadata"] == "the-meta"
+        mock_reader.get_trace_spans_io.assert_called_once()
+
+    def test_unknown_fields_returns_400(self, client, mock_reader):
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        resp = client.get("/api/v1/public/traces/abc123?fields=bogus", headers=AUTH_HEADER)
+        assert resp.status_code == 400
+        assert "bogus" in resp.json()["detail"]
+        mock_reader.get_trace_spans_io.assert_not_called()
+
     def test_404_when_trace_missing(self, client, mock_reader):
         mock_reader.get_trace.return_value = None
         resp = client.get("/api/v1/public/traces/nonexistent", headers=AUTH_HEADER)

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -177,6 +177,82 @@ class TestGetTraceSkeleton:
         assert service.get_trace("proj", "missing") is None
 
 
+class TestGetTraceSpansIO:
+    """Bulk per-span I/O reader: one trace-scoped query, span-id-keyed map,
+    column pruning driven by the requested projection."""
+
+    def test_single_query_returns_span_id_keyed_map(self):
+        calls = []
+
+        def side_effect(query, parameters=None):
+            calls.append((query, parameters))
+            return _rows(
+                [
+                    ("span-1", "in-1", "out-1", "meta-1"),
+                    ("span-2", "in-2", "out-2", "meta-2"),
+                ]
+            )
+
+        service, _ = _make_service(side_effect)
+        result = service.get_trace_spans_io(
+            "proj", "abc123", frozenset({"input", "output", "metadata"})
+        )
+
+        # Exactly one trace-scoped query (no N+1 single-span fan-out).
+        assert len(calls) == 1
+        query, params = calls[0]
+        assert "FROM spans FINAL" in query
+        assert params == {"project_id": "proj", "trace_id": "abc123"}
+        # No span_id filter — it is trace-wide.
+        assert "span_id =" not in query
+        # Keyed by span_id, each value carries all requested columns.
+        assert result == {
+            "span-1": {"input": "in-1", "output": "out-1", "metadata": "meta-1"},
+            "span-2": {"input": "in-2", "output": "out-2", "metadata": "meta-2"},
+        }
+
+    def test_prunes_to_requested_columns_only(self):
+        """A metadata-only projection must SELECT only span_id + metadata."""
+        captured = {}
+
+        def side_effect(query, parameters=None):
+            captured["query"] = query
+            return _rows([("span-1", "meta-1")])
+
+        service, _ = _make_service(side_effect)
+        result = service.get_trace_spans_io("proj", "abc123", frozenset({"metadata"}))
+
+        select_clause = captured["query"].split("FROM spans")[0]
+        cols = {c.strip() for c in select_clause.replace("SELECT", "").split(",")}
+        assert cols == {"span_id", "metadata"}
+        assert "input" not in cols
+        assert "output" not in cols
+        assert result == {"span-1": {"metadata": "meta-1"}}
+
+    def test_empty_columns_skips_query(self):
+        """No requested blob columns -> no query issued, empty map."""
+        calls = []
+
+        def side_effect(query, parameters=None):
+            calls.append(query)
+            return _rows([])
+
+        service, _ = _make_service(side_effect)
+        result = service.get_trace_spans_io("proj", "abc123", frozenset())
+        assert result == {}
+        assert calls == []
+
+    def test_null_blobs_pass_through(self):
+        def side_effect(query, parameters=None):
+            return _rows([("span-1", None, None, None)])
+
+        service, _ = _make_service(side_effect)
+        result = service.get_trace_spans_io(
+            "proj", "abc123", frozenset({"input", "output", "metadata"})
+        )
+        assert result == {"span-1": {"input": None, "output": None, "metadata": None}}
+
+
 class TestGetSpanIO:
     def test_returns_blobs_for_existing_span(self):
         def side_effect(query, parameters=None):

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -3,6 +3,7 @@
 Uses FastAPI TestClient with mocked dependencies — no ClickHouse needed.
 """
 
+import copy
 from datetime import datetime
 from unittest.mock import MagicMock
 
@@ -195,38 +196,82 @@ class TestGetTrace:
         response = client.get("/api/v1/projects/test-project/traces/nonexistent")
         assert response.status_code == 404
 
-    def test_spans_are_skeletons_without_io(self, client, mock_trace_reader):
-        """The trace-detail response must NOT carry per-span input/output/metadata.
+    def test_default_skeleton_io_is_null_and_no_bulk_query(self, client, mock_trace_reader):
+        """Default (skeleton) projection: per-span I/O fields are present but null,
+        and the bulk span-I/O query is NOT issued.
 
-        This is the core of two-phase loading: the bulk response stays sub-MB by
-        omitting the large free-text blobs. Even if the service were to leak them,
-        the SpanSkeletonResponse model strips them out.
+        The #1040 win is preserved by never *fetching* the heavy blobs on the
+        default read; the null I/O keys are additive (a few bytes/span) so the
+        shipped CLI's generated types keep finding the fields they declare.
         """
-        # Service returns blobs (simulating a stale/over-fetching service) —
-        # the response model must still drop them.
-        leaky_detail = {
-            **TRACE_DETAIL,
-            "spans": [
-                {
-                    **TRACE_DETAIL["spans"][0],
-                    "input": "should-not-appear",
-                    "output": "should-not-appear",
-                    "metadata": "should-not-appear",
-                }
-            ],
-        }
-        mock_trace_reader.get_trace.return_value = leaky_detail
+        mock_trace_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
         response = client.get("/api/v1/projects/test-project/traces/abc123")
         assert response.status_code == 200
         span = response.json()["spans"][0]
-        assert "input" not in span
-        assert "output" not in span
-        assert "metadata" not in span
-        # Tree/display fields are still present on the skeleton.
+        # I/O fields are present and null — the bulk read was skipped.
+        assert span["input"] is None
+        assert span["output"] is None
+        assert span["metadata"] is None
+        mock_trace_reader.get_trace_spans_io.assert_not_called()
+        # Tree/display fields are still present.
         assert span["span_id"] == "span-1"
         assert span["parent_span_id"] is None
         assert "usage_details" in span
         assert "cost_details" in span
+
+    def test_fields_full_merges_bulk_span_io(self, client, mock_trace_reader):
+        """fields=full issues ONE bulk query and attaches per-span I/O."""
+        mock_trace_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
+        mock_trace_reader.get_trace_spans_io.return_value = {
+            "span-1": {"input": "the-in", "output": "the-out", "metadata": "the-meta"}
+        }
+        response = client.get("/api/v1/projects/test-project/traces/abc123?fields=full")
+        assert response.status_code == 200
+        span = response.json()["spans"][0]
+        assert span["input"] == "the-in"
+        assert span["output"] == "the-out"
+        assert span["metadata"] == "the-meta"
+        # One trace-scoped bulk query, all three columns requested.
+        mock_trace_reader.get_trace_spans_io.assert_called_once()
+        kw = mock_trace_reader.get_trace_spans_io.call_args.kwargs
+        assert kw["project_id"] == "test-project"
+        assert kw["trace_id"] == "abc123"
+        assert set(kw["columns"]) == {"input", "output", "metadata"}
+
+    def test_fields_io_requests_input_output_only(self, client, mock_trace_reader):
+        """fields=io requests input+output (not metadata); metadata stays null."""
+        mock_trace_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
+        mock_trace_reader.get_trace_spans_io.return_value = {
+            "span-1": {"input": "the-in", "output": "the-out"}
+        }
+        response = client.get("/api/v1/projects/test-project/traces/abc123?fields=io")
+        assert response.status_code == 200
+        span = response.json()["spans"][0]
+        assert span["input"] == "the-in"
+        assert span["output"] == "the-out"
+        assert span["metadata"] is None
+        assert set(mock_trace_reader.get_trace_spans_io.call_args.kwargs["columns"]) == {
+            "input",
+            "output",
+        }
+
+    def test_fields_full_missing_span_in_map_serializes_null(self, client, mock_trace_reader):
+        """A span absent from the bulk I/O map keeps null I/O (no 500)."""
+        mock_trace_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
+        mock_trace_reader.get_trace_spans_io.return_value = {}  # span-1 absent
+        response = client.get("/api/v1/projects/test-project/traces/abc123?fields=full")
+        assert response.status_code == 200
+        span = response.json()["spans"][0]
+        assert span["input"] is None
+        assert span["output"] is None
+        assert span["metadata"] is None
+
+    def test_unknown_fields_returns_400(self, client, mock_trace_reader):
+        mock_trace_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
+        response = client.get("/api/v1/projects/test-project/traces/abc123?fields=bogus")
+        assert response.status_code == 400
+        assert "bogus" in response.json()["detail"]
+        mock_trace_reader.get_trace_spans_io.assert_not_called()
 
     def test_trace_level_io_is_preserved(self, client, mock_trace_reader):
         """Trace-level input/output/metadata stay on the trace (only spans drop I/O)."""


### PR DESCRIPTION
## Summary

Fixes #1241 

Trace **export and agent reads returned skeleton spans** — per-span `input`, `output`, and `metadata` came back `null`. An export is meant to be the full-fidelity copy of a trace, so dropping the prompts/completions/metadata broke its primary use (CLI export, agent trace download, offline debugging).

This was a regression from the #1040 trace-detail optimization, which made the lightweight span skeleton the **only** read path. That optimization is correct for the dashboard (it cut the heaviest trace from ~24 MB / ~7.3 s to ~39 KB / ~28 ms) and is **kept**. This PR completes it by adding a **`fields` projection** so the caller chooses payload weight — the dashboard stays lightweight, while export and the agent can ask for everything in one read. No revert, no one-off `?include=io` boolean.

## How it works

A single `fields` query parameter selects named field groups on the existing trace read/export endpoints:

```
GET /traces/{id}                          → skeleton (default)  — no per-span I/O fetched
GET /traces/{id}?fields=full              → core,usage,io,metadata
GET /traces/{id}?fields=core,usage,io     → explicit projection
GET /traces/{id}/export                   → full (default)      — an export takes the whole trace
GET /traces/{id}/export?fields=skeleton   → narrowed            — skips the bulk I/O query
```

- **Groups:** `core` (tree/timing/status, always included), `usage` (tokens/cost), `io` (per-span input/output), `metadata`.
- **Aliases:** `skeleton` → `core,usage`; `full` → everything.
- **Defaults:** public/internal `get` → `skeleton` (dashboard); `export` → `full`; the agent passes `fields=full`.
- The extra bulk span-I/O query runs **only** when the projection requests `io`/`metadata`, so the default read never touches the heavy blobs — the #1040 win holds.
- Unknown `fields` values return **400** (catch typos / protect API integrity), not silently ignored.

```
get_trace (skeleton, cheap)
  → projection requests io/metadata?
      no  → return skeleton spans (input/output/metadata = null)
      yes → get_trace_spans_io (one trace-scoped, column-pruned ClickHouse query)
              → merge_span_io attaches blobs onto skeleton spans (missing spans stay null)
```

## What's included (Backend, Python)

- `backend/rest/projection.py` *(new)* — shared field-group vocabulary: `core`/`usage`/`io`/`metadata`, `skeleton`/`full` aliases, `resolve_span_fields` (400 on unknown), `io_columns`, and `merge_span_io` (in-place bulk-I/O attach).
- `backend/rest/services/trace_reader.py` — `get_trace_spans_io(project_id, trace_id, columns)`: one trace-scoped `SELECT` returning a `{span_id: {...}}` map, pruned to the requested columns. The trace-wide sibling of `get_span_io`, with no N+1 single-span fan-out.
- `backend/rest/schemas/traces.py` — new `SpanResponse(SpanSkeletonResponse)` with nullable `input`/`output`/`metadata`; `TraceDetailResponse.spans` uses it.
- `backend/rest/schemas/public.py` — `PublicTraceExportResponse.spans` uses `SpanResponse`.
- `backend/rest/routers/public/traces_read.py` — `get`/`export` gain a `fields` param; `get` defaults to `skeleton`, `export` to `full`; bulk I/O fetched only when the projection asks for it.
- `backend/rest/routers/traces.py` — internal `get` gains a `fields` param (default `skeleton`); full-fidelity callers (the agent) pass `fields=full`.
- `backend/rest/openapi_public.py` + `backend/rest/openapi/public.json` — `fields` param, `SpanResponse`, and the 400 documented; public artifact regenerated.

## Design notes

- **Skeleton keeps `input/output/metadata: null`** rather than omitting them — additive (a few bytes/span), and it matches the fields the shipped CLI's generated types already declare. The #1040 win is about not *fetching/sending blob content*, which still holds.
- **`export.trace == get` at equal `fields`** — the documented export/get invariant is preserved per projection.
- Finer `io.input`/`io.output`, `preview_length`, and a `shape` axis are deliberate follow-ups under the trace-read-projection epic — out of scope here.

## Test plan

- [x] `tests/rest/` green (216 passed) — projection vocabulary, bulk reader, both routers
- [x] OpenAPI drift check passes (`scripts/sync_public_openapi.py --check`)
- [x] `ruff check` + `ruff format --check` clean
- [x] Export includes span `input`/`output`/`metadata` by default
- [x] `get` default is skeleton and does **not** issue the bulk I/O query
- [x] `get?fields=full` and `export` include per-span I/O
- [x] `export?fields=skeleton` omits I/O and skips the bulk query
- [x] Span missing from the bulk map serializes with `null` I/O (no 500)
- [x] Unknown `fields` value returns 400
- [x] Live E2E: seed a trace with I/O, verify the 6 `curl` cases against a running backend
- [x] CLI `traceroot traces export <id>` writes real per-span I/O into `spans.json` (no CLI change — export defaults to `full`)

> Agent adoption (`download_traces` → `fields=full`) and CLI verification land as their own follow-up PRs (`agent-trace-download`, `cli-export`); this PR is the backend `fields` projection only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores full-fidelity trace export and adds a `fields` projection so callers can include per-span input/output/metadata while keeping default reads lightweight. Updates public docs and OpenAPI with clear projection options and 400s for bad input.

- **New Features**
  - `fields` on public/internal `GET /traces/{id}` and public `GET /traces/{id}/export`; groups: `core`, `usage`, `io`, `metadata`; aliases: `skeleton` (`core,usage`), `full` (all).
  - Defaults: `GET /traces/{id}` → `skeleton`; `GET /traces/{id}/export` → `full`.
  - Centralized in `rest/projection` (`resolve_span_fields`, `io_columns`, `hydrate_span_io`, `merge_span_io`); bulk `get_trace_spans_io` issues one trace-scoped query with column pruning for `io`/`metadata` only.
  - Spans use `SpanResponse` (nullable `input`/`output`/`metadata`) in both detail and export; OpenAPI documents `fields` and 400s; endpoint docstrings add Args/Returns.

- **Bug Fixes**
  - Export includes per-span `input`/`output`/`metadata` by default; `fields=skeleton` omits them and skips the bulk I/O query.
  - `get?fields=full` and `export?fields=full` return identical spans; skeleton reads remain fast and skip I/O.
  - Empty or separator-only `fields` (e.g. `fields=`, `fields=" , "`) use the endpoint’s default; unknown tokens return 400.
  - Tests cover parsing (aliases, empties, 400s), the bulk I/O gate, column pruning, endpoint defaults, and the export/get equality at equal `fields`.

<sup>Written for commit fccd51d671525a706e4a6a10954c844341c4f51d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



