### PR TITLE
feat(ui): show RCA status in trace panel

### DIFF
--- a/frontend/ui/src/features/detectors/hooks/use-findings.test.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-findings.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { describeRcaStatus } from "./use-findings";
+import { describeRcaStatus, describeTraceRcaStatus } from "./use-findings";
 
 describe("describeRcaStatus — the Agent analysis column vocabulary", () => {
   it("renders an em dash when the field is absent (enrichment unavailable)", () => {
@@ -28,8 +28,11 @@ describe("describeRcaStatus — the Agent analysis column vocabulary", () => {
     expect(p.className).toContain("text-destructive");
   });
 
-  it("renders Running… for both pending and running (in-flight states)", () => {
-    expect(describeRcaStatus("pending").label).toBe("Running…");
+  it("renders Queued for pending analysis", () => {
+    expect(describeRcaStatus("pending").label).toBe("Queued");
+  });
+
+  it("renders Running… for running analysis", () => {
     expect(describeRcaStatus("running").label).toBe("Running…");
   });
 
@@ -39,5 +42,19 @@ describe("describeRcaStatus — the Agent analysis column vocabulary", () => {
     const p = describeRcaStatus("canceled" as never);
     expect(p.label).toBe("canceled");
     expect(p.title).toBeUndefined();
+  });
+});
+
+describe("describeTraceRcaStatus — the trace detail header vocabulary", () => {
+  it("uses explicit RCA labels for each worker status", () => {
+    expect(describeTraceRcaStatus("pending").label).toBe("RCA queued");
+    expect(describeTraceRcaStatus("running").label).toBe("RCA running…");
+    expect(describeTraceRcaStatus("done").label).toBe("RCA ready");
+    expect(describeTraceRcaStatus("failed").label).toBe("RCA failed");
+  });
+
+  it("marks only running as busy", () => {
+    expect(describeTraceRcaStatus("pending").busy).toBeUndefined();
+    expect(describeTraceRcaStatus("running").busy).toBe(true);
   });
 });

--- a/frontend/ui/src/features/detectors/hooks/use-findings.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-findings.ts
@@ -27,7 +27,8 @@ export interface RcaStatusPresentation {
  * Single source of truth for the agent-analysis status vocabulary:
  * absent field (enrichment unavailable) -> "—", null (no stored RCA row) ->
  * "Skipped", terminal/in-flight statuses -> their labels. An unrecognized
- * future status renders as its raw value rather than a misleading "Running…".
+ * future status renders as its raw value rather than a misleading in-flight
+ * state.
  */
 export function describeRcaStatus(status: BackendFinding["rca_status"]): RcaStatusPresentation {
   if (status === undefined) {
@@ -42,9 +43,8 @@ export function describeRcaStatus(status: BackendFinding["rca_status"]): RcaStat
   }
   if (status === "failed") return { label: "Failed", className: "text-destructive" };
   if (status === "done") return { label: "Done", className: "text-foreground" };
-  if (status === "pending" || status === "running") {
-    return { label: "Running…", className: "text-muted-foreground" };
-  }
+  if (status === "pending") return { label: "Queued", className: "text-muted-foreground" };
+  if (status === "running") return { label: "Running…", className: "text-muted-foreground" };
   return { label: status, className: "text-muted-foreground" };
 }
 
@@ -129,6 +129,48 @@ export interface DetectorRca {
   result: string | null;
   completedAt: string | null;
   createTime: string;
+}
+
+/** How an RCA status renders in the trace-detail header. */
+export interface TraceRcaStatusPresentation {
+  label: string;
+  className: string;
+  title: string;
+  busy?: boolean;
+}
+
+export function describeTraceRcaStatus(status: DetectorRca["status"]): TraceRcaStatusPresentation {
+  if (status === "pending") {
+    return {
+      label: "RCA queued",
+      className:
+        "border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400",
+      title: "Root cause analysis is queued",
+    };
+  }
+  if (status === "running") {
+    return {
+      label: "RCA running…",
+      className:
+        "border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-400",
+      title: "Root cause analysis is running",
+      busy: true,
+    };
+  }
+  if (status === "done") {
+    return {
+      label: "RCA ready",
+      className:
+        "border-red-300 bg-red-50 text-red-700 hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60",
+      title: "Open root cause analysis",
+    };
+  }
+  return {
+    label: "RCA failed",
+    className:
+      "border-destructive/40 bg-destructive/10 text-destructive dark:border-destructive/50",
+    title: "Root cause analysis failed",
+  };
 }
 
 async function fetchRca(

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -1,18 +1,35 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup } from "@testing-library/react";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   sidebarCollapsed: false,
+  traceFindingsData: undefined as { findings: Array<{ finding_id: string }> } | undefined,
+  rcaData: undefined as
+    | {
+        rca: {
+          id: string;
+          findingId: string;
+          sessionId: string | null;
+          status: "pending" | "running" | "done" | "failed";
+          result: string | null;
+          completedAt: string | null;
+          createTime: string;
+        } | null;
+      }
+    | undefined,
+  setAiPanelOpen: vi.fn(),
+  setAiContext: vi.fn(),
+  setAiInitialSessionId: vi.fn(),
 }));
 
 // Layout context drives the fullscreen width math (sidebar width).
 vi.mock("@/components/layout/app-layout", () => ({
   useLayout: () => ({
     aiPanelOpen: false,
-    setAiPanelOpen: vi.fn(),
-    setAiContext: vi.fn(),
-    setAiInitialSessionId: vi.fn(),
+    setAiPanelOpen: mocks.setAiPanelOpen,
+    setAiContext: mocks.setAiContext,
+    setAiInitialSessionId: mocks.setAiInitialSessionId,
     registerAiHost: () => () => {},
     sidebarCollapsed: mocks.sidebarCollapsed,
   }),
@@ -24,10 +41,14 @@ vi.mock("@tanstack/react-query", () => ({
 }));
 vi.mock("@/lib/api", () => ({ getTrace: vi.fn() }));
 vi.mock("../hooks/use-trace-stream", () => ({ useTraceStream: vi.fn() }));
-vi.mock("@/features/detectors/hooks/use-findings", () => ({
-  useTraceFindings: () => ({ data: undefined }),
-  useRca: () => ({ data: undefined }),
-}));
+vi.mock("@/features/detectors/hooks/use-findings", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/detectors/hooks/use-findings")>();
+  return {
+    ...actual,
+    useTraceFindings: () => ({ data: mocks.traceFindingsData }),
+    useRca: () => ({ data: mocks.rcaData }),
+  };
+});
 
 // Heavy children + resizable layout — replace with passthroughs so only the
 // panel's own root wrapper (which carries the width class) matters.
@@ -64,6 +85,11 @@ function renderPanel(props: { initialFullscreen?: boolean } = {}) {
 afterEach(() => {
   cleanup();
   mocks.sidebarCollapsed = false;
+  mocks.traceFindingsData = undefined;
+  mocks.rcaData = undefined;
+  mocks.setAiPanelOpen.mockClear();
+  mocks.setAiContext.mockClear();
+  mocks.setAiInitialSessionId.mockClear();
 });
 
 describe("TraceViewerPanel layout", () => {
@@ -84,5 +110,60 @@ describe("TraceViewerPanel layout", () => {
     const panel = renderPanel({ initialFullscreen: false });
     expect(panel.className).toContain("w-[70%]");
     expect(panel.className).toContain("top-0");
+  });
+});
+
+function setRcaStatus(status: "pending" | "running" | "done" | "failed", sessionId = "s-1") {
+  mocks.traceFindingsData = { findings: [{ finding_id: "f-1" }] };
+  mocks.rcaData = {
+    rca: {
+      id: "rca-1",
+      findingId: "f-1",
+      sessionId,
+      status,
+      result: null,
+      completedAt: null,
+      createTime: "2026-06-22T00:00:00.000Z",
+    },
+  };
+}
+
+describe("TraceViewerPanel RCA status", () => {
+  it("renders queued status for pending RCA", () => {
+    setRcaStatus("pending");
+    renderPanel();
+    expect(screen.getByText("RCA queued")).toBeTruthy();
+  });
+
+  it("renders running status for running RCA", () => {
+    setRcaStatus("running");
+    renderPanel();
+    expect(screen.getByText("RCA running…")).toBeTruthy();
+  });
+
+  it("renders failed status for failed RCA", () => {
+    setRcaStatus("failed");
+    renderPanel();
+    expect(screen.getByText("RCA failed")).toBeTruthy();
+  });
+
+  it("opens the RCA session when ready", () => {
+    setRcaStatus("done", "session-1");
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: "RCA ready" }));
+
+    expect(mocks.setAiContext).toHaveBeenCalledWith({ traceId: "trace-1" });
+    expect(mocks.setAiInitialSessionId).toHaveBeenCalledWith("session-1");
+    expect(mocks.setAiPanelOpen).toHaveBeenCalledWith(true);
+  });
+
+  it("does not render an RCA control without an RCA row", () => {
+    mocks.traceFindingsData = { findings: [{ finding_id: "f-1" }] };
+    mocks.rcaData = { rca: null };
+
+    renderPanel();
+
+    expect(screen.queryByText(/RCA/)).toBeNull();
   });
 });

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -8,6 +8,7 @@ import {
   ArrowUp,
   ArrowDown,
   BotMessageSquare,
+  Loader2,
   ListTree,
   SquareGanttChart,
   Expand,
@@ -26,7 +27,11 @@ import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistan
 import { useTraceStream } from "../hooks/use-trace-stream";
 import { SpanTimelineView } from "./SpanTimelineView";
 import { TREE_LAYOUT } from "../utils";
-import { useTraceFindings, useRca } from "@/features/detectors/hooks/use-findings";
+import {
+  useTraceFindings,
+  useRca,
+  describeTraceRcaStatus,
+} from "@/features/detectors/hooks/use-findings";
 
 interface TraceViewerPanelProps {
   projectId: string;
@@ -114,17 +119,19 @@ export function TraceViewerPanel({
 
   const [hoveredSpanId, setHoveredSpanId] = useState<string | null>(null);
 
-  // Detector findings → Alert button + auto-open RCA chat when entered from
+  // Detector findings → RCA status affordance + auto-open RCA chat when entered from
   // the findings page. The trace-level finding (at most one per trace) carries
-  // the RCA session the worker already populated. The Alert button opens that
-  // analysis, so it only renders when an RCA record exists — a finding from an
-  // RCA-disabled detector has no analysis to open (gate on the record, not the
-  // sessionId, so the button doesn't flicker while the RCA is still pending).
+  // the RCA session the worker already populated. The ready state opens that
+  // analysis; in-flight/failed states are status-only. A finding from an
+  // RCA-disabled detector has no analysis to open, so we gate on the RCA record.
   const { data: traceFindingsData } = useTraceFindings(projectId, traceId);
   const traceFinding = traceFindingsData?.findings?.[0];
   const { data: rcaData } = useRca(projectId, traceFinding?.finding_id ?? "");
-  const hasRca = !!traceFinding && !!rcaData?.rca;
-  const rcaSessionId = rcaData?.rca?.sessionId ?? undefined;
+  const rca = rcaData?.rca;
+  const hasRca = !!traceFinding && !!rca;
+  const rcaSessionId = rca?.sessionId ?? undefined;
+  const rcaStatus = rca ? describeTraceRcaStatus(rca.status) : null;
+  const canOpenRca = rca?.status === "done" && !!rcaSessionId;
 
   // Auto-open chat with RCA session loaded when arriving from /detectors.
   // Waits for rcaSessionId so the chat opens already pointing at the session,
@@ -231,20 +238,36 @@ export function TraceViewerPanel({
             <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
           </div>
           <div className="flex items-center gap-1">
-            {hasRca && (
-              <button
-                type="button"
-                onClick={() => {
-                  setAiContext({ traceId });
-                  setAiInitialSessionId(rcaSessionId);
-                  setAiPanelOpen(true);
-                }}
-                className="rounded-md border border-red-300 bg-red-50 px-2 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60"
-                title="Findings detected — open root cause analysis"
-              >
-                Alert
-              </button>
-            )}
+            {hasRca &&
+              rcaStatus &&
+              (canOpenRca ? (
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAiContext({ traceId });
+                    setAiInitialSessionId(rcaSessionId);
+                    setAiPanelOpen(true);
+                  }}
+                  className={cn(
+                    "inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px] font-medium transition-colors",
+                    rcaStatus.className,
+                  )}
+                  title={rcaStatus.title}
+                >
+                  {rcaStatus.label}
+                </button>
+              ) : (
+                <span
+                  className={cn(
+                    "inline-flex h-7 items-center gap-1 rounded-md border px-2 text-[11px] font-medium",
+                    rcaStatus.className,
+                  )}
+                  title={rcaStatus.title}
+                >
+                  {rcaStatus.busy && <Loader2 className="h-3 w-3 animate-spin" />}
+                  {rcaStatus.label}
+                </span>
+              ))}
             <Button
               variant="outline"
               size="sm"


### PR DESCRIPTION
Fixes #1114

## Summary

Shows RCA status in the trace detail panel header.

## Type of Change

- [x] feat - A new feature
- [x] test - Adding missing tests or correcting existing tests

## Details

- Replaces the static `Alert` label with RCA status labels.
- Keeps RCA opening available when RCA is ready.
- Adds tests for RCA status rendering and ready-state click behavior.

## Repro / Testing

1. Started local TraceRoot with `make dev-lite`.
2. Created a local detector that always flags traces.
3. Ran the Gemini tool-agent example to create a trace and detector finding.
4. Opened the finding in the trace detail panel.
5. Updated the RCA row directly in local Postgres to verify every status:

   ```sql
   UPDATE detector_rcas
   SET status = 'pending'
   WHERE finding_id = '<finding_id>';

   UPDATE detector_rcas
   SET status = 'running'
   WHERE finding_id = '<finding_id>';

   UPDATE detector_rcas
   SET status = 'done'
   WHERE finding_id = '<finding_id>';

   UPDATE detector_rcas
   SET status = 'failed'
   WHERE finding_id = '<finding_id>';
   ```

Added tests cover:

- RCA status helper labels for `pending`, `running`, `done`, and `failed`.
- Trace panel rendering for `RCA queued`, `RCA running…`, and `RCA failed`.
- `RCA ready` click behavior opens the RCA session.
- No RCA control renders when there is no RCA row.


## Screenshots / Recordings (if applicable)`

- `RCA failed`
<img width="310" height="43" alt="Screenshot 2026-06-22 113541" src="https://github.com/user-attachments/assets/006bc65e-58e6-4e29-a0b2-0dc188bbfa58" />

- `RCA ready`
<img width="311" height="40" alt="Screenshot 2026-06-22 113525" src="https://github.com/user-attachments/assets/cc48fbad-d7f2-4e96-87dc-d786ea966092" />

- `RCA running…`
<img width="349" height="43" alt="Screenshot 2026-06-22 113444" src="https://github.com/user-attachments/assets/4acc120e-b8ed-4eb5-a2dc-29df97e4e360" />

- `RCA queued`
<img width="307" height="37" alt="Screenshot 2026-06-22 113617" src="https://github.com/user-attachments/assets/46a57dd0-7e41-41f5-b0ce-57fae8405888" />

## Notes to consider

- The RCA status label helpers could be backed by a shared status map so the status copy has a single source of truth.
- The trace header now has both the RCA status control and the general agent button. It may be worth considering whether those should become one combined button.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show RCA status in the trace detail header and replace the generic Alert label with clear RCA chips. When RCA is ready, the chip opens the analysis session.

- New Features
  - Trace header shows RCA chips: "RCA queued", "RCA running…" (with spinner), "RCA failed", and "RCA ready" (click to open).
  - Chip renders only when an RCA record exists; no control when RCA is absent.
  - Auto-opens the assistant panel with the RCA session when status is "done".
  - Updated findings table vocabulary: pending → "Queued", running → "Running…".
  - Added tests for status labels, header rendering, ready-state click, and no-control when RCA is missing.

<sup>Written for commit b3872734003160ce733ad6b74d7da9222cf90182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

