### PR TITLE
fix(detectors): dedup pre-merge ReplacingMergeTree rows in list_detec…

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -280,6 +280,10 @@ async def list_detector_runs(
 ):
     """List runs for a detector, newest first.
 
+    Runs and findings are read with FINAL so pre-merge ReplacingMergeTree
+    duplicates don't fan out the JOIN, leak stale versions into the page,
+    or inflate the total count.
+
     Param naming and pagination shape mirror the trace listing endpoints
     (`page`/`limit`/`start_after`/`end_before`/`search_query`) so the same
     `useListPageState` queryOptions can flow through unchanged.
@@ -349,8 +353,8 @@ async def list_detector_runs(
             r.status      AS status,
             r.timestamp   AS timestamp,
             {summary_expr} AS summary
-        FROM detector_runs r
-        LEFT JOIN detector_findings f
+        FROM (SELECT * FROM detector_runs FINAL) AS r
+        LEFT JOIN (SELECT * FROM detector_findings FINAL) AS f
           ON r.finding_id = f.finding_id AND r.project_id = f.project_id
         WHERE {where_clause}
         ORDER BY r.timestamp DESC
@@ -361,8 +365,8 @@ async def list_detector_runs(
 
     count_query = f"""
         SELECT count()
-        FROM detector_runs r
-        LEFT JOIN detector_findings f
+        FROM (SELECT * FROM detector_runs FINAL) AS r
+        LEFT JOIN (SELECT * FROM detector_findings FINAL) AS f
           ON r.finding_id = f.finding_id AND r.project_id = f.project_id
         WHERE {where_clause}
     """

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -282,6 +282,22 @@ class TestListDetectorRuns:
         assert "start_after" not in data_sql
         assert "end_before" not in data_sql
 
+    def test_data_and_count_queries_dedup_pre_merge_rows(self, client, mock_ch, secret):
+        """Pre-merge ReplacingMergeTree duplicates must not fan out the JOIN."""
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(1)]
+        resp = client.get(
+            "/api/v1/internal/detector-runs",
+            params={"project_id": "p1", "detector_id": "d1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        data_sql = mock_ch.query.call_args_list[0].args[0]
+        assert "(SELECT * FROM detector_runs FINAL) AS r" in data_sql
+        assert "(SELECT * FROM detector_findings FINAL) AS f" in data_sql
+        count_sql = mock_ch.query.call_args_list[1].args[0]
+        assert "(SELECT * FROM detector_runs FINAL) AS r" in count_sql
+        assert "(SELECT * FROM detector_findings FINAL) AS f" in count_sql
+
 
 # =============================================================================
 # POST /detector-findings


### PR DESCRIPTION
…tor_runs

GET /detector-runs joins detector_runs against detector_findings without FINAL on either side. Both tables are ReplacingMergeTree, deduped only on background merge — list_detector_findings and list_detector_counts already guard this with (SELECT * FROM ... FINAL) AS x (and have tests for it), but this endpoint's identical join shape was missed.

detector_tasks.py retries writeDetectorRun up to 5x with exponential backoff on transient failures, so until the background merge collapses a retried row, the run list renders it twice and meta.total (used for pagination) is inflated by the same duplicate.

Added a regression test mirroring TestListDetectorFindings/ TestListDetectorCounts. Full tests/rest suite (257 tests) passes; ruff clean.

Fixes <issue-id>

## Summary

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate rows and inflated totals in GET /detector-runs by reading `detector_runs` and `detector_findings` with FINAL. This prevents join fan-out and stabilizes pagination after retried writes.

- **Bug Fixes**
  - Use `(SELECT * FROM detector_runs FINAL)` and `(SELECT * FROM detector_findings FINAL)` in data and count queries.
  - Add regression test to ensure both queries use FINAL.

<sup>Written for commit f0ffd6b2c6fa34262085e49610d13019bbcdb98b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

