### PR TITLE
fix(ci): clean release tag in custom-branch image build (staging path)

### DIFF
--- a/.github/workflows/_docker-images-custom.yml
+++ b/.github/workflows/_docker-images-custom.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Resolve app version
         id: app_version
-        run: echo "value=$(git describe --tags --always --dirty)" >> "$GITHUB_OUTPUT"
+        run: echo "value=$(git describe --tags --abbrev=0 2>/dev/null || echo dev)" >> "$GITHUB_OUTPUT"
 
       - name: Sanitize branch ref for Docker tag
         id: sanitize


### PR DESCRIPTION
## What

Follow-up to #1320. That PR switched the version stamp to `git describe --tags --abbrev=0` in `next.config.js`, the `Makefile`, and `docker-images.yml` — but missed **`_docker-images-custom.yml`**, the `workflow_dispatch` build used for staging / custom-prefix images.

That workflow still baked `git describe --tags --always --dirty` into the `APP_VERSION` build arg, so staging's sidebar badge showed e.g. `v0.3.0-9-g2d0b94` instead of `v0.3.0`.

## Change

`_docker-images-custom.yml` line 74 → `git describe --tags --abbrev=0 2>/dev/null || echo dev` (same form as the other build paths; the guard handles a tagless checkout, which `--abbrev=0` errors on unlike `--always`).

## To actually fix staging

Merging this is not enough on its own — the staging web image must be **rebuilt** via this workflow (with the env prefix) and the deployment rolled to pick it up:
1. Merge.
2. Re-run **Build Docker Images (Custom Branch)** for the staging prefix at the target ref.
3. Roll the `web` deployment to the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align custom-branch Docker image builds with other paths by using a clean release tag for `APP_VERSION`. This fixes staging’s sidebar badge so it shows `v0.3.0` instead of `v0.3.0-9-g2d0b94` by updating `_docker-images-custom.yml` to `git describe --tags --abbrev=0 2>/dev/null || echo dev`.

- **Migration**
  - Merge.
  - Re-run "Build Docker Images (Custom Branch)" for the staging prefix at the target ref.
  - Roll the `web` deployment to the new image.

<sup>Written for commit b9454b89f78b13a44c345f7ae67e2eaad74e929c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

