### PR TITLE
fix(ui): clear stale model provider test result

### DIFF
--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ModelProvidersTab } from "./ModelProvidersTab";
+
+const mocks = vi.hoisted(() => ({
+  getModelProviders: vi.fn(),
+  createModelProvider: vi.fn(),
+  updateModelProvider: vi.fn(),
+  deleteModelProvider: vi.fn(),
+  testModelProvider: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getModelProviders: mocks.getModelProviders,
+  createModelProvider: mocks.createModelProvider,
+  updateModelProvider: mocks.updateModelProvider,
+  deleteModelProvider: mocks.deleteModelProvider,
+  testModelProvider: mocks.testModelProvider,
+}));
+
+function renderWithQueryClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ModelProvidersTab workspaceId="workspace-1" />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ModelProvidersTab", () => {
+  function mockExistingProvider() {
+    mocks.getModelProviders.mockResolvedValue({
+      byokEnabled: true,
+      providers: [
+        {
+          id: "provider-1",
+          adapter: "openai",
+          provider: "OpenAI",
+          keyPreview: "sk-...",
+          baseUrl: "http://localhost:9999",
+          customModels: [],
+          withDefaultModels: true,
+          config: null,
+          enabled: true,
+          createdBy: "user-1",
+          createTime: "2026-06-24T00:00:00.000Z",
+          updateTime: "2026-06-24T00:00:00.000Z",
+        },
+      ],
+    });
+  }
+
+  it("clears a stale connection test result when the Base URL changes", async () => {
+    mockExistingProvider();
+    mocks.testModelProvider.mockResolvedValue({
+      success: false,
+      error: "Unable to connect",
+    });
+
+    renderWithQueryClient();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Test Connection" }));
+
+    expect(await screen.findByText("Unable to connect")).toBeTruthy();
+
+    fireEvent.change(screen.getByPlaceholderText("Default: https://api.openai.com/v1"), {
+      target: { value: "https://api.openai.com/v1" },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Unable to connect")).toBeNull();
+    });
+  });
+
+  it("ignores an older in-flight connection test after the Base URL changes", async () => {
+    mockExistingProvider();
+    let resolveTest: (result: { success: boolean; error?: string }) => void = () => {};
+    mocks.testModelProvider.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTest = resolve;
+      }),
+    );
+
+    renderWithQueryClient();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Edit" }));
+    fireEvent.click(screen.getByRole("button", { name: "Test Connection" }));
+
+    await waitFor(() => expect(mocks.testModelProvider).toHaveBeenCalledTimes(1));
+
+    fireEvent.change(screen.getByPlaceholderText("Default: https://api.openai.com/v1"), {
+      target: { value: "https://api.openai.com/v1" },
+    });
+
+    await act(async () => {
+      resolveTest({ success: false, error: "Unable to connect" });
+    });
+
+    expect(screen.queryByText("Unable to connect")).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus, Loader2, CheckCircle2, XCircle, ArrowUpRight, X } from "lucide-react";
 import { ProviderIcon } from "@/components/icons/provider-icons";
@@ -57,6 +57,7 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
   const [baseUrl, setBaseUrl] = useState("");
   const [customModels, setCustomModels] = useState<string[]>([]);
   const [testResult, setTestResult] = useState<{ success: boolean; error?: string } | null>(null);
+  const testRequestVersionRef = useRef(0);
   const [saveError, setSaveError] = useState<string | null>(null);
   // Per-model API protocol overrides: modelId -> protocol
   const [modelProtocols, setModelProtocols] = useState<Record<string, string>>({});
@@ -103,9 +104,13 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
   });
 
   const testMutation = useMutation({
-    mutationFn: (input: Parameters<typeof testModelProvider>[1]) =>
+    mutationFn: ({ input }: { input: Parameters<typeof testModelProvider>[1]; version: number }) =>
       testModelProvider(workspaceId, input),
-    onSuccess: (result) => setTestResult(result),
+    onSuccess: (result, variables) => {
+      if (variables.version === testRequestVersionRef.current) {
+        setTestResult(result);
+      }
+    },
   });
 
   function closeDialog() {
@@ -217,7 +222,15 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     }
     if (baseUrl) testData.baseUrl = baseUrl;
     setTestResult(null);
-    testMutation.mutate(testData as any);
+    testMutation.mutate({
+      input: testData as Parameters<typeof testModelProvider>[1],
+      version: testRequestVersionRef.current,
+    });
+  }
+
+  function invalidateTestResult() {
+    testRequestVersionRef.current += 1;
+    setTestResult(null);
   }
 
   function handleAdapterChange(value: string) {
@@ -503,7 +516,10 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                 </label>
                 <Input
                   value={baseUrl}
-                  onChange={(e) => setBaseUrl(e.target.value)}
+                  onChange={(e) => {
+                    setBaseUrl(e.target.value);
+                    invalidateTestResult();
+                  }}
                   placeholder={
                     adapterConfig.requiresBaseUrl
                       ? "https://your-resource.openai.azure.com"


### PR DESCRIPTION
Fixes #1321

## Summary

Clears the model provider connection test result when the Base URL changes after a test has already run, and ignores older in-flight test responses after the Base URL has changed.

## Type of Change

- [x] fix - A bug fix
- [x] test - Adding missing tests or correcting existing tests

## Details

- Clears stale connection-test feedback from the Base URL input handler.
- Tracks a local test request version so older in-flight connection-test responses cannot repopulate stale pass/fail feedback after the Base URL changes.
- Keeps the existing API key behavior unchanged.
- Adds focused UI regression tests for both visible stale feedback and the in-flight response race.

## Screenshots / Recordings (if applicable)

I can add a short screen recording showing the stale Base URL test result before and after the fix.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

Validation:

- pnpm exec vitest run src/features/settings/workspace/components/ModelProvidersTab.test.tsx
- pnpm exec prettier --check src/features/settings/workspace/components/ModelProvidersTab.tsx src/features/settings/workspace/components/ModelProvidersTab.test.tsx
- pnpm exec eslint src/features/settings/workspace/components/ModelProvidersTab.tsx src/features/settings/workspace/components/ModelProvidersTab.test.tsx

Note: ESLint passes with no errors. It reports existing no-explicit-any warnings in ModelProvidersTab.tsx around existing mutation calls.

[screen-capture.webm](https://github.com/user-attachments/assets/5e513e4b-3bbc-46b7-979b-ea1e7b5d32fb)
