### PR TITLE
feat(worker): add detector digest primitives (block builder, queue, reader, senders)

### DIFF
--- a/frontend/packages/slack/src/__tests__/block-kit.test.ts
+++ b/frontend/packages/slack/src/__tests__/block-kit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCombinedAlertBlocks } from "../block-kit.ts";
+import { buildCombinedAlertBlocks, buildDigestAlertBlocks } from "../block-kit.ts";
 
 const base = {
   detectorName: "Hallucination",
@@ -53,5 +53,105 @@ describe("buildCombinedAlertBlocks", () => {
     for (const s of sections) {
       expect(s.text.text.length).toBeLessThanOrEqual(3000);
     }
+  });
+});
+
+const digestBase = {
+  projectId: "proj_1",
+  projectName: "checkout-svc",
+  appBaseUrl: "https://app.example.test",
+  windowStart: new Date("2026-06-23T12:00:00.000Z"),
+  windowEnd: new Date("2026-06-23T12:30:00.000Z"),
+  total: 5,
+  entries: [
+    {
+      detectorId: "d1",
+      detectorName: "Latency regression",
+      findingCount: 4,
+      latestTraceId: "a1b2c3d4",
+    },
+    {
+      detectorId: "d2",
+      detectorName: "PII leak check",
+      findingCount: 1,
+      latestTraceId: "ffee0011",
+    },
+  ],
+};
+
+describe("buildDigestAlertBlocks", () => {
+  it("uses a plural header and one line per detector with a window-filtered deep-link", () => {
+    const text = JSON.stringify(buildDigestAlertBlocks(digestBase));
+    expect(text).toContain("5 findings");
+    expect(text).toContain("checkout-svc");
+    expect(text).toContain("Latency regression");
+    // the representative finding is labelled "latest" (most recent), not "top"
+    expect(text).toContain("· latest: <");
+    expect(text).not.toContain("· top:");
+    // deep-link carries the window start/end as ISO custom range
+    expect(text).toContain(
+      "/projects/proj_1/detectors/d1?date_filter=custom&start=2026-06-23T12%3A00%3A00.000Z&end=2026-06-23T12%3A30%3A00.000Z",
+    );
+  });
+
+  it("groups content with dividers and a window/detector-count context footer", () => {
+    const blocks = buildDigestAlertBlocks(digestBase);
+    expect(blocks.filter((b: any) => b.type === "divider")).toHaveLength(2);
+    const footer = blocks.find((b: any) => b.type === "context") as any;
+    expect(footer).toBeTruthy();
+    const footerText = footer.elements[0].text;
+    // same-day window collapses to one date; UTC keeps it unambiguous
+    expect(footerText).toContain("Jun 23");
+    expect(footerText).toContain("12:00");
+    expect(footerText).toContain("12:30");
+    expect(footerText).toContain("UTC");
+    expect(footerText).toContain("2 detectors");
+  });
+
+  it("footer spans both dates for a window that crosses midnight (UTC)", () => {
+    const blocks = buildDigestAlertBlocks({
+      ...digestBase,
+      windowStart: new Date("2026-06-23T23:50:00.000Z"),
+      windowEnd: new Date("2026-06-24T00:20:00.000Z"),
+    });
+    const footer = blocks.find((b: any) => b.type === "context") as any;
+    expect(footer.elements[0].text).toContain("Jun 23");
+    expect(footer.elements[0].text).toContain("Jun 24");
+  });
+
+  it("uses a singular header for a single finding", () => {
+    const text = JSON.stringify(
+      buildDigestAlertBlocks({
+        ...digestBase,
+        total: 1,
+        entries: [digestBase.entries[1]],
+      }),
+    );
+    expect(text).toContain("1 finding in");
+    expect(text).not.toContain("1 findings");
+    expect(text).toContain("1 detector");
+    expect(text).not.toContain("1 detectors");
+  });
+
+  it("escapes mrkdwn injection in the detector name but leaves the deep-link intact", () => {
+    const text = JSON.stringify(
+      buildDigestAlertBlocks({
+        ...digestBase,
+        total: 1,
+        entries: [
+          {
+            detectorId: "d1",
+            detectorName: "Pinged <!channel> & co",
+            findingCount: 1,
+            latestTraceId: "a1b2c3d4",
+          },
+        ],
+      }),
+    );
+    // user-controlled text is escaped...
+    expect(text).toContain("&lt;!channel&gt;");
+    expect(text).not.toContain("<!channel>");
+    // ...while the URL's own query separators survive (not over-escaped to &amp;)
+    expect(text).toContain("date_filter=custom&start=");
   });
 });

--- a/frontend/packages/slack/src/__tests__/block-kit.test.ts
+++ b/frontend/packages/slack/src/__tests__/block-kit.test.ts
@@ -154,4 +154,38 @@ describe("buildDigestAlertBlocks", () => {
     // ...while the URL's own query separators survive (not over-escaped to &amp;)
     expect(text).toContain("date_filter=custom&start=");
   });
+
+  it("caps detector lines at the Slack 50-block limit and notes the overflow", () => {
+    const entries = Array.from({ length: 50 }, (_, i) => ({
+      detectorId: `d${i}`,
+      detectorName: `Detector ${i}`,
+      findingCount: 1,
+      latestTraceId: `trace${i}`,
+    }));
+    const blocks = buildDigestAlertBlocks({ ...digestBase, total: 50, entries });
+
+    // never exceeds Slack's hard 50-block cap
+    expect(blocks.length).toBeLessThanOrEqual(50);
+    // 45 detector lines listed, the 46th line is the overflow note for the rest
+    expect(JSON.stringify(blocks)).toContain("_+5 more detectors_");
+    expect(JSON.stringify(blocks)).toContain("Detector 44");
+    expect(JSON.stringify(blocks)).not.toContain("Detector 45");
+    // the footer still reports the true total detector count
+    const footer = blocks.find((b: any) => b.type === "context") as any;
+    expect(footer.elements[0].text).toContain("50 detectors");
+  });
+
+  it("renders all detectors without an overflow note at the block-budget boundary", () => {
+    const entries = Array.from({ length: 46 }, (_, i) => ({
+      detectorId: `d${i}`,
+      detectorName: `Detector ${i}`,
+      findingCount: 1,
+      latestTraceId: `trace${i}`,
+    }));
+    const blocks = buildDigestAlertBlocks({ ...digestBase, total: 46, entries });
+
+    expect(blocks.length).toBe(50);
+    expect(JSON.stringify(blocks)).not.toContain("more detector");
+    expect(JSON.stringify(blocks)).toContain("Detector 45");
+  });
 });

--- a/frontend/packages/slack/src/block-kit.ts
+++ b/frontend/packages/slack/src/block-kit.ts
@@ -69,3 +69,79 @@ export function buildCombinedAlertBlocks(params: CombinedAlertParams): unknown[]
     },
   ];
 }
+
+export interface DigestEntry {
+  detectorId: string;
+  detectorName: string;
+  findingCount: number;
+  latestTraceId: string;
+}
+
+export interface DigestAlertParams {
+  projectId: string;
+  projectName: string;
+  appBaseUrl: string;
+  windowStart: Date;
+  windowEnd: Date;
+  total: number;
+  entries: DigestEntry[];
+}
+
+// Human-readable UTC window range for the digest footer, e.g.
+// "Jun 23, 12:00–12:30 UTC" (same day) or "Jun 23, 23:50 – Jun 24, 00:20 UTC".
+// UTC keeps it unambiguous across a channel's mixed timezones.
+function formatWindowRange(start: Date, end: Date): string {
+  const day = (d: Date) =>
+    new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" }).format(d);
+  const time = (d: Date) =>
+    new Intl.DateTimeFormat("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+      timeZone: "UTC",
+    }).format(d);
+  return day(start) === day(end)
+    ? `${day(start)}, ${time(start)}–${time(end)} UTC`
+    : `${day(start)} ${time(start)} – ${day(end)} ${time(end)} UTC`;
+}
+
+export function buildDigestAlertBlocks(params: DigestAlertParams): unknown[] {
+  const { appBaseUrl, projectId, projectName, windowStart, windowEnd, total, entries } = params;
+  const noun = total === 1 ? "finding" : "findings";
+  const headerText = truncate(`${total} ${noun} in ${projectName}`, 150);
+
+  // date_filter=custom is REQUIRED — the detector page's useUrlDateFilter only
+  // hydrates a custom start/end when date_filter=custom is present; without it
+  // start/end are ignored and the deep-link lands on the default range.
+  const range =
+    `date_filter=custom` +
+    `&start=${encodeURIComponent(windowStart.toISOString())}` +
+    `&end=${encodeURIComponent(windowEnd.toISOString())}`;
+
+  const lines = entries.map((e) => {
+    const findingsUrl = `${appBaseUrl}/projects/${encodeURIComponent(projectId)}/detectors/${encodeURIComponent(e.detectorId)}?${range}`;
+    const traceUrl = `${appBaseUrl}/projects/${encodeURIComponent(projectId)}/traces?traceId=${encodeURIComponent(e.latestTraceId)}`;
+    const shortTrace = e.latestTraceId.slice(0, 8);
+    // Escape the detector name (user-controlled); the URL is built from encoded
+    // params, so escaping it would mangle the query-string separators and break
+    // the Slack <url|text> link syntax.
+    const name = escapeMrkdwn(e.detectorName);
+    const text =
+      `*<${findingsUrl}|${name}>* — ${e.findingCount} ${e.findingCount === 1 ? "finding" : "findings"}` +
+      (e.latestTraceId ? ` · latest: <${traceUrl}|${shortTrace}>` : "");
+    return { type: "section", text: { type: "mrkdwn", text: truncate(text) } };
+  });
+
+  const detectorCount = entries.length;
+  const footer =
+    `${formatWindowRange(windowStart, windowEnd)} · ` +
+    `${detectorCount} detector${detectorCount === 1 ? "" : "s"}`;
+
+  return [
+    { type: "header", text: { type: "plain_text", text: headerText, emoji: true } },
+    { type: "divider" },
+    ...lines,
+    { type: "divider" },
+    { type: "context", elements: [{ type: "mrkdwn", text: footer }] },
+  ];
+}

--- a/frontend/packages/slack/src/block-kit.ts
+++ b/frontend/packages/slack/src/block-kit.ts
@@ -105,10 +105,20 @@ function formatWindowRange(start: Date, end: Date): string {
     : `${day(start)} ${time(start)} – ${day(end)} ${time(end)} UTC`;
 }
 
+// Slack rejects a message with more than 50 blocks. The digest spends 4 on the
+// header, two dividers, and the footer, leaving 46 for the per-detector lines.
+const MAX_DIGEST_LINES = 46;
+
 export function buildDigestAlertBlocks(params: DigestAlertParams): unknown[] {
   const { appBaseUrl, projectId, projectName, windowStart, windowEnd, total, entries } = params;
   const noun = total === 1 ? "finding" : "findings";
   const headerText = truncate(`${total} ${noun} in ${projectName}`, 150);
+
+  // Cap the rendered detector lines so a project with many triggered detectors
+  // can't blow the 50-block limit and fail the whole send. When we truncate,
+  // one line is spent on an overflow note, so only 45 detectors are listed.
+  const overflow = entries.length > MAX_DIGEST_LINES;
+  const shown = overflow ? entries.slice(0, MAX_DIGEST_LINES - 1) : entries;
 
   // date_filter=custom is REQUIRED — the detector page's useUrlDateFilter only
   // hydrates a custom start/end when date_filter=custom is present; without it
@@ -118,7 +128,7 @@ export function buildDigestAlertBlocks(params: DigestAlertParams): unknown[] {
     `&start=${encodeURIComponent(windowStart.toISOString())}` +
     `&end=${encodeURIComponent(windowEnd.toISOString())}`;
 
-  const lines = entries.map((e) => {
+  const lines = shown.map((e) => {
     const findingsUrl = `${appBaseUrl}/projects/${encodeURIComponent(projectId)}/detectors/${encodeURIComponent(e.detectorId)}?${range}`;
     const traceUrl = `${appBaseUrl}/projects/${encodeURIComponent(projectId)}/traces?traceId=${encodeURIComponent(e.latestTraceId)}`;
     const shortTrace = e.latestTraceId.slice(0, 8);
@@ -131,6 +141,14 @@ export function buildDigestAlertBlocks(params: DigestAlertParams): unknown[] {
       (e.latestTraceId ? ` · latest: <${traceUrl}|${shortTrace}>` : "");
     return { type: "section", text: { type: "mrkdwn", text: truncate(text) } };
   });
+
+  if (overflow) {
+    const more = entries.length - shown.length;
+    lines.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `_+${more} more detector${more === 1 ? "" : "s"}_` },
+    });
+  }
 
   const detectorCount = entries.length;
   const footer =

--- a/frontend/worker/src/detection/__tests__/findings-reader.test.ts
+++ b/frontend/worker/src/detection/__tests__/findings-reader.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock global fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { readDetectorCounts, readLatestFinding } from "../findings-reader.js";
+
+const START = new Date("2026-06-01T00:00:00.000Z");
+const END = new Date("2026-06-08T00:00:00.000Z");
+
+describe("readDetectorCounts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GETs detector-counts with project_id and window bounds, returns the data map", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { d1: { finding_count: 3, run_count: 9 } } }),
+    });
+
+    const counts = await readDetectorCounts("proj-1", START, END);
+
+    expect(counts).toEqual({ d1: { finding_count: 3, run_count: 9 } });
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/api/v1/internal/detector-counts");
+    expect(url).toContain("project_id=proj-1");
+    expect(url).toContain(`start_after=${encodeURIComponent(START.toISOString())}`);
+    expect(url).toContain(`end_before=${encodeURIComponent(END.toISOString())}`);
+  });
+
+  it("sends the X-Internal-Secret header", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ data: {} }) });
+
+    await readDetectorCounts("proj-1", START, END);
+
+    const headers = mockFetch.mock.calls[0][1].headers;
+    expect(headers).toHaveProperty("X-Internal-Secret");
+  });
+
+  it("throws on a non-ok response", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: async () => "boom",
+    });
+
+    await expect(readDetectorCounts("proj-1", START, END)).rejects.toThrow(
+      "Backend API error: 500",
+    );
+  });
+});
+
+describe("readLatestFinding", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("GETs detector-findings and returns the newest finding's trace id", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: [{ trace_id: "t-abc", summary: "..." }],
+        meta: { total: 3 },
+      }),
+    });
+
+    const traceId = await readLatestFinding("proj-1", "d1", START, END);
+
+    expect(traceId).toBe("t-abc");
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/api/v1/internal/detector-findings");
+    expect(url).toContain("project_id=proj-1");
+    expect(url).toContain("detector_id=d1");
+    expect(url).toContain("page=0");
+    expect(url).toContain("limit=1");
+  });
+
+  it("returns null when there are no findings in the window", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: [], meta: { total: 0 } }),
+    });
+
+    const traceId = await readLatestFinding("proj-1", "d1", START, END);
+
+    expect(traceId).toBeNull();
+  });
+});

--- a/frontend/worker/src/detection/findings-reader.ts
+++ b/frontend/worker/src/detection/findings-reader.ts
@@ -1,0 +1,77 @@
+/**
+ * Internal API client for reading detector findings/counts for digests.
+ * The TypeScript worker calls the Python backend's internal API, which runs
+ * the actual ClickHouse queries.
+ * Pattern matches frontend/worker/src/ee/billing/clickhouse.ts
+ */
+
+const BACKEND_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
+const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
+
+/**
+ * Make an authenticated GET request to the internal backend API.
+ */
+async function internalGet<T>(path: string, params: Record<string, string>): Promise<T> {
+  const url = new URL(path, BACKEND_URL);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value);
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Internal-Secret": INTERNAL_API_SECRET,
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Backend API error: ${response.status} - ${text}`);
+  }
+
+  return response.json() as Promise<T>;
+}
+
+export type DetectorCounts = Record<string, { finding_count: number; run_count: number }>;
+
+/**
+ * Read per-detector finding and run counts for a project over a time window.
+ * Detectors with zero runs in the window are absent from the map.
+ */
+export async function readDetectorCounts(
+  projectId: string,
+  start: Date,
+  end: Date,
+): Promise<DetectorCounts> {
+  const body = await internalGet<{ data: DetectorCounts }>("/api/v1/internal/detector-counts", {
+    project_id: projectId,
+    start_after: start.toISOString(),
+    end_before: end.toISOString(),
+  });
+  return body.data;
+}
+
+/**
+ * Return the trace id of the latest finding for a detector in the window,
+ * or null when the detector produced no findings.
+ */
+export async function readLatestFinding(
+  projectId: string,
+  detectorId: string,
+  start: Date,
+  end: Date,
+): Promise<string | null> {
+  const body = await internalGet<{ data: Array<{ trace_id: string }> }>(
+    "/api/v1/internal/detector-findings",
+    {
+      project_id: projectId,
+      detector_id: detectorId,
+      start_after: start.toISOString(),
+      end_before: end.toISOString(),
+      page: "0",
+      limit: "1",
+    },
+  );
+  return body.data[0]?.trace_id ?? null;
+}

--- a/frontend/worker/src/notifications/__tests__/email-digest.test.ts
+++ b/frontend/worker/src/notifications/__tests__/email-digest.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMail = vi.fn();
+const createTransport = vi.fn(() => ({ sendMail }));
+
+vi.mock("nodemailer", () => ({
+  default: { createTransport: () => createTransport() },
+}));
+
+const baseParams = {
+  to: ["a@example.com"],
+  projectId: "p1",
+  projectName: "billing",
+  windowStart: new Date("2026-06-24T14:00:00Z"),
+  windowEnd: new Date("2026-06-24T15:00:00Z"),
+  total: 3,
+  entries: [
+    {
+      detectorId: "d1",
+      detectorName: "Hallucination",
+      findingCount: 2,
+      latestTraceId: "abcdef1234567890",
+    },
+    {
+      detectorId: "d2",
+      detectorName: "Latency spike",
+      findingCount: 1,
+      latestTraceId: "0011223344556677",
+    },
+  ],
+};
+
+describe("sendDigestAlertEmail", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sendMail.mockReset();
+    sendMail.mockResolvedValue(undefined);
+    createTransport.mockClear();
+    process.env.TRACEROOT_SMTP_URL = "smtp://user:pass@localhost:587";
+    process.env.NEXT_PUBLIC_APP_URL = "https://app.example.com";
+  });
+
+  afterEach(() => {
+    delete process.env.TRACEROOT_SMTP_URL;
+    delete process.env.NEXT_PUBLIC_APP_URL;
+  });
+
+  it("sends a digest email with subject, window-filtered deep-links, and subline", async () => {
+    const { sendDigestAlertEmail } = await import("../email.js");
+    await sendDigestAlertEmail(baseParams);
+
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    const mail = sendMail.mock.calls[0][0];
+
+    expect(mail.subject).toBe("[TraceRoot Alert] 3 findings — billing");
+    expect(mail.to).toBe("a@example.com");
+
+    // each detector name present
+    expect(mail.html).toContain("Hallucination");
+    expect(mail.html).toContain("Latency spike");
+
+    // window-filtered deep-link (verbatim filter prefix + same shape as slack)
+    expect(mail.html).toContain(
+      "https://app.example.com/projects/p1/detectors/d1?date_filter=custom&start=",
+    );
+    expect(mail.html).toContain(encodeURIComponent("2026-06-24T14:00:00.000Z"));
+
+    // subline with detector count
+    expect(mail.html).toContain("· 2 detectors");
+
+    // plain-text twin lists each detector
+    expect(mail.text).toContain("- Hallucination — 2 findings");
+    expect(mail.text).toContain("- Latency spike — 1 finding");
+  });
+
+  it("early-returns without sending when the recipient list is empty", async () => {
+    const { sendDigestAlertEmail } = await import("../email.js");
+    await sendDigestAlertEmail({ ...baseParams, to: [] });
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+
+  it("early-returns without sending when SMTP is not configured", async () => {
+    delete process.env.TRACEROOT_SMTP_URL;
+    const { sendDigestAlertEmail } = await import("../email.js");
+    await sendDigestAlertEmail(baseParams);
+
+    expect(sendMail).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/worker/src/notifications/__tests__/slack-digest.test.ts
+++ b/frontend/worker/src/notifications/__tests__/slack-digest.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const postMessage = vi.fn();
+const createSlackClient = vi.fn((_token: string) => ({ chat: { postMessage } }));
+const buildDigestAlertBlocks = vi.fn(() => [
+  { type: "section", text: { type: "mrkdwn", text: "digest" } },
+]);
+const findUnique = vi.fn();
+const hasEntitlement = vi.fn();
+
+vi.mock("@traceroot/slack", () => ({
+  createSlackClient: (token: string) => createSlackClient(token),
+  buildCombinedAlertBlocks: () => [{ type: "section", text: { type: "mrkdwn", text: "block" } }],
+  buildDigestAlertBlocks: (...a: unknown[]) => buildDigestAlertBlocks(...(a as [])),
+}));
+vi.mock("@traceroot/core", () => ({
+  decryptKey: (s: string) => `decrypted(${s})`,
+  hasEntitlement: (...a: unknown[]) => hasEntitlement(...a),
+  prisma: { workspace: { findUnique: (...a: unknown[]) => findUnique(...a) } },
+}));
+
+const baseParams = {
+  workspaceId: "ws_1",
+  encryptedBotToken: "enc-tok",
+  channelId: "C1",
+  projectId: "p1",
+  projectName: "billing",
+  windowStart: new Date(0),
+  windowEnd: new Date(1000),
+  total: 2,
+  entries: [],
+};
+
+describe("sendDigestAlertSlack", () => {
+  beforeEach(() => {
+    postMessage.mockReset();
+    createSlackClient.mockClear();
+    buildDigestAlertBlocks.mockClear();
+    findUnique.mockReset();
+    hasEntitlement.mockReset();
+  });
+
+  it("posts digest blocks when the workspace has the slack entitlement", async () => {
+    findUnique.mockResolvedValue({ billingPlan: "starter" });
+    hasEntitlement.mockReturnValue(true);
+    postMessage.mockResolvedValue({ ok: true, ts: "1.2" });
+
+    const { sendDigestAlertSlack } = await import("../slack.js");
+    await sendDigestAlertSlack(baseParams);
+
+    expect(hasEntitlement).toHaveBeenCalledWith("starter", "slack-integration");
+    expect(createSlackClient).toHaveBeenCalledWith("decrypted(enc-tok)");
+    expect(buildDigestAlertBlocks).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    const arg = postMessage.mock.calls[0][0];
+    expect(arg.channel).toBe("C1");
+    expect(arg.text).toContain("2 findings");
+    expect(arg.unfurl_links).toBe(false);
+    expect(Array.isArray(arg.blocks)).toBe(true);
+  });
+
+  it("treats a missing workspace row as free plan", async () => {
+    findUnique.mockResolvedValue(null);
+    hasEntitlement.mockReturnValue(true);
+    postMessage.mockResolvedValue({ ok: true });
+
+    const { sendDigestAlertSlack } = await import("../slack.js");
+    await sendDigestAlertSlack(baseParams);
+
+    expect(hasEntitlement).toHaveBeenCalledWith("free", "slack-integration");
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("silently skips when the entitlement check returns false", async () => {
+    findUnique.mockResolvedValue({ billingPlan: "free" });
+    hasEntitlement.mockReturnValue(false);
+
+    const { sendDigestAlertSlack } = await import("../slack.js");
+    await sendDigestAlertSlack(baseParams);
+
+    expect(createSlackClient).not.toHaveBeenCalled();
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/worker/src/notifications/email.ts
+++ b/frontend/worker/src/notifications/email.ts
@@ -81,3 +81,87 @@ ${htmlRcaSection}
     `.trim(),
   });
 }
+
+// Human-readable UTC window range, mirroring the digest Slack footer:
+// "Jun 24, 14:00–15:00 UTC" (same day) or
+// "Jun 23 23:50 – Jun 24 00:20 UTC" (cross-day). UTC keeps it unambiguous.
+function formatWindowRange(start: Date, end: Date): string {
+  const day = (d: Date) =>
+    new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" }).format(d);
+  const time = (d: Date) =>
+    new Intl.DateTimeFormat("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+      timeZone: "UTC",
+    }).format(d);
+  return day(start) === day(end)
+    ? `${day(start)}, ${time(start)}–${time(end)} UTC`
+    : `${day(start)} ${time(start)} – ${day(end)} ${time(end)} UTC`;
+}
+
+/**
+ * Send a windowed digest email summarizing all findings in a time window:
+ * one row per detector with its finding count and latest trace. No RCA and no
+ * per-finding summary — matches the Slack digest content.
+ */
+export async function sendDigestAlertEmail(params: {
+  to: string[];
+  projectId: string;
+  projectName: string;
+  windowStart: Date;
+  windowEnd: Date;
+  total: number;
+  entries: import("@traceroot/slack").DigestEntry[];
+}): Promise<void> {
+  const transport = createTransport();
+  if (!transport || params.to.length === 0) return;
+
+  const { projectId, projectName, windowStart, windowEnd, total, entries } = params;
+  const noun = total === 1 ? "finding" : "findings";
+  const windowRange = formatWindowRange(windowStart, windowEnd);
+
+  // date_filter=custom is REQUIRED — the detector page only hydrates the custom
+  // start/end when it is present; without it the deep-link lands on the default
+  // range. Mirrors the Slack digest deep-link shape exactly.
+  const range =
+    `date_filter=custom` +
+    `&start=${encodeURIComponent(windowStart.toISOString())}` +
+    `&end=${encodeURIComponent(windowEnd.toISOString())}`;
+  const findingsUrlFor = (detectorId: string) =>
+    `${APP_BASE_URL}/projects/${encodeURIComponent(projectId)}/detectors/${encodeURIComponent(detectorId)}?${range}`;
+  const traceUrlFor = (traceId: string) =>
+    `${APP_BASE_URL}/projects/${encodeURIComponent(projectId)}/traces?traceId=${encodeURIComponent(traceId)}`;
+
+  const textParts = [
+    `${total} ${noun} in project ${projectName}.`,
+    `${windowRange} · ${entries.length} detector${entries.length === 1 ? "" : "s"}`,
+    ``,
+  ];
+  for (const e of entries) {
+    const findingNoun = e.findingCount === 1 ? "finding" : "findings";
+    textParts.push(
+      `- ${e.detectorName} — ${e.findingCount} ${findingNoun} · latest ${e.latestTraceId.slice(0, 8)}`,
+      `  ${findingsUrlFor(e.detectorId)}`,
+    );
+  }
+
+  const htmlRows = entries
+    .map((e) => {
+      const findingNoun = e.findingCount === 1 ? "finding" : "findings";
+      return `<p style="margin:6px 0;"><a href="${findingsUrlFor(e.detectorId)}">${escapeHtml(e.detectorName)}</a> <span style="color:#888;">— ${e.findingCount} ${findingNoun} · latest <a href="${traceUrlFor(e.latestTraceId)}" style="color:#888;">${e.latestTraceId.slice(0, 8)}</a></span></p>`;
+    })
+    .join("\n");
+
+  await transport.sendMail({
+    from: SMTP_FROM,
+    to: params.to.join(", "),
+    subject: `[TraceRoot Alert] ${total} ${noun} — ${projectName}`,
+    text: textParts.join("\n"),
+    html: `
+<p><strong>${total} ${noun}</strong> in project <strong>${escapeHtml(projectName)}</strong>.</p>
+<p style="color:#888;font-size:12px;">${windowRange} · ${entries.length} detector${entries.length === 1 ? "" : "s"}</p>
+${htmlRows}
+    `.trim(),
+  });
+}

--- a/frontend/worker/src/notifications/slack.ts
+++ b/frontend/worker/src/notifications/slack.ts
@@ -1,4 +1,8 @@
-import { createSlackClient, buildCombinedAlertBlocks } from "@traceroot/slack";
+import {
+  createSlackClient,
+  buildCombinedAlertBlocks,
+  buildDigestAlertBlocks,
+} from "@traceroot/slack";
 import { decryptKey, hasEntitlement, prisma, type PlanType } from "@traceroot/core";
 
 const APP_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
@@ -42,6 +46,50 @@ export async function sendCombinedAlertSlack(params: SendCombinedAlertSlackParam
     channel: params.channelId,
     blocks: blocks as any,
     text: `Alert: ${params.detectorName} fired on ${params.projectName}`,
+    unfurl_links: false,
+    unfurl_media: false,
+  });
+}
+
+export interface SendDigestAlertSlackParams {
+  workspaceId: string;
+  encryptedBotToken: string;
+  channelId: string;
+  projectId: string;
+  projectName: string;
+  windowStart: Date;
+  windowEnd: Date;
+  total: number;
+  entries: import("@traceroot/slack").DigestEntry[];
+}
+
+export async function sendDigestAlertSlack(params: SendDigestAlertSlackParams): Promise<void> {
+  const workspace = await prisma.workspace.findUnique({
+    where: { id: params.workspaceId },
+    select: { billingPlan: true },
+  });
+  const plan = (workspace?.billingPlan ?? "free") as PlanType;
+  if (!hasEntitlement(plan, "slack-integration")) {
+    console.log(
+      `[slack] Skipping digest for workspace ${params.workspaceId}: plan "${plan}" lacks slack-integration entitlement`,
+    );
+    return;
+  }
+
+  const client = createSlackClient(decryptKey(params.encryptedBotToken));
+  const blocks = buildDigestAlertBlocks({
+    projectId: params.projectId,
+    projectName: params.projectName,
+    appBaseUrl: APP_BASE_URL,
+    windowStart: params.windowStart,
+    windowEnd: params.windowEnd,
+    total: params.total,
+    entries: params.entries,
+  });
+  await client.chat.postMessage({
+    channel: params.channelId,
+    blocks: blocks as any,
+    text: `Alert digest: ${params.total} findings on ${params.projectName}`,
     unfurl_links: false,
     unfurl_media: false,
   });

--- a/frontend/worker/src/queues/__tests__/digest-queue.test.ts
+++ b/frontend/worker/src/queues/__tests__/digest-queue.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { DETECTOR_DIGEST_QUEUE, windowStartFor, type DigestFlushJob } from "../digest-queue.js";
+
+describe("digest queue", () => {
+  it("queue name constant", () => {
+    expect(DETECTOR_DIGEST_QUEUE).toBe("detector-digest");
+  });
+
+  it("windowStartFor floors a finding timestamp to the window boundary", () => {
+    const W = 1_800_000; // 30m
+    expect(windowStartFor(0, W)).toBe(0);
+    expect(windowStartFor(W - 1, W)).toBe(0);
+    expect(windowStartFor(W, W)).toBe(W);
+    expect(windowStartFor(W + 5, W)).toBe(W);
+  });
+});
+
+describe("DigestFlushJob type shape", () => {
+  it("accepts valid job shape", () => {
+    const job: DigestFlushJob = {
+      projectId: "proj-789",
+      windowStart: 1_800_000,
+      windowMs: 1_800_000,
+    };
+    expect(job.projectId).toBe("proj-789");
+    expect(job.windowStart).toBe(1_800_000);
+    expect(job.windowMs).toBe(1_800_000);
+  });
+});

--- a/frontend/worker/src/queues/digest-queue.ts
+++ b/frontend/worker/src/queues/digest-queue.ts
@@ -1,0 +1,24 @@
+import { Queue } from "bullmq";
+import { Redis } from "ioredis";
+
+// Reuse the shared Redis connection factory rather than re-declaring config.
+export { createRedisConnection } from "./detector-run-queue.js";
+
+export const DETECTOR_DIGEST_QUEUE = "detector-digest";
+
+/** A single coalesced flush for one project's alert window. */
+export interface DigestFlushJob {
+  projectId: string;
+  windowStart: number; // ms epoch, floored to the window boundary
+  windowMs: number; // window length in ms (from ALERT_WINDOWS)
+}
+
+/** Floor a finding timestamp to its window's start so every finding in the
+ *  same window resolves to one deterministic flush key. */
+export function windowStartFor(findingTsMs: number, windowMs: number): number {
+  return Math.floor(findingTsMs / windowMs) * windowMs;
+}
+
+export function createDetectorDigestQueue(connection: Redis): Queue<DigestFlushJob> {
+  return new Queue<DigestFlushJob>(DETECTOR_DIGEST_QUEUE, { connection });
+}


### PR DESCRIPTION
Part of epic #1296 §2 (detector alert aggregation). Adds the standalone, tested building blocks for the windowed digest — not yet wired into the worker (that lands in the next PR in the stack).

- Slack `buildDigestAlertBlocks` + `formatWindowRange` + `DigestEntry`
- BullMQ digest flush queue + `windowStartFor` window math
- internal-API findings/counts reader (per-detector counts + latest trace)
- Slack + email digest senders (entitlement-gated)

Stacked on #1329 — review/merge that first.

closes #1303
closes #1304
closes #1307
closes #1308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds standalone, tested primitives for windowed detector digest alerts: Slack blocks, a `bullmq` flush queue, internal readers, and Slack/email senders. Closes #1303, #1304, #1307, and #1308 for epic #1296 (detector alert aggregation); wiring into the worker comes next.

- New Features
  - Slack digest blocks in `@traceroot/slack`: `buildDigestAlertBlocks` with UTC window footer, mrkdwn-escaped detector names, and window-filtered deep-links (`date_filter=custom` + start/end); shows the “latest” trace per detector.
  - Digest queue: `DETECTOR_DIGEST_QUEUE`, `createDetectorDigestQueue`, and `windowStartFor` to floor timestamps to window boundaries.
  - Internal readers: `readDetectorCounts` and `readLatestFinding` for per-detector counts and newest finding in a window (via internal API with `X-Internal-Secret`).
  - Senders: `sendDigestAlertSlack` (entitlement-gated) and `sendDigestAlertEmail` with HTML/text bodies and the same windowed links.

- Bug Fixes
  - Cap digest detector lines to 46 to stay under Slack’s 50-block limit, add an overflow note, and keep the footer’s detector count accurate.

<sup>Written for commit 42440e4f77812d09e667dc70d0b0a24075631c76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

