### PR TITLE
fix(detector): restore digest alerts via /detector-window-summary fold-in

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field
 
 from db.clickhouse.client import get_clickhouse_client
 from rest.schemas.detectors import (
-    DetectorCountsResponse,
+    DetectorWindowSummaryResponse,
     RunListResponse,
 )
 from rest.sql_utils import escape_ilike, to_utc_naive
@@ -635,11 +635,11 @@ async def list_trace_detector_runs(trace_id: str, project_id: str):
 
 
 @router.get(
-    "/detector-counts",
-    response_model=DetectorCountsResponse,
+    "/detector-window-summary",
+    response_model=DetectorWindowSummaryResponse,
     dependencies=[Depends(verify_internal_secret)],
 )
-async def list_detector_counts(
+async def list_detector_window_summary(
     project_id: str,
     start_after: datetime = Query(
         ..., description="Lower bound on detector_runs.timestamp (inclusive)"
@@ -648,48 +648,78 @@ async def list_detector_counts(
         None, description="Upper bound on detector_runs.timestamp (exclusive)"
     ),
 ):
-    """Aggregate finding and run counts per detector for a project, in one query.
+    """Aggregate run/finding counts and the latest triggered trace per detector.
 
-    Runs are read with FINAL so pre-merge ReplacingMergeTree duplicates don't
-    inflate the counts. A run carries its finding_id when it triggered; since
-    findings are never withdrawn, counting runs with a non-null finding_id per
-    detector gives that detector's finding count.
+    Dedup without FINAL: ``detector_runs`` is a ``ReplacingMergeTree`` whose
+    duplicates are idempotent retries sharing a deterministic ``run_id`` (the
+    larger ``timestamp`` wins). The inner query collapses each ``run_id`` to its
+    latest version via ``argMax`` / ``max(timestamp)`` over the project's whole
+    history; the outer query then windows on that collapsed ``ts``. That yields
+    exactly the rows ``FINAL`` would have surfaced ("latest row wins, then
+    filter") — including for a retry that re-stamps across a window boundary —
+    but as a streamed aggregate rather than a merge-on-read (the construct that
+    OOM-killed rest on the big ``spans`` table; see the 2026-06-25 incident).
 
-    Detectors with zero runs in the window are absent from the result map; the
-    frontend defaults absent entries to {findingCount: 0, runCount: 0}.
+    A run carries its ``finding_id`` and the ``trace_id`` it fired on, so
+    ``finding_count`` and ``sample_trace_ids`` come straight off the runs — no
+    ``detector_findings`` JOIN, and no second per-detector read (the digest used
+    to fetch the latest trace via a now-removed ``GET /detector-findings``;
+    folding it in here removes that N+1). ``sample_trace_ids`` holds the most
+    recent *triggered* run's trace (one today, shaped as a list so we can
+    surface more later), or an empty list for a detector that ran but never
+    fired.
+
+    Detectors with no runs in the window are omitted; the frontend defaults
+    absent entries to {findingCount: 0, runCount: 0}.
     """
     ch = get_clickhouse_client()
 
-    conditions = [
-        "r.project_id = {project_id:String}",
-        "r.timestamp >= {start_after:DateTime64(3)}",
-    ]
+    # Window on the collapsed timestamp (outer), not the raw rows (inner): the
+    # dedup must happen first so a run is placed by its latest version, matching
+    # FINAL across retries that re-stamp near a window boundary.
     params: dict = {
         "project_id": project_id,
         "start_after": to_utc_naive(start_after),
     }
+    window_conditions = ["ts >= {start_after:DateTime64(3)}"]
     if end_before is not None:
-        conditions.append("r.timestamp < {end_before:DateTime64(3)}")
+        window_conditions.append("ts < {end_before:DateTime64(3)}")
         params["end_before"] = to_utc_naive(end_before)
+    window_clause = " AND ".join(window_conditions)
 
-    where_clause = " AND ".join(conditions)
     query = f"""
         SELECT
-            r.detector_id AS detector_id,
-            count()                            AS run_count,
-            countIf(r.finding_id IS NOT NULL)  AS finding_count
-        FROM (SELECT * FROM detector_runs FINAL) AS r
-        WHERE {where_clause}
-        GROUP BY r.detector_id
+            detector_id,
+            count()                                                      AS run_count,
+            countIf(latest_finding_id IS NOT NULL)                       AS finding_count,
+            argMaxIf(latest_trace_id, ts, latest_finding_id IS NOT NULL) AS latest_trace_id
+        FROM (
+            SELECT
+                detector_id,
+                run_id,
+                argMax(finding_id, timestamp) AS latest_finding_id,
+                argMax(trace_id,   timestamp) AS latest_trace_id,
+                max(timestamp)                AS ts
+            FROM detector_runs
+            WHERE project_id = {{project_id:String}}
+            GROUP BY detector_id, run_id
+        )
+        WHERE {window_clause}
+        GROUP BY detector_id
     """
 
     result = ch.query(query, parameters=params)
-    data: dict[str, dict[str, int]] = {}
+    data: dict[str, dict] = {}
     for row in result.result_rows:
         row_dict = dict(zip(result.column_names, row))
+        # One representative trace today, shaped as a list so surfacing more
+        # later (groupArray in the query) needs no contract change. "" (a
+        # detector that ran but never fired) collapses to an empty list.
+        latest_trace_id = row_dict["latest_trace_id"]
         data[row_dict["detector_id"]] = {
             "finding_count": int(row_dict["finding_count"]),
             "run_count": int(row_dict["run_count"]),
+            "sample_trace_ids": [latest_trace_id] if latest_trace_id else [],
         }
 
     return {"data": data}

--- a/backend/rest/schemas/detectors.py
+++ b/backend/rest/schemas/detectors.py
@@ -27,15 +27,20 @@ class RunListResponse(BaseModel):
     meta: PaginationMeta
 
 
-class DetectorCountsItem(BaseModel):
-    """Aggregated counts for a single detector over a time window."""
+class DetectorWindowSummary(BaseModel):
+    """Per-detector rollup for a time window: counts plus a few sample traces."""
 
     finding_count: int
     run_count: int
+    # Representative traces for this detector's window, newest-first; empty when
+    # it never fired. Plural + sample-shaped so we can surface more than one
+    # later (a SQL-only change) without touching this contract — and so the
+    # digest gets its deep-link target without a second per-detector read.
+    sample_trace_ids: list[str] = []
 
 
-class DetectorCountsResponse(BaseModel):
-    """Map of detector_id -> counts. Detectors with zero runs in the window
-    are omitted; the frontend defaults absent entries to {0, 0}."""
+class DetectorWindowSummaryResponse(BaseModel):
+    """Map of detector_id -> window summary. Detectors with zero runs in the
+    window are omitted; the frontend defaults absent entries to {0, 0}."""
 
-    data: dict[str, DetectorCountsItem]
+    data: dict[str, DetectorWindowSummary]

--- a/frontend/ui/src/app/api/projects/[projectId]/detector-counts/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detector-counts/route.ts
@@ -8,7 +8,8 @@ const INTERNAL_API_SECRET = env.INTERNAL_API_SECRET || "";
 type RouteParams = { params: Promise<{ projectId: string }> };
 
 // GET /api/projects/[projectId]/detector-counts
-// Proxies to Python backend: GET /api/v1/internal/detector-counts
+// Proxies to Python backend: GET /api/v1/internal/detector-window-summary
+// (the UI only reads the counts; the backend endpoint also returns sample traces)
 export async function GET(req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
@@ -35,7 +36,7 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
   let response: Response;
   try {
     response = await fetch(
-      `${BACKEND_URL}/api/v1/internal/detector-counts?${backendParams.toString()}`,
+      `${BACKEND_URL}/api/v1/internal/detector-window-summary?${backendParams.toString()}`,
       {
         headers: {
           "X-Internal-Secret": INTERNAL_API_SECRET,

--- a/frontend/worker/src/detection/__tests__/findings-reader.test.ts
+++ b/frontend/worker/src/detection/__tests__/findings-reader.test.ts
@@ -4,26 +4,30 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-import { readDetectorCounts, readLatestFinding } from "../findings-reader.js";
+import { readDetectorWindowSummary } from "../findings-reader.js";
 
 const START = new Date("2026-06-01T00:00:00.000Z");
 const END = new Date("2026-06-08T00:00:00.000Z");
 
-describe("readDetectorCounts", () => {
+describe("readDetectorWindowSummary", () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it("GETs detector-counts with project_id and window bounds, returns the data map", async () => {
+  it("GETs detector-window-summary with project_id and window bounds, returns the data map", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ data: { d1: { finding_count: 3, run_count: 9 } } }),
+      json: async () => ({
+        data: { d1: { finding_count: 3, run_count: 9, sample_trace_ids: ["t-abc"] } },
+      }),
     });
 
-    const counts = await readDetectorCounts("proj-1", START, END);
+    const summary = await readDetectorWindowSummary("proj-1", START, END);
 
-    expect(counts).toEqual({ d1: { finding_count: 3, run_count: 9 } });
+    expect(summary).toEqual({
+      d1: { finding_count: 3, run_count: 9, sample_trace_ids: ["t-abc"] },
+    });
 
     const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/api/v1/internal/detector-counts");
+    expect(url).toContain("/api/v1/internal/detector-window-summary");
     expect(url).toContain("project_id=proj-1");
     expect(url).toContain(`start_after=${encodeURIComponent(START.toISOString())}`);
     expect(url).toContain(`end_before=${encodeURIComponent(END.toISOString())}`);
@@ -32,7 +36,7 @@ describe("readDetectorCounts", () => {
   it("sends the X-Internal-Secret header", async () => {
     mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ data: {} }) });
 
-    await readDetectorCounts("proj-1", START, END);
+    await readDetectorWindowSummary("proj-1", START, END);
 
     const headers = mockFetch.mock.calls[0][1].headers;
     expect(headers).toHaveProperty("X-Internal-Secret");
@@ -45,44 +49,8 @@ describe("readDetectorCounts", () => {
       text: async () => "boom",
     });
 
-    await expect(readDetectorCounts("proj-1", START, END)).rejects.toThrow(
+    await expect(readDetectorWindowSummary("proj-1", START, END)).rejects.toThrow(
       "Backend API error: 500",
     );
-  });
-});
-
-describe("readLatestFinding", () => {
-  beforeEach(() => vi.clearAllMocks());
-
-  it("GETs detector-findings and returns the newest finding's trace id", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        data: [{ trace_id: "t-abc", summary: "..." }],
-        meta: { total: 3 },
-      }),
-    });
-
-    const traceId = await readLatestFinding("proj-1", "d1", START, END);
-
-    expect(traceId).toBe("t-abc");
-
-    const url = mockFetch.mock.calls[0][0] as string;
-    expect(url).toContain("/api/v1/internal/detector-findings");
-    expect(url).toContain("project_id=proj-1");
-    expect(url).toContain("detector_id=d1");
-    expect(url).toContain("page=0");
-    expect(url).toContain("limit=1");
-  });
-
-  it("returns null when there are no findings in the window", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ data: [], meta: { total: 0 } }),
-    });
-
-    const traceId = await readLatestFinding("proj-1", "d1", START, END);
-
-    expect(traceId).toBeNull();
   });
 });

--- a/frontend/worker/src/detection/findings-reader.ts
+++ b/frontend/worker/src/detection/findings-reader.ts
@@ -33,52 +33,32 @@ async function internalGet<T>(path: string, params: Record<string, string>): Pro
   return response.json() as Promise<T>;
 }
 
-// The worker's digest only needs finding_count; the backend /detector-counts
-// endpoint also returns run_count (consumed by the UI), which we don't type here.
-export type DetectorCounts = Record<string, { finding_count: number }>;
+// The digest needs finding_count plus sample_trace_ids (deep-link targets,
+// newest-first); the backend window-summary endpoint also returns run_count
+// (consumed by the UI), which we don't type here. sample_trace_ids is empty for
+// a detector that ran but never fired.
+export type DetectorWindowSummary = Record<
+  string,
+  { finding_count: number; sample_trace_ids: string[] }
+>;
 
 /**
- * Read per-detector finding counts for a project over a time window.
- * Detectors with zero runs in the window are absent from the map.
+ * Read the per-detector window summary (finding counts + each detector's sample
+ * triggered traces) for a project over a time window. Detectors with zero runs
+ * in the window are absent from the map.
  */
-export async function readDetectorCounts(
+export async function readDetectorWindowSummary(
   projectId: string,
   start: Date,
   end: Date,
-): Promise<DetectorCounts> {
-  const body = await internalGet<{ data: DetectorCounts }>("/api/v1/internal/detector-counts", {
-    project_id: projectId,
-    start_after: start.toISOString(),
-    end_before: end.toISOString(),
-  });
-  return body.data;
-}
-
-/**
- * Return the trace id of the latest finding for a detector in the window,
- * or null when the detector produced no findings.
- *
- * Relies on /detector-findings defaulting to newest-first (ORDER BY timestamp
- * DESC); page 0 / limit 1 takes that top row. That ordering has no stable
- * tiebreaker, so on tied timestamps the chosen "latest" trace can differ from
- * the detector list's top row — tracked as a deterministic-ordering follow-up.
- */
-export async function readLatestFinding(
-  projectId: string,
-  detectorId: string,
-  start: Date,
-  end: Date,
-): Promise<string | null> {
-  const body = await internalGet<{ data: Array<{ trace_id: string }> }>(
-    "/api/v1/internal/detector-findings",
+): Promise<DetectorWindowSummary> {
+  const body = await internalGet<{ data: DetectorWindowSummary }>(
+    "/api/v1/internal/detector-window-summary",
     {
       project_id: projectId,
-      detector_id: detectorId,
       start_after: start.toISOString(),
       end_before: end.toISOString(),
-      page: "0",
-      limit: "1",
     },
   );
-  return body.data[0]?.trace_id ?? null;
+  return body.data;
 }

--- a/frontend/worker/src/processors/__tests__/detector-digest-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-digest-processor.test.ts
@@ -1,15 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const readDetectorCounts = vi.fn();
-const readLatestFinding = vi.fn();
+const readDetectorWindowSummary = vi.fn();
 const detectorFindMany = vi.fn();
 const projectFindUnique = vi.fn();
 const sendDigestAlertSlack = vi.fn();
 const sendDigestAlertEmail = vi.fn();
 
 vi.mock("../../detection/findings-reader.js", () => ({
-  readDetectorCounts: (...a: any[]) => readDetectorCounts(...a),
-  readLatestFinding: (...a: any[]) => readLatestFinding(...a),
+  readDetectorWindowSummary: (...a: any[]) => readDetectorWindowSummary(...a),
 }));
 
 vi.mock("@traceroot/core", () => ({
@@ -41,11 +39,10 @@ const PROJECT = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  readDetectorCounts.mockResolvedValue({
-    d1: { finding_count: 4, run_count: 9 },
-    d2: { finding_count: 1, run_count: 3 },
+  readDetectorWindowSummary.mockResolvedValue({
+    d1: { finding_count: 4, run_count: 9, sample_trace_ids: ["trace-d1"] },
+    d2: { finding_count: 1, run_count: 3, sample_trace_ids: ["trace-d2"] },
   });
-  readLatestFinding.mockImplementation(async (_p: string, id: string) => `trace-${id}`);
   detectorFindMany.mockResolvedValue([
     { id: "d1", name: "Latency", enableRca: true },
     { id: "d2", name: "Errors", enableRca: true },
@@ -100,9 +97,9 @@ describe("flushDigest", () => {
   });
 
   it("sends nothing when no detector has findings in the window", async () => {
-    readDetectorCounts.mockResolvedValue({
-      d1: { finding_count: 0, run_count: 9 },
-      d2: { finding_count: 0, run_count: 3 },
+    readDetectorWindowSummary.mockResolvedValue({
+      d1: { finding_count: 0, run_count: 9, sample_trace_ids: [] },
+      d2: { finding_count: 0, run_count: 3, sample_trace_ids: [] },
     });
 
     await run();
@@ -122,7 +119,6 @@ describe("flushDigest", () => {
 
     // resolveRecipients runs first (project has channels), but we still bail at
     // the RCA-disabled filter before building entries or sending.
-    expect(readLatestFinding).not.toHaveBeenCalled();
     expect(sendDigestAlertSlack).not.toHaveBeenCalled();
     expect(sendDigestAlertEmail).not.toHaveBeenCalled();
   });
@@ -145,7 +141,7 @@ describe("flushDigest", () => {
 
     await run();
 
-    expect(readDetectorCounts).not.toHaveBeenCalled(); // resolved first, bailed before the count read
+    expect(readDetectorWindowSummary).not.toHaveBeenCalled(); // resolved first, bailed before the summary read
     expect(sendDigestAlertSlack).not.toHaveBeenCalled();
     expect(sendDigestAlertEmail).not.toHaveBeenCalled();
   });
@@ -159,7 +155,7 @@ describe("flushDigest", () => {
 
     await run();
 
-    expect(readDetectorCounts).not.toHaveBeenCalled();
+    expect(readDetectorWindowSummary).not.toHaveBeenCalled();
     expect(detectorFindMany).not.toHaveBeenCalled();
     expect(sendDigestAlertSlack).not.toHaveBeenCalled();
     expect(sendDigestAlertEmail).not.toHaveBeenCalled();

--- a/frontend/worker/src/processors/detector-digest-processor.ts
+++ b/frontend/worker/src/processors/detector-digest-processor.ts
@@ -7,9 +7,8 @@ import {
   createRedisConnection,
 } from "../queues/digest-queue.js";
 import {
-  readDetectorCounts,
-  readLatestFinding,
-  type DetectorCounts,
+  readDetectorWindowSummary,
+  type DetectorWindowSummary,
 } from "../detection/findings-reader.js";
 import { sendDigestAlertSlack } from "../notifications/slack.js";
 import { sendDigestAlertEmail } from "../notifications/email.js";
@@ -44,8 +43,8 @@ export async function flushDigest(job: DigestFlushJob): Promise<void> {
     return;
   }
 
-  const counts = await readDetectorCounts(projectId, start, end);
-  const triggeredIds = Object.keys(counts).filter((id) => counts[id].finding_count > 0);
+  const summary = await readDetectorWindowSummary(projectId, start, end);
+  const triggeredIds = Object.keys(summary).filter((id) => summary[id].finding_count > 0);
   if (triggeredIds.length === 0) {
     console.log(`[Digest] skip project=${projectId} window=${window} reason=no-findings`);
     return; // nothing triggered in the window
@@ -64,7 +63,7 @@ export async function flushDigest(job: DigestFlushJob): Promise<void> {
     return; // only RCA-disabled detectors fired → no digest
   }
 
-  const entries = await buildEntries(projectId, detectorIds, nameById, counts, start, end);
+  const entries = buildEntries(detectorIds, nameById, summary);
   const total = entries.reduce((sum, e) => sum + e.findingCount, 0);
 
   await fanOut(recipients, { projectId, windowStart: start, windowEnd: end, total, entries });
@@ -79,25 +78,21 @@ export async function flushDigest(job: DigestFlushJob): Promise<void> {
 }
 
 /**
- * Build one digest entry per detector, fetching each detector's latest trace in
- * the window concurrently (one round-trip each).
+ * Build one digest entry per detector. The window-summary read already carries
+ * each detector's sample triggered traces (folded into the endpoint), so no
+ * per-detector round-trip is needed. The entry shows the newest one today.
  */
-async function buildEntries(
-  projectId: string,
+function buildEntries(
   detectorIds: string[],
   nameById: Map<string, string>,
-  counts: DetectorCounts,
-  start: Date,
-  end: Date,
-): Promise<DigestEntry[]> {
-  return Promise.all(
-    detectorIds.map(async (id) => ({
-      detectorId: id,
-      detectorName: nameById.get(id) ?? id,
-      findingCount: counts[id].finding_count,
-      latestTraceId: (await readLatestFinding(projectId, id, start, end)) ?? "",
-    })),
-  );
+  summary: DetectorWindowSummary,
+): DigestEntry[] {
+  return detectorIds.map((id) => ({
+    detectorId: id,
+    detectorName: nameById.get(id) ?? id,
+    findingCount: summary[id].finding_count,
+    latestTraceId: summary[id].sample_trace_ids[0] ?? "",
+  }));
 }
 
 interface DigestContent {

--- a/tests/rest/test_detector_endpoints.py
+++ b/tests/rest/test_detector_endpoints.py
@@ -416,23 +416,24 @@ class TestInternalAuth:
 
 
 # =============================================================================
-# /detector-counts (#810)
+# /detector-window-summary (#810)
 # =============================================================================
 
 
-class TestListDetectorCounts:
+class TestListDetectorWindowSummary:
     def _fake_aggregate(self, rows: list[tuple]):
+        # Rows are (detector_id, run_count, finding_count, latest_trace_id).
         return _make_query_result(
             rows=rows,
-            column_names=["detector_id", "run_count", "finding_count"],
+            column_names=["detector_id", "run_count", "finding_count", "latest_trace_id"],
         )
 
     def test_returns_per_detector_counts(self, client, mock_ch, secret):
         mock_ch.query.side_effect = [
-            self._fake_aggregate([("d-a", 100, 7), ("d-b", 25, 0)]),
+            self._fake_aggregate([("d-a", 100, 7, "t-a"), ("d-b", 25, 0, "")]),
         ]
         resp = client.get(
-            "/api/v1/internal/detector-counts",
+            "/api/v1/internal/detector-window-summary",
             params={
                 "project_id": "p1",
                 "start_after": "2026-04-20T00:00:00Z",
@@ -443,15 +444,15 @@ class TestListDetectorCounts:
         body = resp.json()
         assert body == {
             "data": {
-                "d-a": {"finding_count": 7, "run_count": 100},
-                "d-b": {"finding_count": 0, "run_count": 25},
+                "d-a": {"finding_count": 7, "run_count": 100, "sample_trace_ids": ["t-a"]},
+                "d-b": {"finding_count": 0, "run_count": 25, "sample_trace_ids": []},
             }
         }
 
     def test_empty_when_no_runs_in_window(self, client, mock_ch, secret):
         mock_ch.query.side_effect = [self._fake_aggregate([])]
         resp = client.get(
-            "/api/v1/internal/detector-counts",
+            "/api/v1/internal/detector-window-summary",
             params={
                 "project_id": "p1",
                 "start_after": "2026-04-20T00:00:00Z",
@@ -464,7 +465,7 @@ class TestListDetectorCounts:
     def test_passes_end_before_when_provided(self, client, mock_ch, secret):
         mock_ch.query.side_effect = [self._fake_aggregate([])]
         client.get(
-            "/api/v1/internal/detector-counts",
+            "/api/v1/internal/detector-window-summary",
             params={
                 "project_id": "p1",
                 "start_after": "2026-04-20T00:00:00Z",
@@ -475,13 +476,15 @@ class TestListDetectorCounts:
         call_args = mock_ch.query.call_args
         sql = call_args.args[0] if call_args.args else call_args.kwargs.get("query")
         params = call_args.kwargs.get("parameters", {})
-        assert "timestamp <" in sql
+        # The window upper bound is applied to the collapsed timestamp (ts), not
+        # the raw rows.
+        assert "ts <" in sql
         assert "end_before" in params
 
     def test_omits_end_before_when_absent(self, client, mock_ch, secret):
         mock_ch.query.side_effect = [self._fake_aggregate([])]
         client.get(
-            "/api/v1/internal/detector-counts",
+            "/api/v1/internal/detector-window-summary",
             params={
                 "project_id": "p1",
                 "start_after": "2026-04-20T00:00:00Z",
@@ -491,30 +494,30 @@ class TestListDetectorCounts:
         call_args = mock_ch.query.call_args
         sql = call_args.args[0] if call_args.args else call_args.kwargs.get("query")
         params = call_args.kwargs.get("parameters", {})
-        assert "timestamp <" not in sql or "end_before" not in sql
+        assert "ts <" not in sql
         assert "end_before" not in params
 
     def test_requires_internal_secret(self, client, mock_ch):
         resp = client.get(
-            "/api/v1/internal/detector-counts",
+            "/api/v1/internal/detector-window-summary",
             params={"project_id": "p1", "start_after": "2026-04-20T00:00:00Z"},
         )
         assert resp.status_code == 403
 
     def test_requires_start_after(self, client, mock_ch, secret):
         resp = client.get(
-            "/api/v1/internal/detector-counts",
+            "/api/v1/internal/detector-window-summary",
             params={"project_id": "p1"},
             headers={"X-Internal-Secret": secret},
         )
         assert resp.status_code == 422
 
-    def test_runs_deduplicated_and_finding_count(self, client, mock_ch, secret):
-        """run_count must dedup pre-merge run rows; finding_count counts runs
-        that carry a finding_id (findings are never withdrawn)."""
-        mock_ch.query.side_effect = [self._fake_aggregate([("d-a", 10, 3)])]
+    def test_dedups_via_argmax_without_final(self, client, mock_ch, secret):
+        """Runs are deduped by run_id via argMax (no FINAL), and finding_count
+        comes straight off the run's finding_id (no detector_findings JOIN)."""
+        mock_ch.query.side_effect = [self._fake_aggregate([("d-a", 10, 3, "t-x")])]
         resp = client.get(
-            "/api/v1/internal/detector-counts",
+            "/api/v1/internal/detector-window-summary",
             params={
                 "project_id": "p1",
                 "start_after": "2026-04-20T00:00:00Z",
@@ -523,22 +526,63 @@ class TestListDetectorCounts:
         )
         assert resp.status_code == 200
         sql = mock_ch.query.call_args.args[0]
-        # Runs deduplicated before counting.
-        assert "(SELECT * FROM detector_runs FINAL) AS r" in sql
-        # Finding count comes straight off the run's finding_id; no findings JOIN.
-        assert "countIf(r.finding_id IS NOT NULL)" in sql
-        assert "retracted" not in sql
-        assert "LEFT JOIN" not in sql
+        # No FINAL — the OOM-shaped merge-on-read is gone.
+        assert "FINAL" not in sql
+        # Dedup is an argMax aggregate per run_id.
+        assert "GROUP BY detector_id, run_id" in sql
+        assert "argMax(finding_id, timestamp)" in sql
+        # Finding count straight off the collapsed run; no findings JOIN.
+        assert "countIf(latest_finding_id IS NOT NULL)" in sql
+        assert "JOIN" not in sql
 
-    def test_detector_with_runs_but_no_findings(self, client, mock_ch, secret):
-        # A detector that ran 10 times but never triggered: 0 findings, 10 runs.
-        mock_ch.query.side_effect = [self._fake_aggregate([("d-a", 10, 0)])]
+    def test_dedups_before_windowing(self, client, mock_ch, secret):
+        """The window filter is applied to the collapsed timestamp (ts), AFTER
+        the per-run dedup — so a retry that re-stamps across a window boundary is
+        placed by its latest version, matching FINAL's semantics."""
+        mock_ch.query.side_effect = [self._fake_aggregate([])]
+        client.get(
+            "/api/v1/internal/detector-window-summary",
+            params={
+                "project_id": "p1",
+                "start_after": "2026-04-20T00:00:00Z",
+                "end_before": "2026-05-01T00:00:00Z",
+            },
+            headers={"X-Internal-Secret": secret},
+        )
+        sql = mock_ch.query.call_args.args[0]
+        # The inner dedup (GROUP BY run_id) must come before the outer window
+        # filter on the collapsed ts.
+        assert sql.index("GROUP BY detector_id, run_id") < sql.index("ts >=")
+        assert sql.index("GROUP BY detector_id, run_id") < sql.index("ts <")
+
+    def test_returns_sample_trace_ids(self, client, mock_ch, secret):
+        """The latest *triggered* run's trace (argMaxIf) is surfaced as a
+        one-element sample_trace_ids list."""
+        mock_ch.query.side_effect = [self._fake_aggregate([("d-a", 10, 3, "trace-latest")])]
         resp = client.get(
-            "/api/v1/internal/detector-counts",
+            "/api/v1/internal/detector-window-summary",
             params={
                 "project_id": "p1",
                 "start_after": "2026-04-20T00:00:00Z",
             },
             headers={"X-Internal-Secret": secret},
         )
-        assert resp.json() == {"data": {"d-a": {"finding_count": 0, "run_count": 10}}}
+        assert resp.json()["data"]["d-a"]["sample_trace_ids"] == ["trace-latest"]
+        sql = mock_ch.query.call_args.args[0]
+        assert "argMaxIf(latest_trace_id, ts, latest_finding_id IS NOT NULL)" in sql
+
+    def test_detector_with_runs_but_no_findings(self, client, mock_ch, secret):
+        # A detector that ran 10 times but never triggered: 0 findings, 10 runs,
+        # and no sample traces (argMaxIf over no triggered runs -> "" -> []).
+        mock_ch.query.side_effect = [self._fake_aggregate([("d-a", 10, 0, "")])]
+        resp = client.get(
+            "/api/v1/internal/detector-window-summary",
+            params={
+                "project_id": "p1",
+                "start_after": "2026-04-20T00:00:00Z",
+            },
+            headers={"X-Internal-Secret": secret},
+        )
+        assert resp.json() == {
+            "data": {"d-a": {"finding_count": 0, "run_count": 10, "sample_trace_ids": []}}
+        }


### PR DESCRIPTION
## What
Restore detector **digest alerts** (silently broken on main/staging — see #1359) by folding each detector's latest trace into the per-detector window rollup, and rename the endpoint to reflect what it now returns.

## Why it broke
The digest worker fetched each detector's latest trace via `GET /detector-findings` — a route removed by the #1327 detector-API redesign that landed while this stack was un-rebased. The three-way merge dropped the route (delete-vs-unchanged, no conflict) while keeping the caller, so every flush `405`'d and the whole `flushDigest` threw → all digest alerts silently lost. It only surfaced post-merge, which is why feature-branch e2e passed. Full root cause in #1359.

## The change
- **Backend:** `GET /detector-counts` → **`GET /detector-window-summary`**, now returning `sample_trace_ids` per detector (plural, newest-first — one today, growable to N via `groupArray` with no contract change). The query **drops `FINAL`**: it dedups `detector_runs` by `run_id` with `argMax`/`max(timestamp)` and windows on the *collapsed* timestamp, reproducing the prior merge-on-read semantics (incl. a retry that re-stamps across a window boundary) as a streamed aggregate. Models renamed `DetectorCounts*` → `DetectorWindowSummary*`.
- **Worker:** delete `readLatestFinding` (the dead 405 call); `buildEntries` reads the trace off the rollup. `readDetectorCounts`/`DetectorCounts` → `readDetectorWindowSummary`/`DetectorWindowSummary`.
- **UI:** the detectors-page proxy retargets the renamed endpoint; its own counts-named hook/route are intentionally unchanged (it's a counts display and never used the traces).

One change fixes the `405`, removes the per-detector **N+1**, and takes **`FINAL`** off the digest hot path.

## Screenshots
<img width="1728" height="876" alt="Screenshot 2026-06-28 at 2 14 49 PM" src="https://github.com/user-attachments/assets/6cfe0edb-5d30-4c5e-95a2-df071bb97e20" />
<img width="1722" height="874" alt="Screenshot 2026-06-28 at 2 14 38 PM" src="https://github.com/user-attachments/assets/0151b78a-5e59-49bb-8709-9c3ea7a588c1" />
<img width="1075" height="661" alt="Screenshot 2026-06-28 at 2 14 12 PM" src="https://github.com/user-attachments/assets/f6733629-be7a-4749-8020-71040c49b581" />



## Tests / verification
- **Worker:** `tsc` clean; vitest green (updated `findings-reader` + `detector-digest-processor` specs).
- **Backend:** `pytest` green, incl. new coverage that the query has **no `FINAL`**, dedups via `argMax` **before** windowing, and surfaces `sample_trace_ids`.
- **Local e2e:** digest sends to Slack; `/detector-window-summary` returns `200` (24×); **zero `405`s**; no `GET /detector-findings` calls.

## Note
`/detector-window-summary` dedups over the project's run history (the same scan `FINAL` did) — fine at detector-table scale; a bounded lookback or materialized rollup is a future optimization if volume ever warrants.

Closes #1359

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores detector digest alerts by folding each detector’s latest triggered trace into a new per-detector window summary endpoint. Fixes the 405s from the removed findings route and removes N+1 calls and `FINAL` from the digest path.

- **Bug Fixes**
  - Backend: replace `GET /detector-counts` with `GET /detector-window-summary`, returning per-detector `finding_count`, `run_count`, and `sample_trace_ids` (newest-first, empty when none).
  - Query: dedup `detector_runs` by `run_id` via `argMax` and window on the collapsed timestamp; no `FINAL` or findings JOIN.
  - Worker: delete `readLatestFinding`; use `readDetectorWindowSummary` and build entries from `sample_trace_ids` (no per-detector round-trips).
  - UI: proxy retargeted to `GET /detector-window-summary` (counts-only consumer unchanged).
  - Verified via unit tests and local e2e (Slack digests sent; `200` on `detector-window-summary`; no `405`s).

<sup>Written for commit 3f60e26deebab277b2961e6e78dd3a0549d551a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

