### PR TITLE
ci: auto-announce releases to Discord with full notes

### DIFF
--- a/.github/workflows/announce-release-discord.yml
+++ b/.github/workflows/announce-release-discord.yml
@@ -1,0 +1,98 @@
+# .github/workflows/announce-release-discord.yml
+# Posts the FULL release notes (not just the title) to a Discord channel as a
+# rich embed, under a custom "Github Boy" identity. Replaces GitHub's native
+# Discord integration, which only posts a one-line title link for releases.
+#
+# Two triggers:
+#   - release: published   -> auto-announce every new release (uses the event payload)
+#   - workflow_dispatch     -> re-announce ANY existing tag on demand, for testing
+#                              the Discord path without cutting a real release
+#
+# Setup (one-time):
+#   1. Discord: #release channel -> Edit Channel -> Integrations -> Webhooks ->
+#      copy the webhook URL. Use the PLAIN URL (do NOT append /github).
+#   2. GitHub: repo Settings -> Secrets and variables -> Actions -> New secret
+#      named DISCORD_RELEASE_CHANNEL_WEBHOOK_URL = that plain URL.
+#   3. Remove the old native /github release webhook so releases don't double-post.
+name: Announce Release to Discord
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to (re)announce, e.g. v0.3.1"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: announce-release-${{ github.event.release.tag_name || github.event.inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post release notes to Discord
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_CHANNEL_WEBHOOK_URL }}
+          REPO: ${{ github.repository }}
+          # The tag from whichever trigger fired; passed via env (never inlined)
+          # so it can't break or inject into the script.
+          INPUT_TAG: ${{ github.event.inputs.tag }}
+          EV_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${WEBHOOK_URL:-}" ]; then
+            echo "::error::DISCORD_RELEASE_CHANNEL_WEBHOOK_URL secret is not set."
+            exit 1
+          fi
+
+          # Both triggers resolve to a tag, then fetch the release the same way,
+          # so a manual workflow_dispatch run exercises the exact path a real
+          # release:published takes.
+          TAG="${INPUT_TAG:-$EV_TAG}"
+          rel="$(gh release view "$TAG" --repo "$REPO" --json name,url,body)"
+          NAME="$(printf '%s' "$rel" | jq -r '.name')"
+          URL="$(printf '%s' "$rel" | jq -r '.url')"
+          BODY="$(printf '%s' "$rel" | jq -r '.body')"
+          [ -n "$NAME" ] && [ "$NAME" != "null" ] || NAME="$TAG"
+
+          # Discord embed descriptions cap at 4096 chars. Leave headroom and
+          # append a "read more" pointer when the notes are longer.
+          limit=3900
+          if [ "${#BODY}" -gt "$limit" ]; then
+            BODY="$(printf '%s' "$BODY" | head -c "$limit")"
+            BODY="$(printf '%s\n\n… **[full release notes →](%s)**' "$BODY" "$URL")"
+          fi
+
+          # Build the payload with jq so the body is JSON-escaped safely.
+          payload="$(jq -n \
+            --arg username "Github Boy" \
+            --arg title "$NAME" \
+            --arg url "$URL" \
+            --arg desc "$BODY" \
+            --arg footer "$REPO" \
+            '{
+              username: $username,
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $desc,
+                color: 5025616,
+                footer: { text: $footer }
+              }]
+            }')"
+
+          # Fail loudly on any non-2xx so a broken post is visible in CI.
+          curl -sS -f \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d "$payload" \
+            "$WEBHOOK_URL"
+          echo "Announced ${TAG} to Discord."

--- a/.github/workflows/announce-release-discord.yml
+++ b/.github/workflows/announce-release-discord.yml
@@ -63,15 +63,10 @@ jobs:
           BODY="$(printf '%s' "$rel" | jq -r '.body')"
           [ -n "$NAME" ] && [ "$NAME" != "null" ] || NAME="$TAG"
 
-          # Discord embed descriptions cap at 4096 chars. Leave headroom and
-          # append a "read more" pointer when the notes are longer.
-          limit=3900
-          if [ "${#BODY}" -gt "$limit" ]; then
-            BODY="$(printf '%s' "$BODY" | head -c "$limit")"
-            BODY="$(printf '%s\n\n… **[full release notes →](%s)**' "$BODY" "$URL")"
-          fi
-
           # Build the payload with jq so the body is JSON-escaped safely.
+          # Discord caps embed descriptions at 4096 chars; truncate by codepoint
+          # inside jq (never by byte, which can split a multi-byte char and emit
+          # invalid UTF-8) and append a "read more" link when the notes are long.
           payload="$(jq -n \
             --arg username "Github Boy" \
             --arg title "$NAME" \
@@ -83,7 +78,12 @@ jobs:
               embeds: [{
                 title: $title,
                 url: $url,
-                description: $desc,
+                description: (
+                  if ($desc | length) > 3900
+                  then $desc[0:3900] + "\n\n… **[full release notes →](" + $url + ")**"
+                  else $desc
+                  end
+                ),
                 color: 5025616,
                 footer: { text: $footer }
               }]


### PR DESCRIPTION
Closes #1394

## What

Adds `.github/workflows/announce-release-discord.yml` — posts the **full release notes** to the `#release` Discord channel as a rich embed when a release is published. The native GitHub→Discord integration only posts a one-line title link and omits the notes.

## How

- **`release: published`** → auto-announces every new release. It hangs off the release *event*, so it works no matter how the release is cut (CLI, UI, or a future release pipeline) and stays decoupled.
- **`workflow_dispatch` (tag input)** → re-announce any existing tag on demand, to test the Discord path without cutting a real release. Both triggers share one code path — `gh release view <tag> --json name,url,body` — so the manual run exercises exactly what the auto path does.
- Builds the embed with `jq` (so the body is JSON-escaped safely) and POSTs with `curl -sS -f` (fails the job on a non-2xx webhook response).
- Truncates past Discord's 4096-char embed limit with a "full notes →" link.
- The tag is passed via `env:` and never inlined into the script, so an arbitrary release body/tag can't break or inject into the shell. `permissions: contents: read` only.

## One-time setup before this is live (human)

1. Create a Discord webhook in `#release`; store the **plain** URL (no `/github` suffix) as repo secret `DISCORD_RELEASE_CHANNEL_WEBHOOK_URL`.
2. Remove the existing native `/github` release webhook so releases don't double-post.

## Testing

- `yaml` lint passes (pre-commit).
- Payload-build + truncation logic validated locally against release bodies containing quotes, backticks, and markdown — produces valid JSON within the embed limit.
- After merge + secret: Actions → "Announce Release to Discord" → Run workflow → tag `v0.3.1` to verify the live post end-to-end.

## Follow-ups (out of scope)

- Curated `#github-activity` channel (issues + PRs + stars + discussions).
- First-time-contributor highlight (needs author-association filtering).
- One-button `release.yml` cutter; public self-host image pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `.github/workflows/announce-release-discord.yml` to auto-post full release notes to the `#release` Discord channel as a rich embed when a release is published, with manual re-announcements for any tag.

- **New Features**
  - Triggers: `release: published` and `workflow_dispatch` (`tag` input).
  - Fetches notes via `gh release view --json name,url,body`, builds payload with `jq`, and posts with `curl -sS -f`.
  - Truncates safely by codepoint in `jq` to Discord’s embed limit and adds a “full notes →” link.
  - Tag passed via env; `permissions: contents: read`; per-tag concurrency.

- **Migration**
  - Add secret `DISCORD_RELEASE_CHANNEL_WEBHOOK_URL` with the plain webhook URL for `#release` (no `/github` suffix).
  - Remove the native `/github` Discord release integration to prevent double posts.

<sup>Written for commit b725ce8905a91fbd96056b4a9a7758ec31b26667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

