### PR TITLE
perf: replace FINAL with dedup subquery in get_trace, get_trace_spans_io, and get_span_io

### DIFF
--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -291,8 +291,18 @@ class TraceReaderService:
                 model_name, cost, input_tokens, output_tokens, total_tokens,
                 usage_details,
                 git_source_file, git_source_line, git_source_function
-            FROM spans FINAL
-            WHERE {spans_where_clause}
+            FROM (
+                SELECT
+                    span_id, trace_id, parent_span_id, name, span_kind,
+                    span_start_time, span_end_time, status, status_message,
+                    model_name, cost, input_tokens, output_tokens, total_tokens,
+                    usage_details,
+                    git_source_file, git_source_line, git_source_function
+                FROM spans
+                WHERE {spans_where_clause}
+                ORDER BY ch_update_time DESC
+                LIMIT 1 BY span_id
+            )
             ORDER BY span_start_time ASC
         """
         spans_result = self._client.query(
@@ -365,8 +375,13 @@ class TraceReaderService:
         select_clause = ", ".join(["span_id", *selected])
         query = f"""
             SELECT {select_clause}
-            FROM spans FINAL
-            WHERE project_id = {{project_id:String}} AND trace_id = {{trace_id:String}}
+            FROM (
+                SELECT {select_clause}
+                FROM spans
+                WHERE project_id = {{project_id:String}} AND trace_id = {{trace_id:String}}
+                ORDER BY ch_update_time DESC
+                LIMIT 1 BY span_id
+            )
         """
         result = self._client.query(
             query,
@@ -385,10 +400,11 @@ class TraceReaderService:
         """
         query = """
             SELECT span_id, trace_id, input, output, metadata
-            FROM spans FINAL
+            FROM spans
             WHERE project_id = {project_id:String}
               AND trace_id = {trace_id:String}
               AND span_id = {span_id:String}
+            ORDER BY ch_update_time DESC
             LIMIT 1
         """
         result = self._client.query(

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -202,8 +202,10 @@ class TestGetTraceSkeleton:
         # The token columns (which share a prefix with the blobs) are still there.
         assert "input_tokens" in cols
         assert "output_tokens" in cols
-        # Still selects via FINAL (correctness for ReplacingMergeTree).
-        assert "FROM spans FINAL" in spans_sql
+        # Uses dedup subquery instead of FINAL for better read performance.
+        assert "LIMIT 1 BY span_id" in spans_sql
+        assert "ch_update_time DESC" in spans_sql
+        assert "FROM spans FINAL" not in spans_sql
         # Bound by the already-read trace_start_time so ClickHouse can prune
         # monthly span partitions before the trace.
         from rest.services.trace_reader import TRACE_SPAN_LOOKBACK_HOURS
@@ -355,7 +357,9 @@ class TestGetTraceSpansIO:
         # Exactly one trace-scoped query (no N+1 single-span fan-out).
         assert len(calls) == 1
         query, params = calls[0]
-        assert "FROM spans FINAL" in query
+        assert "LIMIT 1 BY span_id" in query
+        assert "ch_update_time DESC" in query
+        assert "FROM spans FINAL" not in query
         assert params == {"project_id": "proj", "trace_id": "abc123"}
         # No span_id filter — it is trace-wide.
         assert "span_id =" not in query
@@ -376,9 +380,11 @@ class TestGetTraceSpansIO:
         service, _ = _make_service(side_effect)
         result = service.get_trace_spans_io("proj", "abc123", frozenset({"metadata"}))
 
-        select_clause = captured["query"].split("FROM spans")[0]
-        cols = {c.strip() for c in select_clause.replace("SELECT", "").split(",")}
-        assert cols == {"span_id", "metadata"}
+        # Extract inner SELECT (after the last "FROM (") to get the actual projected cols.
+        inner_select = captured["query"].split("FROM spans")[0].split("FROM (")[-1]
+        cols = {c.strip() for c in inner_select.replace("SELECT", "").split(",")}
+        assert "span_id" in cols
+        assert "metadata" in cols
         assert "input" not in cols
         assert "output" not in cols
         assert result == {"span-1": {"metadata": "meta-1"}}
@@ -410,7 +416,8 @@ class TestGetTraceSpansIO:
 class TestGetSpanIO:
     def test_returns_blobs_for_existing_span(self):
         def side_effect(query, parameters=None):
-            assert "FROM spans FINAL" in query
+            assert "ch_update_time DESC" in query
+            assert "FROM spans FINAL" not in query
             # All three blob columns must be in the SELECT.
             assert "input" in query
             assert "output" in query
@@ -452,3 +459,35 @@ class TestGetSpanIO:
             "output": None,
             "metadata": None,
         }
+
+    def test_latest_row_wins_when_span_reingested(self):
+        """When a span is re-ingested the query must return the newest version.
+
+        The dedup relies on ORDER BY ch_update_time DESC + LIMIT 1 inside
+        ClickHouse. This test simulates what ClickHouse returns after applying
+        that dedup: a single row with the latest input/output values. The
+        service must surface that row without further modification.
+        """
+        t_old = datetime(2024, 1, 1, 10, 0, 0)
+        t_new = datetime(2024, 1, 1, 12, 0, 0)
+
+        call_count = {"n": 0}
+
+        def side_effect(query, parameters=None):
+            call_count["n"] += 1
+            # Verify the query uses the dedup pattern, not FINAL.
+            assert "ORDER BY ch_update_time DESC" in query
+            assert "LIMIT 1" in query
+            assert "FROM spans FINAL" not in query
+            # ClickHouse applies ORDER BY + LIMIT 1 and returns only the newest row.
+            _ = t_old  # older version — not returned by ClickHouse
+            return _rows([("span-1", "abc123", "new-input", "new-output", "new-meta")])
+
+        service, _ = _make_service(side_effect)
+        result = service.get_span_io("proj", "abc123", "span-1")
+
+        assert call_count["n"] == 1
+        assert result["input"] == "new-input"
+        assert result["output"] == "new-output"
+        assert result["metadata"] == "new-meta"
+        _ = t_new  # newest version — confirmed above

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -461,26 +461,19 @@ class TestGetSpanIO:
         }
 
     def test_latest_row_wins_when_span_reingested(self):
-        """When a span is re-ingested the query must return the newest version.
+        """Asserts the dedup query shape and single-row pass-through.
 
-        The dedup relies on ORDER BY ch_update_time DESC + LIMIT 1 inside
-        ClickHouse. This test simulates what ClickHouse returns after applying
-        that dedup: a single row with the latest input/output values. The
-        service must surface that row without further modification.
+        Newest-wins ordering is enforced by ClickHouse (ORDER BY ch_update_time
+        DESC + LIMIT 1). The mock returns the single post-dedup row; the service
+        must surface it without further modification.
         """
-        t_old = datetime(2024, 1, 1, 10, 0, 0)
-        t_new = datetime(2024, 1, 1, 12, 0, 0)
-
         call_count = {"n": 0}
 
         def side_effect(query, parameters=None):
             call_count["n"] += 1
-            # Verify the query uses the dedup pattern, not FINAL.
             assert "ORDER BY ch_update_time DESC" in query
             assert "LIMIT 1" in query
             assert "FROM spans FINAL" not in query
-            # ClickHouse applies ORDER BY + LIMIT 1 and returns only the newest row.
-            _ = t_old  # older version — not returned by ClickHouse
             return _rows([("span-1", "abc123", "new-input", "new-output", "new-meta")])
 
         service, _ = _make_service(side_effect)
@@ -490,4 +483,3 @@ class TestGetSpanIO:
         assert result["input"] == "new-input"
         assert result["output"] == "new-output"
         assert result["metadata"] == "new-meta"
-        _ = t_new  # newest version — confirmed above


### PR DESCRIPTION
Closes #1229

## What

Replaced `FROM spans FINAL` with a dedup subquery in three hot-path reads:

- `get_trace` skeleton query (`trace_reader.py`)
- `get_trace_spans_io` bulk I/O reader (`trace_reader.py`)
- `get_span_io` single-span fetch (`trace_reader.py`)

## Why

`FINAL` forces ClickHouse to merge all data parts at read time, adding CPU/IO on every trace open. The list reads (`list_traces`, `list_sessions`, `list_users`) already avoid this using `ORDER BY ch_update_time DESC` + `LIMIT 1 BY span_id`. This brings the three detail reads in line with that existing pattern.

## Why it's safe

- `spans` is `ReplacingMergeTree(ch_update_time)` with no `is_deleted`/sign column — no deletion semantics to preserve.
- `ORDER BY ch_update_time DESC` + `LIMIT 1 BY span_id` keeps exactly one row per span (the latest), identical to what `FINAL` returns.
- The `span_start_time` lower bound is kept inside the dedup subquery so ClickHouse can still prune old monthly partitions.
- Span ordering (`span_start_time ASC`) is preserved — the outer query re-sorts after dedup.

## Pattern applied

sql
SELECT <columns>
FROM (
    SELECT <columns>
    FROM spans
    WHERE {spans_where_clause}
    ORDER BY ch_update_time DESC
    LIMIT 1 BY span_id
)
ORDER BY span_start_time ASC

Note: This supersedes #1248 which was closed unintentionally due to a force-push on the source branch.




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `FROM spans FINAL` with a dedup subquery in `get_trace`, `get_trace_spans_io`, and `get_span_io` to speed up hot-path reads. Preserves correctness, “latest row wins,” span ordering, and partition pruning.

- **Refactors**
  - `get_trace` and `get_trace_spans_io`: inner SELECT with `ORDER BY ch_update_time DESC` + `LIMIT 1 BY span_id`, then re-sort (`get_trace`) by `span_start_time ASC`; keeps the `span_start_time` lower bound inside for partition pruning.
  - `get_span_io`: select latest via `ORDER BY ch_update_time DESC LIMIT 1` (no `FINAL`).
  - Tests updated to assert the dedup shape (no `FINAL`), check ordering clauses, validate inner SELECT projection, and cover “latest row wins” on reingest.

<sup>Written for commit d25f22372dc92f23bd91296b4e9d156d4b4a1aa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



