### PR TITLE
ci: prefix the Discord embed title with the repo name

### DIFF
--- a/.github/workflows/announce-release-discord.yml
+++ b/.github/workflows/announce-release-discord.yml
@@ -81,7 +81,7 @@ jobs:
             --arg footer "$REPO" \
             '{
               embeds: [{
-                title: $title,
+                title: $title[0:256],
                 url: $url,
                 description: (
                   if ($desc | length) > 3900

--- a/.github/workflows/announce-release-discord.yml
+++ b/.github/workflows/announce-release-discord.yml
@@ -75,7 +75,7 @@ jobs:
           # inside jq (never by byte, which can split a multi-byte char and emit
           # invalid UTF-8) and append a "read more" link when the notes are long.
           payload="$(jq -n \
-            --arg title "$NAME" \
+            --arg title "${REPO##*/} $NAME" \
             --arg url "$URL" \
             --arg desc "$BODY" \
             --arg footer "$REPO" \


### PR DESCRIPTION
Follow-up to #1395 / #1396 / #1397.

## What

The Discord release embed's title is now `<repo> <version>` (e.g. **`traceroot v0.3.1`**) instead of just `v0.3.1`. The repo short-name is derived from `github.repository` (`${REPO##*/}`) — no hardcoding.

## Why

The repo was only identifiable from the small footer line. With the prefix, the source is obvious at a glance, and **multiple repos can announce into the same channel unambiguously**: a copy of this workflow in `traceroot-ts` would post `traceroot-ts vX.Y.Z` for free, with no config change.

## Testing

- `yaml` lint passes (pre-commit).
- Verified locally: `traceroot-ai/traceroot` → `traceroot v0.3.1`, `traceroot-ai/traceroot-ts` → `traceroot-ts v0.3.1`, and the value survives `jq` as the embed title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefix the Discord release embed title with the repo short name so multi-repo announcements are clear. Title now uses "<repo> <version>" (e.g., "traceroot v0.3.1"), derived from `github.repository` via `${REPO##*/}`, and is capped at 256 chars to meet Discord’s limit.

<sup>Written for commit d81be7daecd1608c1f9f96304dec596c72389922. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

