### PR TITLE
fix(detector): align digest windows by stamping the finding timestamp on rows

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -205,6 +205,8 @@ class DetectorRunPayload(BaseModel):
     trace_id: str = Field(alias="traceId")
     finding_id: str | None = Field(default=None, alias="findingId")
     status: str
+    # Optional worker epoch-ms time for the row; see _maybe_stamp_timestamp.
+    timestamp_ms: int | None = Field(default=None, alias="timestampMs")
 
 
 class DetectorFindingPayload(BaseModel):
@@ -215,45 +217,95 @@ class DetectorFindingPayload(BaseModel):
     trace_id: str = Field(alias="traceId")
     summary: str
     payload: str
+    # See DetectorRunPayload.timestamp_ms.
+    timestamp_ms: int | None = Field(default=None, alias="timestampMs")
+
+
+def _maybe_stamp_timestamp(
+    cols: list[str], vals: list[str], params: dict, timestamp_ms: int | None
+) -> None:
+    """Append the optional worker timestamp to an INSERT's column/value/param lists.
+
+    When ``timestamp_ms`` is provided the worker's finding-capture time is stored
+    verbatim, so the digest window count (which filters on ``timestamp``) uses the
+    same clock the flush is keyed off; when ``None`` the column is omitted and
+    ClickHouse applies its ``now64(3)`` default.
+
+    Args:
+        cols (list[str]): INSERT column names, appended in place.
+        vals (list[str]): INSERT value placeholders, appended in place.
+        params (dict): Bound query parameters, updated in place.
+        timestamp_ms (int | None): Worker epoch-ms timestamp, or None to skip.
+
+    Returns:
+        None
+    """
+    if timestamp_ms is not None:
+        cols.append("timestamp")
+        vals.append("fromUnixTimestamp64Milli({timestamp_ms:Int64})")
+        params["timestamp_ms"] = timestamp_ms
 
 
 @router.post("/detector-runs", dependencies=[Depends(verify_internal_secret)])
 async def write_detector_run(body: DetectorRunPayload):
-    """Record a detector run result in ClickHouse."""
+    """Record a detector run result in ClickHouse.
+
+    A worker-supplied ``timestamp_ms`` is written into ``timestamp`` verbatim so
+    the digest's window count uses the same clock the flush is keyed off;
+    otherwise ClickHouse defaults the column to ``now64(3)`` at INSERT.
+    """
     ch = get_clickhouse_client()
+    cols = ["run_id", "detector_id", "project_id", "trace_id", "finding_id", "status"]
+    vals = [
+        "{run_id:String}",
+        "{detector_id:String}",
+        "{project_id:String}",
+        "{trace_id:String}",
+        "{finding_id:Nullable(String)}",
+        "{status:String}",
+    ]
+    params = {
+        "run_id": body.run_id,
+        "detector_id": body.detector_id,
+        "project_id": body.project_id,
+        "trace_id": body.trace_id,
+        "finding_id": body.finding_id,
+        "status": body.status,
+    }
+    _maybe_stamp_timestamp(cols, vals, params, body.timestamp_ms)
     ch.query(
-        """INSERT INTO detector_runs
-           (run_id, detector_id, project_id, trace_id, finding_id, status)
-           VALUES ({run_id:String}, {detector_id:String}, {project_id:String},
-                   {trace_id:String}, {finding_id:Nullable(String)}, {status:String})""",
-        parameters={
-            "run_id": body.run_id,
-            "detector_id": body.detector_id,
-            "project_id": body.project_id,
-            "trace_id": body.trace_id,
-            "finding_id": body.finding_id,
-            "status": body.status,
-        },
+        f"INSERT INTO detector_runs ({', '.join(cols)}) VALUES ({', '.join(vals)})",
+        parameters=params,
     )
     return {"ok": True}
 
 
 @router.post("/detector-findings", dependencies=[Depends(verify_internal_secret)])
 async def write_detector_finding(body: DetectorFindingPayload):
-    """Record a detector finding in ClickHouse."""
+    """Record a detector finding in ClickHouse.
+
+    ``timestamp_ms`` behaves as in :func:`write_detector_run`.
+    """
     ch = get_clickhouse_client()
+    cols = ["finding_id", "project_id", "trace_id", "summary", "payload"]
+    vals = [
+        "{finding_id:String}",
+        "{project_id:String}",
+        "{trace_id:String}",
+        "{summary:String}",
+        "{payload:String}",
+    ]
+    params = {
+        "finding_id": body.finding_id,
+        "project_id": body.project_id,
+        "trace_id": body.trace_id,
+        "summary": body.summary,
+        "payload": body.payload,
+    }
+    _maybe_stamp_timestamp(cols, vals, params, body.timestamp_ms)
     ch.query(
-        """INSERT INTO detector_findings
-           (finding_id, project_id, trace_id, summary, payload)
-           VALUES ({finding_id:String}, {project_id:String},
-                   {trace_id:String}, {summary:String}, {payload:String})""",
-        parameters={
-            "finding_id": body.finding_id,
-            "project_id": body.project_id,
-            "trace_id": body.trace_id,
-            "summary": body.summary,
-            "payload": body.payload,
-        },
+        f"INSERT INTO detector_findings ({', '.join(cols)}) VALUES ({', '.join(vals)})",
+        parameters=params,
     )
     return {"ok": True}
 

--- a/frontend/worker/src/detection/__tests__/clickhouse-writer.test.ts
+++ b/frontend/worker/src/detection/__tests__/clickhouse-writer.test.ts
@@ -61,6 +61,23 @@ describe("writeDetectorRun", () => {
     const headers = mockFetch.mock.calls[0][1].headers;
     expect(headers).toHaveProperty("X-Internal-Secret");
   });
+
+  it("forwards timestampMs in the request body when provided", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    await writeDetectorRun({
+      runId: "r",
+      detectorId: "d",
+      projectId: "p",
+      traceId: "t",
+      findingId: "f",
+      status: "completed",
+      timestampMs: 1_700_000_000_123,
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.timestampMs).toBe(1_700_000_000_123);
+  });
 });
 
 describe("writeDetectorFinding", () => {
@@ -81,5 +98,21 @@ describe("writeDetectorFinding", () => {
       expect.stringContaining("/api/v1/internal/detector-findings"),
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+  it("forwards timestampMs in the request body when provided", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    await writeDetectorFinding({
+      findingId: "finding-1",
+      projectId: "proj-1",
+      traceId: "trace-1",
+      summary: "Something bad",
+      payload: "{}",
+      timestampMs: 1_700_000_000_123,
+    });
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.timestampMs).toBe(1_700_000_000_123);
   });
 });

--- a/frontend/worker/src/detection/clickhouse-writer.ts
+++ b/frontend/worker/src/detection/clickhouse-writer.ts
@@ -30,6 +30,10 @@ export async function writeDetectorRun(params: {
   traceId: string;
   findingId: string | null;
   status: "completed" | "failed";
+  // Worker epoch-ms time to store as the row timestamp. Omit to let ClickHouse
+  // default to now64(3). Set for triggered runs so the digest window count
+  // shares the clock that keys the flush.
+  timestampMs?: number;
 }): Promise<void> {
   await internalPost("/api/v1/internal/detector-runs", params);
 }
@@ -40,6 +44,7 @@ export async function writeDetectorFinding(params: {
   traceId: string;
   summary: string;
   payload: string;
+  timestampMs?: number;
 }): Promise<void> {
   await internalPost("/api/v1/internal/detector-findings", params);
 }

--- a/frontend/worker/src/processors/__tests__/detector-run-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-run-processor.test.ts
@@ -164,6 +164,14 @@ describe("processTrace — finding + RCA", () => {
     expect(mockWriteFinding.mock.calls[0][0]).not.toHaveProperty("retracted");
     expect(mockWriteRun).toHaveBeenCalled();
     expect(mockQueueAdd).toHaveBeenCalledTimes(1); // one RCA job
+
+    // The finding row, its triggered run, and the RCA job that keys the digest
+    // flush all carry the SAME capture time, so the count window the flush reads
+    // matches the window the key selects (no clock-boundary skew).
+    const ts = mockWriteFinding.mock.calls[0][0].timestampMs;
+    expect(typeof ts).toBe("number");
+    expect(mockWriteRun.mock.calls[0][0].timestampMs).toBe(ts);
+    expect(mockQueueAdd.mock.calls[0][1].findingTimestamp).toBe(ts);
   });
 
   it("writes no finding when nothing triggers", async () => {

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -293,9 +293,9 @@ export async function processRcaJob(job: Job<DetectorRcaJob>) {
   let alertWindow: string = DEFAULT_ALERT_WINDOW;
 
   // Every detector alert is a windowed digest: schedule one deduped flush per
-  // (project, windowStart) keyed off the worker's finding-capture time, which is
-  // close to (but a few ms before) the server-stamped detector_runs.timestamp
-  // the flush reads back. The deterministic jobId makes
+  // (project, windowStart) keyed off the finding timestamp, which the worker also
+  // stamps onto the detector_runs the flush counts — so the window the key selects
+  // and the window the count reads are identical. The deterministic jobId makes
   // the first finding of the window schedule the flush and every later finding a
   // no-op enqueue. Age-based retention keeps a late re-enqueue (slow RCA) a no-op
   // past the largest window + RCA tail. Findings must never fail silently, so

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -380,11 +380,11 @@ async function evaluateTrace(
     })),
   );
 
-  // Worker capture time for this finding, used to key the digest window. Note
-  // this is close to but not identical to the server-stamped
-  // detector_runs.timestamp the flush reads back (the row is stamped a few ms
-  // later, at INSERT), so a finding within that margin of a window boundary can
-  // land in an adjacent count window. Sub-second and boundary-only today.
+  // Single capture time for this finding. Stamped onto the finding row AND every
+  // triggered run below (timestampMs), and threaded to the RCA job to key the
+  // digest flush. Because the same value is both the row timestamp the flush
+  // counts and the window key, a finding always falls in exactly the window its
+  // flush covers — no boundary skew between the worker and server clocks.
   const findingTimestamp = Date.now();
 
   await writeDetectorFinding({
@@ -393,9 +393,12 @@ async function evaluateTrace(
     traceId,
     summary: combinedSummary,
     payload,
+    timestampMs: findingTimestamp,
   });
 
   // Write runs for all triggered detectors, all pointing to the same finding_id
+  // and stamped with the shared findingTimestamp so the digest count window
+  // matches the flush key.
   await Promise.allSettled(
     triggered.map((r) =>
       writeDetectorRun({
@@ -405,6 +408,7 @@ async function evaluateTrace(
         traceId,
         findingId,
         status: "completed",
+        timestampMs: findingTimestamp,
       }).catch((err) => console.error("[Detector] Failed to write run:", err)),
     ),
   );

--- a/frontend/worker/src/queues/detector-run-queue.ts
+++ b/frontend/worker/src/queues/detector-run-queue.ts
@@ -19,7 +19,7 @@ export interface DetectorRcaJob {
   traceId: string;
   workspaceId: string;
   findings: DetectorRcaFinding[];
-  // epoch ms; worker capture time, used to key the digest window. Optional
+  // epoch ms; stamped on the detector rows + keys the digest window. Optional
   // because legacy jobs serialized to Redis before this field existed deserialize
   // without it — scheduleDigestFlush guards the undefined case.
   findingTimestamp?: number;

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -309,6 +309,76 @@ class TestWriteDetectorFinding:
         assert "INSERT INTO detector_findings" in sql
         assert "retracted" not in sql
 
+    def test_stamps_timestamp_when_provided(self, client, mock_ch, secret):
+        resp = client.post(
+            "/api/v1/internal/detector-findings",
+            json={**self._body(), "timestampMs": 1_700_000_000_123},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        sql = mock_ch.query.call_args.args[0]
+        params = mock_ch.query.call_args.kwargs["parameters"]
+        assert "fromUnixTimestamp64Milli({timestamp_ms:Int64})" in sql
+        assert params["timestamp_ms"] == 1_700_000_000_123
+
+    def test_omits_timestamp_when_absent(self, client, mock_ch, secret):
+        resp = client.post(
+            "/api/v1/internal/detector-findings",
+            json=self._body(),
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        sql = mock_ch.query.call_args.args[0]
+        params = mock_ch.query.call_args.kwargs["parameters"]
+        assert "fromUnixTimestamp64Milli" not in sql
+        assert "timestamp_ms" not in params
+
+
+class TestWriteDetectorRun:
+    def _body(self) -> dict:
+        return {
+            "runId": "r1",
+            "detectorId": "d1",
+            "projectId": "p1",
+            "traceId": "trace-aaa",
+            "findingId": "f1",
+            "status": "completed",
+        }
+
+    def test_writes_run_row(self, client, mock_ch, secret):
+        resp = client.post(
+            "/api/v1/internal/detector-runs",
+            json=self._body(),
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        sql = mock_ch.query.call_args.args[0]
+        assert "INSERT INTO detector_runs" in sql
+
+    def test_stamps_timestamp_when_provided(self, client, mock_ch, secret):
+        resp = client.post(
+            "/api/v1/internal/detector-runs",
+            json={**self._body(), "timestampMs": 1_700_000_000_123},
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        sql = mock_ch.query.call_args.args[0]
+        params = mock_ch.query.call_args.kwargs["parameters"]
+        assert "fromUnixTimestamp64Milli({timestamp_ms:Int64})" in sql
+        assert params["timestamp_ms"] == 1_700_000_000_123
+
+    def test_omits_timestamp_when_absent(self, client, mock_ch, secret):
+        resp = client.post(
+            "/api/v1/internal/detector-runs",
+            json=self._body(),
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.status_code == 200
+        sql = mock_ch.query.call_args.args[0]
+        params = mock_ch.query.call_args.kwargs["parameters"]
+        assert "fromUnixTimestamp64Milli" not in sql
+        assert "timestamp_ms" not in params
+
 
 # =============================================================================
 # /traces/{trace_id}/findings


### PR DESCRIPTION
Part of epic #1296 §2 (follow-up fix surfaced during e2e). The digest flush is keyed off the worker's finding timestamp, but the count it reads filters on the server-stamped `detector_runs.timestamp` — so a finding written near a window boundary could be counted in an adjacent window and, if it were the sole finding there, its alert dropped. This threads an optional `timestampMs` through the internal write endpoints so the finding row and its triggered runs carry the exact timestamp the flush keys off.

Stacked on #1344 — review/merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns digest windows by stamping the worker’s finding timestamp onto ClickHouse `detector_findings` and `detector_runs` so the digest flush key and the count use the same clock, preventing dropped alerts at window boundaries (Linear #1296 §2).

- **Bug Fixes**
  - Internal endpoints accept optional `timestampMs`; backend writes it into `timestamp` via `fromUnixTimestamp64Milli({timestamp_ms:Int64})`, or omits the column to let `now64(3)` default.
  - Worker captures one timestamp, stamps it on the finding and all triggered runs, and threads it to the RCA job; tests cover forwarding, identical timestamps across finding/run/RCA job, and backend stamping/omission for both endpoints.

<sup>Written for commit 32187cb56294e888023a2c7c6920981014a0834e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

