### PR TITLE
feat(api): public detector findings read API

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -21,6 +21,7 @@ from slowapi.errors import RateLimitExceeded
 from rest.rate_limit import limiter, rate_limit_exceeded_handler
 from rest.routers.internal import router as internal_router
 from rest.routers.live import router as live_router
+from rest.routers.public.detectors_read import router as public_detectors_read_router
 from rest.routers.public.traces import router as public_traces_router
 from rest.routers.public.traces_read import router as public_traces_read_router
 from rest.routers.public.whoami import router as public_whoami_router
@@ -71,6 +72,7 @@ app.include_router(public_traces_router, prefix="/api/v1")
 # Public read API for API-key clients (e.g. the CLI)
 app.include_router(public_whoami_router, prefix="/api/v1")
 app.include_router(public_traces_read_router, prefix="/api/v1")
+app.include_router(public_detectors_read_router, prefix="/api/v1")
 
 # Internal API for worker/service communication (protected by secret)
 app.include_router(internal_router, prefix="/api/v1")

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1,6 +1,41 @@
 {
   "components": {
     "schemas": {
+      "DetectorItem": {
+        "description": "A detector from the project's catalog (Postgres ``detectors``).\n\n``detector_id`` is the value to pass to ``findings list --detector`` to filter\nfindings to this detector.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "detector_id": {
+            "title": "Detector Id",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "template": {
+            "title": "Template",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detector_id",
+          "name",
+          "template",
+          "enabled",
+          "created_at"
+        ],
+        "title": "DetectorItem",
+        "type": "object"
+      },
       "DetectorResultItem": {
         "description": "One detector's result within a finding, normalized from the stored payload.\n\nThe stored finding ``payload`` uses camelCase keys (``detectorId`` /\n``detectorName``); the public API exposes snake_case. Only triggered detectors\nare persisted, so ``identified`` is always ``True`` for a present item. ``data``\nis the detector's opaque output, passed through verbatim. ``template`` is looked\nup from the Postgres ``detectors`` row and is ``None`` when that row is absent\n(e.g. a deleted detector).",
         "properties": {
@@ -334,6 +369,27 @@
           "total"
         ],
         "title": "PaginationMeta",
+        "type": "object"
+      },
+      "PublicDetectorListResponse": {
+        "description": "Paginated list of the project's detectors for the public API.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DetectorItem"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "PublicDetectorListResponse",
         "type": "object"
       },
       "PublicFindingListResponse": {
@@ -1051,6 +1107,104 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/public/detectors": {
+      "get": {
+        "description": "List the detectors in the API key's project (newest first).",
+        "operationId": "list_detectors_api_v1_public_detectors_get",
+        "parameters": [
+          {
+            "description": "Items per page",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Items per page",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDetectorListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to list detectors"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List Detectors",
+        "tags": [
+          "Detectors (Public)"
+        ]
+      }
+    },
     "/api/v1/public/detectors/findings": {
       "get": {
         "description": "List recent detector findings for the API key's project (newest first).",

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1,6 +1,57 @@
 {
   "components": {
     "schemas": {
+      "DetectorResultItem": {
+        "description": "One detector's result within a finding, normalized from the stored payload.\n\nThe stored finding ``payload`` uses camelCase keys (``detectorId`` /\n``detectorName``); the public API exposes snake_case. Only triggered detectors\nare persisted, so ``identified`` is always ``True`` for a present item. ``data``\nis the detector's opaque output, passed through verbatim. ``template`` is looked\nup from the Postgres ``detectors`` row and is ``None`` when that row is absent\n(e.g. a deleted detector).",
+        "properties": {
+          "data": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "detector_id": {
+            "title": "Detector Id",
+            "type": "string"
+          },
+          "detector_name": {
+            "title": "Detector Name",
+            "type": "string"
+          },
+          "identified": {
+            "title": "Identified",
+            "type": "boolean"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template"
+          }
+        },
+        "required": [
+          "detector_id",
+          "detector_name",
+          "template",
+          "summary",
+          "identified",
+          "data"
+        ],
+        "title": "DetectorResultItem",
+        "type": "object"
+      },
       "ExportManifest": {
         "description": "manifest.json: index of the bundle's parts.",
         "properties": {
@@ -31,6 +82,111 @@
           "files"
         ],
         "title": "ExportManifest",
+        "type": "object"
+      },
+      "FindingDetail": {
+        "description": "A finding plus its per-detector results and optional free-text RCA.",
+        "properties": {
+          "detectors": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "finding_id": {
+            "title": "Finding Id",
+            "type": "string"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "string"
+          },
+          "rca": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RCAResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/DetectorResultItem"
+            },
+            "title": "Results",
+            "type": "array"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "finding_id",
+          "project_id",
+          "trace_id",
+          "summary",
+          "timestamp",
+          "detectors",
+          "results",
+          "rca"
+        ],
+        "title": "FindingDetail",
+        "type": "object"
+      },
+      "FindingSummary": {
+        "description": "A detector finding row for the list view; ``detectors`` are display labels.",
+        "properties": {
+          "detectors": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "finding_id": {
+            "title": "Finding Id",
+            "type": "string"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "string"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "finding_id",
+          "project_id",
+          "trace_id",
+          "summary",
+          "timestamp",
+          "detectors"
+        ],
+        "title": "FindingSummary",
         "type": "object"
       },
       "GitContext": {
@@ -178,6 +334,27 @@
           "total"
         ],
         "title": "PaginationMeta",
+        "type": "object"
+      },
+      "PublicFindingListResponse": {
+        "description": "Paginated list of detector findings for the public API.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/FindingSummary"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "PublicFindingListResponse",
         "type": "object"
       },
       "PublicTraceDetailResponse": {
@@ -496,6 +673,32 @@
           "meta"
         ],
         "title": "PublicTraceListResponse",
+        "type": "object"
+      },
+      "RCAResult": {
+        "description": "Free-text root-cause analysis for a finding (Postgres ``detector_rcas``).",
+        "properties": {
+          "result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "result"
+        ],
+        "title": "RCAResult",
         "type": "object"
       },
       "SpanResponse": {
@@ -848,6 +1051,319 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/public/detectors/findings": {
+      "get": {
+        "description": "List recent detector findings for the API key's project (newest first).",
+        "operationId": "list_findings_api_v1_public_detectors_findings_get",
+        "parameters": [
+          {
+            "description": "Items per page",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Items per page",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Only findings at or after this time (inclusive, ISO 8601)",
+            "in": "query",
+            "name": "start_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only findings at or after this time (inclusive, ISO 8601)",
+              "title": "Start After"
+            }
+          },
+          {
+            "description": "Only findings before this time (exclusive, ISO 8601)",
+            "in": "query",
+            "name": "end_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only findings before this time (exclusive, ISO 8601)",
+              "title": "End Before"
+            }
+          },
+          {
+            "description": "Filter by detector id, name, or template",
+            "in": "query",
+            "name": "detector",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by detector id, name, or template",
+              "title": "Detector"
+            }
+          },
+          {
+            "description": "Filter to a single trace",
+            "in": "query",
+            "name": "trace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single trace",
+              "title": "Trace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicFindingListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List Findings",
+        "tags": [
+          "Detectors (Public)"
+        ]
+      }
+    },
+    "/api/v1/public/detectors/findings/{finding_id}": {
+      "get": {
+        "description": "Get a single finding by id for the key's project.",
+        "operationId": "get_finding_api_v1_public_detectors_findings__finding_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "finding_id",
+            "required": true,
+            "schema": {
+              "title": "Finding Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FindingDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get Finding",
+        "tags": [
+          "Detectors (Public)"
+        ]
+      }
+    },
+    "/api/v1/public/detectors/traces/{trace_id}/finding": {
+      "get": {
+        "description": "Get the finding for a single trace (findings are 1-per-trace).",
+        "operationId": "get_finding_by_trace_api_v1_public_detectors_traces__trace_id__finding_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "trace_id",
+            "required": true,
+            "schema": {
+              "title": "Trace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FindingDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get Finding By Trace",
+        "tags": [
+          "Detectors (Public)"
+        ]
+      }
+    },
     "/api/v1/public/traces": {
       "get": {
         "description": "List recent traces for the API key's project (newest first).",

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1125,6 +1125,44 @@
               "title": "Limit",
               "type": "integer"
             }
+          },
+          {
+            "description": "Only detectors created at or after this time (inclusive, ISO 8601)",
+            "in": "query",
+            "name": "start_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only detectors created at or after this time (inclusive, ISO 8601)",
+              "title": "Start After"
+            }
+          },
+          {
+            "description": "Only detectors created before this time (exclusive, ISO 8601)",
+            "in": "query",
+            "name": "end_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only detectors created before this time (exclusive, ISO 8601)",
+              "title": "End Before"
+            }
           }
         ],
         "responses": {

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1181,6 +1181,21 @@
             },
             "description": "Validation Error"
           },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to list findings"
+          },
           "503": {
             "content": {
               "application/json": {
@@ -1249,6 +1264,21 @@
             },
             "description": "Authentication failed"
           },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Finding not found"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -1258,6 +1288,21 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to read finding"
           },
           "503": {
             "content": {
@@ -1327,6 +1372,21 @@
             },
             "description": "Authentication failed"
           },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Finding not found"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -1336,6 +1396,21 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to read finding"
           },
           "503": {
             "content": {

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -84,6 +84,19 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
             op["responses"].setdefault("404", _error_response("Trace not found"))
             op["responses"].setdefault("500", _error_response("Failed to get trace"))
 
+    # Detector findings read error contract (matches the route code).
+    findings_list_op = schema["paths"].get("/api/v1/public/detectors/findings", {}).get("get")
+    if findings_list_op is not None:
+        findings_list_op["responses"].setdefault("500", _error_response("Failed to list findings"))
+    for path in (
+        "/api/v1/public/detectors/findings/{finding_id}",
+        "/api/v1/public/detectors/traces/{trace_id}/finding",
+    ):
+        op = schema["paths"].get(path, {}).get("get")
+        if op is not None:
+            op["responses"].setdefault("404", _error_response("Finding not found"))
+            op["responses"].setdefault("500", _error_response("Failed to read finding"))
+
 
 def _collect_refs(node: Any, acc: set[str]) -> None:
     """Collect component schema names referenced by `$ref` anywhere under `node`."""

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -84,6 +84,13 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
             op["responses"].setdefault("404", _error_response("Trace not found"))
             op["responses"].setdefault("500", _error_response("Failed to get trace"))
 
+    # Detector catalog list error contract (matches the route code).
+    detectors_list_op = schema["paths"].get("/api/v1/public/detectors", {}).get("get")
+    if detectors_list_op is not None:
+        detectors_list_op["responses"].setdefault(
+            "500", _error_response("Failed to list detectors")
+        )
+
     # Detector findings read error contract (matches the route code).
     findings_list_op = schema["paths"].get("/api/v1/public/detectors/findings", {}).get("get")
     if findings_list_op is not None:

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -20,12 +20,42 @@ from rest.rate_limit import (
 )
 from rest.routers.public.deps import StampedAuth
 from rest.schemas.common import PaginationMeta
-from rest.schemas.public import FindingDetail, PublicFindingListResponse
+from rest.schemas.public import (
+    FindingDetail,
+    PublicDetectorListResponse,
+    PublicFindingListResponse,
+)
 from rest.services.detector_reader import DetectorReaderService, get_detector_reader_service
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/public/detectors", tags=["Detectors (Public)"])
+
+
+@router.get("", response_model=PublicDetectorListResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_detectors(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+):
+    """List the detectors in the API key's project (newest first)."""
+    try:
+        items, total = service.list_detectors(project_id=auth.project_id, limit=limit)
+    except Exception as e:
+        logger.exception(f"Error listing detectors: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list detectors",
+        ) from e
+
+    return PublicDetectorListResponse(
+        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    )
 
 
 @router.get("/findings", response_model=PublicFindingListResponse)

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -1,0 +1,114 @@
+"""Public, API-key-authenticated read API for detector findings.
+
+Mirrors the public traces read stack (StampedAuth, READ-bucket rate limiting,
+project-scoped reads). All access is scoped to the project resolved from the API
+key; a finding outside that project simply isn't found (404).
+"""
+
+import logging
+from collections.abc import Callable
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+
+from rest.rate_limit import (
+    BUCKET_READ,
+    is_request_rate_limit_exempt,
+    key_read,
+    limiter,
+    resolve_limit,
+)
+from rest.routers.public.deps import StampedAuth
+from rest.schemas.common import PaginationMeta
+from rest.schemas.public import FindingDetail, PublicFindingListResponse
+from rest.services.detector_reader import DetectorReaderService, get_detector_reader_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/public/detectors", tags=["Detectors (Public)"])
+
+
+@router.get("/findings", response_model=PublicFindingListResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_findings(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    start_after: datetime | None = Query(
+        None, description="Only findings at or after this time (inclusive, ISO 8601)"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only findings before this time (exclusive, ISO 8601)"
+    ),
+    detector: str | None = Query(None, description="Filter by detector id, name, or template"),
+    trace_id: str | None = Query(None, description="Filter to a single trace"),
+):
+    """List recent detector findings for the API key's project (newest first)."""
+    try:
+        items, total = service.list_findings(
+            project_id=auth.project_id,
+            limit=limit,
+            start_after=start_after,
+            end_before=end_before,
+            detector=detector,
+            trace_id=trace_id,
+        )
+    except Exception as e:
+        logger.exception(f"Error listing detector findings: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list findings",
+        ) from e
+
+    return PublicFindingListResponse(
+        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    )
+
+
+@router.get("/findings/{finding_id}", response_model=FindingDetail)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def get_finding(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    finding_id: str,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+):
+    """Get a single finding by id for the key's project."""
+    return _require_finding(lambda: service.get_finding(auth.project_id, finding_id))
+
+
+@router.get("/traces/{trace_id}/finding", response_model=FindingDetail)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def get_finding_by_trace(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    trace_id: str,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+):
+    """Get the finding for a single trace (findings are 1-per-trace)."""
+    return _require_finding(lambda: service.get_finding_by_trace(auth.project_id, trace_id))
+
+
+def _require_finding(fetch: Callable[[], FindingDetail | None]) -> FindingDetail:
+    """Run a reader fetch, mapping None -> 404 and reader errors -> a clean 500."""
+    try:
+        finding = fetch()
+    except Exception as e:
+        logger.exception(f"Error reading detector finding: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to read finding",
+        ) from e
+    if finding is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Finding not found")
+    return finding

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -42,10 +42,21 @@ async def list_detectors(
     auth: StampedAuth,
     service: DetectorReaderService = Depends(get_detector_reader_service),
     limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    start_after: datetime | None = Query(
+        None, description="Only detectors created at or after this time (inclusive, ISO 8601)"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only detectors created before this time (exclusive, ISO 8601)"
+    ),
 ):
     """List the detectors in the API key's project (newest first)."""
     try:
-        items, total = service.list_detectors(project_id=auth.project_id, limit=limit)
+        items, total = service.list_detectors(
+            project_id=auth.project_id,
+            limit=limit,
+            start_after=start_after,
+            end_before=end_before,
+        )
     except Exception as e:
         logger.exception(f"Error listing detectors: {e}")
         raise HTTPException(

--- a/tests/rest/test_public_detectors_read.py
+++ b/tests/rest/test_public_detectors_read.py
@@ -1,0 +1,194 @@
+"""API tests for the public detector findings read endpoints.
+
+Auth is overridden and the reader service is replaced with a fake, so these run
+with no live databases.
+"""
+
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from rest.routers.public.deps import AuthResult, authenticate_api_key
+from rest.schemas.public import (
+    DetectorResultItem,
+    FindingDetail,
+    FindingSummary,
+    RCAResult,
+)
+from rest.services.detector_reader import get_detector_reader_service
+
+
+def make_auth(project_id: str = "proj-A") -> AuthResult:
+    return AuthResult(
+        project_id=project_id,
+        workspace_id="ws-1",
+        billing_plan="pro",
+        ingestion_blocked=False,
+    )
+
+
+class FakeReader:
+    def __init__(self):
+        self.list_args: dict | None = None
+        self.list_return: tuple = ([], 0)
+        self.raise_on_list = False
+        self.finding: FindingDetail | None = None
+        self.by_trace: FindingDetail | None = None
+        self.last_get: tuple | None = None
+        self.last_by_trace: tuple | None = None
+
+    def list_findings(self, **kwargs):
+        self.list_args = kwargs
+        if self.raise_on_list:
+            raise RuntimeError("boom")
+        return self.list_return
+
+    def get_finding(self, project_id, finding_id):
+        self.last_get = (project_id, finding_id)
+        return self.finding
+
+    def get_finding_by_trace(self, project_id, trace_id):
+        self.last_by_trace = (project_id, trace_id)
+        return self.by_trace
+
+
+@pytest.fixture()
+def reader():
+    return FakeReader()
+
+
+@pytest.fixture()
+def client(reader):
+    # conftest's autouse fixture clears app.dependency_overrides after each test.
+    app.dependency_overrides[authenticate_api_key] = lambda: make_auth()
+    app.dependency_overrides[get_detector_reader_service] = lambda: reader
+    return TestClient(app)
+
+
+def _summary(**over):
+    base = dict(
+        finding_id="f1",
+        project_id="proj-A",
+        trace_id="t1",
+        summary="s",
+        timestamp=datetime(2026, 6, 29, 10, 42),
+        detectors=["hallucination"],
+    )
+    base.update(over)
+    return FindingSummary(**base)
+
+
+def _detail(**over):
+    base = dict(
+        finding_id="f1",
+        project_id="proj-A",
+        trace_id="t1",
+        summary="s",
+        timestamp=datetime(2026, 6, 29, 10, 42),
+        detectors=["hallucination"],
+        results=[
+            DetectorResultItem(
+                detector_id="d1",
+                detector_name="hallucination",
+                template="hallucination",
+                summary="x",
+                identified=True,
+                data={"k": "v"},
+            )
+        ],
+        rca=RCAResult(status="done", result="rc"),
+    )
+    base.update(over)
+    return FindingDetail(**base)
+
+
+def test_list_returns_findings_with_pagination_meta(client, reader):
+    reader.list_return = ([_summary()], 1)
+    resp = client.get("/api/v1/public/detectors/findings")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["meta"] == {"page": 0, "limit": 50, "total": 1}
+    assert body["data"][0]["finding_id"] == "f1"
+    assert body["data"][0]["detectors"] == ["hallucination"]
+
+
+def test_list_empty_returns_200_with_empty_data(client, reader):
+    reader.list_return = ([], 0)
+    resp = client.get("/api/v1/public/detectors/findings")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["data"] == []
+    assert body["meta"] == {"page": 0, "limit": 50, "total": 0}
+
+
+def test_list_forwards_filters_and_project_scope(client, reader):
+    client.get(
+        "/api/v1/public/detectors/findings"
+        "?limit=10&detector=hallucination&trace_id=t9"
+        "&start_after=2026-06-01T00:00:00Z&end_before=2026-06-30T00:00:00Z"
+    )
+    args = reader.list_args
+    assert args["project_id"] == "proj-A"
+    assert args["limit"] == 10
+    assert args["detector"] == "hallucination"
+    assert args["trace_id"] == "t9"
+    assert args["start_after"] is not None
+    assert args["end_before"] is not None
+
+
+@pytest.mark.parametrize("limit", [0, 500])
+def test_list_rejects_out_of_range_limit(client, limit):
+    assert client.get(f"/api/v1/public/detectors/findings?limit={limit}").status_code == 422
+
+
+def test_list_reader_failure_returns_sanitized_500(client, reader):
+    reader.raise_on_list = True
+    resp = client.get("/api/v1/public/detectors/findings")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to list findings"
+    assert "boom" not in resp.text
+
+
+def test_detail_by_finding_id_returns_results_and_rca(client, reader):
+    reader.finding = _detail()
+    resp = client.get("/api/v1/public/detectors/findings/f1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert reader.last_get == ("proj-A", "f1")
+    assert body["results"][0]["detector_id"] == "d1"
+    assert body["results"][0]["identified"] is True
+    assert body["rca"] == {"status": "done", "result": "rc"}
+
+
+def test_detail_without_rca_returns_null(client, reader):
+    reader.finding = _detail(rca=None, results=[])
+    body = client.get("/api/v1/public/detectors/findings/f1").json()
+    assert body["rca"] is None
+
+
+def test_detail_404_when_missing(client, reader):
+    reader.finding = None
+    assert client.get("/api/v1/public/detectors/findings/nope").status_code == 404
+
+
+def test_detail_by_trace_returns_finding(client, reader):
+    reader.by_trace = _detail(trace_id="t9", results=[], rca=None)
+    resp = client.get("/api/v1/public/detectors/traces/t9/finding")
+    assert resp.status_code == 200
+    assert reader.last_by_trace == ("proj-A", "t9")
+    assert resp.json()["trace_id"] == "t9"
+
+
+def test_detail_by_trace_404_when_none(client, reader):
+    reader.by_trace = None
+    assert client.get("/api/v1/public/detectors/traces/none/finding").status_code == 404
+
+
+def test_auth_required_without_key(reader):
+    # Only the service is overridden; with no auth override the real key check runs
+    # and a request without a key is rejected before reaching the reader.
+    app.dependency_overrides[get_detector_reader_service] = lambda: reader
+    resp = TestClient(app).get("/api/v1/public/detectors/findings")
+    assert resp.status_code in (401, 403)

--- a/tests/rest/test_public_detectors_read.py
+++ b/tests/rest/test_public_detectors_read.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from rest.main import app
 from rest.routers.public.deps import AuthResult, authenticate_api_key
 from rest.schemas.public import (
+    DetectorItem,
     DetectorResultItem,
     FindingDetail,
     FindingSummary,
@@ -34,6 +35,9 @@ class FakeReader:
         self.list_args: dict | None = None
         self.list_return: tuple = ([], 0)
         self.raise_on_list = False
+        self.detectors_args: dict | None = None
+        self.detectors_return: tuple = ([], 0)
+        self.raise_on_detectors = False
         self.finding: FindingDetail | None = None
         self.by_trace: FindingDetail | None = None
         self.last_get: tuple | None = None
@@ -44,6 +48,12 @@ class FakeReader:
         if self.raise_on_list:
             raise RuntimeError("boom")
         return self.list_return
+
+    def list_detectors(self, **kwargs):
+        self.detectors_args = kwargs
+        if self.raise_on_detectors:
+            raise RuntimeError("boom")
+        return self.detectors_return
 
     def get_finding(self, project_id, finding_id):
         self.last_get = (project_id, finding_id)
@@ -102,6 +112,55 @@ def _detail(**over):
     )
     base.update(over)
     return FindingDetail(**base)
+
+
+def _detector(**over):
+    base = dict(
+        detector_id="d1",
+        name="My Hallucination Detector",
+        template="hallucination",
+        enabled=True,
+        created_at=datetime(2026, 6, 29, 10, 42),
+    )
+    base.update(over)
+    return DetectorItem(**base)
+
+
+def test_list_detectors_returns_items_with_pagination_meta(client, reader):
+    reader.detectors_return = ([_detector()], 1)
+    resp = client.get("/api/v1/public/detectors")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["meta"] == {"page": 0, "limit": 50, "total": 1}
+    assert body["data"][0]["detector_id"] == "d1"
+    assert body["data"][0]["template"] == "hallucination"
+    assert body["data"][0]["enabled"] is True
+
+
+def test_list_detectors_forwards_limit_and_project_scope(client, reader):
+    client.get("/api/v1/public/detectors?limit=10")
+    args = reader.detectors_args
+    assert args["project_id"] == "proj-A"
+    assert args["limit"] == 10
+
+
+@pytest.mark.parametrize("limit", [0, 500])
+def test_list_detectors_rejects_out_of_range_limit(client, limit):
+    assert client.get(f"/api/v1/public/detectors?limit={limit}").status_code == 422
+
+
+def test_list_detectors_reader_failure_returns_sanitized_500(client, reader):
+    reader.raise_on_detectors = True
+    resp = client.get("/api/v1/public/detectors")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to list detectors"
+    assert "boom" not in resp.text
+
+
+def test_list_detectors_auth_required_without_key(reader):
+    app.dependency_overrides[get_detector_reader_service] = lambda: reader
+    resp = TestClient(app).get("/api/v1/public/detectors")
+    assert resp.status_code in (401, 403)
 
 
 def test_list_returns_findings_with_pagination_meta(client, reader):

--- a/tests/rest/test_public_detectors_read.py
+++ b/tests/rest/test_public_detectors_read.py
@@ -144,6 +144,15 @@ def test_list_detectors_forwards_limit_and_project_scope(client, reader):
     assert args["limit"] == 10
 
 
+def test_list_detectors_forwards_time_window(client, reader):
+    client.get(
+        "/api/v1/public/detectors?start_after=2026-06-01T00:00:00Z&end_before=2026-06-30T00:00:00Z"
+    )
+    args = reader.detectors_args
+    assert args["start_after"] is not None
+    assert args["end_before"] is not None
+
+
 @pytest.mark.parametrize("limit", [0, 500])
 def test_list_detectors_rejects_out_of_range_limit(client, limit):
     assert client.get(f"/api/v1/public/detectors?limit={limit}").status_code == 422

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -152,3 +152,10 @@ def test_read_endpoints_document_error_responses():
         responses = paths[p]["get"]["responses"]
         assert set(responses) >= {"200", "401", "404", "500"}
         assert responses["404"]["description"] == "Trace not found"
+
+
+def test_detectors_list_route_documents_error_responses():
+    paths = _schema()["paths"]
+    assert "get" in paths["/api/v1/public/detectors"]
+    responses = paths["/api/v1/public/detectors"]["get"]["responses"]
+    assert set(responses) >= {"200", "401", "500"}


### PR DESCRIPTION
## Summary

Fixes #1380

Adds the public, API-key-authenticated read API for detectors and detector findings — the HTTP surface over the Issue #1379 reader service. Four project-scoped `GET` endpoints mirror the public traces read stack (`StampedAuth`, READ-bucket rate limiting). Stacked on #1379.

It exposes only data that exists today and stays read-only: no severity, no detector gates, no structured RCA packets, no MCP, no detector creation, no write paths.

## How the router works

```
GET /api/v1/public/detectors/* (Bearer key)
  → StampedAuth resolves project_id server-side + stamps the READ rate-limit identity
    → DetectorReaderService (Depends-injected, project-scoped)
      → list  -> PublicFindingListResponse { data, meta(page=0, limit, total) }
        detail -> FindingDetail | 404
  errors: reader returns None -> 404 "Finding not found" (no missing-vs-cross-project
          distinction); reader exception -> sanitized 500; empty list -> 200; rca: null is normal
```

The router is thin — auth, query params, service calls, response model, error mapping. It does not re-parse payloads; the reader returns schema objects directly.

## Endpoints

| Method | Path | Response | Purpose |
|--------|------|----------|---------|
| GET | `/api/v1/public/detectors` | `PublicDetectorListResponse` | List the detector catalog (filtered) |
| GET | `/api/v1/public/detectors/findings` | `PublicFindingListResponse` | List findings (filtered) |
| GET | `/api/v1/public/detectors/findings/{finding_id}` | `FindingDetail` | Detail by finding id |
| GET | `/api/v1/public/detectors/traces/{trace_id}/finding` | `FindingDetail` | Detail by trace id (1-per-trace) |

List query params: `limit: int = Query(50, ge=1, le=200)`, `start_after`/`end_before: datetime | None` (creation-time window for detectors, finding-timestamp window for findings), plus `detector: str | None` and `trace_id: str | None` on findings. Every reader call is scoped to `auth.project_id`; the client never supplies a project id. `meta` is `PaginationMeta(page=0, limit, total)`, matching `trace_reader.list_traces` (no `page` query param, no cursors).

## Data model (read-only; nothing new added)

No schema or table changes. The router reads through the Issue #1379 reader service: ClickHouse `detector_findings`, plus Postgres `detectors` (template / `--detector` resolution) and `detector_rcas` (free-text RCA).

## What's included

### Router — `backend/rest/routers/public/detectors_read.py` (new)
- `APIRouter(prefix="/public/detectors", tags=["Detectors (Public)"])`; the four routes above (the bare `GET ""` catalog list plus the three findings routes).
- `StampedAuth` + the existing READ-bucket limiter (`@limiter.shared_limit(resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt)`), exactly as `traces_read.py`.
- Service is dependency-injected: `service: DetectorReaderService = Depends(get_detector_reader_service)`.
- Detail `None` → 404; reader exception → controlled 500 with no raw exception text.

### Wiring — `backend/rest/main.py`
- `app.include_router(public_detectors_read_router, prefix="/api/v1")`, next to the public traces read router.

### OpenAPI — `backend/rest/openapi/public.json` + `backend/rest/openapi_public.py`
- Regenerated via `scripts/sync_public_openapi.py` to add the four detector paths + the seven component schemas; `_apply_public_contract` documents the per-route error responses (the catalog list's `500`, plus the findings routes' `404`/`500`), keeping `test_public_openapi` in sync. CLI vendoring (`traceroot-cli/openapi.json` → `schema.ts`) is intentionally **not** done here — that's #1381.

### Tests — `tests/rest/test_public_detectors_read.py` (new)
- Auth + service are overridden via `app.dependency_overrides`, so tests run with no live databases.

## Test plan

- [x] Router/API tests (`tests/rest/test_public_detectors_read.py`) — detector-catalog list with `meta` + limit/time-window/project-scope forwarding + `422`/sanitized `500`; findings list with `meta`, empty list → 200, filter + project-scope forwarding, `422` on bad `limit`, sanitized `500`, detail by id (results + RCA), detail without RCA (`rca: null`), `404`s for missing id/trace, detail by trace, auth required
- [x] OpenAPI tests (`tests/rest/test_public_openapi.py`) — the detectors-list route is present and documents `200`/`401`/`500`
- [x] Full REST suite green (283 passed), including `test_public_openapi` sync
- [x] `mypy` clean on the new router module
- [ ] Live ClickHouse + Postgres integration — deferred to an integration pass
