### PR TITLE
fix(worker): skip spans with malformed OTEL timestamps

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -162,14 +162,14 @@ def decode_otel_id(b64_value: str | None) -> str | None:
         return b64_value  # Return as-is if decoding fails
 
 
-def nanos_to_datetime(nanos: int | str | None) -> datetime | None:
+def nanos_to_datetime(nanos: object) -> datetime | None:
     """Convert nanoseconds since epoch to datetime.
 
     Args:
         nanos: Unix timestamp in nanoseconds (int or string representation)
 
     Returns:
-        datetime object, or None if input is None/empty
+        datetime object, or None if input is None/empty/malformed
     """
     if nanos is None:
         return None
@@ -177,10 +177,19 @@ def nanos_to_datetime(nanos: int | str | None) -> datetime | None:
     if isinstance(nanos, str):
         if not nanos:
             return None
-        nanos = int(nanos)
+        try:
+            nanos = int(nanos)
+        except ValueError:
+            return None
+    elif isinstance(nanos, bool) or not isinstance(nanos, int):
+        return None
+
     # Convert nanos to seconds (float to preserve precision)
-    seconds = nanos / 1_000_000_000
-    return datetime.fromtimestamp(seconds, tz=UTC).replace(tzinfo=None)
+    try:
+        seconds = nanos / 1_000_000_000
+        return datetime.fromtimestamp(seconds, tz=UTC).replace(tzinfo=None)
+    except (OverflowError, OSError, ValueError):
+        return None
 
 
 def extract_attribute_value(attr_value: dict) -> Any:

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -117,6 +117,17 @@ class TestNanosToDatetime:
     def test_empty_string_returns_none(self):
         assert nanos_to_datetime("") is None
 
+    def test_invalid_string_returns_none(self):
+        assert nanos_to_datetime("not-a-number") is None
+
+    @pytest.mark.parametrize("value", [True, False, [], {}, 1.5])
+    def test_unsupported_value_returns_none(self, value):
+        assert nanos_to_datetime(value) is None
+
+    @pytest.mark.parametrize("value", [10**1000, -(10**1000), str(10**1000)])
+    def test_out_of_range_timestamp_returns_none(self, value):
+        assert nanos_to_datetime(value) is None
+
     def test_zero_returns_epoch(self):
         result = nanos_to_datetime(0)
         assert result == datetime(1970, 1, 1, 0, 0, 0)
@@ -247,6 +258,55 @@ class TestTransformOtelToClickhouse:
         assert spans[0]["parent_span_id"] is None
         assert len(traces) == 1
         assert traces[0]["name"] == "root"
+
+    def test_malformed_start_time_skips_only_bad_span(self):
+        """A bad startTimeUnixNano must not abort valid siblings in the batch."""
+        trace_hex = "aa" * 16
+        bad_span_hex = "11" * 8
+        good_span_hex = "22" * 8
+        payload = make_otel_payload(
+            [
+                make_span(trace_hex, bad_span_hex, name="bad", start_nanos="not-a-number"),
+                make_span(trace_hex, good_span_hex, name="good"),
+            ]
+        )
+
+        traces, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert [span["span_id"] for span in spans] == [good_span_hex]
+        assert [trace["trace_id"] for trace in traces] == [trace_hex]
+        assert traces[0]["name"] == "good"
+
+    def test_malformed_later_start_time_does_not_drop_earlier_valid_span(self):
+        """Match #1365: a bad later span must not discard an earlier valid span."""
+        trace_hex = "aa" * 16
+        good_span_hex = "22" * 8
+        bad_span_hex = "11" * 8
+        payload = make_otel_payload(
+            [
+                make_span(trace_hex, good_span_hex, name="good"),
+                make_span(trace_hex, bad_span_hex, name="bad", start_nanos="not-a-number"),
+            ]
+        )
+
+        traces, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert [span["span_id"] for span in spans] == [good_span_hex]
+        assert [trace["trace_id"] for trace in traces] == [trace_hex]
+        assert traces[0]["name"] == "good"
+
+    def test_malformed_end_time_keeps_span_with_missing_end_time(self):
+        trace_hex = "aa" * 16
+        span_hex = "bb" * 8
+        payload = make_otel_payload(
+            [make_span(trace_hex, span_hex, name="open", end_nanos="not-a-number")]
+        )
+
+        traces, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert [trace["trace_id"] for trace in traces] == [trace_hex]
+        assert len(spans) == 1
+        assert spans[0]["span_end_time"] is None
 
     def test_child_span_does_not_create_trace(self):
         """Child span creates span record but not trace record."""


### PR DESCRIPTION
Fixes #1365

## Summary

Malformed OTEL timestamp values could raise inside `nanos_to_datetime`, aborting the whole S3 ingest batch before later valid spans were transformed. This patch treats malformed, unsupported, and out-of-range timestamp values as missing so the existing required-start-time guard skips only the bad span.

Optional malformed `endTimeUnixNano` values now keep the span with `span_end_time=None`, matching the existing nullable end-time behavior.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Guard timestamp string parsing so invalid strings return `None` instead of raising `ValueError`.
- Treat booleans, floats, lists, dicts, and other unsupported timestamp shapes as missing.
- Treat out-of-range timestamp values as missing if conversion to `datetime` raises.
- Add regression coverage proving a malformed `startTimeUnixNano` skips only that span while a valid sibling still transforms.
- Add coverage proving malformed optional `endTimeUnixNano` keeps the span open with `span_end_time=None`.

## Screenshots / Recordings (if applicable)

Not applicable; this is a worker ingest-path fix.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

## Tests

Commands run:

- `uv run pytest tests/worker/test_otel_transform.py -q -k "invalid_string_returns_none or unsupported_value_returns_none or out_of_range_timestamp_returns_none or malformed_start_time_skips_only_bad_span or malformed_later_start_time_does_not_drop_earlier_valid_span or malformed_end_time_keeps_span_with_missing_end_time"` — passed (`12 passed, 102 deselected`)
- `uv run pytest tests/worker/test_otel_transform.py -q` — passed (`114 passed`)
- `uv run pytest tests/worker -q` — passed (`343 passed`)
- `uv run pytest -q` — passed (`624 passed, 1 StarletteDeprecationWarning`)
- `uv run mypy backend/worker/otel_transform.py tests/worker/test_otel_transform.py` — passed
- `uv run ruff check backend/worker/otel_transform.py tests/worker/test_otel_transform.py` — passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed (`119 files already formatted`)
- `git diff --check` — passed

## Risk

Risk level: low.

The change is limited to timestamp parsing in the OTEL worker transform. Valid integer and numeric-string nanosecond timestamps keep the existing conversion behavior. Malformed required start timestamps now flow into the existing missing-start skip path, and malformed optional end timestamps keep the span with a missing end time.

Rollback is a single-commit revert of this timestamp parsing change and its regression tests.

## Notes for maintainers

This intentionally does not change OTEL ID decoding, parent-span semantics, public payload limits, detector scheduling, live trace completion, environment persistence, or agent trace export behavior. Those are separate follow-up opportunities and are left out to keep this PR focused on #1365.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened OTEL timestamp parsing in the worker so malformed values no longer abort an S3 ingest batch. Bad start times drop only that span; bad end times keep the span open (Fixes #1365).

- **Bug Fixes**
  - Guarded `nanos_to_datetime` to return None for invalid strings, unsupported types, or out-of-range values.
  - Used the existing required-start-time check to skip spans with malformed `startTimeUnixNano` while keeping valid siblings.
  - Kept spans with malformed `endTimeUnixNano` by setting `span_end_time=None`; added regression tests.

<sup>Written for commit c5cf2a6d7c23a519dedae78ffc5a0f0318a9366e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

