### PR TITLE
fix(ui): explain Project API Keys info icon

### DIFF
--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -251,6 +251,13 @@ describe("AccessKeysTab", () => {
     });
     expect(screen.getByText(".env example")).toBeDefined();
     expect(screen.getByText('TRACEROOT_API_KEY="tr-..."')).toBeDefined();
+
+    rerenderWithProject("proj_123");
+
+    await waitFor(() => {
+      expect(screen.queryByText('TRACEROOT_API_KEY="tr-project-one-secret"')).toBeNull();
+    });
+    expect(screen.queryByRole("button", { name: /copy api key environment variable/i })).toBeNull();
   });
 
   it("ignores in-flight key creation that resolves after switching projects", async () => {
@@ -290,6 +297,13 @@ describe("AccessKeysTab", () => {
 
     expect(screen.queryByRole("button", { name: /copy api key environment variable/i })).toBeNull();
     expect(clipboardWriteText).not.toHaveBeenCalled();
+
+    rerenderWithProject("proj_123");
+
+    await waitFor(() => {
+      expect(screen.queryByText('TRACEROOT_API_KEY="tr-project-one-pending-secret"')).toBeNull();
+    });
+    expect(screen.queryByRole("button", { name: /copy api key environment variable/i })).toBeNull();
   });
 
   it("shows an in-flight created secret if the user returns to the origin project before it resolves", async () => {

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -123,9 +123,7 @@ describe("AccessKeysTab", () => {
     renderAccessKeysTab();
 
     expect(await screen.findByText(".env masked hint")).toBeDefined();
-    expect(
-      screen.getByText(/create a new api key to copy a full traceroot_api_key value/i),
-    ).toBeDefined();
+    expect(screen.getByText(/create a new api key and update traceroot_api_key/i)).toBeDefined();
 
     expect(screen.queryByRole("button", { name: /copy api key environment variable/i })).toBeNull();
   });
@@ -196,6 +194,14 @@ describe("AccessKeysTab", () => {
 
     await waitFor(() => {
       expect(clipboardWriteText).toHaveBeenCalledWith('TRACEROOT_API_KEY="tr-full-secret-value"');
+    });
+
+    clipboardWriteText.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: /copy new api key/i }));
+
+    await waitFor(() => {
+      expect(clipboardWriteText).toHaveBeenCalledWith("tr-full-secret-value");
     });
   });
 
@@ -463,7 +469,7 @@ describe("AccessKeysTab", () => {
     expect(screen.getByText("Edit Note")).toBeDefined();
   });
 
-  it("does not let an older note update close a newly opened edit dialog after returning to the same project", async () => {
+  it("keeps same-project note updates disabled until the older request settles", async () => {
     mocks.getAccessKeys.mockResolvedValue({
       access_keys: [
         {
@@ -494,15 +500,85 @@ describe("AccessKeysTab", () => {
     rerenderWithProject("proj_456");
     rerenderWithProject("proj_123");
 
-    fireEvent.click(await screen.findByRole("button", { name: "Production" }));
-    expect(screen.getByText("Edit Note")).toBeDefined();
+    const sameProjectNoteButton = await screen.findByRole("button", { name: "Production" });
+    expect(sameProjectNoteButton).toHaveProperty("disabled", true);
+
+    fireEvent.click(sameProjectNoteButton);
+    expect(screen.queryByText("Edit Note")).toBeNull();
 
     await act(async () => {
       deferredUpdate.resolve();
       await deferredUpdate.promise;
     });
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Production" })).toHaveProperty("disabled", false);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Production" }));
     expect(screen.getByText("Edit Note")).toBeDefined();
+  });
+
+  it("keeps the active note update pending when an older project update resolves first", async () => {
+    mocks.getAccessKeys.mockResolvedValue({
+      access_keys: [
+        {
+          id: "key_123",
+          key_hint: "tr-1234567890abcdef",
+          name: "Production",
+          expire_time: null,
+          last_use_time: null,
+          create_time: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const projectOneUpdate = createDeferred<void>();
+    const projectTwoUpdate = createDeferred<void>();
+    mocks.updateAccessKey
+      .mockReturnValueOnce(projectOneUpdate.promise)
+      .mockReturnValueOnce(projectTwoUpdate.promise);
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Production" }));
+    fireEvent.change(screen.getByPlaceholderText(/production, development/i), {
+      target: { value: "Renamed One" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mocks.updateAccessKey).toHaveBeenCalledWith("proj_123", "key_123", "Renamed One");
+    });
+
+    rerenderWithProject("proj_456");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Production" }));
+    fireEvent.change(screen.getByPlaceholderText(/production, development/i), {
+      target: { value: "Renamed Two" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mocks.updateAccessKey).toHaveBeenCalledWith("proj_456", "key_123", "Renamed Two");
+    });
+    expect(await screen.findByRole("button", { name: /saving/i })).toHaveProperty("disabled", true);
+
+    await act(async () => {
+      projectOneUpdate.resolve();
+      await projectOneUpdate.promise;
+    });
+
+    expect(screen.getByRole("button", { name: /saving/i })).toHaveProperty("disabled", true);
+    expect(screen.getByText("Edit Note")).toBeDefined();
+
+    await act(async () => {
+      projectTwoUpdate.resolve();
+      await projectTwoUpdate.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Edit Note")).toBeNull();
+    });
   });
 
   it("does not let an in-flight delete close the next project's delete dialog", async () => {
@@ -556,7 +632,7 @@ describe("AccessKeysTab", () => {
     expect(screen.getByRole("heading", { name: "Delete API Key" })).toBeDefined();
   });
 
-  it("does not let an older delete close a newly opened delete dialog after returning to the same project", async () => {
+  it("keeps same-project delete controls disabled until the older request settles", async () => {
     mocks.getAccessKeys.mockResolvedValue({
       access_keys: [
         {
@@ -587,14 +663,90 @@ describe("AccessKeysTab", () => {
     rerenderWithProject("proj_456");
     rerenderWithProject("proj_123");
 
-    fireEvent.click(await screen.findByRole("button", { name: "Delete API key" }));
-    expect(screen.getByRole("heading", { name: "Delete API Key" })).toBeDefined();
+    const sameProjectDeleteButton = await screen.findByRole("button", { name: "Delete API key" });
+    expect(sameProjectDeleteButton).toHaveProperty("disabled", true);
+
+    fireEvent.click(sameProjectDeleteButton);
+    expect(screen.queryByRole("heading", { name: "Delete API Key" })).toBeNull();
 
     await act(async () => {
       deferredDelete.resolve();
       await deferredDelete.promise;
     });
 
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Delete API key" })).toHaveProperty(
+        "disabled",
+        false,
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete API key" }));
     expect(screen.getByRole("heading", { name: "Delete API Key" })).toBeDefined();
+  });
+
+  it("keeps the active delete pending when an older project delete resolves first", async () => {
+    mocks.getAccessKeys.mockResolvedValue({
+      access_keys: [
+        {
+          id: "key_123",
+          key_hint: "tr-1234567890abcdef",
+          name: "Production",
+          expire_time: null,
+          last_use_time: null,
+          create_time: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const projectOneDelete = createDeferred<void>();
+    const projectTwoDelete = createDeferred<void>();
+    mocks.deleteAccessKey
+      .mockReturnValueOnce(projectOneDelete.promise)
+      .mockReturnValueOnce(projectTwoDelete.promise);
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete API key" }));
+    fireEvent.change(screen.getByPlaceholderText("API key name"), {
+      target: { value: "Production" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Delete API Key" }));
+
+    await waitFor(() => {
+      expect(mocks.deleteAccessKey).toHaveBeenCalledWith("proj_123", "key_123");
+    });
+
+    rerenderWithProject("proj_456");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete API key" }));
+    fireEvent.change(screen.getByPlaceholderText("API key name"), {
+      target: { value: "Production" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Delete API Key" }));
+
+    await waitFor(() => {
+      expect(mocks.deleteAccessKey).toHaveBeenCalledWith("proj_456", "key_123");
+    });
+    expect(await screen.findByRole("button", { name: /deleting/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+
+    await act(async () => {
+      projectOneDelete.resolve();
+      await projectOneDelete.promise;
+    });
+
+    expect(screen.getByRole("button", { name: /deleting/i })).toHaveProperty("disabled", true);
+    expect(screen.getByRole("heading", { name: "Delete API Key" })).toBeDefined();
+
+    await act(async () => {
+      projectTwoDelete.resolve();
+      await projectTwoDelete.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("heading", { name: "Delete API Key" })).toBeNull();
+    });
   });
 });

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -127,6 +127,42 @@ describe("AccessKeysTab", () => {
     expect(copyMaskedHint).toHaveProperty("disabled", true);
   });
 
+  it("closes project-scoped edit and delete dialogs when the project changes", async () => {
+    mocks.getAccessKeys.mockResolvedValue({
+      access_keys: [
+        {
+          id: "key_123",
+          key_hint: "tr-1234567890abcdef",
+          name: "Production",
+          expire_time: null,
+          last_use_time: null,
+          create_time: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Production" }));
+    expect(screen.getByText("Edit Note")).toBeDefined();
+
+    rerenderWithProject("proj_456");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Edit Note")).toBeNull();
+    });
+    await screen.findByRole("button", { name: "Production" });
+
+    fireEvent.click(screen.getByRole("button", { name: /delete api key/i }));
+    expect(screen.getAllByText("Delete API Key").length).toBeGreaterThan(0);
+
+    rerenderWithProject("proj_789");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Delete API Key")).toBeNull();
+    });
+  });
+
   it("copies the full environment variable only after a new key is created", async () => {
     mocks.createAccessKey.mockResolvedValue({
       data: {

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mocks = vi.hoisted(() => ({
@@ -19,17 +19,38 @@ vi.mock("@/lib/api", () => ({
 
 import { AccessKeysTab } from "./AccessKeysTab";
 
-function renderAccessKeysTab() {
+const clipboardWriteText = vi.fn();
+
+function renderAccessKeysTab(projectId = "proj_123") {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
 
-  return render(
+  const renderResult = render(
     <QueryClientProvider client={queryClient}>
-      <AccessKeysTab projectId="proj_123" />
+      <AccessKeysTab projectId={projectId} />
     </QueryClientProvider>,
   );
+
+  return {
+    ...renderResult,
+    rerenderWithProject(nextProjectId: string) {
+      renderResult.rerender(
+        <QueryClientProvider client={queryClient}>
+          <AccessKeysTab projectId={nextProjectId} />
+        </QueryClientProvider>,
+      );
+    },
+  };
 }
+
+beforeEach(() => {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText: clipboardWriteText },
+  });
+  clipboardWriteText.mockResolvedValue(undefined);
+});
 
 afterEach(() => {
   cleanup();
@@ -37,6 +58,7 @@ afterEach(() => {
   mocks.createAccessKey.mockReset();
   mocks.updateAccessKey.mockReset();
   mocks.deleteAccessKey.mockReset();
+  clipboardWriteText.mockReset();
 });
 
 describe("AccessKeysTab", () => {
@@ -53,6 +75,18 @@ describe("AccessKeysTab", () => {
     expect(tooltip.textContent).toMatch(/copy the full secret immediately/i);
     expect(tooltip.textContent).toMatch(/store it as traceroot_api_key/i);
     expect(tooltip.textContent).toMatch(/only a masked hint is shown/i);
+  });
+
+  it("renders a disabled example environment variable when there are no API keys", async () => {
+    renderAccessKeysTab();
+
+    expect(await screen.findByText(".env example")).toBeDefined();
+    expect(screen.getByText('TRACEROOT_API_KEY = "tr-..."')).toBeDefined();
+
+    const copyExample = screen.getByRole("button", {
+      name: /create a new api key to copy the full environment variable/i,
+    });
+    expect(copyExample).toHaveProperty("disabled", true);
   });
 
   it("does not offer to copy masked API key hints as usable secrets", async () => {
@@ -80,5 +114,58 @@ describe("AccessKeysTab", () => {
       name: /create a new api key to copy the full environment variable/i,
     });
     expect(copyMaskedHint).toHaveProperty("disabled", true);
+  });
+
+  it("copies the full environment variable only after a new key is created", async () => {
+    mocks.createAccessKey.mockResolvedValue({
+      data: {
+        key: "tr-full-secret-value",
+        key_hint: "tr-full...alue",
+      },
+    });
+
+    renderAccessKeysTab();
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+    fireEvent.change(screen.getByPlaceholderText(/production, development/i), {
+      target: { value: "Production" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(await screen.findByText(".env")).toBeDefined();
+    expect(screen.getByText('TRACEROOT_API_KEY = "tr-full-secret-value"')).toBeDefined();
+
+    const copyEnv = screen.getByRole("button", { name: /copy api key environment variable/i });
+    expect(copyEnv).toHaveProperty("disabled", false);
+
+    fireEvent.click(copyEnv);
+
+    await waitFor(() => {
+      expect(clipboardWriteText).toHaveBeenCalledWith('TRACEROOT_API_KEY = "tr-full-secret-value"');
+    });
+  });
+
+  it("does not carry a one-time secret across project changes", async () => {
+    mocks.createAccessKey.mockResolvedValue({
+      data: {
+        key: "tr-project-one-secret",
+        key_hint: "tr-proj...cret",
+      },
+    });
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(await screen.findByText('TRACEROOT_API_KEY = "tr-project-one-secret"')).toBeDefined();
+
+    rerenderWithProject("proj_456");
+
+    await waitFor(() => {
+      expect(screen.queryByText('TRACEROOT_API_KEY = "tr-project-one-secret"')).toBeNull();
+    });
+    expect(screen.getByText(".env example")).toBeDefined();
+    expect(screen.getByText('TRACEROOT_API_KEY = "tr-..."')).toBeDefined();
   });
 });

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const mocks = vi.hoisted(() => ({
@@ -20,6 +20,17 @@ vi.mock("@/lib/api", () => ({
 import { AccessKeysTab } from "./AccessKeysTab";
 
 const clipboardWriteText = vi.fn();
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+
+  return { promise, resolve, reject };
+}
 
 function renderAccessKeysTab(projectId = "proj_123") {
   const queryClient = new QueryClient({
@@ -167,5 +178,43 @@ describe("AccessKeysTab", () => {
     });
     expect(screen.getByText(".env example")).toBeDefined();
     expect(screen.getByText('TRACEROOT_API_KEY = "tr-..."')).toBeDefined();
+  });
+
+  it("ignores in-flight key creation that resolves after switching projects", async () => {
+    const createResult = {
+      data: {
+        key: "tr-project-one-pending-secret",
+        key_hint: "tr-pend...cret",
+      },
+    };
+    const deferredCreate = createDeferred<typeof createResult>();
+    mocks.createAccessKey.mockReturnValue(deferredCreate.promise);
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => {
+      expect(mocks.createAccessKey).toHaveBeenCalledWith("proj_123", undefined);
+    });
+
+    rerenderWithProject("proj_456");
+
+    await act(async () => {
+      deferredCreate.resolve(createResult);
+      await deferredCreate.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('TRACEROOT_API_KEY = "tr-project-one-pending-secret"')).toBeNull();
+    });
+    expect(screen.getByText(".env example")).toBeDefined();
+
+    const copyEnv = screen.getByRole("button", {
+      name: /create a new api key to copy the full environment variable/i,
+    });
+    expect(copyEnv).toHaveProperty("disabled", true);
+    expect(clipboardWriteText).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+const mocks = vi.hoisted(() => ({
+  getAccessKeys: vi.fn().mockResolvedValue({ access_keys: [] }),
+  createAccessKey: vi.fn(),
+  updateAccessKey: vi.fn(),
+  deleteAccessKey: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getAccessKeys: (...args: unknown[]) => mocks.getAccessKeys(...args),
+  createAccessKey: (...args: unknown[]) => mocks.createAccessKey(...args),
+  updateAccessKey: (...args: unknown[]) => mocks.updateAccessKey(...args),
+  deleteAccessKey: (...args: unknown[]) => mocks.deleteAccessKey(...args),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div role="tooltip">{children}</div>,
+}));
+
+import { AccessKeysTab } from "./AccessKeysTab";
+
+function renderAccessKeysTab() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AccessKeysTab projectId="proj_123" />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.getAccessKeys.mockReset().mockResolvedValue({ access_keys: [] });
+  mocks.createAccessKey.mockReset();
+  mocks.updateAccessKey.mockReset();
+  mocks.deleteAccessKey.mockReset();
+});
+
+describe("AccessKeysTab", () => {
+  it("explains what the Project API Keys info icon means", () => {
+    renderAccessKeysTab();
+
+    const trigger = screen.getByRole("button", { name: /about project api keys/i });
+    expect(trigger).toBeDefined();
+    expect(trigger.getAttribute("title")).toMatch(/authenticate traceroot sdk and api requests/i);
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip.textContent).toMatch(/authenticate traceroot sdk and api requests/i);
+    expect(tooltip.textContent).toMatch(/full secret is shown only once/i);
+  });
+});

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -88,11 +88,20 @@ describe("AccessKeysTab", () => {
     expect(tooltip.textContent).toMatch(/only a masked hint is shown/i);
   });
 
+  it("opens Project API Keys help when the info icon is clicked", async () => {
+    renderAccessKeysTab();
+
+    fireEvent.click(screen.getByRole("button", { name: /about project api keys/i }));
+
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip.textContent).toMatch(/authenticate traceroot sdk and api requests/i);
+  });
+
   it("renders a disabled example environment variable when there are no API keys", async () => {
     renderAccessKeysTab();
 
     expect(await screen.findByText(".env example")).toBeDefined();
-    expect(screen.getByText('TRACEROOT_API_KEY = "tr-..."')).toBeDefined();
+    expect(screen.getByText('TRACEROOT_API_KEY="tr-..."')).toBeDefined();
 
     expect(screen.queryByRole("button", { name: /copy api key environment variable/i })).toBeNull();
   });
@@ -178,7 +187,7 @@ describe("AccessKeysTab", () => {
     });
 
     expect(await screen.findByText(".env")).toBeDefined();
-    expect(screen.getByText('TRACEROOT_API_KEY = "tr-full-secret-value"')).toBeDefined();
+    expect(screen.getByText('TRACEROOT_API_KEY="tr-full-secret-value"')).toBeDefined();
 
     const copyEnv = screen.getByRole("button", { name: /copy api key environment variable/i });
     expect(copyEnv).toHaveProperty("disabled", false);
@@ -186,7 +195,7 @@ describe("AccessKeysTab", () => {
     fireEvent.click(copyEnv);
 
     await waitFor(() => {
-      expect(clipboardWriteText).toHaveBeenCalledWith('TRACEROOT_API_KEY = "tr-full-secret-value"');
+      expect(clipboardWriteText).toHaveBeenCalledWith('TRACEROOT_API_KEY="tr-full-secret-value"');
     });
   });
 
@@ -203,17 +212,15 @@ describe("AccessKeysTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
     fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
-    expect(
-      await screen.findByText('TRACEROOT_API_KEY = "tr-dismissed-secret-value"'),
-    ).toBeDefined();
+    expect(await screen.findByText('TRACEROOT_API_KEY="tr-dismissed-secret-value"')).toBeDefined();
 
     fireEvent.click(screen.getByRole("button", { name: /i've copied the key/i }));
 
     await waitFor(() => {
-      expect(screen.queryByText('TRACEROOT_API_KEY = "tr-dismissed-secret-value"')).toBeNull();
+      expect(screen.queryByText('TRACEROOT_API_KEY="tr-dismissed-secret-value"')).toBeNull();
     });
     expect(screen.getByText(".env example")).toBeDefined();
-    expect(screen.getByText('TRACEROOT_API_KEY = "tr-..."')).toBeDefined();
+    expect(screen.getByText('TRACEROOT_API_KEY="tr-..."')).toBeDefined();
   });
 
   it("does not carry a one-time secret across project changes", async () => {
@@ -229,15 +236,15 @@ describe("AccessKeysTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
     fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
-    expect(await screen.findByText('TRACEROOT_API_KEY = "tr-project-one-secret"')).toBeDefined();
+    expect(await screen.findByText('TRACEROOT_API_KEY="tr-project-one-secret"')).toBeDefined();
 
     rerenderWithProject("proj_456");
 
     await waitFor(() => {
-      expect(screen.queryByText('TRACEROOT_API_KEY = "tr-project-one-secret"')).toBeNull();
+      expect(screen.queryByText('TRACEROOT_API_KEY="tr-project-one-secret"')).toBeNull();
     });
     expect(screen.getByText(".env example")).toBeDefined();
-    expect(screen.getByText('TRACEROOT_API_KEY = "tr-..."')).toBeDefined();
+    expect(screen.getByText('TRACEROOT_API_KEY="tr-..."')).toBeDefined();
   });
 
   it("ignores in-flight key creation that resolves after switching projects", async () => {
@@ -271,12 +278,47 @@ describe("AccessKeysTab", () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText('TRACEROOT_API_KEY = "tr-project-one-pending-secret"')).toBeNull();
+      expect(screen.queryByText('TRACEROOT_API_KEY="tr-project-one-pending-secret"')).toBeNull();
     });
     expect(screen.getByText(".env example")).toBeDefined();
 
     expect(screen.queryByRole("button", { name: /copy api key environment variable/i })).toBeNull();
     expect(clipboardWriteText).not.toHaveBeenCalled();
+  });
+
+  it("shows an in-flight created secret if the user returns to the origin project before it resolves", async () => {
+    const createResult = {
+      data: {
+        key: "tr-returned-project-secret",
+        key_hint: "tr-retu...cret",
+      },
+    };
+    const deferredCreate = createDeferred<typeof createResult>();
+    mocks.createAccessKey.mockReturnValue(deferredCreate.promise);
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => {
+      expect(mocks.createAccessKey).toHaveBeenCalledWith("proj_123", undefined);
+    });
+
+    rerenderWithProject("proj_456");
+    rerenderWithProject("proj_123");
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+    expect(screen.getByRole("button", { name: /creating/i })).toHaveProperty("disabled", true);
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(mocks.createAccessKey).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferredCreate.resolve(createResult);
+      await deferredCreate.promise;
+    });
+
+    expect(await screen.findByText('TRACEROOT_API_KEY="tr-returned-project-secret"')).toBeDefined();
   });
 
   it("does not submit duplicate creates with Enter while a create is pending", async () => {
@@ -294,7 +336,9 @@ describe("AccessKeysTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
 
     const nameInput = screen.getByPlaceholderText(/production, development/i);
+    const createButton = screen.getByRole("button", { name: /^create$/i });
     fireEvent.keyDown(nameInput, { key: "Enter", code: "Enter" });
+    fireEvent.click(createButton);
 
     await waitFor(() => {
       expect(mocks.createAccessKey).toHaveBeenCalledTimes(1);
@@ -360,7 +404,7 @@ describe("AccessKeysTab", () => {
       await projectOneCreate.promise;
     });
 
-    expect(screen.queryByText('TRACEROOT_API_KEY = "tr-project-one-stale-secret"')).toBeNull();
+    expect(screen.queryByText('TRACEROOT_API_KEY="tr-project-one-stale-secret"')).toBeNull();
     expect(screen.getByRole("button", { name: /creating/i })).toHaveProperty("disabled", true);
 
     await act(async () => {
@@ -369,9 +413,9 @@ describe("AccessKeysTab", () => {
     });
 
     expect(
-      await screen.findByText('TRACEROOT_API_KEY = "tr-project-two-active-secret"'),
+      await screen.findByText('TRACEROOT_API_KEY="tr-project-two-active-secret"'),
     ).toBeDefined();
-    expect(screen.queryByText('TRACEROOT_API_KEY = "tr-project-one-stale-secret"')).toBeNull();
+    expect(screen.queryByText('TRACEROOT_API_KEY="tr-project-one-stale-secret"')).toBeNull();
   });
 
   it("does not let an in-flight note update close the next project's edit dialog", async () => {
@@ -410,6 +454,48 @@ describe("AccessKeysTab", () => {
 
     fireEvent.click(await screen.findByRole("button", { name: "Production" }));
     expect(screen.getByRole("button", { name: /^save$/i })).toHaveProperty("disabled", false);
+
+    await act(async () => {
+      deferredUpdate.resolve();
+      await deferredUpdate.promise;
+    });
+
+    expect(screen.getByText("Edit Note")).toBeDefined();
+  });
+
+  it("does not let an older note update close a newly opened edit dialog after returning to the same project", async () => {
+    mocks.getAccessKeys.mockResolvedValue({
+      access_keys: [
+        {
+          id: "key_123",
+          key_hint: "tr-1234567890abcdef",
+          name: "Production",
+          expire_time: null,
+          last_use_time: null,
+          create_time: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const deferredUpdate = createDeferred<void>();
+    mocks.updateAccessKey.mockReturnValue(deferredUpdate.promise);
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Production" }));
+    fireEvent.change(screen.getByPlaceholderText(/production, development/i), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mocks.updateAccessKey).toHaveBeenCalledWith("proj_123", "key_123", "Renamed");
+    });
+
+    rerenderWithProject("proj_456");
+    rerenderWithProject("proj_123");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Production" }));
+    expect(screen.getByText("Edit Note")).toBeDefined();
 
     await act(async () => {
       deferredUpdate.resolve();
@@ -461,6 +547,48 @@ describe("AccessKeysTab", () => {
       "disabled",
       false,
     );
+
+    await act(async () => {
+      deferredDelete.resolve();
+      await deferredDelete.promise;
+    });
+
+    expect(screen.getByRole("heading", { name: "Delete API Key" })).toBeDefined();
+  });
+
+  it("does not let an older delete close a newly opened delete dialog after returning to the same project", async () => {
+    mocks.getAccessKeys.mockResolvedValue({
+      access_keys: [
+        {
+          id: "key_123",
+          key_hint: "tr-1234567890abcdef",
+          name: "Production",
+          expire_time: null,
+          last_use_time: null,
+          create_time: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const deferredDelete = createDeferred<void>();
+    mocks.deleteAccessKey.mockReturnValue(deferredDelete.promise);
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete API key" }));
+    fireEvent.change(screen.getByPlaceholderText("API key name"), {
+      target: { value: "Production" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Delete API Key" }));
+
+    await waitFor(() => {
+      expect(mocks.deleteAccessKey).toHaveBeenCalledWith("proj_123", "key_123");
+    });
+
+    rerenderWithProject("proj_456");
+    rerenderWithProject("proj_123");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete API key" }));
+    expect(screen.getByRole("heading", { name: "Delete API Key" })).toBeDefined();
 
     await act(async () => {
       deferredDelete.resolve();

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -1,8 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { ReactNode } from "react";
 
 const mocks = vi.hoisted(() => ({
   getAccessKeys: vi.fn().mockResolvedValue({ access_keys: [] }),
@@ -16,13 +15,6 @@ vi.mock("@/lib/api", () => ({
   createAccessKey: (...args: unknown[]) => mocks.createAccessKey(...args),
   updateAccessKey: (...args: unknown[]) => mocks.updateAccessKey(...args),
   deleteAccessKey: (...args: unknown[]) => mocks.deleteAccessKey(...args),
-}));
-
-vi.mock("@/components/ui/tooltip", () => ({
-  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
-  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
-  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-  TooltipContent: ({ children }: { children: ReactNode }) => <div role="tooltip">{children}</div>,
 }));
 
 import { AccessKeysTab } from "./AccessKeysTab";
@@ -48,14 +40,15 @@ afterEach(() => {
 });
 
 describe("AccessKeysTab", () => {
-  it("explains what the Project API Keys info icon means", () => {
+  it("shows Project API Keys help from the info icon", async () => {
     renderAccessKeysTab();
 
     const trigger = screen.getByRole("button", { name: /about project api keys/i });
     expect(trigger).toBeDefined();
-    expect(trigger.getAttribute("title")).toMatch(/authenticate traceroot sdk and api requests/i);
 
-    const tooltip = screen.getByRole("tooltip");
+    fireEvent.focus(trigger);
+
+    const tooltip = await screen.findByRole("tooltip");
     expect(tooltip.textContent).toMatch(/authenticate traceroot sdk and api requests/i);
     expect(tooltip.textContent).toMatch(/full secret is shown only once/i);
   });

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -50,6 +50,8 @@ describe("AccessKeysTab", () => {
 
     const tooltip = await screen.findByRole("tooltip");
     expect(tooltip.textContent).toMatch(/authenticate traceroot sdk and api requests/i);
-    expect(tooltip.textContent).toMatch(/full secret is shown only once/i);
+    expect(tooltip.textContent).toMatch(/copy the full secret immediately/i);
+    expect(tooltip.textContent).toMatch(/store it as traceroot_api_key/i);
+    expect(tooltip.textContent).toMatch(/only a masked hint is shown/i);
   });
 });

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -94,10 +94,7 @@ describe("AccessKeysTab", () => {
     expect(await screen.findByText(".env example")).toBeDefined();
     expect(screen.getByText('TRACEROOT_API_KEY = "tr-..."')).toBeDefined();
 
-    const copyExample = screen.getByRole("button", {
-      name: /create a new api key to copy the full environment variable/i,
-    });
-    expect(copyExample).toHaveProperty("disabled", true);
+    expect(screen.queryByRole("button", { name: /copy api key environment variable/i })).toBeNull();
   });
 
   it("does not offer to copy masked API key hints as usable secrets", async () => {
@@ -121,10 +118,7 @@ describe("AccessKeysTab", () => {
       screen.getByText(/create a new api key to copy a full traceroot_api_key value/i),
     ).toBeDefined();
 
-    const copyMaskedHint = screen.getByRole("button", {
-      name: /create a new api key to copy the full environment variable/i,
-    });
-    expect(copyMaskedHint).toHaveProperty("disabled", true);
+    expect(screen.queryByRole("button", { name: /copy api key environment variable/i })).toBeNull();
   });
 
   it("closes project-scoped edit and delete dialogs when the project changes", async () => {
@@ -277,10 +271,198 @@ describe("AccessKeysTab", () => {
     });
     expect(screen.getByText(".env example")).toBeDefined();
 
-    const copyEnv = screen.getByRole("button", {
-      name: /create a new api key to copy the full environment variable/i,
-    });
-    expect(copyEnv).toHaveProperty("disabled", true);
+    expect(screen.queryByRole("button", { name: /copy api key environment variable/i })).toBeNull();
     expect(clipboardWriteText).not.toHaveBeenCalled();
+  });
+
+  it("does not submit duplicate creates with Enter while a create is pending", async () => {
+    const createResult = {
+      data: {
+        key: "tr-pending-secret",
+        key_hint: "tr-pend...cret",
+      },
+    };
+    const deferredCreate = createDeferred<typeof createResult>();
+    mocks.createAccessKey.mockReturnValue(deferredCreate.promise);
+
+    renderAccessKeysTab();
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+
+    const nameInput = screen.getByPlaceholderText(/production, development/i);
+    fireEvent.keyDown(nameInput, { key: "Enter", code: "Enter" });
+
+    await waitFor(() => {
+      expect(mocks.createAccessKey).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByRole("button", { name: /creating/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+
+    fireEvent.keyDown(nameInput, { key: "Enter", code: "Enter" });
+
+    expect(mocks.createAccessKey).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferredCreate.resolve(createResult);
+      await deferredCreate.promise;
+    });
+  });
+
+  it("keeps the active create pending when an older project create resolves first", async () => {
+    const projectOneResult = {
+      data: {
+        key: "tr-project-one-stale-secret",
+        key_hint: "tr-stal...cret",
+      },
+    };
+    const projectTwoResult = {
+      data: {
+        key: "tr-project-two-active-secret",
+        key_hint: "tr-acti...cret",
+      },
+    };
+    const projectOneCreate = createDeferred<typeof projectOneResult>();
+    const projectTwoCreate = createDeferred<typeof projectTwoResult>();
+    mocks.createAccessKey
+      .mockReturnValueOnce(projectOneCreate.promise)
+      .mockReturnValueOnce(projectTwoCreate.promise);
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => {
+      expect(mocks.createAccessKey).toHaveBeenCalledWith("proj_123", undefined);
+    });
+
+    rerenderWithProject("proj_456");
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => {
+      expect(mocks.createAccessKey).toHaveBeenCalledWith("proj_456", undefined);
+    });
+    expect(await screen.findByRole("button", { name: /creating/i })).toHaveProperty(
+      "disabled",
+      true,
+    );
+
+    await act(async () => {
+      projectOneCreate.resolve(projectOneResult);
+      await projectOneCreate.promise;
+    });
+
+    expect(screen.queryByText('TRACEROOT_API_KEY = "tr-project-one-stale-secret"')).toBeNull();
+    expect(screen.getByRole("button", { name: /creating/i })).toHaveProperty("disabled", true);
+
+    await act(async () => {
+      projectTwoCreate.resolve(projectTwoResult);
+      await projectTwoCreate.promise;
+    });
+
+    expect(
+      await screen.findByText('TRACEROOT_API_KEY = "tr-project-two-active-secret"'),
+    ).toBeDefined();
+    expect(screen.queryByText('TRACEROOT_API_KEY = "tr-project-one-stale-secret"')).toBeNull();
+  });
+
+  it("does not let an in-flight note update close the next project's edit dialog", async () => {
+    mocks.getAccessKeys.mockResolvedValue({
+      access_keys: [
+        {
+          id: "key_123",
+          key_hint: "tr-1234567890abcdef",
+          name: "Production",
+          expire_time: null,
+          last_use_time: null,
+          create_time: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const deferredUpdate = createDeferred<void>();
+    mocks.updateAccessKey.mockReturnValue(deferredUpdate.promise);
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Production" }));
+    fireEvent.change(screen.getByPlaceholderText(/production, development/i), {
+      target: { value: "Renamed" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(mocks.updateAccessKey).toHaveBeenCalledWith("proj_123", "key_123", "Renamed");
+    });
+
+    rerenderWithProject("proj_456");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Edit Note")).toBeNull();
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Production" }));
+    expect(screen.getByRole("button", { name: /^save$/i })).toHaveProperty("disabled", false);
+
+    await act(async () => {
+      deferredUpdate.resolve();
+      await deferredUpdate.promise;
+    });
+
+    expect(screen.getByText("Edit Note")).toBeDefined();
+  });
+
+  it("does not let an in-flight delete close the next project's delete dialog", async () => {
+    mocks.getAccessKeys.mockResolvedValue({
+      access_keys: [
+        {
+          id: "key_123",
+          key_hint: "tr-1234567890abcdef",
+          name: "Production",
+          expire_time: null,
+          last_use_time: null,
+          create_time: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const deferredDelete = createDeferred<void>();
+    mocks.deleteAccessKey.mockReturnValue(deferredDelete.promise);
+
+    const { rerenderWithProject } = renderAccessKeysTab("proj_123");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete API key" }));
+    fireEvent.change(screen.getByPlaceholderText("API key name"), {
+      target: { value: "Production" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Delete API Key" }));
+
+    await waitFor(() => {
+      expect(mocks.deleteAccessKey).toHaveBeenCalledWith("proj_123", "key_123");
+    });
+
+    rerenderWithProject("proj_456");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Delete API Key")).toBeNull();
+    });
+
+    fireEvent.click(await screen.findByRole("button", { name: "Delete API key" }));
+    fireEvent.change(screen.getByPlaceholderText("API key name"), {
+      target: { value: "Production" },
+    });
+    expect(screen.getByRole("button", { name: "Delete API Key" })).toHaveProperty(
+      "disabled",
+      false,
+    );
+
+    await act(async () => {
+      deferredDelete.resolve();
+      await deferredDelete.promise;
+    });
+
+    expect(screen.getByRole("heading", { name: "Delete API Key" })).toBeDefined();
   });
 });

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -156,6 +156,32 @@ describe("AccessKeysTab", () => {
     });
   });
 
+  it("clears the one-time secret after the user confirms it was copied", async () => {
+    mocks.createAccessKey.mockResolvedValue({
+      data: {
+        key: "tr-dismissed-secret-value",
+        key_hint: "tr-dism...alue",
+      },
+    });
+
+    renderAccessKeysTab();
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(
+      await screen.findByText('TRACEROOT_API_KEY = "tr-dismissed-secret-value"'),
+    ).toBeDefined();
+
+    fireEvent.click(screen.getByRole("button", { name: /i've copied the key/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('TRACEROOT_API_KEY = "tr-dismissed-secret-value"')).toBeNull();
+    });
+    expect(screen.getByText(".env example")).toBeDefined();
+    expect(screen.getByText('TRACEROOT_API_KEY = "tr-..."')).toBeDefined();
+  });
+
   it("does not carry a one-time secret across project changes", async () => {
     mocks.createAccessKey.mockResolvedValue({
       data: {
@@ -200,6 +226,10 @@ describe("AccessKeysTab", () => {
     });
 
     rerenderWithProject("proj_456");
+
+    fireEvent.click(screen.getByRole("button", { name: /create new api key/i }));
+    expect(screen.getByRole("button", { name: /^create$/i })).toHaveProperty("disabled", false);
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
 
     await act(async () => {
       deferredCreate.resolve(createResult);

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -173,6 +173,10 @@ describe("AccessKeysTab", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
+    await waitFor(() => {
+      expect(mocks.createAccessKey).toHaveBeenCalledWith("proj_123", "Production");
+    });
+
     expect(await screen.findByText(".env")).toBeDefined();
     expect(screen.getByText('TRACEROOT_API_KEY = "tr-full-secret-value"')).toBeDefined();
 

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -72,6 +72,9 @@ describe("AccessKeysTab", () => {
     renderAccessKeysTab();
 
     expect(await screen.findByText(".env masked hint")).toBeDefined();
+    expect(
+      screen.getByText(/create a new api key to copy a full traceroot_api_key value/i),
+    ).toBeDefined();
 
     const copyMaskedHint = screen.getByRole("button", {
       name: /create a new api key to copy the full environment variable/i,

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.test.tsx
@@ -54,4 +54,28 @@ describe("AccessKeysTab", () => {
     expect(tooltip.textContent).toMatch(/store it as traceroot_api_key/i);
     expect(tooltip.textContent).toMatch(/only a masked hint is shown/i);
   });
+
+  it("does not offer to copy masked API key hints as usable secrets", async () => {
+    mocks.getAccessKeys.mockResolvedValue({
+      access_keys: [
+        {
+          id: "key_123",
+          key_hint: "tr-1234567890abcdef",
+          name: "Production",
+          expire_time: null,
+          last_use_time: null,
+          create_time: "2026-07-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    renderAccessKeysTab();
+
+    expect(await screen.findByText(".env masked hint")).toBeDefined();
+
+    const copyMaskedHint = screen.getByRole("button", {
+      name: /create a new api key to copy the full environment variable/i,
+    });
+    expect(copyMaskedHint).toHaveProperty("disabled", true);
+  });
 });

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -114,6 +114,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     : accessKeys.length > 0
       ? ".env masked hint"
       : ".env example";
+  const showsMaskedEnvHint = !hasCopyableEnvValue && accessKeys.length > 0;
 
   return (
     <div className="space-y-4">
@@ -157,6 +158,11 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         <div className="bg-muted px-4 py-3 font-mono text-xs">
           <pre className="whitespace-pre-wrap">{envBlockContent}</pre>
         </div>
+        {showsMaskedEnvHint && (
+          <p className="border-t px-4 py-2 text-xs text-muted-foreground">
+            Create a new API key to copy a full TRACEROOT_API_KEY value.
+          </p>
+        )}
       </div>
 
       {newKeyData && (

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -47,6 +47,7 @@ function formatKeyHint(keyHint: string): string {
 export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   const queryClient = useQueryClient();
   const currentProjectIdRef = useRef(projectId);
+  const resetCreateMutationRef = useRef<() => void>(() => {});
   currentProjectIdRef.current = projectId;
 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
@@ -71,19 +72,21 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     onSuccess: (response, variables) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
 
-      if (variables.projectId !== currentProjectIdRef.current) {
-        return;
+      if (variables.projectId === currentProjectIdRef.current) {
+        setNewKeyData({
+          projectId: variables.projectId,
+          key: response.data.key,
+          keyHint: response.data.key_hint,
+        });
+        setNewKeyName("");
+        setShowCreateDialog(false);
       }
 
-      setNewKeyData({
-        projectId: variables.projectId,
-        key: response.data.key,
-        keyHint: response.data.key_hint,
-      });
-      setNewKeyName("");
-      setShowCreateDialog(false);
+      resetCreateMutationRef.current();
     },
   });
+
+  resetCreateMutationRef.current = createMutation.reset;
 
   const updateMutation = useMutation({
     mutationFn: ({ keyId, name }: { keyId: string; name: string | null }) =>
@@ -107,6 +110,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     setNewKeyData((current) => (current?.projectId === projectId ? current : null));
     setNewKeyName("");
     setShowCreateDialog(false);
+    resetCreateMutationRef.current();
   }, [projectId]);
 
   const handleCreate = () => {
@@ -115,6 +119,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
   const handleCloseNewKey = () => {
     setNewKeyData(null);
+    resetCreateMutationRef.current();
   };
 
   const handleSaveNote = () => {

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -55,12 +55,11 @@ type DeleteAccessKeyMutationVariables = {
 };
 
 type NewKeyData = {
-  requestId: number;
   key: string;
 };
 
 const PROJECT_API_KEYS_HELP_TEXT =
-  "Project API keys authenticate TraceRoot SDK and API requests for this project. When you create a new key, copy the full secret immediately and store it as TRACEROOT_API_KEY. Later, only a masked hint is shown.";
+  "Project API keys authenticate TraceRoot SDK and API requests for this project. When you create a new key, copy the full secret immediately and store it as TRACEROOT_API_KEY. The full secret cannot be viewed again after this one-time display; later, only a masked hint is shown.";
 
 function formatKeyHint(keyHint: string): string {
   if (keyHint.startsWith("tr-")) {
@@ -80,9 +79,9 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   const pendingCreateRequestsRef = useRef<Record<string, number>>({});
   const createSecretByRequestIdRef = useRef(new Map<number, string>());
   const updateRequestCounterRef = useRef(0);
-  const activeUpdateRequestIdRef = useRef<number | null>(null);
+  const pendingUpdateRequestsRef = useRef<Record<string, number>>({});
   const deleteRequestCounterRef = useRef(0);
-  const activeDeleteRequestIdRef = useRef<number | null>(null);
+  const pendingDeleteRequestsRef = useRef<Record<string, number>>({});
   const resetCreateMutationRef = useRef<() => void>(() => {});
   const resetUpdateMutationRef = useRef<() => void>(() => {});
   const resetDeleteMutationRef = useRef<() => void>(() => {});
@@ -96,10 +95,14 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     Record<string, number>
   >({});
   const [editingKey, setEditingKey] = useState<{ id: string; name: string } | null>(null);
-  const [pendingUpdateRequestId, setPendingUpdateRequestId] = useState<number | null>(null);
+  const [pendingUpdateRequestsByProject, setPendingUpdateRequestsByProject] = useState<
+    Record<string, number>
+  >({});
   const [keyToDelete, setKeyToDelete] = useState<AccessKey | null>(null);
   const [deleteConfirmText, setDeleteConfirmText] = useState("");
-  const [pendingDeleteRequestId, setPendingDeleteRequestId] = useState<number | null>(null);
+  const [pendingDeleteRequestsByProject, setPendingDeleteRequestsByProject] = useState<
+    Record<string, number>
+  >({});
 
   const setPendingCreateRequest = (requestProjectId: string, requestId: number) => {
     const next = { ...pendingCreateRequestsRef.current, [requestProjectId]: requestId };
@@ -116,6 +119,40 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     delete next[requestProjectId];
     pendingCreateRequestsRef.current = next;
     setPendingCreateRequestsByProject(next);
+  };
+
+  const setPendingUpdateRequest = (requestProjectId: string, requestId: number) => {
+    const next = { ...pendingUpdateRequestsRef.current, [requestProjectId]: requestId };
+    pendingUpdateRequestsRef.current = next;
+    setPendingUpdateRequestsByProject(next);
+  };
+
+  const clearPendingUpdateRequest = (requestProjectId: string, requestId: number) => {
+    if (pendingUpdateRequestsRef.current[requestProjectId] !== requestId) {
+      return;
+    }
+
+    const next = { ...pendingUpdateRequestsRef.current };
+    delete next[requestProjectId];
+    pendingUpdateRequestsRef.current = next;
+    setPendingUpdateRequestsByProject(next);
+  };
+
+  const setPendingDeleteRequest = (requestProjectId: string, requestId: number) => {
+    const next = { ...pendingDeleteRequestsRef.current, [requestProjectId]: requestId };
+    pendingDeleteRequestsRef.current = next;
+    setPendingDeleteRequestsByProject(next);
+  };
+
+  const clearPendingDeleteRequest = (requestProjectId: string, requestId: number) => {
+    if (pendingDeleteRequestsRef.current[requestProjectId] !== requestId) {
+      return;
+    }
+
+    const next = { ...pendingDeleteRequestsRef.current };
+    delete next[requestProjectId];
+    pendingDeleteRequestsRef.current = next;
+    setPendingDeleteRequestsByProject(next);
   };
 
   const setProjectNewKeyData = (requestProjectId: string, data: NewKeyData) => {
@@ -136,15 +173,27 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
   const closeEditDialog = () => {
     setEditingKey(null);
-    activeUpdateRequestIdRef.current = null;
-    setPendingUpdateRequestId(null);
+  };
+
+  const requestCloseEditDialog = () => {
+    if (pendingUpdateRequestsRef.current[projectId] !== undefined) {
+      return;
+    }
+
+    closeEditDialog();
   };
 
   const closeDeleteDialog = () => {
     setKeyToDelete(null);
     setDeleteConfirmText("");
-    activeDeleteRequestIdRef.current = null;
-    setPendingDeleteRequestId(null);
+  };
+
+  const requestCloseDeleteDialog = () => {
+    if (pendingDeleteRequestsRef.current[projectId] !== undefined) {
+      return;
+    }
+
+    closeDeleteDialog();
   };
 
   const { data, isLoading } = useQuery({
@@ -173,7 +222,6 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
       if (isLatestProjectRequest && createdKey) {
         setProjectNewKeyData(variables.projectId, {
-          requestId: variables.requestId,
           key: createdKey,
         });
       }
@@ -199,21 +247,17 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
       updateAccessKey(requestProjectId, keyId, name),
     onSuccess: (_response, variables) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
-      const isActiveRequest =
-        variables.requestId === activeUpdateRequestIdRef.current &&
-        variables.projectId === currentProjectIdRef.current;
+      const isLatestProjectRequest =
+        pendingUpdateRequestsRef.current[variables.projectId] === variables.requestId;
 
-      if (isActiveRequest) {
-        setEditingKey(null);
-        activeUpdateRequestIdRef.current = null;
-        setPendingUpdateRequestId(null);
+      if (isLatestProjectRequest && variables.projectId === currentProjectIdRef.current) {
+        closeEditDialog();
         resetUpdateMutationRef.current();
       }
     },
     onSettled: (_data, _error, variables) => {
-      if (variables?.requestId === activeUpdateRequestIdRef.current) {
-        activeUpdateRequestIdRef.current = null;
-        setPendingUpdateRequestId(null);
+      if (variables) {
+        clearPendingUpdateRequest(variables.projectId, variables.requestId);
       }
     },
   });
@@ -225,22 +269,17 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
       deleteAccessKey(requestProjectId, keyId),
     onSuccess: (_response, variables) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
-      const isActiveRequest =
-        variables.requestId === activeDeleteRequestIdRef.current &&
-        variables.projectId === currentProjectIdRef.current;
+      const isLatestProjectRequest =
+        pendingDeleteRequestsRef.current[variables.projectId] === variables.requestId;
 
-      if (isActiveRequest) {
-        setKeyToDelete(null);
-        setDeleteConfirmText("");
-        activeDeleteRequestIdRef.current = null;
-        setPendingDeleteRequestId(null);
+      if (isLatestProjectRequest && variables.projectId === currentProjectIdRef.current) {
+        closeDeleteDialog();
         resetDeleteMutationRef.current();
       }
     },
     onSettled: (_data, _error, variables) => {
-      if (variables?.requestId === activeDeleteRequestIdRef.current) {
-        activeDeleteRequestIdRef.current = null;
-        setPendingDeleteRequestId(null);
+      if (variables) {
+        clearPendingDeleteRequest(variables.projectId, variables.requestId);
       }
     },
   });
@@ -250,13 +289,8 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   useEffect(() => {
     setNewKeyName("");
     setShowCreateDialog(false);
-    setEditingKey(null);
-    activeUpdateRequestIdRef.current = null;
-    setPendingUpdateRequestId(null);
-    setKeyToDelete(null);
-    setDeleteConfirmText("");
-    activeDeleteRequestIdRef.current = null;
-    setPendingDeleteRequestId(null);
+    closeEditDialog();
+    closeDeleteDialog();
     resetCreateMutationRef.current();
     resetUpdateMutationRef.current();
     resetDeleteMutationRef.current();
@@ -279,11 +313,10 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   };
 
   const handleSaveNote = () => {
-    if (editingKey && pendingUpdateRequestId === null) {
+    if (editingKey && pendingUpdateRequestsRef.current[projectId] === undefined) {
       const requestId = updateRequestCounterRef.current + 1;
       updateRequestCounterRef.current = requestId;
-      activeUpdateRequestIdRef.current = requestId;
-      setPendingUpdateRequestId(requestId);
+      setPendingUpdateRequest(projectId, requestId);
       updateMutation.mutate({
         projectId,
         keyId: editingKey.id,
@@ -296,6 +329,8 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   const accessKeys = data?.access_keys || [];
   const activeNewKeyData = newKeyDataByProject[projectId] ?? null;
   const isCreatePendingForProject = pendingCreateRequestsByProject[projectId] !== undefined;
+  const pendingUpdateRequestId = pendingUpdateRequestsByProject[projectId] ?? null;
+  const pendingDeleteRequestId = pendingDeleteRequestsByProject[projectId] ?? null;
 
   const hasCopyableEnvValue = !!activeNewKeyData;
   const envBlockContent = hasCopyableEnvValue
@@ -352,7 +387,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         </div>
         {showsMaskedEnvHint && (
           <p className="border-t px-4 py-2 text-xs text-muted-foreground">
-            Create a new API key to copy a full TRACEROOT_API_KEY value.
+            Create a new API key and update TRACEROOT_API_KEY if you need a full secret value.
           </p>
         )}
       </div>
@@ -361,7 +396,8 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         <div className="border border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-950">
           <div className="px-4 py-3">
             <p className="mb-2 text-xs font-medium text-green-800 dark:text-green-200">
-              New API key created! Copy it now - you won&apos;t see it again.
+              New API key created! Copy it now. This full secret can&apos;t be recovered after you
+              dismiss it.
             </p>
             <div className="mb-2 flex items-center gap-2">
               <code className="flex-1 border bg-white px-2 py-1.5 font-mono text-xs dark:bg-black">
@@ -413,7 +449,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         </DialogContent>
       </Dialog>
 
-      <Dialog open={!!editingKey} onOpenChange={(open) => !open && closeEditDialog()}>
+      <Dialog open={!!editingKey} onOpenChange={(open) => !open && requestCloseEditDialog()}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Edit Note</DialogTitle>
@@ -430,7 +466,11 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
             />
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={closeEditDialog}>
+            <Button
+              variant="outline"
+              onClick={requestCloseEditDialog}
+              disabled={pendingUpdateRequestId !== null}
+            >
               Cancel
             </Button>
             <Button onClick={handleSaveNote} disabled={pendingUpdateRequestId !== null}>
@@ -444,7 +484,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         open={!!keyToDelete}
         onOpenChange={(open) => {
           if (!open) {
-            closeDeleteDialog();
+            requestCloseDeleteDialog();
           }
         }}
       >
@@ -475,17 +515,20 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
             />
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={closeDeleteDialog}>
+            <Button
+              variant="outline"
+              onClick={requestCloseDeleteDialog}
+              disabled={pendingDeleteRequestId !== null}
+            >
               Cancel
             </Button>
             <Button
               variant="destructive"
               onClick={() => {
-                if (keyToDelete && pendingDeleteRequestId === null) {
+                if (keyToDelete && pendingDeleteRequestsRef.current[projectId] === undefined) {
                   const requestId = deleteRequestCounterRef.current + 1;
                   deleteRequestCounterRef.current = requestId;
-                  activeDeleteRequestIdRef.current = requestId;
-                  setPendingDeleteRequestId(requestId);
+                  setPendingDeleteRequest(projectId, requestId);
                   deleteMutation.mutate({ projectId, keyId: keyToDelete.id, requestId });
                 }
               }}
@@ -526,7 +569,8 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
                   <td className="px-3 py-2">
                     <button
                       onClick={() => setEditingKey({ id: key.id, name: key.name || "" })}
-                      className="cursor-pointer text-left hover:underline"
+                      className="cursor-pointer text-left hover:underline disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:no-underline"
+                      disabled={pendingUpdateRequestId !== null}
                     >
                       {key.name || <span className="text-muted-foreground">-</span>}
                     </button>

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -46,6 +46,8 @@ function formatKeyHint(keyHint: string): string {
 
 export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   const queryClient = useQueryClient();
+  const currentProjectIdRef = useRef(projectId);
+  currentProjectIdRef.current = projectId;
 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
@@ -64,10 +66,20 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   });
 
   const createMutation = useMutation({
-    mutationFn: (name: string) => createAccessKey(projectId, name || undefined),
-    onSuccess: (response) => {
-      queryClient.invalidateQueries({ queryKey: ["access-keys", projectId] });
-      setNewKeyData({ projectId, key: response.data.key, keyHint: response.data.key_hint });
+    mutationFn: ({ projectId: requestProjectId, name }: { projectId: string; name: string }) =>
+      createAccessKey(requestProjectId, name || undefined),
+    onSuccess: (response, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
+
+      if (variables.projectId !== currentProjectIdRef.current) {
+        return;
+      }
+
+      setNewKeyData({
+        projectId: variables.projectId,
+        key: response.data.key,
+        keyHint: response.data.key_hint,
+      });
       setNewKeyName("");
       setShowCreateDialog(false);
     },
@@ -93,10 +105,12 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
   useEffect(() => {
     setNewKeyData((current) => (current?.projectId === projectId ? current : null));
+    setNewKeyName("");
+    setShowCreateDialog(false);
   }, [projectId]);
 
   const handleCreate = () => {
-    createMutation.mutate(newKeyName);
+    createMutation.mutate({ projectId, name: newKeyName });
   };
 
   const handleCloseNewKey = () => {

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -55,7 +55,6 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   const [newKeyData, setNewKeyData] = useState<{
     projectId: string;
     key: string;
-    keyHint: string;
   } | null>(null);
   const [editingKey, setEditingKey] = useState<{ id: string; name: string } | null>(null);
   const [keyToDelete, setKeyToDelete] = useState<AccessKey | null>(null);
@@ -76,7 +75,6 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         setNewKeyData({
           projectId: variables.projectId,
           key: response.data.key,
-          keyHint: response.data.key_hint,
         });
         setNewKeyName("");
         setShowCreateDialog(false);
@@ -110,6 +108,9 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     setNewKeyData((current) => (current?.projectId === projectId ? current : null));
     setNewKeyName("");
     setShowCreateDialog(false);
+    setEditingKey(null);
+    setKeyToDelete(null);
+    setDeleteConfirmText("");
     resetCreateMutationRef.current();
   }, [projectId]);
 
@@ -372,6 +373,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
                   <td className="px-3 py-2">
                     <DeleteIconButton
                       className="h-6 w-6"
+                      aria-label="Delete API key"
                       onClick={() => {
                         setKeyToDelete(key);
                         setDeleteConfirmText("");

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -49,7 +49,11 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
-  const [newKeyData, setNewKeyData] = useState<{ key: string; keyHint: string } | null>(null);
+  const [newKeyData, setNewKeyData] = useState<{
+    projectId: string;
+    key: string;
+    keyHint: string;
+  } | null>(null);
   const [editingKey, setEditingKey] = useState<{ id: string; name: string } | null>(null);
   const [keyToDelete, setKeyToDelete] = useState<AccessKey | null>(null);
   const [deleteConfirmText, setDeleteConfirmText] = useState("");
@@ -63,7 +67,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     mutationFn: (name: string) => createAccessKey(projectId, name || undefined),
     onSuccess: (response) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", projectId] });
-      setNewKeyData({ key: response.data.key, keyHint: response.data.key_hint });
+      setNewKeyData({ projectId, key: response.data.key, keyHint: response.data.key_hint });
       setNewKeyName("");
       setShowCreateDialog(false);
     },
@@ -87,6 +91,10 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     },
   });
 
+  useEffect(() => {
+    setNewKeyData((current) => (current?.projectId === projectId ? current : null));
+  }, [projectId]);
+
   const handleCreate = () => {
     createMutation.mutate(newKeyName);
   };
@@ -102,10 +110,11 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   };
 
   const accessKeys = data?.access_keys || [];
+  const activeNewKeyData = newKeyData?.projectId === projectId ? newKeyData : null;
 
-  const hasCopyableEnvValue = !!newKeyData;
+  const hasCopyableEnvValue = !!activeNewKeyData;
   const envBlockContent = hasCopyableEnvValue
-    ? `TRACEROOT_API_KEY = "${newKeyData.key}"`
+    ? `TRACEROOT_API_KEY = "${activeNewKeyData.key}"`
     : accessKeys.length > 0
       ? `TRACEROOT_API_KEY = "${formatKeyHint(accessKeys[0].key_hint)}"`
       : `TRACEROOT_API_KEY = "tr-..."`;
@@ -165,7 +174,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         )}
       </div>
 
-      {newKeyData && (
+      {activeNewKeyData && (
         <div className="border border-green-300 bg-green-50 dark:border-green-800 dark:bg-green-950">
           <div className="px-4 py-3">
             <p className="mb-2 text-xs font-medium text-green-800 dark:text-green-200">
@@ -173,9 +182,13 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
             </p>
             <div className="mb-2 flex items-center gap-2">
               <code className="flex-1 border bg-white px-2 py-1.5 font-mono text-xs dark:bg-black">
-                {newKeyData.key}
+                {activeNewKeyData.key}
               </code>
-              <CopyButton value={newKeyData.key} variant="outline" aria-label="Copy new API key" />
+              <CopyButton
+                value={activeNewKeyData.key}
+                variant="outline"
+                aria-label="Copy new API key"
+              />
             </div>
             <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={handleCloseNewKey}>
               I&apos;ve copied the key

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -31,7 +31,7 @@ interface AccessKeysTabProps {
 }
 
 const PROJECT_API_KEYS_HELP_TEXT =
-  "Project API keys authenticate TraceRoot SDK and API requests for this project. Copy the .env value into your app, and save new keys immediately because the full secret is shown only once.";
+  "Project API keys authenticate TraceRoot SDK and API requests for this project. When you create a new key, copy the full secret immediately and store it as TRACEROOT_API_KEY. Later, only a masked hint is shown.";
 
 function formatKeyHint(keyHint: string): string {
   if (keyHint.startsWith("tr-")) {

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -8,6 +8,7 @@ import { AddButton } from "@/components/ui/add-button";
 import { DeleteIconButton } from "@/components/ui/delete-button";
 import { CopyButton } from "@/components/ui/copy-button";
 import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -28,6 +29,9 @@ import {
 interface AccessKeysTabProps {
   projectId: string;
 }
+
+const PROJECT_API_KEYS_HELP_TEXT =
+  "Project API keys authenticate TraceRoot SDK and API requests for this project. Copy the .env value into your app, and save new keys immediately because the full secret is shown only once.";
 
 function formatKeyHint(keyHint: string): string {
   if (keyHint.startsWith("tr-")) {
@@ -110,7 +114,23 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1.5">
           <h2 className="text-lg font-semibold">Project API Keys</h2>
-          <Info className="h-3.5 w-3.5 text-muted-foreground" />
+          <TooltipProvider delayDuration={150}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label="About Project API Keys"
+                  title={PROJECT_API_KEYS_HELP_TEXT}
+                  className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  <Info aria-hidden="true" className="h-3.5 w-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs text-left">
+                {PROJECT_API_KEYS_HELP_TEXT}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
         <AddButton onClick={() => setShowCreateDialog(true)}>Create new API key</AddButton>
       </div>

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -36,11 +36,6 @@ type CreateAccessKeyMutationVariables = {
   requestId: number;
 };
 
-type CreateAccessKeyMutationResult = {
-  projectId: string;
-  requestId: number;
-};
-
 type UpdateAccessKeyMutationVariables = {
   projectId: string;
   keyId: string;
@@ -201,15 +196,10 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     queryFn: () => getAccessKeys(projectId),
   });
 
-  const createMutation = useMutation<
-    CreateAccessKeyMutationResult,
-    Error,
-    CreateAccessKeyMutationVariables
-  >({
+  const createMutation = useMutation<void, Error, CreateAccessKeyMutationVariables>({
     mutationFn: async ({ projectId: requestProjectId, name, requestId }) => {
       const response = await createAccessKey(requestProjectId, name || undefined);
       createSecretByRequestIdRef.current.set(requestId, response.data.key);
-      return { projectId: requestProjectId, requestId };
     },
     onSuccess: (_result, variables) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
@@ -220,7 +210,11 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         pendingCreateRequestsRef.current[variables.projectId] === variables.requestId;
       clearPendingCreateRequest(variables.projectId, variables.requestId);
 
-      if (isLatestProjectRequest && createdKey) {
+      if (
+        isLatestProjectRequest &&
+        createdKey &&
+        variables.projectId === currentProjectIdRef.current
+      ) {
         setProjectNewKeyData(variables.projectId, {
           key: createdKey,
         });
@@ -287,6 +281,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   resetDeleteMutationRef.current = deleteMutation.reset;
 
   useEffect(() => {
+    setNewKeyDataByProject({});
     setNewKeyName("");
     setShowCreateDialog(false);
     closeEditDialog();

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -30,6 +30,28 @@ interface AccessKeysTabProps {
   projectId: string;
 }
 
+type CreateAccessKeyMutationVariables = {
+  projectId: string;
+  name: string;
+  requestId: number;
+};
+
+type CreateAccessKeyMutationResult = {
+  projectId: string;
+  requestId: number;
+};
+
+type UpdateAccessKeyMutationVariables = {
+  projectId: string;
+  keyId: string;
+  name: string | null;
+};
+
+type DeleteAccessKeyMutationVariables = {
+  projectId: string;
+  keyId: string;
+};
+
 const PROJECT_API_KEYS_HELP_TEXT =
   "Project API keys authenticate TraceRoot SDK and API requests for this project. When you create a new key, copy the full secret immediately and store it as TRACEROOT_API_KEY. Later, only a masked hint is shown.";
 
@@ -47,7 +69,12 @@ function formatKeyHint(keyHint: string): string {
 export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   const queryClient = useQueryClient();
   const currentProjectIdRef = useRef(projectId);
+  const createRequestCounterRef = useRef(0);
+  const activeCreateRequestIdRef = useRef<number | null>(null);
+  const createSecretByRequestIdRef = useRef(new Map<number, string>());
   const resetCreateMutationRef = useRef<() => void>(() => {});
+  const resetUpdateMutationRef = useRef<() => void>(() => {});
+  const resetDeleteMutationRef = useRef<() => void>(() => {});
   currentProjectIdRef.current = projectId;
 
   const [showCreateDialog, setShowCreateDialog] = useState(false);
@@ -65,44 +92,77 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     queryFn: () => getAccessKeys(projectId),
   });
 
-  const createMutation = useMutation({
-    mutationFn: ({ projectId: requestProjectId, name }: { projectId: string; name: string }) =>
-      createAccessKey(requestProjectId, name || undefined),
-    onSuccess: (response, variables) => {
+  const createMutation = useMutation<
+    CreateAccessKeyMutationResult,
+    Error,
+    CreateAccessKeyMutationVariables
+  >({
+    mutationFn: async ({ projectId: requestProjectId, name, requestId }) => {
+      const response = await createAccessKey(requestProjectId, name || undefined);
+      createSecretByRequestIdRef.current.set(requestId, response.data.key);
+      return { projectId: requestProjectId, requestId };
+    },
+    onSuccess: (_result, variables) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
 
-      if (variables.projectId === currentProjectIdRef.current) {
+      const createdKey = createSecretByRequestIdRef.current.get(variables.requestId);
+      createSecretByRequestIdRef.current.delete(variables.requestId);
+
+      const isActiveRequest =
+        variables.requestId === activeCreateRequestIdRef.current &&
+        variables.projectId === currentProjectIdRef.current;
+
+      if (isActiveRequest && createdKey) {
         setNewKeyData({
           projectId: variables.projectId,
-          key: response.data.key,
+          key: createdKey,
         });
         setNewKeyName("");
         setShowCreateDialog(false);
+        activeCreateRequestIdRef.current = null;
+        resetCreateMutationRef.current();
+      } else if (variables.requestId === activeCreateRequestIdRef.current) {
+        activeCreateRequestIdRef.current = null;
+        resetCreateMutationRef.current();
+      } else if (activeCreateRequestIdRef.current === null) {
+        resetCreateMutationRef.current();
       }
-
-      resetCreateMutationRef.current();
+    },
+    onSettled: (_data, _error, variables) => {
+      if (variables) {
+        createSecretByRequestIdRef.current.delete(variables.requestId);
+      }
     },
   });
 
   resetCreateMutationRef.current = createMutation.reset;
 
-  const updateMutation = useMutation({
-    mutationFn: ({ keyId, name }: { keyId: string; name: string | null }) =>
-      updateAccessKey(projectId, keyId, name),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["access-keys", projectId] });
-      setEditingKey(null);
+  const updateMutation = useMutation<unknown, Error, UpdateAccessKeyMutationVariables>({
+    mutationFn: ({ projectId: requestProjectId, keyId, name }) =>
+      updateAccessKey(requestProjectId, keyId, name),
+    onSuccess: (_response, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
+      if (variables.projectId === currentProjectIdRef.current) {
+        setEditingKey(null);
+      }
     },
   });
 
-  const deleteMutation = useMutation({
-    mutationFn: (keyId: string) => deleteAccessKey(projectId, keyId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["access-keys", projectId] });
-      setKeyToDelete(null);
-      setDeleteConfirmText("");
+  resetUpdateMutationRef.current = updateMutation.reset;
+
+  const deleteMutation = useMutation<unknown, Error, DeleteAccessKeyMutationVariables>({
+    mutationFn: ({ projectId: requestProjectId, keyId }) =>
+      deleteAccessKey(requestProjectId, keyId),
+    onSuccess: (_response, variables) => {
+      queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
+      if (variables.projectId === currentProjectIdRef.current) {
+        setKeyToDelete(null);
+        setDeleteConfirmText("");
+      }
     },
   });
+
+  resetDeleteMutationRef.current = deleteMutation.reset;
 
   useEffect(() => {
     setNewKeyData((current) => (current?.projectId === projectId ? current : null));
@@ -111,21 +171,34 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
     setEditingKey(null);
     setKeyToDelete(null);
     setDeleteConfirmText("");
+    activeCreateRequestIdRef.current = null;
+    createSecretByRequestIdRef.current.clear();
     resetCreateMutationRef.current();
+    resetUpdateMutationRef.current();
+    resetDeleteMutationRef.current();
   }, [projectId]);
 
   const handleCreate = () => {
-    createMutation.mutate({ projectId, name: newKeyName });
+    if (createMutation.isPending) {
+      return;
+    }
+
+    const requestId = createRequestCounterRef.current + 1;
+    createRequestCounterRef.current = requestId;
+    activeCreateRequestIdRef.current = requestId;
+    createMutation.mutate({ projectId, name: newKeyName, requestId });
   };
 
   const handleCloseNewKey = () => {
     setNewKeyData(null);
+    activeCreateRequestIdRef.current = null;
+    createSecretByRequestIdRef.current.clear();
     resetCreateMutationRef.current();
   };
 
   const handleSaveNote = () => {
     if (editingKey) {
-      updateMutation.mutate({ keyId: editingKey.id, name: editingKey.name || null });
+      updateMutation.mutate({ projectId, keyId: editingKey.id, name: editingKey.name || null });
     }
   };
 
@@ -173,16 +246,13 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
       <div className="border">
         <div className="flex items-center justify-between border-b px-4 py-2">
           <span className="text-xs text-muted-foreground">{envBlockLabel}</span>
-          <CopyButton
-            value={envBlockContent}
-            className="h-6 w-6"
-            aria-label={
-              hasCopyableEnvValue
-                ? "Copy API key environment variable"
-                : "Create a new API key to copy the full environment variable"
-            }
-            disabled={!hasCopyableEnvValue}
-          />
+          {hasCopyableEnvValue && (
+            <CopyButton
+              value={envBlockContent}
+              className="h-6 w-6"
+              aria-label="Copy API key environment variable"
+            />
+          )}
         </div>
         <div className="bg-muted px-4 py-3 font-mono text-xs">
           <pre className="whitespace-pre-wrap">{envBlockContent}</pre>
@@ -231,7 +301,12 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
               placeholder="e.g., Production, Development"
               value={newKeyName}
               onChange={(e) => setNewKeyName(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleCreate()}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleCreate();
+                }
+              }}
             />
           </div>
           <DialogFooter>
@@ -315,7 +390,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
               variant="destructive"
               onClick={() => {
                 if (keyToDelete) {
-                  deleteMutation.mutate(keyToDelete.id);
+                  deleteMutation.mutate({ projectId, keyId: keyToDelete.id });
                 }
               }}
               disabled={

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -45,11 +45,18 @@ type UpdateAccessKeyMutationVariables = {
   projectId: string;
   keyId: string;
   name: string | null;
+  requestId: number;
 };
 
 type DeleteAccessKeyMutationVariables = {
   projectId: string;
   keyId: string;
+  requestId: number;
+};
+
+type NewKeyData = {
+  requestId: number;
+  key: string;
 };
 
 const PROJECT_API_KEYS_HELP_TEXT =
@@ -70,22 +77,75 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   const queryClient = useQueryClient();
   const currentProjectIdRef = useRef(projectId);
   const createRequestCounterRef = useRef(0);
-  const activeCreateRequestIdRef = useRef<number | null>(null);
+  const pendingCreateRequestsRef = useRef<Record<string, number>>({});
   const createSecretByRequestIdRef = useRef(new Map<number, string>());
+  const updateRequestCounterRef = useRef(0);
+  const activeUpdateRequestIdRef = useRef<number | null>(null);
+  const deleteRequestCounterRef = useRef(0);
+  const activeDeleteRequestIdRef = useRef<number | null>(null);
   const resetCreateMutationRef = useRef<() => void>(() => {});
   const resetUpdateMutationRef = useRef<() => void>(() => {});
   const resetDeleteMutationRef = useRef<() => void>(() => {});
   currentProjectIdRef.current = projectId;
 
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
-  const [newKeyData, setNewKeyData] = useState<{
-    projectId: string;
-    key: string;
-  } | null>(null);
+  const [newKeyDataByProject, setNewKeyDataByProject] = useState<Record<string, NewKeyData>>({});
+  const [pendingCreateRequestsByProject, setPendingCreateRequestsByProject] = useState<
+    Record<string, number>
+  >({});
   const [editingKey, setEditingKey] = useState<{ id: string; name: string } | null>(null);
+  const [pendingUpdateRequestId, setPendingUpdateRequestId] = useState<number | null>(null);
   const [keyToDelete, setKeyToDelete] = useState<AccessKey | null>(null);
   const [deleteConfirmText, setDeleteConfirmText] = useState("");
+  const [pendingDeleteRequestId, setPendingDeleteRequestId] = useState<number | null>(null);
+
+  const setPendingCreateRequest = (requestProjectId: string, requestId: number) => {
+    const next = { ...pendingCreateRequestsRef.current, [requestProjectId]: requestId };
+    pendingCreateRequestsRef.current = next;
+    setPendingCreateRequestsByProject(next);
+  };
+
+  const clearPendingCreateRequest = (requestProjectId: string, requestId: number) => {
+    if (pendingCreateRequestsRef.current[requestProjectId] !== requestId) {
+      return;
+    }
+
+    const next = { ...pendingCreateRequestsRef.current };
+    delete next[requestProjectId];
+    pendingCreateRequestsRef.current = next;
+    setPendingCreateRequestsByProject(next);
+  };
+
+  const setProjectNewKeyData = (requestProjectId: string, data: NewKeyData) => {
+    setNewKeyDataByProject((current) => ({ ...current, [requestProjectId]: data }));
+  };
+
+  const clearProjectNewKeyData = (requestProjectId: string) => {
+    setNewKeyDataByProject((current) => {
+      if (!current[requestProjectId]) {
+        return current;
+      }
+
+      const next = { ...current };
+      delete next[requestProjectId];
+      return next;
+    });
+  };
+
+  const closeEditDialog = () => {
+    setEditingKey(null);
+    activeUpdateRequestIdRef.current = null;
+    setPendingUpdateRequestId(null);
+  };
+
+  const closeDeleteDialog = () => {
+    setKeyToDelete(null);
+    setDeleteConfirmText("");
+    activeDeleteRequestIdRef.current = null;
+    setPendingDeleteRequestId(null);
+  };
 
   const { data, isLoading } = useQuery({
     queryKey: ["access-keys", projectId],
@@ -107,29 +167,26 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
       const createdKey = createSecretByRequestIdRef.current.get(variables.requestId);
       createSecretByRequestIdRef.current.delete(variables.requestId);
+      const isLatestProjectRequest =
+        pendingCreateRequestsRef.current[variables.projectId] === variables.requestId;
+      clearPendingCreateRequest(variables.projectId, variables.requestId);
 
-      const isActiveRequest =
-        variables.requestId === activeCreateRequestIdRef.current &&
-        variables.projectId === currentProjectIdRef.current;
-
-      if (isActiveRequest && createdKey) {
-        setNewKeyData({
-          projectId: variables.projectId,
+      if (isLatestProjectRequest && createdKey) {
+        setProjectNewKeyData(variables.projectId, {
+          requestId: variables.requestId,
           key: createdKey,
         });
+      }
+
+      if (isLatestProjectRequest && variables.projectId === currentProjectIdRef.current) {
         setNewKeyName("");
         setShowCreateDialog(false);
-        activeCreateRequestIdRef.current = null;
-        resetCreateMutationRef.current();
-      } else if (variables.requestId === activeCreateRequestIdRef.current) {
-        activeCreateRequestIdRef.current = null;
-        resetCreateMutationRef.current();
-      } else if (activeCreateRequestIdRef.current === null) {
         resetCreateMutationRef.current();
       }
     },
     onSettled: (_data, _error, variables) => {
       if (variables) {
+        clearPendingCreateRequest(variables.projectId, variables.requestId);
         createSecretByRequestIdRef.current.delete(variables.requestId);
       }
     },
@@ -142,8 +199,21 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
       updateAccessKey(requestProjectId, keyId, name),
     onSuccess: (_response, variables) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
-      if (variables.projectId === currentProjectIdRef.current) {
+      const isActiveRequest =
+        variables.requestId === activeUpdateRequestIdRef.current &&
+        variables.projectId === currentProjectIdRef.current;
+
+      if (isActiveRequest) {
         setEditingKey(null);
+        activeUpdateRequestIdRef.current = null;
+        setPendingUpdateRequestId(null);
+        resetUpdateMutationRef.current();
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      if (variables?.requestId === activeUpdateRequestIdRef.current) {
+        activeUpdateRequestIdRef.current = null;
+        setPendingUpdateRequestId(null);
       }
     },
   });
@@ -155,9 +225,22 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
       deleteAccessKey(requestProjectId, keyId),
     onSuccess: (_response, variables) => {
       queryClient.invalidateQueries({ queryKey: ["access-keys", variables.projectId] });
-      if (variables.projectId === currentProjectIdRef.current) {
+      const isActiveRequest =
+        variables.requestId === activeDeleteRequestIdRef.current &&
+        variables.projectId === currentProjectIdRef.current;
+
+      if (isActiveRequest) {
         setKeyToDelete(null);
         setDeleteConfirmText("");
+        activeDeleteRequestIdRef.current = null;
+        setPendingDeleteRequestId(null);
+        resetDeleteMutationRef.current();
+      }
+    },
+    onSettled: (_data, _error, variables) => {
+      if (variables?.requestId === activeDeleteRequestIdRef.current) {
+        activeDeleteRequestIdRef.current = null;
+        setPendingDeleteRequestId(null);
       }
     },
   });
@@ -165,52 +248,61 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
   resetDeleteMutationRef.current = deleteMutation.reset;
 
   useEffect(() => {
-    setNewKeyData((current) => (current?.projectId === projectId ? current : null));
     setNewKeyName("");
     setShowCreateDialog(false);
     setEditingKey(null);
+    activeUpdateRequestIdRef.current = null;
+    setPendingUpdateRequestId(null);
     setKeyToDelete(null);
     setDeleteConfirmText("");
-    activeCreateRequestIdRef.current = null;
-    createSecretByRequestIdRef.current.clear();
+    activeDeleteRequestIdRef.current = null;
+    setPendingDeleteRequestId(null);
     resetCreateMutationRef.current();
     resetUpdateMutationRef.current();
     resetDeleteMutationRef.current();
   }, [projectId]);
 
   const handleCreate = () => {
-    if (createMutation.isPending) {
+    if (pendingCreateRequestsRef.current[projectId] !== undefined) {
       return;
     }
 
     const requestId = createRequestCounterRef.current + 1;
     createRequestCounterRef.current = requestId;
-    activeCreateRequestIdRef.current = requestId;
+    setPendingCreateRequest(projectId, requestId);
     createMutation.mutate({ projectId, name: newKeyName, requestId });
   };
 
   const handleCloseNewKey = () => {
-    setNewKeyData(null);
-    activeCreateRequestIdRef.current = null;
-    createSecretByRequestIdRef.current.clear();
+    clearProjectNewKeyData(projectId);
     resetCreateMutationRef.current();
   };
 
   const handleSaveNote = () => {
-    if (editingKey) {
-      updateMutation.mutate({ projectId, keyId: editingKey.id, name: editingKey.name || null });
+    if (editingKey && pendingUpdateRequestId === null) {
+      const requestId = updateRequestCounterRef.current + 1;
+      updateRequestCounterRef.current = requestId;
+      activeUpdateRequestIdRef.current = requestId;
+      setPendingUpdateRequestId(requestId);
+      updateMutation.mutate({
+        projectId,
+        keyId: editingKey.id,
+        name: editingKey.name || null,
+        requestId,
+      });
     }
   };
 
   const accessKeys = data?.access_keys || [];
-  const activeNewKeyData = newKeyData?.projectId === projectId ? newKeyData : null;
+  const activeNewKeyData = newKeyDataByProject[projectId] ?? null;
+  const isCreatePendingForProject = pendingCreateRequestsByProject[projectId] !== undefined;
 
   const hasCopyableEnvValue = !!activeNewKeyData;
   const envBlockContent = hasCopyableEnvValue
-    ? `TRACEROOT_API_KEY = "${activeNewKeyData.key}"`
+    ? `TRACEROOT_API_KEY="${activeNewKeyData.key}"`
     : accessKeys.length > 0
-      ? `TRACEROOT_API_KEY = "${formatKeyHint(accessKeys[0].key_hint)}"`
-      : `TRACEROOT_API_KEY = "tr-..."`;
+      ? `TRACEROOT_API_KEY="${formatKeyHint(accessKeys[0].key_hint)}"`
+      : `TRACEROOT_API_KEY="tr-..."`;
   const envBlockLabel = hasCopyableEnvValue
     ? ".env"
     : accessKeys.length > 0
@@ -224,12 +316,13 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         <div className="flex items-center gap-1.5">
           <h2 className="text-lg font-semibold">Project API Keys</h2>
           <TooltipProvider delayDuration={150}>
-            <Tooltip>
+            <Tooltip open={isHelpOpen} onOpenChange={setIsHelpOpen}>
               <TooltipTrigger asChild>
                 <button
                   type="button"
                   aria-label="About Project API Keys"
                   className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  onClick={() => setIsHelpOpen(true)}
                 >
                   <Info aria-hidden="true" className="h-3.5 w-3.5" />
                 </button>
@@ -313,14 +406,14 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
             <Button variant="outline" onClick={() => setShowCreateDialog(false)}>
               Cancel
             </Button>
-            <Button onClick={handleCreate} disabled={createMutation.isPending}>
-              {createMutation.isPending ? "Creating..." : "Create"}
+            <Button onClick={handleCreate} disabled={isCreatePendingForProject}>
+              {isCreatePendingForProject ? "Creating..." : "Create"}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      <Dialog open={!!editingKey} onOpenChange={(open) => !open && setEditingKey(null)}>
+      <Dialog open={!!editingKey} onOpenChange={(open) => !open && closeEditDialog()}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Edit Note</DialogTitle>
@@ -337,11 +430,11 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
             />
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setEditingKey(null)}>
+            <Button variant="outline" onClick={closeEditDialog}>
               Cancel
             </Button>
-            <Button onClick={handleSaveNote} disabled={updateMutation.isPending}>
-              {updateMutation.isPending ? "Saving..." : "Save"}
+            <Button onClick={handleSaveNote} disabled={pendingUpdateRequestId !== null}>
+              {pendingUpdateRequestId !== null ? "Saving..." : "Save"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -351,8 +444,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
         open={!!keyToDelete}
         onOpenChange={(open) => {
           if (!open) {
-            setKeyToDelete(null);
-            setDeleteConfirmText("");
+            closeDeleteDialog();
           }
         }}
       >
@@ -383,21 +475,26 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
             />
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setKeyToDelete(null)}>
+            <Button variant="outline" onClick={closeDeleteDialog}>
               Cancel
             </Button>
             <Button
               variant="destructive"
               onClick={() => {
-                if (keyToDelete) {
-                  deleteMutation.mutate({ projectId, keyId: keyToDelete.id });
+                if (keyToDelete && pendingDeleteRequestId === null) {
+                  const requestId = deleteRequestCounterRef.current + 1;
+                  deleteRequestCounterRef.current = requestId;
+                  activeDeleteRequestIdRef.current = requestId;
+                  setPendingDeleteRequestId(requestId);
+                  deleteMutation.mutate({ projectId, keyId: keyToDelete.id, requestId });
                 }
               }}
               disabled={
-                deleteConfirmText !== (keyToDelete?.name || "delete") || deleteMutation.isPending
+                deleteConfirmText !== (keyToDelete?.name || "delete") ||
+                pendingDeleteRequestId !== null
               }
             >
-              {deleteMutation.isPending ? "Deleting..." : "Delete API Key"}
+              {pendingDeleteRequestId !== null ? "Deleting..." : "Delete API Key"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -453,7 +550,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
                         setKeyToDelete(key);
                         setDeleteConfirmText("");
                       }}
-                      disabled={deleteMutation.isPending}
+                      disabled={pendingDeleteRequestId !== null}
                     />
                   </td>
                 </tr>

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -103,11 +103,17 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
   const accessKeys = data?.access_keys || [];
 
-  const envBlockContent = newKeyData
+  const hasCopyableEnvValue = !!newKeyData;
+  const envBlockContent = hasCopyableEnvValue
     ? `TRACEROOT_API_KEY = "${newKeyData.key}"`
     : accessKeys.length > 0
       ? `TRACEROOT_API_KEY = "${formatKeyHint(accessKeys[0].key_hint)}"`
       : `TRACEROOT_API_KEY = "tr-..."`;
+  const envBlockLabel = hasCopyableEnvValue
+    ? ".env"
+    : accessKeys.length > 0
+      ? ".env masked hint"
+      : ".env example";
 
   return (
     <div className="space-y-4">
@@ -136,8 +142,17 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
 
       <div className="border">
         <div className="flex items-center justify-between border-b px-4 py-2">
-          <span className="text-xs text-muted-foreground">.env</span>
-          <CopyButton value={envBlockContent} className="h-6 w-6" />
+          <span className="text-xs text-muted-foreground">{envBlockLabel}</span>
+          <CopyButton
+            value={envBlockContent}
+            className="h-6 w-6"
+            aria-label={
+              hasCopyableEnvValue
+                ? "Copy API key environment variable"
+                : "Create a new API key to copy the full environment variable"
+            }
+            disabled={!hasCopyableEnvValue}
+          />
         </div>
         <div className="bg-muted px-4 py-3 font-mono text-xs">
           <pre className="whitespace-pre-wrap">{envBlockContent}</pre>
@@ -154,7 +169,7 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
               <code className="flex-1 border bg-white px-2 py-1.5 font-mono text-xs dark:bg-black">
                 {newKeyData.key}
               </code>
-              <CopyButton value={newKeyData.key} variant="outline" />
+              <CopyButton value={newKeyData.key} variant="outline" aria-label="Copy new API key" />
             </div>
             <Button size="sm" variant="ghost" className="h-7 text-xs" onClick={handleCloseNewKey}>
               I&apos;ve copied the key

--- a/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/AccessKeysTab.tsx
@@ -120,7 +120,6 @@ export function AccessKeysTab({ projectId }: AccessKeysTabProps) {
                 <button
                   type="button"
                   aria-label="About Project API Keys"
-                  title={PROJECT_API_KEYS_HELP_TEXT}
                   className="inline-flex h-5 w-5 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 >
                   <Info aria-hidden="true" className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

Fixes the inert info icon next to **Project API Keys** on the project access keys settings page. The icon now uses the existing tooltip primitive, has an accessible label/focus target, and explains what project API keys are for, tells users to save the full secret when creating a new key, and clarifies that later views show only a masked hint.

## Changes

- Wrap the `Project API Keys` info icon in the shared tooltip component so the help opens on hover/focus and click.
- Add concise credential guidance for SDK/API authentication, create-time full-secret handling, unrecoverable one-time display, and later masked-hint behavior.
- Label masked `.env` hints, show visible guidance to create a new key for a full value, and remove dead copy affordances so only fresh full secrets are copyable.
- Scope freshly created one-time secret state to the project/request that created it, preserve it if the user returns to that project before the response resolves, prevent same-render duplicate creates, and request-scope create/update/delete mutation callbacks so stale completions cannot close newer dialogs or expose/copy a key in the wrong project. Keep update/delete in-flight guards separate from dialog visibility so close/reopen or A→B→A navigation cannot submit duplicate destructive mutations before settlement.
- Add accessible labels to the API-key copy controls and row delete action.
- Add focused `AccessKeysTab` component tests covering the accessible trigger, real tooltip behavior, empty/example state, masked-hint copy protection, full-secret env copying, one-time secret cleanup, duplicate-create prevention while pending, stale create completions across project switches, and in-flight edit/delete cleanup across project navigation.

## Why this matters

The previous icon looked interactive but did nothing on hover or click, which made a credential setup path feel broken. This keeps the UI affordance, makes it accessible, and gives users useful context without changing API key storage or recovery behavior. It also avoids treating masked hints as copyable secrets, keeps one-time full-secret display scoped to the project/request that created it, clarifies that the full secret cannot be recovered after dismissal, avoids replaying full secrets after project navigation, and prevents stale async completions or close/reopen flows from disrupting newer project dialogs.

## Screenshots / Recordings

Generated against this PR branch with the real `AccessKeysTab` component and mock project data. The visual evidence files live on a separate fork branch so they do not add binary artifacts to this PR diff.

| State | Screenshot |
| --- | --- |
| Tooltip opened from the info icon | ![Project API Keys tooltip](https://raw.githubusercontent.com/DivyamTalwar/traceroot/visual/pr-1406-access-keys-17ba6046/pr-1406-access-keys/pr-1406-tooltip.png) |
| Existing key: masked `.env` hint is labelled and not copyable | ![Masked API key hint state](https://raw.githubusercontent.com/DivyamTalwar/traceroot/visual/pr-1406-access-keys-17ba6046/pr-1406-access-keys/pr-1406-existing.png) |
| Fresh key: one-time full secret is copyable | ![Fresh API key one-time secret state](https://raw.githubusercontent.com/DivyamTalwar/traceroot/visual/pr-1406-access-keys-17ba6046/pr-1406-access-keys/pr-1406-fresh.png) |

## Tests

Commands run:

- `cd frontend/ui && pnpm vitest run src/features/settings/project/components/AccessKeysTab.test.tsx --reporter=verbose` — passed (18 tests)
- `cd frontend/ui && pnpm vitest run src/features/settings/project/components/AccessKeysTab.test.tsx src/features/settings/project/components/DetectorsTab.test.tsx` — passed (21 tests)
- `cd frontend/ui && pnpm exec eslint src/features/settings/project/components/AccessKeysTab.tsx src/features/settings/project/components/AccessKeysTab.test.tsx` — passed
- `cd frontend/ui && pnpm exec prettier --check src/features/settings/project/components/AccessKeysTab.tsx src/features/settings/project/components/AccessKeysTab.test.tsx` — passed
- `cd frontend/ui && pnpm lint` — passed with existing warnings outside this PR
- `cd frontend/ui && pnpm format:check` — passed
- `git diff --check` — passed

Additional checks:

- `cd frontend/ui && pnpm test` — not passing on the current local baseline; this PR's `AccessKeysTab.test.tsx` passed, but unchanged `src/components/layout/GitHubStarWidget.test.tsx` fails because `localStorage.clear` is not available in that local test environment setup.
- `cd frontend/ui && pnpm exec tsc --noEmit --project tsconfig.json` — not passing on current local baseline due unchanged existing test type errors in `src/__tests__/next-config.test.ts` and `src/app/api/projects/__tests__/route.test.ts`.

## Risk

Risk level: low

This is a focused UI/accessibility and client-side credential-copy-state change using existing components. It does not change backend API key creation, deletion, storage, recovery, API behavior, or permissions. It does change client-side copy affordances for masked hints and request-scoped one-time-secret display/mutation cleanup after project switches; full secrets are not replayed after leaving and later returning to a project. While update/delete requests are pending, the relevant controls remain disabled until the matching request settles to avoid duplicate submissions. Rollback is a single component/test revert.

## Issue

Fixes #993

## Notes for maintainers

I chose to keep the icon and add helpful text instead of removing it because the issue's expected behavior allowed helpful text, and this gives users context in a sensitive credential setup flow while preserving the one-time secret model.
