### PR TITLE
fix: pin google-genai <2.0 in gemini-tool-agent example

### DIFF
--- a/examples/python/gemini-tool-agent/requirements.txt
+++ b/examples/python/gemini-tool-agent/requirements.txt
@@ -1,4 +1,9 @@
-google-genai>=1.0.0
+# Pin to the 1.x line: google-genai 2.0 renamed the private `_interactions`
+# module to a public `interactions` module, which breaks the
+# openinference-instrumentation-google-genai (<1.0) that traceroot 0.1.11
+# depends on ("Failed to instrument google_genai"). Drop the upper bound once
+# traceroot bumps to an instrumentor that supports google-genai >= 2.0.
+google-genai>=1.57.0,<2.0
 python-dotenv>=1.0.0
 
 traceroot==0.1.11


### PR DESCRIPTION
google-genai 2.0 renamed the private `_interactions` package to a public `interactions` module. The openinference-instrumentation-google-genai (<1.0) that traceroot 0.1.11 depends on still imports
`google.genai._interactions.resources`, so installing the example with an unpinned `google-genai>=1.0.0` pulls 2.x and fails at startup with "Failed to instrument google_genai" (ModuleNotFoundError: No module named 'google.genai._interactions'). google-genai calls then go untraced.

Pin to `>=1.57.0,<2.0` (the instrumentor's own floor) so the instrumentor attaches cleanly. Verified the GoogleGenAIInstrumentor instruments without error against google-genai 1.75.0.

Fixes - #1284

## Summary

## Type of Change

- [x] fix - A bug fix


## Details

- `examples/python/gemini-tool-agent/requirements.txt`: `google-genai>=1.0.0` →
  `google-genai>=1.57.0,<2.0` (`1.57.0` is the instrumentor's own minimum), with a comment explaining the
  cap and the condition under which it can be dropped.
- Verified: with the pin, `google-genai` resolves to `1.75.0`, `GoogleGenAIInstrumentor().instrument()`
  succeeds with no traceback, and `python main.py` runs both example queries cleanly.
- Interim fix. Root cause is the SDK's `<1.0` instrumentor pin; the latest instrumentor (`1.1.0`)
  supports `google-genai` 2.x. Once `traceroot` allows `>=1.0`, the `<2.0` cap here can be removed
  (tracked in #1284).

## Screenshots / Recordings (if applicable)

<img width="917" height="767" alt="error-screenshot" src="https://github.com/user-attachments/assets/7acacfa8-ce1f-4acd-ba12-79aa10a0c56c" />

## Before

<img width="1052" height="653" alt="Image" src="https://github.com/user-attachments/assets/95c61834-be21-4263-905f-2b993cb93c5e" />

## After

<img width="1143" height="765" alt="Image" src="https://github.com/user-attachments/assets/48d98228-b884-4f9a-8eb7-b35199da8cfd" />

- No `Failed to instrument google_genai` traceback at startup — `Integration.GOOGLE_GENAI` attaches cleanly.
- Each `llm_completion` now has a child **`GenerateContent`** span — the auto-instrumented LLM span for the Gemini call.
- **Token counts** (`1.4K → 587 (2K)`) and **cost** (`$0.001882`) now show on the trace, derived from the LLM-span attributes.
- The agent flow (`agent_turn`, `execute_tool`, tools) is unchanged — those come from `@observe` and were never affected.

  | | Before (2.9.0, broken) | After (1.75.0, fixed) |
  |---|---|---|
  | Startup traceback | yes | none |
  | `GenerateContent` LLM spans | absent | present |
  | Token counts / cost | absent | present |

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin `google-genai` to >=1.57.0,<2.0 in the `examples/python/gemini-tool-agent` example to avoid 2.x’s `_interactions` rename, which breaks `openinference-instrumentation-google-genai` used by `traceroot` 0.1.11 and prevents tracing. Tracing now works again (verified with `google-genai` 1.75.0); remove the cap once `traceroot` uses an instrumentor that supports 2.x (refs #1284).

<sup>Written for commit 95330c0b9f462812b75b00f3f3937e5524170849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

