### PR TITLE
fix(agent): request fields=full on trace download

### DIFF
--- a/frontend/packages/agent/src/tools/__tests__/download-traces.test.ts
+++ b/frontend/packages/agent/src/tools/__tests__/download-traces.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { downloadOneTrace } from "../download-traces.js";
+import type { Executor } from "../../executors/interface.js";
+
+// Only writeFile is exercised by downloadOneTrace; stub the rest of Executor.
+const executor = {
+  writeFile: vi.fn().mockResolvedValue(undefined),
+} as unknown as Executor;
+
+describe("downloadOneTrace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests the full projection (fields=full) on the internal trace read", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        name: "demo",
+        spans: [{ span_id: "s1", parent_span_id: null, name: "root", input: "in" }],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await downloadOneTrace(
+      "tid-1",
+      "/workspace/traces",
+      "proj-1",
+      "user-1",
+      executor,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const url = fetchMock.mock.calls[0][0] as string;
+    // The agent must opt into full fidelity so spans carry per-span I/O — the
+    // internal read defaults to a lightweight skeleton otherwise (#1040).
+    expect(url).toContain("/api/v1/projects/proj-1/traces/tid-1");
+    expect(url).toContain("?fields=full");
+    expect(result.spanCount).toBe(1);
+  });
+});

--- a/frontend/packages/agent/src/tools/download-traces.ts
+++ b/frontend/packages/agent/src/tools/download-traces.ts
@@ -37,7 +37,10 @@ export async function downloadOneTrace(
   executor: Executor,
   signal?: AbortSignal,
 ): Promise<{ dir: string; spanCount: number; traceName: string }> {
-  const url = `${FASTAPI_URL}/api/v1/projects/${projectId}/traces/${traceId}`;
+  // Request the full projection so spans carry per-span input/output/metadata.
+  // The dashboard read defaults to a lightweight skeleton (#1040); the agent
+  // needs full fidelity for root-cause analysis.
+  const url = `${FASTAPI_URL}/api/v1/projects/${projectId}/traces/${traceId}?fields=full`;
   const res = await fetch(url, {
     headers: {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

Fixes #1244 

The agentic debugger's `download_traces` tool fetches a whole trace into its workspace for deep analysis. The backend trace read now defaults to a lightweight **skeleton** projection (no per-span `input`/`output`/`metadata`) to keep the dashboard payload small; full fidelity is opt-in via `?fields=full`. This one-line change makes the agent request `fields=full` so spans carry their I/O again — without it, the agent analyses failures with empty LLM prompts/completions.

## What changed

- `frontend/packages/agent/src/tools/download-traces.ts` — the internal trace fetch URL gains `?fields=full`:

```diff
- const url = `${FASTAPI_URL}/api/v1/projects/${projectId}/traces/${traceId}`;
+ const url = `${FASTAPI_URL}/api/v1/projects/${projectId}/traces/${traceId}?fields=full`;
```

Single line; no other behavior changes. The dashboard/UI read is untouched (it keeps the skeleton default and lazy-loads per-span I/O on demand).

## Depends on

- The `fields` projection in the backend (#1242). Until that merges, `?fields=full` is simply an ignored query param and the agent keeps getting the skeleton; after it merges, the agent gets full per-span I/O in one read (one extra trace-scoped query, no N+1).

## Test plan

- [x] Agent package typechecks (`tsc --noEmit`).
- [x] Live E2E against the rebuilt agent container: a session running "download everything from this trace" issued `GET /api/v1/projects/{id}/traces/{id}?fields=full → 200`, and the written `spans.jsonl` carried real per-span `input`/`output`/`metadata` (null before).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Request full trace fields in the agent’s `download_traces` tool so spans include input/output/metadata and analyses work again. Adds `?fields=full` to the trace fetch and a unit test to enforce the full projection; the dashboard keeps its lightweight skeleton default.

- **Dependencies**
  - Depends on backend support for the `fields` projection; until available, the query is ignored and the agent still receives the skeleton projection.

<sup>Written for commit 7ab464afec651d0a6d1ba1d4743cd4ac0f07401d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



