### PR TITLE
feat(api): list detector runs by trace

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -339,6 +339,9 @@ async def list_detector_runs(
 
     where_clause = " AND ".join(conditions)
 
+    # Read both tables with FINAL so pre-merge ReplacingMergeTree duplicates (a
+    # retried run/finding re-written under the same deterministic id) don't fan
+    # out the LEFT JOIN into duplicate rows or inflate the paginated count.
     data_query = f"""
         SELECT
             r.run_id      AS run_id,
@@ -349,8 +352,8 @@ async def list_detector_runs(
             r.status      AS status,
             r.timestamp   AS timestamp,
             {summary_expr} AS summary
-        FROM detector_runs r
-        LEFT JOIN detector_findings f
+        FROM (SELECT * FROM detector_runs FINAL) AS r
+        LEFT JOIN (SELECT * FROM detector_findings FINAL) AS f
           ON r.finding_id = f.finding_id AND r.project_id = f.project_id
         WHERE {where_clause}
         ORDER BY r.timestamp DESC
@@ -361,8 +364,8 @@ async def list_detector_runs(
 
     count_query = f"""
         SELECT count()
-        FROM detector_runs r
-        LEFT JOIN detector_findings f
+        FROM (SELECT * FROM detector_runs FINAL) AS r
+        LEFT JOIN (SELECT * FROM detector_findings FINAL) AS f
           ON r.finding_id = f.finding_id AND r.project_id = f.project_id
         WHERE {where_clause}
     """

--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -586,6 +586,76 @@ async def get_trace_findings(trace_id: str, project_id: str):
 
 
 @router.get(
+    "/traces/{trace_id}/detector-runs",
+    dependencies=[Depends(verify_internal_secret)],
+)
+async def list_trace_detector_runs(trace_id: str, project_id: str):
+    """List every detector run recorded against a single trace.
+
+    Both ``detector_runs`` and ``detector_findings`` are ReplacingMergeTree
+    tables that can hold pre-merge duplicates (a run/finding may be re-written
+    under the same deterministic id on a retry), so both are read with
+    ``FINAL`` to collapse to one row apiece. Triggered runs LEFT JOIN their
+    finding to surface this detector's per-detector summary string; clean runs
+    have a null ``finding_id`` and an empty summary.
+
+    Args:
+        trace_id (str): Trace whose detector runs to return.
+        project_id (str): Project that owns the trace; scopes the query.
+
+    Returns:
+        dict: ``{"runs": list[dict]}`` ordered by ``detector_id``, each run a
+            dict of ``run_id``, ``detector_id``, ``project_id``, ``trace_id``,
+            ``finding_id`` (``None`` for clean runs), ``status``, ISO-8601
+            ``timestamp`` and ``summary``. Empty when the trace has no runs.
+    """
+    ch = get_clickhouse_client()
+
+    # Per-detector summary expression; identical to list_detector_runs so the
+    # meaning of "the summary for this detector" stays in one place.
+    summary_expr = (
+        "if("
+        "  r.finding_id IS NOT NULL,"
+        "  JSONExtractString("
+        "    arrayFirst("
+        "      x -> JSONExtractString(x, 'detectorId') = r.detector_id,"
+        "      JSONExtractArrayRaw(f.payload)"
+        "    ),"
+        "    'summary'"
+        "  ),"
+        "  ''"
+        ")"
+    )
+
+    query = f"""
+        SELECT
+            r.run_id      AS run_id,
+            r.detector_id AS detector_id,
+            r.project_id  AS project_id,
+            r.trace_id    AS trace_id,
+            r.finding_id  AS finding_id,
+            r.status      AS status,
+            r.timestamp   AS timestamp,
+            {summary_expr} AS summary
+        FROM (SELECT * FROM detector_runs FINAL) AS r
+        LEFT JOIN (SELECT * FROM detector_findings FINAL) AS f
+          ON r.finding_id = f.finding_id AND r.project_id = f.project_id
+        WHERE r.trace_id = {{trace_id:String}}
+          AND r.project_id = {{project_id:String}}
+        ORDER BY r.detector_id
+    """
+    result = ch.query(query, parameters={"trace_id": trace_id, "project_id": project_id})
+
+    runs = []
+    for row in result.result_rows:
+        row_dict = dict(zip(result.column_names, row))
+        if hasattr(row_dict.get("timestamp"), "isoformat"):
+            row_dict["timestamp"] = row_dict["timestamp"].isoformat()
+        runs.append(row_dict)
+    return {"runs": runs}
+
+
+@router.get(
     "/detector-counts",
     response_model=DetectorCountsResponse,
     dependencies=[Depends(verify_internal_secret)],

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -282,6 +282,29 @@ class TestListDetectorRuns:
         assert "start_after" not in data_sql
         assert "end_before" not in data_sql
 
+    def test_data_query_dedups_both_sides(self, client, mock_ch, secret):
+        """Pre-merge ReplacingMergeTree duplicates must not fan out the JOIN."""
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(1)]
+        client.get(
+            "/api/v1/internal/detector-runs",
+            params={"project_id": "p1", "detector_id": "d1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        data_sql = mock_ch.query.call_args_list[0].args[0]
+        assert "(SELECT * FROM detector_runs FINAL) AS r" in data_sql
+        assert "(SELECT * FROM detector_findings FINAL) AS f" in data_sql
+
+    def test_count_query_dedups_both_sides(self, client, mock_ch, secret):
+        mock_ch.query.side_effect = [self._fake_data(), self._fake_count(1)]
+        client.get(
+            "/api/v1/internal/detector-runs",
+            params={"project_id": "p1", "detector_id": "d1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        count_sql = mock_ch.query.call_args_list[1].args[0]
+        assert "(SELECT * FROM detector_runs FINAL) AS r" in count_sql
+        assert "(SELECT * FROM detector_findings FINAL) AS f" in count_sql
+
 
 # =============================================================================
 # /traces/{trace_id}/detector-runs

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -284,6 +284,100 @@ class TestListDetectorRuns:
 
 
 # =============================================================================
+# /traces/{trace_id}/detector-runs
+# =============================================================================
+
+
+class TestListTraceDetectorRuns:
+    TS = datetime(2026, 6, 24, 12, 30, 45)
+
+    def _fake_data(self):
+        return _make_query_result(
+            rows=[
+                ("r1", "d-a", "p1", "trace-1", "f1", "triggered", self.TS, "Found it"),
+                ("r2", "d-b", "p1", "trace-1", None, "clean", self.TS, ""),
+            ],
+            column_names=[
+                "run_id",
+                "detector_id",
+                "project_id",
+                "trace_id",
+                "finding_id",
+                "status",
+                "timestamp",
+                "summary",
+            ],
+        )
+
+    def test_returns_runs_envelope_with_each_field(self, client, mock_ch, secret):
+        mock_ch.query.return_value = self._fake_data()
+        resp = client.get(
+            "/api/v1/internal/traces/trace-1/detector-runs",
+            params={"project_id": "p1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert set(body.keys()) == {"runs"}
+        runs = body["runs"]
+        assert len(runs) == 2
+
+        assert runs[0] == {
+            "run_id": "r1",
+            "detector_id": "d-a",
+            "project_id": "p1",
+            "trace_id": "trace-1",
+            "finding_id": "f1",
+            "status": "triggered",
+            "timestamp": self.TS.isoformat(),
+            "summary": "Found it",
+        }
+        assert runs[1] == {
+            "run_id": "r2",
+            "detector_id": "d-b",
+            "project_id": "p1",
+            "trace_id": "trace-1",
+            "finding_id": None,
+            "status": "clean",
+            "timestamp": self.TS.isoformat(),
+            "summary": "",
+        }
+
+    def test_filters_by_trace_and_project(self, client, mock_ch, secret):
+        mock_ch.query.return_value = _make_query_result(rows=[], column_names=[])
+        resp = client.get(
+            "/api/v1/internal/traces/trace-9/detector-runs",
+            params={"project_id": "p9"},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        mock_ch.query.assert_called_once()
+        params = mock_ch.query.call_args.kwargs["parameters"]
+        assert params == {"trace_id": "trace-9", "project_id": "p9"}
+        sql = mock_ch.query.call_args.args[0]
+        assert "r.trace_id = {trace_id:String}" in sql
+        assert "r.project_id = {project_id:String}" in sql
+
+    def test_uses_final_on_both_tables(self, client, mock_ch, secret):
+        mock_ch.query.return_value = _make_query_result(rows=[], column_names=[])
+        client.get(
+            "/api/v1/internal/traces/trace-1/detector-runs",
+            params={"project_id": "p1"},
+            headers={"X-Internal-Secret": secret},
+        )
+        sql = mock_ch.query.call_args.args[0]
+        assert "detector_runs FINAL" in sql
+        assert "detector_findings FINAL" in sql
+
+    def test_missing_secret_returns_403(self, client, mock_ch):
+        resp = client.get(
+            "/api/v1/internal/traces/trace-1/detector-runs",
+            params={"project_id": "p1"},
+        )
+        assert resp.status_code == 403
+
+
+# =============================================================================
 # POST /detector-findings
 # =============================================================================
 


### PR DESCRIPTION
Part of the detector-experience epic (Section 1). **Backend slice only** — the Next.js proxy route, React hook, and Detectors-tab UI land in a separate frontend PR.

## `feat(api)` — trace detector-runs endpoint
Adds `GET /api/v1/internal/traces/{trace_id}/detector-runs?project_id=...` (internal-secret gated) returning every detector run on a trace as an unpaginated `{"runs": [...]}` envelope:

- `detector_runs` and `detector_findings` are both read with `FINAL` so pre-merge `ReplacingMergeTree` (retry) duplicates collapse to one row each.
- Each run is `LEFT JOIN`ed to its finding to surface the per-detector `summary`.
- Timestamps normalized to ISO-8601; `finding_id` is `null` / `summary` is `""` for clean runs.
- Mirrors the existing `get_trace_findings` endpoint.

## `fix(api)` — dedup `list_detector_runs` with FINAL
While building the above I found the existing `list_detector_runs` endpoint read `detector_runs LEFT JOIN detector_findings` **without `FINAL`**. A pre-merge `ReplacingMergeTree` duplicate finding (e.g. a retried finding written under the same deterministic id) fans out the `LEFT JOIN` into duplicate run rows and inflates the paginated `count()`. This wraps both tables in `FINAL` subqueries in the data **and** count queries, matching `list_detector_findings` and the new endpoint. (This is the inconsistency the new endpoint deliberately avoided — now fixed at the source.)

## Tests
`tests/rest/test_detector_endpoints.py` — the new endpoint's envelope/filter/FINAL/403 coverage, plus two dedup tests on `list_detector_runs`. **32 tests pass**; diff-coverage 100% on changed lines.

closes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
