### PR TITLE
spike: validate the ClickHouse SQL security model (DEFINER views + read-only user + bound-param scoping)

### DIFF
--- a/scripts/spikes/clickhouse_connect_bound_param.py
+++ b/scripts/spikes/clickhouse_connect_bound_param.py
@@ -1,0 +1,54 @@
+"""
+Test 7: clickhouse-connect bound parameter in parameterized view call.
+
+Connects to localhost:18123 and runs the bound-param view-call form:
+  SELECT span_id FROM spike.spans_definer_v1(project_id = {scope_project_id:String})
+  ORDER BY span_id
+  parameters={"scope_project_id": "proj_A"}
+
+Note: uses spike_ro (no_password, no HOST restriction) because the `default` user
+has HOST LOCAL set, which blocks HTTP connections arriving through Docker port-mapping
+(the container sees a Docker bridge IP, not 127.0.0.1).  The `spike_ro` user has
+SELECT on `spike.spans_definer_v1` and can reach the HTTP port from the host.
+
+PASS  iff rows = ['sA1', 'sA2'] and no exception.
+"""
+
+import sys
+
+try:
+    import clickhouse_connect
+except ImportError as e:
+    print(f"SKIP: clickhouse_connect not installed: {e}", file=sys.stderr)
+    sys.exit(0)
+
+_ver = getattr(clickhouse_connect.__version__, "version", None) or getattr(
+    clickhouse_connect.__version__, "__version__", str(clickhouse_connect.__version__)
+)
+print(f"clickhouse_connect version: {_ver}", flush=True)
+
+client = clickhouse_connect.get_client(
+    host="localhost", port=18123, username="spike_ro", password=""
+)
+
+query = (
+    "SELECT span_id FROM spike.spans_definer_v1(project_id = {scope_project_id:String})"
+    " ORDER BY span_id"
+)
+params = {"scope_project_id": "proj_A"}
+
+try:
+    result = client.query(query, parameters=params)
+    rows = [row[0] for row in result.result_rows]
+    print(f"Rows returned: {rows}")
+    expected = ["sA1", "sA2"]
+    if rows == expected:
+        print("PASS: bound-param view-call via clickhouse-connect works correctly")
+    else:
+        print(f"FAIL: expected {expected}, got {rows}")
+        sys.exit(1)
+except Exception as e:
+    print(f"FAIL: exception: {e}", file=sys.stderr)
+    sys.exit(1)
+finally:
+    client.close()

--- a/scripts/spikes/clickhouse_connect_bound_param.py
+++ b/scripts/spikes/clickhouse_connect_bound_param.py
@@ -1,6 +1,9 @@
 """
 Test 7: clickhouse-connect bound parameter in parameterized view call.
 
+Prerequisite: run `scripts/spikes/clickhouse_sql_security_24_3.sh` first — it
+creates the `spike_ro` user and the `spike.spans_definer_v1` view this script uses.
+
 Connects to localhost:18123 and runs the bound-param view-call form:
   SELECT span_id FROM spike.spans_definer_v1(project_id = {scope_project_id:String})
   ORDER BY span_id

--- a/scripts/spikes/clickhouse_connect_bound_param.py
+++ b/scripts/spikes/clickhouse_connect_bound_param.py
@@ -47,6 +47,25 @@ try:
     else:
         print(f"FAIL: expected {expected}, got {rows}")
         sys.exit(1)
+
+    # Injection payloads over the HTTP path: bound params must NOT leak or execute.
+    inj_q = "SELECT span_id FROM spike.spans_definer_v1(project_id = {p:String}) ORDER BY span_id"
+    for payload in [
+        "proj_A' OR project_id='proj_B",
+        "proj_A'); DROP TABLE spike.spans_phys; --",
+    ]:
+        leaked = [r[0] for r in client.query(inj_q, parameters={"p": payload}).result_rows]
+        if leaked:
+            print(
+                f"FAIL: injection leaked rows {leaked!r} for payload {payload!r}", file=sys.stderr
+            )
+            sys.exit(1)
+        print(f"PASS: injection payload returned 0 rows: {payload!r}")
+    survived = client.query(
+        "SELECT count() FROM spike.spans_definer_v1(project_id = {p:String})",
+        parameters={"p": "proj_A"},
+    ).result_rows[0][0]
+    print(f"PASS: physical table intact after injection attempts (proj_A rows = {survived})")
 except Exception as e:
     print(f"FAIL: exception: {e}", file=sys.stderr)
     sys.exit(1)

--- a/scripts/spikes/clickhouse_connect_bound_param.py
+++ b/scripts/spikes/clickhouse_connect_bound_param.py
@@ -4,7 +4,9 @@ Test 7: clickhouse-connect bound parameter in parameterized view call.
 Prerequisite: run `scripts/spikes/clickhouse_sql_security_24_3.sh` first — it
 creates the `spike_ro` user and the `spike.spans_definer_v1` view this script uses.
 
-Connects to localhost:18123 and runs the bound-param view-call form:
+Connects to localhost:$CH_HTTP_PORT (default 18123) — the same variable the spike
+script publishes the container on, so a non-default port reaches the right server —
+and runs the bound-param view-call form:
   SELECT span_id FROM spike.spans_definer_v1(project_id = {scope_project_id:String})
   ORDER BY span_id
   parameters={"scope_project_id": "proj_A"}
@@ -17,6 +19,7 @@ SELECT on `spike.spans_definer_v1` and can reach the HTTP port from the host.
 PASS  iff rows = ['sA1', 'sA2'] and no exception.
 """
 
+import os
 import sys
 
 try:
@@ -30,8 +33,10 @@ _ver = getattr(clickhouse_connect.__version__, "version", None) or getattr(
 )
 print(f"clickhouse_connect version: {_ver}", flush=True)
 
+_PORT = int(os.environ.get("CH_HTTP_PORT", "18123"))
+
 client = clickhouse_connect.get_client(
-    host="localhost", port=18123, username="spike_ro", password=""
+    host="localhost", port=_PORT, username="spike_ro", password=""
 )
 
 query = (

--- a/scripts/spikes/clickhouse_connect_bound_param.py
+++ b/scripts/spikes/clickhouse_connect_bound_param.py
@@ -4,7 +4,7 @@ Test 7: clickhouse-connect bound parameter in parameterized view call.
 Prerequisite: run `scripts/spikes/clickhouse_sql_security_24_3.sh` first — it
 creates the `spike_ro` user and the `spike.spans_definer_v1` view this script uses.
 
-Connects to localhost:$CH_HTTP_PORT (default 18123) — the same variable the spike
+Connects to 127.0.0.1:$CH_HTTP_PORT (default 18123) — the same variable the spike
 script publishes the container on, so a non-default port reaches the right server —
 and runs the bound-param view-call form:
   SELECT span_id FROM spike.spans_definer_v1(project_id = {scope_project_id:String})
@@ -15,6 +15,10 @@ Note: uses spike_ro (no_password, no HOST restriction) because the `default` use
 has HOST LOCAL set, which blocks HTTP connections arriving through Docker port-mapping
 (the container sees a Docker bridge IP, not 127.0.0.1).  The `spike_ro` user has
 SELECT on `spike.spans_definer_v1` and can reach the HTTP port from the host.
+
+Because spike_ro is deliberately unrestricted by host and has no password, the spike
+script publishes the container ports on 127.0.0.1 only.  Do not republish them on
+0.0.0.0 to reach this server from another machine.
 
 PASS  iff rows = ['sA1', 'sA2'] and no exception.
 """
@@ -36,7 +40,7 @@ print(f"clickhouse_connect version: {_ver}", flush=True)
 _PORT = int(os.environ.get("CH_HTTP_PORT", "18123"))
 
 client = clickhouse_connect.get_client(
-    host="localhost", port=_PORT, username="spike_ro", password=""
+    host="127.0.0.1", port=_PORT, username="spike_ro", password=""
 )
 
 query = (

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# clickhouse_sql_security_24_3.sh
+#
+# Re-runnable spike: ClickHouse 24.3 SQL SECURITY / DEFINER + parameterized views.
+# Idempotent: drops and recreates the `spike` database, users, and profiles on each run.
+#
+# Prerequisites:
+#   docker container named `ch_sql_spike` running clickhouse/clickhouse-server:24.3
+#   Ports: HTTP localhost:18123, native localhost:19000
+#
+# Usage:
+#   bash scripts/spikes/clickhouse_sql_security_24_3.sh
+
+set -euo pipefail
+
+CH="docker exec ch_sql_spike clickhouse-client"
+
+sep() { echo; echo "===================================================="; echo "  $*"; echo "===================================================="; }
+
+# ---------------------------------------------------------------------------
+# SETUP — idempotent teardown + recreate
+# ---------------------------------------------------------------------------
+sep "SETUP: drop and recreate spike database, users, profiles"
+
+$CH --query "DROP DATABASE IF EXISTS spike"
+$CH --query "DROP USER IF EXISTS spike_ro"          || true
+$CH --query "DROP USER IF EXISTS spike_tiny_cap"    || true
+$CH --query "DROP USER IF EXISTS spike_http_test"   || true
+$CH --query "DROP SETTINGS PROFILE IF EXISTS spike_ro_profile"       || true
+$CH --query "DROP SETTINGS PROFILE IF EXISTS spike_tiny_cap_profile" || true
+
+$CH --query "CREATE DATABASE spike"
+
+$CH --query "CREATE TABLE spike.spans_phys (
+  project_id String, span_id String, trace_id String, name String,
+  ch_update_time DateTime64(3) DEFAULT now64(3)
+) ENGINE = ReplacingMergeTree(ch_update_time)
+ORDER BY (project_id, span_id)"
+
+$CH --query "INSERT INTO spike.spans_phys (project_id,span_id,trace_id,name) VALUES
+ ('proj_A','sA1','tA1','a-one'),('proj_A','sA2','tA2','a-two'),('proj_B','sB1','tB1','b-one')"
+
+echo "SETUP OK"
+
+# ---------------------------------------------------------------------------
+# TEST 0 — Environment
+# ---------------------------------------------------------------------------
+sep "TEST 0: version + image"
+echo "version:"
+$CH --query "SELECT version()"
+echo "image digest (host): sha256:85b97f63dcfff47790d26bb5d5801637aaddb2b93e5e9aee27a686c2fb2b9916"
+echo "image tag: clickhouse/clickhouse-server:24.3"
+
+# ---------------------------------------------------------------------------
+# TEST 1 — Parameterized view, literal arg
+# ---------------------------------------------------------------------------
+sep "TEST 1: parameterized view — literal arg"
+
+$CH --query "CREATE VIEW spike.spans_public_v1 AS
+SELECT span_id, trace_id, name FROM (
+  SELECT * FROM spike.spans_phys WHERE project_id = {project_id:String}
+  ORDER BY ch_update_time DESC LIMIT 1 BY span_id
+)"
+
+echo "Query (expect sA1, sA2 — no sB1):"
+$CH --query "SELECT span_id FROM spike.spans_public_v1(project_id = 'proj_A') ORDER BY span_id"
+
+# ---------------------------------------------------------------------------
+# TEST 2 — Bound parameter inside the view call
+# ---------------------------------------------------------------------------
+sep "TEST 2: bound parameter inside view call (--param_ form)"
+
+echo "Query with --param_scope_project_id=proj_A (expect sA1, sA2):"
+docker exec ch_sql_spike clickhouse-client \
+  --param_scope_project_id=proj_A \
+  --query "SELECT span_id FROM spike.spans_public_v1(project_id = {scope_project_id:String}) ORDER BY span_id"
+
+# ---------------------------------------------------------------------------
+# TEST 3 — SQL SECURITY DEFINER + parameterized view
+# ---------------------------------------------------------------------------
+sep "TEST 3: SQL SECURITY DEFINER on parameterized view"
+
+$CH --query "CREATE VIEW spike.spans_definer_v1
+  DEFINER = default SQL SECURITY DEFINER AS
+SELECT span_id, trace_id, name FROM (
+  SELECT * FROM spike.spans_phys WHERE project_id = {project_id:String}
+  ORDER BY ch_update_time DESC LIMIT 1 BY span_id
+)"
+
+echo "SHOW CREATE VIEW (expect DEFINER = default SQL SECURITY DEFINER in output):"
+$CH --query "SHOW CREATE VIEW spike.spans_definer_v1"
+
+# ---------------------------------------------------------------------------
+# TEST 4 — Read-only user + grants (hardened model)
+# ---------------------------------------------------------------------------
+sep "TEST 4: read-only user, settings profile, grants"
+
+$CH --query "CREATE SETTINGS PROFILE spike_ro_profile SETTINGS
+  readonly = 1,
+  max_execution_time = 30 CONST,
+  max_result_rows = 100000 CONST,
+  max_result_bytes = 536870912 CONST,
+  max_memory_usage = 4294967296 CONST"
+
+$CH --query "CREATE USER spike_ro IDENTIFIED WITH no_password SETTINGS PROFILE 'spike_ro_profile'"
+
+$CH --query "GRANT SELECT ON spike.spans_definer_v1 TO spike_ro"
+
+echo ""
+echo "--- 4a: spike_ro reads definer view (expect sA1, sA2 — DEFINER lets view body read physical table) ---"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id"
+
+echo ""
+echo "--- 4b: spike_ro reads physical table (EXPECTED-DENY) ---"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT * FROM spike.spans_phys LIMIT 1" || true
+
+echo ""
+echo "--- 4c: spike_ro INSERT into physical table (EXPECTED-DENY) ---"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "INSERT INTO spike.spans_phys (project_id,span_id,trace_id,name) VALUES ('proj_C','sC1','tC1','c-one')" || true
+
+echo ""
+echo "--- 4d: spike_ro system.tables (expect only granted objects visible) ---"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT database, name FROM system.tables ORDER BY database, name"
+
+echo ""
+echo "--- 4d: spike_ro system.clusters (EXPECTED-DENY) ---"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT * FROM system.clusters LIMIT 1" || true
+
+# ---------------------------------------------------------------------------
+# TEST 5 — Tenant isolation
+# ---------------------------------------------------------------------------
+sep "TEST 5: tenant isolation"
+
+echo "--- 5a: flat query proj_A (expect only sA1, sA2) ---"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id"
+
+echo ""
+echo "--- 5b: CTE query proj_A (expect only sA1, sA2) ---"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "WITH v AS (SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A'))
+           SELECT span_id FROM v ORDER BY span_id"
+
+echo ""
+echo "--- 5c: forged quote injection via bound param (expect 0 rows, no sB1 leak) ---"
+docker exec ch_sql_spike clickhouse-client \
+  --param_pid="proj_A' OR project_id='proj_B" \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = {pid:String}) ORDER BY span_id"
+echo "(0 rows above = PASS)"
+
+echo ""
+echo "--- 5d: forged semicolon DROP injection via bound param (expect 0 rows, table survives) ---"
+docker exec ch_sql_spike clickhouse-client \
+  --param_pid="proj_A'); DROP TABLE spike.spans_phys; --" \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = {pid:String}) ORDER BY span_id"
+echo "(0 rows above = PASS)"
+
+echo ""
+echo "--- 5d verify: table still has rows after injection attempt ---"
+$CH --query "SELECT count(*) FROM spike.spans_phys"
+
+# ---------------------------------------------------------------------------
+# TEST 6 — Resource caps / profile
+# ---------------------------------------------------------------------------
+sep "TEST 6: resource caps / readonly profile"
+
+echo "--- 6a: spike_ro tries to RAISE max_execution_time to 99999 (EXPECTED-DENY) ---"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A')
+           ORDER BY span_id SETTINGS max_execution_time = 99999" || true
+
+echo ""
+echo "--- 6b: spike_ro tries a more-restrictive setting max_result_rows=1 (EXPECTED-DENY under readonly=1) ---"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A')
+           ORDER BY span_id SETTINGS max_result_rows = 1" || true
+
+echo ""
+echo "--- 6c: cap fires in practice (spike_tiny_cap: max_execution_time=0.001) ---"
+$CH --query "CREATE SETTINGS PROFILE spike_tiny_cap_profile SETTINGS
+  readonly = 1, max_execution_time = 0.001 CONST, max_result_rows = 1 CONST"
+$CH --query "CREATE USER spike_tiny_cap IDENTIFIED WITH no_password SETTINGS PROFILE 'spike_tiny_cap_profile'"
+$CH --query "GRANT SELECT ON spike.spans_definer_v1 TO spike_tiny_cap"
+
+docker exec ch_sql_spike clickhouse-client --user spike_tiny_cap \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id" || true
+echo "(TIMEOUT_EXCEEDED above = PASS — cap fired)"
+
+sep "ALL TESTS COMPLETE"

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -191,4 +191,52 @@ docker exec ch_sql_spike clickhouse-client --user spike_tiny_cap \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id" || true
 echo "(TIMEOUT_EXCEEDED above = PASS — cap fired)"
 
+# ---------------------------------------------------------------------------
+# TEST 8 — DEFINER with a SCOPED (non-superuser) writer user
+# ---------------------------------------------------------------------------
+sep "TEST 8: DEFINER = scoped writer user (not superuser)"
+$CH --query "CREATE USER IF NOT EXISTS spike_writer IDENTIFIED WITH no_password"
+$CH --query "GRANT SELECT ON spike.spans_phys TO spike_writer"   # writer scoped to the physical table only
+$CH --query "CREATE OR REPLACE VIEW spike.spans_definer_scoped_v1 DEFINER = spike_writer SQL SECURITY DEFINER AS
+SELECT span_id, trace_id, name FROM (
+  SELECT * FROM spike.spans_phys WHERE project_id = {project_id:String}
+  ORDER BY ch_update_time DESC LIMIT 1 BY span_id )"
+$CH --query "GRANT SELECT ON spike.spans_definer_scoped_v1 TO spike_ro"
+echo "RO reads scoped-writer DEFINER view (expect sA1, sA2):"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT span_id FROM spike.spans_definer_scoped_v1(project_id = 'proj_A') ORDER BY span_id"
+echo "scoped writer denied system.clusters (EXPECTED-DENY):"
+docker exec ch_sql_spike clickhouse-client --user spike_writer \
+  --query "SELECT count() FROM system.clusters" || true
+
+# ---------------------------------------------------------------------------
+# TEST 9 — Cross-tenant view call has NO DB-layer deny (gateway-only isolation)
+# ---------------------------------------------------------------------------
+sep "TEST 9: RO calls view with FOREIGN project_id (DB has no deny — proves gateway-only isolation)"
+echo "RO calls spans_definer_v1(project_id='proj_B') — returns sB1 (NO DB backstop):"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_B') ORDER BY span_id"
+echo "(sB1 above = expected: tenant isolation is enforced by the gateway rewriter, not the DB)"
+
+# ---------------------------------------------------------------------------
+# TEST 10 — Broader system.* sweep as RO (establish validator coverage)
+# ---------------------------------------------------------------------------
+sep "TEST 10: system.* readability as RO (validator must reject all of these)"
+for t in processes query_log text_log settings functions databases users grants merges parts; do
+  echo "--- system.$t (count, or EXPECTED-DENY) ---"
+  { docker exec ch_sql_spike clickhouse-client --user spike_ro \
+      --query "SELECT count() FROM system.$t" 2>&1 | head -1; } || true
+done
+
+# ---------------------------------------------------------------------------
+# TEST 11 — View chaining / nested DEFINER + parameterized view
+# ---------------------------------------------------------------------------
+sep "TEST 11: nested DEFINER view selecting from another parameterized view"
+$CH --query "CREATE OR REPLACE VIEW spike.spans_chain_v1 DEFINER = default SQL SECURITY DEFINER AS
+SELECT span_id FROM spike.spans_definer_v1(project_id = {project_id:String})"
+$CH --query "GRANT SELECT ON spike.spans_chain_v1 TO spike_ro"
+echo "RO reads chained view (expect sA1, sA2 — param passes through the chain):"
+docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT span_id FROM spike.spans_chain_v1(project_id = 'proj_A') ORDER BY span_id"
+
 sep "ALL TESTS COMPLETE"

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -17,6 +17,73 @@ CH="docker exec ch_sql_spike clickhouse-client"
 
 sep() { echo; echo "===================================================="; echo "  $*"; echo "===================================================="; }
 
+# --- Assertion helpers: a security spike must FAIL LOUDLY, never print PASS unconditionally ---
+
+# expect_deny "label" <cmd...> : PASS only if the command exits non-zero (access denied / error).
+# Fails the whole script (exit 1) if the command unexpectedly SUCCEEDS.
+expect_deny() {
+  local label="$1"; shift
+  local out
+  if out=$("$@" 2>&1); then
+    echo "FAIL [$label]: command unexpectedly SUCCEEDED (expected access-denied):"
+    printf '%s\n' "$out" | head -3
+    exit 1
+  fi
+  echo "PASS [$label]: denied as expected -> $(printf '%s' "$out" | head -1)"
+}
+
+# expect_timeout "label" <cmd...> : PASS only if the command fails specifically with a timeout.
+# Fails if the query succeeds (cap did not fire) OR fails for some other reason.
+expect_timeout() {
+  local label="$1"; shift
+  local out
+  if out=$("$@" 2>&1); then
+    echo "FAIL [$label]: query unexpectedly SUCCEEDED — resource cap did NOT fire:"
+    printf '%s\n' "$out" | head -3
+    exit 1
+  fi
+  if ! printf '%s' "$out" | grep -qiE 'TIMEOUT_EXCEEDED|Code: 159'; then
+    echo "FAIL [$label]: failed but NOT with a timeout (cap may not be the cause):"
+    printf '%s\n' "$out" | head -3
+    exit 1
+  fi
+  echo "PASS [$label]: cap fired -> $(printf '%s' "$out" | grep -iE 'TIMEOUT_EXCEEDED|Code: 159' | head -1)"
+}
+
+# expect_empty "label" <cmd...> : PASS only if the command succeeds AND returns no rows.
+# Fails if it errors, or if it returns any output (possible tenant leak).
+expect_empty() {
+  local label="$1"; shift
+  local out
+  if ! out=$("$@" 2>&1); then
+    echo "FAIL [$label]: command errored unexpectedly:"
+    printf '%s\n' "$out" | head -3
+    exit 1
+  fi
+  if [ -n "$out" ]; then
+    echo "FAIL [$label]: expected 0 rows but got output (possible leak):"
+    printf '%s\n' "$out" | head -3
+    exit 1
+  fi
+  echo "PASS [$label]: returned 0 rows as expected"
+}
+
+# expect_eq "label" "expected" <cmd...> : PASS only if the command's trimmed stdout equals expected.
+expect_eq() {
+  local label="$1" expected="$2"; shift 2
+  local out
+  if ! out=$("$@" 2>&1); then
+    echo "FAIL [$label]: command errored unexpectedly:"
+    printf '%s\n' "$out" | head -3
+    exit 1
+  fi
+  if [ "$out" != "$expected" ]; then
+    echo "FAIL [$label]: expected '$expected' but got '$out'"
+    exit 1
+  fi
+  echo "PASS [$label]: got '$out' as expected"
+}
+
 # ---------------------------------------------------------------------------
 # SETUP — idempotent teardown + recreate
 # ---------------------------------------------------------------------------
@@ -113,14 +180,14 @@ docker exec ch_sql_spike clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id"
 
 echo ""
-echo "--- 4b: spike_ro reads physical table (EXPECTED-DENY) ---"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
-  --query "SELECT * FROM spike.spans_phys LIMIT 1" || true
+expect_deny "4b: spike_ro reads physical table" \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT * FROM spike.spans_phys LIMIT 1"
 
 echo ""
-echo "--- 4c: spike_ro INSERT into physical table (EXPECTED-DENY) ---"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
-  --query "INSERT INTO spike.spans_phys (project_id,span_id,trace_id,name) VALUES ('proj_C','sC1','tC1','c-one')" || true
+expect_deny "4c: spike_ro INSERT into physical table" \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "INSERT INTO spike.spans_phys (project_id,span_id,trace_id,name) VALUES ('proj_C','sC1','tC1','c-one')"
 
 echo ""
 echo "--- 4d: spike_ro system.tables (expect only granted objects visible) ---"
@@ -128,9 +195,9 @@ docker exec ch_sql_spike clickhouse-client --user spike_ro \
   --query "SELECT database, name FROM system.tables ORDER BY database, name"
 
 echo ""
-echo "--- 4d: spike_ro system.clusters (EXPECTED-DENY) ---"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
-  --query "SELECT * FROM system.clusters LIMIT 1" || true
+expect_deny "4d: spike_ro system.clusters" \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT * FROM system.clusters LIMIT 1"
 
 # ---------------------------------------------------------------------------
 # TEST 5 — Tenant isolation
@@ -148,49 +215,45 @@ docker exec ch_sql_spike clickhouse-client --user spike_ro \
            SELECT span_id FROM v ORDER BY span_id"
 
 echo ""
-echo "--- 5c: forged quote injection via bound param (expect 0 rows, no sB1 leak) ---"
-docker exec ch_sql_spike clickhouse-client \
+expect_empty "5c: forged quote injection returns no rows (no proj_B leak)" \
+  docker exec ch_sql_spike clickhouse-client \
   --param_pid="proj_A' OR project_id='proj_B" \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = {pid:String}) ORDER BY span_id"
-echo "(0 rows above = PASS)"
 
 echo ""
-echo "--- 5d: forged semicolon DROP injection via bound param (expect 0 rows, table survives) ---"
-docker exec ch_sql_spike clickhouse-client \
+expect_empty "5d: forged semicolon-DROP injection returns no rows" \
+  docker exec ch_sql_spike clickhouse-client \
   --param_pid="proj_A'); DROP TABLE spike.spans_phys; --" \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = {pid:String}) ORDER BY span_id"
-echo "(0 rows above = PASS)"
 
 echo ""
-echo "--- 5d verify: table still has rows after injection attempt ---"
-$CH --query "SELECT count(*) FROM spike.spans_phys"
+expect_eq "5d: physical table survived injection attempt" "3" \
+  docker exec ch_sql_spike clickhouse-client --query "SELECT count(*) FROM spike.spans_phys"
 
 # ---------------------------------------------------------------------------
 # TEST 6 — Resource caps / profile
 # ---------------------------------------------------------------------------
 sep "TEST 6: resource caps / readonly profile"
 
-echo "--- 6a: spike_ro tries to RAISE max_execution_time to 99999 (EXPECTED-DENY) ---"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
-  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A')
-           ORDER BY span_id SETTINGS max_execution_time = 99999" || true
+expect_deny "6a: spike_ro raises max_execution_time (readonly blocks it)" \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id SETTINGS max_execution_time = 99999"
 
 echo ""
-echo "--- 6b: spike_ro tries a more-restrictive setting max_result_rows=1 (EXPECTED-DENY under readonly=1) ---"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
-  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A')
-           ORDER BY span_id SETTINGS max_result_rows = 1" || true
+expect_deny "6b: spike_ro sets more-restrictive max_result_rows (readonly blocks any SETTINGS)" \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id SETTINGS max_result_rows = 1"
 
 echo ""
-echo "--- 6c: cap fires in practice (spike_tiny_cap: max_execution_time=0.001) ---"
+echo "--- 6c: CONST cap fires in practice (spike_tiny_cap: max_execution_time=0.001) ---"
 $CH --query "CREATE SETTINGS PROFILE spike_tiny_cap_profile SETTINGS
-  readonly = 1, max_execution_time = 0.001 CONST, max_result_rows = 1 CONST"
+  readonly = 1, max_execution_time = 0.001 CONST"
 $CH --query "CREATE USER spike_tiny_cap IDENTIFIED WITH no_password SETTINGS PROFILE 'spike_tiny_cap_profile'"
 $CH --query "GRANT SELECT ON spike.spans_definer_v1 TO spike_tiny_cap"
 
-docker exec ch_sql_spike clickhouse-client --user spike_tiny_cap \
-  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id" || true
-echo "(TIMEOUT_EXCEEDED above = PASS — cap fired)"
+expect_timeout "6c: tiny-cap profile aborts the query" \
+  docker exec ch_sql_spike clickhouse-client --user spike_tiny_cap \
+  --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id"
 
 # ---------------------------------------------------------------------------
 # TEST 8 — DEFINER with a SCOPED (non-superuser) writer user
@@ -206,9 +269,9 @@ $CH --query "GRANT SELECT ON spike.spans_definer_scoped_v1 TO spike_ro"
 echo "RO reads scoped-writer DEFINER view (expect sA1, sA2):"
 docker exec ch_sql_spike clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_scoped_v1(project_id = 'proj_A') ORDER BY span_id"
-echo "scoped writer denied system.clusters (EXPECTED-DENY):"
-docker exec ch_sql_spike clickhouse-client --user spike_writer \
-  --query "SELECT count() FROM system.clusters" || true
+expect_deny "8: scoped writer denied system.clusters" \
+  docker exec ch_sql_spike clickhouse-client --user spike_writer \
+  --query "SELECT count() FROM system.clusters"
 
 # ---------------------------------------------------------------------------
 # TEST 9 — Cross-tenant view call has NO DB-layer deny (gateway-only isolation)

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -24,6 +24,7 @@ sep "SETUP: drop and recreate spike database, users, profiles"
 
 $CH --query "DROP DATABASE IF EXISTS spike"
 $CH --query "DROP USER IF EXISTS spike_ro"          || true
+$CH --query "DROP USER IF EXISTS spike_writer"      || true
 $CH --query "DROP USER IF EXISTS spike_tiny_cap"    || true
 $CH --query "DROP USER IF EXISTS spike_http_test"   || true
 $CH --query "DROP SETTINGS PROFILE IF EXISTS spike_ro_profile"       || true

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -84,6 +84,22 @@ expect_eq() {
   echo "PASS [$label]: got '$out' as expected"
 }
 
+# expect_count "label" <cmd...> : PASS only if the command succeeds AND returns a non-negative integer.
+expect_count() {
+  local label="$1"; shift
+  local out
+  if ! out=$("$@" 2>&1); then
+    echo "FAIL [$label]: expected readable but command errored:"
+    printf '%s\n' "$out" | head -3
+    exit 1
+  fi
+  if ! printf '%s' "$out" | grep -qE '^[0-9]+$'; then
+    echo "FAIL [$label]: expected a numeric count but got '$out'"
+    exit 1
+  fi
+  echo "PASS [$label]: readable (count=$out)"
+}
+
 # ---------------------------------------------------------------------------
 # SETUP — idempotent teardown + recreate
 # ---------------------------------------------------------------------------
@@ -113,11 +129,24 @@ echo "SETUP OK"
 # ---------------------------------------------------------------------------
 # TEST 0 — Environment
 # ---------------------------------------------------------------------------
-sep "TEST 0: version + image"
-echo "version:"
-$CH --query "SELECT version()"
-echo "image digest (host): sha256:85b97f63dcfff47790d26bb5d5801637aaddb2b93e5e9aee27a686c2fb2b9916"
-echo "image tag: clickhouse/clickhouse-server:24.3"
+sep "TEST 0: version + image (verified against the pinned baseline)"
+EXPECTED_VERSION="24.3.18.7"
+EXPECTED_DIGEST="sha256:85b97f63dcfff47790d26bb5d5801637aaddb2b93e5e9aee27a686c2fb2b9916"
+
+expect_eq "0: ClickHouse version matches the pinned baseline" "$EXPECTED_VERSION" \
+  docker exec ch_sql_spike clickhouse-client --query "SELECT version()"
+
+# Verify the RUNNING container's image repo-digest against the pinned baseline (drift detection),
+# rather than echoing a hardcoded value.
+IMG_ID=$(docker inspect --format '{{.Image}}' ch_sql_spike)
+ACTUAL_DIGEST=$(docker image inspect "$IMG_ID" --format '{{range .RepoDigests}}{{println .}}{{end}}' \
+  | grep -oE 'sha256:[0-9a-f]+' | head -1)
+echo "running image: $(docker inspect --format '{{.Config.Image}}' ch_sql_spike)  digest: ${ACTUAL_DIGEST:-<none>}"
+if [ "$ACTUAL_DIGEST" != "$EXPECTED_DIGEST" ]; then
+  echo "FAIL [0: image digest matches pinned baseline]: expected $EXPECTED_DIGEST, running image is ${ACTUAL_DIGEST:-<none>}"
+  exit 1
+fi
+echo "PASS [0: image digest matches pinned baseline]: $ACTUAL_DIGEST"
 
 # ---------------------------------------------------------------------------
 # TEST 1 — Parameterized view, literal arg
@@ -130,16 +159,17 @@ SELECT span_id, trace_id, name FROM (
   ORDER BY ch_update_time DESC LIMIT 1 BY span_id
 )"
 
-echo "Query (expect sA1, sA2 — no sB1):"
-$CH --query "SELECT span_id FROM spike.spans_public_v1(project_id = 'proj_A') ORDER BY span_id"
+expect_eq "1: parameterized view returns only proj_A rows" $'sA1\nsA2' \
+  docker exec ch_sql_spike clickhouse-client \
+  --query "SELECT span_id FROM spike.spans_public_v1(project_id = 'proj_A') ORDER BY span_id"
 
 # ---------------------------------------------------------------------------
 # TEST 2 — Bound parameter inside the view call
 # ---------------------------------------------------------------------------
 sep "TEST 2: bound parameter inside view call (--param_ form)"
 
-echo "Query with --param_scope_project_id=proj_A (expect sA1, sA2):"
-docker exec ch_sql_spike clickhouse-client \
+expect_eq "2: bound-param view call returns only proj_A rows" $'sA1\nsA2' \
+  docker exec ch_sql_spike clickhouse-client \
   --param_scope_project_id=proj_A \
   --query "SELECT span_id FROM spike.spans_public_v1(project_id = {scope_project_id:String}) ORDER BY span_id"
 
@@ -175,8 +205,8 @@ $CH --query "CREATE USER spike_ro IDENTIFIED WITH no_password SETTINGS PROFILE '
 $CH --query "GRANT SELECT ON spike.spans_definer_v1 TO spike_ro"
 
 echo ""
-echo "--- 4a: spike_ro reads definer view (expect sA1, sA2 — DEFINER lets view body read physical table) ---"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
+expect_eq "4a: spike_ro reads definer view (DEFINER lets body read the physical table)" $'sA1\nsA2' \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id"
 
 echo ""
@@ -190,8 +220,8 @@ expect_deny "4c: spike_ro INSERT into physical table" \
   --query "INSERT INTO spike.spans_phys (project_id,span_id,trace_id,name) VALUES ('proj_C','sC1','tC1','c-one')"
 
 echo ""
-echo "--- 4d: spike_ro system.tables (expect only granted objects visible) ---"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
+expect_eq "4d: spike_ro system.tables shows only the granted view" $'spike\tspans_definer_v1' \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
   --query "SELECT database, name FROM system.tables ORDER BY database, name"
 
 echo ""
@@ -204,15 +234,14 @@ expect_deny "4d: spike_ro system.clusters" \
 # ---------------------------------------------------------------------------
 sep "TEST 5: tenant isolation"
 
-echo "--- 5a: flat query proj_A (expect only sA1, sA2) ---"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
+expect_eq "5a: flat query returns only proj_A" $'sA1\nsA2' \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id"
 
 echo ""
-echo "--- 5b: CTE query proj_A (expect only sA1, sA2) ---"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
-  --query "WITH v AS (SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A'))
-           SELECT span_id FROM v ORDER BY span_id"
+expect_eq "5b: CTE query returns only proj_A" $'sA1\nsA2' \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  --query "WITH v AS (SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A')) SELECT span_id FROM v ORDER BY span_id"
 
 echo ""
 expect_empty "5c: forged quote injection returns no rows (no proj_B leak)" \
@@ -266,8 +295,8 @@ SELECT span_id, trace_id, name FROM (
   SELECT * FROM spike.spans_phys WHERE project_id = {project_id:String}
   ORDER BY ch_update_time DESC LIMIT 1 BY span_id )"
 $CH --query "GRANT SELECT ON spike.spans_definer_scoped_v1 TO spike_ro"
-echo "RO reads scoped-writer DEFINER view (expect sA1, sA2):"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
+expect_eq "8: RO reads the scoped-writer DEFINER view" $'sA1\nsA2' \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_scoped_v1(project_id = 'proj_A') ORDER BY span_id"
 expect_deny "8: scoped writer denied system.clusters" \
   docker exec ch_sql_spike clickhouse-client --user spike_writer \
@@ -277,19 +306,28 @@ expect_deny "8: scoped writer denied system.clusters" \
 # TEST 9 — Cross-tenant view call has NO DB-layer deny (gateway-only isolation)
 # ---------------------------------------------------------------------------
 sep "TEST 9: RO calls view with FOREIGN project_id (DB has no deny — proves gateway-only isolation)"
-echo "RO calls spans_definer_v1(project_id='proj_B') — returns sB1 (NO DB backstop):"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
+# Expected BY DESIGN: a foreign project_id returns that tenant's row — the DB has NO backstop,
+# so tenant isolation MUST be enforced by the gateway binding the authenticated project_id.
+expect_eq "9: foreign project_id returns proj_B row (DB has no cross-tenant backstop)" "sB1" \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_B') ORDER BY span_id"
-echo "(sB1 above = expected: tenant isolation is enforced by the gateway rewriter, not the DB)"
 
 # ---------------------------------------------------------------------------
 # TEST 10 — Broader system.* sweep as RO (establish validator coverage)
 # ---------------------------------------------------------------------------
-sep "TEST 10: system.* readability as RO (validator must reject all of these)"
-for t in processes query_log text_log settings functions databases users grants merges parts; do
-  echo "--- system.$t (count, or EXPECTED-DENY) ---"
-  { docker exec ch_sql_spike clickhouse-client --user spike_ro \
-      --query "SELECT count() FROM system.$t" 2>&1 | head -1; } || true
+sep "TEST 10: system.* readability as RO (gateway validator must reject all system.* refs)"
+# Tables the RO user must NOT be able to read (no grant): assert each is denied.
+for t in processes query_log text_log users grants merges parts; do
+  expect_deny "10: system.$t denied to RO" \
+    docker exec ch_sql_spike clickhouse-client --user spike_ro \
+    --query "SELECT count() FROM system.$t"
+done
+# Tables that ARE readable on 24.3 (config/function metadata, no tenant data): assert they return a
+# count — this is exactly why the gateway validator must reject ALL system.* references.
+for t in settings functions databases; do
+  expect_count "10: system.$t readable by RO (gateway must still reject it)" \
+    docker exec ch_sql_spike clickhouse-client --user spike_ro \
+    --query "SELECT count() FROM system.$t"
 done
 
 # ---------------------------------------------------------------------------
@@ -299,8 +337,8 @@ sep "TEST 11: nested DEFINER view selecting from another parameterized view"
 $CH --query "CREATE OR REPLACE VIEW spike.spans_chain_v1 DEFINER = default SQL SECURITY DEFINER AS
 SELECT span_id FROM spike.spans_definer_v1(project_id = {project_id:String})"
 $CH --query "GRANT SELECT ON spike.spans_chain_v1 TO spike_ro"
-echo "RO reads chained view (expect sA1, sA2 — param passes through the chain):"
-docker exec ch_sql_spike clickhouse-client --user spike_ro \
+expect_eq "11: nested DEFINER view propagates the param through the chain" $'sA1\nsA2' \
+  docker exec ch_sql_spike clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_chain_v1(project_id = 'proj_A') ORDER BY span_id"
 
 sep "ALL TESTS COMPLETE"

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -140,7 +140,7 @@ expect_eq "0: ClickHouse version matches the pinned baseline" "$EXPECTED_VERSION
 # rather than echoing a hardcoded value.
 IMG_ID=$(docker inspect --format '{{.Image}}' ch_sql_spike)
 ACTUAL_DIGEST=$(docker image inspect "$IMG_ID" --format '{{range .RepoDigests}}{{println .}}{{end}}' \
-  | grep -oE 'sha256:[0-9a-f]+' | head -1)
+  | sed -nE 's|.*clickhouse/clickhouse-server@(sha256:[0-9a-f]+).*|\1|p' | head -1)
 echo "running image: $(docker inspect --format '{{.Config.Image}}' ch_sql_spike)  digest: ${ACTUAL_DIGEST:-<none>}"
 if [ "$ACTUAL_DIGEST" != "$EXPECTED_DIGEST" ]; then
   echo "FAIL [0: image digest matches pinned baseline]: expected $EXPECTED_DIGEST, running image is ${ACTUAL_DIGEST:-<none>}"

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -199,7 +199,12 @@ else
   esac
 fi
 IMG_REPO="${IMG_REPO%%@*}"   # drop any @sha256:... suffix
-IMG_REPO="${IMG_REPO%:*}"    # drop the tag, keeping any registry:port prefix
+# Strip a tag, but only a tag. A registry may carry a port ("registry:5000/foo"), and
+# blindly cutting at the last colon turned that into "registry". A colon is only a tag
+# separator when it appears in the LAST path segment.
+case "${IMG_REPO##*/}" in
+  *:*) IMG_REPO="${IMG_REPO%:*}" ;;
+esac
 
 # Exact prefix comparison rather than a regex: a repository can contain characters
 # that are regex metacharacters (a registry host has dots), and matching those

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -64,6 +64,24 @@ else
     echo "FATAL: container '$CH_CONTAINER' not found. Set CH_IMAGE to have this script start one." >&2
     exit 1
   fi
+  # Port bindings only describe reachability when the container actually has its own network
+  # namespace. Under host networking ClickHouse listens straight on this machine's interfaces
+  # and NetworkSettings.Ports is empty, so the loop below would find nothing and wave it
+  # through; a shared namespace is governed by the other container's bindings, not this one's.
+  _netmode=$(docker inspect -f '{{.HostConfig.NetworkMode}}' "$CH_CONTAINER" 2>/dev/null)
+  case "$_netmode" in
+    host)
+      echo "FATAL: '$CH_CONTAINER' uses host networking, so ClickHouse listens directly on this" >&2
+      echo "       machine's interfaces and no port binding confines it. This spike creates" >&2
+      echo "       no-password accounts and will not seed them into such a server." >&2
+      exit 1 ;;
+    container:*)
+      echo "FATAL: '$CH_CONTAINER' shares another container's network namespace ($_netmode), so its" >&2
+      echo "       reachability is governed by that container's port bindings, which this script" >&2
+      echo "       cannot vouch for. Use a container with its own loopback-published ports." >&2
+      exit 1 ;;
+  esac
+
   _bad=""
   for _binding in $(docker inspect \
       -f '{{range $p, $c := .NetworkSettings.Ports}}{{range $c}}{{$p}}@{{.HostIp}} {{end}}{{end}}' \

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -40,8 +40,14 @@ if [ -n "$CH_IMAGE" ]; then
   # (clickhouse_connect_bound_param.py) connects over HTTP from the host, and it runs
   # AFTER this script against the users and views this script creates. Teardown is
   # therefore skippable: set CH_KEEP=1 to leave the server up for it.
+  #
+  # They are bound to loopback only. This server runs with ALLOW_EMPTY_PASSWORD and
+  # creates spike accounts with no password, so publishing on 0.0.0.0 would let anything
+  # that can route to this host read the physical tables directly and bypass the
+  # view-only scoping the spike exists to demonstrate.
   docker run -d --name "$CH_CONTAINER" -e ALLOW_EMPTY_PASSWORD=yes \
-    -p "${CH_HTTP_PORT:-18123}:8123" -p "${CH_NATIVE_PORT:-19000}:9000" "$CH_IMAGE" >/dev/null
+    -p "127.0.0.1:${CH_HTTP_PORT:-18123}:8123" \
+    -p "127.0.0.1:${CH_NATIVE_PORT:-19000}:9000" "$CH_IMAGE" >/dev/null
   if [ -z "${CH_KEEP:-}" ]; then
     trap 'docker rm -f "$CH_CONTAINER" >/dev/null 2>&1 || true' EXIT
   fi

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -55,6 +55,31 @@ if [ -n "$CH_IMAGE" ]; then
     docker exec "$CH_CONTAINER" clickhouse-client --query "SELECT 1" >/dev/null 2>&1 && break
     sleep 3
   done
+else
+  # Existing-container mode: this script did not choose how that container publishes its
+  # ports, so the loopback guarantee above does not carry over. It seeds no-password accounts
+  # (spike_ro is deliberately not host-restricted so the companion HTTP test can log in), so
+  # refuse to create them on a server that is reachable off-box.
+  if ! docker inspect "$CH_CONTAINER" >/dev/null 2>&1; then
+    echo "FATAL: container '$CH_CONTAINER' not found. Set CH_IMAGE to have this script start one." >&2
+    exit 1
+  fi
+  _bad=""
+  for _binding in $(docker inspect \
+      -f '{{range $p, $c := .NetworkSettings.Ports}}{{range $c}}{{$p}}@{{.HostIp}} {{end}}{{end}}' \
+      "$CH_CONTAINER" 2>/dev/null); do
+    case "${_binding#*@}" in
+      127.0.0.1|::1|localhost) ;;
+      *) _bad="$_bad $_binding" ;;
+    esac
+  done
+  if [ -n "$_bad" ]; then
+    echo "FATAL: '$CH_CONTAINER' publishes ports on non-loopback addresses:$_bad" >&2
+    echo "       This spike creates no-password accounts, so it will not seed them into a" >&2
+    echo "       server that is reachable off-box. Republish those ports on 127.0.0.1," >&2
+    echo "       or unset CH_CONTAINER and set CH_IMAGE to let this script start its own." >&2
+    exit 1
+  fi
 fi
 
 CH="docker exec $CH_CONTAINER clickhouse-client"
@@ -76,8 +101,8 @@ expect_deny() {
     printf '%s\n' "$out" | head -3
     exit 1
   fi
-  if printf '%s' "$out" | grep -qiE 'AUTHENTICATION_FAILED|Code: 516|Code: 210|NETWORK_ERROR|Connection refused|Cannot connect|Timeout exceeded while connecting'; then
-    echo "FAIL [$label]: failed BEFORE the server could refuse it (login/connection error, not a denial):"
+  if printf '%s' "$out" | grep -qiE 'AUTHENTICATION_FAILED|Code: 516|Code: 210|NETWORK_ERROR|Connection refused|Cannot connect|Timeout exceeded while connecting|Error response from daemon|No such container|is not running|OCI runtime exec failed|Cannot connect to the Docker daemon'; then
+    echo "FAIL [$label]: failed BEFORE the server could refuse it (login/connection/container error, not a denial):"
     printf '%s\n' "$out" | head -3
     exit 1
   fi
@@ -299,7 +324,8 @@ $CH --query "CREATE SETTINGS PROFILE spike_ro_profile SETTINGS
 # spike_ro is deliberately NOT host-restricted: the companion bound-parameter test
 # (clickhouse_connect_bound_param.py) logs in as this user over HTTP from the host, which
 # arrives as a Docker bridge IP and would be rejected by HOST LOCAL. It is confined instead
-# by publishing the container ports on loopback only (see the docker run above).
+# by the container's ports being loopback-only -- published that way above when this script
+# starts the server, and verified above when an existing CH_CONTAINER is supplied.
 $CH --query "CREATE USER spike_ro IDENTIFIED WITH no_password SETTINGS PROFILE 'spike_ro_profile'"
 
 $CH --query "GRANT SELECT ON spike.spans_definer_v1 TO spike_ro"

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -180,17 +180,42 @@ expect_eq "0: ClickHouse version matches the pinned baseline" "$EXPECTED_VERSION
 # Verify the RUNNING container's image repo-digest against the pinned baseline (drift detection),
 # rather than echoing a hardcoded value.
 IMG_ID=$(docker inspect --format '{{.Image}}' "$CH_CONTAINER")
-# Repo-agnostic: the baseline image is not always clickhouse/clickhouse-server
-# (the deployed build is a different repository), and a repo-specific pattern here
-# silently yielded an empty digest rather than a mismatch.
-# Matched against the repository actually configured, not merely the first entry:
-# an image can carry digests for several repositories, and comparing the pin to an
-# unrelated one would either pass or fail for the wrong reason.
-IMG_REPO=$(docker inspect --format '{{.Config.Image}}' "$CH_CONTAINER")
-IMG_REPO="${IMG_REPO%%:*}"
-ACTUAL_DIGEST=$(docker image inspect "$IMG_ID" --format '{{range .RepoDigests}}{{println .}}{{end}}' \
-  | sed -nE "s|^${IMG_REPO}@(sha256:[0-9a-f]+)\$|\1|p" | head -1)
-echo "running image: $(docker inspect --format '{{.Config.Image}}' "$CH_CONTAINER")  digest: ${ACTUAL_DIGEST:-<none>}"
+
+# Resolving the repository has been wrong three times, so this does it once, properly.
+# The three failure modes, all real:
+#   - a hardcoded repo yields an EMPTY digest on any other image, failing as <none>
+#     rather than as a mismatch, which is a drift check that cannot detect drift;
+#   - matching any repo lets an image carrying several digests compare against an
+#     unrelated one;
+#   - `.Config.Image` is the reference as given, which is an image ID (sha256:...)
+#     whenever the container was started by ID rather than by tag.
+# CH_IMAGE is authoritative when set, because it is what we asked Docker to run.
+if [ -n "$CH_IMAGE" ]; then
+  IMG_REPO="$CH_IMAGE"
+else
+  IMG_REPO=$(docker inspect --format '{{.Config.Image}}' "$CH_CONTAINER")
+  case "$IMG_REPO" in
+    sha256:*) IMG_REPO=$(docker image inspect "$IMG_ID" --format '{{if .RepoTags}}{{index .RepoTags 0}}{{end}}') ;;
+  esac
+fi
+IMG_REPO="${IMG_REPO%%@*}"   # drop any @sha256:... suffix
+IMG_REPO="${IMG_REPO%:*}"    # drop the tag, keeping any registry:port prefix
+
+# Exact prefix comparison rather than a regex: a repository can contain characters
+# that are regex metacharacters (a registry host has dots), and matching those
+# loosely is how an unrelated repository's digest gets accepted.
+ACTUAL_DIGEST=""
+while IFS= read -r _rd; do
+  [ -n "$_rd" ] || continue
+  if [ "${_rd#"${IMG_REPO}@"}" != "$_rd" ]; then
+    ACTUAL_DIGEST="${_rd#*@}"
+    break
+  fi
+done <<EOF
+$(docker image inspect "$IMG_ID" --format '{{range .RepoDigests}}{{println .}}{{end}}')
+EOF
+
+echo "running image: ${CH_IMAGE:-$(docker inspect --format '{{.Config.Image}}' "$CH_CONTAINER")}  repo: $IMG_REPO  digest: ${ACTUAL_DIGEST:-<none>}"
 if [ "$ACTUAL_DIGEST" != "$EXPECTED_DIGEST" ]; then
   echo "FAIL [0: image digest matches pinned baseline]: expected $EXPECTED_DIGEST, running image is ${ACTUAL_DIGEST:-<none>}"
   echo "       To prove the matrix on this image, re-run with it pinned:"

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -21,7 +21,12 @@
 # Usage:
 #   bash scripts/spikes/clickhouse_sql_security_24_3.sh
 #   CH_IMAGE=clickhouse/clickhouse-server:24.3 EXPECTED_VERSION=24.3.18.7 bash ...
-#   CH_IMAGE=bitnamilegacy/clickhouse:25.2.1-debian-12-r0 EXPECTED_VERSION=25.2.1.3085 bash ...
+#   CH_IMAGE=bitnamilegacy/clickhouse:25.2.1-debian-12-r0 \\
+#     EXPECTED_VERSION=25.2.1.3085 \\
+#     EXPECTED_DIGEST=sha256:3c1f49548968dce24832ea2487647fe80dcfbd832d2dbb2e9e735629d7c7fc31 bash ...
+#
+#   EXPECTED_DIGEST is required for any image other than the default: it defaults to the
+#   24.3 pin, so omitting it makes test 0 fail against a different build.
 #
 # EXPECTED_VERSION is asserted, so a run always records which server proved the model.
 
@@ -31,8 +36,15 @@ CH_CONTAINER="${CH_CONTAINER:-ch_sql_spike}"
 CH_IMAGE="${CH_IMAGE:-}"
 if [ -n "$CH_IMAGE" ]; then
   docker rm -f "$CH_CONTAINER" >/dev/null 2>&1 || true
-  docker run -d --name "$CH_CONTAINER" -e ALLOW_EMPTY_PASSWORD=yes "$CH_IMAGE" >/dev/null
-  trap 'docker rm -f "$CH_CONTAINER" >/dev/null 2>&1 || true' EXIT
+  # Ports are published because the companion bound-parameter test
+  # (clickhouse_connect_bound_param.py) connects over HTTP from the host, and it runs
+  # AFTER this script against the users and views this script creates. Teardown is
+  # therefore skippable: set CH_KEEP=1 to leave the server up for it.
+  docker run -d --name "$CH_CONTAINER" -e ALLOW_EMPTY_PASSWORD=yes \
+    -p "${CH_HTTP_PORT:-18123}:8123" -p "${CH_NATIVE_PORT:-19000}:9000" "$CH_IMAGE" >/dev/null
+  if [ -z "${CH_KEEP:-}" ]; then
+    trap 'docker rm -f "$CH_CONTAINER" >/dev/null 2>&1 || true' EXIT
+  fi
   for _ in $(seq 1 50); do
     docker exec "$CH_CONTAINER" clickhouse-client --query "SELECT 1" >/dev/null 2>&1 && break
     sleep 3
@@ -171,8 +183,13 @@ IMG_ID=$(docker inspect --format '{{.Image}}' "$CH_CONTAINER")
 # Repo-agnostic: the baseline image is not always clickhouse/clickhouse-server
 # (the deployed build is a different repository), and a repo-specific pattern here
 # silently yielded an empty digest rather than a mismatch.
+# Matched against the repository actually configured, not merely the first entry:
+# an image can carry digests for several repositories, and comparing the pin to an
+# unrelated one would either pass or fail for the wrong reason.
+IMG_REPO=$(docker inspect --format '{{.Config.Image}}' "$CH_CONTAINER")
+IMG_REPO="${IMG_REPO%%:*}"
 ACTUAL_DIGEST=$(docker image inspect "$IMG_ID" --format '{{range .RepoDigests}}{{println .}}{{end}}' \
-  | sed -nE 's|.*@(sha256:[0-9a-f]+).*|\1|p' | head -1)
+  | sed -nE "s|^${IMG_REPO}@(sha256:[0-9a-f]+)\$|\1|p" | head -1)
 echo "running image: $(docker inspect --format '{{.Config.Image}}' "$CH_CONTAINER")  digest: ${ACTUAL_DIGEST:-<none>}"
 if [ "$ACTUAL_DIGEST" != "$EXPECTED_DIGEST" ]; then
   echo "FAIL [0: image digest matches pinned baseline]: expected $EXPECTED_DIGEST, running image is ${ACTUAL_DIGEST:-<none>}"

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -63,13 +63,21 @@ sep() { echo; echo "===================================================="; echo 
 
 # --- Assertion helpers: a security spike must FAIL LOUDLY, never print PASS unconditionally ---
 
-# expect_deny "label" <cmd...> : PASS only if the command exits non-zero (access denied / error).
-# Fails the whole script (exit 1) if the command unexpectedly SUCCEEDS.
+# expect_deny "label" <cmd...> : PASS only if the SERVER refused the query.
+# Fails the whole script (exit 1) if the command unexpectedly SUCCEEDS, and also if it
+# failed without ever reaching the server. A login or connection failure exits non-zero
+# too, so accepting any non-zero exit would let an unreachable account masquerade as a
+# denied one -- the assertion would still print PASS while testing nothing.
 expect_deny() {
   local label="$1"; shift
   local out
   if out=$("$@" 2>&1); then
     echo "FAIL [$label]: command unexpectedly SUCCEEDED (expected access-denied):"
+    printf '%s\n' "$out" | head -3
+    exit 1
+  fi
+  if printf '%s' "$out" | grep -qiE 'AUTHENTICATION_FAILED|Code: 516|Code: 210|NETWORK_ERROR|Connection refused|Cannot connect|Timeout exceeded while connecting'; then
+    echo "FAIL [$label]: failed BEFORE the server could refuse it (login/connection error, not a denial):"
     printf '%s\n' "$out" | head -3
     exit 1
   fi
@@ -288,6 +296,10 @@ $CH --query "CREATE SETTINGS PROFILE spike_ro_profile SETTINGS
   max_result_bytes = 536870912 CONST,
   max_memory_usage = 4294967296 CONST"
 
+# spike_ro is deliberately NOT host-restricted: the companion bound-parameter test
+# (clickhouse_connect_bound_param.py) logs in as this user over HTTP from the host, which
+# arrives as a Docker bridge IP and would be rejected by HOST LOCAL. It is confined instead
+# by publishing the container ports on loopback only (see the docker run above).
 $CH --query "CREATE USER spike_ro IDENTIFIED WITH no_password SETTINGS PROFILE 'spike_ro_profile'"
 
 $CH --query "GRANT SELECT ON spike.spans_definer_v1 TO spike_ro"
@@ -365,7 +377,7 @@ echo ""
 echo "--- 6c: CONST cap fires in practice (spike_tiny_cap: max_execution_time=0.001) ---"
 $CH --query "CREATE SETTINGS PROFILE spike_tiny_cap_profile SETTINGS
   readonly = 1, max_execution_time = 0.001 CONST"
-$CH --query "CREATE USER spike_tiny_cap IDENTIFIED WITH no_password SETTINGS PROFILE 'spike_tiny_cap_profile'"
+$CH --query "CREATE USER spike_tiny_cap IDENTIFIED WITH no_password HOST LOCAL SETTINGS PROFILE 'spike_tiny_cap_profile'"
 $CH --query "GRANT SELECT ON spike.spans_definer_v1 TO spike_tiny_cap"
 
 expect_timeout "6c: tiny-cap profile aborts the query" \
@@ -376,7 +388,11 @@ expect_timeout "6c: tiny-cap profile aborts the query" \
 # TEST 8 — DEFINER with a SCOPED (non-superuser) writer user
 # ---------------------------------------------------------------------------
 sep "TEST 8: DEFINER = scoped writer user (not superuser)"
-$CH --query "CREATE USER IF NOT EXISTS spike_writer IDENTIFIED WITH no_password"
+# HOST LOCAL, not HOST NONE: this account is the view's DEFINER *and* test 8 logs in as it
+# to prove the grant boundary. HOST NONE would block that login, and since a failed login
+# also exits non-zero, test 8 would report PASS while asserting nothing. HOST LOCAL still
+# refuses connections arriving through Docker port-mapping, which is the exposure that matters.
+$CH --query "CREATE USER IF NOT EXISTS spike_writer IDENTIFIED WITH no_password HOST LOCAL"
 $CH --query "GRANT SELECT ON spike.spans_phys TO spike_writer"   # writer scoped to the physical table only
 $CH --query "CREATE OR REPLACE VIEW spike.spans_definer_scoped_v1 DEFINER = spike_writer SQL SECURITY DEFINER AS
 SELECT span_id, trace_id, name FROM (

--- a/scripts/spikes/clickhouse_sql_security_24_3.sh
+++ b/scripts/spikes/clickhouse_sql_security_24_3.sh
@@ -1,19 +1,45 @@
 #!/usr/bin/env bash
 # clickhouse_sql_security_24_3.sh
 #
-# Re-runnable spike: ClickHouse 24.3 SQL SECURITY / DEFINER + parameterized views.
+# Re-runnable spike: ClickHouse SQL SECURITY / DEFINER + parameterized views.
+#
+# Proven on:
+#   24.3.18.7   (clickhouse/clickhouse-server:24.3)             -- the original baseline
+#   25.2.1.3085 (bitnamilegacy/clickhouse:25.2.1-debian-12-r0)  -- the build staging deploys
+#
+# 31 assertions, 0 failures on both, with the version and image digest pinned per run.
+#
+# The version and image digest are asserted rather than assumed, so every run records
+# which server proved the model. Pass EXPECTED_VERSION / EXPECTED_DIGEST to prove it on
+# another build; the failure message prints the values to pin.
 # Idempotent: drops and recreates the `spike` database, users, and profiles on each run.
 #
 # Prerequisites:
-#   docker container named `ch_sql_spike` running clickhouse/clickhouse-server:24.3
-#   Ports: HTTP localhost:18123, native localhost:19000
+#   A running container named by CH_CONTAINER (default `ch_sql_spike`), or set
+#   CH_IMAGE and this script starts and tears down its own disposable server.
 #
 # Usage:
 #   bash scripts/spikes/clickhouse_sql_security_24_3.sh
+#   CH_IMAGE=clickhouse/clickhouse-server:24.3 EXPECTED_VERSION=24.3.18.7 bash ...
+#   CH_IMAGE=bitnamilegacy/clickhouse:25.2.1-debian-12-r0 EXPECTED_VERSION=25.2.1.3085 bash ...
+#
+# EXPECTED_VERSION is asserted, so a run always records which server proved the model.
 
 set -euo pipefail
 
-CH="docker exec ch_sql_spike clickhouse-client"
+CH_CONTAINER="${CH_CONTAINER:-ch_sql_spike}"
+CH_IMAGE="${CH_IMAGE:-}"
+if [ -n "$CH_IMAGE" ]; then
+  docker rm -f "$CH_CONTAINER" >/dev/null 2>&1 || true
+  docker run -d --name "$CH_CONTAINER" -e ALLOW_EMPTY_PASSWORD=yes "$CH_IMAGE" >/dev/null
+  trap 'docker rm -f "$CH_CONTAINER" >/dev/null 2>&1 || true' EXIT
+  for _ in $(seq 1 50); do
+    docker exec "$CH_CONTAINER" clickhouse-client --query "SELECT 1" >/dev/null 2>&1 && break
+    sleep 3
+  done
+fi
+
+CH="docker exec $CH_CONTAINER clickhouse-client"
 
 sep() { echo; echo "===================================================="; echo "  $*"; echo "===================================================="; }
 
@@ -130,20 +156,29 @@ echo "SETUP OK"
 # TEST 0 — Environment
 # ---------------------------------------------------------------------------
 sep "TEST 0: version + image (verified against the pinned baseline)"
-EXPECTED_VERSION="24.3.18.7"
-EXPECTED_DIGEST="sha256:85b97f63dcfff47790d26bb5d5801637aaddb2b93e5e9aee27a686c2fb2b9916"
+EXPECTED_VERSION="${EXPECTED_VERSION:-24.3.18.7}"
+# Pinned per image. Overridable so the same matrix can be proven on another build,
+# but never silently skipped: a security spike that cannot say which image it ran
+# against is not evidence of anything.
+EXPECTED_DIGEST="${EXPECTED_DIGEST:-sha256:85b97f63dcfff47790d26bb5d5801637aaddb2b93e5e9aee27a686c2fb2b9916}"
 
 expect_eq "0: ClickHouse version matches the pinned baseline" "$EXPECTED_VERSION" \
-  docker exec ch_sql_spike clickhouse-client --query "SELECT version()"
+  docker exec "$CH_CONTAINER" clickhouse-client --query "SELECT version()"
 
 # Verify the RUNNING container's image repo-digest against the pinned baseline (drift detection),
 # rather than echoing a hardcoded value.
-IMG_ID=$(docker inspect --format '{{.Image}}' ch_sql_spike)
+IMG_ID=$(docker inspect --format '{{.Image}}' "$CH_CONTAINER")
+# Repo-agnostic: the baseline image is not always clickhouse/clickhouse-server
+# (the deployed build is a different repository), and a repo-specific pattern here
+# silently yielded an empty digest rather than a mismatch.
 ACTUAL_DIGEST=$(docker image inspect "$IMG_ID" --format '{{range .RepoDigests}}{{println .}}{{end}}' \
-  | sed -nE 's|.*clickhouse/clickhouse-server@(sha256:[0-9a-f]+).*|\1|p' | head -1)
-echo "running image: $(docker inspect --format '{{.Config.Image}}' ch_sql_spike)  digest: ${ACTUAL_DIGEST:-<none>}"
+  | sed -nE 's|.*@(sha256:[0-9a-f]+).*|\1|p' | head -1)
+echo "running image: $(docker inspect --format '{{.Config.Image}}' "$CH_CONTAINER")  digest: ${ACTUAL_DIGEST:-<none>}"
 if [ "$ACTUAL_DIGEST" != "$EXPECTED_DIGEST" ]; then
   echo "FAIL [0: image digest matches pinned baseline]: expected $EXPECTED_DIGEST, running image is ${ACTUAL_DIGEST:-<none>}"
+  echo "       To prove the matrix on this image, re-run with it pinned:"
+  echo "       EXPECTED_DIGEST=${ACTUAL_DIGEST:-<pull the image so it has a repo digest>} \\"
+  echo "       EXPECTED_VERSION=<its version> CH_IMAGE=<image> bash $0"
   exit 1
 fi
 echo "PASS [0: image digest matches pinned baseline]: $ACTUAL_DIGEST"
@@ -160,7 +195,7 @@ SELECT span_id, trace_id, name FROM (
 )"
 
 expect_eq "1: parameterized view returns only proj_A rows" $'sA1\nsA2' \
-  docker exec ch_sql_spike clickhouse-client \
+  docker exec "$CH_CONTAINER" clickhouse-client \
   --query "SELECT span_id FROM spike.spans_public_v1(project_id = 'proj_A') ORDER BY span_id"
 
 # ---------------------------------------------------------------------------
@@ -169,7 +204,7 @@ expect_eq "1: parameterized view returns only proj_A rows" $'sA1\nsA2' \
 sep "TEST 2: bound parameter inside view call (--param_ form)"
 
 expect_eq "2: bound-param view call returns only proj_A rows" $'sA1\nsA2' \
-  docker exec ch_sql_spike clickhouse-client \
+  docker exec "$CH_CONTAINER" clickhouse-client \
   --param_scope_project_id=proj_A \
   --query "SELECT span_id FROM spike.spans_public_v1(project_id = {scope_project_id:String}) ORDER BY span_id"
 
@@ -206,27 +241,27 @@ $CH --query "GRANT SELECT ON spike.spans_definer_v1 TO spike_ro"
 
 echo ""
 expect_eq "4a: spike_ro reads definer view (DEFINER lets body read the physical table)" $'sA1\nsA2' \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id"
 
 echo ""
 expect_deny "4b: spike_ro reads physical table" \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT * FROM spike.spans_phys LIMIT 1"
 
 echo ""
 expect_deny "4c: spike_ro INSERT into physical table" \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "INSERT INTO spike.spans_phys (project_id,span_id,trace_id,name) VALUES ('proj_C','sC1','tC1','c-one')"
 
 echo ""
 expect_eq "4d: spike_ro system.tables shows only the granted view" $'spike\tspans_definer_v1' \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT database, name FROM system.tables ORDER BY database, name"
 
 echo ""
 expect_deny "4d: spike_ro system.clusters" \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT * FROM system.clusters LIMIT 1"
 
 # ---------------------------------------------------------------------------
@@ -235,29 +270,29 @@ expect_deny "4d: spike_ro system.clusters" \
 sep "TEST 5: tenant isolation"
 
 expect_eq "5a: flat query returns only proj_A" $'sA1\nsA2' \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id"
 
 echo ""
 expect_eq "5b: CTE query returns only proj_A" $'sA1\nsA2' \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "WITH v AS (SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A')) SELECT span_id FROM v ORDER BY span_id"
 
 echo ""
 expect_empty "5c: forged quote injection returns no rows (no proj_B leak)" \
-  docker exec ch_sql_spike clickhouse-client \
+  docker exec "$CH_CONTAINER" clickhouse-client \
   --param_pid="proj_A' OR project_id='proj_B" \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = {pid:String}) ORDER BY span_id"
 
 echo ""
 expect_empty "5d: forged semicolon-DROP injection returns no rows" \
-  docker exec ch_sql_spike clickhouse-client \
+  docker exec "$CH_CONTAINER" clickhouse-client \
   --param_pid="proj_A'); DROP TABLE spike.spans_phys; --" \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = {pid:String}) ORDER BY span_id"
 
 echo ""
 expect_eq "5d: physical table survived injection attempt" "3" \
-  docker exec ch_sql_spike clickhouse-client --query "SELECT count(*) FROM spike.spans_phys"
+  docker exec "$CH_CONTAINER" clickhouse-client --query "SELECT count(*) FROM spike.spans_phys"
 
 # ---------------------------------------------------------------------------
 # TEST 6 — Resource caps / profile
@@ -265,12 +300,12 @@ expect_eq "5d: physical table survived injection attempt" "3" \
 sep "TEST 6: resource caps / readonly profile"
 
 expect_deny "6a: spike_ro raises max_execution_time (readonly blocks it)" \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id SETTINGS max_execution_time = 99999"
 
 echo ""
 expect_deny "6b: spike_ro sets more-restrictive max_result_rows (readonly blocks any SETTINGS)" \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id SETTINGS max_result_rows = 1"
 
 echo ""
@@ -281,7 +316,7 @@ $CH --query "CREATE USER spike_tiny_cap IDENTIFIED WITH no_password SETTINGS PRO
 $CH --query "GRANT SELECT ON spike.spans_definer_v1 TO spike_tiny_cap"
 
 expect_timeout "6c: tiny-cap profile aborts the query" \
-  docker exec ch_sql_spike clickhouse-client --user spike_tiny_cap \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_tiny_cap \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_A') ORDER BY span_id"
 
 # ---------------------------------------------------------------------------
@@ -296,10 +331,10 @@ SELECT span_id, trace_id, name FROM (
   ORDER BY ch_update_time DESC LIMIT 1 BY span_id )"
 $CH --query "GRANT SELECT ON spike.spans_definer_scoped_v1 TO spike_ro"
 expect_eq "8: RO reads the scoped-writer DEFINER view" $'sA1\nsA2' \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_scoped_v1(project_id = 'proj_A') ORDER BY span_id"
 expect_deny "8: scoped writer denied system.clusters" \
-  docker exec ch_sql_spike clickhouse-client --user spike_writer \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_writer \
   --query "SELECT count() FROM system.clusters"
 
 # ---------------------------------------------------------------------------
@@ -309,7 +344,7 @@ sep "TEST 9: RO calls view with FOREIGN project_id (DB has no deny — proves ga
 # Expected BY DESIGN: a foreign project_id returns that tenant's row — the DB has NO backstop,
 # so tenant isolation MUST be enforced by the gateway binding the authenticated project_id.
 expect_eq "9: foreign project_id returns proj_B row (DB has no cross-tenant backstop)" "sB1" \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_definer_v1(project_id = 'proj_B') ORDER BY span_id"
 
 # ---------------------------------------------------------------------------
@@ -319,14 +354,14 @@ sep "TEST 10: system.* readability as RO (gateway validator must reject all syst
 # Tables the RO user must NOT be able to read (no grant): assert each is denied.
 for t in processes query_log text_log users grants merges parts; do
   expect_deny "10: system.$t denied to RO" \
-    docker exec ch_sql_spike clickhouse-client --user spike_ro \
+    docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
     --query "SELECT count() FROM system.$t"
 done
 # Tables that ARE readable on 24.3 (config/function metadata, no tenant data): assert they return a
 # count — this is exactly why the gateway validator must reject ALL system.* references.
 for t in settings functions databases; do
   expect_count "10: system.$t readable by RO (gateway must still reject it)" \
-    docker exec ch_sql_spike clickhouse-client --user spike_ro \
+    docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
     --query "SELECT count() FROM system.$t"
 done
 
@@ -338,7 +373,7 @@ $CH --query "CREATE OR REPLACE VIEW spike.spans_chain_v1 DEFINER = default SQL S
 SELECT span_id FROM spike.spans_definer_v1(project_id = {project_id:String})"
 $CH --query "GRANT SELECT ON spike.spans_chain_v1 TO spike_ro"
 expect_eq "11: nested DEFINER view propagates the param through the chain" $'sA1\nsA2' \
-  docker exec ch_sql_spike clickhouse-client --user spike_ro \
+  docker exec "$CH_CONTAINER" clickhouse-client --user spike_ro \
   --query "SELECT span_id FROM spike.spans_chain_v1(project_id = 'proj_A') ORDER BY span_id"
 
 sep "ALL TESTS COMPLETE"


### PR DESCRIPTION
## Summary

Fixes #1332 

Feasibility spike verifying, against ClickHouse 24.3 (`24.3.18.7`), whether the planned hardened SQL-access model works before it is built: parameterized views + `SQL SECURITY DEFINER` + a read-only user granted only on curated views + an immutable (`CONST`) settings profile + bound-parameter project scoping.

All 13 assertions pass. Decision: **GO** — use the hardened model (no ClickHouse version bump needed) and bind `project_id` as a query parameter. This branch adds only disposable spike scripts; no application code is changed.

## How it works

```
Disposable clickhouse/clickhouse-server:24.3 container
  → physical table (ReplacingMergeTree) + parameterized views (plain + SQL SECURITY DEFINER)
    → read-only user + CONST settings profile, granted SELECT on the views ONLY
      → run assertions: parameterized views, bound-param view calls, DEFINER grants,
        tenant isolation, injection resistance, resource caps, scoped-writer DEFINER,
        cross-tenant probe, system.* sweep, nested view chaining
```

Key finding: **the database provides no cross-tenant backstop.** A read-only user holding a grant on a curated view can call it with *any* `project_id` and receive that tenant's rows — so tenant isolation must be enforced by the application binding the authenticated `project_id`. The DEFINER + view-only-grant model only blocks access to the raw physical tables; it does not scope the parameter value.

## Outcome / decisions

| Decision | Choice |
|---|---|
| Go / no-go | **GO** — all assertions pass on 24.3.18.7 |
| Scoping | bind `project_id` as a query parameter (`{scope_project_id:String}`); string-literal scoping kept only as a dormant fallback |
| DEFINER / grants | `DEFINER = <dedicated-writer-user> SQL SECURITY DEFINER`; the writer needs `SELECT` on the physical tables only (not a superuser); the read-only user is granted `SELECT` on the curated views only |
| Resource caps | enforced entirely by the read-only user's `CONST` settings profile; the query layer must not send per-query `SETTINGS` (rejected with Code 164 under `readonly = 1`) |
| Row cap | applied via a `LIMIT` wrapper in the query text (plain SQL, allowed under readonly), not a per-query setting |
| Version pin | `24.3.18.7` / `clickhouse/clickhouse-server:24.3` / `sha256:85b97f63dcfff47790d26bb5d5801637aaddb2b93e5e9aee27a686c2fb2b9916` |

## What's included

### Spike scripts
- `scripts/spikes/clickhouse_sql_security_24_3.sh` — idempotent runner (drops + recreates the `spike` database, users, and profiles each run); covers parameterized views, `SQL SECURITY DEFINER` grants, read-only user isolation, tenant separation, injection resistance, resource caps, scoped-writer DEFINER, the cross-tenant probe, the `system.*` sweep, and nested view chaining.
- `scripts/spikes/clickhouse_connect_bound_param.py` — exercises the bound-parameter view-call form and injection payloads over the HTTP path via clickhouse-connect 0.10.0.

No application, CLI, UI, or migration changes — spike-only branch.

## Test plan

- [x] Confirm exact version (`SELECT version()` → 24.3.18.7), image tag, and digest
- [x] Parameterized view returns only the requested project's rows (literal arg)
- [x] Bound parameter (`{name:Type}`) works as the view-call argument (clickhouse-client)
- [x] `SQL SECURITY DEFINER` clause is accepted and persists in `SHOW CREATE VIEW`
- [x] Read-only user reads the DEFINER view but is denied the physical table and INSERT (Code 497)
- [x] Read-only user metadata scope: `system.tables` grant-filtered; `system.clusters` denied
- [x] Tenant isolation holds across flat + CTE; quote/semicolon injection payloads return 0 rows
- [x] `CONST` caps cannot be raised — or even tightened — under `readonly = 1` (Code 164)
- [x] A `CONST` cap fires in practice (`max_execution_time = 0.001` → Code 159)
- [x] Bound-param view call + injection payloads work/contained over HTTP (clickhouse-connect)
- [x] DEFINER works with a scoped non-superuser writer (not the superuser account)
- [x] Cross-tenant probe: a read-only user calling the view with a foreign `project_id` returns that tenant's rows (confirms isolation must be enforced by the application)
- [x] `system.*` sweep: `system.settings` / `functions` / `databases` readable, all others denied
- [x] Nested DEFINER view chaining propagates the parameter correctly

### Reproduction

```bash
docker run -d --name ch_sql_spike -p 18123:8123 -p 19000:9000 clickhouse/clickhouse-server:24.3
bash scripts/spikes/clickhouse_sql_security_24_3.sh           # idempotent
uv run python scripts/spikes/clickhouse_connect_bound_param.py  # run the shell script first
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates #1332’s hardened ClickHouse SQL-access model before implementation: parameterized `SQL SECURITY DEFINER` views, view-only read access, `CONST` resource limits, and bound `project_id` parameters. All 31 assertions pass on ClickHouse 24.3.18.7 and staging’s 25.2.1.3085; because the database still accepts any project ID, the gateway must bind the authenticated `project_id`. No application changes are included.

**Spike coverage**

- `scripts/spikes/clickhouse_sql_security_24_3.sh` idempotently creates a disposable server, pins and verifies the image version and repository digest, and checks grants, injection resistance, limits, tenant scoping, `system.*` access, scoped `DEFINER` users, and nested views; it also refuses to seed the passwordless spike accounts into an existing container that publishes ports off-loopback, uses host networking, or shares another container’s network namespace.
- `scripts/spikes/clickhouse_connect_bound_param.py` verifies bound-parameter view calls and injection containment over HTTP; run the shell script first.

<sup>Written for commit a71e00161e8478889e2038bd113b8612c32909bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



