### PR TITLE
feat(ui): add sample trace onboarding

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -4,7 +4,10 @@ These endpoints are protected by X-Internal-Secret header and not exposed public
 """
 
 import hmac
-from datetime import datetime
+import json
+import uuid
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
@@ -56,6 +59,11 @@ class UsageDetailsResponse(BaseModel):
     traces: int
     spans: int
     detector_runs: int = 0
+
+
+class SampleTraceResponse(BaseModel):
+    trace_id: str
+    span_count: int
 
 
 @router.get(
@@ -189,6 +197,136 @@ async def get_usage_details(
     )
 
     return UsageDetailsResponse(traces=traces, spans=spans, detector_runs=detector_runs)
+
+
+# =============================================================================
+# Demo Data Endpoints
+# =============================================================================
+
+
+def _sample_span_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+@router.post(
+    "/projects/{project_id}/sample-trace",
+    response_model=SampleTraceResponse,
+    dependencies=[Depends(verify_internal_secret)],
+)
+async def create_sample_trace(project_id: str) -> SampleTraceResponse:
+    """Create a realistic sample trace so users can explore without an LLM key."""
+    now = datetime.now(UTC).replace(tzinfo=None)
+    trace_id = uuid.uuid4().hex
+    root_span_id = _sample_span_id()
+    plan_span_id = _sample_span_id()
+    tool_span_id = _sample_span_id()
+    llm_span_id = _sample_span_id()
+
+    trace = {
+        "trace_id": trace_id,
+        "project_id": project_id,
+        "trace_start_time": now,
+        "name": "Sample support agent run",
+        "user_id": "demo-user",
+        "session_id": "demo-session",
+        "git_ref": "demo",
+        "git_repo": "traceroot-ai/traceroot",
+        "input": json.dumps(
+            {"message": "User asks why their payment failed and wants a concise answer."}
+        ),
+        "output": json.dumps(
+            {
+                "answer": (
+                    "The payment failed because the card was declined. The agent suggested "
+                    "retrying with a different card and linked the billing page."
+                )
+            }
+        ),
+        "metadata": json.dumps({"source": "sample-trace", "created_by": "onboarding"}),
+    }
+
+    spans = [
+        {
+            "span_id": root_span_id,
+            "trace_id": trace_id,
+            "parent_span_id": None,
+            "project_id": project_id,
+            "span_start_time": now,
+            "span_end_time": now + timedelta(milliseconds=920),
+            "name": "support_agent.respond",
+            "span_kind": "AGENT",
+            "status": "OK",
+            "input": trace["input"],
+            "output": trace["output"],
+            "metadata": json.dumps({"demo": True, "step": "root"}),
+        },
+        {
+            "span_id": plan_span_id,
+            "trace_id": trace_id,
+            "parent_span_id": root_span_id,
+            "project_id": project_id,
+            "span_start_time": now + timedelta(milliseconds=45),
+            "span_end_time": now + timedelta(milliseconds=180),
+            "name": "agent.plan",
+            "span_kind": "AGENT",
+            "status": "OK",
+            "input": json.dumps({"goal": "Diagnose billing failure"}),
+            "output": json.dumps({"plan": ["check account", "inspect last payment", "reply"]}),
+            "metadata": json.dumps({"demo": True, "step": "planning"}),
+        },
+        {
+            "span_id": tool_span_id,
+            "trace_id": trace_id,
+            "parent_span_id": root_span_id,
+            "project_id": project_id,
+            "span_start_time": now + timedelta(milliseconds=210),
+            "span_end_time": now + timedelta(milliseconds=420),
+            "name": "tool.lookup_payment",
+            "span_kind": "TOOL",
+            "status": "OK",
+            "input": json.dumps({"customer_id": "demo-user", "invoice": "inv_demo_42"}),
+            "output": json.dumps({"status": "failed", "reason": "card_declined"}),
+            "metadata": json.dumps({"demo": True, "tool": "billing"}),
+        },
+        {
+            "span_id": llm_span_id,
+            "trace_id": trace_id,
+            "parent_span_id": root_span_id,
+            "project_id": project_id,
+            "span_start_time": now + timedelta(milliseconds=460),
+            "span_end_time": now + timedelta(milliseconds=905),
+            "name": "llm.generate_user_reply",
+            "span_kind": "LLM",
+            "status": "OK",
+            "model_name": "demo-model",
+            "cost": Decimal("0.00042"),
+            "input_tokens": 278,
+            "output_tokens": 86,
+            "total_tokens": 364,
+            "usage_details": {"input": 278, "output": 86},
+            "input": json.dumps(
+                {
+                    "system": "Answer support questions clearly.",
+                    "context": "Payment lookup returned card_declined.",
+                }
+            ),
+            "output": json.dumps(
+                {
+                    "message": (
+                        "Your payment was declined by the card provider. Please retry with "
+                        "another card or update billing details."
+                    )
+                }
+            ),
+            "metadata": json.dumps({"demo": True, "provider": "sample"}),
+        },
+    ]
+
+    ch = get_clickhouse_client()
+    ch.insert_traces_batch([trace])
+    ch.insert_spans_batch(spans)
+
+    return SampleTraceResponse(trace_id=trace_id, span_count=len(spans))
 
 
 # =============================================================================

--- a/docs/tracing/get-started.mdx
+++ b/docs/tracing/get-started.mdx
@@ -10,16 +10,8 @@ Create API Keys either with [TraceRoot Cloud](https://app.traceroot.ai) or [Self
 ## 2. Install the SDK
 
 <Tabs>
-  <Tab title="Python">
-    ```bash
-    pip install traceroot
-    ```
-  </Tab>
-  <Tab title="TypeScript">
-    ```bash
-    npm install @traceroot-ai/traceroot
-    ```
-  </Tab>
+  <Tab title="Python">```bash pip install traceroot ```</Tab>
+  <Tab title="TypeScript">```bash npm install @traceroot-ai/traceroot ```</Tab>
 </Tabs>
 
 ## 3. Set Environment Variables
@@ -45,6 +37,7 @@ TRACEROOT_HOST_URL=https://app.traceroot.ai  # or your self-hosted URL
 
     client = OpenAI()
     ```
+
   </Tab>
   <Tab title="TypeScript">
     Add a single line at the start of your application to instrument all OpenAI API calls.
@@ -58,6 +51,7 @@ TRACEROOT_HOST_URL=https://app.traceroot.ai  # or your self-hosted URL
 
     const openai = new OpenAI();
     ```
+
   </Tab>
 </Tabs>
 
@@ -66,6 +60,8 @@ For full SDK details, see the [Python SDK](/tracing/python-sdk) or [TypeScript S
 ## 5. View Your Traces
 
 Open [TraceRoot Cloud](https://app.traceroot.ai) (or your self-hosted dashboard), navigate to your project, and you'll see the full span hierarchy, token usage, cost, and timing.
+
+If your project does not have traces yet, use **Create sample trace** on the empty tracing page to generate a demo agent trace without configuring an app, SDK integration, or LLM provider key.
 
 Prefer the terminal? The [TraceRoot CLI](/cli/get-started) lists, inspects, and exports the same traces without leaving your shell.
 

--- a/docs/tracing/get-started.mdx
+++ b/docs/tracing/get-started.mdx
@@ -10,8 +10,16 @@ Create API Keys either with [TraceRoot Cloud](https://app.traceroot.ai) or [Self
 ## 2. Install the SDK
 
 <Tabs>
-  <Tab title="Python">```bash pip install traceroot ```</Tab>
-  <Tab title="TypeScript">```bash npm install @traceroot-ai/traceroot ```</Tab>
+  <Tab title="Python">
+    ```bash
+    pip install traceroot
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```bash
+    npm install @traceroot-ai/traceroot
+    ```
+  </Tab>
 </Tabs>
 
 ## 3. Set Environment Variables

--- a/frontend/ui/src/app/api/projects/[projectId]/sample-trace/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/sample-trace/route.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@traceroot/core", () => ({ Role: { MEMBER: "MEMBER" } }));
+vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({
+    status,
+    json: async () => data,
+  }),
+}));
+
+import { POST } from "./route";
+
+function makeParams() {
+  return { params: Promise.resolve({ projectId: "proj-1" }) };
+}
+
+beforeEach(() => {
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 201,
+    json: async () => ({ trace_id: "trace-1", span_count: 4 }),
+  }) as typeof fetch;
+});
+
+describe("POST .../sample-trace", () => {
+  it("requires member project access before creating the sample trace", async () => {
+    await POST({} as Request, makeParams());
+
+    expect(requireProjectAccessMock).toHaveBeenCalledWith("user-1", "proj-1", "MEMBER");
+  });
+
+  it("calls the internal sample-trace endpoint with the internal secret", async () => {
+    const res = await POST({} as Request, makeParams());
+
+    expect(res.status).toBe(201);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://localhost:8000/api/v1/internal/projects/proj-1/sample-trace",
+      {
+        method: "POST",
+        headers: { "X-Internal-Secret": "test-secret" },
+      },
+    );
+    await expect(res.json()).resolves.toEqual({ trace_id: "trace-1", span_count: 4 });
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/sample-trace/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/sample-trace/route.ts
@@ -1,0 +1,39 @@
+import { Role } from "@traceroot/core";
+import { env } from "@/env";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+const BACKEND_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
+
+// POST /api/projects/[projectId]/sample-trace - create a demo trace for onboarding.
+export async function POST(_request: Request, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { user } = authResult;
+
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/v1/internal/projects/${projectId}/sample-trace`, {
+      method: "POST",
+      headers: { "X-Internal-Secret": env.INTERNAL_API_SECRET },
+    });
+
+    const data = await res.json().catch(() => null);
+    if (!res.ok) {
+      return errorResponse(data?.detail || "Failed to create sample trace", res.status);
+    }
+
+    return successResponse(data, 201);
+  } catch {
+    return errorResponse("Failed to create sample trace", 500);
+  }
+}

--- a/frontend/ui/src/features/traces/components/GettingStarted/SampleTraceButton.test.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/SampleTraceButton.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const pushMock = vi.fn();
+const createSampleTraceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  createSampleTrace: (...args: unknown[]) => createSampleTraceMock(...args),
+}));
+
+import { SampleTraceButton } from "./SampleTraceButton";
+
+function renderButton() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <SampleTraceButton projectId="proj-1" />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  pushMock.mockReset();
+  createSampleTraceMock.mockReset();
+});
+
+describe("SampleTraceButton", () => {
+  it("creates a sample trace and opens it", async () => {
+    createSampleTraceMock.mockResolvedValue({ trace_id: "trace-1", span_count: 4 });
+
+    renderButton();
+    fireEvent.click(screen.getByRole("button", { name: "Create sample trace" }));
+
+    await waitFor(() => {
+      expect(createSampleTraceMock).toHaveBeenCalledWith("proj-1");
+    });
+    expect(pushMock).toHaveBeenCalledWith("/projects/proj-1/traces?traceId=trace-1&fullscreen=1");
+  });
+
+  it("shows an error when sample trace creation fails", async () => {
+    createSampleTraceMock.mockRejectedValue(new Error("boom"));
+
+    renderButton();
+    fireEvent.click(screen.getByRole("button", { name: "Create sample trace" }));
+
+    expect(
+      await screen.findByText("Couldn't create the sample trace. Please try again."),
+    ).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/features/traces/components/GettingStarted/SampleTraceButton.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/SampleTraceButton.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { createSampleTrace } from "@/lib/api";
+
+interface SampleTraceButtonProps {
+  projectId: string;
+}
+
+export function SampleTraceButton({ projectId }: SampleTraceButtonProps) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: () => createSampleTrace(projectId),
+    onSuccess: async (trace) => {
+      await queryClient.invalidateQueries({ queryKey: ["traces", projectId] });
+      await queryClient.invalidateQueries({ queryKey: ["trace", projectId, trace.trace_id] });
+      router.push(`/projects/${projectId}/traces?traceId=${trace.trace_id}&fullscreen=1`);
+    },
+  });
+
+  return (
+    <div className="rounded-sm border border-border bg-muted/30 px-4 py-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-medium text-foreground">Want to see TraceRoot first?</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Create a sample agent trace without configuring an app or LLM provider.
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 shrink-0 text-xs"
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending}
+        >
+          {mutation.isPending ? "Creating..." : "Create sample trace"}
+        </Button>
+      </div>
+      {mutation.isError && (
+        <p className="mt-2 text-xs text-destructive">
+          Couldn&apos;t create the sample trace. Please try again.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
+++ b/frontend/ui/src/features/traces/components/GettingStarted/index.tsx
@@ -5,6 +5,7 @@ import { Sparkle, Code2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AITab } from "./AITab";
 import { ManualTab } from "./ManualTab";
+import { SampleTraceButton } from "./SampleTraceButton";
 
 type Tab = "ai" | "manual";
 
@@ -24,6 +25,10 @@ export function GettingStarted({ projectId }: GettingStartedProps) {
         <p className="mt-1 text-sm text-muted-foreground">
           You don&apos;t have any traces yet. Choose how you&apos;d like to set up.
         </p>
+
+        <div className="mt-5">
+          <SampleTraceButton projectId={projectId} />
+        </div>
 
         <div className="mt-6 inline-flex gap-0.5 rounded-sm border border-border bg-muted p-0.5">
           <button

--- a/frontend/ui/src/lib/api/index.ts
+++ b/frontend/ui/src/lib/api/index.ts
@@ -58,7 +58,7 @@ export {
 } from "./model-providers";
 
 // Trace APIs
-export { getTraces, getTrace, getSpanIO } from "./traces";
+export { getTraces, getTrace, getSpanIO, createSampleTrace } from "./traces";
 
 // Re-export all types from types/api.ts for backward compatibility
 export type {

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -1,8 +1,13 @@
 /**
  * Trace API functions (Python backend - ClickHouse)
  */
-import { fetchTraceApi, type TraceApiUser } from "./client";
+import { fetchNextApi, fetchTraceApi, type TraceApiUser } from "./client";
 import type { SpanIO, TraceDetail, TraceListResponse, TraceQueryOptions } from "@/types/api";
+
+export interface SampleTraceResponse {
+  trace_id: string;
+  span_count: number;
+}
 
 export async function getTraces(
   projectId: string,
@@ -50,4 +55,10 @@ export async function getSpanIO(
     {},
     user,
   );
+}
+
+export async function createSampleTrace(projectId: string): Promise<SampleTraceResponse> {
+  return fetchNextApi<SampleTraceResponse>(`/projects/${projectId}/sample-trace`, {
+    method: "POST",
+  });
 }

--- a/tests/rest/test_internal_sample_trace.py
+++ b/tests/rest/test_internal_sample_trace.py
@@ -1,0 +1,28 @@
+from rest.routers.internal import create_sample_trace
+
+
+class FakeClickHouse:
+    def __init__(self):
+        self.traces = []
+        self.spans = []
+
+    def insert_traces_batch(self, traces):
+        self.traces.extend(traces)
+
+    def insert_spans_batch(self, spans):
+        self.spans.extend(spans)
+
+
+async def test_create_sample_trace_inserts_realistic_trace(monkeypatch):
+    fake = FakeClickHouse()
+    monkeypatch.setattr("rest.routers.internal.get_clickhouse_client", lambda: fake)
+
+    response = await create_sample_trace("proj-1")
+
+    assert response.span_count == 4
+    assert len(response.trace_id) == 32
+    assert fake.traces[0]["project_id"] == "proj-1"
+    assert fake.traces[0]["name"] == "Sample support agent run"
+    assert {span["span_kind"] for span in fake.spans} == {"AGENT", "TOOL", "LLM"}
+    assert fake.spans[0]["parent_span_id"] is None
+    assert all(span["trace_id"] == response.trace_id for span in fake.spans)


### PR DESCRIPTION
Fixes #1324

## Summary

Adds a first-run sample trace action to the empty tracing onboarding state so users can explore TraceRoot without first configuring an app, SDK integration, or LLM provider key.

## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies
- [ ] ci - Changes to CI configuration files and scripts
- [ ] chore - Other changes that do not modify src or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Adds an internal backend endpoint that creates a realistic sample trace for a project.
- Adds an authenticated Next.js route that checks project member access before calling the internal endpoint.
- Adds a small empty-state card/button to create the sample trace and open it fullscreen.
- Includes root agent, planning, tool, and LLM spans so the trace UI is explorable without external setup.

I noticed the feature request template asks contributors to wait for approval on new features. I opened the linked issue first and am sharing this PR as a concrete implementation proposal; happy to adjust scope or close it if the direction is not right.

## Screenshots / Recordings (if applicable)

I will add before/after screenshots in the PR conversation showing the empty tracing page and the generated sample trace.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

## Testing

- `uv run ruff format backend/rest/routers/internal.py tests/rest/test_internal_sample_trace.py`
- `uv run ruff check backend/rest/routers/internal.py tests/rest/test_internal_sample_trace.py`
- `uv run pytest tests/rest/test_internal_sample_trace.py`
- `pnpm --dir frontend/ui exec prettier --write frontend/ui/src/app/api/projects/[projectId]/sample-trace/route.ts frontend/ui/src/app/api/projects/[projectId]/sample-trace/route.test.ts frontend/ui/src/features/traces/components/GettingStarted/SampleTraceButton.tsx frontend/ui/src/features/traces/components/GettingStarted/SampleTraceButton.test.tsx frontend/ui/src/features/traces/components/GettingStarted/index.tsx frontend/ui/src/lib/api/index.ts frontend/ui/src/lib/api/traces.ts`
- `pnpm --dir frontend/ui exec vitest run src/app/api/projects/[projectId]/sample-trace/route.test.ts src/features/traces/components/GettingStarted/SampleTraceButton.test.tsx`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-run sample trace so new projects can explore tracing without any setup. Users can generate a realistic demo trace from the empty state and open it in fullscreen immediately.

- **New Features**
  - Backend internal endpoint `POST /api/v1/internal/projects/:project_id/sample-trace` that creates a realistic trace with agent, planning, tool, and LLM spans and returns `{ trace_id, span_count }`.
  - Authenticated Next.js route `POST /api/projects/[projectId]/sample-trace` that requires member access (`@traceroot/core` Role.MEMBER) and forwards the request with `X-Internal-Secret`.
  - UI: Added an empty-state card with a “Create sample trace” button. On success, it invalidates trace queries and navigates to `/projects/[projectId]/traces?traceId=...&fullscreen=1`.
  - Docs: Updated Get Started to mention the “Create sample trace” option for empty projects and restored tab code fences.

<sup>Written for commit a07811ac80f77401bc72537a14fdbf114ee465af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

