### PR TITLE
ci: bake per-env NEXT_PUBLIC_APP_URL + BETTER_AUTH_URL into the web image (fixes localhost login trap)

### DIFF
--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -9,6 +9,14 @@ on:
   #   # Daily at 3am — disabled until we have a use for it
   #   - cron: "0 3 * * *"
   workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target ECR repo prefix (repos are named traceroot-<environment>-<service>)"
+        type: choice
+        options:
+          - staging
+          - production
+        default: staging
 
 concurrency:
   group: docker-images-${{ github.ref }}
@@ -73,7 +81,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.ECR_REGISTRY }}/traceroot-${{ matrix.service }}
+          images: ${{ env.ECR_REGISTRY }}/traceroot-${{ inputs.environment }}-${{ matrix.service }}
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=sha,prefix=sha-

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -95,8 +95,20 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Per-environment build args. NEXT_PUBLIC_APP_URL and BETTER_AUTH_URL
+          # are inlined into the web client bundle at BUILD time (Next.js) and
+          # default to http://localhost:3000 in docker/Dockerfile.web — if they
+          # are not passed, login breaks in the deployed env. They are public,
+          # deterministic per-env URLs (not secrets), so derive them from the
+          # `environment` input rather than a deletable GitHub secret. PostHog
+          # is production-only (empty -> dropped by build-push-action -> the
+          # Dockerfile default of "" -> analytics disabled, as on staging).
           build-args: |
             APP_VERSION=${{ steps.app_version.outputs.value }}
+            NEXT_PUBLIC_APP_URL=${{ inputs.environment == 'production' && 'https://app.traceroot.ai' || 'https://staging.traceroot.ai' }}
+            BETTER_AUTH_URL=${{ inputs.environment == 'production' && 'https://app.traceroot.ai' || 'https://staging.traceroot.ai' }}
+            NEXT_PUBLIC_POSTHOG_KEY=${{ inputs.environment == 'production' && secrets.NEXT_PUBLIC_POSTHOG_KEY || '' }}
+            NEXT_PUBLIC_POSTHOG_HOST=${{ inputs.environment == 'production' && secrets.NEXT_PUBLIC_POSTHOG_HOST || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64


### PR DESCRIPTION
## What
Adds per-environment build args to the web image build in `docker-images.yml`:
- `NEXT_PUBLIC_APP_URL` and `BETTER_AUTH_URL` → `https://app.traceroot.ai` for `production`, else `https://staging.traceroot.ai`
- `NEXT_PUBLIC_POSTHOG_*` → production-only (empty on staging)

Derived from the `environment` input — **no secret**.

## Why (the bug this prevents)
`docker/Dockerfile.web` defaults `NEXT_PUBLIC_APP_URL` and `BETTER_AUTH_URL` to `http://localhost:3000`, and Next.js **inlines `NEXT_PUBLIC_APP_URL` into the client bundle at build time**. The build only passed `APP_VERSION`, so the web image baked `localhost:3000` → **login breaks in the deployed environment**.

This is the exact trap that took down **staging login on 2026-06-26**: the single `NEXT_PUBLIC_APP_URL` GitHub secret was removed, so every build silently fell back to the localhost default. These URLs are **public, deterministic per-env values, not secrets** — storing them as a single deletable secret was the root fragility. Deriving from `environment` removes that failure mode and lets staging/prod both be correct.

## Why this matters now
This is **blocker 0a** for the prod `005` migration deploy — the next prod web rebuild would otherwise bake localhost and break prod login. This branch (`ci/parameterize-image-env`) already carries Layer-1 + the 005 migration, so with this fix it's a valid, login-safe prod build source.

## Follow-up (not in this PR)
Add a build guardrail: fail the web build if the bundle still contains `localhost:3000` (`grep -q localhost:3000 .next/... && exit 1`) — turns a silent breakage into a loud red build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bake environment-specific app URLs into the web Docker image so the Next.js bundle uses the correct domain, fixing the localhost login trap in staging and production. PostHog envs are now production-only.

- **Bug Fixes**
  - Derive `NEXT_PUBLIC_APP_URL` and `BETTER_AUTH_URL` from the workflow `environment` input and pass as build args to avoid `http://localhost:3000` being inlined.
  - Pass `NEXT_PUBLIC_POSTHOG_KEY` and `NEXT_PUBLIC_POSTHOG_HOST` only in production; leave empty on staging to disable analytics.

<sup>Written for commit bfcac0dd0ecdb0919defae6301e24c0aaaab12d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

