### PR TITLE
feat(api): public detector findings schemas + reader service

### DIFF
--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -134,3 +134,24 @@ class PublicFindingListResponse(BaseModel):
 
     data: list[FindingSummary]
     meta: PaginationMeta
+
+
+class DetectorItem(BaseModel):
+    """A detector from the project's catalog (Postgres ``detectors``).
+
+    ``detector_id`` is the value to pass to ``findings list --detector`` to filter
+    findings to this detector.
+    """
+
+    detector_id: str
+    name: str
+    template: str
+    enabled: bool
+    created_at: datetime
+
+
+class PublicDetectorListResponse(BaseModel):
+    """Paginated list of the project's detectors for the public API."""
+
+    data: list[DetectorItem]
+    meta: PaginationMeta

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -1,5 +1,8 @@
 """Response schemas for the public, API-key-authenticated API."""
 
+from datetime import datetime
+from typing import Any
+
 from pydantic import BaseModel
 
 from rest.schemas.common import PaginationMeta
@@ -80,3 +83,54 @@ class PublicTraceExportResponse(BaseModel):
     # null. See rest.projection and the export endpoint's default `fields`.
     spans: list[SpanResponse]
     git_context: GitContext
+
+
+class DetectorResultItem(BaseModel):
+    """One detector's result within a finding, normalized from the stored payload.
+
+    The stored finding ``payload`` uses camelCase keys (``detectorId`` /
+    ``detectorName``); the public API exposes snake_case. Only triggered detectors
+    are persisted, so ``identified`` is always ``True`` for a present item. ``data``
+    is the detector's opaque output, passed through verbatim. ``template`` is looked
+    up from the Postgres ``detectors`` row and is ``None`` when that row is absent
+    (e.g. a deleted detector).
+    """
+
+    detector_id: str
+    detector_name: str
+    template: str | None
+    summary: str
+    identified: bool
+    data: Any | None
+
+
+class RCAResult(BaseModel):
+    """Free-text root-cause analysis for a finding (Postgres ``detector_rcas``)."""
+
+    status: str
+    result: str | None
+
+
+class FindingSummary(BaseModel):
+    """A detector finding row for the list view; ``detectors`` are display labels."""
+
+    finding_id: str
+    project_id: str
+    trace_id: str
+    summary: str
+    timestamp: datetime
+    detectors: list[str]
+
+
+class FindingDetail(FindingSummary):
+    """A finding plus its per-detector results and optional free-text RCA."""
+
+    results: list[DetectorResultItem]
+    rca: RCAResult | None
+
+
+class PublicFindingListResponse(BaseModel):
+    """Paginated list of detector findings for the public API."""
+
+    data: list[FindingSummary]
+    meta: PaginationMeta

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -20,6 +20,7 @@ import psycopg2
 
 from db.clickhouse import get_clickhouse_client
 from rest.schemas.public import (
+    DetectorItem,
     DetectorResultItem,
     FindingDetail,
     FindingSummary,
@@ -69,6 +70,38 @@ class DetectorReaderService:
             for item in self._parse_payload(payload)
             if isinstance(item, dict) and item.get("detectorName") is not None
         ]
+
+    # ------------------------------------------------------------------ #
+    # detector catalog
+    # ------------------------------------------------------------------ #
+    def list_detectors(self, project_id: str, limit: int) -> tuple[list[DetectorItem], int]:
+        """List the project's detectors (Postgres catalog), newest first.
+
+        Returns the page of items plus the total match count. Unlike the RCA /
+        template enrichment reads, a catalog-read failure is NOT swallowed — it
+        propagates so the router can return a controlled 500.
+        """
+        count_rows = self._pg_rows(
+            "SELECT count(*) FROM detectors WHERE project_id = %s", (project_id,)
+        )
+        total = count_rows[0][0] if count_rows else 0
+
+        rows = self._pg_rows(
+            "SELECT id, name, template, enabled, create_time FROM detectors "
+            "WHERE project_id = %s ORDER BY create_time DESC LIMIT %s",
+            (project_id, limit),
+        )
+        items = [
+            DetectorItem(
+                detector_id=row[0],
+                name=row[1],
+                template=row[2],
+                enabled=row[3],
+                created_at=row[4],
+            )
+            for row in rows
+        ]
+        return items, total
 
     # ------------------------------------------------------------------ #
     # list

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -74,22 +74,38 @@ class DetectorReaderService:
     # ------------------------------------------------------------------ #
     # detector catalog
     # ------------------------------------------------------------------ #
-    def list_detectors(self, project_id: str, limit: int) -> tuple[list[DetectorItem], int]:
+    def list_detectors(
+        self,
+        project_id: str,
+        limit: int,
+        start_after: datetime | None = None,
+        end_before: datetime | None = None,
+    ) -> tuple[list[DetectorItem], int]:
         """List the project's detectors (Postgres catalog), newest first.
 
-        Returns the page of items plus the total match count. Unlike the RCA /
-        template enrichment reads, a catalog-read failure is NOT swallowed — it
-        propagates so the router can return a controlled 500.
+        The optional ``start_after`` / ``end_before`` bounds filter on the
+        detector's creation time (inclusive lower, exclusive upper), mirroring the
+        findings/traces list windows. Returns the page of items plus the total
+        match count. Unlike the RCA / template enrichment reads, a catalog-read
+        failure is NOT swallowed — it propagates so the router returns a 500.
         """
-        count_rows = self._pg_rows(
-            "SELECT count(*) FROM detectors WHERE project_id = %s", (project_id,)
-        )
+        conditions = ["project_id = %s"]
+        params: list[Any] = [project_id]
+        if start_after is not None:
+            conditions.append("create_time >= %s")
+            params.append(to_utc_naive(start_after))
+        if end_before is not None:
+            conditions.append("create_time < %s")
+            params.append(to_utc_naive(end_before))
+        where = " AND ".join(conditions)
+
+        count_rows = self._pg_rows(f"SELECT count(*) FROM detectors WHERE {where}", tuple(params))
         total = count_rows[0][0] if count_rows else 0
 
         rows = self._pg_rows(
-            "SELECT id, name, template, enabled, create_time FROM detectors "
-            "WHERE project_id = %s ORDER BY create_time DESC LIMIT %s",
-            (project_id, limit),
+            f"SELECT id, name, template, enabled, create_time FROM detectors "
+            f"WHERE {where} ORDER BY create_time DESC LIMIT %s",
+            (*params, limit),
         )
         items = [
             DetectorItem(

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -81,13 +81,22 @@ class DetectorReaderService:
         start_after: datetime | None = None,
         end_before: datetime | None = None,
     ) -> tuple[list[DetectorItem], int]:
-        """List the project's detectors (Postgres catalog), newest first.
+        """List the project's detectors from the Postgres catalog, newest first.
 
-        The optional ``start_after`` / ``end_before`` bounds filter on the
-        detector's creation time (inclusive lower, exclusive upper), mirroring the
-        findings/traces list windows. Returns the page of items plus the total
-        match count. Unlike the RCA / template enrichment reads, a catalog-read
-        failure is NOT swallowed — it propagates so the router returns a 500.
+        Args:
+            project_id: Owning project; every query is scoped to it.
+            limit: Max items in the returned page (already validated by the router).
+            start_after: Inclusive lower bound on the detector's ``create_time``.
+            end_before: Exclusive upper bound on the detector's ``create_time``.
+
+        Returns:
+            ``(items, total)`` — the page of :class:`DetectorItem` ordered by
+            ``create_time`` DESC, plus the total number of catalog rows matching the
+            filters (for pagination).
+
+        The ``start_after`` / ``end_before`` window mirrors the findings/traces list
+        windows. Unlike the best-effort RCA/template enrichment reads, a failure
+        here is NOT swallowed: it propagates so the router returns a controlled 500.
         """
         conditions = ["project_id = %s"]
         params: list[Any] = [project_id]
@@ -131,17 +140,40 @@ class DetectorReaderService:
         detector: str | None,
         trace_id: str | None,
     ) -> tuple[list[FindingSummary], int]:
-        """List findings for a project, newest first, with the total match count."""
+        """List a project's detector findings, newest first, with the total match count.
+
+        Args:
+            project_id: Owning project; every query is scoped to it.
+            limit: Max findings in the returned page (already validated by the router).
+            start_after: Inclusive lower bound on a finding's (latest) ``timestamp``.
+            end_before: Exclusive upper bound on a finding's ``timestamp``.
+            detector: Optional selector (id / name / template); resolved server-side
+                to the set of matching detector names+ids and matched against the
+                stored payload. An unresolved token simply matches nothing.
+            trace_id: Optional restriction to a single trace's finding.
+
+        Returns:
+            ``(items, total)`` — the page of :class:`FindingSummary` ordered by
+            ``timestamp`` DESC, plus the total number of distinct findings matching
+            the filters.
+
+        ``detector_findings`` is a ``ReplacingMergeTree(timestamp)``, so every query
+        first dedups to the latest row per ``finding_id`` (``LIMIT 1 BY``), and
+        filter placement is both correctness- and cost-critical:
+
+        * ``project_id`` / ``trace_id`` (immutable across re-ingested versions) and
+          ``start_after`` are applied BEFORE the dedup. ``start_after`` is safe
+          there because a finding's latest version carries the max timestamp, so it
+          survives ``timestamp >= start`` iff its latest version does — this scopes
+          the expensive dedup + count to the window instead of all history.
+        * ``end_before`` and the payload-based ``detector`` predicate are
+          version-sensitive and applied AFTER the dedup; on raw pre-merge rows an
+          older version ``< end_before`` (or an outdated payload) could otherwise
+          resurface a finding whose latest version no longer matches.
+        """
         params: dict[str, Any] = {"project_id": project_id, "limit": limit}
 
-        # Filters safe to apply BEFORE dedup — they scope the (expensive) dedup +
-        # count aggregation to fewer rows instead of the project's full finding
-        # history. project_id/trace_id are immutable across re-ingested versions.
-        # start_after is safe too: a finding's LATEST version has the MAX timestamp,
-        # so the finding survives `timestamp >= start` in the pre-dedup scan iff its
-        # latest version does — no stale version can slip through the lower bound.
-        # Since `--since` sets only start_after, the common windowed query is now
-        # bounded to the window rather than deduping every finding ever produced.
+        # Pre-dedup filters (see the docstring: safe here + they prune the scan).
         base_conditions = ["project_id = {project_id:String}"]
         if trace_id is not None:
             base_conditions.append("trace_id = {trace_id:String}")
@@ -150,12 +182,7 @@ class DetectorReaderService:
             base_conditions.append("timestamp >= {start_after:DateTime64(3)}")
             params["start_after"] = to_utc_naive(start_after)
 
-        # Version-sensitive filters — applied AFTER dedup, to the latest version
-        # only. detector_findings is a ReplacingMergeTree(timestamp); an UPPER time
-        # bound or the payload-based detector predicate on raw pre-merge rows could
-        # surface a stale finding whose latest version no longer matches (an older
-        # version < end_before, or an outdated payload). So we dedup to the latest
-        # row per finding first, then filter.
+        # Post-dedup, version-sensitive filters (see the docstring).
         outer_conditions: list[str] = []
         if end_before is not None:
             outer_conditions.append("timestamp < {end_before:DateTime64(3)}")

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -97,12 +97,15 @@ class DetectorReaderService:
             params["trace_id"] = trace_id
         if detector is not None:
             # Backend-owned resolution: match a finding whose payload contains any
-            # of the resolved detector names. The raw token is always included, so
-            # an unresolved token simply matches nothing (empty list, not an error).
+            # of the resolved tokens by detectorName OR detectorId. The raw token is
+            # always included, so `detector=<id>` matches a payload detectorId even
+            # when Postgres resolves nothing; an unresolved token matches nothing
+            # (empty list, not an error).
             params["detector_names"] = self._resolve_detector_names(project_id, detector)
             conditions.append(
                 "arrayExists("
-                "x -> JSONExtractString(x, 'detectorName') IN {detector_names:Array(String)}, "
+                "x -> JSONExtractString(x, 'detectorName') IN {detector_names:Array(String)} "
+                "OR JSONExtractString(x, 'detectorId') IN {detector_names:Array(String)}, "
                 "JSONExtractArrayRaw(payload))"
             )
 

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -1,0 +1,263 @@
+"""Service for reading detector findings from ClickHouse + Postgres.
+
+Findings live in ClickHouse (`detector_findings`, a `ReplacingMergeTree` keyed by
+`timestamp`); the free-text RCA (`detector_rcas`) and the detector catalog
+(`detectors`, used to resolve the `--detector` selector and look up templates)
+live in Postgres. All reads are scoped to the caller's `project_id`.
+
+Postgres is best-effort for enrichment: an RCA or template lookup that is missing
+or fails degrades to ``None`` and never prevents a finding from being returned. A
+ClickHouse failure on the finding read itself propagates (the router maps it to a
+controlled 500).
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+import psycopg2
+
+from db.clickhouse import get_clickhouse_client
+from rest.schemas.public import (
+    DetectorResultItem,
+    FindingDetail,
+    FindingSummary,
+    RCAResult,
+)
+from rest.sql_utils import to_utc_naive
+from shared.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class DetectorReaderService:
+    """Read detector findings (ClickHouse) plus RCA/templates (Postgres)."""
+
+    def __init__(self):
+        self._client = get_clickhouse_client()
+
+    # ------------------------------------------------------------------ #
+    # Postgres boundary (single read-only seam; mocked in unit tests)
+    # ------------------------------------------------------------------ #
+    def _pg_rows(self, sql: str, params: tuple) -> list[tuple]:
+        """Run a read-only Postgres query and return all rows."""
+        conn = psycopg2.connect(settings.database_url)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                return cur.fetchall()
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------ #
+    # payload helpers
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _parse_payload(payload: str) -> list[dict]:
+        """Parse the stored finding payload JSON array; [] on any malformed input."""
+        try:
+            data = json.loads(payload) if payload else []
+        except (ValueError, TypeError):
+            return []
+        return data if isinstance(data, list) else []
+
+    def _detector_labels(self, payload: str) -> list[str]:
+        """Display labels (`detectorName`) for the DETECTORS column."""
+        return [
+            str(item["detectorName"])
+            for item in self._parse_payload(payload)
+            if isinstance(item, dict) and item.get("detectorName") is not None
+        ]
+
+    # ------------------------------------------------------------------ #
+    # list
+    # ------------------------------------------------------------------ #
+    def list_findings(
+        self,
+        project_id: str,
+        limit: int,
+        start_after: datetime | None,
+        end_before: datetime | None,
+        detector: str | None,
+        trace_id: str | None,
+    ) -> tuple[list[FindingSummary], int]:
+        """List findings for a project, newest first, with the total match count."""
+        conditions = ["project_id = {project_id:String}"]
+        params: dict[str, Any] = {"project_id": project_id, "limit": limit}
+
+        if start_after is not None:
+            conditions.append("timestamp >= {start_after:DateTime64(3)}")
+            params["start_after"] = to_utc_naive(start_after)
+        if end_before is not None:
+            conditions.append("timestamp < {end_before:DateTime64(3)}")
+            params["end_before"] = to_utc_naive(end_before)
+        if trace_id is not None:
+            conditions.append("trace_id = {trace_id:String}")
+            params["trace_id"] = trace_id
+        if detector is not None:
+            # Backend-owned resolution: match a finding whose payload contains any
+            # of the resolved detector names. The raw token is always included, so
+            # an unresolved token simply matches nothing (empty list, not an error).
+            params["detector_names"] = self._resolve_detector_names(project_id, detector)
+            conditions.append(
+                "arrayExists("
+                "x -> JSONExtractString(x, 'detectorName') IN {detector_names:Array(String)}, "
+                "JSONExtractArrayRaw(payload))"
+            )
+
+        where = " AND ".join(conditions)
+
+        count_query = f"""
+            SELECT count(DISTINCT finding_id)
+            FROM detector_findings
+            WHERE {where}
+        """
+        count_result = self._client.query(count_query, parameters=params)
+        total = count_result.result_rows[0][0] if count_result.result_rows else 0
+
+        # Dedup the ReplacingMergeTree rows (latest per finding_id) BEFORE limiting.
+        list_query = f"""
+            SELECT finding_id, project_id, trace_id, summary, payload, timestamp
+            FROM (
+                SELECT finding_id, project_id, trace_id, summary, payload, timestamp
+                FROM detector_findings
+                WHERE {where}
+                ORDER BY timestamp DESC
+                LIMIT 1 BY finding_id
+            )
+            ORDER BY timestamp DESC
+            LIMIT {{limit:UInt32}}
+        """
+        result = self._client.query(list_query, parameters=params)
+        items = [
+            FindingSummary(
+                finding_id=row[0],
+                project_id=row[1],
+                trace_id=row[2],
+                summary=row[3],
+                timestamp=row[5],
+                detectors=self._detector_labels(row[4]),
+            )
+            for row in result.result_rows
+        ]
+        return items, total
+
+    def _resolve_detector_names(self, project_id: str, token: str) -> list[str]:
+        """Resolve a `--detector` token to the set of matching detector names.
+
+        Always includes the raw token (so a name typed directly still matches the
+        payload), plus any project detector whose id, name, or template equals the
+        token. A Postgres failure degrades to just the raw token.
+        """
+        names = {token}
+        try:
+            rows = self._pg_rows(
+                "SELECT name FROM detectors "
+                "WHERE project_id = %s AND (id = %s OR name = %s OR template = %s)",
+                (project_id, token, token, token),
+            )
+            names.update(r[0] for r in rows if r and r[0] is not None)
+        except Exception:
+            logger.warning("detector resolution failed; using raw token", exc_info=True)
+        return list(names)
+
+    # ------------------------------------------------------------------ #
+    # detail
+    # ------------------------------------------------------------------ #
+    def get_finding(self, project_id: str, finding_id: str) -> FindingDetail | None:
+        row = self._fetch_finding(
+            "finding_id = {finding_id:String}",
+            {"project_id": project_id, "finding_id": finding_id},
+        )
+        return self._build_detail(project_id, row) if row else None
+
+    def get_finding_by_trace(self, project_id: str, trace_id: str) -> FindingDetail | None:
+        row = self._fetch_finding(
+            "trace_id = {trace_id:String}",
+            {"project_id": project_id, "trace_id": trace_id},
+        )
+        return self._build_detail(project_id, row) if row else None
+
+    def _fetch_finding(self, predicate: str, params: dict) -> tuple | None:
+        query = f"""
+            SELECT finding_id, project_id, trace_id, summary, payload, timestamp
+            FROM detector_findings
+            WHERE project_id = {{project_id:String}} AND {predicate}
+            ORDER BY timestamp DESC
+            LIMIT 1
+        """
+        result = self._client.query(query, parameters=params)
+        rows = result.result_rows
+        return rows[0] if rows else None
+
+    def _build_detail(self, project_id: str, row: tuple) -> FindingDetail:
+        finding_id, _project_id, trace_id, summary, payload, timestamp = row
+        parsed = self._parse_payload(payload)
+        templates = self._read_templates(
+            project_id, [item.get("detectorId") for item in parsed if isinstance(item, dict)]
+        )
+        results = [
+            DetectorResultItem(
+                detector_id=item.get("detectorId") or "",
+                detector_name=item.get("detectorName") or "",
+                template=templates.get(item.get("detectorId")),
+                summary=item.get("summary") or "",
+                identified=True,
+                data=item.get("data"),
+            )
+            for item in parsed
+            if isinstance(item, dict)
+        ]
+        return FindingDetail(
+            finding_id=finding_id,
+            project_id=project_id,
+            trace_id=trace_id,
+            summary=summary,
+            timestamp=timestamp,
+            detectors=[r.detector_name for r in results],
+            results=results,
+            rca=self._read_rca(project_id, finding_id),
+        )
+
+    def _read_templates(self, project_id: str, detector_ids: list[str]) -> dict[str, str | None]:
+        """Map detector_id -> template from Postgres; {} on missing/failed lookup."""
+        ids = [d for d in detector_ids if d]
+        if not ids:
+            return {}
+        try:
+            rows = self._pg_rows(
+                "SELECT id, template FROM detectors WHERE project_id = %s AND id = ANY(%s)",
+                (project_id, ids),
+            )
+            return {r[0]: r[1] for r in rows}
+        except Exception:
+            logger.warning("template lookup failed; templates will be null", exc_info=True)
+            return {}
+
+    def _read_rca(self, project_id: str, finding_id: str) -> RCAResult | None:
+        """Read the finding's free-text RCA from Postgres; None if missing/failed."""
+        try:
+            rows = self._pg_rows(
+                "SELECT status, result FROM detector_rcas "
+                "WHERE project_id = %s AND finding_id = %s LIMIT 1",
+                (project_id, finding_id),
+            )
+        except Exception:
+            logger.warning("RCA lookup failed; returning rca=None", exc_info=True)
+            return None
+        if not rows:
+            return None
+        return RCAResult(status=rows[0][0], result=rows[0][1])
+
+
+# Singleton instance
+_service: DetectorReaderService | None = None
+
+
+def get_detector_reader_service() -> DetectorReaderService:
+    """Get or create the singleton DetectorReaderService."""
+    global _service
+    if _service is None:
+        _service = DetectorReaderService()
+    return _service

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -134,22 +134,29 @@ class DetectorReaderService:
         """List findings for a project, newest first, with the total match count."""
         params: dict[str, Any] = {"project_id": project_id, "limit": limit}
 
-        # Immutable filters — safe to apply BEFORE dedup because a finding's
-        # project_id and trace_id never change across re-ingested versions.
+        # Filters safe to apply BEFORE dedup — they scope the (expensive) dedup +
+        # count aggregation to fewer rows instead of the project's full finding
+        # history. project_id/trace_id are immutable across re-ingested versions.
+        # start_after is safe too: a finding's LATEST version has the MAX timestamp,
+        # so the finding survives `timestamp >= start` in the pre-dedup scan iff its
+        # latest version does — no stale version can slip through the lower bound.
+        # Since `--since` sets only start_after, the common windowed query is now
+        # bounded to the window rather than deduping every finding ever produced.
         base_conditions = ["project_id = {project_id:String}"]
         if trace_id is not None:
             base_conditions.append("trace_id = {trace_id:String}")
             params["trace_id"] = trace_id
+        if start_after is not None:
+            base_conditions.append("timestamp >= {start_after:DateTime64(3)}")
+            params["start_after"] = to_utc_naive(start_after)
 
         # Version-sensitive filters — applied AFTER dedup, to the latest version
-        # only. detector_findings is a ReplacingMergeTree(timestamp); filtering the
-        # time window or the payload-based detector predicate on raw pre-merge rows
-        # could surface a stale finding version whose latest version no longer
-        # matches. So we dedup to the latest row per finding first, then filter.
+        # only. detector_findings is a ReplacingMergeTree(timestamp); an UPPER time
+        # bound or the payload-based detector predicate on raw pre-merge rows could
+        # surface a stale finding whose latest version no longer matches (an older
+        # version < end_before, or an outdated payload). So we dedup to the latest
+        # row per finding first, then filter.
         outer_conditions: list[str] = []
-        if start_after is not None:
-            outer_conditions.append("timestamp >= {start_after:DateTime64(3)}")
-            params["start_after"] = to_utc_naive(start_after)
         if end_before is not None:
             outer_conditions.append("timestamp < {end_before:DateTime64(3)}")
             params["end_before"] = to_utc_naive(end_before)

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -83,20 +83,20 @@ class DetectorReaderService:
     ) -> tuple[list[DetectorItem], int]:
         """List the project's detectors from the Postgres catalog, newest first.
 
-        Args:
-            project_id: Owning project; every query is scoped to it.
-            limit: Max items in the returned page (already validated by the router).
-            start_after: Inclusive lower bound on the detector's ``create_time``.
-            end_before: Exclusive upper bound on the detector's ``create_time``.
-
-        Returns:
-            ``(items, total)`` — the page of :class:`DetectorItem` ordered by
-            ``create_time`` DESC, plus the total number of catalog rows matching the
-            filters (for pagination).
-
         The ``start_after`` / ``end_before`` window mirrors the findings/traces list
         windows. Unlike the best-effort RCA/template enrichment reads, a failure
         here is NOT swallowed: it propagates so the router returns a controlled 500.
+
+        Args:
+            project_id (str): Owning project; every query is scoped to it.
+            limit (int): Max items in the returned page (already validated by the router).
+            start_after (datetime | None): Inclusive lower bound on ``create_time``.
+            end_before (datetime | None): Exclusive upper bound on ``create_time``.
+
+        Returns:
+            tuple[list[DetectorItem], int]: The page of :class:`DetectorItem` ordered
+            by ``create_time`` DESC, plus the total number of catalog rows matching
+            the filters (for pagination).
         """
         conditions = ["project_id = %s"]
         params: list[Any] = [project_id]
@@ -142,21 +142,6 @@ class DetectorReaderService:
     ) -> tuple[list[FindingSummary], int]:
         """List a project's detector findings, newest first, with the total match count.
 
-        Args:
-            project_id: Owning project; every query is scoped to it.
-            limit: Max findings in the returned page (already validated by the router).
-            start_after: Inclusive lower bound on a finding's (latest) ``timestamp``.
-            end_before: Exclusive upper bound on a finding's ``timestamp``.
-            detector: Optional selector (id / name / template); resolved server-side
-                to the set of matching detector names+ids and matched against the
-                stored payload. An unresolved token simply matches nothing.
-            trace_id: Optional restriction to a single trace's finding.
-
-        Returns:
-            ``(items, total)`` — the page of :class:`FindingSummary` ordered by
-            ``timestamp`` DESC, plus the total number of distinct findings matching
-            the filters.
-
         ``detector_findings`` is a ``ReplacingMergeTree(timestamp)``, so every query
         first dedups to the latest row per ``finding_id`` (``LIMIT 1 BY``), and
         filter placement is both correctness- and cost-critical:
@@ -170,6 +155,21 @@ class DetectorReaderService:
           version-sensitive and applied AFTER the dedup; on raw pre-merge rows an
           older version ``< end_before`` (or an outdated payload) could otherwise
           resurface a finding whose latest version no longer matches.
+
+        Args:
+            project_id (str): Owning project; every query is scoped to it.
+            limit (int): Max findings in the returned page (already validated by the router).
+            start_after (datetime | None): Inclusive lower bound on ``timestamp``.
+            end_before (datetime | None): Exclusive upper bound on ``timestamp``.
+            detector (str | None): Optional selector (id / name / template); resolved
+                server-side to the matching detector names+ids and matched against
+                the stored payload. An unresolved token simply matches nothing.
+            trace_id (str | None): Optional restriction to a single trace's finding.
+
+        Returns:
+            tuple[list[FindingSummary], int]: The page of :class:`FindingSummary`
+            ordered by ``timestamp`` DESC, plus the total number of distinct findings
+            matching the filters.
         """
         params: dict[str, Any] = {"project_id": project_id, "limit": limit}
 

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -83,18 +83,27 @@ class DetectorReaderService:
         trace_id: str | None,
     ) -> tuple[list[FindingSummary], int]:
         """List findings for a project, newest first, with the total match count."""
-        conditions = ["project_id = {project_id:String}"]
         params: dict[str, Any] = {"project_id": project_id, "limit": limit}
 
+        # Immutable filters — safe to apply BEFORE dedup because a finding's
+        # project_id and trace_id never change across re-ingested versions.
+        base_conditions = ["project_id = {project_id:String}"]
+        if trace_id is not None:
+            base_conditions.append("trace_id = {trace_id:String}")
+            params["trace_id"] = trace_id
+
+        # Version-sensitive filters — applied AFTER dedup, to the latest version
+        # only. detector_findings is a ReplacingMergeTree(timestamp); filtering the
+        # time window or the payload-based detector predicate on raw pre-merge rows
+        # could surface a stale finding version whose latest version no longer
+        # matches. So we dedup to the latest row per finding first, then filter.
+        outer_conditions: list[str] = []
         if start_after is not None:
-            conditions.append("timestamp >= {start_after:DateTime64(3)}")
+            outer_conditions.append("timestamp >= {start_after:DateTime64(3)}")
             params["start_after"] = to_utc_naive(start_after)
         if end_before is not None:
-            conditions.append("timestamp < {end_before:DateTime64(3)}")
+            outer_conditions.append("timestamp < {end_before:DateTime64(3)}")
             params["end_before"] = to_utc_naive(end_before)
-        if trace_id is not None:
-            conditions.append("trace_id = {trace_id:String}")
-            params["trace_id"] = trace_id
         if detector is not None:
             # Backend-owned resolution: match a finding whose payload contains any
             # of the resolved tokens by detectorName OR detectorId. The raw token is
@@ -102,33 +111,32 @@ class DetectorReaderService:
             # when Postgres resolves nothing; an unresolved token matches nothing
             # (empty list, not an error).
             params["detector_names"] = self._resolve_detector_names(project_id, detector)
-            conditions.append(
+            outer_conditions.append(
                 "arrayExists("
                 "x -> JSONExtractString(x, 'detectorName') IN {detector_names:Array(String)} "
                 "OR JSONExtractString(x, 'detectorId') IN {detector_names:Array(String)}, "
                 "JSONExtractArrayRaw(payload))"
             )
 
-        where = " AND ".join(conditions)
+        base_where = " AND ".join(base_conditions)
+        outer_where = (" WHERE " + " AND ".join(outer_conditions)) if outer_conditions else ""
 
-        count_query = f"""
-            SELECT count(DISTINCT finding_id)
+        # Dedup the ReplacingMergeTree rows to the latest per finding_id first.
+        deduped = f"""
+            SELECT finding_id, project_id, trace_id, summary, payload, timestamp
             FROM detector_findings
-            WHERE {where}
+            WHERE {base_where}
+            ORDER BY timestamp DESC
+            LIMIT 1 BY finding_id
         """
+
+        count_query = f"SELECT count() FROM ({deduped}){outer_where}"
         count_result = self._client.query(count_query, parameters=params)
         total = count_result.result_rows[0][0] if count_result.result_rows else 0
 
-        # Dedup the ReplacingMergeTree rows (latest per finding_id) BEFORE limiting.
         list_query = f"""
             SELECT finding_id, project_id, trace_id, summary, payload, timestamp
-            FROM (
-                SELECT finding_id, project_id, trace_id, summary, payload, timestamp
-                FROM detector_findings
-                WHERE {where}
-                ORDER BY timestamp DESC
-                LIMIT 1 BY finding_id
-            )
+            FROM ({deduped}){outer_where}
             ORDER BY timestamp DESC
             LIMIT {{limit:UInt32}}
         """

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -46,7 +46,7 @@ class DetectorReaderService:
         try:
             with conn.cursor() as cur:
                 cur.execute(sql, params)
-                return cur.fetchall()
+                return list(cur.fetchall())
         finally:
             conn.close()
 
@@ -193,21 +193,19 @@ class DetectorReaderService:
 
     def _build_detail(self, project_id: str, row: tuple) -> FindingDetail:
         finding_id, _project_id, trace_id, summary, payload, timestamp = row
-        parsed = self._parse_payload(payload)
-        templates = self._read_templates(
-            project_id, [item.get("detectorId") for item in parsed if isinstance(item, dict)]
-        )
+        items = [item for item in self._parse_payload(payload) if isinstance(item, dict)]
+        detector_ids = [str(item.get("detectorId") or "") for item in items]
+        templates = self._read_templates(project_id, [d for d in detector_ids if d])
         results = [
             DetectorResultItem(
-                detector_id=item.get("detectorId") or "",
-                detector_name=item.get("detectorName") or "",
-                template=templates.get(item.get("detectorId")),
-                summary=item.get("summary") or "",
+                detector_id=detector_id,
+                detector_name=str(item.get("detectorName") or ""),
+                template=templates.get(detector_id),
+                summary=str(item.get("summary") or ""),
                 identified=True,
                 data=item.get("data"),
             )
-            for item in parsed
-            if isinstance(item, dict)
+            for item, detector_id in zip(items, detector_ids)
         ]
         return FindingDetail(
             finding_id=finding_id,

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -126,7 +126,7 @@ def test_list_findings_detector_filter_matches_detector_id_without_resolution(re
     assert names == ["d1"]
 
 
-def test_list_findings_deduplicates_before_version_sensitive_filters(reader, monkeypatch):
+def test_list_findings_places_time_filters_for_dedup_correctness(reader, monkeypatch):
     reader._client.rows = []
     reader._client.count_rows = [(0,)]
     monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
@@ -135,18 +135,23 @@ def test_list_findings_deduplicates_before_version_sensitive_filters(reader, mon
         project_id="p1",
         limit=50,
         start_after=datetime(2026, 6, 1),
-        end_before=None,
+        end_before=datetime(2026, 6, 30),
         detector="hallucination",
         trace_id=None,
     )
 
-    # The version-sensitive filters (timestamp window + payload predicate) must be
-    # applied to the deduped subquery, i.e. AFTER `LIMIT 1 BY finding_id` — otherwise
-    # a stale finding version could be surfaced on a ReplacingMergeTree table.
+    # Filter placement is correctness- AND performance-critical on a
+    # ReplacingMergeTree(timestamp):
+    #   - start_after (lower bound) goes BEFORE `LIMIT 1 BY finding_id` so the
+    #     dedup + count only process the window's rows; it's safe because a
+    #     finding's latest version has the max timestamp.
+    #   - end_before (upper bound) and the payload predicate go AFTER dedup, or a
+    #     stale version could resurface a finding whose latest version is excluded.
     for query, _ in reader._client.calls:
-        assert "LIMIT 1 BY finding_id" in query
-        assert query.index("LIMIT 1 BY finding_id") < query.index("arrayExists")
-        assert query.index("LIMIT 1 BY finding_id") < query.index("timestamp >=")
+        dedup = query.index("LIMIT 1 BY finding_id")
+        assert query.index("timestamp >=") < dedup
+        assert query.index("timestamp <") > dedup
+        assert query.index("arrayExists") > dedup
 
 
 def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -101,6 +101,31 @@ def test_list_findings_detector_filter_includes_token_and_resolved_names(reader,
     assert "p1" in captured["params"]  # resolution scoped to the project
 
 
+def test_list_findings_detector_filter_matches_detector_id_without_resolution(reader, monkeypatch):
+    reader._client.rows = []
+    reader._client.count_rows = [(0,)]
+    monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])  # Postgres resolves nothing
+
+    reader.list_findings(
+        project_id="p1",
+        limit=50,
+        start_after=None,
+        end_before=None,
+        detector="d1",
+        trace_id=None,
+    )
+
+    # The raw token is the only resolved name, and the predicate checks detectorId too,
+    # so `detector=d1` can match a payload entry whose detectorId is "d1".
+    queries_with_names = [q for q, p in reader._client.calls if p and "detector_names" in p]
+    assert queries_with_names
+    assert "detectorId" in queries_with_names[0]
+    names = next(
+        p["detector_names"] for _, p in reader._client.calls if p and "detector_names" in p
+    )
+    assert names == ["d1"]
+
+
 def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):
     payload = json.dumps(
         [{"detectorId": "d1", "detectorName": "hallucination", "summary": "s", "data": {"x": 1}}]

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -1,0 +1,183 @@
+"""Unit tests for the detector findings reader service.
+
+ClickHouse is faked (dispatches by SQL content) and the Postgres boundary
+(`_pg_rows`) is monkeypatched, so these run with no live databases.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _ch_result(rows):
+    r = MagicMock()
+    r.result_rows = rows
+    return r
+
+
+class FakeCH:
+    """Fake ClickHouse client: count queries get count_rows, others get rows."""
+
+    def __init__(self):
+        self.calls: list[tuple] = []
+        self.count_rows = [(0,)]
+        self.rows: list[tuple] = []
+
+    def query(self, query, parameters=None):
+        self.calls.append((query, parameters))
+        if "count(" in query.lower():
+            return _ch_result(self.count_rows)
+        return _ch_result(self.rows)
+
+
+@pytest.fixture()
+def reader(monkeypatch):
+    import rest.services.detector_reader as mod
+
+    fake = FakeCH()
+    monkeypatch.setattr(mod, "get_clickhouse_client", lambda: fake)
+    svc = mod.DetectorReaderService()
+    return svc
+
+
+def test_list_findings_parses_payload_into_summaries(reader):
+    payload = json.dumps(
+        [
+            {
+                "detectorId": "d1",
+                "detectorName": "hallucination",
+                "summary": "s1",
+                "data": {"a": 1},
+            },
+            {"detectorId": "d2", "detectorName": "logic", "summary": "s2", "data": None},
+        ]
+    )
+    reader._client.rows = [("f1", "p1", "t1", "combined", payload, datetime(2026, 6, 29, 10, 42))]
+    reader._client.count_rows = [(1,)]
+
+    items, total = reader.list_findings(
+        project_id="p1", limit=50, start_after=None, end_before=None, detector=None, trace_id=None
+    )
+
+    assert total == 1
+    assert len(items) == 1
+    assert items[0].finding_id == "f1"
+    assert items[0].detectors == ["hallucination", "logic"]
+    # every query is project-scoped
+    assert all(p and p.get("project_id") == "p1" for _, p in reader._client.calls)
+
+
+def test_list_findings_detector_filter_includes_token_and_resolved_names(reader, monkeypatch):
+    reader._client.rows = []
+    reader._client.count_rows = [(0,)]
+    captured = {}
+
+    def fake_pg(sql, params):
+        if "from detectors" in sql.lower():
+            captured["params"] = params
+            return [("My Hallucination Detector",)]
+        return []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    reader.list_findings(
+        project_id="p1",
+        limit=50,
+        start_after=None,
+        end_before=None,
+        detector="hallucination",
+        trace_id=None,
+    )
+
+    name_params = [
+        p["detector_names"] for _, p in reader._client.calls if p and "detector_names" in p
+    ]
+    assert name_params, "expected detector_names passed to ClickHouse"
+    names = name_params[0]
+    assert "hallucination" in names  # raw token always included
+    assert "My Hallucination Detector" in names  # resolved via Postgres
+    assert "p1" in captured["params"]  # resolution scoped to the project
+
+
+def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):
+    payload = json.dumps(
+        [{"detectorId": "d1", "detectorName": "hallucination", "summary": "s", "data": {"x": 1}}]
+    )
+    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+
+    def fake_pg(sql, params):
+        s = sql.lower()
+        if "from detectors" in s:
+            return [("d1", "hallucination")]  # id, template
+        if "from detector_rcas" in s:
+            return [("done", "root cause text")]  # status, result
+        return []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    detail = reader.get_finding("p1", "f1")
+
+    assert detail is not None
+    item = detail.results[0]
+    assert (item.detector_id, item.detector_name) == ("d1", "hallucination")
+    assert item.template == "hallucination"
+    assert item.identified is True
+    assert item.data == {"x": 1}
+    assert detail.detectors == ["hallucination"]
+    assert detail.rca.status == "done"
+    assert detail.rca.result == "root cause text"
+
+
+def test_get_finding_returns_none_when_missing(reader):
+    reader._client.rows = []
+    assert reader.get_finding("p1", "missing") is None
+
+
+def test_get_finding_absent_rca_yields_none(reader, monkeypatch):
+    payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
+    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+    monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
+
+    detail = reader.get_finding("p1", "f1")
+
+    assert detail.rca is None
+    assert detail.results[0].template is None
+
+
+def test_get_finding_rca_lookup_failure_still_returns_finding(reader, monkeypatch):
+    payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
+    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+
+    def boom(sql, params):
+        raise RuntimeError("postgres down")
+
+    monkeypatch.setattr(reader, "_pg_rows", boom)
+
+    detail = reader.get_finding("p1", "f1")  # must not raise
+
+    assert detail is not None
+    assert detail.rca is None
+    assert detail.results[0].template is None
+
+
+def test_get_finding_by_trace_is_project_and_trace_scoped(reader, monkeypatch):
+    payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
+    reader._client.rows = [("f1", "p1", "t9", "sum", payload, datetime(2026, 6, 29))]
+    monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
+
+    detail = reader.get_finding_by_trace("p1", "t9")
+
+    assert detail.trace_id == "t9"
+    _, params = reader._client.calls[-1]
+    assert params["project_id"] == "p1"
+    assert params["trace_id"] == "t9"
+
+
+def test_get_detector_reader_service_is_singleton(monkeypatch):
+    import rest.services.detector_reader as mod
+
+    monkeypatch.setattr(mod, "get_clickhouse_client", lambda: MagicMock())
+    mod._service = None
+    assert mod.get_detector_reader_service() is mod.get_detector_reader_service()

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -126,6 +126,29 @@ def test_list_findings_detector_filter_matches_detector_id_without_resolution(re
     assert names == ["d1"]
 
 
+def test_list_findings_deduplicates_before_version_sensitive_filters(reader, monkeypatch):
+    reader._client.rows = []
+    reader._client.count_rows = [(0,)]
+    monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
+
+    reader.list_findings(
+        project_id="p1",
+        limit=50,
+        start_after=datetime(2026, 6, 1),
+        end_before=None,
+        detector="hallucination",
+        trace_id=None,
+    )
+
+    # The version-sensitive filters (timestamp window + payload predicate) must be
+    # applied to the deduped subquery, i.e. AFTER `LIMIT 1 BY finding_id` — otherwise
+    # a stale finding version could be surfaced on a ReplacingMergeTree table.
+    for query, _ in reader._client.calls:
+        assert "LIMIT 1 BY finding_id" in query
+        assert query.index("LIMIT 1 BY finding_id") < query.index("arrayExists")
+        assert query.index("LIMIT 1 BY finding_id") < query.index("timestamp >=")
+
+
 def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):
     payload = json.dumps(
         [{"detectorId": "d1", "detectorName": "hallucination", "summary": "s", "data": {"x": 1}}]

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -223,6 +223,53 @@ def test_get_finding_by_trace_is_project_and_trace_scoped(reader, monkeypatch):
     assert params["trace_id"] == "t9"
 
 
+def test_list_detectors_returns_items_and_total(reader, monkeypatch):
+    def fake_pg(sql, params):
+        if "count(" in sql.lower():
+            return [(2,)]
+        return [
+            (
+                "d1",
+                "My Hallucination Detector",
+                "hallucination",
+                True,
+                datetime(2026, 6, 29, 10, 42),
+            ),
+            ("d2", "Failure Watch", "failure", False, datetime(2026, 6, 28, 9, 0)),
+        ]
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    items, total = reader.list_detectors(project_id="p1", limit=50)
+
+    assert total == 2
+    assert [i.detector_id for i in items] == ["d1", "d2"]
+    assert items[0].name == "My Hallucination Detector"
+    assert items[0].template == "hallucination"
+    assert items[0].enabled is True
+    assert items[1].enabled is False
+
+
+def test_list_detectors_is_project_scoped_limited_and_newest_first(reader, monkeypatch):
+    captured: list[tuple] = []
+
+    def fake_pg(sql, params):
+        captured.append((sql, params))
+        return [(0,)] if "count(" in sql.lower() else []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    reader.list_detectors(project_id="p1", limit=25)
+
+    assert captured, "expected Postgres queries"
+    assert all("p1" in params for _, params in captured)  # every query project-scoped
+    list_calls = [(sql, params) for sql, params in captured if "count(" not in sql.lower()]
+    assert list_calls
+    sql, params = list_calls[0]
+    assert 25 in params  # limit forwarded
+    assert "order by create_time desc" in sql.lower()  # newest first
+
+
 def test_get_detector_reader_service_is_singleton(monkeypatch):
     import rest.services.detector_reader as mod
 

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -270,6 +270,30 @@ def test_list_detectors_is_project_scoped_limited_and_newest_first(reader, monke
     assert "order by create_time desc" in sql.lower()  # newest first
 
 
+def test_list_detectors_applies_create_time_window(reader, monkeypatch):
+    captured: list[tuple] = []
+
+    def fake_pg(sql, params):
+        captured.append((sql.lower(), params))
+        return [(0,)] if "count(" in sql.lower() else []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    reader.list_detectors(
+        project_id="p1",
+        limit=50,
+        start_after=datetime(2026, 6, 1),
+        end_before=datetime(2026, 6, 30),
+    )
+
+    # Both the count and list queries carry the inclusive-lower / exclusive-upper
+    # create_time window, so pagination totals match the returned page.
+    assert captured
+    for sql, _params in captured:
+        assert "create_time >= %s" in sql
+        assert "create_time < %s" in sql
+
+
 def test_get_detector_reader_service_is_singleton(monkeypatch):
     import rest.services.detector_reader as mod
 

--- a/tests/rest/test_public_detector_schemas.py
+++ b/tests/rest/test_public_detector_schemas.py
@@ -1,0 +1,92 @@
+"""Schema contract tests for the public detector findings API."""
+
+from datetime import datetime
+
+from rest.schemas.common import PaginationMeta
+from rest.schemas.public import (
+    DetectorResultItem,
+    FindingDetail,
+    FindingSummary,
+    PublicFindingListResponse,
+    RCAResult,
+)
+
+
+def test_detector_result_item_fields_are_snake_case():
+    item = DetectorResultItem(
+        detector_id="d1",
+        detector_name="hallucination",
+        template="hallucination",
+        summary="unsupported claims",
+        identified=True,
+        data={"k": "v"},
+    )
+    assert item.model_dump() == {
+        "detector_id": "d1",
+        "detector_name": "hallucination",
+        "template": "hallucination",
+        "summary": "unsupported claims",
+        "identified": True,
+        "data": {"k": "v"},
+    }
+
+
+def test_detector_result_item_allows_null_template_and_data():
+    item = DetectorResultItem(
+        detector_id="d1",
+        detector_name="hallucination",
+        template=None,
+        summary="s",
+        identified=True,
+        data=None,
+    )
+    assert item.template is None
+    assert item.data is None
+
+
+def test_rca_result_result_is_optional():
+    assert RCAResult(status="pending", result=None).result is None
+    assert RCAResult(status="done", result="root cause").result == "root cause"
+
+
+def test_finding_detail_allows_null_rca():
+    detail = FindingDetail(
+        finding_id="f1",
+        project_id="p1",
+        trace_id="t1",
+        summary="x",
+        timestamp=datetime(2026, 6, 29, 10, 42),
+        detectors=["hallucination"],
+        results=[
+            DetectorResultItem(
+                detector_id="d1",
+                detector_name="hallucination",
+                template="hallucination",
+                summary="s",
+                identified=True,
+                data=None,
+            )
+        ],
+        rca=None,
+    )
+    assert detail.rca is None
+    assert detail.detectors == ["hallucination"]
+    assert detail.results[0].detector_id == "d1"
+
+
+def test_public_finding_list_response_wraps_summaries_with_pagination():
+    resp = PublicFindingListResponse(
+        data=[
+            FindingSummary(
+                finding_id="f1",
+                project_id="p1",
+                trace_id="t1",
+                summary="x",
+                timestamp=datetime(2026, 6, 29),
+                detectors=["failure", "logic"],
+            )
+        ],
+        meta=PaginationMeta(page=0, limit=50, total=1),
+    )
+    assert resp.meta.page == 0
+    assert resp.data[0].detectors == ["failure", "logic"]

--- a/tests/rest/test_public_detector_schemas.py
+++ b/tests/rest/test_public_detector_schemas.py
@@ -4,12 +4,47 @@ from datetime import datetime
 
 from rest.schemas.common import PaginationMeta
 from rest.schemas.public import (
+    DetectorItem,
     DetectorResultItem,
     FindingDetail,
     FindingSummary,
+    PublicDetectorListResponse,
     PublicFindingListResponse,
     RCAResult,
 )
+
+
+def test_detector_item_fields_are_snake_case():
+    item = DetectorItem(
+        detector_id="d1",
+        name="My Hallucination Detector",
+        template="hallucination",
+        enabled=True,
+        created_at=datetime(2026, 6, 29, 10, 42),
+    )
+    dumped = item.model_dump()
+    assert dumped["detector_id"] == "d1"
+    assert dumped["name"] == "My Hallucination Detector"
+    assert dumped["template"] == "hallucination"
+    assert dumped["enabled"] is True
+
+
+def test_public_detector_list_response_wraps_items_with_pagination():
+    resp = PublicDetectorListResponse(
+        data=[
+            DetectorItem(
+                detector_id="d1",
+                name="n",
+                template="failure",
+                enabled=False,
+                created_at=datetime(2026, 6, 29),
+            )
+        ],
+        meta=PaginationMeta(page=0, limit=50, total=1),
+    )
+    assert resp.meta.total == 1
+    assert resp.data[0].detector_id == "d1"
+    assert resp.data[0].enabled is False
 
 
 def test_detector_result_item_fields_are_snake_case():


### PR DESCRIPTION
## Summary

Adds the backend foundation for CLI access to detectors and detector findings: the public response **schemas** and a project-scoped, read-only **reader service**. This is the first slice of [CLI Access to Detectors & Findings](https://github.com/traceroot-ai/traceroot/issues/1382) — it has **no runtime HTTP surface** of its own; it publishes the schema + service contract that the public read API router consumes.

It reads only data that exists today: the detector catalog, `template`, and `--detector` resolution from Postgres `detectors`, findings from ClickHouse `detector_findings`, and the free-text RCA from Postgres `detector_rcas`. No severity, no structured RCA, no write paths.

Closes #1379. The router/endpoints that expose this over HTTP land in a follow-up (#1380); CLI type generation is #1381.

## How the reader works

```
DetectorReaderService (project-scoped, read-only)
  list_detectors(project, limit, start_after, end_before) -> ([DetectorItem], total)
    └── Postgres detectors             catalog page, newest-first by create_time, matching count(*); failure propagates
  list_findings(project, limit, start_after, end_before, detector, trace_id) -> ([FindingSummary], total)
    ├── ClickHouse detector_findings   dedup latest per finding_id, newest-first, count(DISTINCT) total
    └── Postgres detectors             resolve --detector by id/name/template (single arrayExists predicate)
  get_finding / get_finding_by_trace -> FindingDetail | None
    ├── ClickHouse detector_findings   single project-scoped row (None if absent)
    ├── normalize payload camelCase -> snake_case, identified=True, data verbatim
    ├── Postgres detectors             template per detector_id
    └── Postgres detector_rcas         free-text RCA
```

Key behaviors:
- **`--detector` is backend-owned.** The token always matches `detectorName` in the payload directly, and also resolves against the project's `detectors` by `id`/`name`/`template`; the resolved name set becomes a single ClickHouse `arrayExists(... JSONExtractString ...)` predicate. An unresolved token simply matches nothing → empty list (not an error).
- **RCA never blocks a finding.** A missing `detector_rcas` row *or* a Postgres lookup failure degrades to `rca = None`; the finding still returns. A ClickHouse failure on the finding read itself propagates (to be mapped to a controlled 500 by the router PR).
- **`identified` is `True` for persisted entries only** — only triggered detectors are stored; the reader does not expand into non-triggered `detector_runs`.
- **Snake_case normalization.** Stored payload keys (`detectorId`/`detectorName`) are exposed as `detector_id`/`detector_name`; the per-detector `data` blob is opaque and passed through verbatim. `template` is looked up from Postgres and is `None` when the detector row is absent.

## Data model (read-only; nothing new added)

- **ClickHouse** `detector_findings` — one row per trace where ≥1 detector fired; `summary` + JSON `payload` array of `{detectorId, detectorName, summary, data}`.
- **Postgres** `detectors` — resolves the `--detector` selector and supplies `template`.
- **Postgres** `detector_rcas` — free-text RCA (`status`, `result`), keyed by `finding_id`.

## What's included

### Schemas — `backend/rest/schemas/public.py`
- `DetectorResultItem { detector_id, detector_name, template, summary, identified, data }`
- `RCAResult { status, result }`
- `FindingSummary { finding_id, project_id, trace_id, summary, timestamp, detectors }`
- `FindingDetail` (extends `FindingSummary` with `results` + `rca`)
- `PublicFindingListResponse { data, meta }`
- `DetectorItem { detector_id, name, template, enabled, created_at }`
- `PublicDetectorListResponse { data, meta }`

### Reader service — `backend/rest/services/detector_reader.py` (new)
- `DetectorReaderService` + `get_detector_reader_service()` singleton, mirroring `trace_reader.py` (sync; ClickHouse client + a single read-only psycopg2 seam).
- `list_detectors` (Postgres catalog page, newest-first, inclusive/exclusive `create_time` window; failure propagates), `list_findings`, `get_finding`, `get_finding_by_trace`, plus `_resolve_detector_names`, `_read_templates`, `_read_rca`.

## Notable decision

`main` already defines `FindingItem` / `FindingListResponse` in `rest/schemas/detectors.py` for the internal raw-findings endpoint, and public response models live in `rest/schemas/public.py` by convention (`PublicTrace*`). So the public models live in `public.py` and the list wrapper is named **`PublicFindingListResponse`** rather than the `FindingListResponse` originally written in #1379, to avoid the collision.

## Test plan

- [x] Schema contract tests (`tests/rest/test_public_detector_schemas.py`) — snake_case fields, nullable `template`/`rca`, `PaginationMeta` wrapping, `DetectorItem`/`PublicDetectorListResponse`
- [x] Reader unit tests (`tests/rest/test_detector_reader.py`) — `list_detectors` items + total, project scope, newest-first, `create_time` window; payload parsing/normalization, `template` from Postgres (null when absent), RCA present/absent/lookup-failure, project scoping, `--detector` resolution (token + resolved names), by-trace scoping, singleton
- [x] Full REST suite green (269 passed) and `mypy` clean on the new modules
- [x] Live ClickHouse + Postgres integration — exercised once the read API router (#1380) lands
