### PR TITLE
perf(rest): dedup spans/traces reads without FINAL

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -407,9 +407,16 @@ async def get_spans_jsonl(trace_id: str, project_id: str):
     from fastapi.responses import PlainTextResponse
 
     ch = get_clickhouse_client()
+    # Dedup ReplacingMergeTree rows without FINAL (FINAL scans all parts and
+    # defeats the trace_id-first sort key / no-IO projection): keep the latest
+    # version per span_id, then order for output.
     result = ch.query(
-        """SELECT * FROM spans FINAL
-           WHERE trace_id = {trace_id:String} AND project_id = {project_id:String}
+        """SELECT * FROM (
+               SELECT * FROM spans
+               WHERE trace_id = {trace_id:String} AND project_id = {project_id:String}
+               ORDER BY ch_update_time DESC
+               LIMIT 1 BY span_id
+           )
            ORDER BY span_start_time""",
         parameters={"trace_id": trace_id, "project_id": project_id},
     )

--- a/backend/rest/routers/live.py
+++ b/backend/rest/routers/live.py
@@ -27,12 +27,19 @@ def _is_trace_complete_in_clickhouse(project_id: str, trace_id: str) -> bool:
     from db.clickhouse.client import get_clickhouse_client
 
     ch_client = get_clickhouse_client()
+    # Dedup ReplacingMergeTree rows without FINAL: keep the latest version per
+    # span_id (filtered to this trace), then test the root-complete condition on
+    # the deduped rows.
     result = ch_client.query(
         """
-        SELECT count() FROM spans FINAL
-        WHERE project_id = {project_id:String}
-          AND trace_id   = {trace_id:String}
-          AND isNull(parent_span_id)
+        SELECT count() FROM (
+            SELECT parent_span_id, span_end_time FROM spans
+            WHERE project_id = {project_id:String}
+              AND trace_id   = {trace_id:String}
+            ORDER BY ch_update_time DESC
+            LIMIT 1 BY span_id
+        )
+        WHERE isNull(parent_span_id)
           AND isNotNull(span_end_time)
         """,
         parameters={"project_id": project_id, "trace_id": trace_id},

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -223,13 +223,16 @@ class TraceReaderService:
         small and already present.
         """
         # Fetch trace
+        # Dedup the ReplacingMergeTree row without FINAL: keep the latest version
+        # of this trace_id.
         trace_query = """
             SELECT
                 trace_id, project_id, name, trace_start_time,
                 user_id, session_id, git_ref, git_repo, input, output, metadata
-            FROM traces FINAL
+            FROM traces
             WHERE project_id = {project_id:String} AND trace_id = {trace_id:String}
-            LIMIT 1
+            ORDER BY ch_update_time DESC
+            LIMIT 1 BY trace_id
         """
         trace_result = self._client.query(
             trace_query,
@@ -571,17 +574,36 @@ class TraceReaderService:
 
         # Backfill input/output from spans for sessions with empty trace-level I/O
         if session_ids_needing_span_io:
+            # Dedup both sides without FINAL: resolve the sessions' traces first
+            # (latest per trace), then dedup only the spans in those traces
+            # (scoped via the trace_id IN subquery so we never dedup the whole
+            # project), then join + aggregate.
             span_io_query = """
+                WITH session_traces AS (
+                    SELECT t.session_id, t.trace_id, t.project_id
+                    FROM traces AS t
+                    WHERE t.project_id = {project_id:String}
+                      AND t.session_id IN ({session_ids:Array(String)})
+                    ORDER BY t.ch_update_time DESC
+                    LIMIT 1 BY t.project_id, t.trace_id
+                ),
+                spans_dedup AS (
+                    SELECT trace_id, project_id, input, output, span_start_time, span_end_time
+                    FROM spans
+                    WHERE project_id = {project_id:String}
+                      AND trace_id IN (SELECT trace_id FROM session_traces)
+                    ORDER BY ch_update_time DESC
+                    LIMIT 1 BY span_id
+                )
                 SELECT
-                    t.session_id,
+                    st.session_id,
                     argMin(s.input, s.span_start_time) as first_input,
                     argMax(s.output, s.span_end_time) as last_output
-                FROM traces AS t FINAL
-                JOIN spans AS s FINAL ON t.trace_id = s.trace_id AND t.project_id = s.project_id
-                WHERE t.project_id = {project_id:String}
-                  AND t.session_id IN ({session_ids:Array(String)})
-                  AND ((s.input != '' AND s.input != '{}') OR (s.output != '' AND s.output != '{}'))
-                GROUP BY t.session_id
+                FROM session_traces AS st
+                JOIN spans_dedup AS s
+                    ON st.trace_id = s.trace_id AND st.project_id = s.project_id
+                WHERE ((s.input != '' AND s.input != '{}') OR (s.output != '' AND s.output != '{}'))
+                GROUP BY st.session_id
             """
             span_io_result = self._client.query(
                 span_io_query,
@@ -639,8 +661,28 @@ class TraceReaderService:
 
         where_clause = " AND ".join(conditions)
 
-        # Step 1: Get all traces for this session with basic info
+        # Step 1: Get all traces for this session with basic info.
+        # Dedup both sides without FINAL: dedup this session's traces first, then
+        # dedup only the spans in those traces (scoped via trace_id IN, so the
+        # whole project is never deduped), then LEFT JOIN + aggregate.
         traces_query = f"""
+            WITH traces_dedup AS (
+                SELECT
+                    t.trace_id, t.project_id, t.name, t.trace_start_time,
+                    t.user_id, t.input, t.output
+                FROM traces AS t
+                WHERE {where_clause}
+                ORDER BY t.ch_update_time DESC
+                LIMIT 1 BY t.project_id, t.trace_id
+            ),
+            spans_dedup AS (
+                SELECT trace_id, project_id, span_start_time, span_end_time, status
+                FROM spans
+                WHERE project_id = {{project_id:String}}
+                  AND trace_id IN (SELECT trace_id FROM traces_dedup)
+                ORDER BY ch_update_time DESC
+                LIMIT 1 BY span_id
+            )
             SELECT
                 t.trace_id,
                 t.name,
@@ -654,9 +696,8 @@ class TraceReaderService:
                     NULL
                 ) as duration_ms,
                 if(countIf(s.status = 'ERROR') > 0, 'error', 'ok') as status
-            FROM traces AS t FINAL
-            LEFT JOIN spans AS s FINAL ON t.trace_id = s.trace_id AND t.project_id = s.project_id
-            WHERE {where_clause}
+            FROM traces_dedup AS t
+            LEFT JOIN spans_dedup AS s ON t.trace_id = s.trace_id AND t.project_id = s.project_id
             GROUP BY t.trace_id, t.name, t.trace_start_time, t.user_id, t.input, t.output
             ORDER BY t.trace_start_time ASC
         """
@@ -693,15 +734,22 @@ class TraceReaderService:
         if needs_span_io and trace_ids:
             # Get the first span's input and last span's output per trace
             # (root span = no parent, or earliest AGENT span with real data)
+            # Dedup spans without FINAL (latest per span_id, scoped to these
+            # traces), then aggregate I/O over the deduped rows.
             span_io_query = """
                 SELECT
                     trace_id,
                     argMin(input, span_start_time) as first_input,
                     argMax(output, span_end_time) as last_output
-                FROM spans FINAL
-                WHERE project_id = {project_id:String}
-                  AND trace_id IN ({trace_ids:Array(String)})
-                  AND ((input != '' AND input != '{}') OR (output != '' AND output != '{}'))
+                FROM (
+                    SELECT trace_id, input, output, span_start_time, span_end_time
+                    FROM spans
+                    WHERE project_id = {project_id:String}
+                      AND trace_id IN ({trace_ids:Array(String)})
+                    ORDER BY ch_update_time DESC
+                    LIMIT 1 BY span_id
+                )
+                WHERE ((input != '' AND input != '{}') OR (output != '' AND output != '{}'))
                 GROUP BY trace_id
             """
             span_io_result = self._client.query(
@@ -722,14 +770,20 @@ class TraceReaderService:
                         t["output"] = span_io[1]
 
         # Step 3: Get token totals from spans for all traces in this session
+        # Dedup spans without FINAL (latest per span_id), then sum tokens/cost.
         tokens_query = """
             SELECT
                 sum(input_tokens) as total_input_tokens,
                 sum(output_tokens) as total_output_tokens,
                 sum(cost) as total_cost
-            FROM spans FINAL
-            WHERE project_id = {project_id:String}
-              AND trace_id IN ({trace_ids:Array(String)})
+            FROM (
+                SELECT input_tokens, output_tokens, cost
+                FROM spans
+                WHERE project_id = {project_id:String}
+                  AND trace_id IN ({trace_ids:Array(String)})
+                ORDER BY ch_update_time DESC
+                LIMIT 1 BY span_id
+            )
         """
         tokens_result = self._client.query(
             tokens_query,

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -141,7 +141,7 @@ class TestGetTraceSkeleton:
         captured = {}
 
         def side_effect(query, parameters=None):
-            if "FROM traces FINAL" in query:
+            if "FROM traces" in query and "FROM spans" not in query:
                 return _rows(
                     [
                         (
@@ -247,7 +247,7 @@ class TestGetTraceSkeleton:
         captured = {}
 
         def side_effect(query, parameters=None):
-            if "FROM traces FINAL" in query:
+            if "FROM traces" in query and "FROM spans" not in query:
                 return _rows(
                     [
                         (
@@ -292,7 +292,7 @@ class TestGetTraceSkeleton:
         )
 
         def side_effect(query, parameters=None):
-            if "FROM traces FINAL" in query:
+            if "FROM traces" in query and "FROM spans" not in query:
                 return _rows(
                     [
                         (


### PR DESCRIPTION
Stacked on #1350 (base = `perf/rebuild-spans-005`).

## What

Removes the remaining `FINAL` reads on the **spans/traces** tables so single-trace and session queries stop paying merge-on-read — and so they can actually use the `trace_id`-first sort key and no-IO projection #1350 adds (`FINAL` disables projection usage).

## How

Each `FROM spans/traces FINAL` is replaced with the dedup-without-FINAL pattern already used in the reader (#1285):

```sql
... FROM spans WHERE ... ORDER BY ch_update_time DESC LIMIT 1 BY span_id
```

which keeps the latest ReplacingMergeTree version per logical id without a full-parts merge.

Sites:
- `internal.py` `get_spans_jsonl` — the detector path behind the original OOM
- `live.py` completion-count check
- `trace_reader` `get_trace` traces lookup
- `trace_reader` `get_session` token totals + span-IO aggregate (dedup in a subquery, then aggregate)
- two `traces × spans` `FINAL` **joins** (`list_sessions` backfill, `get_session` detail) → scoped CTEs: resolve the session's traces first, then dedup only those traces' spans (never the whole project) before joining/aggregating

`detector_runs` / `detector_findings` FINALs are intentionally **kept** — tiny operational tables where FINAL is cheap and the dedup is a correctness requirement.

## Tests

Updated `trace_reader` test mocks to match the deduped traces lookup (the existing assertions — no FINAL in the spans query — are unchanged). `tests/rest/test_trace_reader.py` + `test_traces_router.py` green (40 passed).

## Notes

- Depends on #1350 — the projection only pays off once `FINAL` is gone. Merge #1350 first; this PR's base retargets to `main` automatically.
- Suggested follow-up: a CI gate asserting `FROM .* FINAL` in `backend/rest` only matches the detector tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates spans and traces without ClickHouse FINAL to avoid merge-on-read and unlock the trace_id-first sort key and no-IO projection. This speeds up single-trace and session reads and reduces I/O.

- **Refactors**
  - Replace all `FROM spans/traces FINAL` with dedup reads: `ORDER BY ch_update_time DESC LIMIT 1 BY span_id/trace_id`, scoped by `trace_id` where applicable.
  - Rewrite two traces×spans FINAL joins (`list_sessions` backfill, `get_session`) as scoped CTEs: dedup this session’s traces, dedup spans only for those traces, then join/aggregate.
  - Apply the pattern in `internal.get_spans_jsonl`, `live._is_trace_complete_in_clickhouse`, `trace_reader.get_trace`, `trace_reader.get_session` (I/O and token totals).
  - Keep FINAL on `detector_runs` and `detector_findings` (small tables; needed for correctness).
  - Update tests to match the dedupbed traces lookup.

<sup>Written for commit 51c4c11d8a3a6b729ed3483ee3e5aece2cd14a3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

