### PR TITLE
feat(api): trace-filter field registry + predicate translator

### DIFF
--- a/backend/rest/services/filters/columns.py
+++ b/backend/rest/services/filters/columns.py
@@ -1,0 +1,176 @@
+"""Field registry for trace-list filtering — the single source of truth.
+
+Every filterable column is declared once here: its ClickHouse type, which tier it
+lowers to, the input type the UI renders, the operators the translator will accept,
+and where its categorical options come from. The predicate translator
+(``translate.py``) and the meta endpoints (``/filter-fields``, ``/filter-values``)
+both read this registry, so adding a filter is one entry here.
+
+This is a vendored snapshot of the SQL Gateway's curated-column contract
+(``rest.services.sql.schema.PUBLIC_TABLES``), which is not yet on this branch. A
+parity test cross-checks the two once the Gateway merges.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class FilterLevel(StrEnum):
+    """How a predicate on the field lowers into the trace-list WHERE clause."""
+
+    TRACE = "TRACE"  # inline predicate on the traces row (t.*)
+    SPAN_MEMBERSHIP = "SPAN_MEMBERSHIP"  # trace_id IN (SELECT … FROM spans WHERE …)
+    SPAN_AGGREGATE = "SPAN_AGGREGATE"  # trace_id IN (SELECT … GROUP BY trace_id HAVING …)
+
+
+class FilterType(StrEnum):
+    """The kind of input the UI renders for the field."""
+
+    CATEGORICAL = "categorical"  # single-select value dropdown
+    NUMERIC = "numeric"  # number input
+
+
+class FilterOperator(StrEnum):
+    """Operators the translator whitelists per field (safety boundary)."""
+
+    IN = "in"
+    # The single numeric operator: a [min, max] range where either bound may be null,
+    # which is how the UI's greater-than / less-than / equals are expressed without
+    # separate ops. Lowering (see translate.py:_having_clause):
+    #   value [0.5, null]  -> agg >= 0.5            (UI "greater than", inclusive lower)
+    #   value [null, 10]   -> agg < 10              (UI "less than", STRICT upper)
+    #   value [0.5, 10]    -> agg BETWEEN 0.5 AND 10  (inclusive; "equals" uses [x, x])
+    # The translator keys off which bounds are present.
+    BETWEEN = "between"
+
+
+class ValueSource(StrEnum):
+    """Where the dropdown sources a categorical field's options."""
+
+    STATIC_ENUM = "static_enum"  # a fixed shared StrEnum (no field uses this currently)
+    DISTINCT_QUERY = "distinct_query"  # a distinct-values query (model_name, environment)
+    RANGE = "range"  # numeric field — no enumerated options, a number input
+
+
+@dataclass(frozen=True)
+class FilterColumn:
+    """A single filterable column.
+
+    Attributes:
+        name (str): The ClickHouse column name, also the predicate ``field`` key.
+        label (str): Human-readable label for the filter pill.
+        ch_type (str): ClickHouse type, used to bind query parameters.
+        level (str): One of ``FilterLevel`` — how the predicate lowers to SQL.
+        type (str): One of ``FilterType`` — the UI input kind.
+        operators (tuple[str, ...]): Allowed ``FilterOperator`` values (whitelist).
+        value_source (str): One of ``ValueSource`` — where options come from.
+        enum_values (tuple[str, ...]): Static options for ``STATIC_ENUM`` fields.
+        aggregate_expr (str | None): For ``SPAN_AGGREGATE`` fields, the per-trace
+            aggregate the HAVING clause filters on (e.g. ``sum(cost)``). ``None`` for
+            non-aggregate fields.
+    """
+
+    name: str
+    label: str
+    ch_type: str
+    level: str
+    type: str
+    operators: tuple[str, ...]
+    value_source: str
+    enum_values: tuple[str, ...] = ()
+    aggregate_expr: str | None = None
+
+    @property
+    def is_integer(self) -> bool:
+        """Whether the column binds whole-number parameters (Int*/UInt*). A fractional
+        bound on such a field is a BAD_QUERY_PARAMETER at ClickHouse, so the translator
+        rejects it and the UI restricts the input to integers."""
+        return self.ch_type.startswith(("Int", "UInt"))
+
+
+# Latency is the trace's wall-clock span, not a sum: max end minus min start across
+# the trace's spans — the same expression the list query's span_agg already uses.
+_DURATION_EXPR = "dateDiff('millisecond', min(span_start_time), max(span_end_time))"
+
+# A tuple, not a list/frozenset: an immutable constant whose order is the UI render
+# / serialization order; keyed lookup is FILTER_COLUMNS_BY_NAME below.
+FILTER_COLUMNS: tuple[FilterColumn, ...] = (
+    # Membership tier — "trace has ≥1 span where …" (span semi-join).
+    FilterColumn(
+        name="model_name",
+        label="Model",
+        ch_type="String",
+        level=FilterLevel.SPAN_MEMBERSHIP,
+        type=FilterType.CATEGORICAL,
+        operators=(FilterOperator.IN,),
+        value_source=ValueSource.DISTINCT_QUERY,
+    ),
+    FilterColumn(
+        name="environment",
+        label="Environment",
+        ch_type="String",
+        level=FilterLevel.SPAN_MEMBERSHIP,
+        type=FilterType.CATEGORICAL,
+        operators=(FilterOperator.IN,),
+        value_source=ValueSource.DISTINCT_QUERY,
+    ),
+    # Aggregate tier — time-bounded GROUP BY trace_id HAVING <agg> BETWEEN ….
+    FilterColumn(
+        name="cost",
+        label="Cost",
+        ch_type="Decimal64(9)",
+        level=FilterLevel.SPAN_AGGREGATE,
+        type=FilterType.NUMERIC,
+        operators=(FilterOperator.BETWEEN,),
+        value_source=ValueSource.RANGE,
+        aggregate_expr="sum(cost)",
+    ),
+    FilterColumn(
+        name="total_tokens",
+        label="Tokens",
+        ch_type="Int64",
+        level=FilterLevel.SPAN_AGGREGATE,
+        type=FilterType.NUMERIC,
+        operators=(FilterOperator.BETWEEN,),
+        value_source=ValueSource.RANGE,
+        aggregate_expr="sum(total_tokens)",
+    ),
+    FilterColumn(
+        name="duration_ms",
+        label="Latency",
+        ch_type="Int64",
+        level=FilterLevel.SPAN_AGGREGATE,
+        type=FilterType.NUMERIC,
+        operators=(FilterOperator.BETWEEN,),
+        value_source=ValueSource.RANGE,
+        aggregate_expr=_DURATION_EXPR,
+    ),
+    # Per-trace error-span count, filtered like the other numeric aggregates
+    # (e.g. "errors between 3 and ∞"). `errors` is derived, not a stored column —
+    # the aggregate_expr counts spans whose status is ERROR.
+    FilterColumn(
+        name="errors",
+        label="Errors",
+        ch_type="UInt64",
+        level=FilterLevel.SPAN_AGGREGATE,
+        type=FilterType.NUMERIC,
+        operators=(FilterOperator.BETWEEN,),
+        value_source=ValueSource.RANGE,
+        aggregate_expr="countIf(status = 'ERROR')",
+    ),
+)
+
+FILTER_COLUMNS_BY_NAME: dict[str, FilterColumn] = {c.name: c for c in FILTER_COLUMNS}
+
+
+def get_column(name: str) -> FilterColumn | None:
+    """Look up a filter column by field name.
+
+    Args:
+        name (str): The predicate ``field`` / ClickHouse column name.
+
+    Returns:
+        FilterColumn | None: The registry entry, or ``None`` if the field is not
+        filterable (the translator rejects unknown fields on this signal).
+    """
+    return FILTER_COLUMNS_BY_NAME.get(name)

--- a/backend/rest/services/filters/columns.py
+++ b/backend/rest/services/filters/columns.py
@@ -35,10 +35,11 @@ class FilterOperator(StrEnum):
 
     IN = "in"
     # The single numeric operator: a [min, max] range where either bound may be null,
-    # which is how the UI's greater-than / less-than / equals are expressed without
-    # separate ops. Lowering (see translate.py:_having_clause):
-    #   value [0.5, null]  -> agg >= 0.5            (UI "greater than", inclusive lower)
-    #   value [null, 10]   -> agg < 10              (UI "less than", STRICT upper)
+    # which is how the UI's "greater/less than or equal to" and "equals" are expressed
+    # without separate ops. Lowering (see translate.py:_having_clause) — both bounds
+    # inclusive:
+    #   value [0.5, null]  -> agg >= 0.5            (UI "greater than or equal to")
+    #   value [null, 10]   -> agg <= 10             (UI "less than or equal to")
     #   value [0.5, 10]    -> agg BETWEEN 0.5 AND 10  (inclusive; "equals" uses [x, x])
     # The translator keys off which bounds are present.
     BETWEEN = "between"

--- a/backend/rest/services/filters/translate.py
+++ b/backend/rest/services/filters/translate.py
@@ -203,12 +203,11 @@ def _membership_semijoin(frags: list[tuple[int, FilterColumn, Predicate]], param
 def _having_clause(idx: int, col: FilterColumn, pred: Predicate, params: dict) -> str | None:
     """One per-trace aggregate HAVING comparison, with nullable open-ended bounds.
 
-    Bound semantics (note: the "greater than" UI operator is an INCLUSIVE ``>=`` bound):
-    ``[lo, None]`` -> ``>=`` (UI "greater than", i.e. greater-than-or-equal),
-    ``[None, hi]`` -> ``<`` (UI "less than", strict), both bounds -> inclusive ``BETWEEN``
-    (colloquial "between a and b"). Returns ``None`` when both bounds are absent (a no-op
-    filter). Param names carry ``idx`` so duplicate predicates on the same field don't
-    collide.
+    Bound semantics — both bounds are INCLUSIVE, matching the UI's "greater than or equal
+    to" / "less than or equal to" operators so the label never misrepresents the result:
+    ``[lo, None]`` -> ``>=``, ``[None, hi]`` -> ``<=``, both bounds -> inclusive ``BETWEEN``.
+    Returns ``None`` when both bounds are absent (a no-op filter). Param names carry
+    ``idx`` so duplicate predicates on the same field don't collide.
     """
     lo, hi = pred.value[0], pred.value[1]
     agg, ch = col.aggregate_expr, col.ch_type
@@ -224,10 +223,10 @@ def _having_clause(idx: int, col: FilterColumn, pred: Predicate, params: dict) -
         return f"{agg} BETWEEN {{{lo_name}:{ch}}} AND {{{hi_name}:{ch}}}"
     if lo is not None:
         params[lo_name] = lo
-        return f"{agg} >= {{{lo_name}:{ch}}}"  # "greater than" is an inclusive >= bound
+        return f"{agg} >= {{{lo_name}:{ch}}}"  # "greater than or equal to"
     if hi is not None:
         params[hi_name] = hi
-        return f"{agg} < {{{hi_name}:{ch}}}"
+        return f"{agg} <= {{{hi_name}:{ch}}}"  # "less than or equal to" (inclusive)
     return None
 
 

--- a/backend/rest/services/filters/translate.py
+++ b/backend/rest/services/filters/translate.py
@@ -1,0 +1,294 @@
+"""Predicate -> parameterized WHERE translator for the trace list.
+
+Turns filter predicates into SQL condition strings that the caller appends to the
+shared ``conditions`` list in ``TraceReaderService.list_traces`` — the list that feeds
+BOTH the page CTE and the separate count query. Every condition is keyed on
+``t.trace_id`` and bound through query parameters (never string-interpolated), so a
+filter narrows the page and the total identically and safely.
+
+Structured as a per-field lowering plus a small assembler that groups predicates by
+registry level. Membership predicates merge into one span semi-join; the safety boundary
+is the per-field operator whitelist validated against the registry here, not downstream.
+"""
+
+import json
+import math
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from rest.services.filters.columns import (
+    FilterColumn,
+    FilterLevel,
+    FilterOperator,
+    get_column,
+)
+
+
+class Predicate(BaseModel):
+    """A single filter clause from the ``?filters=`` array.
+
+    Attributes:
+        field (str): The registry column name to filter on.
+        op (str): The operator (validated against the field's whitelist).
+        value (Any): The operand — a list for ``in``, a ``[min, max]`` pair for
+            ``between`` (either bound may be ``None`` for an open-ended range).
+    """
+
+    field: str
+    op: str
+    value: Any
+
+
+def parse_filters_param(raw: str | None) -> list[Predicate]:
+    """Parse the URL-encoded ``?filters=`` JSON array into validated predicates.
+
+    Args:
+        raw (str | None): The raw query-param value — a JSON array of
+            ``{field, op, value}`` objects, or ``None``/empty for no filters.
+
+    Returns:
+        list[Predicate]: The parsed, registry-validated predicates.
+
+    Raises:
+        ValueError: If the value is not a JSON array of valid predicate objects, or
+            names an unknown field or a non-whitelisted operator.
+    """
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"filters is not valid JSON: {e}") from e
+    if not isinstance(data, list):
+        raise ValueError("filters must be a JSON array of predicate objects")
+    predicates: list[Predicate] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError(f"each filter must be an object, got: {item!r}")
+        try:
+            pred = Predicate(**item)
+        except ValidationError as e:
+            raise ValueError(f"invalid filter predicate: {e}") from e
+        validate_predicate(pred)  # registry field/op whitelist
+        predicates.append(pred)
+    return predicates
+
+
+def validate_predicate(pred: Predicate) -> FilterColumn:
+    """Resolve a predicate's field to a registry column and check its operator.
+
+    Args:
+        pred (Predicate): The predicate to validate.
+
+    Returns:
+        FilterColumn: The matching registry entry.
+
+    Raises:
+        ValueError: If the field is not filterable or the operator is not whitelisted
+            for that field.
+    """
+    col = get_column(pred.field)
+    if col is None:
+        raise ValueError(f"unknown filter field: {pred.field!r}")
+    if pred.op not in col.operators:
+        raise ValueError(f"operator {pred.op!r} not allowed for field {pred.field!r}")
+    _validate_value(pred, col)
+    return col
+
+
+def _is_number(x: object) -> bool:
+    # bool is a subclass of int; a JSON boolean is not a valid numeric bound.
+    return isinstance(x, (int, float)) and not isinstance(x, bool)
+
+
+# Inclusive max of each numeric column type used by filterable fields. A bound larger
+# than this can't bind to the parameter and would be a BAD_QUERY_PARAMETER in ClickHouse.
+# Decimal64(9) is Decimal(18, 9) — 9 integer digits — so its largest value is < 10**9; the
+# whole-number cap is deliberately conservative (rejects the absurd top fractional cent
+# too) to guarantee no overflow rather than track the exact per-scale maximum.
+_NUMERIC_TYPE_MAX = {"Int64": 2**63 - 1, "UInt64": 2**64 - 1, "Decimal64(9)": 10**9 - 1}
+
+
+def _validate_value(pred: Predicate, col: FilterColumn) -> None:
+    """Check the value matches the operator's shape, so a malformed (but typed) filter
+    is a 422 at the edge rather than a 500 from deep in query building.
+
+    Raises:
+        ValueError: If ``in`` lacks a list of strings; if ``between`` lacks a two-element
+            ``[min, max]`` list of numbers (either bound may be ``null``); or if a bound
+            can't safely bind to the column's ClickHouse type — non-finite (NaN/inf),
+            negative (the metrics are all non-negative; a negative can't bind to a
+            ``UInt64``), fractional on an integer field, or beyond the column type's
+            range. Each of these would otherwise be a BAD_QUERY_PARAMETER 500.
+    """
+    if pred.op == FilterOperator.IN:
+        if (
+            not isinstance(pred.value, list)
+            or not pred.value  # an empty IN list matches nothing — reject it
+            or not all(isinstance(v, str) for v in pred.value)
+        ):
+            raise ValueError(f"'in' filter on {pred.field!r} requires a non-empty list of strings")
+    elif pred.op == FilterOperator.BETWEEN:
+        v = pred.value
+        if not isinstance(v, list) or len(v) != 2 or not all(x is None or _is_number(x) for x in v):
+            raise ValueError(
+                f"'between' filter on {pred.field!r} requires [min, max] numbers "
+                "(either bound may be null)"
+            )
+        max_val = _NUMERIC_TYPE_MAX.get(col.ch_type)
+        for x in v:
+            if x is None:
+                continue
+            # A bound must bind safely to the column's type or ClickHouse 500s. Guard the
+            # float coercions: math.isfinite()/is_integer() OverflowError on an
+            # arbitrary-size JSON int, so only NaN/inf-check floats and compare ranges
+            # directly (int/Decimal alike — an oversized cost overflows Decimal64 too).
+            if isinstance(x, float) and not math.isfinite(x):
+                raise ValueError(f"'between' filter on {pred.field!r} bounds must be finite")
+            if x < 0:
+                raise ValueError(
+                    f"'between' filter on {pred.field!r} takes non-negative numbers (got {x!r})"
+                )
+            if col.is_integer and isinstance(x, float) and not x.is_integer():
+                raise ValueError(
+                    f"'between' filter on {pred.field!r} takes whole numbers only (got {x!r})"
+                )
+            if max_val is not None and x > max_val:
+                raise ValueError(f"'between' filter on {pred.field!r} exceeds its maximum value")
+
+
+def _span_time_bound(params: dict) -> str:
+    """The active-window lower bound on span scans, when the list has a start date.
+
+    Every span starts at or after its trace's start, so the list's ``start_after``
+    is a valid lower bound on ``span_start_time`` — it prunes monthly partitions in
+    the span sub-queries. Emitted only when the caller has bound ``start_after``.
+    """
+    if "start_after" in params:
+        return " AND span_start_time >= {start_after:DateTime64(3)}"
+    return ""
+
+
+def _membership_semijoin(frags: list[tuple[int, FilterColumn, Predicate]], params: dict) -> str:
+    """Merge membership predicates into one project-scoped span semi-join.
+
+    Matches traces with >=1 span satisfying ALL membership predicates. Dedups
+    ReplacingMergeTree spans to the latest ``ch_update_time`` version per span BEFORE
+    applying the categorical predicates (like the aggregate/distinct paths), so a stale
+    row can't match a value the latest version no longer has. Scoped to the same
+    ``project_id`` as the outer query (tenant isolation) and keyed on ``t.trace_id`` so
+    it filters the page and the count alike. Param names carry the predicate's index so
+    two predicates on the same field don't collide.
+    """
+    member_conds: list[str] = []
+    select_cols = ["project_id", "trace_id", "span_id"]
+    for i, col, pred in frags:
+        pname = f"f_{col.name}_{i}"
+        params[pname] = pred.value
+        member_conds.append(f"{col.name} IN {{{pname}:Array({col.ch_type})}}")
+        select_cols.append(col.name)
+    # dict.fromkeys dedups columns (two predicates on the same field select it once).
+    inner = (
+        f"SELECT {', '.join(dict.fromkeys(select_cols))} "
+        "FROM spans "
+        "WHERE project_id = {project_id:String}" + _span_time_bound(params) + " "
+        "ORDER BY ch_update_time DESC "
+        "LIMIT 1 BY project_id, trace_id, span_id"
+    )
+    where = " AND ".join(member_conds)
+    return f"t.trace_id IN (SELECT trace_id FROM ({inner}) WHERE {where})"
+
+
+def _having_clause(idx: int, col: FilterColumn, pred: Predicate, params: dict) -> str | None:
+    """One per-trace aggregate HAVING comparison, with nullable open-ended bounds.
+
+    Bound semantics (note: the "greater than" UI operator is an INCLUSIVE ``>=`` bound):
+    ``[lo, None]`` -> ``>=`` (UI "greater than", i.e. greater-than-or-equal),
+    ``[None, hi]`` -> ``<`` (UI "less than", strict), both bounds -> inclusive ``BETWEEN``
+    (colloquial "between a and b"). Returns ``None`` when both bounds are absent (a no-op
+    filter). Param names carry ``idx`` so duplicate predicates on the same field don't
+    collide.
+    """
+    lo, hi = pred.value[0], pred.value[1]
+    agg, ch = col.aggregate_expr, col.ch_type
+    if col.is_integer:
+        # Bounds are validated whole numbers; bind them as int so a JSON float like 5.0
+        # doesn't reach ClickHouse as "5.0" (unparseable as Int64/UInt64).
+        lo = int(lo) if lo is not None else None
+        hi = int(hi) if hi is not None else None
+    lo_name, hi_name = f"f_{col.name}_{idx}_min", f"f_{col.name}_{idx}_max"
+    if lo is not None and hi is not None:
+        params[lo_name] = lo
+        params[hi_name] = hi
+        return f"{agg} BETWEEN {{{lo_name}:{ch}}} AND {{{hi_name}:{ch}}}"
+    if lo is not None:
+        params[lo_name] = lo
+        return f"{agg} >= {{{lo_name}:{ch}}}"  # "greater than" is an inclusive >= bound
+    if hi is not None:
+        params[hi_name] = hi
+        return f"{agg} < {{{hi_name}:{ch}}}"
+    return None
+
+
+def _aggregate_semijoin(
+    frags: list[tuple[int, FilterColumn, Predicate]], params: dict
+) -> str | None:
+    """Merge aggregate predicates into one time-bounded GROUP BY ... HAVING semi-join.
+
+    Dedups ReplacingMergeTree spans (latest ``ch_update_time`` per span) within the
+    active window, rolls them up per trace, and keeps traces whose aggregates satisfy
+    all HAVING comparisons. Keyed on ``t.trace_id`` so it filters page and count alike.
+    Returns ``None`` if every predicate was an empty (no-bound) range.
+    """
+    having = [c for c in (_having_clause(i, col, pred, params) for i, col, pred in frags) if c]
+    if not having:
+        return None
+    inner = (
+        "SELECT trace_id, span_id, project_id, status, cost, total_tokens, "
+        "span_start_time, span_end_time "
+        "FROM spans "
+        "WHERE project_id = {project_id:String}" + _span_time_bound(params) + " "
+        "ORDER BY ch_update_time DESC "
+        "LIMIT 1 BY project_id, trace_id, span_id"
+    )
+    return (
+        f"t.trace_id IN (SELECT trace_id FROM ({inner}) "
+        f"GROUP BY trace_id HAVING {' AND '.join(having)})"
+    )
+
+
+def build_conditions(filters: list[Predicate], params: dict) -> list[str]:
+    """Lower filter predicates to parameterized WHERE conditions.
+
+    Args:
+        filters (list[Predicate]): The predicates to apply (AND-combined).
+        params (dict): The query parameter map, mutated in place with the bound values
+            the returned conditions reference.
+
+    Returns:
+        list[str]: SQL condition strings to append to the shared ``conditions`` list
+        (and thus AND-ed into both the page query and the count query).
+
+    Raises:
+        ValueError: On an unknown field or a non-whitelisted operator.
+    """
+    membership: list[tuple[int, FilterColumn, Predicate]] = []
+    aggregate: list[tuple[int, FilterColumn, Predicate]] = []
+    for i, pred in enumerate(filters):
+        col = validate_predicate(pred)
+        if col.level == FilterLevel.SPAN_MEMBERSHIP:
+            membership.append((i, col, pred))
+        elif col.level == FilterLevel.SPAN_AGGREGATE:
+            aggregate.append((i, col, pred))
+        else:
+            raise NotImplementedError(f"level {col.level} not yet lowered: {col.name}")
+
+    conditions: list[str] = []
+    if membership:
+        conditions.append(_membership_semijoin(membership, params))
+    if aggregate:
+        agg = _aggregate_semijoin(aggregate, params)
+        if agg:
+            conditions.append(agg)
+    return conditions

--- a/backend/rest/services/filters/translate.py
+++ b/backend/rest/services/filters/translate.py
@@ -158,15 +158,28 @@ def _validate_value(pred: Predicate, col: FilterColumn) -> None:
                 raise ValueError(f"'between' filter on {pred.field!r} exceeds its maximum value")
 
 
+# Back off the span-scan lower bound from ``start_after`` by this much. ``start_after``
+# bounds the TRACE query exactly, but a span can start slightly before its trace's stored
+# ``trace_start_time`` (clock skew / trace_start_time isn't always the true earliest span —
+# the same drift ``TRACE_SPAN_LOOKBACK_HOURS`` allows for in the trace-detail read). Without
+# this, a matching span of an in-window trace that started just before the window boundary
+# would be dropped — a silent false negative. Well under a month, so partition pruning holds.
+SPAN_TIME_BOUND_LOOKBACK_HOURS = 1
+
+
 def _span_time_bound(params: dict) -> str:
     """The active-window lower bound on span scans, when the list has a start date.
 
-    Every span starts at or after its trace's start, so the list's ``start_after``
-    is a valid lower bound on ``span_start_time`` — it prunes monthly partitions in
-    the span sub-queries. Emitted only when the caller has bound ``start_after``.
+    Bounds ``span_start_time`` at ``start_after`` minus a small lookback so a span that
+    started just before the window boundary (clock skew vs. the stored ``trace_start_time``)
+    isn't dropped, which would false-negative an otherwise-matching in-window trace. Still
+    prunes monthly partitions. Emitted only when the caller has bound ``start_after``.
     """
     if "start_after" in params:
-        return " AND span_start_time >= {start_after:DateTime64(3)}"
+        return (
+            " AND span_start_time >= "
+            f"{{start_after:DateTime64(3)}} - INTERVAL {SPAN_TIME_BOUND_LOOKBACK_HOURS} HOUR"
+        )
     return ""
 
 

--- a/tests/rest/test_filter_columns_parity.py
+++ b/tests/rest/test_filter_columns_parity.py
@@ -1,0 +1,104 @@
+"""Parity snapshot for the trace-filter field registry.
+
+Pins the exact filterable-column set, their tiers, and per-field semantics so the
+registry can't silently drift. The ``skipif`` cross-check against the SQL Gateway's
+``PUBLIC_TABLES`` activates automatically once that module merges, so the vendored
+snapshot stays in sync with the curated-column contract it mirrors.
+"""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from rest.services.filters import columns as reg
+
+MEMBERSHIP_FIELDS = {"model_name", "environment"}
+AGGREGATE_FIELDS = {"cost", "total_tokens", "duration_ms", "errors"}
+
+
+def test_registry_column_set_is_exactly_the_two_tiers():
+    """The registry holds precisely the membership + aggregate fields — nothing else."""
+    assert {c.name for c in reg.FILTER_COLUMNS} == MEMBERSHIP_FIELDS | AGGREGATE_FIELDS
+
+
+def test_membership_fields_are_span_membership_categorical_in():
+    """Membership fields lower to a span semi-join and take a multi-select ``in``."""
+    for name in MEMBERSHIP_FIELDS:
+        col = reg.get_column(name)
+        assert col.level is reg.FilterLevel.SPAN_MEMBERSHIP
+        assert col.type is reg.FilterType.CATEGORICAL
+        assert col.operators == (reg.FilterOperator.IN,)
+        assert col.aggregate_expr is None
+
+
+def test_aggregate_fields_are_span_aggregate_numeric_between():
+    """Aggregate fields lower to a HAVING semi-join and take a numeric ``between``."""
+    for name in AGGREGATE_FIELDS:
+        col = reg.get_column(name)
+        assert col.level is reg.FilterLevel.SPAN_AGGREGATE
+        assert col.type is reg.FilterType.NUMERIC
+        assert col.operators == (reg.FilterOperator.BETWEEN,)
+        assert col.value_source is reg.ValueSource.RANGE
+
+
+def test_errors_is_a_numeric_count_of_error_spans():
+    """`errors` is a derived per-trace count, filtered like the other numeric aggregates."""
+    col = reg.get_column("errors")
+    assert col.level is reg.FilterLevel.SPAN_AGGREGATE
+    assert col.type is reg.FilterType.NUMERIC
+    assert col.aggregate_expr == "countIf(status = 'ERROR')"
+
+
+def test_open_ended_categoricals_use_a_distinct_query_with_no_static_values():
+    """model_name/environment are unbounded — options come from a distinct-values query."""
+    for name in ("model_name", "environment"):
+        col = reg.get_column(name)
+        assert col.value_source is reg.ValueSource.DISTINCT_QUERY
+        assert col.enum_values == ()
+
+
+def test_duration_aggregates_via_min_max_while_cost_and_tokens_sum():
+    """duration is max(end)-min(start), NOT a sum — the lowering must differ."""
+    assert reg.get_column("cost").aggregate_expr == "sum(cost)"
+    assert reg.get_column("total_tokens").aggregate_expr == "sum(total_tokens)"
+    dur = reg.get_column("duration_ms").aggregate_expr
+    assert "min(span_start_time)" in dur and "max(span_end_time)" in dur
+    assert "sum(" not in dur
+
+
+def test_get_column_returns_none_for_unknown_field():
+    assert reg.get_column("not_a_field") is None
+
+
+def test_filter_columns_are_immutable():
+    """Frozen entries — the registry is a constant, not mutable state."""
+    with pytest.raises(FrozenInstanceError):
+        reg.FILTER_COLUMNS[0].name = "mutated"
+
+
+# Derived fields with no stored-column equivalent (computed aggregates) are exempt
+# from the curated-column cross-check — they reference real columns via aggregate_expr.
+_DERIVED_FIELDS = {"errors"}
+
+# --- Cross-check against the SQL Gateway curated columns (lights up on merge) ---
+
+try:
+    from rest.services.sql import schema as gateway_schema
+
+    _HAS_GATEWAY = hasattr(gateway_schema, "PUBLIC_TABLES")
+except ImportError:
+    gateway_schema = None
+    _HAS_GATEWAY = False
+
+
+@pytest.mark.skipif(
+    not _HAS_GATEWAY,
+    reason="SQL Gateway PUBLIC_TABLES not merged on this branch; vendored snapshot in use",
+)
+def test_registry_columns_exist_in_gateway_public_tables():
+    """Every filter column must be a real curated column once the Gateway merges."""
+    tables = gateway_schema.PUBLIC_TABLES
+    iterable = tables.values() if isinstance(tables, dict) else tables
+    gateway_cols = {getattr(c, "name", c) for tbl in iterable for c in getattr(tbl, "columns", [])}
+    missing = {c.name for c in reg.FILTER_COLUMNS} - gateway_cols - _DERIVED_FIELDS
+    assert not missing, f"registry columns absent from Gateway curated schema: {missing}"

--- a/tests/rest/test_filter_translate.py
+++ b/tests/rest/test_filter_translate.py
@@ -201,14 +201,14 @@ def test_aggregate_between_lowers_to_a_having_semijoin_with_both_bounds():
 def test_aggregate_open_lower_bound_lowers_to_inclusive_gte():
     params = {"project_id": "p1"}
     cond = build_conditions([Predicate(field="cost", op="between", value=[0.5, None])], params)[0]
-    assert "sum(cost) >=" in cond  # "greater than" is an inclusive >= bound
+    assert "sum(cost) >=" in cond  # "greater than or equal to" is an inclusive >= bound
     assert "BETWEEN" not in cond and "<" not in cond
 
 
-def test_aggregate_open_upper_bound_lowers_to_strict_lt():
+def test_aggregate_open_upper_bound_lowers_to_inclusive_lte():
     params = {"project_id": "p1"}
     cond = build_conditions([Predicate(field="cost", op="between", value=[None, 10])], params)[0]
-    assert "sum(cost) <" in cond and "<=" not in cond  # standalone upper bound is strict
+    assert "sum(cost) <=" in cond  # "less than or equal to" is an inclusive <= bound
     assert "BETWEEN" not in cond and ">=" not in cond
 
 

--- a/tests/rest/test_filter_translate.py
+++ b/tests/rest/test_filter_translate.py
@@ -1,0 +1,251 @@
+"""Translator unit tests: predicates -> parameterized WHERE conditions.
+
+The translator's contract is the load-bearing correctness piece: every condition it
+returns is appended to the shared ``conditions`` list in ``list_traces`` (the one that
+feeds BOTH the page CTE and the separate count query), so a membership/aggregate filter
+keyed on ``t.trace_id`` filters the page and the total identically.
+"""
+
+import pytest
+
+from rest.services.filters.translate import (
+    Predicate,
+    build_conditions,
+    parse_filters_param,
+)
+
+
+def test_parse_none_or_empty_yields_no_predicates():
+    assert parse_filters_param(None) == []
+    assert parse_filters_param("") == []
+
+
+def test_parse_valid_json_array_yields_predicates():
+    preds = parse_filters_param('[{"field":"model_name","op":"in","value":["gpt-4"]}]')
+    assert preds == [Predicate(field="model_name", op="in", value=["gpt-4"])]
+
+
+def test_parse_rejects_non_json():
+    with pytest.raises(ValueError):
+        parse_filters_param("not json")
+
+
+def test_parse_rejects_non_array():
+    with pytest.raises(ValueError):
+        parse_filters_param('{"field":"model_name","op":"in","value":["x"]}')
+
+
+def test_validation_rejects_malformed_in_value():
+    # 'in' needs a list of strings, not a bare value or non-strings.
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="model_name", op="in", value="gpt-4")], {})
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="model_name", op="in", value=[1, 2])], {})
+
+
+def test_validation_rejects_empty_in_list():
+    # An empty IN list matches nothing — reject it rather than emit `col IN []`.
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="model_name", op="in", value=[])], {})
+
+
+def test_validation_rejects_malformed_between_value():
+    # 'between' needs a two-element [min, max] list of numbers (either may be null).
+    for bad in (5, [5], [1, 2, 3], ["a", "b"], [True, None]):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field="cost", op="between", value=bad)], {})
+
+
+def test_validation_rejects_fractional_bound_on_integer_field():
+    # total_tokens/errors/duration_ms are integer-typed; a fractional bound is a
+    # BAD_QUERY_PARAMETER at ClickHouse, so reject it at the edge (422, not a 500).
+    for field in ("total_tokens", "errors", "duration_ms"):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field=field, op="between", value=[1.5, None])], {})
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field=field, op="between", value=[None, 2.5])], {})
+
+
+def test_validation_rejects_negative_bound():
+    # The metrics are all non-negative; a negative bound can't bind to UInt64 (errors)
+    # and would 500 in ClickHouse, so reject it at the edge (422) for every numeric field.
+    for field in ("errors", "total_tokens", "duration_ms", "cost"):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field=field, op="between", value=[-5, None])], {})
+
+
+def test_validation_rejects_non_finite_bound():
+    # json.loads accepts NaN/Infinity by default; a non-finite bound would 500 at bind.
+    for bad in (float("inf"), float("-inf"), float("nan")):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field="cost", op="between", value=[bad, None])], {})
+
+
+def test_validation_rejects_out_of_range_integer_bound():
+    # A value beyond the column's integer type can't bind — total_tokens is Int64. Include
+    # an arbitrary-size int that would OverflowError in float() coercion (must be a clean
+    # ValueError/422, not a 500).
+    for huge in (2**63, 10**400):
+        with pytest.raises(ValueError):
+            build_conditions(
+                [Predicate(field="total_tokens", op="between", value=[huge, None])], {}
+            )
+
+
+def test_validation_rejects_oversized_decimal_bound():
+    # cost is Decimal64(9); a value beyond its range would overflow at binding (500), so
+    # reject it at the edge too — the range check isn't integer-only.
+    for huge in (10**9, 10**30):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field="cost", op="between", value=[huge, None])], {})
+
+
+def test_fractional_bound_allowed_on_decimal_cost():
+    # cost is Decimal-typed — fractional bounds are valid and must not be rejected.
+    conds = build_conditions(
+        [Predicate(field="cost", op="between", value=[0.5, None])], {"project_id": "p1"}
+    )
+    assert conds  # a condition was produced, no ValueError
+
+
+def test_integer_valued_float_bound_is_coerced_to_int():
+    # A whole-number float (e.g. 5.0 from a hand-crafted URL) is accepted and bound as an
+    # int, so it isn't sent to ClickHouse as "5.0" (unparseable as Int64).
+    params = {"project_id": "p1"}
+    build_conditions([Predicate(field="total_tokens", op="between", value=[5.0, 10.0])], params)
+    bounds = [v for k, v in params.items() if k.endswith(("_min", "_max"))]
+    assert set(bounds) == {5, 10}
+    assert all(isinstance(v, int) for v in bounds)
+
+
+def test_duplicate_predicates_on_same_field_get_distinct_params():
+    # Two predicates on one field must not clobber each other's bound params.
+    params = {"project_id": "p1"}
+    build_conditions(
+        [
+            Predicate(field="cost", op="between", value=[1, None]),
+            Predicate(field="cost", op="between", value=[None, 9]),
+        ],
+        params,
+    )
+    assert 1 in params.values() and 9 in params.values()
+
+
+def test_parse_rejects_non_object_array_element():
+    with pytest.raises(ValueError):
+        parse_filters_param("[123]")
+
+
+def test_parse_rejects_predicate_missing_required_keys():
+    with pytest.raises(ValueError):
+        parse_filters_param('[{"op":"in","value":["x"]}]')  # no field
+
+
+def test_parse_rejects_unknown_field():
+    with pytest.raises(ValueError):
+        parse_filters_param('[{"field":"nope","op":"in","value":["x"]}]')
+
+
+def test_parse_rejects_bad_operator_for_field():
+    with pytest.raises(ValueError):
+        parse_filters_param('[{"field":"cost","op":"in","value":[1]}]')
+
+
+def test_membership_predicate_lowers_to_a_project_scoped_span_semijoin():
+    params = {"project_id": "p1"}
+    conditions = build_conditions(
+        [Predicate(field="model_name", op="in", value=["claude-opus-4.8", "gpt-4"])],
+        params,
+    )
+    assert len(conditions) == 1
+    cond = conditions[0]
+    # Keyed on t.trace_id (so it filters page AND count), scoped to the same project.
+    assert "t.trace_id IN (" in cond
+    assert "FROM spans" in cond
+    assert "project_id = {project_id:String}" in cond
+    assert "model_name IN" in cond
+    # Deduped to the latest ReplacingMergeTree version per span before the IN match, so a
+    # stale row can't match a value the latest span version no longer has.
+    assert "LIMIT 1 BY project_id, trace_id, span_id" in cond
+    # The value is bound as a parameter, never interpolated into the SQL text.
+    assert ["claude-opus-4.8", "gpt-4"] in params.values()
+    assert "claude-opus-4.8" not in cond
+
+
+def test_unknown_field_is_rejected():
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="not_a_field", op="in", value=["x"])], {})
+
+
+def test_operator_not_in_field_whitelist_is_rejected():
+    # cost only allows BETWEEN, not IN.
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="cost", op="in", value=[1])], {})
+
+
+def test_aggregate_between_lowers_to_a_having_semijoin_with_both_bounds():
+    params = {"project_id": "p1"}
+    conditions = build_conditions([Predicate(field="cost", op="between", value=[0.5, 10])], params)
+    assert len(conditions) == 1
+    cond = conditions[0]
+    assert "t.trace_id IN (" in cond
+    assert "GROUP BY trace_id" in cond
+    assert "HAVING" in cond
+    assert "sum(cost) BETWEEN" in cond
+    assert "project_id = {project_id:String}" in cond
+    # both bounds bound as params, not interpolated
+    assert 0.5 in params.values() and 10 in params.values()
+    assert "0.5" not in cond
+
+
+def test_aggregate_open_lower_bound_lowers_to_inclusive_gte():
+    params = {"project_id": "p1"}
+    cond = build_conditions([Predicate(field="cost", op="between", value=[0.5, None])], params)[0]
+    assert "sum(cost) >=" in cond  # "greater than" is an inclusive >= bound
+    assert "BETWEEN" not in cond and "<" not in cond
+
+
+def test_aggregate_open_upper_bound_lowers_to_strict_lt():
+    params = {"project_id": "p1"}
+    cond = build_conditions([Predicate(field="cost", op="between", value=[None, 10])], params)[0]
+    assert "sum(cost) <" in cond and "<=" not in cond  # standalone upper bound is strict
+    assert "BETWEEN" not in cond and ">=" not in cond
+
+
+def test_errors_aggregate_counts_error_spans_per_trace():
+    params = {"project_id": "p1"}
+    cond = build_conditions([Predicate(field="errors", op="between", value=[3, None])], params)[0]
+    assert "countIf(status = 'ERROR') >=" in cond
+    assert "GROUP BY trace_id HAVING" in cond
+    assert "status" in cond  # inner SELECT carries status for the count
+
+
+def test_duration_aggregate_uses_min_max_expr_not_sum():
+    params = {"project_id": "p1"}
+    cond = build_conditions(
+        [Predicate(field="duration_ms", op="between", value=[100, 5000])], params
+    )[0]
+    assert "min(span_start_time)" in cond and "max(span_end_time)" in cond
+    assert "sum(" not in cond
+
+
+def test_aggregate_with_no_bounds_is_a_noop_and_emits_nothing():
+    # An empty range (both bounds absent) contributes no SQL — not an error.
+    params = {"project_id": "p1"}
+    assert (
+        build_conditions([Predicate(field="cost", op="between", value=[None, None])], params) == []
+    )
+
+
+def test_start_after_in_params_bounds_both_semijoins():
+    params = {"project_id": "p1", "start_after": "2026-06-01 00:00:00"}
+    conditions = build_conditions(
+        [
+            Predicate(field="model_name", op="in", value=["gpt-4"]),
+            Predicate(field="cost", op="between", value=[1, None]),
+        ],
+        params,
+    )
+    assert len(conditions) == 2  # one membership semi-join, one aggregate semi-join
+    for cond in conditions:
+        assert "span_start_time >= {start_after:DateTime64(3)}" in cond

--- a/tests/rest/test_filter_translate.py
+++ b/tests/rest/test_filter_translate.py
@@ -249,3 +249,12 @@ def test_start_after_in_params_bounds_both_semijoins():
     assert len(conditions) == 2  # one membership semi-join, one aggregate semi-join
     for cond in conditions:
         assert "span_start_time >= {start_after:DateTime64(3)}" in cond
+
+
+def test_span_time_bound_backs_off_for_boundary_drift():
+    """The span-scan lower bound subtracts a small lookback from start_after, so a span
+    that started just before the window boundary (clock skew vs. trace_start_time) is not
+    dropped — which would false-negative an otherwise-matching in-window trace."""
+    params = {"project_id": "p1", "start_after": "2026-06-01 00:00:00"}
+    conditions = build_conditions([Predicate(field="model_name", op="in", value=["gpt-4"])], params)
+    assert "span_start_time >= {start_after:DateTime64(3)} - INTERVAL" in conditions[0]


### PR DESCRIPTION
Closes #1376
Closes #1370

Backend foundation for user-facing trace filters (PR 1/5 of a stacked series; base `main`).

- **Field registry** (`columns.py`) — the single allowlist source for filterable columns, their ClickHouse types, tier (span membership vs aggregate), UI input kind, and per-field operator whitelist. `is_integer` flags Int/UInt columns.
- **Predicate → parameterized WHERE translator** (`translate.py`) — lowers `{field, op, value}` predicates to tenant-scoped, fully parameterized SQL conditions (membership semi-joins and aggregate GROUP BY … HAVING). Validation rejects unknown fields, non-whitelisted operators, malformed values, and **fractional bounds on integer-typed fields** (422 at the edge, not a 500); integer-valued bounds are coerced to int.

Pure logic — no endpoints yet. Unit-tested (translator + registry parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backend support for trace-list filtering with a field registry and a predicate-to-parameterized SQL translator that applies project-scoped conditions to both page and count queries. No endpoints yet; covered by unit tests.

- **New Features**
  - Field registry (`columns.py`): allowlist with ClickHouse types, level (span membership vs aggregate), UI input kind, operator whitelist, and option source. Includes `model_name`, `environment`, `cost`, `total_tokens`, `duration_ms` (min/max expression), and derived `errors` (`countIf(status = 'ERROR')`).
  - Parser + translator (`translate.py`): parses `?filters=` JSON to validated predicates; lowers to `t.trace_id`-keyed conditions. Membership merges into one project-scoped span semi-join with per-span dedup before matching; aggregates dedup spans, then `GROUP BY trace_id HAVING`. Range semantics are inclusive (`>=`, `<=`, or `BETWEEN`). Span scans are time-bounded when `start_after` is set.
  - Validation: rejects unknown fields/ops, empty `IN`, malformed `BETWEEN`, non-finite or negative bounds, fractional bounds on integer fields, and out-of-range numeric bounds (Int64/UInt64/`Decimal64(9)`). Coerces integer-valued floats to ints for integer fields.
  - Tests: registry parity snapshot (with SQL Gateway cross-check hook) and translator tests (param binding, dedup, bound semantics, and `start_after` time bounding).

- **Bug Fixes**
  - Aggregate filters with only an upper bound now use inclusive `<=` to match the UI and two-sided inclusive `BETWEEN`.
  - Span semi-joins back off the lower time bound by 1 hour from `start_after` to prevent boundary false negatives while keeping partition pruning and exact trace windows.

<sup>Written for commit bd2818b9d659f2fe9bc0f1ba9eac6b7e236368fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

