### PR TITLE
ci: normalize release-notes heading sizes in the Discord embed

### DIFF
--- a/.github/workflows/announce-release-discord.yml
+++ b/.github/workflows/announce-release-discord.yml
@@ -64,6 +64,12 @@ jobs:
           BODY="$(printf '%s' "$rel" | jq -r '.body')"
           [ -n "$NAME" ] && [ "$NAME" != "null" ] || NAME="$TAG"
 
+          # GitHub's auto-generated notes use H2 (##) section headers, which
+          # render oversized in Discord. Downgrade them to H3 (###) and promote
+          # the bold "Full Changelog" line to a matching H3, so every section
+          # header renders at one consistent, compact size.
+          BODY="$(printf '%s' "$BODY" | perl -pe 's/^## /### /; s/^\*\*Full Changelog\*\*:\s*(.*)$/### Full Changelog\n$1/')"
+
           # Build the payload with jq so the body is JSON-escaped safely.
           # Discord caps embed descriptions at 4096 chars; truncate by codepoint
           # inside jq (never by byte, which can split a multi-byte char and emit


### PR DESCRIPTION
Follow-up to #1395 / #1396 — formatting polish on the Discord release post.

## Problem

GitHub's `--generate-notes` output uses **H2 (`##`)** for `What's Changed` and `New Contributors`, which Discord renders oversized, while `Full Changelog` is only **bold inline** text (too small). The result is inconsistent heading sizes.

## Fix

Post-process the notes body before building the embed: downgrade the `##` section headers to `###` and promote the bold `Full Changelog` line to a matching `###`. All section headers now render at one consistent, compact size (closer to a clean changelog look).

```
## What's Changed      ->  ### What's Changed
## New Contributors    ->  ### New Contributors
**Full Changelog**: U  ->  ### Full Changelog\nU
```

Done with a single portable `perl -pe` (perl ships on `ubuntu-latest`).

## Testing

- `yaml` lint passes (pre-commit).
- Ran the full pipeline locally against the real `v0.3.1` notes: transform → jq payload → valid JSON, all three headers normalized to `###`, zero `##` remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Discord release embed headings consistent and compact by normalizing GitHub release notes before sending.

- **Bug Fixes**
  - Convert `##` section headers (`What's Changed`, `New Contributors`) to `###` and promote the bold `Full Changelog` line to a `###` header.
  - Apply the transform with a portable `perl -pe` in the workflow before building the JSON payload.

<sup>Written for commit 87605bef7310925c7ff405258de2e470f42a948b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

