### PR TITLE
fix(api): return 503 when trace ingest cannot enqueue

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1106,7 +1106,15 @@
                 }
               }
             },
-            "description": "Authentication service unavailable"
+            "description": "Temporary authentication or ingest queue unavailability; retry the request",
+            "headers": {
+              "Retry-After": {
+                "description": "When present for ingest queue unavailability, delay in seconds before retrying",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -58,7 +58,8 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
 
     # Public ingestion accepts an OTLP protobuf body (read from the raw request)
     # and documents its runtime error contract: 400 (bad/empty/undecodable body),
-    # 402 (plan limit), 415 (wrong Content-Type), 500 (S3 storage failure).
+    # 402 (plan limit), 415 (wrong Content-Type), 503 (auth/enqueue unavailable),
+    # and 500 (S3 storage failure).
     ingest = schema["paths"].get("/api/v1/public/traces", {}).get("post")
     if ingest is not None:
         ingest["requestBody"] = {
@@ -71,6 +72,17 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
         ingest_responses.setdefault("400", _error_response("Invalid request body"))
         ingest_responses.setdefault("402", _error_response("Free plan limit exceeded"))
         ingest_responses.setdefault("415", _error_response("Unsupported media type"))
+        ingest_responses["503"] = _error_response(
+            "Temporary authentication or ingest queue unavailability; retry the request"
+        )
+        ingest_responses["503"]["headers"] = {
+            "Retry-After": {
+                "description": (
+                    "When present for ingest queue unavailability, delay in seconds before retrying"
+                ),
+                "schema": {"type": "string"},
+            }
+        }
         ingest_responses.setdefault("500", _error_response("Storage error"))
 
     # Trace read/export error contract (matches the route code).

--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -15,7 +15,7 @@ import gzip
 import logging
 import uuid
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, HTTPException, Request, Response, status
 from google.protobuf.json_format import MessageToDict
@@ -66,7 +66,7 @@ def decode_otlp_protobuf(data: bytes) -> dict[str, Any]:
     request.ParseFromString(data)
     # MessageToDict converts protobuf to dict with camelCase field names
     # (standard OTLP JSON format) and proper handling of bytes (base64), enums, etc.
-    return MessageToDict(request)
+    return cast("dict[str, Any]", MessageToDict(request))
 
 
 class IngestResponse(BaseModel):
@@ -184,8 +184,12 @@ async def ingest_traces(
         process_s3_traces.delay(s3_key=s3_key, project_id=project_id)
         logger.info(f"Enqueued Celery task for {s3_key}")
     except Exception as e:
-        # Log but don't fail the request - S3 has the data, can retry later
         logger.error(f"Failed to enqueue Celery task for {s3_key}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Ingest temporarily unavailable, please retry",
+            headers={"Retry-After": "5"},
+        ) from e
 
     # 7. Return success (async processing happens in background)
     return IngestResponse(status="ok", file_key=s3_key)

--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -185,6 +185,13 @@ async def ingest_traces(
         logger.info(f"Enqueued Celery task for {s3_key}")
     except Exception as e:
         logger.error(f"Failed to enqueue Celery task for {s3_key}: {e}")
+        try:
+            s3_service.delete_object(s3_key)
+        except Exception as cleanup_error:
+            logger.warning(
+                f"Failed to delete unqueued OTEL JSON {s3_key}: {cleanup_error}",
+                exc_info=True,
+            )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Ingest temporarily unavailable, please retry",

--- a/backend/rest/services/s3.py
+++ b/backend/rest/services/s3.py
@@ -126,6 +126,16 @@ class S3Service:
         body = response["Body"].read()
         return json.loads(body.decode("utf-8"))
 
+    def delete_object(self, s3_key: str) -> None:
+        """Delete an object from S3.
+
+        Args:
+            s3_key: Full S3 key path
+        """
+        client = self._get_client()
+        client.delete_object(Bucket=self._bucket_name, Key=s3_key)
+        logger.debug(f"Deleted s3://{self._bucket_name}/{s3_key}")
+
 
 # Global singleton instance
 _s3_service: S3Service | None = None

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -109,12 +109,20 @@ def test_ingestion_documents_protobuf_request_body():
 
 def test_ingestion_documents_runtime_error_responses():
     # The ingest route raises 400 (bad/empty/undecodable body), 402 (plan limit),
-    # 415 (wrong Content-Type) and 500 (S3 storage failure) at runtime.
+    # 415 (wrong Content-Type), 503 (auth/enqueue unavailable) and 500 (S3 storage
+    # failure) at runtime.
     post = _schema()["paths"]["/api/v1/public/traces"]["post"]
-    for code in ("400", "402", "415", "500"):
+    for code in ("400", "402", "415", "503", "500"):
         assert code in post["responses"], code
+    assert post["responses"]["503"]["description"] == (
+        "Temporary authentication or ingest queue unavailability; retry the request"
+    )
+    assert post["responses"]["503"]["headers"]["Retry-After"] == {
+        "description": "When present for ingest queue unavailability, delay in seconds before retrying",
+        "schema": {"type": "string"},
+    }
     # existing responses are preserved
-    assert set(post["responses"]) >= {"200", "401", "422", "400", "402", "415", "500"}
+    assert set(post["responses"]) >= {"200", "401", "422", "400", "402", "415", "503", "500"}
 
 
 def _public_operations(schema):

--- a/tests/rest/test_public_traces.py
+++ b/tests/rest/test_public_traces.py
@@ -134,6 +134,21 @@ class TestIngestTraces:
         assert response.headers["Retry-After"] == "5"
         mock_s3.upload_json.assert_called_once()
         mock_task.delay.assert_called_once()
+        mock_s3.delete_object.assert_called_once_with(mock_s3.upload_json.call_args[0][0])
+
+    def test_celery_failure_still_returns_503_when_cleanup_fails(self, client):
+        """Cleanup failures should not mask the retryable enqueue failure."""
+        test_client, mock_s3, mock_task = client
+        mock_task.delay.side_effect = Exception("Redis down")
+        mock_s3.delete_object.side_effect = Exception("S3 delete failed")
+        response = test_client.post(
+            "/api/v1/public/traces",
+            content=b"fake-protobuf",
+            headers={"Content-Type": "application/x-protobuf"},
+        )
+        assert response.status_code == 503
+        assert response.headers["Retry-After"] == "5"
+        mock_s3.delete_object.assert_called_once_with(mock_s3.upload_json.call_args[0][0])
 
     def test_s3_key_time_partitioned_format(self, client):
         test_client, mock_s3, _ = client

--- a/tests/rest/test_public_traces.py
+++ b/tests/rest/test_public_traces.py
@@ -120,16 +120,20 @@ class TestIngestTraces:
         )
         assert response.status_code == 500
 
-    def test_celery_failure_still_returns_200(self, client):
-        """Celery enqueue failure is logged but response is still 200 (S3 has the data)."""
-        test_client, _mock_s3, mock_task = client
+    def test_celery_failure_returns_503_so_client_retries(self, client):
+        """If processing cannot be queued, return non-2xx so OTLP clients retry."""
+        test_client, mock_s3, mock_task = client
         mock_task.delay.side_effect = Exception("Redis down")
         response = test_client.post(
             "/api/v1/public/traces",
             content=b"fake-protobuf",
             headers={"Content-Type": "application/x-protobuf"},
         )
-        assert response.status_code == 200
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Ingest temporarily unavailable, please retry"
+        assert response.headers["Retry-After"] == "5"
+        mock_s3.upload_json.assert_called_once()
+        mock_task.delay.assert_called_once()
 
     def test_s3_key_time_partitioned_format(self, client):
         test_client, mock_s3, _ = client

--- a/tests/rest/test_public_traces.py
+++ b/tests/rest/test_public_traces.py
@@ -8,9 +8,10 @@ from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 
 from rest.main import app
-from rest.routers.public.traces import AuthResult, authenticate_api_key
+from rest.routers.public.traces import AuthResult, authenticate_api_key, decode_otlp_protobuf
 
 
 def make_auth_result(project_id: str = "test-project") -> AuthResult:
@@ -44,6 +45,11 @@ def client(monkeypatch):
 
 
 class TestIngestTraces:
+    def test_decode_otlp_protobuf_returns_otlp_json_dict(self):
+        payload = ExportTraceServiceRequest()
+        decoded = decode_otlp_protobuf(payload.SerializeToString())
+        assert decoded == {}
+
     def test_valid_protobuf(self, client):
         test_client, mock_s3, mock_task = client
         response = test_client.post(

--- a/tests/rest/test_s3_service.py
+++ b/tests/rest/test_s3_service.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+from rest.services.s3 import S3Service
+
+
+def test_delete_object_delegates_to_s3_client():
+    client = MagicMock()
+    service = S3Service(bucket_name="trace-bucket")
+    service._client = client
+
+    service.delete_object("events/otel/project/key.json")
+
+    client.delete_object.assert_called_once_with(
+        Bucket="trace-bucket",
+        Key="events/otel/project/key.json",
+    )


### PR DESCRIPTION
Fixes #1363

## Summary

If the public ingest endpoint stored OTEL JSON in S3 but failed to enqueue the Celery processing task, it still returned `200 OK`. That told OTLP clients the payload was accepted, so they would not retry and the S3 object could remain unprocessed.

This changes the enqueue failure path to return `503 Service Unavailable` with a retryable generic message after the S3 upload succeeds but the worker task cannot be queued.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Raise `HTTPException(503)` when `process_s3_traces.delay(...)` fails.
- Keep the successful S3 upload path unchanged; the error occurs only after persistence when queueing fails.
- Return a generic retry-safe detail with `Retry-After: 5`: `Ingest temporarily unavailable, please retry`.
- Update the public OpenAPI artifact so the ingest route documents 503 as temporary auth or ingest queue unavailability and tells callers to retry.
- Document the `Retry-After` response header for the ingest 503 contract.
- Add regression coverage proving enqueue failure returns 503, preserves the S3 upload, and calls the enqueue boundary once.

## Screenshots / Recordings (if applicable)

Not applicable; this is a backend/API reliability fix.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

## Tests

Commands run:

- `uv run pytest tests/rest/test_public_traces.py tests/rest/test_public_openapi.py -q` — passed (`28 passed, 1 StarletteDeprecationWarning`)
- `uv run python scripts/sync_public_openapi.py --check` — passed
- `uv run mypy backend/rest/routers/public/traces.py backend/rest/openapi_public.py tests/rest/test_public_traces.py tests/rest/test_public_openapi.py` — passed
- `uv run ruff check backend/rest/routers/public/traces.py backend/rest/openapi_public.py tests/rest/test_public_traces.py tests/rest/test_public_openapi.py` — passed
- `uv run pytest -q` — passed (`612 passed, 1 StarletteDeprecationWarning`)
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed (`119 files already formatted`)
- `git diff --check` — passed

## Risk

Risk level: low to medium.

This changes an existing failure path from `200 OK` to `503 Service Unavailable` so spec-compliant OTLP clients can retry instead of treating the payload as accepted. The success path is unchanged. The S3 upload still happens before enqueue, so a failed response may leave an already-stored object; this is the existing durability buffer behavior and is preferable to silently losing processing.

The new response includes `Retry-After: 5` to avoid encouraging immediate tight retry loops while keeping this PR focused on the response contract.

This intentionally prefers at-least-once retry behavior over silent non-processing: a retry after a post-upload `503` may create another stored payload and processing attempt, while final trace/span rows are partially bounded by downstream dedupe semantics.

Rollback is a single-commit revert of the route behavior, tests, and regenerated public OpenAPI artifact.

## Notes for maintainers

This intentionally does not add an orphan-S3 rehydration worker or retry sweeper. It only fixes the API response contract so callers can retry when the queue is unavailable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 503 Service Unavailable from the public trace ingest endpoint when Celery enqueue fails after a successful S3 upload, and clean up the just-uploaded object to avoid orphaned payloads. OTLP clients now retry; the success path is unchanged.

- **Bug Fixes**
  - Return 503 with "Ingest temporarily unavailable, please retry" and `Retry-After: 5` when `process_s3_traces.delay(...)` fails.
  - Best-effort delete the uploaded S3 object on enqueue failure; do not mask the 503 if delete fails.
  - Update public OpenAPI to document 503 for temporary auth or ingest queue unavailability and the `Retry-After` header.
  - Add tests for the 503 response and cleanup behavior (including failed cleanup), for `decode_otlp_protobuf` returning an OTLP JSON dict, and for `S3Service.delete_object` delegating to the client.

<sup>Written for commit c6a8ec3d0e75d6a9912373d175651239f7db1d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

