### PR TITLE
ci: let the Discord webhook control the announcer's name + avatar

### DIFF
--- a/.github/workflows/announce-release-discord.yml
+++ b/.github/workflows/announce-release-discord.yml
@@ -1,7 +1,8 @@
 # .github/workflows/announce-release-discord.yml
 # Posts the FULL release notes (not just the title) to a Discord channel as a
-# rich embed, under a custom "Github Boy" identity. Replaces GitHub's native
-# Discord integration, which only posts a one-line title link for releases.
+# rich embed. Replaces GitHub's native Discord integration, which only posts a
+# one-line title link for releases. The post's name + avatar come from the
+# Discord webhook's own config (set those in Discord, not here).
 #
 # Two triggers:
 #   - release: published   -> auto-announce every new release (uses the event payload)
@@ -68,13 +69,11 @@ jobs:
           # inside jq (never by byte, which can split a multi-byte char and emit
           # invalid UTF-8) and append a "read more" link when the notes are long.
           payload="$(jq -n \
-            --arg username "Github Boy" \
             --arg title "$NAME" \
             --arg url "$URL" \
             --arg desc "$BODY" \
             --arg footer "$REPO" \
             '{
-              username: $username,
               embeds: [{
                 title: $title,
                 url: $url,


### PR DESCRIPTION
Follow-up to #1395.

## What

Removes the hardcoded `username: "Github Boy"` from the Discord embed payload. The release post now inherits its **display name and avatar from the Discord webhook's own configuration**, so identity is managed in one place (Discord → webhook settings) with no code change required to rename or re-icon it.

## Why

Previously the name was hardcoded in the workflow while the avatar came from Discord — a split-brain where renaming needed a PR but re-iconing didn't. Centralizing both in the webhook config is simpler and matches the conventional pattern for this kind of announcer.

## After merge (human)

Discord → `#release` → Edit Channel → Integrations → Webhooks → click the webhook → set **Name** (e.g. `Release Bot`) and upload an **avatar** → Save. Next release (or a `workflow_dispatch` test on an existing tag) posts with that identity.

## Testing

- `yaml` lint passes (pre-commit).
- Payload still builds valid JSON with the `username` key removed (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the Discord webhook’s name and avatar for release announcements by removing the hardcoded `username` from the workflow payload. Posts now inherit identity from the webhook settings in Discord, so renaming or re-iconing needs no code change.

- **Migration**
  - In Discord: channel > Integrations > Webhooks > select the webhook > set Name (e.g. Release Bot) and avatar > Save.

<sup>Written for commit 4030c0af1fe549a58fcf88018a5a8db0537fcb2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

