### PR TITLE
fix(ui): show clean release tag in version badge

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Resolve app version
         id: app_version
-        run: echo "value=$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
+        run: echo "value=$(git describe --tags --abbrev=0 2>/dev/null || echo dev)" >> "$GITHUB_OUTPUT"
 
       - name: Docker meta
         id: meta

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # =============================================================================
 
 PROD_COMPOSE := docker compose -f docker-compose.prod.yml
-APP_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+APP_VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo dev)
 
 .PHONY: install-hooks dev dev-lite dev-autoreload dev-reset prod prod-lite prod-reset
 

--- a/frontend/ui/next.config.js
+++ b/frontend/ui/next.config.js
@@ -4,7 +4,7 @@ const path = require("path");
 function resolveAppVersion() {
   if (process.env.APP_VERSION) return process.env.APP_VERSION;
   try {
-    return execSync("git describe --tags --always --dirty", {
+    return execSync("git describe --tags --abbrev=0", {
       cwd: path.join(__dirname, "../"),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],

--- a/frontend/ui/src/__tests__/next-config.test.ts
+++ b/frontend/ui/src/__tests__/next-config.test.ts
@@ -20,7 +20,7 @@ describe("next.config.js env block", () => {
   it("falls back to git describe when APP_VERSION is unset", async () => {
     delete process.env.APP_VERSION;
     const config = await import("../../next.config.js");
-    const expected = execSync("git describe --tags --always --dirty", {
+    const expected = execSync("git describe --tags --abbrev=0", {
       cwd: new URL("../../", import.meta.url),
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],

--- a/frontend/ui/src/__tests__/next-config.test.ts
+++ b/frontend/ui/src/__tests__/next-config.test.ts
@@ -17,14 +17,21 @@ describe("next.config.js env block", () => {
     expect(config.default.env.NEXT_PUBLIC_APP_VERSION).toBe("v0.2.0");
   });
 
-  it("falls back to git describe when APP_VERSION is unset", async () => {
+  it("falls back to git describe (or 'dev' when no tag is reachable) when APP_VERSION is unset", async () => {
     delete process.env.APP_VERSION;
     const config = await import("../../next.config.js");
-    const expected = execSync("git describe --tags --abbrev=0", {
-      cwd: new URL("../../", import.meta.url),
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
+    // Mirror resolveAppVersion(): git describe, falling back to "dev" when it
+    // throws (e.g. a shallow CI checkout with no tags fetched).
+    let expected: string;
+    try {
+      expected = execSync("git describe --tags --abbrev=0", {
+        cwd: new URL("../../", import.meta.url),
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {
+      expected = "dev";
+    }
     expect(config.default.env.NEXT_PUBLIC_APP_VERSION).toBe(expected);
   });
 


### PR DESCRIPTION
## What

PR #1233 wired the sidebar version badge to `git describe --tags --always --dirty`, which renders verbose strings like `v0.3.0-6-ga0d61e62-dirty` that wrap awkwardly across three lines in the header. This switches all version-resolution sites to `git describe --tags --abbrev=0` so the badge shows just the latest release tag (e.g. `v0.3.0`).

## Changes

- **`frontend/ui/next.config.js`** — local-dev fallback
- **`Makefile`** — `make prod` docker build arg
- **`.github/workflows/docker-images.yml`** — CI-built prod images (this is what determines the deployed badge). Added `2>/dev/null || echo dev` since `--abbrev=0` errors on a tagless checkout, unlike `--always`.
- **`frontend/ui/src/__tests__/next-config.test.ts`** — updated expected value to match the new flags

The `APP_VERSION` env override and the `"dev"` fallback are unchanged.

## Notes

Prod picks this up only after the change is on `main`, CI rebuilds images with `APP_VERSION=v0.3.0` baked in, and that image tag is deployed. Terraform alone does not recompute the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clean release tag in the sidebar version badge by switching to the latest tag (e.g. v0.3.0). This removes noisy suffixes and prevents multi-line wrapping.

- **Bug Fixes**
  - Use `git describe --tags --abbrev=0` in `frontend/ui/next.config.js`, `Makefile`, and `.github/workflows/docker-images.yml`.
  - Add `2>/dev/null || echo dev` (or try/catch) fallback for tagless/shallow checkouts; `APP_VERSION` override unchanged.
  - Update `frontend/ui/src/__tests__/next-config.test.ts` to mirror the fallback so CI without tags resolves to "dev".

<sup>Written for commit a3ef01f0dd932823cf742c9a9848d0440621a534. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

