### PR TITLE
docs(examples): add claude-agent-sdk Skill example

### DIFF
--- a/examples/python/claude-agent-sdk/README.md
+++ b/examples/python/claude-agent-sdk/README.md
@@ -33,3 +33,6 @@ surface, so they double as instrumentation smoke tests:
 - `client-mcp.py` — `ClaudeSDKClient` driving **MCP tools** (a self-contained
   in-process SDK MCP server). Covers the `mcp__<server>__<tool>` tool-span path
   production agents lean on; external stdio MCP servers produce the same span shape.
+- `skill.py` — `ClaudeSDKClient` loading an **agent Skill** (scaffolds a tiny
+  local `SKILL.md` and enables it via `skills=[...]`). Covers the `Skill` tool-span
+  path; the skill's follow-up work nests under the LLM turn that drove it.

--- a/examples/python/claude-agent-sdk/requirements.txt
+++ b/examples/python/claude-agent-sdk/requirements.txt
@@ -1,4 +1,4 @@
 claude-agent-sdk>=0.1.72
 python-dotenv>=1.0.0
 
-traceroot>=0.1.9
+traceroot>=0.1.11

--- a/examples/python/claude-agent-sdk/skill.py
+++ b/examples/python/claude-agent-sdk/skill.py
@@ -1,0 +1,123 @@
+"""Agent Skill demo with TraceRoot observability.
+
+Exercises the claude-agent-sdk **Skill** path — the one production agents hit
+when they load an agent Skill (a `SKILL.md` of instructions the model pulls into
+context on demand) and then carry out multi-step work from it. In a trace this
+shows up as a `Skill` tool span followed by the LLM turns / tool calls the skill
+drives.
+
+This is self-contained: it scaffolds a tiny local skill on disk in a temp dir and
+points the SDK at it via `skills=[...]` + `setting_sources=["project"]`, so it runs
+with just an Anthropic key — no preinstalled skills required. We pin
+`setting_sources=["project"]` (rather than the SDK default of
+`["user", "project"]`) so ONLY this scaffolded skill is discovered, never whatever
+skills happen to live in the caller's `~/.claude`.
+
+Driven through the persistent `ClaudeSDKClient` (see client.py), the API real
+agents use.
+
+Usage:
+    cp .env.example .env
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python skill.py
+"""
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found. Using process environment variables.")
+
+import traceroot
+from traceroot import Integration, observe, using_attributes
+
+traceroot.initialize(integrations=[Integration.CLAUDE_AGENT_SDK])
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+# --- A tiny on-disk skill the agent can load -------------------------------
+# A Skill is a SKILL.md with YAML frontmatter (name + description, which the
+# model sees when deciding whether to invoke it) and a body of instructions
+# (loaded into context once the Skill tool fires). This one tells the agent to
+# do a short multi-step calculation via Bash, so the trace shows the Skill span
+# followed by the LLM turns and the Bash tool call it drives.
+SKILL_NAME = "data-cruncher"
+SKILL_MD = """\
+---
+name: data-cruncher
+description: Use when asked to crunch a list of numbers — computes summary statistics (mean, max, standard deviation) with python.
+---
+
+# Data Cruncher
+
+When this skill is invoked, do the following, briefly:
+
+1. Use the Bash tool to run `python3 -c` computing the mean, max, and population
+   standard deviation of the numbers the user gave.
+2. Report the three values in a single short line.
+"""
+
+
+def _scaffold_skill(root: Path) -> None:
+    """Write `<root>/.claude/skills/<name>/SKILL.md` for project-source discovery."""
+    skill_dir = root / ".claude" / "skills" / SKILL_NAME
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(SKILL_MD)
+
+
+PROMPT = (
+    "Use the data-cruncher skill to crunch these numbers: 12, 47, 8, 23, 56. "
+    "Report the mean, max, and standard deviation."
+)
+
+
+@observe(name="skill_pipeline", type="agent")
+async def run_session(workdir: str) -> str:
+    final = ""
+    options = ClaudeAgentOptions(
+        model="sonnet",
+        cwd=workdir,
+        # The single switch that turns skills on; the SDK injects Skill(data-cruncher)
+        # into allowed_tools for us. Bash is what the skill itself needs.
+        skills=[SKILL_NAME],
+        allowed_tools=["Bash"],
+        # Discover ONLY this project's scaffolded skill (not the caller's ~/.claude).
+        setting_sources=["project"],
+        max_turns=8,
+        permission_mode="bypassPermissions",
+    )
+    async with ClaudeSDKClient(options=options) as client:
+        await client.query(PROMPT)
+        async for message in client.receive_response():
+            if hasattr(message, "result"):
+                final = message.result
+    return final
+
+
+@observe(name="demo_session", type="agent")
+async def run_demo():
+    print("=" * 60)
+    print("ClaudeSDKClient + Agent Skill — Demo (TraceRoot)")
+    print("=" * 60)
+    with tempfile.TemporaryDirectory(prefix="traceroot-skill-") as workdir:
+        _scaffold_skill(Path(workdir))
+        result = await run_session(workdir)
+    if result:
+        print(f"\n{result}")
+
+
+if __name__ == "__main__":
+    with using_attributes(user_id="example-user", session_id="claude-agent-sdk-skill-session"):
+        try:
+            asyncio.run(run_demo())
+        finally:
+            traceroot.flush()


### PR DESCRIPTION
## What

Adds `skill.py` to the `claude-agent-sdk` examples — a self-contained demo of the **agent Skill** path. It scaffolds a tiny `SKILL.md` on disk and enables it via `skills=[...]` + `setting_sources=["project"]`, so it runs with just an Anthropic key (no preinstalled skills; the `["project"]` pin keeps it from discovering the caller's `~/.claude`).

## Why

`Skill` was the one tool path in this example set with no coverage. Every example here doubles as an instrumentation smoke test, and an uncovered path is how regressions slip through unnoticed. Skills are also a common production pattern.

Running it surfaced a useful clarification: a Skill is **not** a subagent — the `Skill` tool just loads instructions into the same context, so its follow-up work lands in later orchestrator turns. With the matching SDK fix, the `Skill` span and the tool calls it drives each nest under their LLM turn:

```
ClaudeAgent.query
├─ anthropic.messages.create
│  └─ Skill
├─ anthropic.messages.create
│  └─ Bash
└─ anthropic.messages.create
```

## Also

- Bumps the example's `traceroot` pin to `>=0.1.11` (the release that nests tool spans under their LLM turn).
- Lists the new variant in the README.

Verified end-to-end against live traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a self-contained `skill.py` example to `claude-agent-sdk` that demonstrates the Skill tool end-to-end. It scaffolds a local `SKILL.md`, runs with just an Anthropic key, and updates docs.

- **New Features**
  - Add `skill.py` that creates `.claude/skills/data-cruncher/SKILL.md` and enables it via `skills=[...]` with `setting_sources=["project"]` to ignore `~/.claude`.
  - Uses `ClaudeSDKClient` and `Bash` so traces show the `Skill` span and its follow-up work under the same LLM turn.
  - List the new example in the README.

- **Dependencies**
  - Bump `traceroot` to `>=0.1.11` for nested tool spans.

<sup>Written for commit 6406e07530d60c189a394de1206066c73208123f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

