### PR TITLE
fix(worker): add DeepSeek model pricing

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -850,5 +850,29 @@
       "cacheRead": 0.0000003125,
       "cacheWrite": null
     }
+  },
+  {
+    "id": "tr-deepseek-v4-flash",
+    "modelName": "deepseek-v4-flash",
+    "matchPattern": "(?i)^(deepseek\\/)?(deepseek-v4-flash|deepseek-chat|deepseek-reasoner)(-[\\d-]+)?$",
+    "provider": "deepseek",
+    "prices": {
+      "input": 0.00000014,
+      "output": 0.00000028,
+      "cacheRead": 0.0000000028,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-deepseek-v4-pro",
+    "modelName": "deepseek-v4-pro",
+    "matchPattern": "(?i)^(deepseek\\/)?deepseek-v4-pro(-[\\d-]+)?$",
+    "provider": "deepseek",
+    "prices": {
+      "input": 0.000000435,
+      "output": 0.00000087,
+      "cacheRead": 0.000000003625,
+      "cacheWrite": null
+    }
   }
 ]

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -130,6 +130,17 @@ GEMINI_MODEL_CASES = [
     ("gemini-1.5-pro", "gemini-1.5-pro"),
 ]
 
+DEEPSEEK_MODEL_CASES = [
+    ("deepseek-v4-flash", "deepseek-v4-flash"),
+    ("deepseek/deepseek-v4-flash", "deepseek-v4-flash"),
+    ("deepseek-v4-flash-20260424", "deepseek-v4-flash"),
+    ("deepseek-chat", "deepseek-v4-flash"),
+    ("deepseek-reasoner", "deepseek-v4-flash"),
+    ("deepseek-v4-pro", "deepseek-v4-pro"),
+    ("deepseek/deepseek-v4-pro", "deepseek-v4-pro"),
+    ("deepseek-v4-pro-20260424", "deepseek-v4-pro"),
+]
+
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)
 class TestGetModelPrice:
@@ -192,6 +203,30 @@ class TestGeminiModelIds:
         assert price[MATCHED_MODEL_NAME] == expected_name, (
             f"{model_id} matched a different entry than {expected_name}"
         )
+
+
+class TestDeepSeekModelIds:
+    @pytest.mark.parametrize("model_id,expected_name", DEEPSEEK_MODEL_CASES)
+    def test_matches_expected_model(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert "input" in price and "output" in price
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched a different entry than {expected_name}"
+        )
+
+    def test_deepseek_v4_pro_calculates_cost(self, real_cache):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            result = calculate_cost("deepseek-v4-pro", "Hello world", "Hi there")
+
+        assert result["input_tokens"] is not None
+        assert result["input_tokens"] > 0
+        assert result["output_tokens"] is not None
+        assert result["output_tokens"] > 0
+        assert result["cost"] is not None
+        assert result["cost"] > 0
 
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)


### PR DESCRIPTION
## Summary
- add standard pricing entries for `deepseek-v4-flash` and `deepseek-v4-pro`
- map `deepseek-chat` and `deepseek-reasoner` compatibility aliases to the current V4 Flash pricing entry
- add real-pricing regression coverage so DeepSeek traces no longer get missing/$0 costs

## Pricing source
DeepSeek official models and pricing page: https://api-docs.deepseek.com/quick_start/pricing

## Tests
- `python -m json.tool frontend/packages/core/src/standard-model-prices.json >/tmp/traceroot-prices.json`
- `uv run pytest tests/worker/tokens/test_pricing.py`
- `uv run ruff check tests/worker/tokens/test_pricing.py backend/worker/tokens/pricing.py`

Closes #1268

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pricing for `deepseek-v4-flash` and `deepseek-v4-pro`, and fixes zero-cost DeepSeek traces by mapping aliases and adding regression tests.

- Bug Fixes
  - Added standard pricing entries for `deepseek-v4-flash` and `deepseek-v4-pro` (based on https://api-docs.deepseek.com/quick_start/pricing).
  - Mapped `deepseek-chat` and `deepseek-reasoner` to `deepseek-v4-flash` via match patterns, including `deepseek/` prefixes and date suffixes.
  - Added tests to validate model ID matching and cost calculation, preventing missing/$0 costs for DeepSeek traces.

<sup>Written for commit b6468b45014cf3a06c5fbfe522fd6532efb55759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

