### PR TITLE
perf(rest): cache repeated trace reads briefly

### DIFF
--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -8,6 +8,7 @@ write concerns stay decoupled; both reuse the shared API-key auth dependency.
 
 import logging
 from datetime import datetime
+from typing import cast
 
 from fastapi import APIRouter, HTTPException, Query, Request, Response, status
 
@@ -69,6 +70,7 @@ async def list_traces(
             limit=limit,
             start_after=start_after,
             end_before=end_before,
+            use_cache=False,
         )
     except Exception as e:
         logger.exception(f"Error listing traces: {e}")
@@ -176,7 +178,7 @@ def _resolve_fields(fields: str | None, *, default: frozenset[str]) -> frozenset
         HTTPException: 400 Bad Request if `fields` names an unknown group.
     """
     try:
-        return resolve_span_fields(fields, default=default)
+        return cast(frozenset[str], resolve_span_fields(fields, default=default))
     except InvalidFieldsError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
@@ -205,7 +207,7 @@ def _require_trace(project_id: str, trace_id: str, groups: frozenset[str]) -> di
     """
     try:
         service = get_trace_reader_service()
-        trace = service.get_trace(project_id=project_id, trace_id=trace_id)
+        trace = service.get_trace(project_id=project_id, trace_id=trace_id, use_cache=False)
         if trace:
             hydrate_span_io(service, trace, project_id=project_id, trace_id=trace_id, groups=groups)
     except Exception as e:

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -19,13 +19,28 @@ from rest.rate_limit import (
     limiter,
     resolve_limit,
 )
-from rest.routers.deps import ProjectAccess, RateLimitedProjectAccess
+from rest.routers.deps import ProjectAccess, ProjectAccessInfo, RateLimitedProjectAccess
 from rest.schemas.traces import SpanIOResponse, TraceDetailResponse, TraceListResponse
 from rest.services.trace_reader import get_trace_reader_service
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/projects/{project_id}/traces", tags=["Traces"])
+
+
+def _uses_dashboard_trace_cache(
+    access: ProjectAccessInfo, *, groups: frozenset[str] | None = None
+) -> bool:
+    """Only user-authenticated dashboard reads opt into short-lived trace caching.
+
+    Internal-secret callers do not carry a workspace id and are used by agent
+    and system flows that need fresh trace reads. Detail reads cache only the
+    default skeleton projection; full or partial I/O projections load fresh
+    before hydrating blobs.
+    """
+    if not access.workspace_id:
+        return False
+    return groups is None or groups == SKELETON
 
 
 @router.get("", response_model=TraceListResponse)
@@ -59,6 +74,7 @@ async def list_traces(
             start_after=start_after,
             end_before=end_before,
             search_query=search_query,
+            use_cache=_uses_dashboard_trace_cache(_access),
         )
         return result
     except Exception as e:
@@ -110,7 +126,8 @@ async def get_trace(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
     service = get_trace_reader_service()
-    trace = service.get_trace(project_id=project_id, trace_id=trace_id)
+    use_cache = _uses_dashboard_trace_cache(_access, groups=groups)
+    trace = service.get_trace(project_id=project_id, trace_id=trace_id, use_cache=use_cache)
 
     if not trace:
         raise HTTPException(

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -1,6 +1,14 @@
 """Service for reading traces from ClickHouse."""
 
+from collections import OrderedDict
+from collections.abc import Callable
+from copy import deepcopy
 from datetime import datetime
+from hashlib import sha256
+from sys import getsizeof
+from threading import Lock
+from time import monotonic
+from typing import Any, cast
 
 from db.clickhouse import get_clickhouse_client
 from rest.sql_utils import escape_ilike, to_utc_naive
@@ -15,6 +23,14 @@ from worker.tokens.pricing import cost_breakdown_from_buckets, get_model_price
 # month with toYYYYMM(span_start_time), values under about a month usually skip
 # the same old monthly partitions.
 TRACE_SPAN_LOOKBACK_HOURS = 1
+TRACE_READ_CACHE_TTL_SECONDS = 10.0
+TRACE_READ_CACHE_MAX_ENTRIES = 256
+TRACE_READ_CACHE_MAX_ENTRY_BYTES = 512 * 1024
+TRACE_READ_CACHE_MAX_BYTES = 4 * 1024 * 1024
+
+_CACHE_MISS = object()
+CacheKey = tuple[object, ...]
+CacheEntry = tuple[float, int, float, Any]
 
 
 def span_cost_details(
@@ -54,8 +70,152 @@ def span_cost_details(
 class TraceReaderService:
     """Read traces and spans from ClickHouse."""
 
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        cache_ttl_seconds: float = TRACE_READ_CACHE_TTL_SECONDS,
+        cache_max_entries: int = TRACE_READ_CACHE_MAX_ENTRIES,
+        cache_max_entry_bytes: int = TRACE_READ_CACHE_MAX_ENTRY_BYTES,
+        cache_max_bytes: int = TRACE_READ_CACHE_MAX_BYTES,
+        clock: Callable[[], float] = monotonic,
+    ):
         self._client = get_clickhouse_client()
+        self._cache_ttl_seconds = cache_ttl_seconds
+        self._cache_max_entries = cache_max_entries
+        self._cache_max_entry_bytes = cache_max_entry_bytes
+        self._cache_max_bytes = cache_max_bytes
+        self._clock = clock
+        self._cache_lock = Lock()
+        self._trace_read_cache: OrderedDict[CacheKey, CacheEntry] = OrderedDict()
+        self._trace_read_cache_bytes = 0
+
+    def _read_cache(self, key: CacheKey) -> Any:
+        """Return a defensive copy of a cached read result, or _CACHE_MISS."""
+        if not self._cache_enabled():
+            return _CACHE_MISS
+
+        now = self._clock()
+        with self._cache_lock:
+            cached = self._trace_read_cache.get(key)
+            if cached is None:
+                return _CACHE_MISS
+
+            expires_at, size_bytes, _, value = cached
+            if expires_at <= now:
+                self._drop_cache_entry(key, size_bytes)
+                return _CACHE_MISS
+            self._trace_read_cache.move_to_end(key)
+
+        return deepcopy(value)
+
+    def _write_cache(self, key: CacheKey, value: Any, *, fetched_at: float | None = None) -> None:
+        """Store a defensive copy of a read result."""
+        if not self._cache_enabled():
+            return
+
+        incoming_fetched_at = self._clock() if fetched_at is None else fetched_at
+        size_bytes = self._cache_value_size(key) + self._cache_value_size(value)
+        if size_bytes > self._cache_max_entry_bytes or size_bytes > self._cache_max_bytes:
+            return
+        cached_value = deepcopy(value)
+
+        now = self._clock()
+        expires_at = incoming_fetched_at + self._cache_ttl_seconds
+        if expires_at <= now:
+            return
+
+        with self._cache_lock:
+            self._prune_expired_cache_entries(now)
+            existing = self._trace_read_cache.get(key)
+            if existing is not None:
+                expires_at, existing_size_bytes, existing_fetched_at, _ = existing
+                if expires_at > now and existing_fetched_at >= incoming_fetched_at:
+                    return
+                self._drop_cache_entry(key, existing_size_bytes)
+            while (
+                len(self._trace_read_cache) >= self._cache_max_entries
+                or self._trace_read_cache_bytes + size_bytes > self._cache_max_bytes
+            ):
+                self._evict_oldest_cache_entry()
+
+            self._trace_read_cache[key] = (
+                incoming_fetched_at + self._cache_ttl_seconds,
+                size_bytes,
+                incoming_fetched_at,
+                cached_value,
+            )
+            self._trace_read_cache_bytes += size_bytes
+
+    def _prune_expired_cache_entries(self, now: float) -> None:
+        expired = [
+            key
+            for key, (expires_at, _, _, _) in self._trace_read_cache.items()
+            if expires_at <= now
+        ]
+        for key in expired:
+            self._evict_cache_entry(key)
+
+    def _cache_enabled(self) -> bool:
+        return (
+            self._cache_ttl_seconds > 0
+            and self._cache_max_entries > 0
+            and self._cache_max_entry_bytes > 0
+            and self._cache_max_bytes > 0
+        )
+
+    def _evict_oldest_cache_entry(self) -> None:
+        self._evict_cache_entry(next(iter(self._trace_read_cache)))
+
+    def _evict_cache_entry(self, key: CacheKey) -> None:
+        cached = self._trace_read_cache.get(key)
+        if cached is None:
+            return
+        _, size_bytes, _, _ = cached
+        self._drop_cache_entry(key, size_bytes)
+
+    def _drop_cache_entry(self, key: CacheKey, size_bytes: int) -> None:
+        self._trace_read_cache.pop(key, None)
+        self._trace_read_cache_bytes = max(self._trace_read_cache_bytes - size_bytes, 0)
+
+    def _cache_value_size(self, value: Any) -> int:
+        return self._cache_object_size(value, seen=set())
+
+    def _cache_object_size(self, value: Any, *, seen: set[int]) -> int:
+        obj_id = id(value)
+        if obj_id in seen:
+            return 0
+        seen.add(obj_id)
+
+        size = getsizeof(value)
+        if isinstance(value, dict):
+            size += sum(
+                self._cache_object_size(k, seen=seen) + self._cache_object_size(v, seen=seen)
+                for k, v in value.items()
+            )
+        elif isinstance(value, (list, tuple, set, frozenset)):
+            size += sum(self._cache_object_size(item, seen=seen) for item in value)
+        return size
+
+    @staticmethod
+    def _cache_key_string(value: str | None) -> object:
+        """Return an opaque bounded representation for cache key strings."""
+        if value is None:
+            return None
+        digest = sha256(value.encode("utf-8")).hexdigest()
+        return ("sha256", len(value), digest)
+
+    def _cache_filter_string(self, value: str | None) -> object:
+        """Normalize optional string filters to match their SQL no-op behavior."""
+        if value == "":
+            return None
+        return self._cache_key_string(value)
+
+    @staticmethod
+    def _cache_datetime(value: datetime | None) -> str | None:
+        if value is None:
+            return None
+        normalized: datetime = to_utc_naive(value)
+        return normalized.isoformat(timespec="milliseconds")
 
     def list_traces(
         self,
@@ -67,8 +227,35 @@ class TraceReaderService:
         start_after: datetime | None = None,
         end_before: datetime | None = None,
         search_query: str | None = None,
+        *,
+        use_cache: bool = False,
     ) -> dict:
-        """List traces with aggregated metrics from spans."""
+        """List traces with aggregated metrics from spans.
+
+        ``use_cache`` is an opt-in path for authenticated dashboard reads.
+        Public API, exports, agent/internal download flows, and other callers
+        that need freshest-read semantics should keep the default ``False``.
+        """
+        cache_key: CacheKey | None = None
+        if use_cache:
+            cache_key = (
+                "list_traces",
+                self._cache_key_string(project_id),
+                page,
+                limit,
+                self._cache_filter_string(name),
+                self._cache_filter_string(user_id),
+                self._cache_datetime(start_after),
+                self._cache_datetime(end_before),
+                self._cache_filter_string(search_query),
+            )
+            cached = self._read_cache(cache_key)
+            if cached is not _CACHE_MISS:
+                return cast(dict, cached)
+            cache_fetched_at = self._clock()
+        else:
+            cache_fetched_at = None
+
         offset = page * limit
 
         # Build WHERE conditions
@@ -205,12 +392,16 @@ class TraceReaderService:
                 }
             )
 
-        return {
+        result_payload = {
             "data": data,
             "meta": {"page": page, "limit": limit, "total": total},
         }
+        if use_cache:
+            assert cache_key is not None
+            self._write_cache(cache_key, result_payload, fetched_at=cache_fetched_at)
+        return result_payload
 
-    def get_trace(self, project_id: str, trace_id: str) -> dict | None:
+    def get_trace(self, project_id: str, trace_id: str, *, use_cache: bool = False) -> dict | None:
         """Get single trace with span skeletons (no per-span I/O).
 
         Returns trace metadata plus lightweight span skeletons that omit the
@@ -221,7 +412,25 @@ class TraceReaderService:
 
         Trace-level input/output/metadata (on the trace row) are kept: they're
         small and already present.
+
+        ``use_cache`` is an opt-in path for authenticated dashboard skeleton
+        reads. Public API, exports, agent/internal download flows, and
+        non-skeleton projections should keep the default ``False``.
         """
+        cache_key: CacheKey | None = None
+        if use_cache:
+            cache_key = (
+                "get_trace",
+                self._cache_key_string(project_id),
+                self._cache_key_string(trace_id),
+            )
+            cached = self._read_cache(cache_key)
+            if cached is not _CACHE_MISS:
+                return cast(dict, cached)
+            cache_fetched_at = self._clock()
+        else:
+            cache_fetched_at = None
+
         # Fetch trace
         # Dedup the ReplacingMergeTree row without FINAL: keep the latest version
         # of this trace_id.
@@ -263,7 +472,7 @@ class TraceReaderService:
             "project_id = {project_id:String}",
             "trace_id = {trace_id:String}",
         ]
-        spans_params = {"project_id": project_id, "trace_id": trace_id}
+        spans_params: dict[str, object] = {"project_id": project_id, "trace_id": trace_id}
         if trace["trace_start_time"] is not None:
             # Lower-bound the spans scan by the trace start time so ClickHouse
             # can skip old monthly span partitions. The spans table uses
@@ -345,6 +554,9 @@ class TraceReaderService:
             )
 
         trace["spans"] = spans
+        if use_cache:
+            assert cache_key is not None
+            self._write_cache(cache_key, trace, fetched_at=cache_fetched_at)
         return trace
 
     # Blob columns the bulk I/O reader may project, in a fixed order so the

--- a/tests/rest/test_public_traces_export.py
+++ b/tests/rest/test_public_traces_export.py
@@ -181,6 +181,7 @@ class TestExportBundle:
         kw = mock_reader.get_trace.call_args.kwargs
         assert kw["project_id"] == "proj-A"
         assert kw["trace_id"] == "abc123"
+        assert kw["use_cache"] is False
 
     def test_trace_url_present(self, client, mock_reader):
         mock_reader.get_trace.return_value = dict(TRACE_DETAIL)

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -106,6 +106,7 @@ class TestPublicListTraces:
         resp = client.get("/api/v1/public/traces", headers=AUTH_HEADER)
         assert resp.status_code == 200
         assert mock_reader.list_traces.call_args.kwargs["project_id"] == "proj-A"
+        assert mock_reader.list_traces.call_args.kwargs["use_cache"] is False
 
     def test_client_cannot_override_project_id(self, client, mock_reader):
         mock_reader.list_traces.return_value = {
@@ -214,6 +215,7 @@ class TestPublicGetTrace:
         kw = mock_reader.get_trace.call_args.kwargs
         assert kw["project_id"] == "proj-A"
         assert kw["trace_id"] == "abc123"
+        assert kw["use_cache"] is False
 
     def test_returns_full_payload_with_trace_url(self, client, mock_reader):
         mock_reader.get_trace.return_value = dict(TRACE_DETAIL)

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -3,7 +3,7 @@
 Pure logic — get_model_price is patched, so no DB/ClickHouse is needed.
 """
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -113,7 +113,7 @@ def test_span_cost_details_empty_for_unknown_model():
 # ---------------------------------------------------------------------------
 
 
-def _make_service(query_side_effect):
+def _make_service(query_side_effect, **service_kwargs):
     """Build a TraceReaderService backed by a mock ClickHouse client.
 
     ``query_side_effect`` is a callable invoked with each query string; it
@@ -127,12 +127,726 @@ def _make_service(query_side_effect):
         "rest.services.trace_reader.get_clickhouse_client",
         return_value=client,
     ):
-        service = TraceReaderService()
+        service = TraceReaderService(**service_kwargs)
     return service, client
 
 
 def _rows(rows):
     return SimpleNamespace(result_rows=rows)
+
+
+class _FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def _trace_row(
+    trace_id="abc123",
+    project_id="proj",
+    trace_start_time=datetime(2024, 1, 1),
+    input_value="trace-in",
+    output_value="trace-out",
+    metadata="trace-meta",
+):
+    return (
+        trace_id,
+        project_id,
+        "trace-name",
+        trace_start_time,
+        None,
+        None,
+        None,
+        None,
+        input_value,
+        output_value,
+        metadata,
+    )
+
+
+def _span_row(span_id="span-1", trace_id="abc123", name="root"):
+    return (
+        span_id,
+        trace_id,
+        None,
+        name,
+        "SPAN",
+        datetime(2024, 1, 1),
+        datetime(2024, 1, 1),
+        "OK",
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        {},
+        "file.py",
+        12,
+        "fn",
+    )
+
+
+def _list_trace_row(
+    trace_id="abc123",
+    project_id="proj",
+    trace_start_time=datetime(2024, 1, 1),
+    input_value="trace-in",
+    output_value="trace-out",
+):
+    return (
+        trace_id,
+        project_id,
+        "trace-name",
+        trace_start_time,
+        None,
+        None,
+        1,
+        42,
+        0,
+        input_value,
+        output_value,
+        10,
+        20,
+        0.01,
+    )
+
+
+class TestTraceReadCache:
+    def test_list_traces_reuses_identical_query_within_ttl(self):
+        clock = _FakeClock()
+
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row()])
+
+        service, client = _make_service(
+            side_effect,
+            cache_ttl_seconds=10.0,
+            clock=clock,
+        )
+
+        first = service.list_traces("proj", limit=5, search_query="trace", use_cache=True)
+        first["data"][0]["trace_url"] = "caller mutation"
+        second = service.list_traces("proj", limit=5, search_query="trace", use_cache=True)
+        second["data"][0]["trace_url"] = "cached-return mutation"
+        third = service.list_traces("proj", limit=5, search_query="trace", use_cache=True)
+
+        assert client.query.call_count == 2
+        assert second["data"][0]["trace_id"] == "abc123"
+        assert "trace_url" not in third["data"][0]
+
+    def test_list_traces_cache_key_distinguishes_filters(self):
+        cases = [
+            ({"project_id": "proj-a"}, {"project_id": "proj-b"}),
+            ({"page": 0}, {"page": 1}),
+            ({"limit": 5}, {"limit": 10}),
+            ({"name": "first"}, {"name": "second"}),
+            ({"user_id": "user-a"}, {"user_id": "user-b"}),
+            ({"search_query": "first"}, {"search_query": "second"}),
+            (
+                {"end_before": datetime(2024, 1, 1, 12, 0, tzinfo=UTC)},
+                {"end_before": datetime(2024, 1, 1, 12, 1, tzinfo=UTC)},
+            ),
+        ]
+
+        for first_kwargs, second_kwargs in cases:
+            client = MagicMock()
+
+            def side_effect(query, parameters=None):
+                if "count(DISTINCT t.trace_id)" in query:
+                    return _rows([(1,)])
+                return _rows([_list_trace_row(project_id=parameters["project_id"])])
+
+            client.query.side_effect = side_effect
+            with patch("rest.services.trace_reader.get_clickhouse_client", return_value=client):
+                from rest.services.trace_reader import TraceReaderService
+
+                service = TraceReaderService()
+
+            service.list_traces(
+                **{"project_id": "proj", "limit": 5, "use_cache": True, **first_kwargs}
+            )
+            service.list_traces(
+                **{"project_id": "proj", "limit": 5, "use_cache": True, **second_kwargs}
+            )
+
+            assert client.query.call_count == 4
+
+    @pytest.mark.parametrize("filter_name", ["name", "user_id", "search_query"])
+    def test_list_traces_empty_filter_cache_key_matches_omitted_filter(self, filter_name):
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row()])
+
+        service, client = _make_service(side_effect)
+
+        service.list_traces("proj", use_cache=True, **{filter_name: ""})
+        service.list_traces("proj", use_cache=True)
+
+        assert client.query.call_count == 2
+
+    def test_list_traces_bypasses_cache_when_requested(self):
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row()])
+
+        service, client = _make_service(side_effect)
+
+        service.list_traces("proj", limit=5, use_cache=False)
+        service.list_traces("proj", limit=5, use_cache=False)
+
+        assert client.query.call_count == 4
+
+    def test_list_traces_bypass_does_not_build_cache_key(self):
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row()])
+
+        service, client = _make_service(side_effect)
+
+        with patch.object(service, "_cache_key_string", side_effect=AssertionError):
+            result = service.list_traces("proj", limit=5, use_cache=False)
+
+        assert result["data"][0]["trace_id"] == "abc123"
+        assert client.query.call_count == 2
+
+    def test_list_traces_defaults_to_fresh_reads(self):
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row()])
+
+        service, client = _make_service(side_effect)
+
+        service.list_traces("proj", limit=5)
+        service.list_traces("proj", limit=5)
+
+        assert client.query.call_count == 4
+
+    def test_list_traces_bypass_does_not_seed_empty_cache(self):
+        trace_rows = iter(
+            [
+                _list_trace_row(input_value="fresh-bypass"),
+                _list_trace_row(input_value="cacheable"),
+            ]
+        )
+
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([next(trace_rows)])
+
+        service, client = _make_service(side_effect)
+
+        fresh_bypass = service.list_traces("proj", limit=5, use_cache=False)
+        cacheable = service.list_traces("proj", limit=5, use_cache=True)
+        cached_again = service.list_traces("proj", limit=5, use_cache=True)
+
+        assert fresh_bypass["data"][0]["input"] == "fresh-bypass"
+        assert cacheable["data"][0]["input"] == "cacheable"
+        assert cached_again["data"][0]["input"] == "cacheable"
+        assert client.query.call_count == 4
+
+    def test_list_traces_bypass_does_not_update_existing_cache_entry(self):
+        trace_rows = iter(
+            [
+                _list_trace_row(input_value="cached"),
+                _list_trace_row(input_value="fresh-bypass"),
+            ]
+        )
+
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([next(trace_rows)])
+
+        service, client = _make_service(side_effect)
+
+        cached_seed = service.list_traces("proj", limit=5, use_cache=True)
+        fresh_bypass = service.list_traces("proj", limit=5, use_cache=False)
+        cached_again = service.list_traces("proj", limit=5, use_cache=True)
+
+        assert cached_seed["data"][0]["input"] == "cached"
+        assert fresh_bypass["data"][0]["input"] == "fresh-bypass"
+        assert cached_again["data"][0]["input"] == "cached"
+        assert client.query.call_count == 4
+
+    def test_list_traces_cache_expires_after_ttl(self):
+        clock = _FakeClock()
+
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row()])
+
+        service, client = _make_service(
+            side_effect,
+            cache_ttl_seconds=10.0,
+            clock=clock,
+        )
+
+        service.list_traces("proj", limit=5, use_cache=True)
+        clock.advance(10.1)
+        service.list_traces("proj", limit=5, use_cache=True)
+
+        assert client.query.call_count == 4
+
+    @pytest.mark.parametrize("datetime_filter", ["start_after", "end_before"])
+    def test_list_traces_datetime_cache_key_matches_query_precision(self, datetime_filter):
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row()])
+
+        service, client = _make_service(side_effect)
+        first_value = datetime(2024, 1, 1, 12, 0, 0, 123400, tzinfo=UTC)
+        same_millisecond_value = datetime(
+            2024,
+            1,
+            1,
+            4,
+            0,
+            0,
+            123499,
+            tzinfo=timezone(timedelta(hours=-8)),
+        )
+        adjacent_millisecond_value = datetime(2024, 1, 1, 12, 0, 0, 124000, tzinfo=UTC)
+
+        service.list_traces("proj", use_cache=True, **{datetime_filter: first_value})
+        service.list_traces("proj", use_cache=True, **{datetime_filter: same_millisecond_value})
+        service.list_traces("proj", use_cache=True, **{datetime_filter: adjacent_millisecond_value})
+
+        assert client.query.call_count == 4
+
+    def test_list_traces_records_cache_fetch_time_before_clickhouse_queries(self):
+        clock = _FakeClock()
+
+        def side_effect(query, parameters=None):
+            clock.advance(5.0)
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row()])
+
+        service, _ = _make_service(side_effect, clock=clock)
+        original_write_cache = service._write_cache
+        captured = {}
+
+        def capture_write_cache(key, value, *, fetched_at=None):
+            captured["fetched_at"] = fetched_at
+            original_write_cache(key, value, fetched_at=fetched_at)
+
+        with patch.object(service, "_write_cache", side_effect=capture_write_cache):
+            service.list_traces("proj", use_cache=True)
+
+        assert captured["fetched_at"] == 0.0
+
+    def test_list_traces_cache_evicts_oldest_entry_at_capacity(self):
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row()])
+
+        service, client = _make_service(side_effect, cache_max_entries=2)
+
+        service.list_traces("proj", search_query="first", use_cache=True)
+        service.list_traces("proj", search_query="second", use_cache=True)
+        service.list_traces("proj", search_query="third", use_cache=True)
+        service.list_traces("proj", search_query="second", use_cache=True)
+        service.list_traces("proj", search_query="first", use_cache=True)
+        service.list_traces("proj", search_query="third", use_cache=True)
+
+        assert client.query.call_count == 10
+
+    def test_list_traces_skips_entries_over_size_cap(self):
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(1,)])
+            return _rows([_list_trace_row(input_value="x" * 2048)])
+
+        service, client = _make_service(side_effect, cache_max_entry_bytes=512)
+
+        service.list_traces("proj", limit=5, use_cache=True)
+        service.list_traces("proj", limit=5, use_cache=True)
+
+        assert client.query.call_count == 4
+
+    def test_cache_rejects_oversized_entry_before_deepcopy(self, monkeypatch):
+        def side_effect(query, parameters=None):
+            return _rows([])
+
+        service, _ = _make_service(side_effect, cache_max_entry_bytes=1)
+
+        def fail_deepcopy(value):
+            raise AssertionError("oversized cache values must be rejected before deepcopy")
+
+        monkeypatch.setattr("rest.services.trace_reader.deepcopy", fail_deepcopy)
+
+        service._write_cache(("oversized",), {"payload": "x" * 2048})
+
+        assert service._trace_read_cache == {}
+
+    def test_cache_evicts_oldest_entry_when_total_byte_cap_is_exceeded(self):
+        clock = _FakeClock()
+
+        def side_effect(query, parameters=None):
+            return _rows([])
+
+        service, _ = _make_service(side_effect, clock=clock)
+        from rest.services.trace_reader import _CACHE_MISS
+
+        first_key = ("first",)
+        second_key = ("second",)
+        first_payload = {"payload": "a" * 128}
+        second_payload = {"payload": "b" * 128}
+        first_size = service._cache_value_size(first_key) + service._cache_value_size(first_payload)
+        second_size = service._cache_value_size(second_key) + service._cache_value_size(
+            second_payload
+        )
+        service._cache_max_bytes = first_size + second_size - 1
+
+        service._write_cache(first_key, first_payload, fetched_at=1.0)
+        service._write_cache(second_key, second_payload, fetched_at=2.0)
+
+        assert service._read_cache(first_key) is _CACHE_MISS
+        assert service._read_cache(second_key) == second_payload
+        assert service._trace_read_cache_bytes == second_size
+
+    def test_cache_budget_counts_key_bytes_and_hashes_user_filter_key_strings(self):
+        short_search_query = "secret@example.com"
+        long_search_query = "x" * 100_000
+
+        def side_effect(query, parameters=None):
+            if "count(DISTINCT t.trace_id)" in query:
+                return _rows([(0,)])
+            return _rows([])
+
+        service, _ = _make_service(side_effect)
+
+        service.list_traces("proj", search_query=short_search_query, use_cache=True)
+        service.list_traces("proj", search_query=long_search_query, use_cache=True)
+
+        cache_keys = list(service._trace_read_cache.keys())
+        assert len(cache_keys) == 2
+        for cache_key in cache_keys:
+            assert "proj" not in cache_key
+            assert short_search_query not in cache_key
+            assert long_search_query not in cache_key
+            assert service._trace_read_cache_bytes >= service._cache_value_size(cache_key)
+
+    def test_cache_does_not_overwrite_newer_snapshot_with_older_write(self):
+        clock = _FakeClock()
+
+        def side_effect(query, parameters=None):
+            return _rows([])
+
+        service, _ = _make_service(side_effect, clock=clock)
+        key = ("get_trace", "proj", "abc123")
+
+        service._write_cache(key, {"version": "newer"}, fetched_at=2.0)
+        service._write_cache(key, {"version": "older"}, fetched_at=1.0)
+
+        cached = service._read_cache(key)
+        assert cached == {"version": "newer"}
+
+    def test_cache_does_not_overwrite_snapshot_with_equal_fetch_time(self):
+        clock = _FakeClock()
+
+        def side_effect(query, parameters=None):
+            return _rows([])
+
+        service, _ = _make_service(side_effect, clock=clock)
+        key = ("get_trace", "proj", "abc123")
+
+        service._write_cache(key, {"version": "first"}, fetched_at=1.0)
+        service._write_cache(key, {"version": "same-tick-second"}, fetched_at=1.0)
+
+        cached = service._read_cache(key)
+        assert cached == {"version": "first"}
+
+    def test_cache_skips_result_when_fetch_already_exceeded_ttl(self):
+        clock = _FakeClock()
+
+        def side_effect(query, parameters=None):
+            return _rows([])
+
+        service, _ = _make_service(side_effect, cache_ttl_seconds=10.0, clock=clock)
+        key = ("get_trace", "proj", "abc123")
+
+        clock.advance(10.1)
+        service._write_cache(key, {"version": "too-old"}, fetched_at=0.0)
+
+        from rest.services.trace_reader import _CACHE_MISS
+
+        assert service._read_cache(key) is _CACHE_MISS
+
+    def test_get_trace_reuses_skeleton_within_ttl_without_sharing_mutations(self):
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([_trace_row()])
+            return _rows([_span_row()])
+
+        service, client = _make_service(side_effect)
+
+        first = service.get_trace("proj", "abc123", use_cache=True)
+        first["spans"][0]["input"] = "hydrated by caller"
+        first["spans"].append({"span_id": "caller-added"})
+        second = service.get_trace("proj", "abc123", use_cache=True)
+        second["spans"][0]["input"] = "mutated cached return"
+        third = service.get_trace("proj", "abc123", use_cache=True)
+
+        assert client.query.call_count == 2
+        assert len(second["spans"]) == 1
+        assert len(third["spans"]) == 1
+        assert "input" not in third["spans"][0]
+        assert third["spans"][0]["span_id"] == "span-1"
+
+    def test_get_trace_cache_survives_projection_hydration_without_pollution(self):
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([_trace_row()])
+            return _rows([_span_row()])
+
+        service, client = _make_service(side_effect)
+        from rest.projection import FULL, SKELETON, hydrate_span_io
+
+        hydrated = service.get_trace("proj", "abc123", use_cache=True)
+        with patch.object(
+            service,
+            "get_trace_spans_io",
+            return_value={"span-1": {"input": "the-in", "output": "the-out", "metadata": "m"}},
+        ):
+            hydrate_span_io(
+                service,
+                hydrated,
+                project_id="proj",
+                trace_id="abc123",
+                groups=FULL,
+            )
+
+        skeleton = service.get_trace("proj", "abc123", use_cache=True)
+        hydrate_span_io(service, skeleton, project_id="proj", trace_id="abc123", groups=SKELETON)
+
+        assert client.query.call_count == 2
+        assert "input" not in skeleton["spans"][0]
+        assert "output" not in skeleton["spans"][0]
+        assert "metadata" not in skeleton["spans"][0]
+
+    def test_get_trace_cache_key_distinguishes_project_and_trace(self):
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows(
+                    [
+                        _trace_row(
+                            trace_id=parameters["trace_id"],
+                            project_id=parameters["project_id"],
+                        )
+                    ]
+                )
+            return _rows(
+                [
+                    _span_row(
+                        trace_id=parameters["trace_id"],
+                        name=f"root-{parameters['project_id']}",
+                    )
+                ]
+            )
+
+        service, client = _make_service(side_effect)
+
+        project_a = service.get_trace("proj-a", "abc123", use_cache=True)
+        project_b = service.get_trace("proj-b", "abc123", use_cache=True)
+        trace_b = service.get_trace("proj-a", "trace-b", use_cache=True)
+
+        assert client.query.call_count == 6
+        assert project_a["project_id"] == "proj-a"
+        assert project_b["project_id"] == "proj-b"
+        assert trace_b["trace_id"] == "trace-b"
+
+    def test_get_trace_cache_key_hashes_project_and_trace_strings(self):
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows(
+                    [
+                        _trace_row(
+                            trace_id=parameters["trace_id"],
+                            project_id=parameters["project_id"],
+                        )
+                    ]
+                )
+            return _rows([_span_row(trace_id=parameters["trace_id"])])
+
+        service, _ = _make_service(side_effect)
+
+        service.get_trace("secret-project", "secret-trace-id", use_cache=True)
+
+        [cache_key] = service._trace_read_cache.keys()
+        assert "secret-project" not in cache_key
+        assert "secret-trace-id" not in cache_key
+        assert service._trace_read_cache_bytes >= service._cache_value_size(cache_key)
+
+    def test_get_trace_cache_expires_after_ttl(self):
+        clock = _FakeClock()
+
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([_trace_row()])
+            return _rows([_span_row()])
+
+        service, client = _make_service(
+            side_effect,
+            cache_ttl_seconds=10.0,
+            clock=clock,
+        )
+
+        service.get_trace("proj", "abc123", use_cache=True)
+        clock.advance(10.1)
+        service.get_trace("proj", "abc123", use_cache=True)
+
+        assert client.query.call_count == 4
+
+    def test_get_trace_records_cache_fetch_time_before_clickhouse_queries(self):
+        clock = _FakeClock()
+
+        def side_effect(query, parameters=None):
+            clock.advance(5.0)
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([_trace_row()])
+            return _rows([_span_row()])
+
+        service, _ = _make_service(side_effect, clock=clock)
+        original_write_cache = service._write_cache
+        captured = {}
+
+        def capture_write_cache(key, value, *, fetched_at=None):
+            captured["fetched_at"] = fetched_at
+            original_write_cache(key, value, fetched_at=fetched_at)
+
+        with patch.object(service, "_write_cache", side_effect=capture_write_cache):
+            service.get_trace("proj", "abc123", use_cache=True)
+
+        assert captured["fetched_at"] == 0.0
+
+    def test_get_trace_bypasses_cache_when_requested(self):
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([_trace_row()])
+            return _rows([_span_row()])
+
+        service, client = _make_service(side_effect)
+
+        service.get_trace("proj", "abc123", use_cache=False)
+        service.get_trace("proj", "abc123", use_cache=False)
+
+        assert client.query.call_count == 4
+
+    def test_get_trace_bypass_does_not_build_cache_key(self):
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([_trace_row()])
+            return _rows([_span_row()])
+
+        service, client = _make_service(side_effect)
+
+        with patch.object(service, "_cache_key_string", side_effect=AssertionError):
+            result = service.get_trace("proj", "abc123", use_cache=False)
+
+        assert result["trace_id"] == "abc123"
+        assert client.query.call_count == 2
+
+    def test_get_trace_defaults_to_fresh_reads(self):
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([_trace_row()])
+            return _rows([_span_row()])
+
+        service, client = _make_service(side_effect)
+
+        service.get_trace("proj", "abc123")
+        service.get_trace("proj", "abc123")
+
+        assert client.query.call_count == 4
+
+    def test_get_trace_bypass_does_not_seed_empty_cache(self):
+        trace_rows = iter(
+            [
+                _trace_row(input_value="fresh-bypass"),
+                _trace_row(input_value="cacheable"),
+            ]
+        )
+
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([next(trace_rows)])
+            return _rows([_span_row()])
+
+        service, client = _make_service(side_effect)
+
+        fresh_bypass = service.get_trace("proj", "abc123", use_cache=False)
+        cacheable = service.get_trace("proj", "abc123", use_cache=True)
+        cached_again = service.get_trace("proj", "abc123", use_cache=True)
+
+        assert fresh_bypass["input"] == "fresh-bypass"
+        assert cacheable["input"] == "cacheable"
+        assert cached_again["input"] == "cacheable"
+        assert client.query.call_count == 4
+
+    def test_get_trace_bypass_does_not_update_existing_cache_entry(self):
+        trace_rows = iter(
+            [
+                _trace_row(input_value="cached"),
+                _trace_row(input_value="fresh-bypass"),
+            ]
+        )
+
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([next(trace_rows)])
+            return _rows([_span_row()])
+
+        service, client = _make_service(side_effect)
+
+        cached_seed = service.get_trace("proj", "abc123", use_cache=True)
+        fresh_bypass = service.get_trace("proj", "abc123", use_cache=False)
+        cached_again = service.get_trace("proj", "abc123", use_cache=True)
+
+        assert cached_seed["input"] == "cached"
+        assert fresh_bypass["input"] == "fresh-bypass"
+        assert cached_again["input"] == "cached"
+        assert client.query.call_count == 4
+
+    def test_get_trace_skips_entries_over_size_cap(self):
+        def side_effect(query, parameters=None):
+            if "FROM traces" in query and "FROM spans" not in query:
+                return _rows([_trace_row(input_value="x" * 2048)])
+            return _rows([_span_row()])
+
+        service, client = _make_service(side_effect, cache_max_entry_bytes=512)
+
+        service.get_trace("proj", "abc123", use_cache=True)
+        service.get_trace("proj", "abc123", use_cache=True)
+
+        assert client.query.call_count == 4
+
+    def test_get_trace_missing_result_is_not_cached(self):
+        def side_effect(query, parameters=None):
+            return _rows([])
+
+        service, client = _make_service(side_effect)
+
+        assert service.get_trace("proj", "missing", use_cache=True) is None
+        assert service.get_trace("proj", "missing", use_cache=True) is None
+
+        assert client.query.call_count == 2
 
 
 class TestGetTraceSkeleton:

--- a/tests/rest/test_traces_router.py
+++ b/tests/rest/test_traces_router.py
@@ -119,6 +119,7 @@ class TestListTraces:
         assert data["data"][0]["error_count"] == 0
         assert "status" not in data["data"][0]
         assert data["meta"]["total"] == 1
+        assert mock_trace_reader.list_traces.call_args.kwargs["use_cache"] is True
 
     def test_with_name_and_user_filters(self, client, mock_trace_reader):
         mock_trace_reader.list_traces.return_value = {
@@ -189,6 +190,25 @@ class TestListTraces:
         response = client.get("/api/v1/projects/test-project/traces?page=-1")
         assert response.status_code == 422
 
+    def test_internal_secret_style_access_bypasses_list_cache(self, client, mock_trace_reader):
+        async def mock_get_internal_access(project_id: str, x_user_id=None):
+            return ProjectAccessInfo(
+                project_id=project_id,
+                user_id="agent-user",
+                role="ADMIN",
+            )
+
+        app.dependency_overrides[get_project_access] = mock_get_internal_access
+        mock_trace_reader.list_traces.return_value = {
+            "data": [],
+            "meta": {"page": 0, "limit": 50, "total": 0},
+        }
+
+        response = client.get("/api/v1/projects/test-project/traces")
+
+        assert response.status_code == 200
+        assert mock_trace_reader.list_traces.call_args.kwargs["use_cache"] is False
+
 
 class TestGetTrace:
     def test_200(self, client, mock_trace_reader):
@@ -199,6 +219,7 @@ class TestGetTrace:
         assert data["trace_id"] == "abc123"
         assert len(data["spans"]) == 1
         assert data["spans"][0]["span_id"] == "span-1"
+        assert mock_trace_reader.get_trace.call_args.kwargs["use_cache"] is True
 
     def test_404(self, client, mock_trace_reader):
         mock_trace_reader.get_trace.return_value = None
@@ -236,6 +257,7 @@ class TestGetTrace:
         }
         response = client.get("/api/v1/projects/test-project/traces/abc123?fields=full")
         assert response.status_code == 200
+        assert mock_trace_reader.get_trace.call_args.kwargs["use_cache"] is False
         span = response.json()["spans"][0]
         assert span["input"] == "the-in"
         assert span["output"] == "the-out"
@@ -259,6 +281,7 @@ class TestGetTrace:
         assert span["input"] == "the-in"
         assert span["output"] == "the-out"
         assert span["metadata"] is None
+        assert mock_trace_reader.get_trace.call_args.kwargs["use_cache"] is False
         assert set(mock_trace_reader.get_trace_spans_io.call_args.kwargs["columns"]) == {
             "input",
             "output",
@@ -297,6 +320,22 @@ class TestGetTrace:
         assert data["input"] == "trace-input"
         assert data["output"] == "trace-output"
         assert data["metadata"] == "trace-metadata"
+
+    def test_internal_secret_style_access_bypasses_get_trace_cache(self, client, mock_trace_reader):
+        async def mock_get_internal_access(project_id: str, x_user_id=None):
+            return ProjectAccessInfo(
+                project_id=project_id,
+                user_id="agent-user",
+                role="ADMIN",
+            )
+
+        app.dependency_overrides[get_project_access] = mock_get_internal_access
+        mock_trace_reader.get_trace.return_value = copy.deepcopy(TRACE_DETAIL)
+
+        response = client.get("/api/v1/projects/test-project/traces/abc123")
+
+        assert response.status_code == 200
+        assert mock_trace_reader.get_trace.call_args.kwargs["use_cache"] is False
 
 
 class TestGetSpanIO:


### PR DESCRIPTION
## Summary

Adds a short-lived in-process cache inside `TraceReaderService` for authenticated dashboard trace list/detail reads so repeated polling of the same project/filter/trace can avoid duplicate ClickHouse work. Public API/CLI trace reads, exports, full-projection internal reads, and internal-secret agent reads explicitly bypass this cache so automation/deep-download flows keep freshest-read semantics.

## Changes

- Cache dashboard `list_traces()` and skeleton `get_trace()` results by project, pagination, filters, and trace ID through explicit route opt-in.
- Keep cache entries bounded by TTL, entry count, per-entry estimated bytes, aggregate estimated bytes, and opaque hashed string cache-key components.
- Count cache-key bytes in the cache budget and avoid retaining raw project/filter/trace strings in cache keys.
- Reject oversized entries before creating the defensive cached copy to avoid avoidable memory spikes during cache admission.
- Anchor cache expiry to the read snapshot time and skip writes whose fetch already exceeded the TTL window.
- Preserve snapshot ordering so an older/equal-timestamp overlapping DB read cannot overwrite a newer cached snapshot.
- Return defensive copies from the cache and use LRU-style hit ordering to avoid caller/projection mutation polluting cached data.
- Keep service methods cache-disabled by default so non-dashboard callers must opt in deliberately.
- Add public-route `use_cache=False` wiring for list/detail/export reads.
- Add internal-route bypasses for `fields=full`/non-skeleton trace reads and internal-secret agent calls.
- Add regression coverage for cache hits, default-fresh service semantics, TTL expiry, key separation, empty-filter normalization, datetime precision, request/router bypass behavior, bypass-key construction avoidance, bypass non-pollution, mutation/projection isolation, missing-trace behavior, byte limits, hashed key accounting, aggregate eviction, LRU hit ordering, pre-copy oversized rejection, fetch-time expiry, overwrite ordering, and public API cache bypass.

## Why this matters

Issue #728 calls out repeated dashboard trace reads causing avoidable ClickHouse load. This keeps the optimization narrow and bounded for the authenticated app dashboard path while preserving freshness for public API/CLI and internal agent/deep-download workflows where stale trace data would be surprising.

Validation hypothesis after merge: repeated authenticated dashboard list/detail reads should reduce duplicate ClickHouse trace-read queries during polling/reopen flows without increasing agent-download or public-API missing-data reports. Validate with ClickHouse query logs or backend trace-read query counters over the first 24–72 hours after deploy. Keep the cache if duplicate dashboard trace list/detail queries fall by at least 20% over that window and freshness-related support/debug reports do not increase beyond baseline; otherwise shorten the TTL, narrow cached endpoints further, or remove the cache calls.

## Tests

Commands run:

- `uv run pytest tests/rest/test_trace_reader.py tests/rest/test_public_traces_read.py tests/rest/test_public_traces_export.py tests/rest/test_traces_router.py -q` — passed (`119 passed`, 2 existing warnings: Starlette/httpx deprecation and OpenTelemetry importlib metadata deprecation)
- `uv run ruff check backend/rest/services/trace_reader.py backend/rest/routers/traces.py backend/rest/routers/public/traces_read.py tests/rest/test_trace_reader.py tests/rest/test_traces_router.py tests/rest/test_public_traces_read.py tests/rest/test_public_traces_export.py` — passed
- `uv run ruff format --check backend/rest/services/trace_reader.py backend/rest/routers/traces.py backend/rest/routers/public/traces_read.py tests/rest/test_trace_reader.py tests/rest/test_traces_router.py tests/rest/test_public_traces_read.py tests/rest/test_public_traces_export.py` — passed
- `uv run mypy backend/rest/services/trace_reader.py backend/rest/routers/traces.py backend/rest/routers/public/traces_read.py tests/rest/test_trace_reader.py tests/rest/test_traces_router.py tests/rest/test_public_traces_read.py tests/rest/test_public_traces_export.py` — passed
- `git diff --check` — passed

## Risk

Risk level: medium

The cache intentionally permits authenticated dashboard skeleton/list reads to be stale for up to 10 seconds from the read snapshot time. Cached values may include recent trace list/detail fields already returned by the authenticated dashboard response, including trace-level input/output/metadata; public API/CLI reads, exports, full-projection reads, and internal-secret agent reads are not cached. Cache entries are in-process only, bounded by TTL/count/estimated bytes, and can be disabled or tuned through the service constructor in tests/future wiring. Service methods default to fresh reads unless a caller explicitly opts in. Rollback is simple: remove the cache read/write calls and route `use_cache` flags.

## Issue

Fixes #728

## Notes for maintainers

- This PR does not introduce cross-process/distributed caching.
- This PR does not add write-path invalidation; the bounded TTL is the freshness control for authenticated dashboard skeleton reads.
- Byte accounting uses Python object-size estimates to cap cache admission/retention; it is intended as a safety bound rather than an exact serialized payload measurement.
