### PR TITLE
fix(rest): serialize trace timestamps with explicit UTC offset

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -269,7 +269,6 @@
             "type": "string"
           },
           "trace_start_time": {
-            "format": "date-time",
             "title": "Trace Start Time",
             "type": "string"
           },
@@ -440,7 +439,6 @@
             "type": "string"
           },
           "trace_start_time": {
-            "format": "date-time",
             "title": "Trace Start Time",
             "type": "string"
           },
@@ -637,7 +635,6 @@
           "span_end_time": {
             "anyOf": [
               {
-                "format": "date-time",
                 "type": "string"
               },
               {
@@ -655,7 +652,6 @@
             "type": "string"
           },
           "span_start_time": {
-            "format": "date-time",
             "title": "Span Start Time",
             "type": "string"
           },

--- a/backend/rest/schemas/common.py
+++ b/backend/rest/schemas/common.py
@@ -1,6 +1,16 @@
 """Common API response schemas."""
 
-from pydantic import BaseModel
+from datetime import datetime
+from typing import Annotated
+
+from pydantic import BaseModel, PlainSerializer
+
+from shared.datetime_utils import to_utc_aware
+
+UtcDatetime = Annotated[
+    datetime,
+    PlainSerializer(lambda dt: to_utc_aware(dt).isoformat(), return_type=str, when_used="json"),
+]
 
 
 class HealthResponse(BaseModel):

--- a/backend/rest/schemas/sessions.py
+++ b/backend/rest/schemas/sessions.py
@@ -1,10 +1,8 @@
 """Session-related response schemas."""
 
-from datetime import datetime
-
 from pydantic import BaseModel
 
-from rest.schemas.common import PaginationMeta
+from rest.schemas.common import PaginationMeta, UtcDatetime
 
 
 class SessionListItem(BaseModel):
@@ -13,8 +11,8 @@ class SessionListItem(BaseModel):
     session_id: str
     trace_count: int
     user_ids: list[str]
-    first_trace_time: datetime | None
-    last_trace_time: datetime | None
+    first_trace_time: UtcDatetime | None
+    last_trace_time: UtcDatetime | None
     duration_ms: float | None
     total_input_tokens: int | None
     total_output_tokens: int | None
@@ -35,7 +33,7 @@ class SessionTraceItem(BaseModel):
 
     trace_id: str
     name: str
-    trace_start_time: datetime
+    trace_start_time: UtcDatetime
     user_id: str | None
     input: str | None
     output: str | None
@@ -50,8 +48,8 @@ class SessionDetailResponse(BaseModel):
     traces: list[SessionTraceItem]
     user_ids: list[str]
     trace_count: int
-    first_trace_time: datetime | None
-    last_trace_time: datetime | None
+    first_trace_time: UtcDatetime | None
+    last_trace_time: UtcDatetime | None
     duration_ms: float | None
     total_input_tokens: int | None
     total_output_tokens: int | None

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -1,10 +1,8 @@
 """Trace-related response schemas."""
 
-from datetime import datetime
-
 from pydantic import BaseModel
 
-from rest.schemas.common import PaginationMeta
+from rest.schemas.common import PaginationMeta, UtcDatetime
 
 
 class SpanSkeletonResponse(BaseModel):
@@ -24,8 +22,8 @@ class SpanSkeletonResponse(BaseModel):
     parent_span_id: str | None
     name: str
     span_kind: str
-    span_start_time: datetime
-    span_end_time: datetime | None
+    span_start_time: UtcDatetime
+    span_end_time: UtcDatetime | None
     status: str
     status_message: str | None
     model_name: str | None
@@ -74,7 +72,7 @@ class TraceListItem(BaseModel):
     trace_id: str
     project_id: str
     name: str
-    trace_start_time: datetime
+    trace_start_time: UtcDatetime
     user_id: str | None
     session_id: str | None
     span_count: int
@@ -108,7 +106,7 @@ class TraceDetailResponse(BaseModel):
     trace_id: str
     project_id: str
     name: str
-    trace_start_time: datetime
+    trace_start_time: UtcDatetime
     user_id: str | None
     session_id: str | None
     git_ref: str | None

--- a/backend/rest/schemas/users.py
+++ b/backend/rest/schemas/users.py
@@ -1,10 +1,8 @@
 """User-related response schemas."""
 
-from datetime import datetime
-
 from pydantic import BaseModel
 
-from rest.schemas.common import PaginationMeta
+from rest.schemas.common import PaginationMeta, UtcDatetime
 
 
 class UserItem(BaseModel):
@@ -12,7 +10,7 @@ class UserItem(BaseModel):
 
     user_id: str
     trace_count: int
-    last_trace_time: datetime | None
+    last_trace_time: UtcDatetime | None
     total_input_tokens: int | None = None
     total_output_tokens: int | None = None
     total_cost: float | None = None

--- a/backend/shared/datetime_utils.py
+++ b/backend/shared/datetime_utils.py
@@ -1,0 +1,10 @@
+"""Shared datetime helpers used by REST and worker code."""
+
+from datetime import UTC, datetime
+
+
+def to_utc_aware(dt: datetime) -> datetime:
+    """Treat naive datetimes as UTC (ClickHouse/OTEL store naive UTC); normalize
+    aware datetimes to UTC. Output therefore always carries +00:00 on isoformat().
+    """
+    return dt.replace(tzinfo=UTC) if dt.tzinfo is None else dt.astimezone(UTC)

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -8,6 +8,7 @@ import logging
 from collections import defaultdict
 from datetime import datetime
 
+from shared.datetime_utils import to_utc_aware
 from worker.celery_app import app
 
 logger = logging.getLogger(__name__)
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 def _json_serializer(obj: object) -> str:
     """JSON serializer for datetime objects in span dicts."""
     if isinstance(obj, datetime):
-        return obj.isoformat()
+        return to_utc_aware(obj).isoformat()
     raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -146,6 +146,8 @@ class TestPublicListTraces:
         item = resp.json()["data"][0]
         assert item["trace_url"] == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
         assert "status" not in item
+        # Every timestamp must carry an explicit UTC offset (#1054).
+        assert item["trace_start_time"].endswith("+00:00")
 
     def test_trace_url_uses_public_ui_url_not_internal(self, client, mock_reader, monkeypatch):
         """List trace_url must use the host-usable public UI URL, never the
@@ -226,6 +228,10 @@ class TestPublicGetTrace:
         assert len(data["spans"]) == 1
         assert data["spans"][0]["span_id"] == "span-1"
         assert data["trace_url"] == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
+        # Every timestamp must carry an explicit UTC offset (#1054).
+        assert data["trace_start_time"].endswith("+00:00")
+        assert data["spans"][0]["span_start_time"].endswith("+00:00")
+        assert data["spans"][0]["span_end_time"].endswith("+00:00")
 
     def test_trace_url_uses_public_ui_url_not_internal(self, client, mock_reader, monkeypatch):
         """Get trace_url must use the host-usable public UI URL, never the
@@ -282,6 +288,17 @@ class TestPublicGetTrace:
         resp = client.get("/api/v1/public/traces/abc123", headers=AUTH_HEADER)
         assert resp.status_code == 500
         assert resp.json()["detail"] == "Failed to get trace"
+
+    def test_export_includes_utc_offsets(self, client, mock_reader):
+        """Export bundles inherit the same trace/span schema and must emit offsets."""
+        mock_reader.get_trace.return_value = dict(TRACE_DETAIL)
+        resp = client.get("/api/v1/public/traces/abc123/export", headers=AUTH_HEADER)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["manifest"]["trace_id"] == "abc123"
+        assert data["trace"]["trace_start_time"].endswith("+00:00")
+        assert data["spans"][0]["span_start_time"].endswith("+00:00")
+        assert data["spans"][0]["span_end_time"].endswith("+00:00")
 
 
 class TestPublicTraceReadAuth:

--- a/tests/rest/test_sessions_router.py
+++ b/tests/rest/test_sessions_router.py
@@ -71,6 +71,9 @@ class TestListSessions:
         assert data["data"][0]["input"] == "What is the weather?"
         assert data["data"][0]["output"] == "It is sunny and 72F."
         assert data["data"][0]["total_cost"] == 0.05
+        # Every timestamp must carry an explicit UTC offset (#1054).
+        assert data["data"][0]["first_trace_time"].endswith("+00:00")
+        assert data["data"][0]["last_trace_time"].endswith("+00:00")
 
     def test_pagination(self, client, mock_trace_reader):
         mock_trace_reader.list_sessions.return_value = {
@@ -205,6 +208,11 @@ class TestGetSession:
         assert data["traces"][1]["output"] == "It will rain."
         assert data["trace_count"] == 2
         assert data["total_cost"] == 0.02
+        # Every timestamp must carry an explicit UTC offset (#1054).
+        assert data["first_trace_time"].endswith("+00:00")
+        assert data["last_trace_time"].endswith("+00:00")
+        assert data["traces"][0]["trace_start_time"].endswith("+00:00")
+        assert data["traces"][1]["trace_start_time"].endswith("+00:00")
 
     def test_not_found(self, client, mock_trace_reader):
         mock_trace_reader.get_session.return_value = None

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -119,6 +119,24 @@ class TestListTraces:
         assert data["data"][0]["error_count"] == 0
         assert "status" not in data["data"][0]
         assert data["meta"]["total"] == 1
+        # Every timestamp must carry an explicit UTC offset (#1054).
+        assert data["data"][0]["trace_start_time"].endswith("+00:00")
+
+    def test_trace_start_time_includes_utc_offset(self, client, mock_trace_reader):
+        """Whole-second timestamps previously lost the offset and skewed the UI (#1055)."""
+        mock_trace_reader.list_traces.return_value = {
+            "data": [
+                {
+                    **TRACE_LIST_ITEM,
+                    "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                }
+            ],
+            "meta": {"page": 0, "limit": 50, "total": 1},
+        }
+        response = client.get("/api/v1/projects/test-project/traces")
+        assert response.status_code == 200
+        ts = response.json()["data"][0]["trace_start_time"]
+        assert ts == "2024-01-15T12:00:00+00:00"
 
     def test_with_name_and_user_filters(self, client, mock_trace_reader):
         mock_trace_reader.list_traces.return_value = {
@@ -199,6 +217,32 @@ class TestGetTrace:
         assert data["trace_id"] == "abc123"
         assert len(data["spans"]) == 1
         assert data["spans"][0]["span_id"] == "span-1"
+        # Every timestamp must carry an explicit UTC offset (#1054).
+        assert data["trace_start_time"].endswith("+00:00")
+        assert data["spans"][0]["span_start_time"].endswith("+00:00")
+        assert data["spans"][0]["span_end_time"].endswith("+00:00")
+
+    def test_trace_and_span_times_include_utc_offset(self, client, mock_trace_reader):
+        """Regression guard: whole-second and microsecond timestamps both emit +00:00."""
+        detail = {
+            **TRACE_DETAIL,
+            "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+            "spans": [
+                {
+                    **TRACE_DETAIL["spans"][0],
+                    "span_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                    "span_end_time": datetime(2024, 1, 15, 12, 0, 1, 123456),
+                }
+            ],
+        }
+        mock_trace_reader.get_trace.return_value = detail
+        response = client.get("/api/v1/projects/test-project/traces/abc123")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["trace_start_time"] == "2024-01-15T12:00:00+00:00"
+        span = data["spans"][0]
+        assert span["span_start_time"] == "2024-01-15T12:00:00+00:00"
+        assert span["span_end_time"] == "2024-01-15T12:00:01.123456+00:00"
 
     def test_404(self, client, mock_trace_reader):
         mock_trace_reader.get_trace.return_value = None

--- a/tests/rest/test_users_router.py
+++ b/tests/rest/test_users_router.py
@@ -65,6 +65,8 @@ class TestListUsers:
         assert data["data"][0]["total_input_tokens"] == 500
         assert data["data"][0]["total_output_tokens"] == 1000
         assert data["data"][0]["total_cost"] == 0.03
+        # Every timestamp must carry an explicit UTC offset (#1054).
+        assert data["data"][0]["last_trace_time"].endswith("+00:00")
 
     def test_input_output_tokens_and_cost_null(self, client, mock_trace_reader):
         mock_trace_reader.list_users.return_value = {

--- a/tests/worker/test_ingest_tasks.py
+++ b/tests/worker/test_ingest_tasks.py
@@ -1,11 +1,12 @@
 """Unit tests for Celery task logic with mocked S3 + ClickHouse."""
 
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
 
 from tests.fixtures.otel_payloads import make_otel_payload, make_span
-from worker.ingest_tasks import process_s3_traces
+from worker.ingest_tasks import _json_serializer, process_s3_traces
 
 TRACE_HEX = "aa" * 16
 SPAN_HEX = "bb" * 8
@@ -128,3 +129,19 @@ class TestProcessS3Traces:
         process_s3_traces(s3_key="test/key.json", project_id="proj-1")
 
         mock_detector_enqueue.assert_not_called()
+
+
+class TestJsonSerializer:
+    def test_naive_datetime_serializes_with_utc_offset(self):
+        """SSE payloads built by the worker must emit explicit UTC offsets (#1054)."""
+        assert _json_serializer(datetime(2024, 1, 15, 12, 0, 0)) == "2024-01-15T12:00:00+00:00"
+
+    def test_microsecond_datetime_serializes_with_utc_offset(self):
+        assert (
+            _json_serializer(datetime(2024, 1, 15, 12, 0, 0, 123456))
+            == "2024-01-15T12:00:00.123456+00:00"
+        )
+
+    def test_non_datetime_raises_type_error(self):
+        with pytest.raises(TypeError):
+            _json_serializer(object())


### PR DESCRIPTION
Fixes #1054

## Summary
Response timestamps were emitted as timezone-naive ISO strings, forcing the frontend to guess UTC via a string-sniffing heuristic that caused a 7-hour timeline skew for whole-second timestamps (#1055, band-aided in #1057). This is the durable backend fix: emit every timestamp with an explicit `+00:00` offset at one shared serialization layer so the frontend never has to guess.

Before → after (on the wire):
"2024-01-15T12:00:00"        ->  "2024-01-15T12:00:00+00:00"
"2024-01-15T12:00:00.123456" ->  "2024-01-15T12:00:00.123456+00:00"

## Type of Change
- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our CI Configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous change
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details
- Add shared `to_utc_aware()` helper + a `UtcDatetime` Pydantic annotated type (`PlainSerializer(..., when_used="json")`) that normalizes naive datetimes (ClickHouse/OTEL store naive UTC) to UTC-aware on JSON output.
- Apply `UtcDatetime` to trace/span/session/user response schemas (`backend/rest/schemas/{traces,sessions,users,common}.py`); `SpanResponse` and the public models inherit automatically.
- Route the worker SSE `_json_serializer` through the same helper so `/live` payloads carry `+00:00` (`backend/worker/ingest_tasks.py`).
- Regenerate the public OpenAPI spec (`backend/rest/openapi/public.json`); 3 fields drop `format: date-time`, intrinsic to `PlainSerializer(return_type=str)` — on-wire format unchanged.
- Frontend `parseAsUTC` stays as a defense-in-depth no-op.

### Validation
- 92 tests pass (`.venv/bin/pytest`): traces/sessions/users/public router tests + new whole-second regression guards + worker serializer tests + `test_public_openapi.py` (asserts `public.json` is in sync with the app schema).
- ruff lint + format clean; pre-commit passed on commit.

### Out of scope
Internal/detector endpoint timestamps remain naive — separate future PR.

## Screenshots / Recordings (if applicable)
N/A — backend serialization change, no UI diff.

## Checklist
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable) — N/A, backend only
- [x] I have updated documentation where necessary — no setup/command/UX docs affected

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always serialize REST and SSE timestamps with an explicit +00:00 UTC offset to remove frontend guessing and fix the 7-hour skew. Fixes #1054.

- Bug Fixes
  - Added shared `to_utc_aware()` and a `UtcDatetime` serializer to normalize naive datetimes to UTC and emit ISO strings with +00:00.
  - Applied to trace/span/session/user response schemas and the worker `_json_serializer` so `/live` payloads include offsets.
  - Regenerated public OpenAPI; some fields drop `format: date-time` due to string serialization, wire format unchanged.
  - Added tests covering whole-second and microsecond timestamps and SSE serialization.

<sup>Written for commit 9c4e08dbc9a2989cb1e91cf7113520aca77ec4dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

