### PR TITLE
fix(ui): require write roles for detector mutations

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({ NextRequest: class {} }));
+
+const detectorFindFirstMock = vi.fn();
+const detectorUpdateMock = vi.fn();
+const detectorDeleteMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    detector: {
+      findFirst: (...args: unknown[]) => detectorFindFirstMock(...args),
+      update: (...args: unknown[]) => detectorUpdateMock(...args),
+      delete: (...args: unknown[]) => detectorDeleteMock(...args),
+    },
+  },
+  Role: { VIEWER: "VIEWER", MEMBER: "MEMBER", ADMIN: "ADMIN" },
+}));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({
+    status,
+    json: async () => data,
+  }),
+}));
+
+import { GET, PATCH, DELETE } from "./route";
+
+function makeRequest(body: unknown = {}) {
+  return { json: async () => body } as unknown as Parameters<typeof PATCH>[0];
+}
+
+function makeParams() {
+  return { params: Promise.resolve({ projectId: "proj-1", detectorId: "det-1" }) };
+}
+
+beforeEach(() => {
+  detectorFindFirstMock.mockReset();
+  detectorUpdateMock.mockReset();
+  detectorDeleteMock.mockReset();
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+  detectorFindFirstMock.mockResolvedValue({ id: "det-1", projectId: "proj-1" });
+  detectorUpdateMock.mockResolvedValue({ id: "det-1", enabled: false });
+  detectorDeleteMock.mockResolvedValue({ id: "det-1" });
+});
+
+describe("GET .../detectors/[detectorId] — access", () => {
+  it("allows detector reads with project access only", async () => {
+    const res = await GET(makeRequest(), makeParams());
+
+    expect(res.status).toBe(200);
+    expect(requireProjectAccessMock).toHaveBeenCalledWith("user-1", "proj-1");
+  });
+});
+
+describe("PATCH .../detectors/[detectorId] — access", () => {
+  it("requires MEMBER access to update detectors", async () => {
+    const res = await PATCH(makeRequest({ enabled: false }), makeParams());
+
+    expect(res.status).toBe(200);
+    expect(requireProjectAccessMock).toHaveBeenCalledWith("user-1", "proj-1", "MEMBER");
+    expect(detectorUpdateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not update a detector when MEMBER access is denied", async () => {
+    requireProjectAccessMock.mockResolvedValueOnce({
+      error: { status: 403, json: async () => ({ error: "Requires MEMBER role or higher" }) },
+    });
+    const jsonMock = vi.fn().mockResolvedValue({ enabled: false });
+
+    const res = await PATCH(
+      { json: jsonMock } as unknown as Parameters<typeof PATCH>[0],
+      makeParams(),
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Requires MEMBER role or higher" });
+    expect(jsonMock).not.toHaveBeenCalled();
+    expect(detectorFindFirstMock).not.toHaveBeenCalled();
+    expect(detectorUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE .../detectors/[detectorId] — access", () => {
+  it("requires ADMIN access to delete detectors", async () => {
+    const res = await DELETE(makeRequest(), makeParams());
+
+    expect(res.status).toBe(200);
+    expect(requireProjectAccessMock).toHaveBeenCalledWith("user-1", "proj-1", "ADMIN");
+    expect(detectorDeleteMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not delete a detector when ADMIN access is denied", async () => {
+    requireProjectAccessMock.mockResolvedValueOnce({
+      error: { status: 403, json: async () => ({ error: "Requires ADMIN role or higher" }) },
+    });
+
+    const res = await DELETE(makeRequest(), makeParams());
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Requires ADMIN role or higher" });
+    expect(detectorFindFirstMock).not.toHaveBeenCalled();
+    expect(detectorDeleteMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { prisma } from "@traceroot/core";
+import { prisma, Role } from "@traceroot/core";
 import {
   requireAuth,
   requireProjectAccess,
@@ -31,14 +31,14 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   return successResponse({ detector });
 }
 
-// PATCH /api/projects/[projectId]/detectors/[detectorId] - Partially update a detector
+// PATCH /api/projects/[projectId]/detectors/[detectorId] - Partially update a detector (MEMBER+)
 export async function PATCH(req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
   const { user } = authResult;
 
   const { projectId, detectorId } = await params;
-  const accessResult = await requireProjectAccess(user.id, projectId);
+  const accessResult = await requireProjectAccess(user.id, projectId, Role.MEMBER);
   if (accessResult.error) return accessResult.error;
 
   const existing = await prisma.detector.findFirst({
@@ -160,14 +160,14 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   return successResponse({ detector });
 }
 
-// DELETE /api/projects/[projectId]/detectors/[detectorId] - Delete a detector
+// DELETE /api/projects/[projectId]/detectors/[detectorId] - Delete a detector (ADMIN+)
 export async function DELETE(_req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
   const { user } = authResult;
 
   const { projectId, detectorId } = await params;
-  const accessResult = await requireProjectAccess(user.id, projectId);
+  const accessResult = await requireProjectAccess(user.id, projectId, Role.ADMIN);
   if (accessResult.error) return accessResult.error;
 
   const existing = await prisma.detector.findFirst({

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.test.ts
@@ -3,12 +3,19 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("next/server", () => ({ NextRequest: class {} }));
 
 const detectorCreateMock = vi.fn();
+const detectorFindManyMock = vi.fn();
+const detectorCountMock = vi.fn();
+const transactionMock = vi.fn();
 vi.mock("@traceroot/core", () => ({
   prisma: {
+    $transaction: (...args: unknown[]) => transactionMock(...args),
     detector: {
       create: (...args: unknown[]) => detectorCreateMock(...args),
+      findMany: (...args: unknown[]) => detectorFindManyMock(...args),
+      count: (...args: unknown[]) => detectorCountMock(...args),
     },
   },
+  Role: { VIEWER: "VIEWER", MEMBER: "MEMBER", ADMIN: "ADMIN" },
 }));
 
 const requireAuthMock = vi.fn();
@@ -26,10 +33,14 @@ vi.mock("@/lib/auth-helpers", () => ({
   }),
 }));
 
-import { POST } from "./route";
+import { GET, POST } from "./route";
 
 function makeRequest(body: unknown) {
   return { json: async () => body } as unknown as Parameters<typeof POST>[0];
+}
+
+function makeListRequest(url = "http://localhost/api/projects/proj-1/detectors") {
+  return { nextUrl: new URL(url) } as unknown as Parameters<typeof GET>[0];
 }
 
 function makeParams() {
@@ -43,11 +54,54 @@ function validBody(extra: Record<string, unknown> = {}) {
 
 beforeEach(() => {
   detectorCreateMock.mockReset();
+  detectorFindManyMock.mockReset();
+  detectorCountMock.mockReset();
+  transactionMock.mockReset();
   requireAuthMock.mockReset();
   requireProjectAccessMock.mockReset();
   requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
   requireProjectAccessMock.mockResolvedValue({});
   detectorCreateMock.mockResolvedValue({ id: "det-1" });
+  detectorFindManyMock.mockResolvedValue([]);
+  detectorCountMock.mockResolvedValue(0);
+  transactionMock.mockImplementation(async (operations: Promise<unknown>[]) =>
+    Promise.all(operations),
+  );
+});
+
+describe("GET .../detectors — access", () => {
+  it("allows detector listing with project access only", async () => {
+    const res = await GET(makeListRequest(), makeParams());
+
+    expect(res.status).toBe(200);
+    expect(requireProjectAccessMock).toHaveBeenCalledWith("user-1", "proj-1");
+  });
+});
+
+describe("POST .../detectors — access", () => {
+  it("requires MEMBER access to create detectors", async () => {
+    const res = await POST(makeRequest(validBody()), makeParams());
+
+    expect(res.status).toBe(201);
+    expect(requireProjectAccessMock).toHaveBeenCalledWith("user-1", "proj-1", "MEMBER");
+  });
+
+  it("does not create a detector when MEMBER access is denied", async () => {
+    requireProjectAccessMock.mockResolvedValueOnce({
+      error: { status: 403, json: async () => ({ error: "Requires MEMBER role or higher" }) },
+    });
+    const jsonMock = vi.fn().mockResolvedValue(validBody());
+
+    const res = await POST(
+      { json: jsonMock } as unknown as Parameters<typeof POST>[0],
+      makeParams(),
+    );
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({ error: "Requires MEMBER role or higher" });
+    expect(jsonMock).not.toHaveBeenCalled();
+    expect(detectorCreateMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST .../detectors — sampleRate default", () => {

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { prisma } from "@traceroot/core";
+import { prisma, Role } from "@traceroot/core";
 import { DEFAULT_DETECTOR_SAMPLE_RATE } from "@/features/detectors/templates";
 import {
   requireAuth,
@@ -54,14 +54,14 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
   return successResponse({ data, meta: { page, limit, total } });
 }
 
-// POST /api/projects/[projectId]/detectors - Create a new detector
+// POST /api/projects/[projectId]/detectors - Create a new detector (MEMBER+)
 export async function POST(req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
   const { user } = authResult;
 
   const { projectId } = await params;
-  const accessResult = await requireProjectAccess(user.id, projectId);
+  const accessResult = await requireProjectAccess(user.id, projectId, Role.MEMBER);
   if (accessResult.error) return accessResult.error;
 
   let body: unknown;

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -6,6 +6,11 @@ import { getTemplate } from "@/features/detectors/templates";
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   mutateAsync: vi.fn().mockResolvedValue({ id: "det-1" }),
+  resetMutation: vi.fn(),
+  createError: null as Error | null,
+  workspaceRole: "MEMBER" as string | undefined,
+  workspaceLoading: false,
+  workspaceError: null as Error | null,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -13,10 +18,23 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mocks.push }),
 }));
 vi.mock("@/features/detectors/hooks/use-detectors", () => ({
-  useCreateDetector: () => ({ mutateAsync: mocks.mutateAsync, isPending: false }),
+  useCreateDetector: () => ({
+    mutateAsync: mocks.mutateAsync,
+    reset: mocks.resetMutation,
+    isPending: false,
+    isError: !!mocks.createError,
+    error: mocks.createError,
+  }),
 }));
 vi.mock("@/features/projects/hooks", () => ({
-  useProject: () => ({ data: undefined }),
+  useProject: () => ({ data: { workspace_id: "ws-1" } }),
+}));
+vi.mock("@/features/workspaces/hooks", () => ({
+  useWorkspace: () => ({
+    data: mocks.workspaceRole ? { role: mocks.workspaceRole } : undefined,
+    isLoading: mocks.workspaceLoading,
+    error: mocks.workspaceError,
+  }),
 }));
 vi.mock("@/features/projects/components", () => ({
   ProjectBreadcrumb: () => null,
@@ -39,7 +57,13 @@ import NewDetectorPage from "./page";
 afterEach(() => {
   cleanup();
   mocks.mutateAsync.mockClear();
+  mocks.mutateAsync.mockResolvedValue({ id: "det-1" });
+  mocks.resetMutation.mockClear();
   mocks.push.mockClear();
+  mocks.createError = null;
+  mocks.workspaceRole = "MEMBER";
+  mocks.workspaceLoading = false;
+  mocks.workspaceError = null;
 });
 
 describe("NewDetectorPage", () => {
@@ -64,6 +88,20 @@ describe("NewDetectorPage", () => {
     expect(mocks.push).toHaveBeenCalledWith("/projects/proj-1/detectors");
   });
 
+  it("renders API permission errors when create fails", async () => {
+    mocks.mutateAsync.mockRejectedValue(new Error("Members and admins can create detectors"));
+    mocks.createError = new Error("Members and admins can create detectors");
+
+    render(<NewDetectorPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Create Detector" }));
+
+    await waitFor(() => expect(mocks.mutateAsync).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Members and admins can create detectors",
+    );
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
   it("submits user-edited name and prompt over the template defaults", async () => {
     render(<NewDetectorPage />);
     fireEvent.change(screen.getByDisplayValue("Failure Detector"), {
@@ -80,5 +118,30 @@ describe("NewDetectorPage", () => {
       prompt: "my prompt",
       template: "failure",
     });
+  });
+
+  it("does not expose the create form to viewers", () => {
+    mocks.workspaceRole = "VIEWER";
+    render(<NewDetectorPage />);
+
+    expect(screen.queryByRole("button", { name: "Create Detector" })).toBeNull();
+    expect(
+      screen.getByText("Members and admins can create detectors for this project."),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to Detectors" }));
+    expect(mocks.push).toHaveBeenCalledWith("/projects/proj-1/detectors");
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("does not expose the create form while detector permissions are loading", () => {
+    mocks.workspaceRole = undefined;
+    mocks.workspaceLoading = true;
+
+    render(<NewDetectorPage />);
+
+    expect(screen.queryByRole("button", { name: "Create Detector" })).toBeNull();
+    expect(screen.getByText("Checking detector permissions...")).toBeDefined();
+    expect(mocks.mutateAsync).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -21,14 +21,23 @@ import { AgentModelLink } from "@/features/detectors/components/agent-model-link
 import { RcaToggle } from "@/features/detectors/components/rca-toggle";
 import { useProject } from "@/features/projects/hooks";
 import { ProjectBreadcrumb } from "@/features/projects/components";
+import { useWorkspace } from "@/features/workspaces/hooks";
+import { Role } from "@traceroot/core";
 
 export default function NewDetectorPage() {
   const params = useParams();
   const router = useRouter();
   const projectId = params.projectId as string;
 
-  const { data: project } = useProject(projectId);
+  const { data: project, isLoading: projectLoading, error: projectError } = useProject(projectId);
+  const workspaceId = project?.workspace_id;
+  const {
+    data: workspace,
+    isLoading: workspaceLoading,
+    error: workspaceError,
+  } = useWorkspace(workspaceId ?? "", !!workspaceId);
   const createMutation = useCreateDetector(projectId);
+  const canCreateDetector = workspace?.role === Role.MEMBER || workspace?.role === Role.ADMIN;
 
   const INITIAL_TEMPLATE = DETECTOR_TEMPLATES[0];
 
@@ -63,6 +72,8 @@ export default function NewDetectorPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!canCreateDetector) return;
+    createMutation.reset();
     const template = DETECTOR_TEMPLATES.find((t) => t.id === selectedTemplate)!;
     const input: CreateDetectorInput = {
       ...buildTemplateDetectorInput(template),
@@ -75,11 +86,52 @@ export default function NewDetectorPage() {
       detectionProvider: modelSelection.provider || undefined,
       detectionSource: modelSelection.source === "byok" ? "byok" : "system",
     };
-    await createMutation.mutateAsync(input);
-    router.push(`/projects/${projectId}/detectors`);
+    try {
+      await createMutation.mutateAsync(input);
+      router.push(`/projects/${projectId}/detectors`);
+    } catch {
+      // The mutation state renders the API error message below.
+    }
   };
 
   const selectedTemplateDef = DETECTOR_TEMPLATES.find((t) => t.id === selectedTemplate);
+
+  const renderAccessState = (message: string) => (
+    <div className="relative flex h-full text-[13px]">
+      <ProjectBreadcrumb projectId={projectId} />
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <div className="flex items-center justify-between border-b border-border px-4 py-3">
+          <h1 className="text-[13px] font-medium">New Detector</h1>
+        </div>
+
+        <div className="flex h-64 flex-col items-center justify-center gap-3">
+          <p className="text-[13px] text-muted-foreground">{message}</p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 text-[12px]"
+            onClick={() => router.push(`/projects/${projectId}/detectors`)}
+          >
+            Back to Detectors
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (projectLoading || (!project && !projectError) || workspaceLoading) {
+    return renderAccessState("Checking detector permissions...");
+  }
+
+  if (projectError || workspaceError || !workspaceId || !workspace) {
+    return renderAccessState("Unable to verify detector permissions.");
+  }
+
+  if (!canCreateDetector) {
+    return renderAccessState("Members and admins can create detectors for this project.");
+  }
 
   return (
     <div className="relative flex h-full text-[13px]">
@@ -224,6 +276,12 @@ export default function NewDetectorPage() {
             </div>
 
             {/* Footer */}
+            {createMutation.isError && (
+              <p role="alert" className="text-[12px] text-destructive">
+                {createMutation.error.message}
+              </p>
+            )}
+
             <div className="flex justify-end gap-2 pt-1">
               <Button
                 type="button"
@@ -238,7 +296,9 @@ export default function NewDetectorPage() {
                 type="submit"
                 size="sm"
                 className="h-7 text-[12px]"
-                disabled={createMutation.isPending || !name.trim() || !prompt.trim()}
+                disabled={
+                  createMutation.isPending || !canCreateDetector || !name.trim() || !prompt.trim()
+                }
               >
                 {createMutation.isPending ? "Creating..." : "Create Detector"}
               </Button>

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
@@ -2,7 +2,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 
-const mocks = vi.hoisted(() => ({ push: vi.fn() }));
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  deleteMutate: vi.fn(),
+  deleteReset: vi.fn(),
+  deleteError: null as Error | null,
+  workspaceRole: "ADMIN",
+}));
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "proj-1" }),
@@ -42,15 +48,43 @@ vi.mock("@/features/detectors/hooks/use-detectors", () => ({
     error: null,
   }),
   useDetectorCounts: () => ({ data: {}, isLoading: false }),
-  useDeleteDetector: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeleteDetector: () => ({
+    mutate: mocks.deleteMutate,
+    reset: mocks.deleteReset,
+    isPending: false,
+    isError: !!mocks.deleteError,
+    error: mocks.deleteError,
+  }),
 }));
 
-vi.mock("@/features/projects/hooks", () => ({ useProject: () => ({ data: undefined }) }));
+vi.mock("@/features/projects/hooks", () => ({
+  useProject: () => ({ data: { workspace_id: "ws-1" } }),
+}));
+vi.mock("@/features/workspaces/hooks", () => ({
+  useWorkspace: () => ({ data: { role: mocks.workspaceRole } }),
+}));
 vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
 vi.mock("@/components/search-filter-bar", () => ({ SearchFilterBar: () => null }));
 vi.mock("@/components/list-pagination", () => ({ ListPagination: () => null }));
 vi.mock("@/features/detectors/components/delete-detector-dialog", () => ({
-  DeleteDetectorDialog: () => null,
+  DeleteDetectorDialog: ({
+    detectorName,
+    isOpen,
+    onConfirm,
+    errorMessage,
+  }: {
+    detectorName: string;
+    isOpen: boolean;
+    onConfirm: () => void;
+    errorMessage?: string;
+  }) =>
+    isOpen ? (
+      <div>
+        <p>Delete {detectorName}</p>
+        {errorMessage && <p role="alert">{errorMessage}</p>}
+        <button onClick={onConfirm}>Confirm delete</button>
+      </div>
+    ) : null,
 }));
 vi.mock("@/features/detectors/components/detector-panel", () => ({ DetectorPanel: () => null }));
 
@@ -59,6 +93,10 @@ import DetectorsPage from "./page";
 afterEach(() => {
   cleanup();
   mocks.push.mockClear();
+  mocks.deleteMutate.mockReset();
+  mocks.deleteReset.mockReset();
+  mocks.deleteError = null;
+  mocks.workspaceRole = "ADMIN";
 });
 
 describe("DetectorsPage", () => {
@@ -68,5 +106,45 @@ describe("DetectorsPage", () => {
     fireEvent.click(screen.getByText("My Detector"));
 
     expect(mocks.push).toHaveBeenCalledWith("/projects/proj-1/detectors/det-1?date_filter=7d");
+  });
+
+  it("hides detector mutation controls from viewers", () => {
+    mocks.workspaceRole = "VIEWER";
+    render(<DetectorsPage />);
+
+    expect(screen.queryByRole("button", { name: "New Detector" })).toBeNull();
+    expect(screen.queryByText("Actions")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Actions for My Detector" })).toBeNull();
+  });
+
+  it("shows edit but not delete actions to members", () => {
+    mocks.workspaceRole = "MEMBER";
+    render(<DetectorsPage />);
+
+    expect(screen.getByRole("button", { name: "New Detector" })).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: "Actions for My Detector" }));
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+  });
+
+  it("shows delete actions to admins", () => {
+    render(<DetectorsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Actions for My Detector" }));
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDefined();
+    expect(screen.getByRole("button", { name: "Delete" })).toBeDefined();
+  });
+
+  it("passes delete permission errors into the delete dialog", () => {
+    mocks.deleteError = new Error("Admins can delete detectors for this project.");
+    render(<DetectorsPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Actions for My Detector" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(screen.getByText("Delete My Detector")).toBeDefined();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Admins can delete detectors for this project.",
+    );
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -17,9 +17,11 @@ import {
 import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { DETECTORS_DEFAULT_DATE_FILTER_ID } from "@/lib/date-filter";
 import { useProject } from "@/features/projects/hooks";
+import { useWorkspace } from "@/features/workspaces/hooks";
 import { DeleteDetectorDialog } from "@/features/detectors/components/delete-detector-dialog";
 import { DetectorPanel } from "@/features/detectors/components/detector-panel";
 import { getTemplate } from "@/features/detectors/templates";
+import { Role } from "@traceroot/core";
 
 export default function DetectorsPage() {
   const params = useParams();
@@ -52,6 +54,7 @@ export default function DetectorsPage() {
     });
 
   const { data: project } = useProject(projectId);
+  const { data: workspace } = useWorkspace(project?.workspace_id ?? "", !!project?.workspace_id);
 
   const { data, isLoading, error } = useDetectorList(projectId, {
     page: queryOptions.page,
@@ -67,15 +70,24 @@ export default function DetectorsPage() {
   const deleteMutation = useDeleteDetector(projectId);
   const detectors = data?.data ?? [];
   const meta = data?.meta;
+  const canWriteDetectors = workspace?.role === Role.MEMBER || workspace?.role === Role.ADMIN;
+  const canDeleteDetectors = workspace?.role === Role.ADMIN;
+  const showActions = canWriteDetectors || canDeleteDetectors;
 
   const handleDeleteConfirm = () => {
     if (!deleteTarget) return;
+    deleteMutation.reset();
     deleteMutation.mutate(deleteTarget.id, {
       onSuccess: () => {
         setDeleteTarget(null);
         if (selectedDetectorId === deleteTarget.id) setSelectedDetectorId(null);
       },
     });
+  };
+
+  const closeDeleteDialog = () => {
+    deleteMutation.reset();
+    setDeleteTarget(null);
   };
 
   const openPanel = (detectorId: string) => setSelectedDetectorId(detectorId);
@@ -100,13 +112,15 @@ export default function DetectorsPage() {
         {/* Page header */}
         <div className="flex items-center justify-between border-b border-border px-4 py-2">
           <h1 className="text-[13px] font-medium">Detectors</h1>
-          <Button
-            size="sm"
-            className="h-7 text-[12px]"
-            onClick={() => router.push(`/projects/${projectId}/detectors/new`)}
-          >
-            New Detector
-          </Button>
+          {canWriteDetectors && (
+            <Button
+              size="sm"
+              className="h-7 text-[12px]"
+              onClick={() => router.push(`/projects/${projectId}/detectors/new`)}
+            >
+              New Detector
+            </Button>
+          )}
         </div>
 
         {/* Search / time-range filter */}
@@ -136,15 +150,19 @@ export default function DetectorsPage() {
               <Eye className="h-8 w-8 text-muted-foreground/40" />
               <p className="text-[13px] text-muted-foreground">No detectors yet</p>
               <p className="text-[12px] text-muted-foreground">
-                Create a detector to automatically analyze your traces.
+                {canWriteDetectors
+                  ? "Create a detector to automatically analyze your traces."
+                  : "Members and admins can create detectors for this project."}
               </p>
-              <Button
-                size="sm"
-                className="mt-1 h-7 text-[12px]"
-                onClick={() => router.push(`/projects/${projectId}/detectors/new`)}
-              >
-                New Detector
-              </Button>
+              {canWriteDetectors && (
+                <Button
+                  size="sm"
+                  className="mt-1 h-7 text-[12px]"
+                  onClick={() => router.push(`/projects/${projectId}/detectors/new`)}
+                >
+                  New Detector
+                </Button>
+              )}
             </div>
           ) : isEmptySearch ? (
             <div className="flex h-64 flex-col items-center justify-center gap-3">
@@ -191,9 +209,11 @@ export default function DetectorsPage() {
                   <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
                     Detector ID
                   </th>
-                  <th className="w-[56px] px-2 py-1.5 text-right text-[12px] font-medium text-muted-foreground">
-                    Actions
-                  </th>
+                  {showActions && (
+                    <th className="w-[56px] px-2 py-1.5 text-right text-[12px] font-medium text-muted-foreground">
+                      Actions
+                    </th>
+                  )}
                 </tr>
               </thead>
               <tbody>
@@ -238,47 +258,54 @@ export default function DetectorsPage() {
                       <td className="border-r border-border/50 px-3 py-1.5 font-mono text-[11px] text-muted-foreground">
                         {detector.id}
                       </td>
-                      <td className="px-2 text-right">
-                        <Popover
-                          open={actionsOpen === detector.id}
-                          onOpenChange={(open) => setActionsOpen(open ? detector.id : null)}
-                        >
-                          <PopoverTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              className="h-5 w-6 p-0 text-muted-foreground hover:text-foreground"
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <MoreHorizontal className="h-3.5 w-3.5" />
-                            </Button>
-                          </PopoverTrigger>
-                          <PopoverContent align="end" className="w-36 p-1">
-                            <button
-                              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] hover:bg-muted/60"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                openPanel(detector.id);
-                                setActionsOpen(null);
-                              }}
-                            >
-                              <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
-                              Edit
-                            </button>
-                            <button
-                              className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setDeleteTarget({ id: detector.id, name: detector.name });
-                                setActionsOpen(null);
-                              }}
-                            >
-                              <Trash2 className="h-3.5 w-3.5" />
-                              Delete
-                            </button>
-                          </PopoverContent>
-                        </Popover>
-                      </td>
+                      {showActions && (
+                        <td className="px-2 text-right">
+                          <Popover
+                            open={actionsOpen === detector.id}
+                            onOpenChange={(open) => setActionsOpen(open ? detector.id : null)}
+                          >
+                            <PopoverTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                aria-label={`Actions for ${detector.name}`}
+                                className="h-5 w-6 p-0 text-muted-foreground hover:text-foreground"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <MoreHorizontal className="h-3.5 w-3.5" />
+                              </Button>
+                            </PopoverTrigger>
+                            <PopoverContent align="end" className="w-36 p-1">
+                              {canWriteDetectors && (
+                                <button
+                                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] hover:bg-muted/60"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    openPanel(detector.id);
+                                    setActionsOpen(null);
+                                  }}
+                                >
+                                  <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+                                  Edit
+                                </button>
+                              )}
+                              {canDeleteDetectors && (
+                                <button
+                                  className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    setDeleteTarget({ id: detector.id, name: detector.name });
+                                    setActionsOpen(null);
+                                  }}
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                  Delete
+                                </button>
+                              )}
+                            </PopoverContent>
+                          </Popover>
+                        </td>
+                      )}
                     </tr>
                   );
                 })}
@@ -304,6 +331,7 @@ export default function DetectorsPage() {
           detectorId={selectedDetectorId}
           projectId={projectId}
           workspaceId={project?.workspace_id}
+          canEdit={canWriteDetectors}
           onClose={closePanel}
           onNavigate={navigateDetector}
           canNavigateUp={detectors.findIndex((d) => d.id === selectedDetectorId) > 0}
@@ -317,9 +345,10 @@ export default function DetectorsPage() {
         <DeleteDetectorDialog
           detectorName={deleteTarget.name}
           isOpen={true}
-          onClose={() => setDeleteTarget(null)}
+          onClose={closeDeleteDialog}
           onConfirm={handleDeleteConfirm}
           isDeleting={deleteMutation.isPending}
+          errorMessage={deleteMutation.isError ? deleteMutation.error.message : undefined}
         />
       )}
     </div>

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ModelSelector, type ModelSelection } from "./model-selector";
+
+const mocks = vi.hoisted(() => ({
+  data: {
+    systemModels: [
+      {
+        provider: "openai",
+        adapter: "openai",
+        models: [{ id: "gpt-4o-mini", label: "GPT-4o mini" }],
+      },
+    ],
+    byokProviders: [],
+  },
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: mocks.data }),
+}));
+
+const selected: ModelSelection = {
+  model: "gpt-4o-mini",
+  provider: "openai",
+  source: "system",
+  adapter: "openai",
+};
+
+afterEach(() => cleanup());
+
+describe("ModelSelector", () => {
+  it("renders disabled without opening or backfilling selection", async () => {
+    const onChange = vi.fn();
+
+    render(
+      <ModelSelector
+        workspaceId="ws-1"
+        value={{ ...selected, adapter: "" }}
+        onChange={onChange}
+        disabled
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /gpt-4o mini/i });
+    expect((trigger as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(trigger);
+    expect(screen.queryByRole("button", { name: /gpt-4o mini/i })).toBe(trigger);
+    await waitFor(() => expect(onChange).not.toHaveBeenCalled());
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -20,13 +20,14 @@ interface ModelSelectorProps {
   value: ModelSelection;
   onChange: (selection: ModelSelection) => void;
   workspaceId?: string;
+  disabled?: boolean;
 }
 
 function modelKey(m: { id?: string; model?: string; source: string; provider: string }) {
   return `${m.source}:${m.provider}:${m.id ?? m.model}`;
 }
 
-export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorProps) {
+export function ModelSelector({ value, onChange, workspaceId, disabled }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
 
   const { data } = useQuery({
@@ -46,6 +47,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
   // Without case 2 the selector would silently auto-pick a default when a
   // partially-hydrated saved selection arrives, clobbering the user's choice.
   useEffect(() => {
+    if (disabled) return;
     if (models.length === 0) return;
 
     const exact = models.find(
@@ -84,18 +86,19 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
         adapter: match.adapter,
       });
     }
-  }, [models, value, onChange]);
+  }, [disabled, models, value, onChange]);
 
   const selectedKey = modelKey({ id: value.model, source: value.source, provider: value.provider });
   const selectedModel = models.find((m) => modelKey(m) === selectedKey);
 
   return (
     <div className="flex items-center">
-      <Popover open={open} onOpenChange={setOpen}>
+      <Popover open={disabled ? false : open} onOpenChange={(next) => !disabled && setOpen(next)}>
         <PopoverTrigger asChild>
           <Button
             variant="ghost"
             size="sm"
+            disabled={disabled}
             className="h-7 gap-1 rounded-sm px-2 text-[11px] text-muted-foreground hover:text-foreground"
           >
             {selectedModel?.label || value.model || "Select model"}
@@ -116,8 +119,9 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
             return (
               <button
                 key={key}
+                disabled={disabled}
                 className={cn(
-                  "flex w-full items-center justify-between rounded-md px-2.5 py-2 text-left text-[12px] transition-colors hover:bg-muted/50",
+                  "flex w-full items-center justify-between rounded-md px-2.5 py-2 text-left text-[12px] transition-colors hover:bg-muted/50 disabled:pointer-events-none disabled:opacity-50",
                   isSelected && "font-medium text-foreground",
                 )}
                 onClick={() => {

--- a/frontend/ui/src/features/detectors/components/delete-detector-dialog.test.tsx
+++ b/frontend/ui/src/features/detectors/components/delete-detector-dialog.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import { DeleteDetectorDialog } from "./delete-detector-dialog";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DeleteDetectorDialog", () => {
+  it("renders mutation errors in the confirmation dialog", () => {
+    render(
+      <DeleteDetectorDialog
+        detectorName="Latency spikes"
+        isOpen
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        errorMessage="Admins can delete detectors for this project."
+      />,
+    );
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Admins can delete detectors for this project.",
+    );
+  });
+});

--- a/frontend/ui/src/features/detectors/components/delete-detector-dialog.tsx
+++ b/frontend/ui/src/features/detectors/components/delete-detector-dialog.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { useState } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -11,6 +17,7 @@ interface DeleteDetectorDialogProps {
   onClose: () => void;
   onConfirm: () => void;
   isDeleting?: boolean;
+  errorMessage?: string;
 }
 
 export function DeleteDetectorDialog({
@@ -19,6 +26,7 @@ export function DeleteDetectorDialog({
   onClose,
   onConfirm,
   isDeleting,
+  errorMessage,
 }: DeleteDetectorDialogProps) {
   const [typed, setTyped] = useState("");
 
@@ -37,10 +45,10 @@ export function DeleteDetectorDialog({
         </DialogHeader>
 
         <div className="mt-1 space-y-4">
-          <p className="text-[12px] text-muted-foreground">
+          <DialogDescription className="text-[12px] text-muted-foreground">
             This action cannot be undone. Type{" "}
             <span className="font-medium text-foreground">{detectorName}</span> to confirm.
-          </p>
+          </DialogDescription>
 
           <Input
             className="h-8 text-[12px]"
@@ -49,6 +57,12 @@ export function DeleteDetectorDialog({
             onChange={(e) => setTyped(e.target.value)}
             autoFocus
           />
+
+          {errorMessage && (
+            <p role="alert" className="text-[12px] text-destructive">
+              {errorMessage}
+            </p>
+          )}
 
           <div className="flex justify-end gap-2">
             <Button

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -6,39 +6,58 @@ import type { Detector } from "../hooks/use-detectors";
 const mocks = vi.hoisted(() => ({
   detector: undefined as Detector | undefined,
   mutate: vi.fn(),
+  resetMutation: vi.fn(),
+  updateError: null as Error | null,
+  modelSelectorProps: [] as Array<{ disabled?: boolean }>,
+  triggerEditorProps: [] as Array<{ readOnly?: boolean }>,
 }));
 
 vi.mock("../hooks/use-detectors", () => ({
   useDetector: () => ({ data: mocks.detector }),
-  useUpdateDetector: () => ({ mutate: mocks.mutate, isPending: false }),
+  useUpdateDetector: () => ({
+    mutate: mocks.mutate,
+    reset: mocks.resetMutation,
+    isPending: false,
+    isError: !!mocks.updateError,
+    error: mocks.updateError,
+  }),
 }));
 vi.mock("@/features/projects/hooks", () => ({
   useProject: () => ({ data: undefined }),
 }));
 vi.mock("./trigger-editor", () => ({
-  TriggerEditor: () => null,
+  TriggerEditor: (props: { readOnly?: boolean }) => {
+    mocks.triggerEditorProps.push(props);
+    return <input data-testid="trigger-editor" disabled={props.readOnly} readOnly />;
+  },
 }));
 vi.mock("./agent-model-link", () => ({
   AgentModelLink: () => null,
 }));
 vi.mock("@/features/ai-assistant/components/model-selector", () => ({
-  ModelSelector: () => null,
+  ModelSelector: (props: { disabled?: boolean }) => {
+    mocks.modelSelectorProps.push(props);
+    return <button disabled={props.disabled}>Select model</button>;
+  },
 }));
 vi.mock("./rca-toggle", () => ({
   RcaToggle: ({
     id,
     checked,
     onCheckedChange,
+    disabled,
   }: {
     id: string;
     checked: boolean;
     onCheckedChange: (checked: boolean) => void;
+    disabled?: boolean;
   }) => (
     <input
       type="checkbox"
       data-testid="rca-toggle"
       id={id}
       checked={checked}
+      disabled={disabled}
       onChange={(e) => onCheckedChange(e.target.checked)}
     />
   ),
@@ -63,13 +82,25 @@ const baseDetector: Detector = {
   trigger: { conditions: [] },
 };
 
-function renderPanel(detectorId = "det-1") {
+function renderPanel(detectorId = "det-1", canEdit = true) {
   const onClose = vi.fn();
   const view = render(
-    <DetectorPanel detectorId={detectorId} projectId="proj-1" onClose={onClose} />,
+    <DetectorPanel
+      detectorId={detectorId}
+      projectId="proj-1"
+      canEdit={canEdit}
+      onClose={onClose}
+    />,
   );
   const rerender = () =>
-    view.rerender(<DetectorPanel detectorId={detectorId} projectId="proj-1" onClose={onClose} />);
+    view.rerender(
+      <DetectorPanel
+        detectorId={detectorId}
+        projectId="proj-1"
+        canEdit={canEdit}
+        onClose={onClose}
+      />,
+    );
   return { onClose, rerender };
 }
 
@@ -81,6 +112,10 @@ afterEach(() => {
   cleanup();
   mocks.detector = undefined;
   mocks.mutate.mockReset();
+  mocks.resetMutation.mockReset();
+  mocks.updateError = null;
+  mocks.modelSelectorProps = [];
+  mocks.triggerEditorProps = [];
 });
 
 describe("DetectorPanel", () => {
@@ -111,6 +146,7 @@ describe("DetectorPanel", () => {
     fireEvent.click(saveButton());
 
     expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.resetMutation).toHaveBeenCalledTimes(1);
     expect(mocks.mutate.mock.calls[0][0]).toEqual({ prompt: "new prompt" });
 
     const options = mocks.mutate.mock.calls[0][1] as { onSuccess: () => void };
@@ -126,10 +162,41 @@ describe("DetectorPanel", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it("renders API permission errors when save fails", () => {
+    mocks.detector = baseDetector;
+    mocks.updateError = new Error("Members and admins can edit detectors");
+    renderPanel();
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Members and admins can edit detectors",
+    );
+  });
+
   it("clears the form and disables Save while the loaded detector does not match the id", () => {
     mocks.detector = baseDetector;
     renderPanel("det-2");
     expect(promptBox().value).toBe("");
     expect((saveButton() as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders a read-only message when editing is not allowed", () => {
+    mocks.detector = baseDetector;
+    renderPanel("det-1", false);
+
+    expect(
+      screen.getByText("Members and admins can edit detectors for this project."),
+    ).toBeDefined();
+    expect((screen.getByDisplayValue("Latency spikes") as HTMLInputElement).disabled).toBe(true);
+    expect(promptBox().disabled).toBe(true);
+    expect(rcaToggle().disabled).toBe(true);
+    expect(
+      (screen.getByRole("button", { name: "Select model" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect((screen.getByTestId("trigger-editor") as HTMLInputElement).disabled).toBe(true);
+    expect(mocks.modelSelectorProps[mocks.modelSelectorProps.length - 1]?.disabled).toBe(true);
+    expect(mocks.triggerEditorProps[mocks.triggerEditorProps.length - 1]?.readOnly).toBe(true);
+    expect((saveButton() as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(saveButton());
+    expect(mocks.mutate).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -30,6 +30,7 @@ interface DetectorPanelProps {
   onNavigate?: (direction: "up" | "down") => void;
   canNavigateUp?: boolean;
   canNavigateDown?: boolean;
+  canEdit?: boolean;
 }
 
 export function DetectorPanel({
@@ -40,6 +41,7 @@ export function DetectorPanel({
   onNavigate,
   canNavigateUp,
   canNavigateDown,
+  canEdit = true,
 }: DetectorPanelProps) {
   const { data: detector } = useDetector(projectId, detectorId);
   const { data: project } = useProject(projectId);
@@ -140,6 +142,7 @@ export function DetectorPanel({
   const updateMutation = useUpdateDetector(projectId, detectorId);
 
   const handleSave = () => {
+    if (!canEdit) return;
     // Guard against saving while the new detector's data is still loading.
     // Edit state would be the previous detector's, but the mutation targets
     // the current detectorId; without this guard, stale values would
@@ -149,6 +152,7 @@ export function DetectorPanel({
     if (!detector || detector.id !== detectorId) return;
     const loaded = loadedRef.current;
     if (!loaded || loaded.id !== detectorId) return;
+    updateMutation.reset();
     const patch = buildDetectorPatch(loaded.values, readForm());
     if (Object.keys(patch).length === 0) {
       onClose();
@@ -210,6 +214,12 @@ export function DetectorPanel({
 
       {/* Scrollable form body */}
       <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-4">
+        {!canEdit && (
+          <p className="text-[13px] text-muted-foreground">
+            Members and admins can edit detectors for this project.
+          </p>
+        )}
+
         {/* Name */}
         <div className="border border-border">
           <div className="border-b border-border bg-muted/50 px-3 py-1.5">
@@ -219,6 +229,7 @@ export function DetectorPanel({
             <Input
               value={editName}
               onChange={(e) => setEditName(e.target.value)}
+              disabled={!canEdit}
               className="h-7 text-[13px]"
             />
           </div>
@@ -237,6 +248,7 @@ export function DetectorPanel({
                 value={editModelSelection}
                 onChange={setEditModelSelection}
                 workspaceId={workspaceId}
+                disabled={!canEdit}
               />
               <p className="mt-1 text-[11px] text-muted-foreground">
                 Used to evaluate each trace for this detector.
@@ -257,6 +269,7 @@ export function DetectorPanel({
                 id="edit-enable-rca"
                 checked={editEnableRca}
                 onCheckedChange={setEditEnableRca}
+                disabled={!canEdit}
               />
             </div>
           </div>
@@ -271,15 +284,21 @@ export function DetectorPanel({
             <textarea
               value={editPrompt}
               onChange={(e) => setEditPrompt(e.target.value)}
+              disabled={!canEdit}
               rows={10}
-              className="resize-vertical w-full border border-input bg-background px-3 py-2 font-mono text-[12px] leading-relaxed focus:outline-none focus:ring-1 focus:ring-ring"
+              className="resize-vertical w-full border border-input bg-background px-3 py-2 font-mono text-[12px] leading-relaxed focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
             />
           </div>
         </div>
 
         {/* Filter */}
         <div className="border border-border">
-          <TriggerEditor conditions={editConditions} onChange={setEditConditions} asCard />
+          <TriggerEditor
+            conditions={editConditions}
+            onChange={setEditConditions}
+            readOnly={!canEdit}
+            asCard
+          />
         </div>
 
         {/* Sampling */}
@@ -294,7 +313,8 @@ export function DetectorPanel({
               max={100}
               value={editSampleRate}
               onChange={(e) => setEditSampleRate(Number(e.target.value))}
-              className="flex-1 cursor-pointer accent-foreground"
+              disabled={!canEdit}
+              className="flex-1 cursor-pointer accent-foreground disabled:cursor-not-allowed disabled:opacity-50"
             />
             <span className="w-12 shrink-0 text-right text-[13px] tabular-nums text-muted-foreground">
               {editSampleRate}%
@@ -303,6 +323,12 @@ export function DetectorPanel({
         </div>
 
         {/* Save / Cancel */}
+        {updateMutation.isError && (
+          <p role="alert" className="text-[12px] text-destructive">
+            {updateMutation.error.message}
+          </p>
+        )}
+
         <div className="flex justify-end gap-2 pt-1">
           <Button variant="outline" size="sm" onClick={onClose} className="h-7 text-[12px]">
             Cancel
@@ -310,7 +336,9 @@ export function DetectorPanel({
           <Button
             size="sm"
             onClick={handleSave}
-            disabled={updateMutation.isPending || !detector || detector.id !== detectorId}
+            disabled={
+              updateMutation.isPending || !detector || detector.id !== detectorId || !canEdit
+            }
             className="h-7 text-[12px]"
           >
             {updateMutation.isPending ? "Saving..." : "Save"}

--- a/frontend/ui/src/features/detectors/components/rca-toggle.test.tsx
+++ b/frontend/ui/src/features/detectors/components/rca-toggle.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { RcaToggle } from "./rca-toggle";
+
+afterEach(() => cleanup());
+
+describe("RcaToggle", () => {
+  it("disables the switch when the detector form is read-only", () => {
+    const onCheckedChange = vi.fn();
+
+    render(
+      <RcaToggle id="detector-rca" checked={true} onCheckedChange={onCheckedChange} disabled />,
+    );
+
+    const toggle = screen.getByRole("switch");
+    expect((toggle as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(toggle);
+    expect(onCheckedChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/features/detectors/components/rca-toggle.tsx
+++ b/frontend/ui/src/features/detectors/components/rca-toggle.tsx
@@ -7,13 +7,14 @@ interface RcaToggleProps {
   id: string;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
 }
 
 /**
  * Per-detector "run root cause analysis" toggle. Shared by the create form and
  * the edit panel so the label, copy, and layout stay in one place.
  */
-export function RcaToggle({ id, checked, onCheckedChange }: RcaToggleProps) {
+export function RcaToggle({ id, checked, onCheckedChange, disabled }: RcaToggleProps) {
   return (
     <div className="mt-3 flex flex-col gap-2">
       <label htmlFor={id} className="cursor-pointer text-[11px] text-muted-foreground">
@@ -21,7 +22,7 @@ export function RcaToggle({ id, checked, onCheckedChange }: RcaToggleProps) {
         <br />
         Uses the agent model when this detector fires. Turn off to reduce cost.
       </label>
-      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
+      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} disabled={disabled} />
     </div>
   );
 }

--- a/frontend/ui/src/features/detectors/components/trigger-editor.test.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.test.tsx
@@ -1,0 +1,35 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { TriggerEditor } from "./trigger-editor";
+
+afterEach(() => cleanup());
+
+describe("TriggerEditor", () => {
+  it("prevents condition edits when rendered read-only", () => {
+    const onChange = vi.fn();
+
+    render(
+      <TriggerEditor
+        conditions={[{ field: "environment", op: "=", value: "production" }]}
+        onChange={onChange}
+        readOnly
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /add condition/i })).toBeNull();
+
+    const valueInput = screen.getByDisplayValue("production") as HTMLInputElement;
+    expect(valueInput.disabled).toBe(true);
+
+    fireEvent.change(valueInput, { target: { value: "staging" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("hides card-mode add controls when read-only", () => {
+    render(<TriggerEditor conditions={[]} readOnly asCard />);
+
+    expect(screen.getByText("Runs on all completed traces.")).toBeDefined();
+    expect(screen.queryByRole("button", { name: /add condition/i })).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/detectors/components/trigger-editor.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.tsx
@@ -72,6 +72,7 @@ export function TriggerEditor({
   }, [initialConditions]);
 
   const update = (next: TriggerCondition[]) => {
+    if (readOnly) return;
     setConditions(next);
     if (onChange) {
       onChange(next);
@@ -108,14 +109,18 @@ export function TriggerEditor({
   };
 
   const conditionRows = (
-    <div className={`space-y-1.5 ${readOnly ? "pointer-events-none opacity-60" : ""}`}>
+    <div className={`space-y-1.5 ${readOnly ? "opacity-60" : ""}`}>
       {conditions.map((cond, i) => {
         const fieldDef = FIELD_DEFS.find((d) => d.field === cond.field) ?? FIELD_DEFS[0];
         return (
           <div key={i} className="flex items-center gap-1.5">
             {/* Field */}
-            <Select value={cond.field} onValueChange={(val) => updateCondition(i, { field: val })}>
-              <SelectTrigger className="h-7 w-[120px] shrink-0 text-[12px]">
+            <Select
+              value={cond.field}
+              onValueChange={(val) => updateCondition(i, { field: val })}
+              disabled={readOnly}
+            >
+              <SelectTrigger disabled={readOnly} className="h-7 w-[120px] shrink-0 text-[12px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -128,8 +133,12 @@ export function TriggerEditor({
             </Select>
 
             {/* Op */}
-            <Select value={cond.op} onValueChange={(val) => updateCondition(i, { op: val })}>
-              <SelectTrigger className="h-7 w-14 shrink-0 text-[12px]">
+            <Select
+              value={cond.op}
+              onValueChange={(val) => updateCondition(i, { op: val })}
+              disabled={readOnly}
+            >
+              <SelectTrigger disabled={readOnly} className="h-7 w-14 shrink-0 text-[12px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -146,8 +155,9 @@ export function TriggerEditor({
               <Select
                 value={cond.value as string}
                 onValueChange={(val) => updateCondition(i, { value: val })}
+                disabled={readOnly}
               >
-                <SelectTrigger className="h-7 flex-1 text-[12px]">
+                <SelectTrigger disabled={readOnly} className="h-7 flex-1 text-[12px]">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -163,6 +173,7 @@ export function TriggerEditor({
                 value={cond.value as string}
                 onChange={(e) => updateCondition(i, { value: e.target.value })}
                 placeholder="Enter value..."
+                disabled={readOnly}
                 className="h-7 flex-1 text-[12px]"
               />
             )}

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.test.tsx
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { afterEach, describe, expect, it, vi, type Mock, type MockInstance } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
@@ -38,6 +38,14 @@ function setup() {
   return { wrapper, invalidateSpy };
 }
 
+function failNextFetch(message: string) {
+  (globalThis.fetch as unknown as Mock).mockResolvedValueOnce({
+    ok: false,
+    status: 403,
+    json: async () => ({ error: message }),
+  });
+}
+
 const expectNotified = (invalidateSpy: MockInstance) => {
   expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["detectors"] });
   expect(FakeBroadcastChannel.posted).toEqual([{ type: "invalidate", queryKey: ["detectors"] }]);
@@ -66,5 +74,40 @@ describe("detector mutations notify other tabs on success", () => {
     result.current.mutate("det-1");
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expectNotified(invalidateSpy);
+  });
+});
+
+describe("detector mutations surface API permission errors", () => {
+  it("create: uses the API error message", async () => {
+    const { wrapper } = setup();
+    failNextFetch("Requires MEMBER role or higher");
+    const { result } = renderHook(() => useCreateDetector("proj-1"), { wrapper });
+
+    result.current.mutate({ name: "n", template: "t", prompt: "p", outputSchema: [] });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("Requires MEMBER role or higher");
+  });
+
+  it("update: uses the API error message", async () => {
+    const { wrapper } = setup();
+    failNextFetch("Requires MEMBER role or higher");
+    const { result } = renderHook(() => useUpdateDetector("proj-1", "det-1"), { wrapper });
+
+    result.current.mutate({ enableRca: false });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("Requires MEMBER role or higher");
+  });
+
+  it("delete: uses the API error message", async () => {
+    const { wrapper } = setup();
+    failNextFetch("Requires ADMIN role or higher");
+    const { result } = renderHook(() => useDeleteDetector("proj-1"), { wrapper });
+
+    result.current.mutate("det-1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("Requires ADMIN role or higher");
   });
 });

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.ts
@@ -77,7 +77,7 @@ async function createDetector(projectId: string, input: CreateDetectorInput): Pr
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
-  if (!res.ok) throw new Error(`Failed to create detector: ${res.status}`);
+  if (!res.ok) throw new Error(await mutationErrorMessage(res, "Failed to create detector"));
   const data = (await res.json()) as { detector: Detector };
   return data.detector;
 }
@@ -103,7 +103,7 @@ async function updateDetector(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
-  if (!res.ok) throw new Error(`Failed to update detector: ${res.status}`);
+  if (!res.ok) throw new Error(await mutationErrorMessage(res, "Failed to update detector"));
   const data = (await res.json()) as { detector: Detector };
   return data.detector;
 }
@@ -112,7 +112,17 @@ async function deleteDetector(projectId: string, detectorId: string): Promise<vo
   const res = await fetch(`/api/projects/${projectId}/detectors/${detectorId}`, {
     method: "DELETE",
   });
-  if (!res.ok) throw new Error(`Failed to delete detector: ${res.status}`);
+  if (!res.ok) throw new Error(await mutationErrorMessage(res, "Failed to delete detector"));
+}
+
+async function mutationErrorMessage(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: unknown };
+    if (typeof body.error === "string" && body.error.trim()) return body.error;
+  } catch {
+    // Fall through to the status-based message when the API body is not JSON.
+  }
+  return `${fallback}: ${res.status}`;
 }
 
 /** List detectors for the list page (paginated, optional search). */


### PR DESCRIPTION
Related to #1364

## Summary

Detector write endpoints only required project membership, so a `VIEWER` could create, edit, or delete detectors. That could trigger paid detector/RCA work or disable project detection despite viewer-only access, and the UI still presented detector mutation controls to viewers.

This PR applies the same role policy used by API-key writes: detector create/update now require `MEMBER`, detector delete requires `ADMIN`, and detector read routes continue to allow ordinary project access. The detector UI now hides or disables mutation affordances for roles that cannot use them, while still relying on the API as the security boundary. It intentionally fixes only the authorization portion of #1364; trigger-condition validation is unchanged and remains a separate follow-up.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify src or test files
- [ ] revert - Reverts a previous commit
- [x] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Import `Role` in detector route handlers.
- Require `Role.MEMBER` for detector `POST` and `PATCH`.
- Require `Role.ADMIN` for detector `DELETE`.
- Leave detector list/detail `GET` routes at project-access-only so viewers can still read detectors.
- Hide detector create/edit actions from viewers and hide delete actions from non-admins.
- Block direct access to the new-detector form until workspace role data proves `MEMBER` or `ADMIN` access.
- Disable detector panel edit controls and save handling when a caller marks the panel read-only.
- Render detector create/update/delete API permission messages where the user takes the action.
- Allow the shared model selector and RCA toggle controls to render disabled in read-only detector forms.
- Make read-only trigger filters keyboard-inert instead of only mouse-inert.
- Surface API permission messages from detector create/update/delete hooks instead of generic `403` status text.
- Add route-level, hook-level, and page/component regression tests for role gating, denied-access short-circuit behavior, and permission messages.
- Leave trigger-condition validation unchanged; this PR is limited to the authorization boundary.

## Screenshots / Recordings (if applicable)

Not applicable; this is an API and role-affordance authorization fix.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (not applicable; role affordances are covered by component tests)
- [x] I have updated documentation where necessary

## Tests

Commands run:

- `pnpm exec vitest run 'src/app/api/projects/[projectId]/detectors/route.test.ts' 'src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts' 'src/app/projects/[projectId]/detectors/page.test.tsx' 'src/app/projects/[projectId]/detectors/new/page.test.tsx' 'src/features/detectors/components/detector-panel.test.tsx' 'src/features/detectors/components/delete-detector-dialog.test.tsx' 'src/features/detectors/hooks/use-detectors.test.tsx'` from `frontend/ui` — passed (`7 files, 35 tests`)
- `pnpm exec prettier --check 'ui/src/app/api/projects/[projectId]/detectors/route.ts' 'ui/src/app/api/projects/[projectId]/detectors/route.test.ts' 'ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts' 'ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts' 'ui/src/app/projects/[projectId]/detectors/page.tsx' 'ui/src/app/projects/[projectId]/detectors/page.test.tsx' 'ui/src/app/projects/[projectId]/detectors/new/page.tsx' 'ui/src/app/projects/[projectId]/detectors/new/page.test.tsx' 'ui/src/features/detectors/components/detector-panel.tsx' 'ui/src/features/detectors/components/detector-panel.test.tsx' 'ui/src/features/detectors/components/delete-detector-dialog.tsx' 'ui/src/features/detectors/components/delete-detector-dialog.test.tsx' 'ui/src/features/detectors/components/rca-toggle.tsx' 'ui/src/features/detectors/components/trigger-editor.tsx' 'ui/src/features/detectors/hooks/use-detectors.ts' 'ui/src/features/detectors/hooks/use-detectors.test.tsx' 'ui/src/features/ai-assistant/components/model-selector.tsx'` from `frontend` — passed
- `pnpm exec eslint 'ui/src/app/api/projects/[projectId]/detectors/route.ts' 'ui/src/app/api/projects/[projectId]/detectors/route.test.ts' 'ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts' 'ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts' 'ui/src/app/projects/[projectId]/detectors/page.tsx' 'ui/src/app/projects/[projectId]/detectors/page.test.tsx' 'ui/src/app/projects/[projectId]/detectors/new/page.tsx' 'ui/src/app/projects/[projectId]/detectors/new/page.test.tsx' 'ui/src/features/detectors/components/detector-panel.tsx' 'ui/src/features/detectors/components/detector-panel.test.tsx' 'ui/src/features/detectors/components/delete-detector-dialog.tsx' 'ui/src/features/detectors/components/delete-detector-dialog.test.tsx' 'ui/src/features/detectors/components/rca-toggle.tsx' 'ui/src/features/detectors/components/trigger-editor.tsx' 'ui/src/features/detectors/hooks/use-detectors.ts' 'ui/src/features/detectors/hooks/use-detectors.test.tsx' 'ui/src/features/ai-assistant/components/model-selector.tsx'` from `frontend` — passed
- `git diff --check` — passed

Additional broader checks:

- `pnpm exec vitest run` from `frontend/ui` — failed only in `src/components/layout/GitHubStarWidget.test.tsx` because `localStorage.clear is not a function`; summary was `1 failed | 68 passed` files and `4 failed | 379 passed` tests. Detector route/UI/hook tests passed in that full run.
- `pnpm --filter traceroot-ui exec tsc --noEmit` from `frontend` — failed on pre-existing unrelated errors in `src/__tests__/next-config.test.ts` and `src/app/api/projects/__tests__/route.test.ts`; no error referenced detector route files.

## Risk

Risk level: low to medium.

This intentionally changes detector mutation authorization and matching UI affordances. Existing `VIEWER` users keep detector read access, while write operations now follow the same role model as API-key mutations. Rollback is a single-commit revert of the route role arguments, UI affordance checks, and regression tests.

## Notes for maintainers

Issue #1364 also describes trigger-condition validation. That is intentionally left out so this PR stays focused on the authorization boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require `MEMBER` for detector create/update and `ADMIN` for delete, and hide/disable UI actions for roles without write access. Read endpoints stay open to project viewers, and the UI shows clear permission states and API error messages.

- **Bug Fixes**
  - API: enforce roles on detector `POST`/`PATCH` (`MEMBER`) and `DELETE` (`ADMIN`) using `Role` from `@traceroot/core`; `GET` list/detail routes remain project-access only.
  - UI: gate New Detector by workspace role with loading/error states; hide New and the Actions column for viewers; show Edit to members and Delete to admins; pass `canEdit` into the edit panel to disable inputs and show a read-only note; prevent disabled selectors/popovers from opening or auto-selecting (including `ModelSelector`, `RcaToggle`, `TriggerEditor`); reset mutation state before submit/confirm.
  - Errors: mutation hooks parse API bodies and surface permission messages; create/edit forms and the delete dialog display these messages.
  - Tests: add coverage for API role checks and open reads, route/page role gating, inert read-only controls, disabled popovers, and permission error rendering.
  - Note: addresses the authorization part of #1364 only; trigger-condition validation will be handled separately.

<sup>Written for commit 197d0a2637163e79912fb7a577ee47b4bdee8cf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

