### PR TITLE
perf(worker): refresh model price cache on a TTL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ INTERNAL_API_SECRET=dev-internal-secret  # CHANGEME in production
 # --- Worker (Python/Celery) ---------------------------------------------------
 POLL_INTERVAL_SECONDS=5
 BATCH_SIZE=100
+# How long model prices are cached before the worker re-reads them from the DB
+# (seconds). Lower = fresher pricing, higher = fewer DB reads. Default 300 (5m).
+PRICING_CACHE_TTL_SECONDS=300
 
 # --- Billing Worker (Node.js) -------------------------------------------------
 BACKEND_INTERNAL_URL=http://localhost:8000  # Python backend URL for internal API calls

--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -2,14 +2,19 @@
 
 Prices are loaded from the ``standard_models`` / ``standard_model_prices``
 PostgreSQL tables (synced from standard-model-prices.json by the TS services).
-The in-memory cache is populated on first call and persists for the process
-lifetime (prices only change on deploy/restart).
+The in-memory cache is populated on first call and refreshed on a TTL so that
+pricing updates in the DB propagate to long-running workers without a restart
+(see issue #1096). The refresh interval is configurable via the
+``PRICING_CACHE_TTL_SECONDS`` environment variable (default 300s).
 """
 
 from __future__ import annotations
 
 import logging
+import os
 import re
+import threading
+import time
 from decimal import Decimal
 
 import psycopg2
@@ -22,18 +27,33 @@ from .usage import count_tokens
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# In-memory cache (populated on first call)
+# In-memory cache (populated on first call, refreshed on a TTL)
 # ---------------------------------------------------------------------------
 
+# How long a loaded price cache is served before a refresh is attempted.
+# Configurable so deployments can trade freshness against DB load.
+_CACHE_TTL_SECONDS: float = float(os.getenv("PRICING_CACHE_TTL_SECONDS", "300"))
+
 _cache: list[dict] | None = None
+_cache_loaded_at: float | None = None
+_cache_lock = threading.Lock()
 
 
-def _load_cache() -> list[dict]:
-    global _cache
-    if _cache is not None:
-        return _cache
+def _cache_is_fresh() -> bool:
+    """True when a populated cache exists and is still within its TTL window."""
+    return (
+        _cache is not None
+        and _cache_loaded_at is not None
+        and (time.monotonic() - _cache_loaded_at) < _CACHE_TTL_SECONDS
+    )
 
-    models: list[dict] = []
+
+def _fetch_prices_from_db() -> list[dict]:
+    """Read the price table and group rows by model.
+
+    Returns an empty list when the DB is unavailable, so the caller can decide
+    whether to retry or keep serving a previously loaded cache.
+    """
     try:
         conn = psycopg2.connect(settings.database_url)
         try:
@@ -50,8 +70,6 @@ def _load_cache() -> list[dict]:
         finally:
             conn.close()
     except Exception as exc:
-        # DB unavailable — return empty list but do NOT cache,
-        # so the next call will retry the connection.
         logger.warning(
             "Failed to load model prices from DB — costs will be None until DB is available. Error: %s",
             exc,
@@ -71,9 +89,37 @@ def _load_cache() -> list[dict]:
             float(price) if isinstance(price, Decimal) else price
         )
 
-    models = list(by_model.values())
-    _cache = models
-    return _cache
+    return list(by_model.values())
+
+
+def _load_cache() -> list[dict]:
+    """Return cached model prices, refreshing from the DB once the TTL lapses.
+
+    A fresh cache is served without touching the DB. When the TTL has lapsed,
+    one caller refreshes under a lock (others wait, then reuse the result). If
+    the refresh fails or returns no rows, any previously loaded prices are kept
+    rather than dropping to an empty cache, and the timestamp is left unchanged
+    so the next call retries promptly.
+    """
+    global _cache, _cache_loaded_at
+
+    if _cache_is_fresh():
+        return _cache  # type: ignore[return-value]
+
+    with _cache_lock:
+        # Another thread may have refreshed while we waited for the lock.
+        if _cache_is_fresh():
+            return _cache  # type: ignore[return-value]
+
+        models = _fetch_prices_from_db()
+        if not models:
+            # DB unavailable/empty: keep stale prices if we have them, otherwise
+            # return empty and leave the cache unset so the next call retries.
+            return _cache if _cache is not None else []
+
+        _cache = models
+        _cache_loaded_at = time.monotonic()
+        return _cache
 
 
 # ---------------------------------------------------------------------------

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -262,6 +262,9 @@ services:
       # --- Worker config ---
       POLL_INTERVAL_SECONDS: ${POLL_INTERVAL_SECONDS:-5}
       BATCH_SIZE: ${BATCH_SIZE:-100}
+      # How long the worker caches model prices before re-reading them from the
+      # DB (seconds). Lower = fresher pricing, higher = fewer DB reads.
+      PRICING_CACHE_TTL_SECONDS: ${PRICING_CACHE_TTL_SECONDS:-300}
     depends_on:
       migrate-clickhouse:
         condition: service_completed_successfully

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+import worker.tokens.pricing as pricing_mod
 from worker.tokens.pricing import calculate_cost, get_model_price
 
 MATCHED_MODEL_NAME = "__matched_model_name"
@@ -401,3 +402,95 @@ def test_cost_breakdown_from_buckets_returns_none_without_prices():
     buckets = TokenBuckets(input_uncached=100, output=50)
     assert cost_breakdown_from_buckets(None, buckets) is None
     assert cost_breakdown_from_buckets({}, buckets) is None
+
+
+# ---------------------------------------------------------------------------
+# TTL-based cache refresh (issue #1096) — the in-memory price cache must pick
+# up DB updates within a TTL window instead of living for the whole process.
+# ---------------------------------------------------------------------------
+
+
+class _FakeClock:
+    """Deterministic stand-in for time.monotonic() that we can advance."""
+
+    def __init__(self, start: float = 0.0):
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def _entry(input_price: float) -> dict:
+    return {"model_name": "m", "match_pattern": "m", "prices": {"input": input_price}}
+
+
+@pytest.fixture
+def fresh_cache(monkeypatch):
+    """Reset the module cache and install a controllable clock for each test."""
+    monkeypatch.setattr(pricing_mod, "_cache", None)
+    monkeypatch.setattr(pricing_mod, "_cache_loaded_at", None)
+    clock = _FakeClock()
+    monkeypatch.setattr(pricing_mod.time, "monotonic", clock)
+    return clock
+
+
+def test_cache_served_within_ttl_without_refetch(fresh_cache, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_fetch():
+        calls["n"] += 1
+        return [_entry(1.0)]
+
+    monkeypatch.setattr(pricing_mod, "_fetch_prices_from_db", fake_fetch)
+
+    pricing_mod._load_cache()  # first call populates the cache
+    fresh_cache.advance(pricing_mod._CACHE_TTL_SECONDS - 1)
+    pricing_mod._load_cache()  # still within TTL — no second DB read
+
+    assert calls["n"] == 1
+
+
+def test_cache_refreshes_with_new_prices_after_ttl(fresh_cache, monkeypatch):
+    versions = [[_entry(1.0)], [_entry(2.0)]]
+    calls = {"n": 0}
+
+    def fake_fetch():
+        idx = min(calls["n"], len(versions) - 1)
+        calls["n"] += 1
+        return versions[idx]
+
+    monkeypatch.setattr(pricing_mod, "_fetch_prices_from_db", fake_fetch)
+
+    assert pricing_mod._load_cache()[0]["prices"]["input"] == 1.0
+    fresh_cache.advance(pricing_mod._CACHE_TTL_SECONDS + 1)
+    # TTL lapsed: the updated DB price is now reflected without a restart.
+    assert pricing_mod._load_cache()[0]["prices"]["input"] == 2.0
+    assert calls["n"] == 2
+
+
+def test_stale_cache_served_when_refresh_fails(fresh_cache, monkeypatch):
+    good = [_entry(1.0)]
+    state = {"fail": False}
+
+    monkeypatch.setattr(pricing_mod, "_fetch_prices_from_db", lambda: [] if state["fail"] else good)
+
+    assert pricing_mod._load_cache() == good
+    fresh_cache.advance(pricing_mod._CACHE_TTL_SECONDS + 1)
+    state["fail"] = True
+    # Refresh fails — keep serving the previously loaded prices, not an empty cache.
+    assert pricing_mod._load_cache() == good
+
+
+def test_first_load_failure_returns_empty_and_retries(fresh_cache, monkeypatch):
+    good = [_entry(1.0)]
+    state = {"fail": True}
+
+    monkeypatch.setattr(pricing_mod, "_fetch_prices_from_db", lambda: [] if state["fail"] else good)
+
+    assert pricing_mod._load_cache() == []  # nothing cached yet on first failure
+    state["fail"] = False
+    # Cache was never populated, so the next call retries immediately (no TTL wait).
+    assert pricing_mod._load_cache() == good


### PR DESCRIPTION
Closes #1096

## Problem
The model price cache in `backend/worker/tokens/pricing.py` is populated on first use and then kept for the **entire process lifetime**. As a result, any pricing update in the DB (`standard_models` / `standard_model_prices`) is never picked up by a running worker — the only way to refresh prices is to restart every worker, and until then cost calculations silently use stale values.

## Change
Refresh the cache on a **configurable TTL** (`PRICING_CACHE_TTL_SECONDS`, default `300`):

- A fresh cache is served without touching the DB (unchanged hot-path cost — `get_model_price()` is called per span).
- Once the TTL lapses, **one** caller refreshes under a lock (double-checked); others wait and reuse the result, so there's no refresh stampede.
- If a refresh fails or returns no rows (DB briefly unavailable), the previously loaded prices are **kept** rather than dropping to an empty cache (which would make all costs `None`); the timestamp is left unchanged so the next call retries promptly. First-load failure still returns `[]` and retries, as before.

Also surfaces `PRICING_CACHE_TTL_SECONDS` in `docker-compose.prod.yml` (worker env) and `.env.example` so the interval is tunable per deployment.

## Trade-off
This bounds staleness to **≤ one TTL** instead of "until restart" — it does not make pricing instantly consistent. That's the intended, lightweight middle ground vs. querying the DB per span (too expensive at ingest volume) or event-driven invalidation (LISTEN/NOTIFY — much larger change, possible follow-up). Operators who need fresher prices can lower the TTL.

## Notes for reviewers
- The cache is **per worker process**. The worker runs Celery's default prefork pool, so each child caches independently and refreshes once per TTL — DB load is `cores × replicas` light queries per TTL (negligible).
- The `threading.Lock` is effectively uncontended under the default prefork pool (one task per child at a time); it's kept intentionally so the code stays correct if the pool is switched to `threads`/`gevent`. Zero cost when uncontended.

## Testing
- 4 new unit tests in `tests/worker/tokens/test_pricing.py` (fresh-serve within TTL, refresh-picks-up-new-price after TTL, stale-on-failure, first-load retry).
- `uv run pytest tests/worker` → **289 passed**. `ruff check` clean, `ruff format` applied.
- Validated live in a local Docker stack: confirmed the worker resolves the TTL from env (default 300; `PRICING_CACHE_TTL_SECONDS=120` → `120.0`), prices `gpt-4o` correctly from the live DB (71 rows), and the refresh / stale-on-failure paths behave as designed inside the running worker container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TTL-based refresh to the worker’s model price cache so DB pricing updates are picked up without restarts. Keeps hot-path cost the same and bounds staleness to one TTL.

- **New Features**
  - TTL refresh of cached prices; serve within TTL, then one caller refreshes under a lock to prevent stampedes.
  - On refresh failure or empty result, keep the last good cache and retry on the next call.

- **Migration**
  - Optional: set `PRICING_CACHE_TTL_SECONDS` (default 300) via .env or docker-compose to tune freshness vs. DB reads.

<sup>Written for commit c422e2c0f7f1b1d39671110cd3702ea4c83d9791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

