### PR TITLE
chore: gate feature-request issues behind a needs-approval label

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,12 +1,14 @@
 name: "Feature Request"
 description: "Suggest an idea or enhancement for TraceRoot."
-labels: [enhancement]
+labels: [enhancement, needs approval]
 body:
   - type: markdown
     attributes:
       value: |
         ## Thanks for suggesting a feature!
         Please help us understand your use case and how this feature would help.
+
+        > **Before you start coding:** this request will be tagged `needs approval`. Please wait for a core member to remove that label before opening a PR — we want to confirm direction first. (Bugs, security, perf, and docs fixes are exempt — feel free to start right away.)
   - type: textarea
     id: problem
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ On Windows or in environments without tmux, use `make dev-lite` instead.
 ## Before You Start
 
 - Check for an existing issue before starting larger work, or open one first so the change has clear scope.
+- If an issue has the `needs approval` label, please wait until a core member removes it before starting work — we want to confirm direction first. Bugs, security, perf, and docs issues are exempt: feel free to start right away.
 - If you do not have push access, fork the repo first, create your branch from `main`, push to your fork, and open the PR back to `traceroot-ai/traceroot`.
 - If you have push access, still create a branch from `main` and open a PR instead of working directly on `main`.
 - Keep each pull request focused on one problem and link the related issue when possible.
@@ -77,7 +78,7 @@ Helpful defaults:
 - Explain what changed, why it changed, and how it was validated.
 - Add or update tests for behavior changes.
 - Update documentation for setup, command, or UX changes.
-- Add screenshots or recordings for UI changes.
+- **Required for UI changes:** include before/after screenshots or a short screen recording. PRs that change the UI without them will not be merged until they are added.
 - Reference the issue in the PR body when relevant, for example `Closes #581`.
 - Make sure pre-commit and the relevant tests pass before requesting review.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ Helpful defaults:
 - Explain what changed, why it changed, and how it was validated.
 - Add or update tests for behavior changes.
 - Update documentation for setup, command, or UX changes.
-- **Required for UI changes:** include before/after screenshots or a short screen recording. PRs that change the UI without them will not be merged until they are added.
+- Include before/after screenshots or a short screen recording. PRs that change the UI without them will not be approved until they are added.
 - Reference the issue in the PR body when relevant, for example `Closes #581`.
 - Make sure pre-commit and the relevant tests pass before requesting review.
 


### PR DESCRIPTION
## What

Introduces a single, default-on **`needs approval`** label to make our issue backlog legible to OSS contributors: they can tell at a glance which issues are open to pick up vs. which are pending a core-team direction check.

- **`needs approval` present** = wait; a core member must vet the request and remove the label before work starts.
- **No label = green light.** "What can I work on?" is answerable by filtering out the label.
- **Exemptions:** bugs, security, perf, and docs issues — start right away even if the label is present. Only speculative *features* are gated.

## Changes

- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — adds `needs approval` to the auto-applied labels (alongside `enhancement`), plus an inline notice so the rule is visible at creation time. Bug/docs templates are untouched.
- **`CONTRIBUTING.md`** — documents the gate in "Before You Start" (with the bug/security/perf/docs exemption), and strengthens the PR checklist so **screenshots/recordings are a hard requirement for UI-changing PRs**.

## Setup note

The `needs approval` label already exists in the repo (amber `#FBCA04`) — required for the issue form to apply it. No further setup needed.

## Out of scope (deferred by design)

- A manual `core only` label — add later only if a real need appears.
- `ee/` reserved-paths messaging — covered by the open-core licensing boundary, no label needed.

Design doc: `dev_docs/plans/2026-06-21-contributor-issue-triage-labels.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-apply a `needs approval` label to new feature requests and add an inline notice in the issue form. Clarifies what contributors can pick up (no label = green light; bugs/security/perf/docs are exempt) and simplifies—but keeps mandatory—the `CONTRIBUTING.md` rule to include before/after screenshots or a short recording for UI-changing PRs.

<sup>Written for commit 80f27e68194f5c8d20941b4a88e6635ff9cd1774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

