### PR TITLE
chore: bump traceroot SDK to 0.1.11 in all Python examples

### DIFF
--- a/examples/python/agno-tool-agent/requirements.txt
+++ b/examples/python/agno-tool-agent/requirements.txt
@@ -4,4 +4,4 @@ yfinance>=0.2.0
 duckduckgo-search>=8.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/anthropic-tool-agent/requirements.txt
+++ b/examples/python/anthropic-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 anthropic>=0.40.0
 python-dotenv>=1.0.0
-traceroot==0.1.7
+traceroot==0.1.11
 openinference-instrumentation-anthropic>=1.0.0

--- a/examples/python/autogen-tool-agent/requirements.txt
+++ b/examples/python/autogen-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 ag2[Gemini]>=0.11.5
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/crewai-agent/requirements.txt
+++ b/examples/python/crewai-agent/requirements.txt
@@ -1,4 +1,4 @@
 crewai>=1.10.1
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/deepagents/requirements.txt
+++ b/examples/python/deepagents/requirements.txt
@@ -2,4 +2,4 @@ deepagents>=0.4.0
 langchain>=0.3.0
 langchain-anthropic>=0.3.0
 python-dotenv>=1.0.0
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/deepseek-tool-agent/requirements.txt
+++ b/examples/python/deepseek-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/dspy-agent/requirements.txt
+++ b/examples/python/dspy-agent/requirements.txt
@@ -2,4 +2,4 @@ dspy>=2.6.22,<4.0
 openinference-instrumentation-dspy>=0.1.34,<1.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/gemini-tool-agent/requirements.txt
+++ b/examples/python/gemini-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 google-genai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/google-adk-agent/requirements.txt
+++ b/examples/python/google-adk-agent/requirements.txt
@@ -1,4 +1,4 @@
 google-adk>=1.31.1
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/groq-tool-agent/requirements.txt
+++ b/examples/python/groq-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 groq>=0.9.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/langgraph-code-agent/requirements.txt
+++ b/examples/python/langgraph-code-agent/requirements.txt
@@ -6,4 +6,4 @@ python-dotenv>=1.0.0
 fastapi==0.115.12
 uvicorn==0.34.3
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/llamaindex-rag/requirements.txt
+++ b/examples/python/llamaindex-rag/requirements.txt
@@ -3,4 +3,4 @@ llama-index-llms-openai>=0.1.0
 llama-index-embeddings-openai>=0.1.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/microsoft-agent-framework/requirements.txt
+++ b/examples/python/microsoft-agent-framework/requirements.txt
@@ -8,4 +8,4 @@ agent-framework-openai>=1.0.0
 openinference-instrumentation-agent-framework>=0.1.0,<1.0
 python-dotenv>=1.0.0
 
-traceroot>=0.1.10
+traceroot>=0.1.11

--- a/examples/python/mistral-tool-agent/requirements.txt
+++ b/examples/python/mistral-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 mistralai>=2.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/openai-agents-sdk/requirements.txt
+++ b/examples/python/openai-agents-sdk/requirements.txt
@@ -1,4 +1,4 @@
 openai-agents>=0.0.3
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/openai-tool-agent/requirements.txt
+++ b/examples/python/openai-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/openrouter-tool-agent/requirements.txt
+++ b/examples/python/openrouter-tool-agent/requirements.txt
@@ -1,4 +1,4 @@
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11

--- a/examples/python/pydantic-ai-tool-agent/requirements.txt
+++ b/examples/python/pydantic-ai-tool-agent/requirements.txt
@@ -2,4 +2,4 @@ pydantic-ai>=0.2.0
 openai>=1.0.0
 python-dotenv>=1.0.0
 
-traceroot==0.1.7
+traceroot==0.1.11


### PR DESCRIPTION
## Summary
Bumps the `traceroot` pin in every Python example's `requirements.txt` to **0.1.11**, the latest release on PyPI.

- Most examples were pinned to `traceroot==0.1.7` → now `==0.1.11`
- `microsoft-agent-framework` floor bumped `>=0.1.10` → `>=0.1.11`
- `claude-agent-sdk` was already at `>=0.1.11` (unchanged)

18 files updated.

## Verification
Confirmed `0.1.11` is the latest version published on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `traceroot` to 0.1.11 across all Python example `requirements.txt` files to standardize on the latest SDK and fixes (18 files total, with `microsoft-agent-framework` raised to `>=0.1.11`). Most were `==0.1.7`; the `claude-agent-sdk` example was already `>=0.1.11`.

<sup>Written for commit dd4a1b3b3dffa8788700564ae5d27bab9f39f932. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

