### PR TITLE
fix(examples): microsoft-agent-framework deps — use sub-packages, not the [all] umbrella

### DIFF
--- a/examples/python/microsoft-agent-framework/requirements.txt
+++ b/examples/python/microsoft-agent-framework/requirements.txt
@@ -1,4 +1,10 @@
-agent-framework>=1.9.0
+# Depend on the specific sub-packages this example imports
+# (agent_framework + agent_framework.openai) rather than the `agent-framework`
+# umbrella, which pulls `agent-framework-core[all]` — every integration,
+# including agent-framework-azure-ai-search whose only release was yanked,
+# breaking resolution. Narrow deps resolve as stable, no --prerelease needed.
+agent-framework-core>=1.0.0
+agent-framework-openai>=1.0.0
 openinference-instrumentation-agent-framework>=0.1.0,<1.0
 python-dotenv>=1.0.0
 


### PR DESCRIPTION
## Problem

`examples/python/microsoft-agent-framework` fails to install. The error is confusing because it names a package the example never imports:

```
Because agent-framework-azure-ai-search==0.0.0a1 was yanked … your requirements are unsatisfiable.
```

Chain:
1. `requirements.txt` asked for `agent-framework>=1.9.0`.
2. That's an **umbrella meta-package** — its only dependency is `agent-framework-core[all]==1.9.0`.
3. The **`[all]` extra** fans out to every integration Microsoft ships (Azure AI, Copilot Studio, redis, mem0, **azure-ai-search**, …).
4. `agent-framework-azure-ai-search`'s only matching release (`0.0.0a1`) was **yanked from PyPI**; only `1.0.0bXXX` prereleases remain.
5. uv won't install a yanked version or auto-pick a prerelease → the whole install fails on a package the example doesn't use. `--prerelease=allow` only "fixes" it by force-accepting betas of all those unused integrations.

## Fix

The example imports exactly two things:

```python
from agent_framework import Agent                     # agent-framework-core
from agent_framework.openai import OpenAIChatClient    # agent-framework-openai
```

So depend on those narrow sub-packages instead of the `[all]` umbrella:

```
agent-framework-core>=1.0.0
agent-framework-openai>=1.0.0
```

## Result (measured)

- Resolves as **stable** — no `--prerelease` flag needed.
- **53 packages instead of 176** — the yanked azure-ai-search and every unused integration are gone, so they can't break resolution again.
- README's run command works unchanged; verified end-to-end (the TravelConcierge demo runs both requests and exports traces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix install failure in `examples/python/microsoft-agent-framework` by depending on `agent-framework-core>=1.0.0` and `agent-framework-openai>=1.0.0` instead of the umbrella `agent-framework`. This avoids the yanked `agent-framework-azure-ai-search`, needs no `--prerelease` flag, reduces deps (53 vs 176), and keeps the README run command working.

<sup>Written for commit ba8853580118a704ebafba6e350de9a9bd9c4164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

