### PR TITLE
fix(api): use exclusive upper bound for end_before in list_users (#1366)

### DIFF
--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -843,7 +843,7 @@ class TraceReaderService:
             params["start_after"] = to_utc_naive(start_after)
 
         if end_before:
-            conditions.append("t.trace_start_time <= {end_before:DateTime64(3)}")
+            conditions.append("t.trace_start_time < {end_before:DateTime64(3)}")
             params["end_before"] = to_utc_naive(end_before)
 
         where_clause = " AND ".join(conditions)

--- a/tests/rest/test_list_users_end_before.py
+++ b/tests/rest/test_list_users_end_before.py
@@ -1,0 +1,46 @@
+"""Regression test for #1366.
+
+`TraceReaderService.list_users` filtered `end_before` with `<=`, while
+`list_traces`, `list_sessions` and `get_session` all use `<`. A trace whose
+`trace_start_time` exactly equals `end_before` therefore appeared on the users
+tab but not the others, so per-page totals disagreed across tabs sharing the
+same filter. All `end_before` filters must use an exclusive upper bound (`<`).
+
+The ClickHouse client is mocked; we assert on the SQL issued, never touching a
+real database.
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _service_capturing(queries):
+    from rest.services.trace_reader import TraceReaderService
+
+    client = MagicMock()
+
+    def side_effect(query, parameters=None):
+        queries.append(query)
+        return SimpleNamespace(result_rows=[])
+
+    client.query.side_effect = side_effect
+    with patch(
+        "rest.services.trace_reader.get_clickhouse_client",
+        return_value=client,
+    ):
+        return TraceReaderService()
+
+
+def test_list_users_end_before_is_exclusive():
+    queries: list[str] = []
+    service = _service_capturing(queries)
+
+    service.list_users(
+        project_id="proj",
+        end_before=datetime(2024, 1, 31, 23, 59, 59),
+    )
+
+    sql = "\n".join(queries)
+    assert "t.trace_start_time < {end_before:DateTime64(3)}" in sql
+    assert "t.trace_start_time <= {end_before:DateTime64(3)}" not in sql


### PR DESCRIPTION
## What

`TraceReaderService.list_users` filters `end_before` with `<=`, while `list_traces`, `list_sessions` and `get_session` all use `<`:

```python
# list_users (before)
conditions.append("t.trace_start_time <= {end_before:DateTime64(3)}")
# list_traces / list_sessions / get_session
conditions.append("t.trace_start_time < {end_before:DateTime64(3)}")
```

A trace whose `trace_start_time` exactly equals `end_before` is therefore **included** by the users tab but **excluded** by traces/sessions. With the same `end_before` applied, per-page totals disagree across tabs (one extra boundary trace on the users tab).

## Fix

Align `list_users` with the other readers — an exclusive upper bound (`<`). One-character change.

## Test

Adds `tests/rest/test_list_users_end_before.py`: mocks the ClickHouse client, calls `list_users(end_before=...)`, and asserts the generated SQL uses `t.trace_start_time < {end_before...}` (and not `<=`). Fails on the previous code, passes with this change. Full `tests/rest` suite: **267 passed**.

Closes #1366


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make end_before exclusive (<) in list_users to match other readers, so the users tab no longer includes boundary traces and totals stay consistent across tabs. Add a regression test that asserts the generated SQL uses <.

<sup>Written for commit ad4941d2b35beef76240d12275f9ab28816d91c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

