### PR TITLE
fix(byok): prevent duplicate provider overwrite

### DIFF
--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 // Database
 export { prisma } from "./lib/prisma.ts";
-export { PrismaClient } from "@prisma/client";
+export { PrismaClient, Prisma } from "@prisma/client";
 export * from "./ee/billing/index.ts";
 
 // Encryption

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/[providerId]/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/[providerId]/route.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockRequireAuth = vi.fn();
+const mockRequireWorkspaceMembership = vi.fn();
+const mockFindFirst = vi.fn();
+const mockFindFirstProvider = vi.fn();
+const mockProviderUpdate = vi.fn();
+
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...a: any[]) => mockRequireAuth(...a),
+  requireWorkspaceMembership: (...a: any[]) => mockRequireWorkspaceMembership(...a),
+  errorResponse: (msg: string, s: number) =>
+    new Response(JSON.stringify({ error: msg }), { status: s }),
+  successResponse: (d: any, status = 200) => new Response(JSON.stringify(d), { status }),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    modelProvider: {
+      findFirst: (args: any) => {
+        // Distinguish finding the existing record vs checking for duplicate names
+        if (args.where?.id && typeof args.where.id === "string") {
+          return mockFindFirst(args);
+        }
+        return mockFindFirstProvider(args);
+      },
+      update: (...a: any[]) => mockProviderUpdate(...a),
+    },
+  },
+  Role: { ADMIN: "ADMIN" },
+  encryptKey: (k: string) => `encrypted_${k}`,
+  maskKey: (k: string) => `masked_${k}`,
+}));
+
+describe("PATCH /api/workspaces/[workspaceId]/model-providers/[providerId]", () => {
+  beforeEach(() => {
+    mockRequireAuth.mockReset();
+    mockRequireWorkspaceMembership.mockReset();
+    mockFindFirst.mockReset();
+    mockFindFirstProvider.mockReset();
+    mockProviderUpdate.mockReset();
+  });
+
+  it("updates provider successfully when name is not changed", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+    mockFindFirst.mockResolvedValue({
+      id: "mp1",
+      provider: "My OpenAI",
+      adapter: "openai",
+    });
+    mockProviderUpdate.mockResolvedValue({
+      id: "mp1",
+      provider: "My OpenAI",
+      adapter: "openai",
+      enabled: false,
+    });
+
+    const { PATCH } = await import("./route");
+    const req = new Request("http://localhost/", {
+      method: "PATCH",
+      body: JSON.stringify({
+        enabled: false,
+      }),
+    });
+
+    const res = await PATCH(req, {
+      params: Promise.resolve({ workspaceId: "ws1", providerId: "mp1" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.enabled).toBe(false);
+    expect(mockFindFirstProvider).not.toHaveBeenCalled();
+    expect(mockProviderUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates provider successfully when renamed to an unused name", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+    mockFindFirst.mockResolvedValue({
+      id: "mp1",
+      provider: "My OpenAI",
+      adapter: "openai",
+    });
+    mockFindFirstProvider.mockResolvedValue(null);
+    mockProviderUpdate.mockResolvedValue({
+      id: "mp1",
+      provider: "New OpenAI Name",
+      adapter: "openai",
+    });
+
+    const { PATCH } = await import("./route");
+    const req = new Request("http://localhost/", {
+      method: "PATCH",
+      body: JSON.stringify({
+        provider: "New OpenAI Name",
+      }),
+    });
+
+    const res = await PATCH(req, {
+      params: Promise.resolve({ workspaceId: "ws1", providerId: "mp1" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.provider).toBe("New OpenAI Name");
+    expect(mockFindFirstProvider).toHaveBeenCalledTimes(1);
+    expect(mockProviderUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 409 Conflict when renamed to an existing provider name in workspace", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+    mockFindFirst.mockResolvedValue({
+      id: "mp1",
+      provider: "My OpenAI",
+      adapter: "openai",
+    });
+    mockFindFirstProvider.mockResolvedValue({
+      id: "mp2",
+      provider: "Existing Other Provider",
+    });
+
+    const { PATCH } = await import("./route");
+    const req = new Request("http://localhost/", {
+      method: "PATCH",
+      body: JSON.stringify({
+        provider: "Existing Other Provider",
+      }),
+    });
+
+    const res = await PATCH(req, {
+      params: Promise.resolve({ workspaceId: "ws1", providerId: "mp1" }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("A provider with this name already exists in this workspace");
+    expect(mockProviderUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/[providerId]/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/[providerId]/route.test.ts
@@ -14,6 +14,14 @@ vi.mock("@/lib/auth-helpers", () => ({
   successResponse: (d: any, status = 200) => new Response(JSON.stringify(d), { status }),
 }));
 
+class MockPrismaClientKnownRequestError extends Error {
+  code: string;
+  constructor(message: string, { code }: { code: string }) {
+    super(message);
+    this.code = code;
+  }
+}
+
 vi.mock("@traceroot/core", () => ({
   prisma: {
     modelProvider: {
@@ -30,6 +38,9 @@ vi.mock("@traceroot/core", () => ({
   Role: { ADMIN: "ADMIN" },
   encryptKey: (k: string) => `encrypted_${k}`,
   maskKey: (k: string) => `masked_${k}`,
+  Prisma: {
+    PrismaClientKnownRequestError: MockPrismaClientKnownRequestError,
+  },
 }));
 
 describe("PATCH /api/workspaces/[workspaceId]/model-providers/[providerId]", () => {
@@ -135,5 +146,35 @@ describe("PATCH /api/workspaces/[workspaceId]/model-providers/[providerId]", () 
     const body = await res.json();
     expect(body.error).toBe("A provider with this name already exists in this workspace");
     expect(mockProviderUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 Conflict when database throws unique constraint error on update", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+    mockFindFirst.mockResolvedValue({
+      id: "mp1",
+      provider: "My OpenAI",
+      adapter: "openai",
+    });
+    mockFindFirstProvider.mockResolvedValue(null);
+    mockProviderUpdate.mockRejectedValue(
+      new MockPrismaClientKnownRequestError("Unique constraint failed", { code: "P2002" }),
+    );
+
+    const { PATCH } = await import("./route");
+    const req = new Request("http://localhost/", {
+      method: "PATCH",
+      body: JSON.stringify({
+        provider: "New OpenAI Name",
+      }),
+    });
+
+    const res = await PATCH(req, {
+      params: Promise.resolve({ workspaceId: "ws1", providerId: "mp1" }),
+    });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("A provider with this name already exists in this workspace");
+    expect(mockProviderUpdate).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/[providerId]/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/[providerId]/route.ts
@@ -6,6 +6,7 @@ import {
   encryptKey,
   maskKey,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
+  Prisma,
 } from "@traceroot/core";
 import {
   requireAuth,
@@ -140,29 +141,36 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     data.keyPreview = maskKey(apiKey);
   }
 
-  const updated = await prisma.modelProvider.update({
-    where: { id: providerId },
-    data,
-    select: {
-      id: true,
-      adapter: true,
-      provider: true,
-      keyPreview: true,
-      baseUrl: true,
-      customModels: true,
-      withDefaultModels: true,
-      config: true,
-      enabled: true,
-      createdBy: true,
-      createTime: true,
-      updateTime: true,
-    },
-  });
+  try {
+    const updated = await prisma.modelProvider.update({
+      where: { id: providerId },
+      data,
+      select: {
+        id: true,
+        adapter: true,
+        provider: true,
+        keyPreview: true,
+        baseUrl: true,
+        customModels: true,
+        withDefaultModels: true,
+        config: true,
+        enabled: true,
+        createdBy: true,
+        createTime: true,
+        updateTime: true,
+      },
+    });
 
-  // Invalidate agent cache so the new key takes effect immediately
-  await invalidateAgentProviderCache(workspaceId, existing.provider);
+    // Invalidate agent cache so the new key takes effect immediately
+    await invalidateAgentProviderCache(workspaceId, existing.provider);
 
-  return successResponse(updated);
+    return successResponse(updated);
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return errorResponse("A provider with this name already exists in this workspace", 409);
+    }
+    throw error;
+  }
 }
 
 // DELETE /api/workspaces/[workspaceId]/model-providers/[providerId]

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/[providerId]/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/[providerId]/route.ts
@@ -95,7 +95,21 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
   } = result.data;
 
   const data: Record<string, unknown> = {};
-  if (provider !== undefined) data.provider = provider;
+  if (provider !== undefined) {
+    if (provider !== existing.provider) {
+      const duplicate = await prisma.modelProvider.findFirst({
+        where: {
+          workspaceId,
+          provider,
+          id: { not: providerId },
+        },
+      });
+      if (duplicate) {
+        return errorResponse("A provider with this name already exists in this workspace", 409);
+      }
+    }
+    data.provider = provider;
+  }
   if (baseUrl !== undefined) data.baseUrl = baseUrl;
   if (customModels !== undefined) data.customModels = customModels;
   if (withDefaultModels !== undefined) data.withDefaultModels = withDefaultModels;

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockRequireAuth = vi.fn();
+const mockRequireWorkspaceMembership = vi.fn();
+const mockWorkspaceFindUnique = vi.fn();
+const mockProviderFindUnique = vi.fn();
+const mockProviderCreate = vi.fn();
+
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...a: any[]) => mockRequireAuth(...a),
+  requireWorkspaceMembership: (...a: any[]) => mockRequireWorkspaceMembership(...a),
+  errorResponse: (msg: string, s: number) =>
+    new Response(JSON.stringify({ error: msg }), { status: s }),
+  successResponse: (d: any, status = 200) => new Response(JSON.stringify(d), { status }),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    workspace: { findUnique: (...a: any[]) => mockWorkspaceFindUnique(...a) },
+    modelProvider: {
+      findUnique: (...a: any[]) => mockProviderFindUnique(...a),
+      create: (...a: any[]) => mockProviderCreate(...a),
+    },
+  },
+  Role: { ADMIN: "ADMIN" },
+  hasEntitlement: () => true,
+  encryptKey: (k: string) => `encrypted_${k}`,
+  maskKey: (k: string) => `masked_${k}`,
+  LLMAdapter: { OPENAI: "openai" },
+}));
+
+describe("POST /api/workspaces/[workspaceId]/model-providers", () => {
+  beforeEach(() => {
+    mockRequireAuth.mockReset();
+    mockRequireWorkspaceMembership.mockReset();
+    mockWorkspaceFindUnique.mockReset();
+    mockProviderFindUnique.mockReset();
+    mockProviderCreate.mockReset();
+  });
+
+  it("creates a provider successfully when name is unique", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+    mockWorkspaceFindUnique.mockResolvedValue({ billingPlan: "pro" });
+    mockProviderFindUnique.mockResolvedValue(null);
+    mockProviderCreate.mockResolvedValue({
+      id: "mp1",
+      provider: "My OpenAI",
+      adapter: "openai",
+    });
+
+    const { POST } = await import("./route");
+    const req = new Request("http://localhost/", {
+      method: "POST",
+      body: JSON.stringify({
+        adapter: "openai",
+        provider: "My OpenAI",
+        apiKey: "sk-proj-12345",
+      }),
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ workspaceId: "ws1" }) });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.provider).toBe("My OpenAI");
+    expect(mockProviderCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 409 Conflict when provider name already exists in workspace", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+    mockWorkspaceFindUnique.mockResolvedValue({ billingPlan: "pro" });
+    mockProviderFindUnique.mockResolvedValue({ id: "mp-existing", provider: "My OpenAI" });
+
+    const { POST } = await import("./route");
+    const req = new Request("http://localhost/", {
+      method: "POST",
+      body: JSON.stringify({
+        adapter: "openai",
+        provider: "My OpenAI",
+        apiKey: "sk-proj-12345",
+      }),
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ workspaceId: "ws1" }) });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("A provider with this name already exists in this workspace");
+    expect(mockProviderCreate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.test.ts
@@ -14,6 +14,14 @@ vi.mock("@/lib/auth-helpers", () => ({
   successResponse: (d: any, status = 200) => new Response(JSON.stringify(d), { status }),
 }));
 
+class MockPrismaClientKnownRequestError extends Error {
+  code: string;
+  constructor(message: string, { code }: { code: string }) {
+    super(message);
+    this.code = code;
+  }
+}
+
 vi.mock("@traceroot/core", () => ({
   prisma: {
     workspace: { findUnique: (...a: any[]) => mockWorkspaceFindUnique(...a) },
@@ -27,6 +35,9 @@ vi.mock("@traceroot/core", () => ({
   encryptKey: (k: string) => `encrypted_${k}`,
   maskKey: (k: string) => `masked_${k}`,
   LLMAdapter: { OPENAI: "openai" },
+  Prisma: {
+    PrismaClientKnownRequestError: MockPrismaClientKnownRequestError,
+  },
 }));
 
 describe("POST /api/workspaces/[workspaceId]/model-providers", () => {
@@ -87,5 +98,31 @@ describe("POST /api/workspaces/[workspaceId]/model-providers", () => {
     const body = await res.json();
     expect(body.error).toBe("A provider with this name already exists in this workspace");
     expect(mockProviderCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 Conflict when database throws unique constraint error on create", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" } });
+    mockRequireWorkspaceMembership.mockResolvedValue({ error: null });
+    mockWorkspaceFindUnique.mockResolvedValue({ billingPlan: "pro" });
+    mockProviderFindUnique.mockResolvedValue(null);
+    mockProviderCreate.mockRejectedValue(
+      new MockPrismaClientKnownRequestError("Unique constraint failed", { code: "P2002" }),
+    );
+
+    const { POST } = await import("./route");
+    const req = new Request("http://localhost/", {
+      method: "POST",
+      body: JSON.stringify({
+        adapter: "openai",
+        provider: "My OpenAI",
+        apiKey: "sk-proj-12345",
+      }),
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ workspaceId: "ws1" }) });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("A provider with this name already exists in this workspace");
+    expect(mockProviderCreate).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.ts
@@ -9,6 +9,7 @@ import {
   type PlanType,
   LLMAdapter,
   BEDROCK_USE_DEFAULT_CREDENTIALS,
+  Prisma,
 } from "@traceroot/core";
 import {
   requireAuth,
@@ -173,35 +174,42 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return errorResponse("A provider with this name already exists in this workspace", 409);
   }
 
-  const modelProvider = await prisma.modelProvider.create({
-    data: {
-      workspaceId,
-      adapter,
-      provider,
-      keyCipher,
-      keyPreview: credentialPreview,
-      baseUrl: baseUrl || null,
-      customModels,
-      withDefaultModels,
-      config: Object.keys(providerConfig).length > 0 ? (providerConfig as object) : undefined,
-      enabled: enabled ?? true,
-      createdBy: user.id,
-    },
-    select: {
-      id: true,
-      adapter: true,
-      provider: true,
-      keyPreview: true,
-      baseUrl: true,
-      customModels: true,
-      withDefaultModels: true,
-      config: true,
-      enabled: true,
-      createdBy: true,
-      createTime: true,
-      updateTime: true,
-    },
-  });
+  try {
+    const modelProvider = await prisma.modelProvider.create({
+      data: {
+        workspaceId,
+        adapter,
+        provider,
+        keyCipher,
+        keyPreview: credentialPreview,
+        baseUrl: baseUrl || null,
+        customModels,
+        withDefaultModels,
+        config: Object.keys(providerConfig).length > 0 ? (providerConfig as object) : undefined,
+        enabled: enabled ?? true,
+        createdBy: user.id,
+      },
+      select: {
+        id: true,
+        adapter: true,
+        provider: true,
+        keyPreview: true,
+        baseUrl: true,
+        customModels: true,
+        withDefaultModels: true,
+        config: true,
+        enabled: true,
+        createdBy: true,
+        createTime: true,
+        updateTime: true,
+      },
+    });
 
-  return successResponse(modelProvider, 201);
+    return successResponse(modelProvider, 201);
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+      return errorResponse("A provider with this name already exists in this workspace", 409);
+    }
+    throw error;
+  }
 }

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/route.ts
@@ -164,11 +164,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     providerConfig.awsRegion = awsRegion;
   }
 
-  const modelProvider = await prisma.modelProvider.upsert({
+  const existingProvider = await prisma.modelProvider.findUnique({
     where: {
       workspaceId_provider: { workspaceId, provider },
     },
-    create: {
+  });
+  if (existingProvider) {
+    return errorResponse("A provider with this name already exists in this workspace", 409);
+  }
+
+  const modelProvider = await prisma.modelProvider.create({
+    data: {
       workspaceId,
       adapter,
       provider,
@@ -180,16 +186,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       config: Object.keys(providerConfig).length > 0 ? (providerConfig as object) : undefined,
       enabled: enabled ?? true,
       createdBy: user.id,
-    },
-    update: {
-      adapter,
-      keyCipher,
-      keyPreview: credentialPreview,
-      baseUrl: baseUrl || null,
-      customModels,
-      withDefaultModels,
-      config: Object.keys(providerConfig).length > 0 ? (providerConfig as object) : undefined,
-      enabled: enabled ?? true,
     },
     select: {
       id: true,


### PR DESCRIPTION
Closes #1228

## Summary

Prevent silent overwriting of existing BYOK providers when creating or renaming providers with duplicate names.

Previously, the create endpoint used `upsert` keyed on `(workspaceId, provider)`. Creating a provider with an existing name would unexpectedly update the existing provider instead of creating a new one.

This change introduces explicit duplicate-name validation and returns `409 Conflict` when a provider with the same name already exists in the workspace.

## Changes

* Replace `modelProvider.upsert()` with duplicate lookup + `create()`.
* Return `409 Conflict` when creating a provider with an existing name.
* Add duplicate-name validation to the PATCH endpoint when renaming providers.
* Preserve existing update behavior for the current provider.
* Prevent silent overwrites from both create and rename flows.

## Validation

* Verified duplicate provider creation returns `409 Conflict`.
* Verified duplicate provider rename returns `409 Conflict`.
* Verified existing providers are no longer overwritten.
* Verified frontend receives the server error message through `fetchNextApi`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent silent overwrites of BYOK providers by rejecting duplicate names on create and rename, including race conditions. Returns 409 Conflict instead of updating the existing provider. Closes #1228.

- **Bug Fixes**
  - Replaced `modelProvider.upsert()` with pre-check + `create()` in POST; catch Prisma `P2002` to handle races.
  - Added duplicate-name validation in PATCH (excludes current provider ID) and `P2002` handling on update.
  - Preserved normal updates when the name is unchanged.
  - Added API tests for POST and PATCH covering 409 conflicts, race errors, and success paths.

<sup>Written for commit 2e21534cb8e2676cfe6c35da26111274fdd62788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1252?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

