### PR TITLE
fix(ui): keep list toolbar controls accessible on narrow widths

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -130,7 +130,7 @@ export default function TracesPage() {
       <ProjectBreadcrumb projectId={projectId} />
 
       {/* Main content */}
-      <div className="flex flex-1 flex-col">
+      <div className="flex min-w-0 flex-1 flex-col">
         {/* Tab navigation — hidden during onboarding or while checking */}
         {!checking && !showGettingStarted && (
           <div className="border-b border-border bg-background">

--- a/frontend/ui/src/components/list-pagination.tsx
+++ b/frontend/ui/src/components/list-pagination.tsx
@@ -72,7 +72,7 @@ export function ListPagination({
   };
 
   return (
-    <div className="flex items-center justify-end gap-6 border-t border-border bg-background px-4 py-2.5">
+    <div className="flex flex-wrap items-center justify-end gap-x-6 gap-y-2 border-t border-border bg-background px-4 py-2.5">
       <div className="flex items-center gap-2">
         <span className="text-[12px] text-muted-foreground">Items per page</span>
         <Popover open={itemsPerPageOpen} onOpenChange={setItemsPerPageOpen}>

--- a/frontend/ui/src/components/search-filter-bar.test.tsx
+++ b/frontend/ui/src/components/search-filter-bar.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SearchFilterBar } from "./search-filter-bar";
+import { DATE_FILTER_OPTIONS } from "@/lib/date-filter";
+
+afterEach(cleanup);
+
+describe("SearchFilterBar", () => {
+  function renderBar() {
+    return render(
+      <SearchFilterBar
+        searchValue=""
+        onSearchChange={vi.fn()}
+        searchPlaceholder="Search..."
+        dateFilter={DATE_FILTER_OPTIONS[0]}
+        customStartDate={null}
+        customEndDate={null}
+        onDateFilterChange={vi.fn()}
+        onCustomRangeChange={vi.fn()}
+      >
+        <button type="button">Live</button>
+      </SearchFilterBar>,
+    );
+  }
+
+  it("renders the search input, children, and date filter trigger", () => {
+    renderBar();
+
+    expect(screen.getByPlaceholderText("Search...")).toBeTruthy();
+    expect(screen.getByText("Live")).toBeTruthy();
+    expect(screen.getByText(DATE_FILTER_OPTIONS[0].label)).toBeTruthy();
+  });
+
+  it("reflects the current search value", () => {
+    render(
+      <SearchFilterBar
+        searchValue="checkout"
+        onSearchChange={vi.fn()}
+        dateFilter={DATE_FILTER_OPTIONS[0]}
+        customStartDate={null}
+        customEndDate={null}
+        onDateFilterChange={vi.fn()}
+        onCustomRangeChange={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Search...") as HTMLInputElement;
+    expect(input.value).toBe("checkout");
+  });
+});

--- a/frontend/ui/src/components/search-filter-bar.tsx
+++ b/frontend/ui/src/components/search-filter-bar.tsx
@@ -57,8 +57,8 @@ export function SearchFilterBar({
 
   return (
     <div className="border-b border-border bg-background px-3 py-1.5">
-      <div className="flex items-center gap-3">
-        <div className="relative max-w-md flex-1">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <div className="relative min-w-[12rem] max-w-md flex-1">
           <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
             placeholder={searchPlaceholder}
@@ -68,7 +68,6 @@ export function SearchFilterBar({
           />
         </div>
         {children}
-        <div className="flex-1" />
         <Popover
           open={dateFilterOpen}
           onOpenChange={(open) => {
@@ -80,7 +79,7 @@ export function SearchFilterBar({
             <Button
               variant="outline"
               size="sm"
-              className="h-8 min-w-[140px] justify-between gap-2 text-[13px] font-normal"
+              className="ml-auto h-8 min-w-[140px] justify-between gap-2 text-[13px] font-normal"
             >
               <span>{getDateFilterLabel()}</span>
               <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />


### PR DESCRIPTION


https://github.com/user-attachments/assets/146a0c92-a27e-4cb2-bf58-74fe046cf05d

Closes #1256

## Problem
On narrow window widths, the list-page toolbar controls progressively disappeared instead of collapsing gracefully. As the viewport shrank, the **search / Live / time-range** controls (top) and the **items-per-page / pagination** controls (bottom) were pushed off-screen and became unreachable.

## Root cause
Two things combined:
1. The traces page content column (`flex flex-1 flex-col`) had **no `min-w-0`**, so it refused to shrink below its content's intrinsic width and overflowed the viewport — pushing the right-hand controls off-screen.
2. The toolbar (`SearchFilterBar`) and the pagination bar (`ListPagination`) were single **non-wrapping** flex rows.

## Fix (3 small changes, CSS only — no logic)
- `app/projects/[projectId]/traces/page.tsx`: add `min-w-0` to the content column so it shrinks to the available width (the table keeps its own horizontal scroll area, so nothing is lost).
- `components/search-filter-bar.tsx`: `flex-wrap` + row gap so controls wrap; give the search a `min-w` floor; right-align the date filter with `ml-auto` (replacing the rigid `flex-1` spacer).
- `components/list-pagination.tsx`: `flex-wrap` + row gap so the pagination groups wrap.

Controls now degrade gracefully onto multiple rows at any width — matching the issue's suggested approach.

## Demo (after)
<!-- VIDEO_PLACEHOLDER: drag-drop the recording here -->

(The "before" behavior is shown in the video on the original issue #1256.)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes disappearing list toolbar and pagination controls on narrow viewports by letting the content column shrink and making the bars wrap. Keeps search, Live, time range, items-per-page, and pagination accessible at any width. Closes #1256.

- **Bug Fixes**
  - Add `min-w-0` to the traces page content column to prevent overflow.
  - Update `SearchFilterBar`: enable `flex-wrap` with gaps, give the search a min width, and right-align the date filter with `ml-auto`.
  - Update `ListPagination`: enable `flex-wrap` with row gap.

- **Tests**
  - Add `search-filter-bar.test.tsx` to cover the search input, children slot, date filter trigger, and search value reflection for diff-coverage.

<sup>Written for commit 6561f4022438170915092274e8e141cdc2f2fa58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



