### PR TITLE
fix(worker): add Moonshot/Kimi model pricing (kimi-k2.6)

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -995,5 +995,41 @@
       "cacheRead": 0,
       "cacheWrite": null
     }
+  },
+  {
+    "id": "tr-kimi-k2-6",
+    "modelName": "kimi-k2.6",
+    "matchPattern": "(?i)^(moonshot\\/)?kimi-k2\\.6(-[\\d-]+)?$",
+    "provider": "moonshot",
+    "prices": {
+      "input": 0.00000095,
+      "output": 0.000004,
+      "cacheRead": 0.00000016,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-kimi-k2-5",
+    "modelName": "kimi-k2.5",
+    "matchPattern": "(?i)^(moonshot\\/)?kimi-k2\\.5(-[\\d-]+)?$",
+    "provider": "moonshot",
+    "prices": {
+      "input": 0.0000006,
+      "output": 0.000003,
+      "cacheRead": 0.0000001,
+      "cacheWrite": null
+    }
+  },
+  {
+    "id": "tr-kimi-k2-thinking",
+    "modelName": "kimi-k2-thinking",
+    "matchPattern": "(?i)^(moonshot\\/)?kimi-k2-thinking(-[\\d-]+)?$",
+    "provider": "moonshot",
+    "prices": {
+      "input": 0.0000006,
+      "output": 0.0000025,
+      "cacheRead": 0.00000015,
+      "cacheWrite": null
+    }
   }
 ]

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -1195,6 +1195,18 @@
     }
   },
   {
+    "id": "tr-kimi-k2-6",
+    "modelName": "kimi-k2.6",
+    "matchPattern": "(?i)^(moonshot\\/)?kimi-k2\\.6(-[\\d-]+)?$",
+    "provider": "moonshot",
+    "prices": {
+      "input": 0.00000095,
+      "output": 0.000004,
+      "cacheRead": 0.00000016,
+      "cacheWrite": null
+    }
+  },
+  {
     "id": "tr-grok-4-20",
     "modelName": "grok-4.20",
     "matchPattern": "(?i)^(xai\\/)?grok-4\\.20(-[a-z0-9-]+)?$",

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -162,6 +162,16 @@ DEEPSEEK_MODEL_CASES = [
     ("deepseek-v4-pro-20260424", "deepseek-v4-pro"),
 ]
 
+MOONSHOT_MODEL_CASES = [
+    ("kimi-k2.6", "kimi-k2.6"),
+    ("moonshot/kimi-k2.6", "kimi-k2.6"),
+    ("kimi-k2.6-20260420", "kimi-k2.6"),
+    ("kimi-k2.5", "kimi-k2.5"),
+    ("moonshot/kimi-k2.5", "kimi-k2.5"),
+    ("kimi-k2-thinking", "kimi-k2-thinking"),
+    ("moonshot/kimi-k2-thinking", "kimi-k2-thinking"),
+]
+
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)
 class TestGetModelPrice:
@@ -261,6 +271,36 @@ class TestGLMModelIds:
         assert price[MATCHED_MODEL_NAME] == expected_name, (
             f"{model_id} matched a different entry than {expected_name}"
         )
+
+
+class TestMoonshotModelIds:
+    @pytest.mark.parametrize("model_id,expected_name", MOONSHOT_MODEL_CASES)
+    def test_matches_expected_model(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert "input" in price and "output" in price
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched a different entry than {expected_name}"
+        )
+
+    def test_kimi_k2_thinking_turbo_not_priced_as_thinking(self, real_cache):
+        # kimi-k2-thinking-turbo is a distinct model; the kimi-k2-thinking
+        # entry must not absorb it at the wrong rate.
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            assert get_model_price("kimi-k2-thinking-turbo") is None
+
+    def test_kimi_k2_6_calculates_cost(self, real_cache):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            result = calculate_cost("kimi-k2.6", "Hello world", "Hi there")
+
+        assert result["input_tokens"] is not None
+        assert result["input_tokens"] > 0
+        assert result["output_tokens"] is not None
+        assert result["output_tokens"] > 0
+        assert result["cost"] is not None
+        assert result["cost"] > 0
 
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -221,6 +221,12 @@ KIMI_MODEL_CASES = [
     ("kimi-k3-20260716", "kimi-k3"),
 ]
 
+KIMI_K26_MODEL_CASES = [
+    ("kimi-k2.6", "kimi-k2.6"),
+    ("moonshot/kimi-k2.6", "kimi-k2.6"),
+    ("kimi-k2.6-20260420", "kimi-k2.6"),
+]
+
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)
 class TestGetModelPrice:
@@ -412,6 +418,40 @@ class TestKimiModelIds:
     def test_kimi_k3_calculates_cost(self, real_cache):
         with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
             result = calculate_cost("kimi-k3", "Hello world", "Hi there")
+
+        assert result["input_tokens"] is not None
+        assert result["input_tokens"] > 0
+        assert result["output_tokens"] is not None
+        assert result["output_tokens"] > 0
+        assert result["cost"] is not None
+        assert result["cost"] > 0
+
+
+class TestKimiK26ModelIds:
+    @pytest.mark.parametrize("model_id,expected_name", KIMI_K26_MODEL_CASES)
+    def test_matches_expected_model(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert "input" in price and "output" in price
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched a different entry than {expected_name}"
+        )
+
+    def test_kimi_k2_6_absolute_rates(self):
+        # The id-matching tests pass for any price table, so pin the published rates
+        # (USD per token, from Moonshot's direct-API price page on platform.kimi.ai).
+        entry = next((e for e in _standard_price_entries() if e["modelName"] == "kimi-k2.6"), None)
+        assert entry is not None, "kimi-k2.6 missing from standard-model-prices.json"
+        prices = entry["prices"]
+        assert prices["input"] == pytest.approx(0.00000095)
+        assert prices["output"] == pytest.approx(0.000004)
+        assert prices["cacheRead"] == pytest.approx(0.00000016)
+
+    def test_kimi_k2_6_calculates_cost(self, real_cache):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            result = calculate_cost("kimi-k2.6", "Hello world", "Hi there")
 
         assert result["input_tokens"] is not None
         assert result["input_tokens"] > 0


### PR DESCRIPTION
### What

Adds Moonshot pricing for `kimi-k2.6`. #703 added it to the BYOK dropdown (`ADAPTER_MODELS.moonshot` in `frontend/packages/core/src/llm-providers.ts`) for #702, but no price entry came with it. On main today `get_model_price("kimi-k2.6")` returns `None`, so `calculate_cost()` leaves `cost` as `None` and ingest stores no cost for these spans.

Same shape as #1342 (xAI Grok pricing).

### Change

- One entry, `tr-kimi-k2-6`, placed after `tr-kimi-k3`. USD per 1M tokens from Moonshot's [live price page](https://platform.kimi.ai/docs/pricing/chat-k26): $0.95 input, $4.00 output, $0.16 cached input.
- `TestKimiK26ModelIds` covers bare, `moonshot/`-prefixed and version-suffixed ids, pins the three rates, and checks a cost calculation.

### Notes

`kimi-k2.5` and `kimi-k2-thinking` are dropped from this PR because Moonshot has retired both. Both ids are still listed in `ADAPTER_MODELS.moonshot`, so removing them from the dropdown could be a separate change.
