### PR TITLE
infra: harden rest against heavy-query OOM and liveness flapping

### DIFF
--- a/deploy/helm/templates/rest/deployment.yaml
+++ b/deploy/helm/templates/rest/deployment.yaml
@@ -91,5 +91,10 @@ spec:
               port: {{ .Values.rest.port }}
             initialDelaySeconds: 15
             periodSeconds: 10
+            # Relaxed so a transient slow ClickHouse query that briefly blocks the
+            # event loop doesn't trip a needless restart (k8s defaults are
+            # timeoutSeconds:1 / failureThreshold:3 = killed after ~30s unresponsive).
+            timeoutSeconds: 5
+            failureThreshold: 5
           resources:
             {{- toYaml .Values.rest.resources | nindent 12 }}

--- a/deploy/terraform/aws/traceroot.tf
+++ b/deploy/terraform/aws/traceroot.tf
@@ -37,11 +37,11 @@ rest:
   port: 8000
   resources:
     requests:
-      cpu: "250m"
-      memory: "512Mi"
-    limits:
       cpu: "1"
-      memory: "1Gi"
+      memory: "2Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
 
 worker:
   image:


### PR DESCRIPTION
## What
Harden the `rest` service against the failure mode behind the 2026-06-25 P0:

- **Liveness probe** (`deploy/helm/templates/rest/deployment.yaml`): add `timeoutSeconds: 5` and `failureThreshold: 5`. rest was relying on the k8s defaults (`1s` / `3` → killed after ~30s of an unresponsive `/health`), so a transient slow ClickHouse query that briefly blocks the single-process event loop tripped a needless restart.
- **Resources** (`deploy/terraform/aws/traceroot.tf`): rest `requests 250m/512Mi → 1/2Gi`, `limits 1cpu/1Gi → 2cpu/4Gi`. The 1 GiB limit OOM-killed rest (`exit 137`) when it buffered a ~700 MB query result.

## Why
A detector scan fetched a whole large trace via the internal `/spans-jsonl` endpoint (`SELECT * FROM spans FINAL` → ~18s / ~700 MB). On the 1 GiB, single-process rest pod this OOM-crashed and returned **502 Bad Gateway** to the dashboard for all customers. Both changes were applied to prod manually to stop the bleeding; this PR commits them so they persist and reach staging.

## Notes / caveats
- **Applies to staging too** — `traceroot.tf` rest resources are not environment-conditional and the helm template is shared. The relaxed probe is beneficial there; the 4Gi/2CPU bump is extra Fargate cost for low-traffic staging (acceptable; making rest resources a per-env variable is optional future polish).
- **`rest_replicas=2` is NOT in this PR** — it lives in the gitignored `production.tfvars` (variable default is still `1`). Prod runs 2 replicas operationally; flagged here so it isn't lost on a fresh checkout.
- **Mitigation, not the cure.** The durable fix — replacing `SELECT * FROM spans FINAL` with a dedup subquery at all remaining sites (`get_spans_jsonl`, `get_session` ×2, `live.py`, and `get_trace`'s traces-table lookup) — is tracked separately. See the incident postmortem: `dev_docs/plans/2026-06-25-rest-oom-spans-final-incident.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `rest` service against heavy ClickHouse queries that caused OOMs and liveness flapping. Increases resources and relaxes the liveness probe to prevent unnecessary restarts and 502s during large trace scans.

- **Bug Fixes**
  - Liveness probe: set `timeoutSeconds: 5` and `failureThreshold: 5` in `deploy/helm/templates/rest/deployment.yaml`.
  - Resources in `deploy/terraform/aws/traceroot.tf`: requests `cpu: "1"`, `memory: "2Gi"`; limits `cpu: "2"`, `memory: "4Gi"`.

<sup>Written for commit 86578015e65163a1bbffe42db52c6beff4da4d3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

