### PR TITLE
perf(api): debounce AccessKey lastUseTime writes on key validation

### DIFF
--- a/frontend/ui/src/app/api/internal/validate-api-key/last-use.test.ts
+++ b/frontend/ui/src/app/api/internal/validate-api-key/last-use.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { shouldRefreshLastUseTime, LAST_USE_TIME_REFRESH_INTERVAL_MS } from "./last-use";
+
+describe("shouldRefreshLastUseTime", () => {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+
+  it("refreshes a never-used key (null / undefined lastUseTime)", () => {
+    expect(shouldRefreshLastUseTime(null, now)).toBe(true);
+    expect(shouldRefreshLastUseTime(undefined, now)).toBe(true);
+  });
+
+  it("refreshes when lastUseTime is older than the interval", () => {
+    const stale = new Date(now.getTime() - LAST_USE_TIME_REFRESH_INTERVAL_MS - 1);
+    expect(shouldRefreshLastUseTime(stale, now)).toBe(true);
+  });
+
+  it("refreshes exactly at the interval boundary", () => {
+    const atBoundary = new Date(now.getTime() - LAST_USE_TIME_REFRESH_INTERVAL_MS);
+    expect(shouldRefreshLastUseTime(atBoundary, now)).toBe(true);
+  });
+
+  it("skips when lastUseTime is within the interval", () => {
+    const fresh = new Date(now.getTime() - LAST_USE_TIME_REFRESH_INTERVAL_MS + 1);
+    expect(shouldRefreshLastUseTime(fresh, now)).toBe(false);
+  });
+});

--- a/frontend/ui/src/app/api/internal/validate-api-key/last-use.ts
+++ b/frontend/ui/src/app/api/internal/validate-api-key/last-use.ts
@@ -1,0 +1,22 @@
+// `lastUseTime` is a coarse "last seen" indicator, and the validate-api-key route
+// runs on the hot ingestion path — the Python backend (authenticate_api_key in
+// backend/rest/routers/public/deps.py) validates the API key on every incoming
+// trace request. Refreshing the timestamp on every successful validation amplifies
+// writes against the same row under sustained traffic (and contends on its lock
+// during ingestion bursts), so we debounce: only refresh when the stored value is
+// missing or older than this interval.
+//
+// This lives in its own module rather than route.ts because Next.js route files
+// may only export request handlers and route config — not arbitrary constants.
+export const LAST_USE_TIME_REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Whether a key's stored `lastUseTime` is stale enough to warrant a refresh write.
+ * A missing timestamp (never used) is always considered stale.
+ */
+export function shouldRefreshLastUseTime(
+  lastUse: Date | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  return !lastUse || now.getTime() - lastUse.getTime() >= LAST_USE_TIME_REFRESH_INTERVAL_MS;
+}

--- a/frontend/ui/src/app/api/internal/validate-api-key/route.test.ts
+++ b/frontend/ui/src/app/api/internal/validate-api-key/route.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/lib/auth-helpers", () => ({
 }));
 
 import { POST } from "./route";
+import { LAST_USE_TIME_REFRESH_INTERVAL_MS } from "./last-use";
 
 function makeRequest(body: unknown) {
   return { json: async () => body } as unknown as Parameters<typeof POST>[0];
@@ -41,6 +42,7 @@ function accessKeyRow(overrides: Record<string, unknown> = {}) {
     name: "CI key",
     keyHint: "tr-d0a3-57e3",
     expireTime: null,
+    lastUseTime: null,
     project: {
       id: "proj-123",
       name: "My Project",
@@ -84,8 +86,35 @@ describe("POST /api/internal/validate-api-key", () => {
       ingestionBlocked: false,
       expiresAt: null,
     });
-    // lastUseTime is bumped on every successful validation.
+    // A never-used key (lastUseTime null) gets its "last seen" stamped once.
     expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes lastUseTime when it is older than the interval", async () => {
+    const stale = new Date(Date.now() - LAST_USE_TIME_REFRESH_INTERVAL_MS - 1_000);
+    findUniqueMock.mockResolvedValue(accessKeyRow({ lastUseTime: stale }));
+
+    const res = await POST(makeRequest({ keyHash: "abc123" }));
+
+    expect(res.status).toBe(200);
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: "key-1" },
+      data: { lastUseTime: expect.any(Date) },
+    });
+  });
+
+  it("skips the write when lastUseTime is within the interval", async () => {
+    const fresh = new Date(Date.now() - 1_000);
+    findUniqueMock.mockResolvedValue(accessKeyRow({ lastUseTime: fresh }));
+
+    const res = await POST(makeRequest({ keyHash: "abc123" }));
+    const body = await res.json();
+
+    // Still a successful validation — only the redundant DB write is skipped.
+    expect(res.status).toBe(200);
+    expect(body.valid).toBe(true);
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
   it("returns keyName null when the access key is unnamed", async () => {

--- a/frontend/ui/src/app/api/internal/validate-api-key/route.ts
+++ b/frontend/ui/src/app/api/internal/validate-api-key/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { prisma, PlanType } from "@traceroot/core";
 import { verifyInternalSecret } from "@/lib/auth-helpers";
+import { shouldRefreshLastUseTime } from "./last-use";
 
 const validateKeySchema = z.object({
   keyHash: z.string().min(1, "Key hash is required"),
@@ -68,11 +69,15 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ valid: false, error: "API key has expired" }, { status: 200 });
   }
 
-  // Update lastUseTime
-  await prisma.accessKey.update({
-    where: { id: accessKey.id },
-    data: { lastUseTime: new Date() },
-  });
+  // Refresh lastUseTime only when it is stale (see ./last-use), so heavily-used
+  // keys don't trigger a write on every validation.
+  const now = new Date();
+  if (shouldRefreshLastUseTime(accessKey.lastUseTime, now)) {
+    await prisma.accessKey.update({
+      where: { id: accessKey.id },
+      data: { lastUseTime: now },
+    });
+  }
 
   const billingPlan = accessKey.project.workspace.billingPlan || PlanType.FREE;
 


### PR DESCRIPTION
## What

Debounce `AccessKey.lastUseTime` updates in the internal `validate-api-key` route:
only refresh the timestamp when the stored value is missing or older than a
5-minute interval, instead of writing on every successful validation.

## Why

`authenticate_api_key` (`backend/rest/routers/public/deps.py`) calls this internal
route for **every incoming trace ingestion request**. The route updated
`lastUseTime` unconditionally after each successful validation, so a heavily-used
API key wrote to the same row on every request — write amplification and row-lock
contention during ingestion bursts.

`lastUseTime` is a coarse "last seen" indicator, so per-request precision isn't
needed. Collapsing a burst of validations into at most one write per key per
interval preserves the timestamp's usefulness while removing the redundant writes.

No extra query is added — `lastUseTime` already comes back on the existing
`findUnique` (it uses `include`, so all scalar columns are returned).

## How validated

- New unit tests cover the three branches (the existing test imports the real
  handler and only mocks Prisma/Next):
  - stale key (older than the interval) → writes, with a fresh `Date`
  - fresh key (within the interval) → skips the write, still returns `valid: true`
  - never-used key (`lastUseTime` null) → writes
- `vitest run` (route file): 5/5 pass
- `eslint`, `tsc --noEmit`, `prettier --check` on the changed files: clean

Closes #1095

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Debounced `AccessKey.lastUseTime` updates in the internal `validate-api-key` route to at most once every 5 minutes per key, reducing write amplification and lock contention on ingestion. Addresses Linear #1095 by keeping “last seen” accurate without per-request writes.

- **Refactors**
  - Refresh only when missing or >= 5 minutes old; skip otherwise.
  - Moved interval and staleness check to `last-use.ts`.
  - Added pure-function and route tests; reuse existing `findUnique` (no extra reads).

<sup>Written for commit 6f1f451c62b3efd487b4a541a74f418ec18c89a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

