### PR TITLE
docs: add agent and validation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Agent Instructions
+
+## Project Map
+
+- `backend/`: Python backend services and workers.
+- `frontend/ui/`: Next.js frontend app.
+- `frontend/packages/`: shared TypeScript packages.
+- `frontend/worker/`: TypeScript worker services.
+- `tests/`: backend pytest tests.
+
+## Setup
+
+Read `CONTRIBUTING.md` for contributor setup and workflow. Use `make dev` for the tmux-based development environment, or `make dev-lite` for the Docker workflow without tmux.
+
+## Validation
+
+Run checks relevant to the changed files:
+
+- Python lint/format: `uv run ruff check . && uv run ruff format --check .`
+- Backend tests with coverage: `uv run coverage run -m pytest tests/ && uv run coverage report`
+- Frontend lint/format: `pnpm --dir frontend lint && pnpm --dir frontend format:check`
+- Frontend package tests with coverage: `pnpm --dir frontend/ui test:coverage` or the changed package
+
+Pull requests must pass GitHub Actions, including 80% diff coverage on changed production lines.
+
+## Working Rules
+
+- Keep changes scoped to the requested problem.
+- Prefer existing project patterns over new abstractions.
+- Add or update focused tests when behavior changes.
+- Do not revert user changes unless explicitly asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,3 @@
-# Agent Instructions
-
 ## Project Map
 
 - `backend/`: Python backend services and workers.
@@ -22,10 +20,3 @@ Run checks relevant to the changed files:
 - Frontend package tests with coverage: `pnpm --dir frontend/ui test:coverage` or the changed package
 
 Pull requests must pass GitHub Actions, including 80% diff coverage on changed production lines.
-
-## Working Rules
-
-- Keep changes scoped to the requested problem.
-- Prefer existing project patterns over new abstractions.
-- Add or update focused tests when behavior changes.
-- Do not revert user changes unless explicitly asked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,17 @@ The tmux-based commands handle deps, Docker containers, migrations, and launch s
   <kbd><img src="docs/images/local_dev_mode_v1.png" alt="Local dev mode"></kbd>
 </div>
 
+## Validation Commands
+
+| Change | Command |
+|--------|---------|
+| Python lint/format | `uv run ruff check . && uv run ruff format --check .` |
+| Backend tests with coverage | `uv run coverage run -m pytest tests/ && uv run coverage report` |
+| Frontend lint/format | `pnpm --dir frontend lint && pnpm --dir frontend format:check` |
+| Frontend package tests with coverage | `pnpm --dir frontend/ui test:coverage` or the changed package |
+
+Pull requests must pass the GitHub Actions checks, including diff coverage. Diff coverage requires at least 80% coverage on changed production lines, so tests should execute the changed code. If this gate fails, the Actions summary lists the uncovered files and line numbers.
+
 ## Workflow
 
 1. Create a branch from `main`.
@@ -75,7 +86,7 @@ Helpful defaults:
 
 - Keep the PR scoped to one logical change.
 - Explain what changed, why it changed, and how it was validated.
-- Add or update tests for behavior changes.
+- Add or update tests for behavior changes, including coverage for changed production lines.
 - Update documentation for setup, command, or UX changes.
 - Add screenshots or recordings for UI changes.
 - Reference the issue in the PR body when relevant, for example `Closes #581`.


### PR DESCRIPTION
Fixes #1246

## Summary

Adds validation guidance to `CONTRIBUTING.md`.

Adds a minimal `AGENTS.md` with known repo facts that help coding agents work correctly without adding unnecessary context.

## Type of Change

- [x] docs - Documentation only changes


## Details

Documents the local validation commands and notes that PRs must pass GitHub Actions, including diff coverage on changed production lines.

Keeps `AGENTS.md` short: project map, setup pointer, validation commands, and basic working rules.


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds validation guidance to CONTRIBUTING.md (clear commands for lint, format, and tests) and trims AGENTS.md to a minimal project map, setup pointer, and validation commands to help agents run the right checks (closes #1246). PRs must pass GitHub Actions with at least 80% diff coverage on changed production lines.

<sup>Written for commit 01f6fb15b89639bfda399d177fc38e40decca250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

