### PR TITLE
feat: add support for GLM-5.2 (Zhipu AI)

### DIFF
--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -185,6 +185,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "kimi-k2-thinking", label: "kimi-k2-thinking" },
   ],
   zai: [
+    { id: "glm-5.2", label: "glm-5.2" },
     { id: "glm-5.1", label: "glm-5.1" },
     { id: "glm-5", label: "glm-5" },
     { id: "glm-5-turbo", label: "glm-5-turbo" },

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -886,5 +886,101 @@
       "cacheRead": 0.00000026,
       "cacheWrite": null
     }
+  },
+  {
+    "id": "tr-glm-5-1",
+    "modelName": "glm-5.1",
+    "matchPattern": "(?i)^(zai\\/)?glm-5\\.1(-[\\d-]+)?$",
+    "provider": "zai",
+    "prices": {
+      "input": 0.0000014,
+      "output": 0.0000044,
+      "cacheRead": 0.00000026,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-glm-5",
+    "modelName": "glm-5",
+    "matchPattern": "(?i)^(zai\\/)?glm-5(-[\\d-]+)?$",
+    "provider": "zai",
+    "prices": {
+      "input": 0.000001,
+      "output": 0.0000032,
+      "cacheRead": 0.0000002,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-glm-5-turbo",
+    "modelName": "glm-5-turbo",
+    "matchPattern": "(?i)^(zai\\/)?glm-5-turbo(-[\\d-]+)?$",
+    "provider": "zai",
+    "prices": {
+      "input": 0.0000012,
+      "output": 0.000004,
+      "cacheRead": 0.00000024,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-glm-4-7",
+    "modelName": "glm-4.7",
+    "matchPattern": "(?i)^(zai\\/)?glm-4\\.7(-[\\d-]+)?$",
+    "provider": "zai",
+    "prices": {
+      "input": 0.0000006,
+      "output": 0.0000022,
+      "cacheRead": 0.00000011,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-glm-4-6",
+    "modelName": "glm-4.6",
+    "matchPattern": "(?i)^(zai\\/)?glm-4\\.6(-[\\d-]+)?$",
+    "provider": "zai",
+    "prices": {
+      "input": 0.0000006,
+      "output": 0.0000022,
+      "cacheRead": 0.00000011,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-glm-4-5",
+    "modelName": "glm-4.5",
+    "matchPattern": "(?i)^(zai\\/)?glm-4\\.5(-[\\d-]+)?$",
+    "provider": "zai",
+    "prices": {
+      "input": 0.0000006,
+      "output": 0.0000022,
+      "cacheRead": 0.00000011,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-glm-4-5-air",
+    "modelName": "glm-4.5-air",
+    "matchPattern": "(?i)^(zai\\/)?glm-4\\.5-air(-[\\d-]+)?$",
+    "provider": "zai",
+    "prices": {
+      "input": 0.0000002,
+      "output": 0.0000011,
+      "cacheRead": 0.00000003,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-glm-4-5-flash",
+    "modelName": "glm-4.5-flash",
+    "matchPattern": "(?i)^(zai\\/)?glm-4\\.5-flash(-[\\d-]+)?$",
+    "provider": "zai",
+    "prices": {
+      "input": 0,
+      "output": 0,
+      "cacheRead": 0,
+      "cacheWrite": null
+    }
   }
 ]

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -881,9 +881,9 @@
     "matchPattern": "(?i)^(zai\\/)?glm-5\\.2(-[\\d-]+)?$",
     "provider": "zai",
     "prices": {
-      "input": 0.0000011111,
-      "output": 0.0000034722,
-      "cacheRead": null,
+      "input": 0.0000014,
+      "output": 0.0000044,
+      "cacheRead": 0.00000026,
       "cacheWrite": null
     }
   }

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -874,5 +874,17 @@
       "cacheRead": 0.000000003625,
       "cacheWrite": null
     }
+  },
+  {
+    "id": "tr-glm-5-2",
+    "modelName": "glm-5.2",
+    "matchPattern": "(?i)^(zai\\/)?glm-5\\.2(-[\\d-]+)?$",
+    "provider": "zai",
+    "prices": {
+      "input": 0.0000011111,
+      "output": 0.0000034722,
+      "cacheRead": null,
+      "cacheWrite": null
+    }
   }
 ]

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -112,6 +112,21 @@ OPENAI_MODEL_CASES = [
 GLM_MODEL_CASES = [
     ("glm-5.2", "glm-5.2"),
     ("zai/glm-5.2", "glm-5.2"),
+    ("glm-5.1", "glm-5.1"),
+    ("zai/glm-5.1", "glm-5.1"),
+    ("glm-5", "glm-5"),
+    ("zai/glm-5", "glm-5"),
+    ("glm-5-turbo", "glm-5-turbo"),
+    ("zai/glm-5-turbo", "glm-5-turbo"),
+    ("glm-4.7", "glm-4.7"),
+    ("zai/glm-4.7", "glm-4.7"),
+    ("glm-4.6", "glm-4.6"),
+    ("zai/glm-4.6", "glm-4.6"),
+    ("glm-4.5", "glm-4.5"),
+    ("zai/glm-4.5", "glm-4.5"),
+    ("glm-4.5-air", "glm-4.5-air"),
+    ("zai/glm-4.5-air", "glm-4.5-air"),
+    ("glm-4.5-flash", "glm-4.5-flash"),
 ]
 
 

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -109,6 +109,12 @@ OPENAI_MODEL_CASES = [
     ("babbage-002", "babbage-002"),
 ]
 
+GLM_MODEL_CASES = [
+    ("glm-5.2", "glm-5.2"),
+    ("zai/glm-5.2", "glm-5.2"),
+]
+
+
 GEMINI_MODEL_CASES = [
     ("gemini-3.5-flash", "gemini-3.5-flash"),
     ("google/gemini-3.5-flash", "gemini-3.5-flash"),
@@ -227,6 +233,19 @@ class TestDeepSeekModelIds:
         assert result["output_tokens"] > 0
         assert result["cost"] is not None
         assert result["cost"] > 0
+
+
+class TestGLMModelIds:
+    @pytest.mark.parametrize("model_id,expected_name", GLM_MODEL_CASES)
+    def test_matches_expected_model(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert "input" in price and "output" in price
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched a different entry than {expected_name}"
+        )
 
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)


### PR DESCRIPTION
## Summary

Adds support for GLM-5.2 — Zhipu AI's latest flagship model — across the
model catalog, cost-tracking config, and pricing tests.

Closes #1247

## Type of Change

- [x] feat - A new feature

## Details

**What changed:**

- `standard-model-prices.json` — new entry `tr-glm-5-2` with regex pattern
  that matches both bare (`glm-5.2`) and provider-prefixed (`zai/glm-5.2`)
  model IDs
- `llm-providers.ts` — `glm-5.2` added at the top of the `zai` adapter
  catalog so it appears as the default/first option in the BYOK model selector
- `test_pricing.py` — `TestGLMModelIds` class with parametrized cases
  covering both ID formats

**Pricing note:**

Official GLM-5.2 API pricing has not been published by Zhipu at launch
(open.bigmodel.cn/pricing requires JS and the standalone API rates were not
listed). Prices used are estimated from the flagship tier (¥8/1M input,
¥25/1M output) converted at 7.2 CNY/USD:

- Input: $1.1111/1M tokens → `0.0000011111` per token
- Output: $3.4722/1M tokens → `0.0000034722` per token

**TODO:** update prices once Zhipu publishes official GLM-5.2 API rates.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Zhipu `glm-5.2` in the `zai` model catalog and pricing, and adds cost tracking for the rest of the GLM lineup. Closes #1247.

- **New Features**
  - Added `glm-5.2` to the `zai` adapter catalog (default in BYOK) and pricing entry `tr-glm-5-2` with regex for `glm-5.2` and `zai/glm-5.2`; rates $1.40/$4.40/$0.26 per 1M tokens.
  - Added pricing for existing `zai` GLM models: `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.6`, `glm-4.5`, `glm-4.5-air`, `glm-4.5-flash` (free); rates from Zhipu docs.
  - Extended tests to cover both bare and `zai/`-prefixed IDs for all GLM entries.

<sup>Written for commit 5ef7b8d06fcd666185857b8be8d7dcc8a6d1e89e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

