### PR TITLE
fix(detectors): validate trigger condition payloads

### DIFF
--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -15,9 +15,26 @@ import asyncio
 import hashlib
 import json
 import logging
+import time
 import uuid
+from collections import OrderedDict
+from collections.abc import Mapping
 
 logger = logging.getLogger(__name__)
+_MISSING = object()
+_LEGACY_TRIGGER_OPERATORS = {
+    "eq": "=",
+    "ne": "!=",
+    "neq": "!=",
+    "gt": ">",
+    "gte": ">=",
+    "lt": "<",
+    "lte": "<=",
+}
+_UNSUPPORTED_TRIGGER_WARNING_LIMIT = 1024
+_UNSUPPORTED_TRIGGER_WARNING_TTL_SECONDS = 3600
+_UNSUPPORTED_TRIGGER_WARNING_IDS: OrderedDict[tuple[str, str], tuple[str, float]] = OrderedDict()
+_UNSUPPORTED_TRIGGER_WARNING_SUPPRESSED_PROJECTS: OrderedDict[str, float] = OrderedDict()
 
 # BullMQ queue name — must match TypeScript DETECTOR_RUN_QUEUE constant
 DETECTOR_RUN_QUEUE = "detector-run"
@@ -165,35 +182,157 @@ def _add_bullmq_job(job_id: str, data: dict) -> None:
     asyncio.run(_add())
 
 
-def _eval_condition(trace_summary: dict, condition: dict) -> bool:
-    """Evaluate a single trigger condition against a trace summary dict."""
+def _is_environment_value(value: object) -> bool:
+    return value is None or isinstance(value, str)
+
+
+def _is_evaluable_trigger_condition(condition: object) -> bool:
+    if not isinstance(condition, Mapping):
+        return False
+
     field = condition.get("field")
-    op = condition.get("op")
+    raw_op = condition.get("op")
     value = condition.get("value")
+    if not isinstance(field, str) or not isinstance(raw_op, str) or "value" not in condition:
+        return False
 
-    actual = trace_summary.get(field)
-    # For != conditions, a missing/null field counts as "not equal"
-    if actual is None:
-        return op == "!="
+    op = _LEGACY_TRIGGER_OPERATORS.get(raw_op, raw_op)
+    return field == "environment" and op in {"=", "!="} and _is_environment_value(value)
 
+
+def _has_unsupported_trigger_conditions(conditions: list[object]) -> bool:
+    return any(not _is_evaluable_trigger_condition(condition) for condition in conditions)
+
+
+def _unsupported_trigger_warning_fingerprint(trigger_conditions: list[object]) -> str:
+    encoded = json.dumps(trigger_conditions, sort_keys=True, separators=(",", ":"), default=repr)
+    return hashlib.sha256(encoded.encode()).hexdigest()
+
+
+def _clear_unsupported_trigger_warning_seen(project_id: str, detector_id: str) -> None:
+    _UNSUPPORTED_TRIGGER_WARNING_IDS.pop((project_id, detector_id), None)
+
+
+def _clear_inactive_unsupported_trigger_warnings(
+    project_id: str, active_detector_ids: set[str]
+) -> None:
+    for key in list(_UNSUPPORTED_TRIGGER_WARNING_IDS):
+        if key[0] == project_id and key[1] not in active_detector_ids:
+            del _UNSUPPORTED_TRIGGER_WARNING_IDS[key]
+
+
+def _drop_expired_unsupported_trigger_warnings(now: float) -> None:
+    for key, (_fingerprint, seen_at) in list(_UNSUPPORTED_TRIGGER_WARNING_IDS.items()):
+        if now - seen_at >= _UNSUPPORTED_TRIGGER_WARNING_TTL_SECONDS:
+            del _UNSUPPORTED_TRIGGER_WARNING_IDS[key]
+
+
+def _drop_expired_unsupported_trigger_warning_suppressions(now: float) -> None:
+    for project_id, seen_at in list(_UNSUPPORTED_TRIGGER_WARNING_SUPPRESSED_PROJECTS.items()):
+        if now - seen_at >= _UNSUPPORTED_TRIGGER_WARNING_TTL_SECONDS:
+            del _UNSUPPORTED_TRIGGER_WARNING_SUPPRESSED_PROJECTS[project_id]
+
+
+def _mark_unsupported_trigger_warning_seen(
+    project_id: str, detector_id: str, trigger_conditions: list[object]
+) -> bool:
+    now = time.monotonic()
+    key = (project_id, detector_id)
+    existing = _UNSUPPORTED_TRIGGER_WARNING_IDS.get(key)
+
+    if existing is None:
+        _drop_expired_unsupported_trigger_warnings(now)
+        if len(_UNSUPPORTED_TRIGGER_WARNING_IDS) >= _UNSUPPORTED_TRIGGER_WARNING_LIMIT:
+            return False
+
+    fingerprint = _unsupported_trigger_warning_fingerprint(trigger_conditions)
+    if existing is not None:
+        previous_fingerprint, seen_at = existing
+        if (
+            previous_fingerprint != fingerprint
+            or now - seen_at >= _UNSUPPORTED_TRIGGER_WARNING_TTL_SECONDS
+        ):
+            _UNSUPPORTED_TRIGGER_WARNING_IDS[key] = (fingerprint, now)
+            _UNSUPPORTED_TRIGGER_WARNING_IDS.move_to_end(key)
+            return True
+        _UNSUPPORTED_TRIGGER_WARNING_IDS.move_to_end(key)
+        return False
+
+    _UNSUPPORTED_TRIGGER_WARNING_IDS[key] = (fingerprint, now)
+    return True
+
+
+def _mark_unsupported_trigger_warning_suppression_seen(project_id: str) -> bool:
+    now = time.monotonic()
+    _drop_expired_unsupported_trigger_warning_suppressions(now)
+
+    existing = _UNSUPPORTED_TRIGGER_WARNING_SUPPRESSED_PROJECTS.get(project_id)
+    if existing is not None and now - existing < _UNSUPPORTED_TRIGGER_WARNING_TTL_SECONDS:
+        _UNSUPPORTED_TRIGGER_WARNING_SUPPRESSED_PROJECTS.move_to_end(project_id)
+        return False
+
+    _UNSUPPORTED_TRIGGER_WARNING_SUPPRESSED_PROJECTS[project_id] = now
+    if len(_UNSUPPORTED_TRIGGER_WARNING_SUPPRESSED_PROJECTS) > _UNSUPPORTED_TRIGGER_WARNING_LIMIT:
+        _UNSUPPORTED_TRIGGER_WARNING_SUPPRESSED_PROJECTS.popitem(last=False)
+    return True
+
+
+def _is_unsupported_trigger_warning_suppressed(project_id: str, detector_id: str) -> bool:
+    return (project_id, detector_id) not in _UNSUPPORTED_TRIGGER_WARNING_IDS and len(
+        _UNSUPPORTED_TRIGGER_WARNING_IDS
+    ) >= _UNSUPPORTED_TRIGGER_WARNING_LIMIT
+
+
+def _eval_condition(trace_summary: Mapping[str, object], condition: object) -> bool:
+    """Evaluate a single trigger condition against a trace summary dict."""
+    if not isinstance(condition, Mapping):
+        return False
+
+    field = condition.get("field")
+    raw_op = condition.get("op")
+    value = condition.get("value")
+    if not isinstance(field, str) or not isinstance(raw_op, str):
+        return False
+    if "value" not in condition:
+        return False
+    op = _LEGACY_TRIGGER_OPERATORS.get(raw_op, raw_op)
+
+    actual = trace_summary.get(field, _MISSING)
+    if actual is _MISSING:
+        return False
+
+    if (
+        field != "environment"
+        or not _is_environment_value(actual)
+        or not _is_environment_value(value)
+    ):
+        return False
+    if op not in {"=", "!="}:
+        return False
     if op == "=":
         return actual == value
-    elif op == "!=":
-        return actual != value
-    elif op == ">":
-        return float(actual) > float(value)
-    elif op == ">=":
-        return float(actual) >= float(value)
-    elif op == "<":
-        return float(actual) < float(value)
-    elif op == "<=":
-        return float(actual) <= float(value)
-    return False
+    return actual != value
 
 
-def _passes_trigger(trace_summary: dict, conditions: list[dict]) -> bool:
+def _passes_trigger(trace_summary: Mapping[str, object], conditions: list[object]) -> bool:
     """All conditions must pass (AND logic). Empty conditions list = always passes."""
     return all(_eval_condition(trace_summary, c) for c in conditions)
+
+
+def _coerce_trigger_conditions(conditions: object, *, has_trigger: bool = False) -> list[object]:
+    if conditions is None:
+        return [None] if has_trigger else []
+    if isinstance(conditions, list):
+        return conditions
+    if isinstance(conditions, str):
+        try:
+            parsed = json.loads(conditions)
+        except json.JSONDecodeError:
+            return [None]
+        if parsed is None:
+            return [None]
+        return parsed if isinstance(parsed, list) else [None]
+    return [None]
 
 
 def _get_trace_summaries(project_id: str, trace_ids: list[str]) -> dict[str, dict]:
@@ -243,7 +382,7 @@ def _get_active_detectors(project_id: str) -> list[dict]:
         with conn.cursor() as cur:
             cur.execute(
                 """
-                SELECT d.id, d.sample_rate, dt.conditions
+                SELECT d.id, d.sample_rate, dt.id IS NOT NULL AS has_trigger, dt.conditions
                 FROM detectors d
                 LEFT JOIN detector_triggers dt ON dt.detector_id = d.id
                 WHERE d.project_id = %s AND d.enabled = TRUE
@@ -254,24 +393,40 @@ def _get_active_detectors(project_id: str) -> list[dict]:
     finally:
         conn.close()
 
-    detectors = []
-    for detector_id, sample_rate, conditions in rows:
-        # conditions is a JSON field; psycopg2 may return dict or None
-        if conditions is None:
-            cond_list = []
-        elif isinstance(conditions, list):
-            cond_list = conditions
-        elif isinstance(conditions, str):
-            cond_list = json.loads(conditions)
-        else:
-            # Already parsed by psycopg2 (dict/list from JSONB)
-            cond_list = conditions if isinstance(conditions, list) else []
+    active_detector_ids = {row[0] for row in rows}
+    _clear_inactive_unsupported_trigger_warnings(project_id, active_detector_ids)
 
+    detectors = []
+    for detector_id, sample_rate, has_trigger, conditions in rows:
+        trigger_conditions = _coerce_trigger_conditions(conditions, has_trigger=has_trigger)
+        if has_trigger:
+            if _has_unsupported_trigger_conditions(trigger_conditions):
+                if _mark_unsupported_trigger_warning_seen(
+                    project_id, detector_id, trigger_conditions
+                ):
+                    logger.warning(
+                        "Detector %s in project %s has unsupported or malformed trigger conditions; "
+                        "unsupported conditions will not match",
+                        detector_id,
+                        project_id,
+                    )
+                elif _is_unsupported_trigger_warning_suppressed(
+                    project_id, detector_id
+                ) and _mark_unsupported_trigger_warning_suppression_seen(project_id):
+                    logger.warning(
+                        "Detector trigger warning cache for project %s reached capacity; "
+                        "additional trigger-condition warnings are suppressed",
+                        project_id,
+                    )
+            else:
+                _clear_unsupported_trigger_warning_seen(project_id, detector_id)
+        else:
+            _clear_unsupported_trigger_warning_seen(project_id, detector_id)
         detectors.append(
             {
                 "id": detector_id,
                 "sample_rate": sample_rate,
-                "conditions": cond_list,
+                "conditions": trigger_conditions,
             }
         )
     return detectors
@@ -383,10 +538,9 @@ def enqueue_detector_runs(project_id: str, traces_with_root: set[str]) -> None:
         detectors = _get_active_detectors(project_id)
         summaries = _get_trace_summaries(project_id, root_traces) if detectors else {}
         for trace_id in root_traces:
-            # Per-trace try/except so a malformed condition (e.g. non-numeric
-            # `value` for a `>` op causing float() to ValueError, or a None
-            # sample_rate) only drops the offending trace — remaining traces
-            # in the batch still get enqueued.
+            # Per-trace try/except so unexpected detector data or enqueue failures
+            # only drop the offending trace — remaining traces in the batch still
+            # get enqueued.
             try:
                 _claim_and_enqueue(
                     redis_client,

--- a/backend/worker/tests/test_detector_tasks.py
+++ b/backend/worker/tests/test_detector_tasks.py
@@ -33,11 +33,11 @@ def test_eval_condition_not_equal_operator_fail():
     assert _eval_condition(trace_summary, condition) is False
 
 
-def test_eval_condition_greater_than():
-    """Test greater than operator (>)."""
+def test_eval_condition_greater_than_unsupported_field():
+    """Numeric fields are not evaluated until summaries include them."""
     trace_summary = {"cost": 100.5}
     condition = {"field": "cost", "op": ">", "value": 50.0}
-    assert _eval_condition(trace_summary, condition) is True
+    assert _eval_condition(trace_summary, condition) is False
 
 
 def test_eval_condition_greater_than_fail():
@@ -47,11 +47,11 @@ def test_eval_condition_greater_than_fail():
     assert _eval_condition(trace_summary, condition) is False
 
 
-def test_eval_condition_greater_than_or_equal():
-    """Test greater than or equal operator (>=)."""
+def test_eval_condition_greater_than_or_equal_unsupported_field():
+    """Numeric fields are not evaluated until summaries include them."""
     trace_summary = {"cost": 50.0}
     condition = {"field": "cost", "op": ">=", "value": 50.0}
-    assert _eval_condition(trace_summary, condition) is True
+    assert _eval_condition(trace_summary, condition) is False
 
 
 def test_eval_condition_greater_than_or_equal_fail():
@@ -61,11 +61,11 @@ def test_eval_condition_greater_than_or_equal_fail():
     assert _eval_condition(trace_summary, condition) is False
 
 
-def test_eval_condition_less_than():
-    """Test less than operator (<)."""
+def test_eval_condition_less_than_unsupported_field():
+    """Numeric fields are not evaluated until summaries include them."""
     trace_summary = {"tokens": 500}
     condition = {"field": "tokens", "op": "<", "value": 1000}
-    assert _eval_condition(trace_summary, condition) is True
+    assert _eval_condition(trace_summary, condition) is False
 
 
 def test_eval_condition_less_than_fail():
@@ -75,11 +75,11 @@ def test_eval_condition_less_than_fail():
     assert _eval_condition(trace_summary, condition) is False
 
 
-def test_eval_condition_less_than_or_equal():
-    """Test less than or equal operator (<=)."""
+def test_eval_condition_less_than_or_equal_unsupported_field():
+    """Numeric fields are not evaluated until summaries include them."""
     trace_summary = {"tokens": 1000}
     condition = {"field": "tokens", "op": "<=", "value": 1000}
-    assert _eval_condition(trace_summary, condition) is True
+    assert _eval_condition(trace_summary, condition) is False
 
 
 def test_eval_condition_less_than_or_equal_fail():
@@ -104,10 +104,10 @@ def test_eval_condition_unknown_operator():
 
 
 def test_eval_condition_numeric_strings_in_comparisons():
-    """Numeric operators convert string values correctly."""
+    """Numeric fields are not evaluated until summaries include them."""
     trace_summary = {"cost": "100.5"}
     condition = {"field": "cost", "op": ">", "value": "50.0"}
-    assert _eval_condition(trace_summary, condition) is True
+    assert _eval_condition(trace_summary, condition) is False
 
 
 # ── Tests for _passes_trigger ──────────────────────────────────────
@@ -122,12 +122,8 @@ def test_passes_trigger_empty_conditions():
 
 def test_passes_trigger_all_conditions_pass():
     """All conditions pass returns True."""
-    trace_summary = {"environment": "production", "cost": 100.0, "tokens": 5000}
-    conditions = [
-        {"field": "environment", "op": "=", "value": "production"},
-        {"field": "cost", "op": ">", "value": 50.0},
-        {"field": "tokens", "op": ">=", "value": 5000},
-    ]
+    trace_summary = {"environment": "production"}
+    conditions = [{"field": "environment", "op": "=", "value": "production"}]
     assert _passes_trigger(trace_summary, conditions) is True
 
 
@@ -159,8 +155,8 @@ def test_passes_trigger_legacy_status_condition_is_inert():
     assert _passes_trigger(trace_summary, conditions) is False
 
 
-def test_passes_trigger_single_condition_passes():
-    """Single condition that passes returns True."""
+def test_passes_trigger_numeric_field_is_inert():
+    """Numeric fields are not evaluated until summaries include them."""
     trace_summary = {"cost": 100.0}
     conditions = [{"field": "cost", "op": ">", "value": 50.0}]
-    assert _passes_trigger(trace_summary, conditions) is True
+    assert _passes_trigger(trace_summary, conditions) is False

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({ NextRequest: class {} }));
+
+const detectorFindFirstMock = vi.fn();
+const detectorUpdateMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    detector: {
+      findFirst: (...args: unknown[]) => detectorFindFirstMock(...args),
+      update: (...args: unknown[]) => detectorUpdateMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({
+    status,
+    json: async () => data,
+  }),
+}));
+
+import { PATCH } from "./route";
+
+function makeRequest(body: unknown) {
+  return { json: async () => body } as unknown as Parameters<typeof PATCH>[0];
+}
+
+function makeParams() {
+  return { params: Promise.resolve({ projectId: "proj-1", detectorId: "det-1" }) };
+}
+
+beforeEach(() => {
+  detectorFindFirstMock.mockReset();
+  detectorUpdateMock.mockReset();
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+  detectorFindFirstMock.mockResolvedValue({ id: "det-1" });
+  detectorUpdateMock.mockResolvedValue({ id: "det-1" });
+});
+
+describe("PATCH .../detectors/[detectorId] — triggerConditions validation", () => {
+  it("upserts valid trigger conditions", async () => {
+    const triggerConditions = [
+      { field: "environment", op: "ne", value: "staging" },
+      { field: "environment", op: "=", value: "production" },
+      { field: "environment", op: "=", value: null },
+    ];
+
+    const res = await PATCH(makeRequest({ triggerConditions }), makeParams());
+
+    expect(res.status).toBe(200);
+    expect(detectorUpdateMock).toHaveBeenCalledTimes(1);
+    expect(detectorUpdateMock.mock.calls[0][0].data.trigger.upsert).toEqual({
+      create: {
+        conditions: [
+          { field: "environment", op: "!=", value: "staging" },
+          { field: "environment", op: "=", value: "production" },
+          { field: "environment", op: "=", value: null },
+        ],
+      },
+      update: {
+        conditions: [
+          { field: "environment", op: "!=", value: "staging" },
+          { field: "environment", op: "=", value: "production" },
+          { field: "environment", op: "=", value: null },
+        ],
+      },
+    });
+  });
+
+  it.each([null, [], "not-an-object"])("rejects non-object JSON body %s", async (body) => {
+    const res = await PATCH(makeRequest(body), makeParams());
+
+    expect(res.status).toBe(400);
+    expect(detectorUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores inherited top-level trigger conditions", async () => {
+    const body = Object.create({
+      triggerConditions: [{ field: "environment", op: ">", value: 10 }],
+    });
+
+    const res = await PATCH(makeRequest(body), makeParams());
+
+    expect(res.status).toBe(200);
+    expect(detectorUpdateMock).toHaveBeenCalledTimes(1);
+    expect(detectorUpdateMock.mock.calls[0][0].data.trigger).toBeUndefined();
+  });
+
+  it.each([
+    ["null", { triggerConditions: null }],
+    ["non-array", { triggerConditions: { field: "environment", op: "=", value: "prod" } }],
+    ["non-object entry", { triggerConditions: [null] }],
+    ["blank field", { triggerConditions: [{ field: "", op: "=", value: "prod" }] }],
+    ["unsupported field", { triggerConditions: [{ field: "duration", op: "<=", value: 1000 }] }],
+    [
+      "unsupported field operator",
+      { triggerConditions: [{ field: "environment", op: "<=", value: 1000 }] },
+    ],
+    ["missing value", { triggerConditions: [{ field: "environment", op: "=" }] }],
+    [
+      "unsupported operator",
+      { triggerConditions: [{ field: "environment", op: "contains", value: "prod" }] },
+    ],
+    [
+      "non-scalar value",
+      { triggerConditions: [{ field: "environment", op: "=", value: ["prod"] }] },
+    ],
+    [
+      "unsupported numeric field",
+      { triggerConditions: [{ field: "duration", op: ">=", value: "slow" }] },
+    ],
+    [
+      "prototype field __proto__",
+      { triggerConditions: [{ field: "__proto__", op: "=", value: "prod" }] },
+    ],
+    [
+      "prototype field constructor",
+      { triggerConditions: [{ field: "constructor", op: "=", value: "prod" }] },
+    ],
+    [
+      "prototype field toString",
+      { triggerConditions: [{ field: "toString", op: "=", value: "prod" }] },
+    ],
+  ])("rejects %s trigger conditions", async (_label, body) => {
+    const res = await PATCH(makeRequest(body), makeParams());
+
+    expect(res.status).toBe(400);
+    expect(detectorUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a field-specific operator error", async () => {
+    const res = await PATCH(
+      makeRequest({
+        triggerConditions: [{ field: "environment", op: "contains", value: "production" }],
+      }),
+      makeParams(),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "triggerConditions[0].op must be one of =, != for environment",
+    });
+    expect(detectorUpdateMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/[detectorId]/route.ts
@@ -6,6 +6,7 @@ import {
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
+import { hasOwn, normalizeTriggerConditions } from "../trigger-validation";
 
 type RouteParams = { params: Promise<{ projectId: string; detectorId: string }> };
 
@@ -56,19 +57,25 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     return errorResponse("Invalid JSON", 400);
   }
 
-  const {
-    name,
-    template: _template,
-    prompt,
-    outputSchema,
-    sampleRate,
-    enabled,
-    enableRca,
-    triggerConditions,
-    detectionModel,
-    detectionProvider,
-    detectionSource,
-  } = body as Record<string, unknown>;
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return errorResponse("Body must be a JSON object", 400);
+  }
+
+  const record = body as Record<string, unknown>;
+  const name = hasOwn(record, "name") ? record.name : undefined;
+  const prompt = hasOwn(record, "prompt") ? record.prompt : undefined;
+  const outputSchema = hasOwn(record, "outputSchema") ? record.outputSchema : undefined;
+  const sampleRate = hasOwn(record, "sampleRate") ? record.sampleRate : undefined;
+  const enabled = hasOwn(record, "enabled") ? record.enabled : undefined;
+  const enableRca = hasOwn(record, "enableRca") ? record.enableRca : undefined;
+  const triggerConditions = hasOwn(record, "triggerConditions")
+    ? record.triggerConditions
+    : undefined;
+  const detectionModel = hasOwn(record, "detectionModel") ? record.detectionModel : undefined;
+  const detectionProvider = hasOwn(record, "detectionProvider")
+    ? record.detectionProvider
+    : undefined;
+  const detectionSource = hasOwn(record, "detectionSource") ? record.detectionSource : undefined;
 
   // Validate types up-front so invalid payloads return 400 instead of crashing
   // Prisma later. `Boolean(enabled)` would coerce strings like "false" to true;
@@ -89,8 +96,11 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
       return errorResponse("sampleRate must be an integer between 0 and 100", 400);
     }
   }
-  if (triggerConditions !== undefined && !Array.isArray(triggerConditions)) {
-    return errorResponse("triggerConditions must be an array", 400);
+  let resolvedTriggerConditions: object[] | undefined;
+  if (triggerConditions !== undefined) {
+    const triggerValidation = normalizeTriggerConditions(triggerConditions);
+    if (triggerValidation.error !== null) return errorResponse(triggerValidation.error, 400);
+    resolvedTriggerConditions = triggerValidation.conditions;
   }
   if (outputSchema !== undefined && !Array.isArray(outputSchema)) {
     return errorResponse("outputSchema must be an array", 400);
@@ -143,12 +153,12 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     where: { id: detectorId },
     data: {
       ...detectorData,
-      ...(triggerConditions !== undefined
+      ...(resolvedTriggerConditions !== undefined
         ? {
             trigger: {
               upsert: {
-                create: { conditions: triggerConditions as object },
-                update: { conditions: triggerConditions as object },
+                create: { conditions: resolvedTriggerConditions },
+                update: { conditions: resolvedTriggerConditions },
               },
             },
           }

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.test.ts
@@ -51,6 +51,14 @@ beforeEach(() => {
 });
 
 describe("POST .../detectors — sampleRate default", () => {
+  it.each([null, [], "not-an-object"])("rejects non-object JSON body %s", async (body) => {
+    const res = await POST(makeRequest(body), makeParams());
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Body must be a JSON object" });
+    expect(detectorCreateMock).not.toHaveBeenCalled();
+  });
+
   it("defaults sampleRate to 25 when omitted", async () => {
     const res = await POST(makeRequest(validBody()), makeParams());
 
@@ -71,5 +79,111 @@ describe("POST .../detectors — sampleRate default", () => {
 
     expect(res.status).toBe(400);
     expect(detectorCreateMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["detectionModel", { detectionModel: 123 }, "detectionModel must be a string"],
+    [
+      "detectionProvider",
+      { detectionProvider: { provider: "openai" } },
+      "detectionProvider must be a string",
+    ],
+  ])("rejects non-string %s values", async (_label, extra, error) => {
+    const res = await POST(makeRequest(validBody(extra)), makeParams());
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error });
+    expect(detectorCreateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST .../detectors — triggerConditions validation", () => {
+  it("stores valid trigger conditions", async () => {
+    const triggerConditions = [
+      { field: "environment", op: "eq", value: "production" },
+      { field: "environment", op: "!=", value: "staging" },
+      { field: "environment", op: "=", value: null },
+    ];
+
+    const res = await POST(makeRequest(validBody({ triggerConditions })), makeParams());
+
+    expect(res.status).toBe(201);
+    expect(detectorCreateMock.mock.calls[0][0].data.trigger.create.conditions).toEqual([
+      { field: "environment", op: "=", value: "production" },
+      { field: "environment", op: "!=", value: "staging" },
+      { field: "environment", op: "=", value: null },
+    ]);
+  });
+
+  it("ignores inherited top-level trigger conditions", async () => {
+    const body = Object.assign(
+      Object.create({
+        triggerConditions: [{ field: "environment", op: ">", value: 10 }],
+      }),
+      validBody(),
+    );
+
+    const res = await POST(makeRequest(body), makeParams());
+
+    expect(res.status).toBe(201);
+    expect(detectorCreateMock.mock.calls[0][0].data.trigger.create.conditions).toEqual([]);
+  });
+
+  it.each([
+    ["null", { triggerConditions: null }],
+    ["non-array", { triggerConditions: { field: "environment", op: "=", value: "prod" } }],
+    ["non-object entry", { triggerConditions: ["environment=prod"] }],
+    ["blank field", { triggerConditions: [{ field: " ", op: "=", value: "prod" }] }],
+    ["unsupported field", { triggerConditions: [{ field: "cost", op: ">", value: "10.5" }] }],
+    [
+      "unsupported field operator",
+      { triggerConditions: [{ field: "environment", op: ">", value: 10 }] },
+    ],
+    ["missing value", { triggerConditions: [{ field: "environment", op: "=" }] }],
+    [
+      "unsupported operator",
+      { triggerConditions: [{ field: "environment", op: "contains", value: "prod" }] },
+    ],
+    [
+      "non-scalar value",
+      { triggerConditions: [{ field: "environment", op: "=", value: { env: "prod" } }] },
+    ],
+    [
+      "unsupported numeric field",
+      { triggerConditions: [{ field: "cost", op: ">", value: "abc" }] },
+    ],
+    [
+      "prototype field __proto__",
+      { triggerConditions: [{ field: "__proto__", op: "=", value: "prod" }] },
+    ],
+    [
+      "prototype field constructor",
+      { triggerConditions: [{ field: "constructor", op: "=", value: "prod" }] },
+    ],
+    [
+      "prototype field toString",
+      { triggerConditions: [{ field: "toString", op: "=", value: "prod" }] },
+    ],
+  ])("rejects %s trigger conditions", async (_label, extra) => {
+    const res = await POST(makeRequest(validBody(extra)), makeParams());
+
+    expect(res.status).toBe(400);
+    expect(detectorCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns a field-specific operator error", async () => {
+    const res = await POST(
+      makeRequest(
+        validBody({
+          triggerConditions: [{ field: "environment", op: "contains", value: "production" }],
+        }),
+      ),
+      makeParams(),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: "triggerConditions[0].op must be one of =, != for environment",
+    });
   });
 });

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/route.ts
@@ -7,6 +7,7 @@ import {
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
+import { hasOwn, normalizeTriggerConditions } from "./trigger-validation";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
@@ -76,18 +77,21 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     return errorResponse("Body must be a JSON object", 400);
   }
 
-  const {
-    name,
-    template,
-    prompt,
-    outputSchema,
-    sampleRate,
-    triggerConditions,
-    detectionModel,
-    detectionProvider,
-    detectionSource,
-    enableRca,
-  } = body as Record<string, unknown>;
+  const record = body as Record<string, unknown>;
+  const name = hasOwn(record, "name") ? record.name : undefined;
+  const template = hasOwn(record, "template") ? record.template : undefined;
+  const prompt = hasOwn(record, "prompt") ? record.prompt : undefined;
+  const outputSchema = hasOwn(record, "outputSchema") ? record.outputSchema : undefined;
+  const sampleRate = hasOwn(record, "sampleRate") ? record.sampleRate : undefined;
+  const triggerConditions = hasOwn(record, "triggerConditions")
+    ? record.triggerConditions
+    : undefined;
+  const detectionModel = hasOwn(record, "detectionModel") ? record.detectionModel : undefined;
+  const detectionProvider = hasOwn(record, "detectionProvider")
+    ? record.detectionProvider
+    : undefined;
+  const detectionSource = hasOwn(record, "detectionSource") ? record.detectionSource : undefined;
+  const enableRca = hasOwn(record, "enableRca") ? record.enableRca : undefined;
 
   // Required fields must be non-empty strings (trim catches whitespace-only).
   if (typeof name !== "string" || name.trim().length === 0) {
@@ -115,14 +119,24 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     resolvedSampleRate = sampleRate;
   }
 
-  // Validate triggerConditions and outputSchema are arrays when provided —
-  // a non-array object would otherwise silently produce an empty list and
-  // cause the detector to fire on every trace.
-  if (triggerConditions !== undefined && !Array.isArray(triggerConditions)) {
-    return errorResponse("triggerConditions must be an array", 400);
+  // Validate and canonicalize triggerConditions before storing them; unsupported
+  // fields or operators would otherwise fail later in the worker on every trace.
+  let resolvedTriggerConditions: object[] = [];
+  if (triggerConditions !== undefined) {
+    const triggerValidation = normalizeTriggerConditions(triggerConditions);
+    if (triggerValidation.error !== null) return errorResponse(triggerValidation.error, 400);
+    resolvedTriggerConditions = triggerValidation.conditions;
   }
   if (outputSchema !== undefined && !Array.isArray(outputSchema)) {
     return errorResponse("outputSchema must be an array", 400);
+  }
+  for (const [key, val] of [
+    ["detectionModel", detectionModel],
+    ["detectionProvider", detectionProvider],
+  ] as const) {
+    if (val !== undefined && val !== null && typeof val !== "string") {
+      return errorResponse(`${key} must be a string`, 400);
+    }
   }
 
   // detectionSource: only "system" / "byok" / null are valid. Reject anything
@@ -161,7 +175,7 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
       detectionSource: sourceStr,
       trigger: {
         create: {
-          conditions: (triggerConditions as object) ?? [],
+          conditions: resolvedTriggerConditions,
         },
       },
     },

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/trigger-validation.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/trigger-validation.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTriggerConditions } from "./trigger-validation";
+
+describe("normalizeTriggerConditions", () => {
+  it("accepts empty trigger conditions", () => {
+    expect(normalizeTriggerConditions([])).toEqual({ conditions: [], error: null });
+  });
+
+  it.each(["=", "!="])("accepts null values for environment %s comparisons", (op) => {
+    expect(normalizeTriggerConditions([{ field: "environment", op, value: null }])).toEqual({
+      conditions: [{ field: "environment", op, value: null }],
+      error: null,
+    });
+  });
+
+  it("normalizes legacy equality aliases", () => {
+    expect(
+      normalizeTriggerConditions([{ field: "environment", op: "eq", value: "production" }]),
+    ).toEqual({
+      conditions: [{ field: "environment", op: "=", value: "production" }],
+      error: null,
+    });
+  });
+
+  it("rejects unsupported fields that the worker summary cannot evaluate", () => {
+    const result = normalizeTriggerConditions([{ field: "cost", op: ">", value: "10.5" }]);
+
+    expect(result.error).toBe("triggerConditions[0].field must be one of environment");
+  });
+
+  it.each(["__proto__", "constructor", "toString"])("rejects prototype field name %s", (field) => {
+    const result = normalizeTriggerConditions([{ field, op: "=", value: "production" }]);
+
+    expect(result.error).toBe("triggerConditions[0].field must be one of environment");
+  });
+
+  it("rejects inherited condition fields", () => {
+    const inheritedCondition = Object.create({
+      field: "environment",
+      op: "=",
+      value: "production",
+    }) as unknown;
+
+    const result = normalizeTriggerConditions([inheritedCondition]);
+
+    expect(result.error).toBe("triggerConditions[0].field must be a non-empty string");
+  });
+
+  it.each(["0x10", "0b10", "0o10"])("rejects numeric operators for environment (%s)", (value) => {
+    const result = normalizeTriggerConditions([{ field: "environment", op: ">", value }]);
+
+    expect(result.error).toBe("triggerConditions[0].op must be one of =, != for environment");
+  });
+
+  it.each([42, true, false, {}, []])("rejects non-string environment value %s", (value) => {
+    const result = normalizeTriggerConditions([{ field: "environment", op: "=", value }]);
+
+    expect(result.error).toBe(
+      "triggerConditions[0].value must be a string or null for environment",
+    );
+  });
+
+  it("rejects missing environment values with field-specific copy", () => {
+    const result = normalizeTriggerConditions([{ field: "environment", op: "=" }]);
+
+    expect(result.error).toBe(
+      "triggerConditions[0].value must be a string or null for environment",
+    );
+  });
+
+  it("returns the field-specific operator set for unknown operators", () => {
+    const result = normalizeTriggerConditions([
+      { field: "environment", op: "contains", value: "production" },
+    ]);
+
+    expect(result.error).toBe("triggerConditions[0].op must be one of =, != for environment");
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/detectors/trigger-validation.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/detectors/trigger-validation.ts
@@ -1,0 +1,80 @@
+type TriggerConditionPayload = {
+  field: string;
+  op: string;
+  value: string | null;
+};
+
+const TRIGGER_FIELD_OPERATORS = new Map([["environment", new Set(["=", "!="])]]);
+
+const LEGACY_TRIGGER_OPERATORS = new Map([
+  ["eq", "="],
+  ["ne", "!="],
+  ["neq", "!="],
+  ["gt", ">"],
+  ["gte", ">="],
+  ["lt", "<"],
+  ["lte", "<="],
+]);
+
+function isEnvironmentValue(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+export function hasOwn(record: object, key: string) {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function normalizeOperator(op: string) {
+  return LEGACY_TRIGGER_OPERATORS.get(op) ?? op;
+}
+
+export function normalizeTriggerConditions(
+  triggerConditions: unknown,
+): { conditions: TriggerConditionPayload[]; error: null } | { conditions: null; error: string } {
+  if (!Array.isArray(triggerConditions)) {
+    return { conditions: null, error: "triggerConditions must be an array" };
+  }
+
+  const normalized: TriggerConditionPayload[] = [];
+  for (const [index, condition] of triggerConditions.entries()) {
+    const prefix = `triggerConditions[${index}]`;
+    if (condition === null || typeof condition !== "object" || Array.isArray(condition)) {
+      return { conditions: null, error: `${prefix} must be an object` };
+    }
+
+    const record = condition as Record<string, unknown>;
+    const field = hasOwn(record, "field") ? record.field : undefined;
+    const op = hasOwn(record, "op") ? record.op : undefined;
+    const value = hasOwn(record, "value") ? record.value : undefined;
+    if (typeof field !== "string" || field.trim().length === 0) {
+      return { conditions: null, error: `${prefix}.field must be a non-empty string` };
+    }
+
+    const fieldOperators = TRIGGER_FIELD_OPERATORS.get(field);
+    if (fieldOperators === undefined) {
+      return {
+        conditions: null,
+        error: `${prefix}.field must be one of environment`,
+      };
+    }
+
+    const normalizedOp = typeof op === "string" ? normalizeOperator(op) : op;
+    if (typeof normalizedOp !== "string" || !fieldOperators.has(normalizedOp)) {
+      return {
+        conditions: null,
+        error: `${prefix}.op must be one of ${Array.from(fieldOperators).join(", ")} for ${field}`,
+      };
+    }
+
+    if (!hasOwn(record, "value") || !isEnvironmentValue(value)) {
+      return {
+        conditions: null,
+        error: `${prefix}.value must be a string or null for ${field}`,
+      };
+    }
+
+    normalized.push({ field, op: normalizedOp, value });
+  }
+
+  return { conditions: normalized, error: null };
+}

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -13,6 +13,16 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mocks.push }),
 }));
 vi.mock("@/features/detectors/hooks/use-detectors", () => ({
+  detectorMutationErrorMessage: (error: unknown, fallback: string) =>
+    error instanceof Error &&
+    error.message === "triggerConditions[0].op must be one of =, != for environment"
+      ? "Environment filters only support = or !=."
+      : error instanceof Error
+        ? error.message
+        : fallback,
+  isTriggerConditionMutationError: (message: string) =>
+    message === "Environment filters only support = or !=." ||
+    message.startsWith("triggerConditions"),
   useCreateDetector: () => ({ mutateAsync: mocks.mutateAsync, isPending: false }),
 }));
 vi.mock("@/features/projects/hooks", () => ({
@@ -80,5 +90,21 @@ describe("NewDetectorPage", () => {
       prompt: "my prompt",
       template: "failure",
     });
+  });
+
+  it("shows trigger validation errors without navigating away", async () => {
+    mocks.mutateAsync.mockRejectedValueOnce(
+      new Error("triggerConditions[0].op must be one of =, != for environment"),
+    );
+    render(<NewDetectorPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Create Detector" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toContain(
+        "Environment filters only support = or !=.",
+      ),
+    );
+    expect(mocks.push).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -13,7 +13,11 @@ import {
   DETECTOR_TEMPLATES,
   buildTemplateDetectorInput,
 } from "@/features/detectors/templates";
-import { useCreateDetector } from "@/features/detectors/hooks/use-detectors";
+import {
+  detectorMutationErrorMessage,
+  isTriggerConditionMutationError,
+  useCreateDetector,
+} from "@/features/detectors/hooks/use-detectors";
 import type { CreateDetectorInput } from "@/features/detectors/hooks/use-detectors";
 import { TriggerEditor } from "@/features/detectors/components/trigger-editor";
 import type { TriggerCondition } from "@/features/detectors/components/trigger-editor";
@@ -50,6 +54,7 @@ export default function NewDetectorPage() {
     adapter: "",
   });
   const [enableRca, setEnableRca] = useState(true);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const handleTemplateChange = (templateId: string) => {
     const template = DETECTOR_TEMPLATES.find((t) => t.id === templateId);
@@ -63,6 +68,7 @@ export default function NewDetectorPage() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setSubmitError(null);
     const template = DETECTOR_TEMPLATES.find((t) => t.id === selectedTemplate)!;
     const input: CreateDetectorInput = {
       ...buildTemplateDetectorInput(template),
@@ -75,11 +81,18 @@ export default function NewDetectorPage() {
       detectionProvider: modelSelection.provider || undefined,
       detectionSource: modelSelection.source === "byok" ? "byok" : "system",
     };
-    await createMutation.mutateAsync(input);
-    router.push(`/projects/${projectId}/detectors`);
+    try {
+      await createMutation.mutateAsync(input);
+      router.push(`/projects/${projectId}/detectors`);
+    } catch (error) {
+      setSubmitError(detectorMutationErrorMessage(error, "Failed to create detector"));
+    }
   };
 
   const selectedTemplateDef = DETECTOR_TEMPLATES.find((t) => t.id === selectedTemplate);
+  const filterError =
+    submitError && isTriggerConditionMutationError(submitError) ? submitError : null;
+  const generalSubmitError = submitError && !filterError ? submitError : null;
 
   return (
     <div className="relative flex h-full text-[13px]">
@@ -201,6 +214,14 @@ export default function NewDetectorPage() {
                 onChange={setTriggerConditions}
                 asCard
               />
+              {filterError && (
+                <p
+                  role="alert"
+                  className="border-t border-border px-3 py-2 text-[12px] text-destructive"
+                >
+                  {filterError}
+                </p>
+              )}
             </div>
 
             {/* Sampling */}
@@ -224,6 +245,11 @@ export default function NewDetectorPage() {
             </div>
 
             {/* Footer */}
+            {generalSubmitError && (
+              <p role="alert" className="text-[12px] text-destructive">
+                {generalSubmitError}
+              </p>
+            )}
             <div className="flex justify-end gap-2 pt-1">
               <Button
                 type="button"

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.test.tsx
@@ -8,6 +8,13 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../hooks/use-detectors", () => ({
+  detectorMutationErrorMessage: (error: unknown, fallback: string) =>
+    error instanceof Error &&
+    error.message === "triggerConditions[0].op must be one of =, != for environment"
+      ? "Environment filters only support = or !=."
+      : error instanceof Error
+        ? error.message
+        : fallback,
   useCreateDetector: () => ({ mutateAsync: mocks.mutateAsync }),
 }));
 
@@ -108,7 +115,11 @@ describe("AddDetectorsStep", () => {
     fireEvent.click(pill("Safety"));
     fireEvent.click(continueButton());
 
-    await waitFor(() => expect(screen.getByText(/Couldn't create: Safety/)).toBeDefined());
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toContain(
+        "Safety: Failed to create detector: 500",
+      ),
+    );
     expect(onDone).not.toHaveBeenCalled();
 
     // Retry: only the failed template is re-posted
@@ -119,5 +130,20 @@ describe("AddDetectorsStep", () => {
     await waitFor(() => expect(onDone).toHaveBeenCalledTimes(1));
     expect(mocks.mutateAsync).toHaveBeenCalledTimes(1);
     expect(mocks.mutateAsync.mock.calls[0][0]).toMatchObject({ template: "safety" });
+  });
+
+  it("shows formatted trigger validation errors for failed templates", async () => {
+    mocks.mutateAsync.mockRejectedValue(
+      new Error("triggerConditions[0].op must be one of =, != for environment"),
+    );
+    renderStep();
+    fireEvent.click(pill("Failure"));
+    fireEvent.click(continueButton());
+
+    await waitFor(() =>
+      expect(screen.getByRole("alert").textContent).toContain(
+        "Failure: Environment filters only support = or !=.",
+      ),
+    );
   });
 });

--- a/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
+++ b/frontend/ui/src/features/detectors/components/add-detectors-step.tsx
@@ -7,7 +7,10 @@ import {
   buildTemplateDetectorInput,
   getTemplate,
 } from "@/features/detectors/templates";
-import { useCreateDetector } from "@/features/detectors/hooks/use-detectors";
+import {
+  detectorMutationErrorMessage,
+  useCreateDetector,
+} from "@/features/detectors/hooks/use-detectors";
 
 interface AddDetectorsStepProps {
   projectId: string;
@@ -24,7 +27,7 @@ interface AddDetectorsStepProps {
 export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetectorsStepProps) {
   const [selected, setSelected] = useState<string[]>([]);
   const [previewedId, setPreviewedId] = useState(DETECTOR_QUICK_ADD_TEMPLATES[0].id);
-  const [failedLabels, setFailedLabels] = useState<string[]>([]);
+  const [failedMessages, setFailedMessages] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const createMutation = useCreateDetector(projectId);
 
@@ -40,7 +43,7 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
       return;
     }
     setSubmitting(true);
-    setFailedLabels([]);
+    setFailedMessages([]);
     const results = await Promise.allSettled(
       selected.map((id) =>
         createMutation.mutateAsync(buildTemplateDetectorInput(getTemplate(id)!)),
@@ -52,7 +55,17 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
       return;
     }
     setSelected(failed);
-    setFailedLabels(failed.map((id) => getTemplate(id)?.label ?? id));
+    setFailedMessages(
+      failed.map((id) => {
+        const result = results[selected.indexOf(id)];
+        const label = getTemplate(id)?.label ?? id;
+        const message =
+          result.status === "rejected"
+            ? detectorMutationErrorMessage(result.reason, "Failed to create detector")
+            : "Failed to create detector";
+        return `${label}: ${message}`;
+      }),
+    );
     setSubmitting(false);
   };
 
@@ -90,9 +103,9 @@ export function AddDetectorsStep({ projectId, projectName, onDone }: AddDetector
           </p>
         </div>
       </div>
-      {failedLabels.length > 0 && (
-        <p className="text-[12px] text-destructive">
-          Couldn&apos;t create: {failedLabels.join(", ")}. Try again or skip.
+      {failedMessages.length > 0 && (
+        <p role="alert" className="text-[12px] text-destructive">
+          Couldn&apos;t create {failedMessages.join("; ")}. Try again or skip.
         </p>
       )}
       <div className="flex items-center justify-between pt-1">

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -1,14 +1,28 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent, act } from "@testing-library/react";
 import type { Detector } from "../hooks/use-detectors";
 
 const mocks = vi.hoisted(() => ({
   detector: undefined as Detector | undefined,
   mutate: vi.fn(),
+  triggerEditorProps: [] as Array<{
+    conditions: Array<{ field: string; op: string; value: unknown }>;
+    onChange?: (conditions: Array<{ field: string; op: string; value: unknown }>) => void;
+  }>,
 }));
 
 vi.mock("../hooks/use-detectors", () => ({
+  detectorMutationErrorMessage: (error: unknown, fallback: string) =>
+    error instanceof Error &&
+    error.message === "triggerConditions[0].op must be one of =, != for environment"
+      ? "Environment filters only support = or !=."
+      : error instanceof Error
+        ? error.message
+        : fallback,
+  isTriggerConditionMutationError: (message: string) =>
+    message === "Environment filters only support = or !=." ||
+    message.startsWith("triggerConditions"),
   useDetector: () => ({ data: mocks.detector }),
   useUpdateDetector: () => ({ mutate: mocks.mutate, isPending: false }),
 }));
@@ -16,7 +30,10 @@ vi.mock("@/features/projects/hooks", () => ({
   useProject: () => ({ data: undefined }),
 }));
 vi.mock("./trigger-editor", () => ({
-  TriggerEditor: () => null,
+  TriggerEditor: (props: (typeof mocks.triggerEditorProps)[number]) => {
+    mocks.triggerEditorProps.push(props);
+    return null;
+  },
 }));
 vi.mock("./agent-model-link", () => ({
   AgentModelLink: () => null,
@@ -81,6 +98,7 @@ afterEach(() => {
   cleanup();
   mocks.detector = undefined;
   mocks.mutate.mockReset();
+  mocks.triggerEditorProps = [];
 });
 
 describe("DetectorPanel", () => {
@@ -116,6 +134,209 @@ describe("DetectorPanel", () => {
     const options = mocks.mutate.mock.calls[0][1] as { onSuccess: () => void };
     options.onSuccess();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not overwrite unsupported legacy filter conditions on unrelated edits", () => {
+    mocks.detector = {
+      ...baseDetector,
+      trigger: { conditions: [{ field: "duration", op: "gt", value: 1000 }] },
+    };
+    renderPanel();
+
+    expect(screen.getByText(/hidden legacy filter conditions/i)).toBeDefined();
+    expect(mocks.triggerEditorProps.at(-1)?.conditions).toEqual([]);
+
+    fireEvent.change(promptBox(), { target: { value: "new prompt" } });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ prompt: "new prompt" });
+  });
+
+  it("treats nullable environment filters as supported editable filters", () => {
+    const nullableCondition = { field: "environment", op: "=", value: null };
+    mocks.detector = {
+      ...baseDetector,
+      trigger: { conditions: [nullableCondition] },
+    };
+    renderPanel();
+
+    expect(screen.queryByText(/hidden legacy filter conditions/i)).toBeNull();
+    expect(mocks.triggerEditorProps.at(-1)?.conditions).toEqual([nullableCondition]);
+
+    fireEvent.change(promptBox(), { target: { value: "new prompt" } });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ prompt: "new prompt" });
+  });
+
+  it("saves a nullable environment filter edited from a string value", () => {
+    const initialCondition = { field: "environment", op: "=", value: "production" };
+    const nullableCondition = { field: "environment", op: "=", value: null };
+    mocks.detector = {
+      ...baseDetector,
+      trigger: { conditions: [initialCondition] },
+    };
+    renderPanel();
+
+    act(() => {
+      mocks.triggerEditorProps.at(-1)?.onChange?.([nullableCondition]);
+    });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({
+      triggerConditions: [nullableCondition],
+    });
+  });
+
+  it("sends an empty trigger replacement when discarding unsupported legacy filters", () => {
+    mocks.detector = {
+      ...baseDetector,
+      trigger: { conditions: [{ field: "duration", op: "gt", value: 1000 }] },
+    };
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: /discard hidden filters on save/i }));
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ triggerConditions: [] });
+  });
+
+  it("blocks hidden legacy filter replacement until discard is explicitly selected", () => {
+    const visibleCondition = { field: "environment", op: "=", value: "production" };
+    mocks.detector = {
+      ...baseDetector,
+      trigger: {
+        conditions: [visibleCondition, { field: "duration", op: "gt", value: 1000 }],
+      },
+    };
+    renderPanel();
+
+    expect(mocks.triggerEditorProps.at(-1)?.conditions).toEqual([visibleCondition]);
+    const replacementCondition = { field: "environment", op: "=", value: "staging" };
+    act(() => {
+      mocks.triggerEditorProps.at(-1)?.onChange?.([replacementCondition]);
+    });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Choose Discard hidden filters on save before saving filter changes.",
+    );
+  });
+
+  it("allows unrelated edits after a no-op legacy filter interaction", () => {
+    const visibleCondition = { field: "environment", op: "=", value: "production" };
+    mocks.detector = {
+      ...baseDetector,
+      trigger: {
+        conditions: [visibleCondition, { field: "duration", op: "gt", value: 1000 }],
+      },
+    };
+    renderPanel();
+
+    act(() => {
+      mocks.triggerEditorProps.at(-1)?.onChange?.([visibleCondition]);
+    });
+    fireEvent.change(promptBox(), { target: { value: "new prompt" } });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ prompt: "new prompt" });
+  });
+
+  it("allows unrelated edits after a legacy filter edit is reverted", () => {
+    const visibleCondition = { field: "environment", op: "=", value: "production" };
+    const replacementCondition = { field: "environment", op: "=", value: "staging" };
+    mocks.detector = {
+      ...baseDetector,
+      trigger: {
+        conditions: [visibleCondition, { field: "duration", op: "gt", value: 1000 }],
+      },
+    };
+    renderPanel();
+
+    act(() => {
+      mocks.triggerEditorProps.at(-1)?.onChange?.([replacementCondition]);
+      mocks.triggerEditorProps.at(-1)?.onChange?.([visibleCondition]);
+    });
+    fireEvent.change(promptBox(), { target: { value: "new prompt" } });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ prompt: "new prompt" });
+  });
+
+  it("replaces hidden mixed legacy filters after discard is explicitly selected", () => {
+    const visibleCondition = { field: "environment", op: "=", value: "production" };
+    mocks.detector = {
+      ...baseDetector,
+      trigger: {
+        conditions: [visibleCondition, { field: "duration", op: "gt", value: 1000 }],
+      },
+    };
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: /discard hidden filters on save/i }));
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ triggerConditions: [visibleCondition] });
+  });
+
+  it("lets users undo hidden legacy filter discard before saving", () => {
+    const visibleCondition = { field: "environment", op: "=", value: "production" };
+    mocks.detector = {
+      ...baseDetector,
+      trigger: {
+        conditions: [visibleCondition, { field: "duration", op: "gt", value: 1000 }],
+      },
+    };
+    renderPanel();
+
+    fireEvent.click(screen.getByRole("button", { name: /discard hidden filters on save/i }));
+    fireEvent.click(screen.getByRole("button", { name: /keep hidden filters/i }));
+    fireEvent.change(promptBox(), { target: { value: "new prompt" } });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ prompt: "new prompt" });
+  });
+
+  it("keeps the legacy filter warning visible while replacement edits are unsaved", () => {
+    mocks.detector = {
+      ...baseDetector,
+      trigger: { conditions: [{ field: "duration", op: "gt", value: 1000 }] },
+    };
+    renderPanel();
+
+    mocks.triggerEditorProps
+      .at(-1)
+      ?.onChange?.([{ field: "environment", op: "=", value: "production" }]);
+
+    expect(screen.getByText(/hidden legacy filter conditions/i)).toBeDefined();
+  });
+
+  it("shows mutation validation errors inline when save fails", () => {
+    mocks.detector = baseDetector;
+    mocks.mutate.mockImplementation((_patch, options) => {
+      options.onError(new Error("triggerConditions[0].op must be one of =, != for environment"));
+    });
+    renderPanel();
+
+    act(() => {
+      mocks.triggerEditorProps
+        .at(-1)
+        ?.onChange?.([{ field: "environment", op: ">", value: "production" }]);
+    });
+    fireEvent.click(saveButton());
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "Environment filters only support = or !=.",
+    );
   });
 
   it("closes without a network call when nothing changed", () => {

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Eye, X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
-import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
+import { Eye, X, Copy, Check, ArrowUp, ArrowDown, AlertTriangle } from "lucide-react";
+import {
+  detectorMutationErrorMessage,
+  isTriggerConditionMutationError,
+  useDetector,
+  useUpdateDetector,
+} from "../hooks/use-detectors";
 import { DEFAULT_DETECTOR_SAMPLE_RATE } from "../templates";
 import { useProject } from "@/features/projects/hooks";
 import { TriggerEditor } from "./trigger-editor";
@@ -21,6 +26,9 @@ import {
 } from "@/features/ai-assistant/components/model-selector";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+
+const LEGACY_FILTER_DISCARD_ERROR =
+  "This detector has hidden legacy filters. Choose Discard hidden filters on save before saving filter changes.";
 
 interface DetectorPanelProps {
   detectorId: string;
@@ -54,6 +62,9 @@ export function DetectorPanel({
     adapter: "",
   });
   const [editConditions, setEditConditions] = useState<TriggerCondition[]>([]);
+  const [hasUnsupportedTriggerConditions, setHasUnsupportedTriggerConditions] = useState(false);
+  const [discardLegacyFiltersOnSave, setDiscardLegacyFiltersOnSave] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [editEnableRca, setEditEnableRca] = useState(true);
 
   const emptyForm: DetectorFormValues = {
@@ -65,6 +76,7 @@ export function DetectorPanel({
     detectionProvider: "",
     detectionSource: "system",
     conditions: [],
+    unsupportedTriggerConditions: false,
   };
 
   const readForm = (): DetectorFormValues => ({
@@ -76,6 +88,7 @@ export function DetectorPanel({
     detectionProvider: editModelSelection.provider,
     detectionSource: editModelSelection.source === "byok" ? "byok" : "system",
     conditions: editConditions as DetectorFormValues["conditions"],
+    unsupportedTriggerConditions: hasUnsupportedTriggerConditions,
   });
 
   const applyForm = (values: DetectorFormValues) => {
@@ -90,6 +103,17 @@ export function DetectorPanel({
       adapter: "",
     });
     setEditConditions(values.conditions as TriggerCondition[]);
+    setHasUnsupportedTriggerConditions(values.unsupportedTriggerConditions);
+  };
+
+  const handleConditionsChange = (conditions: TriggerCondition[]) => {
+    setSaveError(null);
+    setEditConditions(conditions);
+  };
+
+  const handleDiscardLegacyFilters = () => {
+    setDiscardLegacyFiltersOnSave((value) => !value);
+    setSaveError(null);
   };
 
   // Snapshot of the server state the form was last populated from, tagged
@@ -123,10 +147,14 @@ export function DetectorPanel({
         // detectors would leak one detector's edits into another.
         applyForm(next);
         loadedRef.current = { id: detector.id, values: next };
+        setDiscardLegacyFiltersOnSave(false);
+        setSaveError(null);
       }
     } else {
       applyForm(emptyForm);
       loadedRef.current = null;
+      setDiscardLegacyFiltersOnSave(false);
+      setSaveError(null);
     }
   }, [detectorId, detector]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -149,13 +177,43 @@ export function DetectorPanel({
     if (!detector || detector.id !== detectorId) return;
     const loaded = loadedRef.current;
     if (!loaded || loaded.id !== detectorId) return;
-    const patch = buildDetectorPatch(loaded.values, readForm());
-    if (Object.keys(patch).length === 0) {
+    const form = readForm();
+    setSaveError(null);
+    const patch = buildDetectorPatch(loaded.values, form);
+    const replacesTriggerConditions = Object.prototype.hasOwnProperty.call(
+      patch,
+      "triggerConditions",
+    );
+    if (
+      loaded.values.unsupportedTriggerConditions &&
+      replacesTriggerConditions &&
+      !discardLegacyFiltersOnSave
+    ) {
+      setSaveError(LEGACY_FILTER_DISCARD_ERROR);
+      return;
+    }
+    const finalPatch = buildDetectorPatch(loaded.values, form, {
+      forceTriggerConditions:
+        loaded.values.unsupportedTriggerConditions && discardLegacyFiltersOnSave,
+    });
+    if (Object.keys(finalPatch).length === 0) {
       onClose();
       return;
     }
-    updateMutation.mutate(patch, { onSuccess: () => onClose() });
+    updateMutation.mutate(finalPatch, {
+      onSuccess: () => onClose(),
+      onError: (error) => {
+        setSaveError(detectorMutationErrorMessage(error, "Failed to update detector"));
+      },
+    });
   };
+
+  const filterError =
+    saveError &&
+    (isTriggerConditionMutationError(saveError) || saveError === LEGACY_FILTER_DISCARD_ERROR)
+      ? saveError
+      : null;
+  const generalSaveError = saveError && !filterError ? saveError : null;
 
   return (
     <div className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 flex w-[70%] flex-col border-l border-border bg-background shadow-xl">
@@ -279,7 +337,50 @@ export function DetectorPanel({
 
         {/* Filter */}
         <div className="border border-border">
-          <TriggerEditor conditions={editConditions} onChange={setEditConditions} asCard />
+          <TriggerEditor
+            conditions={editConditions}
+            onChange={handleConditionsChange}
+            asCard
+            emptyMessage={
+              hasUnsupportedTriggerConditions
+                ? "Unsupported legacy filters are active until you clear or replace them."
+                : undefined
+            }
+          />
+          {hasUnsupportedTriggerConditions && (
+            <div className="flex items-start gap-2 border-t border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-300">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+              <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
+                <p className="min-w-0">
+                  This detector has hidden legacy filter conditions that cannot be edited here.
+                  Normal detector edits preserve them. To replace them with the visible filter rows,
+                  choose discard before saving.
+                  {discardLegacyFiltersOnSave
+                    ? " Hidden legacy filters will be removed on save."
+                    : ""}
+                </p>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleDiscardLegacyFilters}
+                  className="h-6 shrink-0 border-amber-300 bg-amber-50 px-2 text-[11px] text-amber-900 hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-200 dark:hover:bg-amber-900/40"
+                >
+                  {discardLegacyFiltersOnSave
+                    ? "Keep hidden filters"
+                    : "Discard hidden filters on save"}
+                </Button>
+              </div>
+            </div>
+          )}
+          {filterError && (
+            <p
+              role="alert"
+              className="border-t border-border px-3 py-2 text-[12px] text-destructive"
+            >
+              {filterError}
+            </p>
+          )}
         </div>
 
         {/* Sampling */}
@@ -303,6 +404,11 @@ export function DetectorPanel({
         </div>
 
         {/* Save / Cancel */}
+        {generalSaveError && (
+          <p role="alert" className="text-[12px] text-destructive">
+            {generalSaveError}
+          </p>
+        )}
         <div className="flex justify-end gap-2 pt-1">
           <Button variant="outline" size="sm" onClick={onClose} className="h-7 text-[12px]">
             Cancel

--- a/frontend/ui/src/features/detectors/components/trigger-editor.test.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { TriggerEditor } from "./trigger-editor";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TriggerEditor", () => {
+  it("round-trips nullable environment values", () => {
+    const onChange = vi.fn();
+
+    render(
+      <TriggerEditor
+        conditions={[{ field: "environment", op: "=", value: null }]}
+        onChange={onChange}
+      />,
+    );
+
+    const valueInput = screen.getByPlaceholderText("Enter value...") as HTMLInputElement;
+    const unsetCheckbox = screen.getByRole("checkbox", {
+      name: "Value is null",
+    }) as HTMLInputElement;
+
+    expect(valueInput.disabled).toBe(true);
+    expect(valueInput.value).toBe("");
+    expect(unsetCheckbox.checked).toBe(true);
+
+    fireEvent.click(unsetCheckbox);
+
+    expect(onChange).toHaveBeenLastCalledWith([{ field: "environment", op: "=", value: "" }]);
+  });
+
+  it("restores the prior text value when null mode is toggled off", () => {
+    const onChange = vi.fn();
+
+    render(
+      <TriggerEditor
+        conditions={[{ field: "environment", op: "=", value: "production" }]}
+        onChange={onChange}
+      />,
+    );
+
+    const valueInput = screen.getByPlaceholderText("Enter value...") as HTMLInputElement;
+    const nullCheckbox = screen.getByRole("checkbox", {
+      name: "Value is null",
+    }) as HTMLInputElement;
+
+    fireEvent.change(valueInput, { target: { value: "staging" } });
+    fireEvent.click(nullCheckbox);
+    fireEvent.click(nullCheckbox);
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      { field: "environment", op: "=", value: "staging" },
+    ]);
+  });
+
+  it("keeps null restore values with their row after removing another condition", () => {
+    const onChange = vi.fn();
+
+    render(
+      <TriggerEditor
+        conditions={[
+          { field: "environment", op: "=", value: "production" },
+          { field: "environment", op: "!=", value: "staging" },
+        ]}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole("checkbox", { name: "Value is null" })[1]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove condition" })[0]);
+    fireEvent.click(screen.getByRole("checkbox", { name: "Value is null" }));
+
+    expect(onChange).toHaveBeenLastCalledWith([
+      { field: "environment", op: "!=", value: "staging" },
+    ]);
+  });
+
+  it("does not restore a cached value after conditions are externally replaced", () => {
+    const onChange = vi.fn();
+    const { rerender } = render(
+      <TriggerEditor
+        conditions={[{ field: "environment", op: "=", value: "production" }]}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Value is null" }));
+
+    rerender(
+      <TriggerEditor
+        conditions={[{ field: "environment", op: "=", value: null }]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole("checkbox", { name: "Value is null" }));
+
+    expect(onChange).toHaveBeenLastCalledWith([{ field: "environment", op: "=", value: "" }]);
+  });
+});

--- a/frontend/ui/src/features/detectors/components/trigger-editor.tsx
+++ b/frontend/ui/src/features/detectors/components/trigger-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { X, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,6 +23,7 @@ interface FieldDef {
   label: string;
   ops: string[];
   valueType: "text" | "select";
+  nullable?: boolean;
   options?: { label: string; value: string }[];
 }
 
@@ -32,6 +33,7 @@ const FIELD_DEFS: FieldDef[] = [
     label: "Environment",
     ops: ["=", "!="],
     valueType: "text",
+    nullable: true,
   },
 ];
 
@@ -53,6 +55,7 @@ interface TriggerEditorProps {
   readOnly?: boolean;
   /** Card mode: renders as a bordered card section (header + body) for embedding inside a card container */
   asCard?: boolean;
+  emptyMessage?: string;
 }
 
 export function TriggerEditor({
@@ -62,16 +65,43 @@ export function TriggerEditor({
   isSaving,
   readOnly,
   asCard,
+  emptyMessage = "Runs on all completed traces.",
 }: TriggerEditorProps) {
+  const nextConditionKeyRef = useRef(0);
+  const createConditionKey = useCallback(() => `condition-${nextConditionKeyRef.current++}`, []);
   const [conditions, setConditions] = useState<TriggerCondition[]>(initialConditions);
   const [dirty, setDirty] = useState(false);
+  const [conditionKeys, setConditionKeys] = useState<string[]>(() =>
+    initialConditions.map(() => createConditionKey()),
+  );
+  const previousNonNullValuesRef = useRef<Record<string, string>>({});
+  const lastEmittedConditionsRef = useRef<TriggerCondition[] | null>(null);
 
   useEffect(() => {
     setConditions(initialConditions);
+    if (lastEmittedConditionsRef.current === initialConditions) {
+      setConditionKeys((currentKeys) => {
+        const nextKeys = initialConditions.map(
+          (_, index) => currentKeys[index] ?? createConditionKey(),
+        );
+        const liveKeys = new Set(nextKeys);
+        for (const key of Object.keys(previousNonNullValuesRef.current)) {
+          if (!liveKeys.has(key)) {
+            delete previousNonNullValuesRef.current[key];
+          }
+        }
+        return nextKeys;
+      });
+    } else {
+      previousNonNullValuesRef.current = {};
+      setConditionKeys(initialConditions.map(() => createConditionKey()));
+    }
+    lastEmittedConditionsRef.current = null;
     setDirty(false);
-  }, [initialConditions]);
+  }, [createConditionKey, initialConditions]);
 
   const update = (next: TriggerCondition[]) => {
+    lastEmittedConditionsRef.current = next;
     setConditions(next);
     if (onChange) {
       onChange(next);
@@ -82,6 +112,7 @@ export function TriggerEditor({
 
   const addCondition = () => {
     const first = FIELD_DEFS[0];
+    setConditionKeys([...conditionKeys, createConditionKey()]);
     update([
       ...conditions,
       { field: first.field, op: first.ops[0], value: defaultValueForField(first.field) },
@@ -89,10 +120,16 @@ export function TriggerEditor({
   };
 
   const removeCondition = (i: number) => {
+    const removedKey = conditionKeys[i];
+    if (removedKey) {
+      delete previousNonNullValuesRef.current[removedKey];
+    }
+    setConditionKeys(conditionKeys.filter((_, idx) => idx !== i));
     update(conditions.filter((_, idx) => idx !== i));
   };
 
   const updateCondition = (i: number, patch: Partial<TriggerCondition>) => {
+    const rowKey = conditionKeys[i];
     update(
       conditions.map((c, idx) => {
         if (idx !== i) return c;
@@ -101,10 +138,25 @@ export function TriggerEditor({
           const def = FIELD_DEFS.find((d) => d.field === patch.field);
           merged.op = def?.ops[0] ?? "=";
           merged.value = defaultValueForField(patch.field);
+          if (rowKey) {
+            delete previousNonNullValuesRef.current[rowKey];
+          }
         }
         return merged;
       }),
     );
+  };
+
+  const setNullValue = (i: number, cond: TriggerCondition, checked: boolean) => {
+    const rowKey = conditionKeys[i];
+    if (checked) {
+      if (rowKey) {
+        previousNonNullValuesRef.current[rowKey] = String(cond.value ?? "");
+      }
+      updateCondition(i, { value: null });
+      return;
+    }
+    updateCondition(i, { value: rowKey ? (previousNonNullValuesRef.current[rowKey] ?? "") : "" });
   };
 
   const conditionRows = (
@@ -112,7 +164,7 @@ export function TriggerEditor({
       {conditions.map((cond, i) => {
         const fieldDef = FIELD_DEFS.find((d) => d.field === cond.field) ?? FIELD_DEFS[0];
         return (
-          <div key={i} className="flex items-center gap-1.5">
+          <div key={conditionKeys[i] ?? i} className="flex items-center gap-1.5">
             {/* Field */}
             <Select value={cond.field} onValueChange={(val) => updateCondition(i, { field: val })}>
               <SelectTrigger className="h-7 w-[120px] shrink-0 text-[12px]">
@@ -159,18 +211,39 @@ export function TriggerEditor({
                 </SelectContent>
               </Select>
             ) : (
-              <Input
-                value={cond.value as string}
-                onChange={(e) => updateCondition(i, { value: e.target.value })}
-                placeholder="Enter value..."
-                className="h-7 flex-1 text-[12px]"
-              />
+              <div className="flex flex-1 items-center gap-2">
+                <Input
+                  value={cond.value === null ? "" : String(cond.value ?? "")}
+                  onChange={(e) => {
+                    const rowKey = conditionKeys[i];
+                    if (rowKey) {
+                      previousNonNullValuesRef.current[rowKey] = e.target.value;
+                    }
+                    updateCondition(i, { value: e.target.value });
+                  }}
+                  placeholder="Enter value..."
+                  disabled={cond.value === null}
+                  className="h-7 flex-1 text-[12px]"
+                />
+                {fieldDef.nullable && (
+                  <label className="flex shrink-0 items-center gap-1 text-[11px] text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      checked={cond.value === null}
+                      onChange={(e) => setNullValue(i, cond, e.target.checked)}
+                      className="h-3 w-3"
+                    />
+                    Value is null
+                  </label>
+                )}
+              </div>
             )}
 
             {/* Remove — hidden in readOnly */}
             {!readOnly && (
               <button
                 type="button"
+                aria-label="Remove condition"
                 onClick={() => removeCondition(i)}
                 className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
               >
@@ -203,7 +276,7 @@ export function TriggerEditor({
         {/* Card body */}
         <div className="p-3">
           {conditions.length === 0 ? (
-            <p className="text-[12px] text-muted-foreground">Runs on all completed traces.</p>
+            <p className="text-[12px] text-muted-foreground">{emptyMessage}</p>
           ) : (
             <>
               <p className="mb-2 text-[12px] text-muted-foreground">All conditions must match.</p>
@@ -233,7 +306,7 @@ export function TriggerEditor({
       </div>
 
       {conditions.length === 0 ? (
-        <p className="text-[12px] text-muted-foreground">Runs on all completed traces.</p>
+        <p className="text-[12px] text-muted-foreground">{emptyMessage}</p>
       ) : (
         <>
           <p className="mb-2 text-[12px] text-muted-foreground">All conditions must match.</p>

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.test.tsx
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.test.tsx
@@ -3,7 +3,12 @@ import { afterEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
-import { useCreateDetector, useUpdateDetector, useDeleteDetector } from "./use-detectors";
+import {
+  detectorMutationErrorMessage,
+  useCreateDetector,
+  useUpdateDetector,
+  useDeleteDetector,
+} from "./use-detectors";
 
 class FakeBroadcastChannel {
   static posted: unknown[] = [];
@@ -20,16 +25,19 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-function setup() {
+function setup(
+  response: {
+    ok: boolean;
+    status: number;
+    json: () => Promise<unknown>;
+  } = {
+    ok: true,
+    status: 200,
+    json: async () => ({ detector: { id: "det-1" } }),
+  },
+) {
   vi.stubGlobal("BroadcastChannel", FakeBroadcastChannel);
-  vi.stubGlobal(
-    "fetch",
-    vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => ({ detector: { id: "det-1" } }),
-    }),
-  );
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response));
   const queryClient = new QueryClient();
   const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
   const wrapper = ({ children }: { children: ReactNode }) => (
@@ -66,5 +74,131 @@ describe("detector mutations notify other tabs on success", () => {
     result.current.mutate("det-1");
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expectNotified(invalidateSpy);
+  });
+});
+
+describe("detector mutations preserve API error messages", () => {
+  it("create: throws the response error body", async () => {
+    const { wrapper } = setup({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        error: "triggerConditions[0].op must be one of =, != for environment",
+      }),
+    });
+    const { result } = renderHook(() => useCreateDetector("proj-1"), { wrapper });
+
+    result.current.mutate({ name: "n", template: "t", prompt: "p", outputSchema: [] });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(
+      new Error("triggerConditions[0].op must be one of =, != for environment"),
+    );
+  });
+
+  it("create: does not surface trigger-looking debug response bodies", async () => {
+    const { wrapper } = setup({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        error: "triggerConditions debug password=secret",
+      }),
+    });
+    const { result } = renderHook(() => useCreateDetector("proj-1"), { wrapper });
+
+    result.current.mutate({ name: "n", template: "t", prompt: "p", outputSchema: [] });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("Failed to create detector: 400"));
+  });
+
+  it("update: falls back to the status message when the body has no error", async () => {
+    const { wrapper } = setup({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    });
+    const { result } = renderHook(() => useUpdateDetector("proj-1", "det-1"), { wrapper });
+
+    result.current.mutate({ prompt: "updated" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("Failed to update detector: 500"));
+  });
+
+  it("update: does not surface unexpected server error bodies", async () => {
+    const { wrapper } = setup({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "database password=secret stack trace" }),
+    });
+    const { result } = renderHook(() => useUpdateDetector("proj-1", "det-1"), { wrapper });
+
+    result.current.mutate({ prompt: "updated" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("Failed to update detector: 500"));
+  });
+
+  it("create: does not surface unknown 400 response bodies", async () => {
+    const { wrapper } = setup({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: "debug SQL fragment" }),
+    });
+    const { result } = renderHook(() => useCreateDetector("proj-1"), { wrapper });
+
+    result.current.mutate({ name: "n", template: "t", prompt: "p", outputSchema: [] });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("Failed to create detector: 400"));
+  });
+
+  it("delete: throws the response detail body", async () => {
+    const { wrapper } = setup({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "Admin role required to delete detectors" }),
+    });
+    const { result } = renderHook(() => useDeleteDetector("proj-1"), { wrapper });
+
+    result.current.mutate("det-1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("Admin role required to delete detectors"));
+  });
+
+  it("delete: does not surface role-error prefixes with extra diagnostics", async () => {
+    const { wrapper } = setup({
+      ok: false,
+      status: 403,
+      json: async () => ({ detail: "Admin role required to delete detectors token=secret" }),
+    });
+    const { result } = renderHook(() => useDeleteDetector("proj-1"), { wrapper });
+
+    result.current.mutate("det-1");
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toEqual(new Error("Failed to delete detector: 403"));
+  });
+});
+
+describe("detectorMutationErrorMessage", () => {
+  it("formats trigger validation errors for detector UI", () => {
+    expect(
+      detectorMutationErrorMessage(
+        new Error("triggerConditions[0].op must be one of =, != for environment"),
+        "Failed to create detector",
+      ),
+    ).toBe("Environment filters only support = or !=.");
+  });
+
+  it("keeps non-trigger curated errors unchanged", () => {
+    expect(
+      detectorMutationErrorMessage(
+        new Error("Admin role required to delete detectors"),
+        "Failed to delete detector",
+      ),
+    ).toBe("Admin role required to delete detectors");
   });
 });

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.ts
@@ -15,7 +15,7 @@ export interface Detector {
   detectionSource: "system" | "byok" | null;
   createTime: string;
   updateTime: string;
-  trigger?: { conditions: Array<{ field: string; op: string; value: unknown }> } | null;
+  trigger?: { conditions: unknown } | null;
 }
 
 interface PaginationMeta {
@@ -71,13 +71,113 @@ async function fetchDetector(projectId: string, detectorId: string): Promise<Det
   return data.detector;
 }
 
+async function detectorError(res: Response, fallback: string): Promise<Error> {
+  try {
+    const body = (await res.json()) as { error?: unknown; detail?: unknown };
+    const detail = typeof body.error === "string" ? body.error : body.detail;
+    if (typeof detail === "string" && isSafeDetectorErrorMessage(res.status, detail)) {
+      return new Error(detail.trim());
+    }
+  } catch {
+    // Fall back to the status-only message when the response body is absent or invalid.
+  }
+  return new Error(`${fallback}: ${res.status}`);
+}
+
+const SAFE_DETECTOR_ERROR_MESSAGES = new Set([
+  "Unauthorized",
+  "Not a member of this workspace",
+  "Project not found",
+  "Detector not found",
+  "Invalid JSON",
+  "Body must be a JSON object",
+  "name must be a non-empty string",
+  "template must be a non-empty string",
+  "prompt must be a non-empty string",
+  "sampleRate must be an integer between 0 and 100",
+  "enabled must be a boolean",
+  "enableRca must be a boolean",
+  "outputSchema must be an array",
+  'detectionSource must be "system" or "byok"',
+  "name must be a string",
+  "prompt must be a string",
+  "detectionModel must be a string",
+  "detectionProvider must be a string",
+  "detectionSource must be a string",
+  "Admin role required to delete detectors",
+]);
+
+const TRIGGER_CONDITION_USER_MESSAGES = new Set([
+  "Filter conditions must be an array.",
+  "Each filter condition must include a field, operator, and value.",
+  "Each filter condition needs a field.",
+  "Only Environment filters are supported right now.",
+  "Environment filters only support = or !=.",
+  "Environment filter values must be text or null.",
+]);
+
+function isSafeTriggerConditionError(message: string): boolean {
+  return triggerConditionErrorMessage(message) !== null;
+}
+
+function triggerConditionErrorMessage(message: string): string | null {
+  if (message === "triggerConditions must be an array") {
+    return "Filter conditions must be an array.";
+  }
+  if (/^triggerConditions\[\d+\] must be an object$/.test(message)) {
+    return "Each filter condition must include a field, operator, and value.";
+  }
+  if (/^triggerConditions\[\d+\]\.field must be a non-empty string$/.test(message)) {
+    return "Each filter condition needs a field.";
+  }
+  if (/^triggerConditions\[\d+\]\.field must be one of environment$/.test(message)) {
+    return "Only Environment filters are supported right now.";
+  }
+  if (/^triggerConditions\[\d+\]\.op must be one of =, != for environment$/.test(message)) {
+    return "Environment filters only support = or !=.";
+  }
+  if (/^triggerConditions\[\d+\]\.value must be a string or null for environment$/.test(message)) {
+    return "Environment filter values must be text or null.";
+  }
+  return null;
+}
+
+function isSafeDetectorErrorMessage(status: number, message: string): boolean {
+  const trimmed = message.trim();
+  if (status < 400 || status >= 500 || trimmed.length === 0 || trimmed.length > 240) {
+    return false;
+  }
+  if (trimmed.includes("\n") || trimmed.includes("\r")) {
+    return false;
+  }
+  return (
+    SAFE_DETECTOR_ERROR_MESSAGES.has(trimmed) ||
+    isSafeTriggerConditionError(trimmed) ||
+    /^Requires (MEMBER|ADMIN) role or higher$/.test(trimmed)
+  );
+}
+
+export function detectorMutationErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) {
+    return triggerConditionErrorMessage(error.message.trim()) ?? error.message;
+  }
+  return fallback;
+}
+
+export function isTriggerConditionMutationError(message: string): boolean {
+  const trimmed = message.trim();
+  return (
+    TRIGGER_CONDITION_USER_MESSAGES.has(trimmed) || triggerConditionErrorMessage(trimmed) !== null
+  );
+}
+
 async function createDetector(projectId: string, input: CreateDetectorInput): Promise<Detector> {
   const res = await fetch(`/api/projects/${projectId}/detectors`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
-  if (!res.ok) throw new Error(`Failed to create detector: ${res.status}`);
+  if (!res.ok) throw await detectorError(res, "Failed to create detector");
   const data = (await res.json()) as { detector: Detector };
   return data.detector;
 }
@@ -103,7 +203,7 @@ async function updateDetector(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
   });
-  if (!res.ok) throw new Error(`Failed to update detector: ${res.status}`);
+  if (!res.ok) throw await detectorError(res, "Failed to update detector");
   const data = (await res.json()) as { detector: Detector };
   return data.detector;
 }
@@ -112,7 +212,7 @@ async function deleteDetector(projectId: string, detectorId: string): Promise<vo
   const res = await fetch(`/api/projects/${projectId}/detectors/${detectorId}`, {
     method: "DELETE",
   });
-  if (!res.ok) throw new Error(`Failed to delete detector: ${res.status}`);
+  if (!res.ok) throw await detectorError(res, "Failed to delete detector");
 }
 
 /** List detectors for the list page (paginated, optional search). */

--- a/frontend/ui/src/features/detectors/utils/index.test.ts
+++ b/frontend/ui/src/features/detectors/utils/index.test.ts
@@ -21,7 +21,7 @@ const baseDetector: Detector = {
   detectionSource: "system",
   createTime: "2026-06-01T00:00:00Z",
   updateTime: "2026-06-01T00:00:00Z",
-  trigger: { conditions: [{ field: "duration", op: "gt", value: 1000 }] },
+  trigger: { conditions: [{ field: "environment", op: "eq", value: "production" }] },
 };
 
 const baseForm: DetectorFormValues = detectorToFormValues(baseDetector);
@@ -36,7 +36,8 @@ describe("detectorToFormValues", () => {
       detectionModel: "model-a",
       detectionProvider: "provider-a",
       detectionSource: "system",
-      conditions: [{ field: "duration", op: "gt", value: 1000 }],
+      conditions: [{ field: "environment", op: "=", value: "production" }],
+      unsupportedTriggerConditions: false,
     });
   });
 
@@ -52,6 +53,81 @@ describe("detectorToFormValues", () => {
     expect(values.detectionProvider).toBe("");
     expect(values.detectionSource).toBe("system");
     expect(values.conditions).toEqual([]);
+    expect(values.unsupportedTriggerConditions).toBe(false);
+  });
+
+  it("quarantines unsupported legacy trigger rows instead of hydrating them into the editor", () => {
+    const values = detectorToFormValues({
+      ...baseDetector,
+      trigger: { conditions: [{ field: "duration", op: "gt", value: 1000 }] },
+    });
+
+    expect(values.conditions).toEqual([]);
+    expect(values.unsupportedTriggerConditions).toBe(true);
+  });
+
+  it("keeps editable conditions while flagging unsupported rows in mixed trigger arrays", () => {
+    const values = detectorToFormValues({
+      ...baseDetector,
+      trigger: {
+        conditions: [
+          { field: "environment", op: "eq", value: "production" },
+          { field: "duration", op: "gt", value: 1000 },
+          { field: "environment", op: "!=", value: "staging" },
+        ],
+      },
+    });
+
+    expect(values.conditions).toEqual([
+      { field: "environment", op: "=", value: "production" },
+      { field: "environment", op: "!=", value: "staging" },
+    ]);
+    expect(values.unsupportedTriggerConditions).toBe(true);
+  });
+
+  it("quarantines malformed trigger containers instead of hydrating them into the editor", () => {
+    const values = detectorToFormValues({
+      ...baseDetector,
+      trigger: { conditions: { field: "environment", op: "=", value: "production" } },
+    });
+
+    expect(values.conditions).toEqual([]);
+    expect(values.unsupportedTriggerConditions).toBe(true);
+  });
+
+  it("flags a trigger row with null conditions as unsupported", () => {
+    const values = detectorToFormValues({
+      ...baseDetector,
+      trigger: { conditions: null },
+    });
+
+    expect(values.conditions).toEqual([]);
+    expect(values.unsupportedTriggerConditions).toBe(true);
+  });
+
+  it("keeps nullable environment filters editable", () => {
+    const values = detectorToFormValues({
+      ...baseDetector,
+      trigger: { conditions: [{ field: "environment", op: "=", value: null }] },
+    });
+
+    expect(values.conditions).toEqual([{ field: "environment", op: "=", value: null }]);
+    expect(values.unsupportedTriggerConditions).toBe(false);
+  });
+
+  it("quarantines trigger rows whose editable fields are inherited properties", () => {
+    const condition = Object.create({
+      field: "environment",
+      op: "=",
+      value: "production",
+    }) as { field: string; op: string; value: string };
+    const values = detectorToFormValues({
+      ...baseDetector,
+      trigger: { conditions: [condition] },
+    });
+
+    expect(values.conditions).toEqual([]);
+    expect(values.unsupportedTriggerConditions).toBe(true);
   });
 });
 
@@ -90,9 +166,15 @@ describe("buildDetectorPatch", () => {
   });
 
   it("sends changed trigger conditions as triggerConditions", () => {
-    const conditions = [{ field: "status", op: "eq", value: "error" }];
+    const conditions = [{ field: "environment", op: "!=", value: "staging" }];
     const patch = buildDetectorPatch(baseForm, { ...baseForm, conditions });
     expect(patch).toEqual({ triggerConditions: conditions });
+  });
+
+  it("can force a trigger replacement when unsupported stored rows were edited away", () => {
+    const loaded = { ...baseForm, unsupportedTriggerConditions: true };
+    const patch = buildDetectorPatch(loaded, { ...loaded }, { forceTriggerConditions: true });
+    expect(patch).toEqual({ triggerConditions: loaded.conditions });
   });
 });
 
@@ -112,7 +194,7 @@ describe("mergeDetectorIntoForm", () => {
   });
 
   it("keeps the user's edited conditions while applying server values elsewhere", () => {
-    const userConditions = [{ field: "status", op: "eq", value: "error" }];
+    const userConditions = [{ field: "environment", op: "!=", value: "staging" }];
     const form = { ...baseForm, conditions: userConditions };
     const merged = mergeDetectorIntoForm(baseForm, next, form);
     expect(merged.conditions).toEqual(userConditions);
@@ -120,10 +202,33 @@ describe("mergeDetectorIntoForm", () => {
   });
 
   it("takes the server's conditions when the form left them untouched", () => {
-    const serverConditions = [{ field: "latency", op: "gt", value: 5000 }];
+    const serverConditions = [{ field: "environment", op: "=", value: "staging" }];
     const serverNext = { ...baseForm, conditions: serverConditions };
     const merged = mergeDetectorIntoForm(baseForm, serverNext, { ...baseForm });
     expect(merged.conditions).toEqual(serverConditions);
+  });
+
+  it("preserves the form condition reference when a refetch returns the same rows", () => {
+    const formConditions = [{ field: "environment", op: "=", value: "production" }];
+    const serverConditions = [{ field: "environment", op: "=", value: "production" }];
+    const merged = mergeDetectorIntoForm(
+      baseForm,
+      { ...next, conditions: serverConditions },
+      { ...baseForm, conditions: formConditions },
+    );
+
+    expect(merged.conditions).toBe(formConditions);
+  });
+
+  it("keeps hidden legacy trigger warnings from the latest server snapshot when conditions are edited", () => {
+    const userConditions = [{ field: "environment", op: "!=", value: "staging" }];
+    const serverNext = { ...baseForm, unsupportedTriggerConditions: true };
+    const form = { ...baseForm, conditions: userConditions, unsupportedTriggerConditions: false };
+
+    const merged = mergeDetectorIntoForm(baseForm, serverNext, form);
+
+    expect(merged.conditions).toEqual(userConditions);
+    expect(merged.unsupportedTriggerConditions).toBe(true);
   });
 
   it("keeps all three detection fields when the user touched the model selector", () => {

--- a/frontend/ui/src/features/detectors/utils/index.ts
+++ b/frontend/ui/src/features/detectors/utils/index.ts
@@ -1,5 +1,7 @@
 import type { Detector, UpdateDetectorInput } from "../hooks/use-detectors";
 
+type EditableTriggerCondition = { field: string; op: string; value: unknown };
+
 /**
  * The detector edit panel's form as plain data, so dirty-checking and merge
  * logic stay pure and unit-testable. Empty string means "unset" for the
@@ -13,10 +15,72 @@ export interface DetectorFormValues {
   detectionModel: string;
   detectionProvider: string;
   detectionSource: "system" | "byok";
-  conditions: Array<{ field: string; op: string; value: unknown }>;
+  conditions: EditableTriggerCondition[];
+  unsupportedTriggerConditions: boolean;
+}
+
+const LEGACY_TRIGGER_OPERATORS = new Map([
+  ["eq", "="],
+  ["ne", "!="],
+  ["neq", "!="],
+]);
+
+function hasOwn(record: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function isEditableEnvironmentValue(value: unknown): value is string | null {
+  return value === null || typeof value === "string";
+}
+
+function normalizeEditableTriggerConditions(
+  conditions: unknown,
+  hasTrigger: boolean,
+): {
+  conditions: EditableTriggerCondition[];
+  unsupported: boolean;
+} {
+  if (conditions == null) {
+    return { conditions: [], unsupported: hasTrigger };
+  }
+  if (!Array.isArray(conditions)) {
+    return { conditions: [], unsupported: true };
+  }
+
+  const normalized: EditableTriggerCondition[] = [];
+  let unsupported = false;
+  for (const condition of conditions) {
+    if (condition === null || typeof condition !== "object" || Array.isArray(condition)) {
+      unsupported = true;
+      continue;
+    }
+
+    const record = condition as Record<string, unknown>;
+    if (!hasOwn(record, "field") || !hasOwn(record, "op") || !hasOwn(record, "value")) {
+      unsupported = true;
+      continue;
+    }
+    const field = record.field;
+    const rawOp = record.op;
+    const value = record.value;
+    const op = typeof rawOp === "string" ? (LEGACY_TRIGGER_OPERATORS.get(rawOp) ?? rawOp) : rawOp;
+    if (
+      field !== "environment" ||
+      (op !== "=" && op !== "!=") ||
+      !isEditableEnvironmentValue(value)
+    ) {
+      unsupported = true;
+      continue;
+    }
+    normalized.push({ field, op, value });
+  }
+
+  return { conditions: normalized, unsupported };
 }
 
 export function detectorToFormValues(d: Detector): DetectorFormValues {
+  const trigger = normalizeEditableTriggerConditions(d.trigger?.conditions, d.trigger != null);
+
   return {
     name: d.name,
     prompt: d.prompt,
@@ -25,7 +89,8 @@ export function detectorToFormValues(d: Detector): DetectorFormValues {
     detectionModel: d.detectionModel ?? "",
     detectionProvider: d.detectionProvider ?? "",
     detectionSource: d.detectionSource === "byok" ? "byok" : "system",
-    conditions: d.trigger?.conditions ?? [],
+    conditions: trigger.conditions,
+    unsupportedTriggerConditions: trigger.unsupported,
   };
 }
 
@@ -46,13 +111,14 @@ function conditionsEqual(
 export function buildDetectorPatch(
   loaded: DetectorFormValues,
   form: DetectorFormValues,
+  options: { forceTriggerConditions?: boolean } = {},
 ): UpdateDetectorInput {
   const patch: UpdateDetectorInput = {};
   if (form.name !== loaded.name) patch.name = form.name;
   if (form.prompt !== loaded.prompt) patch.prompt = form.prompt;
   if (form.sampleRate !== loaded.sampleRate) patch.sampleRate = form.sampleRate;
   if (form.enableRca !== loaded.enableRca) patch.enableRca = form.enableRca;
-  if (!conditionsEqual(form.conditions, loaded.conditions)) {
+  if (options.forceTriggerConditions || !conditionsEqual(form.conditions, loaded.conditions)) {
     patch.triggerConditions = form.conditions;
   }
   if (form.detectionModel !== loaded.detectionModel && form.detectionModel !== "") {
@@ -95,7 +161,10 @@ export function mergeDetectorIntoForm(
     detectionProvider: touchedSelector ? form.detectionProvider : next.detectionProvider,
     detectionSource: touchedSelector ? form.detectionSource : next.detectionSource,
     conditions: conditionsEqual(form.conditions, previous.conditions)
-      ? next.conditions
+      ? conditionsEqual(form.conditions, next.conditions)
+        ? form.conditions
+        : next.conditions
       : form.conditions,
+    unsupportedTriggerConditions: next.unsupportedTriggerConditions,
   };
 }

--- a/tests/worker/test_detector_tasks.py
+++ b/tests/worker/test_detector_tasks.py
@@ -1,7 +1,10 @@
 """Unit tests for the exactly-once detector enqueue path (Redis lock + BullMQ)."""
 
 import json
+import sys
 import threading
+import types
+from collections import OrderedDict
 from unittest.mock import MagicMock
 
 import pytest
@@ -72,6 +75,613 @@ def _patch_summaries(monkeypatch, summaries):
 def _lock_state(fake_redis, project_id=PROJECT, trace_id=TRACE):
     raw = fake_redis.store.get(dt._lock_key(project_id, trace_id))
     return json.loads(raw) if raw is not None else None
+
+
+# ── Trigger condition evaluation ───────────────────────────────────────
+
+
+class TestTriggerConditionEvaluation:
+    def test_missing_field_does_not_pass_not_equal(self):
+        assert dt._eval_condition({}, {"field": "status", "op": "!=", "value": "ERROR"}) is False
+
+    @pytest.mark.parametrize(
+        ("condition", "expected"),
+        [
+            pytest.param(
+                {"field": "environment", "op": "=", "value": None}, True, id="equals-null"
+            ),
+            pytest.param(
+                {"field": "environment", "op": "!=", "value": None},
+                False,
+                id="not-equals-null",
+            ),
+            pytest.param(
+                {"field": "environment", "op": "!=", "value": "production"},
+                True,
+                id="not-equals-string",
+            ),
+        ],
+    )
+    def test_present_null_uses_scalar_equality(self, condition, expected):
+        assert dt._eval_condition({"environment": None}, condition) is expected
+
+    @pytest.mark.parametrize(
+        "condition",
+        [
+            pytest.param("environment=production", id="string-condition"),
+            pytest.param({"op": "=", "value": "production"}, id="missing-field"),
+            pytest.param({"field": "environment", "value": "production"}, id="missing-op"),
+            pytest.param({"field": "environment", "op": "="}, id="missing-value"),
+        ],
+    )
+    def test_malformed_condition_returns_false(self, condition):
+        assert dt._eval_condition({"environment": "production"}, condition) is False
+
+    def test_missing_value_is_not_treated_as_explicit_null(self):
+        assert (
+            dt._eval_condition({"environment": None}, {"field": "environment", "op": "="}) is False
+        )
+
+    @pytest.mark.parametrize("op", ["=", "!="])
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param({}, id="object"),
+            pytest.param([], id="array"),
+            pytest.param(True, id="true"),
+            pytest.param(False, id="false"),
+            pytest.param(42, id="integer"),
+            pytest.param(3.14, id="float"),
+        ],
+    )
+    def test_malformed_environment_equality_value_returns_false(self, op, value):
+        assert (
+            dt._eval_condition(
+                {"environment": "production"},
+                {"field": "environment", "op": op, "value": value},
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize("op", ["=", "!="])
+    @pytest.mark.parametrize(
+        "actual",
+        [
+            pytest.param({}, id="object"),
+            pytest.param([], id="array"),
+            pytest.param(True, id="true"),
+            pytest.param(False, id="false"),
+            pytest.param(42, id="integer"),
+            pytest.param(3.14, id="float"),
+        ],
+    )
+    def test_malformed_environment_actual_value_returns_false(self, op, actual):
+        assert (
+            dt._eval_condition(
+                {"environment": actual},
+                {"field": "environment", "op": op, "value": "production"},
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize(
+        ("op", "expected"),
+        [
+            pytest.param("eq", True, id="eq"),
+            pytest.param("ne", False, id="ne"),
+            pytest.param("neq", False, id="neq"),
+        ],
+    )
+    def test_legacy_equality_aliases_are_supported(self, op, expected):
+        assert (
+            dt._eval_condition(
+                {"environment": "production"},
+                {"field": "environment", "op": op, "value": "production"},
+            )
+            is expected
+        )
+
+    @pytest.mark.parametrize("op", [">", ">=", "<", "<=", "gt", "gte", "lt", "lte"])
+    def test_numeric_fields_are_unsupported_until_summaries_include_them(self, op):
+        assert dt._eval_condition({"cost": "10"}, {"field": "cost", "op": op, "value": 5}) is False
+
+    @pytest.mark.parametrize(
+        ("trace_summary", "condition"),
+        [
+            pytest.param(
+                {"cost": "100.5"},
+                {"field": "cost", "op": ">", "value": "abc"},
+                id="invalid-expected-value",
+            ),
+            pytest.param(
+                {"cost": "100.5"},
+                {"field": "cost", "op": "<", "value": True},
+                id="boolean-expected-value",
+            ),
+            pytest.param(
+                {"cost": "slow"},
+                {"field": "cost", "op": ">", "value": 10},
+                id="invalid-actual-value",
+            ),
+            pytest.param(
+                {"cost": "nan"},
+                {"field": "cost", "op": ">", "value": 10},
+                id="nan-actual-value",
+            ),
+            pytest.param(
+                {"cost": "inf"},
+                {"field": "cost", "op": ">", "value": 10},
+                id="infinite-actual-value",
+            ),
+        ],
+    )
+    def test_unsupported_numeric_conditions_return_false(self, trace_summary, condition):
+        assert dt._eval_condition(trace_summary, condition) is False
+
+    def test_non_list_stored_trigger_conditions_fail_closed(self):
+        object_condition = {"field": "environment", "op": "!=", "value": "prod"}
+        json_object_condition = '{"field": "environment", "op": "!=", "value": "prod"}'
+
+        assert dt._coerce_trigger_conditions(object_condition) == [None]
+        assert dt._coerce_trigger_conditions(json_object_condition) == [None]
+        assert (
+            dt._passes_trigger(
+                {"environment": "staging"},
+                dt._coerce_trigger_conditions(object_condition),
+            )
+            is False
+        )
+
+    def test_malformed_json_string_trigger_conditions_fail_closed(self):
+        conditions = dt._coerce_trigger_conditions("{bad json")
+
+        assert conditions == [None]
+        assert dt._passes_trigger({"environment": "staging"}, conditions) is False
+
+    def test_json_string_trigger_condition_array_remains_supported(self):
+        conditions = dt._coerce_trigger_conditions(
+            '[{"field": "environment", "op": "eq", "value": "production"}]',
+            has_trigger=True,
+        )
+
+        assert conditions == [{"field": "environment", "op": "eq", "value": "production"}]
+        assert dt._passes_trigger({"environment": "production"}, conditions) is True
+
+    def test_null_condition_without_trigger_row_remains_always_pass(self):
+        assert dt._coerce_trigger_conditions(None, has_trigger=False) == []
+
+    @pytest.mark.parametrize("conditions", [None, "null"])
+    def test_null_condition_with_trigger_row_fails_closed(self, conditions):
+        assert dt._coerce_trigger_conditions(conditions, has_trigger=True) == [None]
+        assert (
+            dt._passes_trigger(
+                {"environment": "staging"},
+                dt._coerce_trigger_conditions(conditions, has_trigger=True),
+            )
+            is False
+        )
+
+    def test_get_active_detectors_uses_trigger_row_presence(self, monkeypatch):
+        rows = [
+            ("no-trigger", 100, False, None),
+            ("json-null", 100, True, "null"),
+            ("db-null", 100, True, None),
+            ("malformed-json", 100, True, "{bad json"),
+            (
+                "valid-trigger",
+                100,
+                True,
+                [{"field": "environment", "op": "=", "value": "production"}],
+            ),
+        ]
+        cursor = None
+
+        class FakeCursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def execute(self, query, params):
+                self.query = query
+                self.params = params
+
+            def fetchall(self):
+                return rows
+
+        class FakeConnection:
+            closed = False
+
+            def cursor(self):
+                nonlocal cursor
+                cursor = FakeCursor()
+                return cursor
+
+            def close(self):
+                self.closed = True
+
+        fake_conn = FakeConnection()
+        monkeypatch.setitem(
+            sys.modules,
+            "psycopg2",
+            types.SimpleNamespace(connect=lambda database_url: fake_conn),
+        )
+
+        detectors = dt._get_active_detectors(PROJECT)
+
+        assert cursor is not None
+        assert "SELECT d.id, d.sample_rate, dt.id IS NOT NULL AS has_trigger, dt.conditions" in (
+            " ".join(cursor.query.split())
+        )
+        assert cursor.params == (PROJECT,)
+        assert detectors == [
+            {"id": "no-trigger", "sample_rate": 100, "conditions": []},
+            {"id": "json-null", "sample_rate": 100, "conditions": [None]},
+            {"id": "db-null", "sample_rate": 100, "conditions": [None]},
+            {"id": "malformed-json", "sample_rate": 100, "conditions": [None]},
+            {
+                "id": "valid-trigger",
+                "sample_rate": 100,
+                "conditions": [{"field": "environment", "op": "=", "value": "production"}],
+            },
+        ]
+        assert fake_conn.closed is True
+
+    def test_get_active_detectors_warns_once_for_unsupported_conditions(self, monkeypatch, caplog):
+        rows = [
+            (
+                "legacy-status",
+                100,
+                True,
+                [{"field": "status", "op": "!=", "value": "ERROR"}],
+            ),
+            (
+                "missing-op",
+                100,
+                True,
+                [{"field": "environment", "value": "production"}],
+            ),
+            ("malformed-entry", 100, True, [None]),
+            (
+                "valid-trigger",
+                100,
+                True,
+                [{"field": "environment", "op": "=", "value": "production"}],
+            ),
+        ]
+
+        class FakeCursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def execute(self, query, params):
+                pass
+
+            def fetchall(self):
+                return rows
+
+        class FakeConnection:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        monkeypatch.setitem(
+            sys.modules,
+            "psycopg2",
+            types.SimpleNamespace(connect=lambda database_url: FakeConnection()),
+        )
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_IDS", OrderedDict())
+
+        with caplog.at_level("WARNING"):
+            dt._get_active_detectors(PROJECT)
+            dt._get_active_detectors(PROJECT)
+
+        warnings = [
+            record
+            for record in caplog.records
+            if "unsupported or malformed trigger conditions" in record.message
+        ]
+        assert len(warnings) == 3
+        assert {record.args[0] for record in warnings} == {
+            "legacy-status",
+            "malformed-entry",
+            "missing-op",
+        }
+
+    def test_get_active_detectors_resets_warning_dedupe_after_supported_conditions(
+        self, monkeypatch, caplog
+    ):
+        rows = [
+            (
+                "det-1",
+                100,
+                True,
+                [{"field": "duration", "op": "gt", "value": 1000}],
+            )
+        ]
+
+        class FakeCursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def execute(self, query, params):
+                pass
+
+            def fetchall(self):
+                return rows
+
+        class FakeConnection:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        monkeypatch.setitem(
+            sys.modules,
+            "psycopg2",
+            types.SimpleNamespace(connect=lambda database_url: FakeConnection()),
+        )
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_IDS", OrderedDict())
+
+        with caplog.at_level("WARNING"):
+            dt._get_active_detectors(PROJECT)
+            dt._get_active_detectors(PROJECT)
+            rows[:] = [
+                (
+                    "det-1",
+                    100,
+                    True,
+                    [{"field": "environment", "op": "=", "value": "production"}],
+                )
+            ]
+            dt._get_active_detectors(PROJECT)
+            rows[:] = [
+                (
+                    "det-1",
+                    100,
+                    True,
+                    [{"field": "duration", "op": "gt", "value": 1000}],
+                )
+            ]
+            dt._get_active_detectors(PROJECT)
+
+        warnings = [
+            record
+            for record in caplog.records
+            if "unsupported or malformed trigger conditions" in record.message
+        ]
+        assert len(warnings) == 2
+        assert [record.args[0] for record in warnings] == ["det-1", "det-1"]
+
+    def test_get_active_detectors_resets_warning_dedupe_after_detector_leaves_active_set(
+        self, monkeypatch, caplog
+    ):
+        rows = [
+            (
+                "det-1",
+                100,
+                True,
+                [{"field": "duration", "op": "gt", "value": 1000}],
+            )
+        ]
+
+        class FakeCursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def execute(self, query, params):
+                pass
+
+            def fetchall(self):
+                return rows
+
+        class FakeConnection:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        monkeypatch.setitem(
+            sys.modules,
+            "psycopg2",
+            types.SimpleNamespace(connect=lambda database_url: FakeConnection()),
+        )
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_IDS", OrderedDict())
+
+        with caplog.at_level("WARNING"):
+            dt._get_active_detectors(PROJECT)
+            dt._get_active_detectors(PROJECT)
+            rows[:] = []
+            dt._get_active_detectors(PROJECT)
+            rows[:] = [
+                (
+                    "det-1",
+                    100,
+                    True,
+                    [{"field": "duration", "op": "gt", "value": 1000}],
+                )
+            ]
+            dt._get_active_detectors(PROJECT)
+            rows[:] = [("det-1", 100, False, None)]
+            dt._get_active_detectors(PROJECT)
+            rows[:] = [
+                (
+                    "det-1",
+                    100,
+                    True,
+                    [{"field": "duration", "op": "gt", "value": 1000}],
+                )
+            ]
+            dt._get_active_detectors(PROJECT)
+
+        warnings = [
+            record
+            for record in caplog.records
+            if "unsupported or malformed trigger conditions" in record.message
+        ]
+        assert len(warnings) == 3
+        assert [record.args[0] for record in warnings] == ["det-1", "det-1", "det-1"]
+
+    def test_unsupported_trigger_warning_dedupe_is_bounded(self, monkeypatch):
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_LIMIT", 2)
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_IDS", OrderedDict())
+
+        bad_conditions = [{"field": "duration", "op": "gt", "value": 1000}]
+
+        assert dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-1", bad_conditions) is True
+        assert dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-2", bad_conditions) is True
+        assert dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-1", bad_conditions) is False
+        assert dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-3", bad_conditions) is False
+
+        assert [key[1] for key in dt._UNSUPPORTED_TRIGGER_WARNING_IDS] == ["det-2", "det-1"]
+        assert dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-2", bad_conditions) is False
+
+    def test_get_active_detectors_does_not_rewarn_after_warning_cache_capacity(
+        self, monkeypatch, caplog
+    ):
+        rows = [
+            ("det-1", 100, True, [{"field": "duration", "op": "gt", "value": 1000}]),
+            ("det-2", 100, True, [{"field": "status", "op": "=", "value": "ERROR"}]),
+            ("det-3", 100, True, [{"field": "cost", "op": "gt", "value": 1}]),
+        ]
+
+        class FakeCursor:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def execute(self, query, params):
+                pass
+
+            def fetchall(self):
+                return rows
+
+        class FakeConnection:
+            def cursor(self):
+                return FakeCursor()
+
+            def close(self):
+                pass
+
+        monkeypatch.setitem(
+            sys.modules,
+            "psycopg2",
+            types.SimpleNamespace(connect=lambda database_url: FakeConnection()),
+        )
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_LIMIT", 2)
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_IDS", OrderedDict())
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_SUPPRESSED_PROJECTS", OrderedDict())
+
+        with caplog.at_level("WARNING"):
+            dt._get_active_detectors(PROJECT)
+            dt._get_active_detectors(PROJECT)
+
+        warnings = [
+            record
+            for record in caplog.records
+            if "unsupported or malformed trigger conditions" in record.message
+        ]
+        assert len(warnings) == 2
+        assert [record.args[0] for record in warnings] == ["det-1", "det-2"]
+        assert [key[1] for key in dt._UNSUPPORTED_TRIGGER_WARNING_IDS] == ["det-1", "det-2"]
+        suppression_warnings = [
+            record
+            for record in caplog.records
+            if "Detector trigger warning cache" in record.message
+        ]
+        assert len(suppression_warnings) == 1
+        assert suppression_warnings[0].args == (PROJECT,)
+
+    def test_unsupported_trigger_warning_dedupe_tracks_condition_changes(self, monkeypatch):
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_IDS", OrderedDict())
+
+        first_bad_conditions = [{"field": "duration", "op": "gt", "value": 1000}]
+        second_bad_conditions = [{"field": "status", "op": "=", "value": "ERROR"}]
+
+        assert (
+            dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-1", first_bad_conditions)
+            is True
+        )
+        assert (
+            dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-1", first_bad_conditions)
+            is False
+        )
+        assert (
+            dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-1", second_bad_conditions)
+            is True
+        )
+
+        dt._clear_unsupported_trigger_warning_seen(PROJECT, "det-1")
+
+        assert (
+            dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-1", second_bad_conditions)
+            is True
+        )
+
+    def test_unsupported_trigger_warning_dedupe_expires(self, monkeypatch):
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_TTL_SECONDS", 10)
+        monkeypatch.setattr(dt, "_UNSUPPORTED_TRIGGER_WARNING_IDS", OrderedDict())
+        now = 1000.0
+        monkeypatch.setattr(dt.time, "monotonic", lambda: now)
+
+        bad_conditions = [{"field": "duration", "op": "gt", "value": 1000}]
+
+        assert dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-1", bad_conditions) is True
+        assert dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-1", bad_conditions) is False
+
+        now = 1011.0
+
+        assert dt._mark_unsupported_trigger_warning_seen(PROJECT, "det-1", bad_conditions) is True
+
+    @pytest.mark.parametrize("op", ["=", "!="])
+    def test_legacy_status_condition_is_inert(self, op):
+        assert (
+            dt._passes_trigger(
+                {"environment": "production"},
+                [{"field": "status", "op": op, "value": "ERROR"}],
+            )
+            is False
+        )
+
+    @pytest.mark.parametrize(
+        "condition",
+        [
+            pytest.param(None, id="null-entry"),
+            pytest.param({"field": "status", "op": "!=", "value": "ERROR"}, id="unsupported-field"),
+            pytest.param({"field": "environment", "value": "production"}, id="missing-op"),
+            pytest.param({"field": "environment", "op": "="}, id="missing-value"),
+            pytest.param({"field": "environment", "op": "=", "value": []}, id="bad-value"),
+        ],
+    )
+    def test_unsupported_trigger_condition_detection(self, condition):
+        assert dt._has_unsupported_trigger_conditions([condition]) is True
+
+    def test_supported_trigger_conditions_are_not_marked_unsupported(self):
+        assert (
+            dt._has_unsupported_trigger_conditions(
+                [
+                    {"field": "environment", "op": "eq", "value": "production"},
+                    {"field": "environment", "op": "!=", "value": None},
+                ]
+            )
+            is False
+        )
 
 
 # ── Primary path: root-bearing batch ────────────────────────────────────
@@ -159,8 +769,10 @@ class TestPrimaryEnqueue:
         mock_add_job.assert_not_called()
         assert _lock_state(fake_redis)["state"] == "sampled_out"
 
-    def test_bad_trace_does_not_drop_rest_of_batch(self, fake_redis, mock_add_job, monkeypatch):
-        """A malformed condition only drops the offending trace."""
+    def test_invalid_numeric_condition_fails_closed_without_stopping_batch(
+        self, fake_redis, mock_add_job, monkeypatch
+    ):
+        """An invalid numeric trigger condition fails closed without stopping the batch."""
         other = "bb" * 16
         _patch_detectors(
             monkeypatch,
@@ -170,8 +782,10 @@ class TestPrimaryEnqueue:
 
         dt.enqueue_detector_runs(PROJECT, {TRACE, other})
 
-        # TRACE raises in float(); `other` has cost missing -> condition False -> sampled_out.
+        # TRACE fails closed on the invalid numeric condition; `other` has cost
+        # missing -> condition False -> sampled_out.
         assert mock_add_job.call_count == 0
+        assert _lock_state(fake_redis, trace_id=TRACE)["state"] == "sampled_out"
         assert _lock_state(fake_redis, trace_id=other)["state"] == "sampled_out"
 
     def test_concurrent_claims_enqueue_exactly_once(self, fake_redis, monkeypatch):


### PR DESCRIPTION
Related to #1364

## Summary

This addresses the `triggerConditions` validation portion of #1364. Detector POST/PATCH routes previously only checked that `triggerConditions` was an array, so malformed or unsupported condition entries could be persisted and later fail during worker-side trigger evaluation.

The change adds a shared detector trigger normalization helper for API writes, hardens the worker evaluator so malformed legacy stored conditions fail closed, and makes the detector UI explicit about legacy filter remediation instead of silently replacing hidden trigger rows.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [x] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

### Changes

- Validate each detector trigger condition has a supported `field`, supported `op`, and field-compatible `value` before POST/PATCH persistence.
- Restrict write-time trigger fields to the currently worker-supported summary field, `environment`, its supported operators, `=` and `!=`, and string/null values.
- Normalize legacy equality aliases like `eq`, `ne`, and `neq` before persistence, and normalize legacy aliases in the worker for existing stored rows.
- Reject prototype-chain field names such as `__proto__`, `constructor`, and `toString` as normal 400 responses, and require trigger condition properties to be own properties on write and UI remediation paths.
- Read top-level POST/PATCH request fields from own properties only so inherited `triggerConditions` cannot be applied accidentally.
- Reject malformed POST/PATCH request bodies with a 400 instead of destructuring non-object JSON.
- Preserve curated detector 4xx API validation/auth messages in detector mutation hooks while keeping unknown bodies and 5xx responses on generic status messages.
- Render create/edit detector mutation errors inline, anchoring trigger validation errors to the Filter section.
- Surface quick-add detector failures with the failed template label plus mutation error detail.
- Quarantine unsupported or malformed persisted trigger conditions before hydrating the edit panel, and show a warning instead of feeding unrepresentable rows into the current `environment` filter editor.
- Preserve hidden legacy trigger rows on ordinary detector edits and block filter edits until the user explicitly chooses `Discard hidden filters on save`.
- Let explicit legacy discard save the visible filter rows as the complete trigger replacement; an all-legacy trigger with no visible rows saves `[]`.
- Let the trigger editor round-trip nullable environment filters with a `Value is null` control instead of mislabeling valid `environment = null` filters as unsupported legacy data.
- Harden `backend/worker/detector_tasks.py` so malformed legacy condition objects, present malformed stored condition containers including JSON `null`, and unsupported numeric fields/operators fail closed.
- Treat unsupported/missing legacy trigger fields as non-matches, including `!=`, while comparing present nullable fields normally for `=` and `!=`.
- Emit a bounded project-aware worker warning keyed by detector with a stored condition fingerprint when an active detector has unsupported or malformed trigger conditions.
- Clear cached warning state after a detector is observed with fully supported trigger conditions, no trigger row, or after it leaves the active detector set.
- Add POST/PATCH route, hook, form utility, detector panel, trigger editor, new detector page, quick-add, and worker regression coverage.

### Why this matters

Invalid detector trigger payloads currently create detectors that can silently never fire or, for malformed stored containers, accidentally behave like an empty always-pass trigger. Returning a 400 at write time gives immediate API feedback, preserving curated validation details keeps errors actionable in the UI, and the worker guard keeps older malformed rows from breaking detection evaluation.

The edit panel now avoids a risky migration path: hidden legacy trigger rows are not removed by a normal supported-filter edit. Replacement requires an explicit discard-on-save action, so detector scope is not broadened accidentally.

### Tests

Commands run:

- `pnpm exec vitest run 'src/app/api/projects/[projectId]/detectors/route.test.ts' 'src/app/api/projects/[projectId]/detectors/[detectorId]/route.test.ts' 'src/app/api/projects/[projectId]/detectors/trigger-validation.test.ts' 'src/features/detectors/hooks/use-detectors.test.tsx' 'src/features/detectors/utils/index.test.ts' 'src/features/detectors/components/detector-panel.test.tsx' 'src/features/detectors/components/trigger-editor.test.tsx' 'src/app/projects/[projectId]/detectors/new/page.test.tsx' 'src/features/detectors/components/add-detectors-step.test.tsx'` from `frontend/ui` - passed (`9 files`, `127 tests`)
- `uv run pytest tests/worker/test_detector_tasks.py backend/worker/tests/test_detector_tasks.py -q` - passed (`110 passed`)
- `uv run pytest tests/worker -q` - passed (`402 passed`)
- `pnpm exec eslint ...` from `frontend/ui` on changed detector files - passed
- `pnpm exec prettier --check ...` from `frontend/ui` on changed detector files - passed
- `uv run ruff check backend/worker/detector_tasks.py backend/worker/tests/test_detector_tasks.py tests/worker/test_detector_tasks.py` - passed
- `uv run ruff format --check backend/worker/detector_tasks.py backend/worker/tests/test_detector_tasks.py tests/worker/test_detector_tasks.py` - passed
- `uv run mypy backend/worker/detector_tasks.py backend/worker/tests/test_detector_tasks.py tests/worker/test_detector_tasks.py` - passed
- `git diff --check` and `git diff --check origin/main...HEAD` - passed

Also run:

- `uv run ruff check backend/worker tests/worker && uv run ruff format --check backend/worker tests/worker && uv run mypy backend/worker tests/worker` - Ruff and format passed, then mypy failed on existing unrelated typing errors in `backend/worker/tokens/pricing.py`, `tests/worker/tokens/test_pricing.py`, and `backend/worker/ingest_tasks.py`; detector-only mypy passed as listed above.
- `pnpm --filter traceroot-ui exec tsc --noEmit --pretty false` from `frontend` - failed on existing unrelated test typing errors in `src/__tests__/next-config.test.ts` and `src/app/api/projects/__tests__/route.test.ts`; no detector files were reported.

### Risk

Risk level: medium

This intentionally rejects detector write payloads that do not match the condition shape the worker can evaluate today. Existing malformed rows are not migrated; malformed legacy rows now fail closed in worker evaluation instead of raising or becoming an empty always-pass condition list. Legacy equality operator aliases continue to evaluate through worker-side normalization for `environment`; numeric aliases and non-`environment` fields are treated as unsupported until the worker summary query and editor contract are expanded. Present nullable `environment` fields now use ordinary `=` / `!=` comparison semantics in the worker, while missing fields still fail closed.

The edit panel keeps supported string and nullable environment filters editable, warns when stored conditions include unsupported rows, and preserves hidden legacy rows on unrelated edits. Saving filter edits while hidden legacy rows exist is blocked until the user explicitly chooses `Discard hidden filters on save`; after that, the visible filter rows become the full stored trigger set. The change is easy to roll back by removing the shared route normalization helper, worker guards, and UI remediation branch.

Before merging or rolling this out to production data, maintainers can estimate affected rows with:

```sql
SELECT
  d.project_id,
  d.id AS detector_id,
  d.name,
  dt.id AS trigger_id,
  dt.conditions
FROM detector_triggers dt
JOIN detectors d ON d.id = dt.detector_id
WHERE jsonb_typeof(dt.conditions) IS DISTINCT FROM 'array'
   OR EXISTS (
     SELECT 1
     FROM jsonb_array_elements(
       CASE
         WHEN jsonb_typeof(dt.conditions) = 'array' THEN dt.conditions
         ELSE '[]'::jsonb
       END
     ) AS elem(value)
     WHERE jsonb_typeof(elem.value) IS DISTINCT FROM 'object'
        OR NOT (elem.value ? 'field')
        OR elem.value->>'field' IS DISTINCT FROM 'environment'
        OR NOT (elem.value ? 'op')
        OR COALESCE(elem.value->>'op', '') NOT IN ('=', '!=', 'eq', 'ne', 'neq')
        OR NOT (elem.value ? 'value')
        OR jsonb_typeof(elem.value->'value') NOT IN ('string', 'null')
   );
```

The worker also logs a bounded warning per affected project and detector when an active detector has unsupported or malformed trigger conditions, and stores a condition fingerprint so condition changes and TTL expiry can re-log once. The cache stops admitting new detector IDs after the cap instead of evicting still-active entries, preventing high-cardinality legacy data from re-warning on every sweep. The warning state is cleared after that detector is observed with fully supported trigger conditions, no trigger row, or after it leaves the active detector set. For remediation, rows that should run on every completed trace can use `[]`; rows that should filter by environment can be rewritten to `[{ "field": "environment", "op": "=", "value": "production" }]`, `[{ "field": "environment", "op": "=", "value": null }]`, or the `!=` equivalents. Rows that intentionally depend on unsupported fields such as duration, status, cost, or token counts should wait for a follow-up that expands the worker trace summary and editor contract.

## Screenshots / Recordings (if applicable)

These screenshots were captured with Playwright from a local Next dev server using the real detector create/edit/onboarding routes, API route mocks, and a local auth cookie. Error-state screenshots use mocked 4xx validation responses to show inline surfacing; they do not indicate that the built-in detector templates fail by default. The captured PNGs are embedded in SVG wrappers only because `gh gist create` rejects binary PNG uploads.

Edit panel warning before explicit legacy filter discard:

![Detector edit panel legacy warning](https://gist.githubusercontent.com/DivyamTalwar/0fb0966b3fcc860cf547513500c17edd/raw/edit-panel-legacy-warning.svg)

Edit panel after choosing the explicit discard-on-save action:

![Detector edit panel discard selected](https://gist.githubusercontent.com/DivyamTalwar/0fb0966b3fcc860cf547513500c17edd/raw/edit-panel-discard-selected.svg)

New detector page with the inline filter validation error anchored to the Filter section (mocked 4xx validation response):

![New detector inline filter validation error](https://gist.githubusercontent.com/DivyamTalwar/0fb0966b3fcc860cf547513500c17edd/raw/new-detector-filter-error.svg)

Onboarding quick-add flow with the failed template label and detector mutation detail (mocked 4xx validation response):

![Onboarding quick-add detector error](https://gist.githubusercontent.com/DivyamTalwar/0fb0966b3fcc860cf547513500c17edd/raw/quick-add-template-error.svg)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

## Issue

Related to #1364. This PR covers the `triggerConditions` validation sub-issue; detector write-role gating is handled separately in #1391.

## Notes for maintainers

Open PR #1390 also touches the detector create route for 0% sample-rate behavior. This PR avoids sample-rate and enabled-state semantics, but may need a small rebase if #1390 lands first.

This PR does not expand the trigger-field surface. Numeric trigger fields such as trace cost, duration, or token counts should be added in a follow-up that first extends the worker summary query and then updates the shared validation contract.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate detector trigger conditions on API writes and harden worker evaluation so malformed or legacy data fails closed, with clear UI remediation. Updated to align with main’s model selector and enabled-state behavior.

- **Bug Fixes**
  - API: Validate/normalize `triggerConditions` on POST/PATCH; allow only `environment` with `=`/`!=` and string/null; normalize `eq`/`ne`/`neq`; reject non-object bodies and inherited props with 400; return curated 4xx messages; validate `detectionModel`/`detectionProvider` as strings; preserve sample-rate and enabled semantics.
  - Worker: Treat malformed/unsupported legacy conditions (including non-arrays and JSON null) as non-matches; compare nullable `environment` for `=`/`!=`; normalize legacy ops; emit bounded project-aware warnings with TTL and clear when fixed.
  - UI: Show inline filter errors and quick-add failures; editor supports `environment = null`; quarantine unsupported legacy rows and require explicit “Discard hidden filters on save.”
  - Tests: Added route, validation, hooks, utils, panel, editor, new-detector, quick-add, and worker coverage.

- **Migration**
  - Existing detectors with unsupported triggers won’t match until fixed. Edit and choose “Discard hidden filters on save,” or rewrite to `[{ "field": "environment", "op": "=", "value": "production" }]`, `[{ "field": "environment", "op": "=", "value": null }]`, or use `[]` for all traces.

<sup>Written for commit f3aa576b0664a2beaddd1d50a20924be77a3a510. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

