### PR TITLE
feat(public-api): add time-range filtering to traces list endpoint

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -866,6 +866,44 @@
               "title": "Limit",
               "type": "integer"
             }
+          },
+          {
+            "description": "Only traces that started at or after this time (inclusive, ISO 8601)",
+            "in": "query",
+            "name": "start_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only traces that started at or after this time (inclusive, ISO 8601)",
+              "title": "Start After"
+            }
+          },
+          {
+            "description": "Only traces that started before this time (exclusive, ISO 8601)",
+            "in": "query",
+            "name": "end_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only traces that started before this time (exclusive, ISO 8601)",
+              "title": "End Before"
+            }
           }
         ],
         "responses": {

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -7,6 +7,7 @@ write concerns stay decoupled; both reuse the shared API-key auth dependency.
 """
 
 import logging
+from datetime import datetime
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response, status
 
@@ -51,11 +52,24 @@ async def list_traces(
     response: Response,
     auth: StampedAuth,
     limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    start_after: datetime | None = Query(
+        None,
+        description="Only traces that started at or after this time (inclusive, ISO 8601)",
+    ),
+    end_before: datetime | None = Query(
+        None,
+        description="Only traces that started before this time (exclusive, ISO 8601)",
+    ),
 ):
     """List recent traces for the API key's project (newest first)."""
     try:
         service = get_trace_reader_service()
-        result = service.list_traces(project_id=auth.project_id, limit=limit)
+        result = service.list_traces(
+            project_id=auth.project_id,
+            limit=limit,
+            start_after=start_after,
+            end_before=end_before,
+        )
     except Exception as e:
         logger.exception(f"Error listing traces: {e}")
         raise HTTPException(

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -4,7 +4,7 @@ GET /api/v1/public/traces and GET /api/v1/public/traces/{trace_id}. Reads are
 scoped to the API key's project; the client never supplies a project id.
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -166,6 +166,36 @@ class TestPublicListTraces:
 
     def test_limit_over_200_rejected(self, client, mock_reader):
         resp = client.get("/api/v1/public/traces?limit=500", headers=AUTH_HEADER)
+        assert resp.status_code == 422
+
+    def test_forwards_start_after_and_end_before(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+        resp = client.get(
+            "/api/v1/public/traces"
+            "?start_after=2024-01-01T00:00:00Z&end_before=2024-01-31T23:59:59Z",
+            headers=AUTH_HEADER,
+        )
+        assert resp.status_code == 200
+        kwargs = mock_reader.list_traces.call_args.kwargs
+        assert kwargs["start_after"] == datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        assert kwargs["end_before"] == datetime(2024, 1, 31, 23, 59, 59, tzinfo=UTC)
+
+    def test_time_range_defaults_to_none_when_absent(self, client, mock_reader):
+        mock_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+        resp = client.get("/api/v1/public/traces", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        kwargs = mock_reader.list_traces.call_args.kwargs
+        assert kwargs["start_after"] is None
+        assert kwargs["end_before"] is None
+
+    def test_invalid_start_after_rejected(self, client, mock_reader):
+        resp = client.get("/api/v1/public/traces?start_after=not-a-date", headers=AUTH_HEADER)
         assert resp.status_code == 422
 
     def test_reader_error_returns_generic_500(self, client, mock_reader):


### PR DESCRIPTION
## Summary

Fixes #1280 

Adds optional `start_after` and `end_before` ISO 8601 datetime query parameters to `GET /api/v1/public/traces`. The bounds are forwarded to the existing trace reader, which already applies them as ClickHouse bound parameters. The lower bound is inclusive, the upper bound is exclusive, and both are normalized to UTC so results are independent of the caller's local zone. With neither parameter supplied, behavior is unchanged — the most recent traces, newest first.

This is the API half of the time-range feature; it unblocks the matching CLI flags in `traceroot-cli`.

## How it works

```
GET /api/v1/public/traces?start_after=<iso>&end_before=<iso>
  → FastAPI parses start_after/end_before (422 if unparseable)
    → forwarded to the trace reader service (project-scoped)
      → ClickHouse bound params: start_after <= started_at < end_before
        → traces in range, newest first
```

Parameters are passed to ClickHouse as bound query parameters (`{start_after:DateTime64(3)}`, `{end_before:DateTime64(3)}`) — never string-concatenated. Aware datetimes (ISO `Z`/offset) are normalized to UTC; the lower bound uses `>=`, the upper bound uses `<`.

## What's included

- `backend/rest/routers/public/traces_read.py` — adds `start_after` and `end_before` (`datetime | None`) query parameters to `list_traces` and forwards them to the existing reader call. FastAPI handles ISO 8601 parsing and rejects an unparseable value with 422 before the handler runs. Omitting either passes `None` through and preserves prior behavior.
- `backend/rest/openapi/public.json` — regenerated public OpenAPI artifact describing the two new optional `date-time` query parameters on the list endpoint.
- `tests/rest/test_public_traces_read.py` — endpoint tests covering: both bounds parsed and forwarded to the reader as UTC-aware `datetime`s, absent bounds defaulting to `None`, and an invalid `start_after` returning 422.

## Example

```bash
# Absolute range (inclusive start, exclusive end)
curl -H "Authorization: Bearer tr_xxxxxxxx" \
  "http://localhost:8000/api/v1/public/traces?start_after=2026-06-01T00:00:00Z&end_before=2026-06-22T00:00:00Z"

# Open-ended lower bound only
curl -H "Authorization: Bearer tr_xxxxxxxx" \
  "http://localhost:8000/api/v1/public/traces?start_after=2026-06-20T00:00:00Z"
```

## Test plan

- [x] Both bounds are parsed and forwarded to the reader as UTC-aware datetimes
- [x] Both bounds default to `None` when absent (behavior unchanged)
- [x] An invalid bound is rejected with 422
- [x] `start_after` is inclusive (`>=`), `end_before` is exclusive (`<`)
- [x] Parameters are bound, not string-concatenated (no injection)
- [x] Public OpenAPI artifact regenerated; drift check passes
- [ ] End-to-end against a live project: a bounded request returns only traces within the window, upper bound excluded

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add optional time-range filtering to GET /api/v1/public/traces using start_after and end_before to return only traces in a UTC-normalized window. Keeps prior behavior when omitted.

- **New Features**
  - Adds ISO 8601 query params: start_after (inclusive) and end_before (exclusive).
  - Invalid datetimes return 422; parsed values are forwarded as bound params to the reader.
  - Updated public OpenAPI; tests cover bounds, defaults, and validation.

<sup>Written for commit 35294e280ddf0ceada573d5ae2df742b50e5cd1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

