### PR TITLE
fix(detector): allow 0% sample rate to pause a detector

### DIFF
--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -97,7 +97,7 @@ def _sample_passes(trace_id: str, detector_id: str, sample_rate: float | None) -
         trace_id (str): Trace being considered.
         detector_id (str): Detector whose sampling is being rolled.
         sample_rate (float | None): Detector sample rate as a percentage. The
-            schema constrains this to an int in 1-100, but it is read straight
+            schema constrains this to an int in 0-100, but it is read straight
             from the DB, so we guard against a missing or out-of-range value
             rather than trust it.
 

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -352,7 +352,7 @@ model Detector {
   template     String   @db.VarChar  // "failure"|"hallucination"|"logic"|"task"|"safety"|"intent"|"blank"
   prompt       String   @db.Text
   outputSchema       Json     @map("output_schema") @db.JsonB
-  sampleRate         Int      @default(25) @map("sample_rate")  // 1–100
+  sampleRate         Int      @default(25) @map("sample_rate")  // 0–100
   enabled            Boolean  @default(true)
   enableRca          Boolean  @default(true) @map("enable_rca")  // run agent-model RCA on this detector's findings
   detectionModel     String?  @map("detection_model") @db.VarChar    // model id; null = worker picks default

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -82,6 +82,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     prompt,
     outputSchema,
     sampleRate,
+    enabled,
     triggerConditions,
     detectionModel,
     detectionProvider,
@@ -147,6 +148,14 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   }
   const resolvedEnableRca = enableRca ?? true;
 
+  // enabled: optional boolean. Defaults to true, but a detector created at 0%
+  // sampling should not show as "enabled but never fires" — fall back to
+  // sampleRate > 0 so a 0% rate creates a paused detector.
+  if (enabled !== undefined && typeof enabled !== "boolean") {
+    return errorResponse("enabled must be a boolean", 400);
+  }
+  const resolvedEnabled = enabled ?? resolvedSampleRate > 0;
+
   const detector = await prisma.detector.create({
     data: {
       projectId,
@@ -155,6 +164,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
       prompt,
       outputSchema: (outputSchema as object) ?? [],
       sampleRate: resolvedSampleRate,
+      enabled: resolvedEnabled,
       enableRca: resolvedEnableRca,
       detectionModel: resolvedModel,
       detectionProvider: resolvedProvider,

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -56,6 +56,7 @@ describe("NewDetectorPage", () => {
       outputSchema: failure.outputSchema,
       triggerConditions: failure.defaultConditions,
       sampleRate: 25,
+      enabled: true,
       enableRca: true,
       detectionModel: undefined,
       detectionProvider: undefined,

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -69,6 +69,7 @@ export default function NewDetectorPage() {
       name,
       prompt,
       sampleRate,
+      enabled: sampleRate > 0,
       enableRca,
       triggerConditions,
       detectionModel: modelSelection.model || undefined,
@@ -211,7 +212,7 @@ export default function NewDetectorPage() {
               <div className="flex items-center gap-3 p-3">
                 <input
                   type="range"
-                  min={1}
+                  min={0}
                   max={100}
                   value={sampleRate}
                   onChange={(e) => setSampleRate(Number(e.target.value))}

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -290,7 +290,7 @@ export function DetectorPanel({
           <div className="flex items-center gap-3 p-3">
             <input
               type="range"
-              min={1}
+              min={0}
               max={100}
               value={editSampleRate}
               onChange={(e) => setEditSampleRate(Number(e.target.value))}

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.ts
@@ -41,6 +41,7 @@ export interface CreateDetectorInput {
   prompt: string;
   outputSchema: Array<{ name: string; type: string }>;
   sampleRate?: number;
+  enabled?: boolean;
   enableRca?: boolean;
   triggerConditions?: Array<{ field: string; op: string; value: unknown }>;
   detectionModel?: string;
@@ -86,6 +87,7 @@ export interface UpdateDetectorInput {
   name?: string;
   prompt?: string;
   sampleRate?: number;
+  enabled?: boolean;
   enableRca?: boolean;
   triggerConditions?: Array<{ field: string; op: string; value: unknown }>;
   detectionModel?: string;

--- a/frontend/ui/src/features/detectors/utils/index.test.ts
+++ b/frontend/ui/src/features/detectors/utils/index.test.ts
@@ -94,6 +94,16 @@ describe("buildDetectorPatch", () => {
     const patch = buildDetectorPatch(baseForm, { ...baseForm, conditions });
     expect(patch).toEqual({ triggerConditions: conditions });
   });
+
+  it("disables the detector when the sample rate drops to 0%", () => {
+    const patch = buildDetectorPatch(baseForm, { ...baseForm, sampleRate: 0 });
+    expect(patch).toEqual({ sampleRate: 0, enabled: false });
+  });
+
+  it("enables the detector when the sample rate is positive", () => {
+    const patch = buildDetectorPatch(baseForm, { ...baseForm, sampleRate: 10 });
+    expect(patch).toEqual({ sampleRate: 10, enabled: true });
+  });
 });
 
 describe("mergeDetectorIntoForm", () => {

--- a/frontend/ui/src/features/detectors/utils/index.ts
+++ b/frontend/ui/src/features/detectors/utils/index.ts
@@ -50,7 +50,14 @@ export function buildDetectorPatch(
   const patch: UpdateDetectorInput = {};
   if (form.name !== loaded.name) patch.name = form.name;
   if (form.prompt !== loaded.prompt) patch.prompt = form.prompt;
-  if (form.sampleRate !== loaded.sampleRate) patch.sampleRate = form.sampleRate;
+  if (form.sampleRate !== loaded.sampleRate) {
+    patch.sampleRate = form.sampleRate;
+    // The sampling rate is the only control on this form that governs whether
+    // the judge runs, so bind it to the enabled flag: 0% disables the detector
+    // (instead of leaving an "enabled but never fires" state on the list page),
+    // and any positive rate re-enables it.
+    patch.enabled = form.sampleRate > 0;
+  }
   if (form.enableRca !== loaded.enableRca) patch.enableRca = form.enableRca;
   if (!conditionsEqual(form.conditions, loaded.conditions)) {
     patch.triggerConditions = form.conditions;


### PR DESCRIPTION
## Summary
- Lower the sampling slider minimum from 1% to 0%
- Bind the sample rate to the `enabled` flag: a 0% rate pauses the detector and any positive rate re-enables it, avoiding the "enabled but never fires" state
- The create detector API accepts an optional `enabled` boolean, defaulting to `sampleRate > 0`

Closes #1384

## ScreenShot

### Lower the sampling slider minimum from 1% to 0%
<img width="1502" height="780" alt="image" src="https://github.com/user-attachments/assets/a2700dc5-5449-423e-86ef-0ee26660ee18" />
<img width="1500" height="840" alt="image" src="https://github.com/user-attachments/assets/00604d3a-5eee-44d5-a1b8-9ae6375e79d9" />

### 100% sampling rate & insert 5 traces & get 5 runs

<img width="1491" height="812" alt="image" src="https://github.com/user-attachments/assets/6f201584-5dd7-4d41-85b1-a3570e82bcbd" />

<img width="1499" height="218" alt="image" src="https://github.com/user-attachments/assets/8d2c4000-fd5a-4cf7-93a4-9ebb49790389" />

### 0% sampling rate & insert 5 more traces & no more detector runs

<img width="1506" height="814" alt="image" src="https://github.com/user-attachments/assets/9f944d6a-ccf1-4cf9-a89a-cdd9619c7f35" />
<img width="1502" height="349" alt="image" src="https://github.com/user-attachments/assets/c3b98962-afab-494e-9975-224dd15d994b" />


### 100% sampling rate & insert 5  more traces & get 10 runs

<img width="1494" height="849" alt="image" src="https://github.com/user-attachments/assets/d1544970-1a87-44c6-8c3a-5948ef4ba350" />
<img width="1511" height="373" alt="image" src="https://github.com/user-attachments/assets/bbff004c-960a-47a9-a341-4e342d2bdd4d" />



## Test plan
- [x] Create a detector with sample rate 0% and confirm it is paused after creation
- [x] Edit an existing detector down to 0% and confirm it becomes disabled; raise it back above 0% and confirm it re-enables
- [x] `buildDetectorPatch` unit tests pass