### PR TITLE
feat(api): filter meta endpoints + ?filters= on the trace list

### DIFF
--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -88,9 +88,14 @@ async def list_traces(
 
 
 @router.get("/filter-fields", response_model=FilterFieldsResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def get_filter_fields(
+    request: Request,
+    response: Response,
     project_id: str,
-    _access: ProjectAccess,  # Validates user has access to project
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
 ):
     """Serialize the filter field registry that drives the filter dropdown.
 
@@ -100,7 +105,7 @@ async def get_filter_fields(
     Args:
         project_id (str): Project from the path; scopes access (the field set itself
             is the same for every project).
-        _access (ProjectAccess): Validates the user's access to the project.
+        _access (RateLimitedProjectAccess): Validates access and sets rate-limit identity.
 
     Returns:
         FilterFieldsResponse: One entry per registry column with its UI metadata.
@@ -123,12 +128,20 @@ async def get_filter_fields(
 
 
 @router.get("/filter-values/{field}", response_model=FilterValuesResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def get_filter_values(
+    request: Request,
+    response: Response,
     project_id: str,
     field: str,
-    _access: ProjectAccess,  # Validates user has access to project
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
     start_after: datetime | None = Query(
         None, description="Only consider spans starting at or after this timestamp"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only consider spans starting before this timestamp"
     ),
 ):
     """Distinct values for an open-ended categorical filter field.
@@ -141,8 +154,10 @@ async def get_filter_values(
     Args:
         project_id (str): Project that owns the spans; server-bound for isolation.
         field (str): The categorical field to enumerate.
-        _access (ProjectAccess): Validates the user's access to the project.
+        _access (RateLimitedProjectAccess): Validates access and sets rate-limit identity.
         start_after (datetime | None): Lower bound on span start time (active window).
+        end_before (datetime | None): Upper bound on span start time (active window),
+            symmetric with ``start_after`` so options match the list's window.
 
     Returns:
         FilterValuesResponse: Distinct values ordered by descending frequency.
@@ -165,7 +180,7 @@ async def get_filter_values(
 
     service = get_trace_reader_service()
     values = service.get_distinct_span_values(
-        project_id=project_id, column=column.name, start_after=start_after
+        project_id=project_id, column=column.name, start_after=start_after, end_before=end_before
     )
     return {"field": field, "values": values}
 

--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -20,7 +20,15 @@ from rest.rate_limit import (
     resolve_limit,
 )
 from rest.routers.deps import ProjectAccess, RateLimitedProjectAccess
-from rest.schemas.traces import SpanIOResponse, TraceDetailResponse, TraceListResponse
+from rest.schemas.traces import (
+    FilterFieldsResponse,
+    FilterValuesResponse,
+    SpanIOResponse,
+    TraceDetailResponse,
+    TraceListResponse,
+)
+from rest.services.filters import columns as filter_columns
+from rest.services.filters.translate import parse_filters_param
 from rest.services.trace_reader import get_trace_reader_service
 
 logger = logging.getLogger(__name__)
@@ -46,8 +54,17 @@ async def list_traces(
     search_query: str | None = Query(
         None, description="Search trace_id, name, session_id, user_id"
     ),
+    filters: str | None = Query(
+        None, description="URL-encoded JSON array of {field, op, value} filter predicates"
+    ),
 ):
     """List traces for a project with pagination and filtering."""
+    # Parse + validate filters before the DB try-block so a bad predicate surfaces as a
+    # 422 rather than being swallowed by the broad 500 handler below.
+    try:
+        parsed_filters = parse_filters_param(filters)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=str(e)) from e
     try:
         service = get_trace_reader_service()
         result = service.list_traces(
@@ -59,6 +76,7 @@ async def list_traces(
             start_after=start_after,
             end_before=end_before,
             search_query=search_query,
+            filters=parsed_filters,
         )
         return result
     except Exception as e:
@@ -67,6 +85,89 @@ async def list_traces(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to list traces",
         ) from e
+
+
+@router.get("/filter-fields", response_model=FilterFieldsResponse)
+async def get_filter_fields(
+    project_id: str,
+    _access: ProjectAccess,  # Validates user has access to project
+):
+    """Serialize the filter field registry that drives the filter dropdown.
+
+    Python is the single source of truth for filterable columns, so the frontend
+    holds no second column list.
+
+    Args:
+        project_id (str): Project from the path; scopes access (the field set itself
+            is the same for every project).
+        _access (ProjectAccess): Validates the user's access to the project.
+
+    Returns:
+        FilterFieldsResponse: One entry per registry column with its UI metadata.
+    """
+    return {
+        "fields": [
+            {
+                "field": c.name,
+                "label": c.label,
+                "type": c.type,
+                "level": c.level,
+                "operators": list(c.operators),
+                "value_source": c.value_source,
+                "enum_values": list(c.enum_values),
+                "integer": c.is_integer,
+            }
+            for c in filter_columns.FILTER_COLUMNS
+        ]
+    }
+
+
+@router.get("/filter-values/{field}", response_model=FilterValuesResponse)
+async def get_filter_values(
+    project_id: str,
+    field: str,
+    _access: ProjectAccess,  # Validates user has access to project
+    start_after: datetime | None = Query(
+        None, description="Only consider spans starting at or after this timestamp"
+    ),
+):
+    """Distinct values for an open-ended categorical filter field.
+
+    Only fields the registry marks as distinct-query (model_name, environment) are
+    listable; static-enum and numeric fields are rejected.
+    The field is resolved through the registry before it reaches SQL, so it can never
+    be a raw client-supplied column name.
+
+    Args:
+        project_id (str): Project that owns the spans; server-bound for isolation.
+        field (str): The categorical field to enumerate.
+        _access (ProjectAccess): Validates the user's access to the project.
+        start_after (datetime | None): Lower bound on span start time (active window).
+
+    Returns:
+        FilterValuesResponse: Distinct values ordered by descending frequency.
+
+    Raises:
+        HTTPException: 404 if the field is not in the registry, 400 if it is not a
+            distinct-query categorical.
+    """
+    column = filter_columns.get_column(field)
+    if column is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown filter field: {field}",
+        )
+    if column.value_source != filter_columns.ValueSource.DISTINCT_QUERY:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Field '{field}' does not support distinct-value listing",
+        )
+
+    service = get_trace_reader_service()
+    values = service.get_distinct_span_values(
+        project_id=project_id, column=column.name, start_after=start_after
+    )
+    return {"field": field, "values": values}
 
 
 @router.get("/{trace_id}", response_model=TraceDetailResponse)

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -117,3 +117,38 @@ class TraceDetailResponse(BaseModel):
     output: str | None
     metadata: str | None
     spans: list[SpanResponse]
+
+
+class FilterField(BaseModel):
+    """A single filterable column, serialized from the registry for the UI."""
+
+    field: str
+    label: str
+    type: str
+    level: str
+    operators: list[str]
+    value_source: str
+    enum_values: list[str] = []
+    # True for integer-typed numeric fields (tokens/latency/errors), so the UI can
+    # restrict their inputs to whole numbers.
+    integer: bool = False
+
+
+class FilterFieldsResponse(BaseModel):
+    """The full set of filterable fields driving the filter dropdown."""
+
+    fields: list[FilterField]
+
+
+class FilterValueCount(BaseModel):
+    """A distinct categorical value and how often it occurs."""
+
+    value: str
+    count: int
+
+
+class FilterValuesResponse(BaseModel):
+    """Distinct values for one categorical filter field, by frequency."""
+
+    field: str
+    values: list[FilterValueCount]

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -1,7 +1,7 @@
 """Service for reading traces from ClickHouse."""
 
 import time
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 
 from db.clickhouse import get_clickhouse_client
 from rest.services.filters.translate import Predicate, build_conditions
@@ -25,6 +25,36 @@ DISTINCT_VALUES_LIMIT = 100
 DISTINCT_VALUES_CACHE_TTL_SECONDS = 30
 # Bound the in-process cache so it can't grow without limit across projects/windows.
 DISTINCT_VALUES_CACHE_MAX = 256
+
+# Default lookback for a span scan that arrives with no lower time bound (the filtered
+# trace list AND the categorical distinct-values dropdown). Those scan spans, so an
+# unbounded window is a full-project span scan — the OOM-prone class. The dashboard
+# always sends at least its default window, so this only bounds direct API callers and
+# open-ended custom ranges. Matches the UI's own default preset ("Last 24 hours").
+DEFAULT_SPAN_SCAN_LOOKBACK_HOURS = 24
+
+
+def _floor_minute(dt: datetime | None) -> datetime | None:
+    """Truncate a datetime to the whole minute (for the distinct-values cache key)."""
+    return dt.replace(second=0, microsecond=0) if dt is not None else None
+
+
+def _default_lookback_start(normalized_end: datetime | None) -> datetime:
+    """Default lower bound for an otherwise-unbounded span scan.
+
+    A fixed lookback before the window's end (``normalized_end``) — or before now when
+    the window is open-ended — so the filtered list and the distinct-values query share
+    one symmetric default and neither ever scans spans all-time.
+
+    Args:
+        normalized_end (datetime | None): Naive-UTC upper bound of the active window,
+            or ``None`` for an open-ended window.
+
+    Returns:
+        datetime: Naive-UTC lower bound, ``lookback`` hours before the upper bound/now.
+    """
+    upper = normalized_end if normalized_end is not None else datetime.now(UTC).replace(tzinfo=None)
+    return upper - timedelta(hours=DEFAULT_SPAN_SCAN_LOOKBACK_HOURS)
 
 
 def span_cost_details(
@@ -74,6 +104,7 @@ class TraceReaderService:
         project_id: str,
         column: str,
         start_after: datetime | None = None,
+        end_before: datetime | None = None,
     ) -> list[dict]:
         """Distinct values of a span column within the active window, by frequency.
 
@@ -88,13 +119,31 @@ class TraceReaderService:
                 names cannot be bound as query parameters.
             start_after (datetime | None): Lower bound on ``span_start_time``; prunes
                 monthly partitions. ``None`` scans all time.
+            end_before (datetime | None): Upper bound on ``span_start_time`` (exclusive),
+                symmetric with the trace list's window so the dropdown never offers
+                values from traces newer than the active window's end.
 
         Returns:
             list[dict]: ``[{"value": str, "count": int}]`` ordered by descending
             frequency, capped at ``DISTINCT_VALUES_LIMIT``.
         """
         normalized_start = to_utc_naive(start_after) if start_after is not None else None
-        cache_key = (project_id, column, normalized_start)
+        normalized_end = to_utc_naive(end_before) if end_before is not None else None
+        # Never scan spans unbounded (the OOM class the filtered list guards against): if no
+        # lower bound was given, default one — symmetric with the filtered trace list. The UI
+        # always sends a window; this bounds a direct API caller that omits one.
+        if normalized_start is None:
+            normalized_start = _default_lookback_start(normalized_end)
+        # Quantize the cache key to whole minutes so per-render jitter in the window
+        # bounds (the UI recomputes "now - duration" every render) can't trivially
+        # bypass the cache and force a fresh full-project GROUP BY on every open. The
+        # 30s TTL already accepts this much staleness in the returned option list.
+        cache_key = (
+            project_id,
+            column,
+            _floor_minute(normalized_start),
+            _floor_minute(normalized_end),
+        )
         now = time.time()
         cached = self._distinct_cache.get(cache_key)
         if cached is not None and cached[0] > now:
@@ -105,6 +154,9 @@ class TraceReaderService:
         if normalized_start is not None:
             inner_conditions.append("span_start_time >= {start_after:DateTime64(3)}")
             params["start_after"] = normalized_start
+        if normalized_end is not None:
+            inner_conditions.append("span_start_time < {end_before:DateTime64(3)}")
+            params["end_before"] = normalized_end
         inner_where = " AND ".join(inner_conditions)
 
         # Dedup ReplacingMergeTree spans to the latest version per span BEFORE counting, so
@@ -165,9 +217,10 @@ class TraceReaderService:
             conditions.append("t.trace_start_time >= {start_after:DateTime64(3)}")
             params["start_after"] = to_utc_naive(start_after)
 
-        if end_before is not None:
+        normalized_end = to_utc_naive(end_before) if end_before is not None else None
+        if normalized_end is not None:
             conditions.append("t.trace_start_time < {end_before:DateTime64(3)}")
-            params["end_before"] = to_utc_naive(end_before)
+            params["end_before"] = normalized_end
 
         # Multi-field keyword search (trace_id, name, session_id, user_id)
         if search_query:
@@ -178,6 +231,14 @@ class TraceReaderService:
                 "OR t.user_id ILIKE {search_kw:String})"
             )
             params["search_kw"] = f"%{escape_ilike(search_query)}%"
+
+        # Filters scan spans (semi-joins), so a filtered list with no lower time bound
+        # would be an unbounded full-project span scan in both the page and count queries.
+        # Default a lookback window so those sub-queries prune monthly partitions, and bound
+        # the trace query to the same window so the page, count, and span scans stay consistent.
+        if filters and start_after is None:
+            params["start_after"] = _default_lookback_start(normalized_end)
+            conditions.append("t.trace_start_time >= {start_after:DateTime64(3)}")
 
         # Registry-driven attribute filters (model/cost/errors/...). Appended to the
         # SHARED conditions so they land in both the page query and the count query;

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -1,8 +1,10 @@
 """Service for reading traces from ClickHouse."""
 
+import time
 from datetime import datetime
 
 from db.clickhouse import get_clickhouse_client
+from rest.services.filters.translate import Predicate, build_conditions
 from rest.sql_utils import escape_ilike, to_utc_naive
 from worker.tokens.buckets import TokenBuckets, reconcile_cache_write_1h
 from worker.tokens.pricing import cost_breakdown_from_buckets, get_model_price
@@ -15,6 +17,14 @@ from worker.tokens.pricing import cost_breakdown_from_buckets, get_model_price
 # month with toYYYYMM(span_start_time), values under about a month usually skip
 # the same old monthly partitions.
 TRACE_SPAN_LOOKBACK_HOURS = 1
+
+# Distinct-values endpoint: cap the option list and cache briefly. The dropdown only
+# needs the frequent values, and the GROUP BY over spans is the heavy part — a short
+# TTL absorbs repeated opens of the same filter without staleness mattering.
+DISTINCT_VALUES_LIMIT = 100
+DISTINCT_VALUES_CACHE_TTL_SECONDS = 30
+# Bound the in-process cache so it can't grow without limit across projects/windows.
+DISTINCT_VALUES_CACHE_MAX = 256
 
 
 def span_cost_details(
@@ -56,6 +66,72 @@ class TraceReaderService:
 
     def __init__(self):
         self._client = get_clickhouse_client()
+        # Per-(project, column, window) cache of distinct values: key -> (expiry, rows).
+        self._distinct_cache: dict[tuple, tuple[float, list[dict]]] = {}
+
+    def get_distinct_span_values(
+        self,
+        project_id: str,
+        column: str,
+        start_after: datetime | None = None,
+    ) -> list[dict]:
+        """Distinct values of a span column within the active window, by frequency.
+
+        Powers the filter dropdown's categorical options (model, environment).
+        Time-bounded and briefly cached so repeatedly opening the same filter does
+        not re-scan spans.
+
+        Args:
+            project_id (str): Project that scopes the span scan (tenant isolation).
+            column (str): A spans column name. MUST be a registry-resolved identifier,
+                never raw user input — it is interpolated into the SQL because column
+                names cannot be bound as query parameters.
+            start_after (datetime | None): Lower bound on ``span_start_time``; prunes
+                monthly partitions. ``None`` scans all time.
+
+        Returns:
+            list[dict]: ``[{"value": str, "count": int}]`` ordered by descending
+            frequency, capped at ``DISTINCT_VALUES_LIMIT``.
+        """
+        normalized_start = to_utc_naive(start_after) if start_after is not None else None
+        cache_key = (project_id, column, normalized_start)
+        now = time.time()
+        cached = self._distinct_cache.get(cache_key)
+        if cached is not None and cached[0] > now:
+            return cached[1]
+
+        params: dict = {"project_id": project_id}
+        inner_conditions = ["project_id = {project_id:String}"]
+        if normalized_start is not None:
+            inner_conditions.append("span_start_time >= {start_after:DateTime64(3)}")
+            params["start_after"] = normalized_start
+        inner_where = " AND ".join(inner_conditions)
+
+        # Dedup ReplacingMergeTree spans to the latest version per span BEFORE counting, so
+        # a since-updated span can't inflate a value's count or surface a stale value. The
+        # column non-empty filter runs on the deduped (latest) value in the outer query.
+        query = f"""
+            SELECT value, count() AS n
+            FROM (
+                SELECT {column} AS value
+                FROM spans
+                WHERE {inner_where}
+                ORDER BY ch_update_time DESC
+                LIMIT 1 BY project_id, trace_id, span_id
+            )
+            WHERE value IS NOT NULL AND value != ''
+            GROUP BY value
+            ORDER BY n DESC
+            LIMIT {DISTINCT_VALUES_LIMIT}
+        """
+        result = self._client.query(query, parameters=params)
+        rows = [{"value": str(row[0]), "count": int(row[1])} for row in result.result_rows]
+        # Bound the cache: drop expired entries, then evict oldest if still at capacity.
+        self._distinct_cache = {k: v for k, v in self._distinct_cache.items() if v[0] > now}
+        if len(self._distinct_cache) >= DISTINCT_VALUES_CACHE_MAX:
+            self._distinct_cache.pop(next(iter(self._distinct_cache)))
+        self._distinct_cache[cache_key] = (now + DISTINCT_VALUES_CACHE_TTL_SECONDS, rows)
+        return rows
 
     def list_traces(
         self,
@@ -67,6 +143,7 @@ class TraceReaderService:
         start_after: datetime | None = None,
         end_before: datetime | None = None,
         search_query: str | None = None,
+        filters: list[Predicate] | None = None,
     ) -> dict:
         """List traces with aggregated metrics from spans."""
         offset = page * limit
@@ -101,6 +178,11 @@ class TraceReaderService:
                 "OR t.user_id ILIKE {search_kw:String})"
             )
             params["search_kw"] = f"%{escape_ilike(search_query)}%"
+
+        # Registry-driven attribute filters (model/cost/errors/...). Appended to the
+        # SHARED conditions so they land in both the page query and the count query;
+        # the span sub-queries reuse start_after (above) as a span-scan lower bound.
+        conditions.extend(build_conditions(filters or [], params))
 
         where_clause = " AND ".join(conditions)
 

--- a/tests/rest/test_trace_filter_meta.py
+++ b/tests/rest/test_trace_filter_meta.py
@@ -102,6 +102,17 @@ class TestFilterValues:
             "start_after"
         ] == datetime(2026, 6, 1, 0, 0, 0)
 
+    def test_end_before_is_threaded_to_the_service(self, client, mock_trace_reader):
+        mock_trace_reader.get_distinct_span_values.return_value = []
+        resp = client.get(
+            "/api/v1/projects/p1/traces/filter-values/environment"
+            "?start_after=2026-06-01T00:00:00&end_before=2026-06-02T00:00:00"
+        )
+        assert resp.status_code == 200
+        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        assert kw["start_after"] == datetime(2026, 6, 1, 0, 0, 0)
+        assert kw["end_before"] == datetime(2026, 6, 2, 0, 0, 0)
+
     def test_unknown_field_is_404(self, client, mock_trace_reader):
         resp = client.get("/api/v1/projects/p1/traces/filter-values/not_a_field")
         assert resp.status_code == 404
@@ -139,7 +150,44 @@ class TestGetDistinctSpanValues:
         assert "project_id = {project_id:String}" in query_text
         params = kwargs["parameters"]
         assert params["project_id"] == "p1"
-        assert "start_after" not in params  # no window → no time bound
+
+    def test_no_window_defaults_a_lookback_bound_never_unbounded(self, monkeypatch):
+        """A direct caller passing no window must not trigger an all-time span scan:
+        a default lower bound is injected (symmetric with the filtered trace list)."""
+        from datetime import UTC, datetime, timedelta
+
+        from rest.services.trace_reader import DEFAULT_SPAN_SCAN_LOOKBACK_HOURS
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        before = datetime.now(UTC).replace(tzinfo=None)
+        svc.get_distinct_span_values(project_id="p1", column="model_name")
+        after = datetime.now(UTC).replace(tzinfo=None)
+
+        sql, kwargs = mock_client.query.call_args
+        assert "span_start_time >= {start_after:DateTime64(3)}" in sql[0]
+        lo, hi = (
+            before - timedelta(hours=DEFAULT_SPAN_SCAN_LOOKBACK_HOURS),
+            after - timedelta(hours=DEFAULT_SPAN_SCAN_LOOKBACK_HOURS),
+        )
+        assert lo <= kwargs["parameters"]["start_after"] <= hi
+
+    def test_end_before_only_defaults_start_relative_to_it(self, monkeypatch):
+        from datetime import datetime, timedelta
+
+        from rest.services.trace_reader import DEFAULT_SPAN_SCAN_LOOKBACK_HOURS
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        end = datetime(2026, 6, 2, 12, 0, 0)
+        svc.get_distinct_span_values(project_id="p1", column="model_name", end_before=end)
+
+        params = mock_client.query.call_args.kwargs["parameters"]
+        assert params["start_after"] == end - timedelta(hours=DEFAULT_SPAN_SCAN_LOOKBACK_HOURS)
 
     def test_start_after_adds_a_time_bound(self, monkeypatch):
         mock_client = MagicMock()
@@ -152,6 +200,36 @@ class TestGetDistinctSpanValues:
         sql, kwargs = mock_client.query.call_args
         assert "span_start_time >= {start_after:DateTime64(3)}" in sql[0]
         assert kwargs["parameters"]["start_after"] is not None
+
+    def test_end_before_adds_an_upper_time_bound(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_span_values(
+            project_id="p1",
+            column="model_name",
+            start_after=datetime(2026, 6, 1),
+            end_before=datetime(2026, 6, 2),
+        )
+        sql, kwargs = mock_client.query.call_args
+        assert "span_start_time < {end_before:DateTime64(3)}" in sql[0]
+        assert kwargs["parameters"]["end_before"] == datetime(2026, 6, 2)
+
+    def test_subminute_window_jitter_reuses_the_cache(self, monkeypatch):
+        """Sub-minute jitter in the window (the UI recomputes "now" each render) must
+        share one cache entry, so it can't trivially bypass the cache."""
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("gpt-4", 10)]
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_span_values(
+            project_id="p1", column="model_name", start_after=datetime(2026, 6, 1, 0, 0, 5)
+        )
+        svc.get_distinct_span_values(
+            project_id="p1", column="model_name", start_after=datetime(2026, 6, 1, 0, 0, 45)
+        )
+        mock_client.query.assert_called_once()  # same minute → one heavy GROUP BY
 
     def test_results_are_cached_per_project_field_window(self, monkeypatch):
         mock_client = MagicMock()

--- a/tests/rest/test_trace_filter_meta.py
+++ b/tests/rest/test_trace_filter_meta.py
@@ -1,0 +1,190 @@
+"""Unit tests for the trace-filter meta endpoints and the distinct-values query.
+
+Covers ``GET /traces/filter-fields`` (registry serialization) and
+``GET /traces/filter-values/{field}`` (distinct categorical values), plus the
+``TraceReaderService.get_distinct_span_values`` query + cache. Uses TestClient with
+mocked dependencies — no ClickHouse needed.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from rest.routers.deps import ProjectAccessInfo, get_project_access
+from rest.services.filters import columns as reg
+
+
+@pytest.fixture()
+def mock_trace_reader():
+    return MagicMock()
+
+
+@pytest.fixture()
+def client(mock_trace_reader):
+    async def mock_get_access(project_id: str, x_user_id=None):
+        return ProjectAccessInfo(
+            project_id=project_id,
+            user_id="test-user",
+            role="ADMIN",
+            workspace_id="ws-test",
+            billing_plan="free",
+        )
+
+    app.dependency_overrides[get_project_access] = mock_get_access
+
+    import rest.routers.traces as traces_mod
+
+    original = traces_mod.get_trace_reader_service
+    traces_mod.get_trace_reader_service = lambda: mock_trace_reader
+    yield TestClient(app)
+    traces_mod.get_trace_reader_service = original
+    app.dependency_overrides.clear()
+
+
+class TestFilterFields:
+    def test_returns_every_registry_field(self, client):
+        resp = client.get("/api/v1/projects/p1/traces/filter-fields")
+        assert resp.status_code == 200
+        fields = resp.json()["fields"]
+        assert {f["field"] for f in fields} == {c.name for c in reg.FILTER_COLUMNS}
+
+    def test_serializes_field_shape_from_registry(self, client):
+        fields = {
+            f["field"]: f
+            for f in client.get("/api/v1/projects/p1/traces/filter-fields").json()["fields"]
+        }
+
+        model = fields["model_name"]
+        assert model["type"] == "categorical"
+        assert model["level"] == "SPAN_MEMBERSHIP"
+        assert model["operators"] == ["in"]
+        assert model["value_source"] == "distinct_query"
+        assert model["enum_values"] == []
+
+        cost = fields["cost"]
+        assert cost["type"] == "numeric"
+        assert cost["operators"] == ["between"]
+        assert cost["value_source"] == "range"
+        # Integer-typed fields are flagged so the UI restricts them to whole numbers;
+        # cost (Decimal) and model (String) are not.
+        assert fields["total_tokens"]["integer"] is True
+        assert fields["duration_ms"]["integer"] is True
+        assert fields["errors"]["integer"] is True
+        assert cost["integer"] is False
+        assert model["integer"] is False
+
+
+class TestFilterValues:
+    def test_model_name_returns_values_by_frequency(self, client, mock_trace_reader):
+        mock_trace_reader.get_distinct_span_values.return_value = [
+            {"value": "gpt-4", "count": 10},
+            {"value": "claude-opus-4.8", "count": 4},
+        ]
+        resp = client.get("/api/v1/projects/p1/traces/filter-values/model_name")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["field"] == "model_name"
+        assert body["values"][0] == {"value": "gpt-4", "count": 10}
+        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        assert kw["project_id"] == "p1"
+        assert kw["column"] == "model_name"
+
+    def test_start_after_is_threaded_to_the_service(self, client, mock_trace_reader):
+        mock_trace_reader.get_distinct_span_values.return_value = []
+        resp = client.get(
+            "/api/v1/projects/p1/traces/filter-values/environment?start_after=2026-06-01T00:00:00"
+        )
+        assert resp.status_code == 200
+        assert mock_trace_reader.get_distinct_span_values.call_args.kwargs[
+            "start_after"
+        ] == datetime(2026, 6, 1, 0, 0, 0)
+
+    def test_unknown_field_is_404(self, client, mock_trace_reader):
+        resp = client.get("/api/v1/projects/p1/traces/filter-values/not_a_field")
+        assert resp.status_code == 404
+        mock_trace_reader.get_distinct_span_values.assert_not_called()
+
+    def test_numeric_field_is_rejected(self, client, mock_trace_reader):
+        resp = client.get("/api/v1/projects/p1/traces/filter-values/cost")
+        assert resp.status_code == 400
+        mock_trace_reader.get_distinct_span_values.assert_not_called()
+
+
+class TestGetDistinctSpanValues:
+    def _service(self, monkeypatch, mock_client):
+        import rest.services.trace_reader as tr_mod
+
+        monkeypatch.setattr(tr_mod, "get_clickhouse_client", lambda: mock_client)
+        return tr_mod.TraceReaderService()
+
+    def test_builds_grouped_project_scoped_query(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("gpt-4", 10), ("claude", 5)]
+        svc = self._service(monkeypatch, mock_client)
+
+        out = svc.get_distinct_span_values(project_id="p1", column="model_name")
+
+        assert out == [
+            {"value": "gpt-4", "count": 10},
+            {"value": "claude", "count": 5},
+        ]
+        sql, kwargs = mock_client.query.call_args
+        query_text = sql[0]
+        assert "FROM spans" in query_text
+        assert "GROUP BY" in query_text
+        assert "model_name" in query_text
+        assert "project_id = {project_id:String}" in query_text
+        params = kwargs["parameters"]
+        assert params["project_id"] == "p1"
+        assert "start_after" not in params  # no window → no time bound
+
+    def test_start_after_adds_a_time_bound(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_span_values(
+            project_id="p1", column="model_name", start_after=datetime(2026, 6, 1)
+        )
+        sql, kwargs = mock_client.query.call_args
+        assert "span_start_time >= {start_after:DateTime64(3)}" in sql[0]
+        assert kwargs["parameters"]["start_after"] is not None
+
+    def test_results_are_cached_per_project_field_window(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("gpt-4", 10)]
+        svc = self._service(monkeypatch, mock_client)
+
+        first = svc.get_distinct_span_values(project_id="p1", column="model_name")
+        second = svc.get_distinct_span_values(project_id="p1", column="model_name")
+
+        assert first == second
+        mock_client.query.assert_called_once()  # second call served from cache
+
+    def test_query_excludes_null_and_empty_values(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_span_values(project_id="p1", column="model_name")
+        query_text = mock_client.query.call_args[0][0]
+        assert "model_name AS value" in query_text
+        assert "value IS NOT NULL" in query_text
+        assert "value != ''" in query_text  # blanks aren't offered as options
+        # Deduped to the latest ReplacingMergeTree version per span before counting.
+        assert "LIMIT 1 BY project_id, trace_id, span_id" in query_text
+
+    def test_cache_is_bounded(self, monkeypatch):
+        from rest.services.trace_reader import DISTINCT_VALUES_CACHE_MAX
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        # Far more distinct cache keys than the cap; size must stay bounded.
+        for i in range(DISTINCT_VALUES_CACHE_MAX + 50):
+            svc.get_distinct_span_values(project_id=f"p{i}", column="model_name")
+        assert len(svc._distinct_cache) <= DISTINCT_VALUES_CACHE_MAX

--- a/tests/rest/test_trace_list_filters.py
+++ b/tests/rest/test_trace_list_filters.py
@@ -1,0 +1,73 @@
+"""Endpoint tests for the trace-list ``?filters=`` param.
+
+Covers that a valid predicate array is parsed and threaded into ``list_traces``, and
+that a malformed array or an unknown field/operator is rejected with 422 (not swallowed
+by the list endpoint's broad 500 handler). Mocked deps — no ClickHouse.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from rest.routers.deps import ProjectAccessInfo, get_project_access
+from rest.services.filters.translate import Predicate
+
+_EMPTY_PAGE = {"data": [], "meta": {"page": 0, "limit": 50, "total": 0}}
+
+
+@pytest.fixture()
+def mock_trace_reader():
+    m = MagicMock()
+    m.list_traces.return_value = _EMPTY_PAGE
+    return m
+
+
+@pytest.fixture()
+def client(mock_trace_reader):
+    async def mock_get_access(project_id: str, x_user_id=None):
+        return ProjectAccessInfo(
+            project_id=project_id,
+            user_id="test-user",
+            role="ADMIN",
+            workspace_id="ws-test",
+            billing_plan="free",
+        )
+
+    app.dependency_overrides[get_project_access] = mock_get_access
+    import rest.routers.traces as traces_mod
+
+    original = traces_mod.get_trace_reader_service
+    traces_mod.get_trace_reader_service = lambda: mock_trace_reader
+    yield TestClient(app)
+    traces_mod.get_trace_reader_service = original
+    app.dependency_overrides.clear()
+
+
+def test_valid_filters_are_parsed_and_threaded_to_the_service(client, mock_trace_reader):
+    raw = json.dumps([{"field": "model_name", "op": "in", "value": ["gpt-4"]}])
+    resp = client.get("/api/v1/projects/p1/traces", params={"filters": raw})
+    assert resp.status_code == 200
+    threaded = mock_trace_reader.list_traces.call_args.kwargs["filters"]
+    assert threaded == [Predicate(field="model_name", op="in", value=["gpt-4"])]
+
+
+def test_no_filters_param_threads_an_empty_list(client, mock_trace_reader):
+    resp = client.get("/api/v1/projects/p1/traces")
+    assert resp.status_code == 200
+    assert mock_trace_reader.list_traces.call_args.kwargs["filters"] == []
+
+
+def test_unknown_field_returns_422(client, mock_trace_reader):
+    raw = json.dumps([{"field": "nope", "op": "in", "value": ["x"]}])
+    resp = client.get("/api/v1/projects/p1/traces", params={"filters": raw})
+    assert resp.status_code == 422
+    mock_trace_reader.list_traces.assert_not_called()
+
+
+def test_malformed_json_returns_422(client, mock_trace_reader):
+    resp = client.get("/api/v1/projects/p1/traces", params={"filters": "not json"})
+    assert resp.status_code == 422
+    mock_trace_reader.list_traces.assert_not_called()

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -7,10 +7,13 @@ would exceed the visible rows. These tests assert the filter condition is interp
 into both, using a mocked ClickHouse client (no live DB), mirroring the repo's pattern.
 """
 
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
 from rest.services.filters.translate import Predicate
-from rest.services.trace_reader import TraceReaderService
+from rest.services.trace_reader import DEFAULT_SPAN_SCAN_LOOKBACK_HOURS, TraceReaderService
+
+_MODEL_FILTER = [Predicate(field="model_name", op="in", value=["gpt-4"])]
 
 
 def _service_with_mock_client():
@@ -68,3 +71,55 @@ def test_no_filters_adds_no_semijoin():
 
     page_sql = svc._client.query.call_args_list[0].args[0]
     assert "t.trace_id IN (" not in page_sql
+
+
+def test_filtered_list_without_window_gets_default_lookback_in_both_queries():
+    """A filtered list with no lower time bound must not emit an unbounded span scan:
+    a default lookback is injected into the page and count queries and bounds the spans."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1", filters=_MODEL_FILTER)
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    count_sql = svc._client.query.call_args_list[1].args[0]
+    assert "t.trace_start_time >= {start_after:DateTime64(3)}" in page_sql
+    assert "t.trace_start_time >= {start_after:DateTime64(3)}" in count_sql
+    # The span semi-join is time-bounded (partition pruning), not all-time.
+    assert "span_start_time >= {start_after:DateTime64(3)}" in page_sql
+    assert "start_after" in svc._client.query.call_args_list[0].kwargs["parameters"]
+
+
+def test_explicit_start_after_is_not_overridden_by_the_default():
+    svc = _service_with_mock_client()
+    _drive(svc)
+    explicit = datetime(2026, 6, 1)
+
+    svc.list_traces(project_id="p1", start_after=explicit, filters=_MODEL_FILTER)
+
+    params = svc._client.query.call_args_list[0].kwargs["parameters"]
+    assert params["start_after"] == explicit  # the caller's window wins
+
+
+def test_default_lookback_is_relative_to_end_before_when_present():
+    svc = _service_with_mock_client()
+    _drive(svc)
+    end = datetime(2026, 6, 2, 12, 0, 0)
+
+    svc.list_traces(project_id="p1", end_before=end, filters=_MODEL_FILTER)
+
+    params = svc._client.query.call_args_list[0].kwargs["parameters"]
+    assert params["start_after"] == end - timedelta(hours=DEFAULT_SPAN_SCAN_LOOKBACK_HOURS)
+
+
+def test_unfiltered_list_without_window_stays_unbounded():
+    """The default lookback is a filtered-path guard; unfiltered behavior is unchanged."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    params = svc._client.query.call_args_list[0].kwargs["parameters"]
+    assert "start_after" not in params
+    assert "t.trace_start_time >=" not in page_sql

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -1,0 +1,70 @@
+"""Wiring tests: a filter predicate must reach BOTH the page query and the count query.
+
+The pagination-correctness invariant for the whole feature. ``list_traces`` runs two
+physically separate queries — the paginated page and the ``count(DISTINCT ...)`` total
+— off one shared ``where_clause``. If a filter reached only the page, ``meta.total``
+would exceed the visible rows. These tests assert the filter condition is interpolated
+into both, using a mocked ClickHouse client (no live DB), mirroring the repo's pattern.
+"""
+
+from unittest.mock import MagicMock
+
+from rest.services.filters.translate import Predicate
+from rest.services.trace_reader import TraceReaderService
+
+
+def _service_with_mock_client():
+    svc = TraceReaderService.__new__(TraceReaderService)  # skip real-client __init__
+    svc._client = MagicMock()
+    return svc
+
+
+def _drive(svc):
+    """Return (page_result, count_result) so list_traces yields an empty page, total 0."""
+    page_res, count_res = MagicMock(), MagicMock()
+    page_res.result_rows = []
+    count_res.result_rows = [[0]]
+    svc._client.query.side_effect = [page_res, count_res]
+
+
+def test_membership_filter_lands_in_both_page_and_count_queries():
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(
+        project_id="p1",
+        filters=[Predicate(field="model_name", op="in", value=["gpt-4"])],
+    )
+
+    assert svc._client.query.call_count == 2
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    count_sql = svc._client.query.call_args_list[1].args[0]
+    assert "t.trace_id IN (" in page_sql
+    assert "t.trace_id IN (" in count_sql  # the invariant — filter reaches the count too
+    params = svc._client.query.call_args_list[0].kwargs["parameters"]
+    assert params["f_model_name_0"] == ["gpt-4"]
+
+
+def test_aggregate_filter_lands_in_both_page_and_count_queries():
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(
+        project_id="p1",
+        filters=[Predicate(field="cost", op="between", value=[0.5, None])],
+    )
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    count_sql = svc._client.query.call_args_list[1].args[0]
+    assert "GROUP BY trace_id HAVING" in page_sql
+    assert "GROUP BY trace_id HAVING" in count_sql
+
+
+def test_no_filters_adds_no_semijoin():
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    assert "t.trace_id IN (" not in page_sql


### PR DESCRIPTION
Closes #1372
Closes #1371

Wires the registry/translator into the API (PR 2/5; base `feat/trace-filter-backend-core`).

- `GET /filter-fields` — serializes the registry (incl. the `integer` hint) that drives the UI; Python stays the single source of truth.
- `GET /filter-values/{field}` — distinct categorical values (model/environment), time-bounded + briefly cached.
- `?filters=` on the trace list — a validated predicate array AND-combined into the **shared** conditions that feed both the page query and the count query, so results and totals stay consistent.
- Reader integration.

Tested: meta endpoints, list filtering, reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds filter metadata endpoints and queryable filters to the trace list, powered by the Python registry. Endpoints are rate-limited, and a default 24h lookback (relative to end_before or now) prevents unbounded span scans so pages and totals stay in sync.

- **New Features**
  - GET /traces/filter-fields — returns registry fields with label, type, level, operators, value_source, enum_values, and an `integer` hint for numeric inputs.
  - GET /traces/filter-values/{field} — top 100 categorical values by frequency, scoped by project and optional start_after/end_before; defaults to a 24h lookback when no lower bound is provided (relative to end_before or now); deduped to the latest span version; null/empty excluded; 30s in-process cache with a bounded size and minute-quantized keys; 404 for unknown fields, 400 if the field doesn’t support distinct listing; rate-limited via the shared read limiter.
  - Trace list `?filters=` — URL-encoded JSON array of {field, op, value}; parsed early and validated (422 on bad JSON/unknown field/op); predicates apply to the shared conditions for both page and total; when filters are present without a lower bound, a 24h lookback (relative to end_before or now) is injected to avoid unbounded span scans.

<sup>Written for commit af24d7e50e87089cdaee292e284f41a77d92aa56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

