### PR TITLE
fix(worker): add xAI Grok model pricing (grok-4, grok-4.20)

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -995,5 +995,29 @@
       "cacheRead": 0,
       "cacheWrite": null
     }
+  },
+  {
+    "id": "tr-grok-4-20",
+    "modelName": "grok-4.20",
+    "matchPattern": "(?i)^(xai\\/)?grok-4\\.20(-[\\d-]+)?$",
+    "provider": "xai",
+    "prices": {
+      "input": 0.00000125,
+      "output": 0.0000025,
+      "cacheRead": 0.0000002,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-grok-4",
+    "modelName": "grok-4",
+    "matchPattern": "(?i)^(xai\\/)?grok-4(-[\\d-]+)?$",
+    "provider": "xai",
+    "prices": {
+      "input": 0.000003,
+      "output": 0.000015,
+      "cacheRead": 0.00000075,
+      "cacheWrite": null
+    }
   }
 ]

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -1095,5 +1095,29 @@
       "cacheRead": 0.0000003,
       "cacheWrite": null
     }
+  },
+  {
+    "id": "tr-grok-4-20",
+    "modelName": "grok-4.20",
+    "matchPattern": "(?i)^(xai\\/)?grok-4\\.20(-[\\d-]+)?$",
+    "provider": "xai",
+    "prices": {
+      "input": 0.00000125,
+      "output": 0.0000025,
+      "cacheRead": 0.0000002,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-grok-4",
+    "modelName": "grok-4",
+    "matchPattern": "(?i)^(xai\\/)?grok-4(-[\\d-]+)?$",
+    "provider": "xai",
+    "prices": {
+      "input": 0.000003,
+      "output": 0.000015,
+      "cacheRead": 0.00000075,
+      "cacheWrite": null
+    }
   }
 ]

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -1099,7 +1099,7 @@
   {
     "id": "tr-grok-4-20",
     "modelName": "grok-4.20",
-    "matchPattern": "(?i)^(xai\\/)?grok-4\\.20(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(xai\\/)?grok-4\\.20(-[a-z0-9-]+)?$",
     "provider": "xai",
     "prices": {
       "input": 0.00000125,
@@ -1114,9 +1114,9 @@
     "matchPattern": "(?i)^(xai\\/)?grok-4(-[\\d-]+)?$",
     "provider": "xai",
     "prices": {
-      "input": 0.000003,
-      "output": 0.000015,
-      "cacheRead": 0.00000075,
+      "input": 0.00000125,
+      "output": 0.0000025,
+      "cacheRead": 0.0000002,
       "cacheWrite": null
     }
   }

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -129,6 +129,15 @@ GLM_MODEL_CASES = [
     ("glm-4.5-flash", "glm-4.5-flash"),
 ]
 
+XAI_MODEL_CASES = [
+    ("grok-4.20", "grok-4.20"),
+    ("xai/grok-4.20", "grok-4.20"),
+    ("grok-4.20-20260601", "grok-4.20"),
+    ("grok-4", "grok-4"),
+    ("xai/grok-4", "grok-4"),
+    ("grok-4-0709", "grok-4"),
+]
+
 
 GEMINI_MODEL_CASES = [
     ("gemini-3.5-flash", "gemini-3.5-flash"),
@@ -261,6 +270,36 @@ class TestGLMModelIds:
         assert price[MATCHED_MODEL_NAME] == expected_name, (
             f"{model_id} matched a different entry than {expected_name}"
         )
+
+
+class TestXAIModelIds:
+    @pytest.mark.parametrize("model_id,expected_name", XAI_MODEL_CASES)
+    def test_matches_expected_model(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert "input" in price and "output" in price
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched a different entry than {expected_name}"
+        )
+
+    def test_grok_4_fast_not_priced_as_grok_4(self, real_cache):
+        # grok-4-fast is a distinct, cheaper xAI model that shares the grok-4
+        # prefix. The grok-4 entry must not absorb it at grok-4's rates.
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            assert get_model_price("grok-4-fast") is None
+
+    def test_grok_4_calculates_cost(self, real_cache):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            result = calculate_cost("grok-4", "Hello world", "Hi there")
+
+        assert result["input_tokens"] is not None
+        assert result["input_tokens"] > 0
+        assert result["output_tokens"] is not None
+        assert result["output_tokens"] > 0
+        assert result["cost"] is not None
+        assert result["cost"] > 0
 
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -140,6 +140,15 @@ GLM_MODEL_CASES = [
     ("glm-4.5-flash", "glm-4.5-flash"),
 ]
 
+XAI_MODEL_CASES = [
+    ("grok-4.20", "grok-4.20"),
+    ("xai/grok-4.20", "grok-4.20"),
+    ("grok-4.20-20260601", "grok-4.20"),
+    ("grok-4", "grok-4"),
+    ("xai/grok-4", "grok-4"),
+    ("grok-4-0709", "grok-4"),
+]
+
 
 GEMINI_MODEL_CASES = [
     ("gemini-3.5-flash", "gemini-3.5-flash"),
@@ -317,6 +326,36 @@ class TestGLMModelIds:
         assert price[MATCHED_MODEL_NAME] == expected_name, (
             f"{model_id} matched a different entry than {expected_name}"
         )
+
+
+class TestXAIModelIds:
+    @pytest.mark.parametrize("model_id,expected_name", XAI_MODEL_CASES)
+    def test_matches_expected_model(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert "input" in price and "output" in price
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched a different entry than {expected_name}"
+        )
+
+    def test_grok_4_fast_not_priced_as_grok_4(self, real_cache):
+        # grok-4-fast is a distinct, cheaper xAI model that shares the grok-4
+        # prefix. The grok-4 entry must not absorb it at grok-4's rates.
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            assert get_model_price("grok-4-fast") is None
+
+    def test_grok_4_calculates_cost(self, real_cache):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            result = calculate_cost("grok-4", "Hello world", "Hi there")
+
+        assert result["input_tokens"] is not None
+        assert result["input_tokens"] > 0
+        assert result["output_tokens"] is not None
+        assert result["output_tokens"] > 0
+        assert result["cost"] is not None
+        assert result["cost"] > 0
 
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -364,9 +364,7 @@ class TestXAIModelIds:
     )
     def test_xai_absolute_rates(self, model_name, input_rate, output_rate, cache_read_rate):
         # The id-matching tests pass for any price table, so pin the published rates.
-        entry = next(
-            (e for e in _standard_price_entries() if e["modelName"] == model_name), None
-        )
+        entry = next((e for e in _standard_price_entries() if e["modelName"] == model_name), None)
         assert entry is not None, f"{model_name} missing from standard-model-prices.json"
         prices = entry["prices"]
         assert prices["input"] == pytest.approx(input_rate)

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -144,6 +144,13 @@ XAI_MODEL_CASES = [
     ("grok-4.20", "grok-4.20"),
     ("xai/grok-4.20", "grok-4.20"),
     ("grok-4.20-20260601", "grok-4.20"),
+    ("grok-4.20-0309-reasoning", "grok-4.20"),
+    ("grok-4.20-0309-non-reasoning", "grok-4.20"),
+    ("grok-4.20-multi-agent-0309", "grok-4.20"),
+    ("xai/grok-4.20-0309-reasoning", "grok-4.20"),
+    ("grok-4.20-non-reasoning-latest", "grok-4.20"),
+    ("grok-4.20-non-reasoning-gv2", "grok-4.20"),
+    ("grok-4.20-multi-agent-experimental-beta-0304", "grok-4.20"),
     ("grok-4", "grok-4"),
     ("xai/grok-4", "grok-4"),
     ("grok-4-0709", "grok-4"),
@@ -345,6 +352,26 @@ class TestXAIModelIds:
         # prefix. The grok-4 entry must not absorb it at grok-4's rates.
         with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
             assert get_model_price("grok-4-fast") is None
+
+    @pytest.mark.parametrize(
+        "model_name,input_rate,output_rate,cache_read_rate",
+        [
+            # USD per token. grok-4 slugs retired on 2026-05-15 and xAI now bills
+            # them at grok-4.3 rates, which grok-4.20 shares.
+            ("grok-4.20", 0.00000125, 0.0000025, 0.0000002),
+            ("grok-4", 0.00000125, 0.0000025, 0.0000002),
+        ],
+    )
+    def test_xai_absolute_rates(self, model_name, input_rate, output_rate, cache_read_rate):
+        # The id-matching tests pass for any price table, so pin the published rates.
+        entry = next(
+            (e for e in _standard_price_entries() if e["modelName"] == model_name), None
+        )
+        assert entry is not None, f"{model_name} missing from standard-model-prices.json"
+        prices = entry["prices"]
+        assert prices["input"] == pytest.approx(input_rate)
+        assert prices["output"] == pytest.approx(output_rate)
+        assert prices["cacheRead"] == pytest.approx(cache_read_rate)
 
     def test_grok_4_calculates_cost(self, real_cache):
         with patch("worker.tokens.pricing._load_cache", lambda: real_cache):


### PR DESCRIPTION
### What

`grok-4` and `grok-4.20` already ship in the BYOK model dropdown (`ADAPTER_MODELS.xai` in `frontend/packages/core/src/llm-providers.ts`) but have **no entries** in `standard-model-prices.json`. So `get_model_price()` falls through to `None` and per-span cost tracking is silently dropped for anyone running xAI models.

### Change

- Add `tr-grok-4` and `tr-grok-4-20` to `standard-model-prices.json`, following the same shape as the recently-merged DeepSeek (#1271) and GLM (#1251) entries.
- Add `XAI_MODEL_CASES` + `TestXAIModelIds` to `tests/worker/tokens/test_pricing.py` covering bare (`grok-4`), provider-prefixed (`xai/grok-4`), and version-suffixed (`grok-4-0709`) ids, plus a cost-calculation test.

### Prices (USD / 1M tokens)

| model | input | output | cached input |
|-------|-------|--------|--------------|
| grok-4 | $3.00 | $15.00 | $0.75 |
| grok-4.20 | $1.25 | $2.50 | $0.20 |

Sourced from the official xAI docs (`docs.x.ai/developers/models`) and cross-checked against OpenRouter. Happy to adjust if you track canonical rates elsewhere.

### Notes

- Match patterns are anchored so `grok-4` does **not** absorb differently-priced variants like `grok-4-fast` (a separate, cheaper xAI model). Added a negative test pinning `grok-4-fast -> None` so a future pattern change can't silently mis-price it.
- Closes the xAI half of the same gap as #702 (Kimi) — happy to send a follow-up for Moonshot pricing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pricing for xAI Grok models (`grok-4`, `grok-4.20`) so worker cost tracking resumes for xAI usage. Previously `get_model_price()` returned `None` for these models; now it returns correct rates.

- Added `tr-grok-4` and `tr-grok-4-20` to `frontend/packages/core/src/standard-model-prices.json` at $1.25 in / $2.50 out / $0.20 cached per 1M tokens, the rates xAI now bills after retiring the original `grok-4` slugs and redirecting them to grok-4.3.
- Match patterns accept bare, `xai/`-prefixed, and version-suffixed IDs, including lettered suffixes like `-0309-reasoning`; explicitly exclude `grok-4-fast`.
- Added tests in `tests/worker/tokens/test_pricing.py` for ID matching, absolute rate pinning, a negative check for `grok-4-fast`, and a `grok-4` cost calculation.

<sup>Written for commit 7f5f187b77ddf1ebd0f6c7fc6a6adbe75b78be04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

