### PR TITLE
fix(ui): preserve saved Agent Model on refresh when catalog hasn't lo…

### DIFF
--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { ModelSelector } from "./model-selector";
+import { SYSTEM_MODELS } from "@traceroot/core";
+
+const mocks = vi.hoisted(() => ({
+  data: undefined as unknown,
+  onChange: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: mocks.data }),
+}));
+
+describe("ModelSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default to undefined so it uses FALLBACK_MODELS
+    mocks.data = undefined;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("does NOT trigger onChange when saved selection has no match (preserves BYOK on refresh)", () => {
+    // The core bug #1218
+    render(
+      <ModelSelector
+        workspaceId="ws1"
+        value={{
+          model: "my-custom-model",
+          provider: "my-openai",
+          source: "byok",
+          adapter: "openai",
+        }}
+        onChange={mocks.onChange}
+      />,
+    );
+    // Since my-custom-model isn't in FALLBACK_MODELS, match is null.
+    // value.model is truthy, so it should NOT call onChange with a default.
+    expect(mocks.onChange).not.toHaveBeenCalled();
+  });
+
+  it("triggers onChange with default pick when value.model is empty", () => {
+    render(
+      <ModelSelector
+        workspaceId="ws1"
+        value={{
+          model: "",
+          provider: "",
+          source: "system",
+          adapter: "",
+        }}
+        onChange={mocks.onChange}
+      />,
+    );
+    // Should auto-pick the default model since value.model is empty
+    expect(mocks.onChange).toHaveBeenCalledOnce();
+    const callArgs = mocks.onChange.mock.calls[0][0];
+    expect(callArgs.model).toBeTruthy();
+    expect(callArgs.source).toBe("system");
+  });
+
+  it("backfills adapter on exact match if missing/stale", () => {
+    // e.g. system model exact match
+    const sysModelId = SYSTEM_MODELS[0].models[0].id;
+    const sysProvider = SYSTEM_MODELS[0].provider;
+    const sysAdapter = SYSTEM_MODELS[0].piAIProvider;
+
+    render(
+      <ModelSelector
+        workspaceId="ws1"
+        value={{
+          model: sysModelId,
+          provider: sysProvider,
+          source: "system",
+          adapter: "wrong-adapter", // stale/wrong
+        }}
+        onChange={mocks.onChange}
+      />,
+    );
+
+    expect(mocks.onChange).toHaveBeenCalledOnce();
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: sysModelId,
+      provider: sysProvider,
+      source: "system",
+      adapter: sysAdapter, // Corrected adapter
+    });
+  });
+
+  it("backfills fully on model-id-only match", () => {
+    const sysModelId = SYSTEM_MODELS[0].models[0].id;
+    const sysProvider = SYSTEM_MODELS[0].provider;
+    const sysAdapter = SYSTEM_MODELS[0].piAIProvider;
+
+    render(
+      <ModelSelector
+        workspaceId="ws1"
+        value={{
+          model: sysModelId,
+          provider: "",
+          source: "system",
+          adapter: "",
+        }}
+        onChange={mocks.onChange}
+      />,
+    );
+
+    expect(mocks.onChange).toHaveBeenCalledOnce();
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: sysModelId,
+      provider: sysProvider,
+      source: "system",
+      adapter: sysAdapter,
+    });
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -56,14 +56,16 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
     const match = exact ?? modelOnly;
 
     if (!match) {
-      const pick = pickDefaultModel(models);
-      if (pick) {
-        onChange({
-          model: pick.id,
-          provider: pick.provider,
-          source: pick.source,
-          adapter: pick.adapter,
-        });
+      if (!value.model) {
+        const pick = pickDefaultModel(models);
+        if (pick) {
+          onChange({
+            model: pick.id,
+            provider: pick.provider,
+            source: pick.source,
+            adapter: pick.adapter,
+          });
+        }
       }
       return;
     }


### PR DESCRIPTION
…aded yet

ModelSelector's reconcile effect auto-picked a default whenever the saved selection had no exact match in the live catalog. On refresh, the catalog query resolves async and the component briefly sees a system-only FALLBACK_MODELS list — long enough for a saved BYOK model to look unmatched and get silently overwritten with a default before the real catalog (with the BYOK model) arrives.

Fix: only auto-pick a default when value.model is empty. A set-but- unmatched selection is now preserved untouched, per #1218's acceptance criteria. Exact-match and model-id-only-match backfill paths are unchanged.

Added model-selector.test.tsx covering all four branches: unmatched selection preserved, empty selection defaults, exact-match adapter backfill, model-id-only backfill. 0 lint errors/warnings on touched files.

Fixes #1218

Fixes <issue-id>

## Summary

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the saved Agent Model on refresh when the catalog hasn’t loaded yet by only defaulting when no model is set. This prevents BYOK selections from being overwritten and satisfies #1218’s acceptance criteria.

- **Bug Fixes**
  - Update ModelSelector: when no catalog match is found, only pick a default if `value.model` is empty; otherwise preserve the saved selection.
  - Keep exact-match and model-id-only backfill logic unchanged.

- **Tests**
  - Add `model-selector.test.tsx` covering: unmatched selection preserved, empty selection defaults, exact-match adapter backfill, and model-id-only backfill.

<sup>Written for commit 9fb9dfed57b6f989d7dcdaa9e93283a1b1aaf368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

