### PR TITLE
feat(ui): trace-filter predicate IR, API client, field registry

### DIFF
--- a/frontend/ui/src/features/filters/predicate-ui.test.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  predicateLabel,
+  buildInPredicate,
+  buildBetweenPredicate,
+  upsertPredicate,
+} from "./predicate-ui";
+
+describe("predicateLabel", () => {
+  it("renders a single-value `in` as an equality", () => {
+    expect(predicateLabel({ field: "model_name", op: "in", value: ["claude-opus-4.8"] })).toBe(
+      "model_name = claude-opus-4.8",
+    );
+  });
+
+  it("renders a multi-value `in` as a list", () => {
+    expect(
+      predicateLabel({ field: "model_name", op: "in", value: ["claude-opus-4.8", "gpt-4"] }),
+    ).toBe("model_name in [claude-opus-4.8, gpt-4]");
+  });
+
+  it("renders an open lower bound as greater-than", () => {
+    expect(predicateLabel({ field: "cost", op: "between", value: [0.5, null] })).toBe("cost > 0.5");
+  });
+
+  it("renders an open upper bound as less-than", () => {
+    expect(predicateLabel({ field: "cost", op: "between", value: [null, 10] })).toBe("cost < 10");
+  });
+
+  it("renders a closed range as between", () => {
+    expect(predicateLabel({ field: "cost", op: "between", value: [0.5, 10] })).toBe(
+      "cost between 0.5 and 10",
+    );
+  });
+
+  it("renders equal bounds (from `equals`) as `=`", () => {
+    expect(predicateLabel({ field: "cost", op: "between", value: [5, 5] })).toBe("cost = 5");
+  });
+
+  it("uses the supplied display name in place of the raw field key", () => {
+    expect(
+      predicateLabel({ field: "duration_ms", op: "between", value: [5, null] }, "latency"),
+    ).toBe("latency > 5");
+    expect(predicateLabel({ field: "model_name", op: "in", value: ["gpt-4"] }, "model")).toBe(
+      "model = gpt-4",
+    );
+  });
+});
+
+describe("predicate builders", () => {
+  it("buildInPredicate makes a categorical `in` predicate", () => {
+    expect(buildInPredicate("status", ["ERROR"])).toEqual({
+      field: "status",
+      op: "in",
+      value: ["ERROR"],
+    });
+  });
+
+  it("buildBetweenPredicate makes a numeric `between` predicate with nullable bounds", () => {
+    expect(buildBetweenPredicate("cost", 0.5, null)).toEqual({
+      field: "cost",
+      op: "between",
+      value: [0.5, null],
+    });
+  });
+});
+
+describe("upsertPredicate", () => {
+  const gt = (f: string, lo: number) => buildBetweenPredicate(f, lo, null);
+  const lt = (f: string, hi: number) => buildBetweenPredicate(f, null, hi);
+
+  it("keeps a lower and an upper bound on the same field to form a range", () => {
+    const afterLower = upsertPredicate([], gt("duration_ms", 5));
+    const afterRange = upsertPredicate(afterLower, lt("duration_ms", 10));
+    expect(afterRange).toEqual([gt("duration_ms", 5), lt("duration_ms", 10)]);
+  });
+
+  it("replaces a same-direction bound rather than stacking two lower bounds", () => {
+    const start = [gt("duration_ms", 5), lt("duration_ms", 10)];
+    expect(upsertPredicate(start, gt("duration_ms", 8))).toEqual([
+      lt("duration_ms", 10),
+      gt("duration_ms", 8),
+    ]);
+  });
+
+  it("a new upper bound that contradicts the lower bound supersedes it (empty range)", () => {
+    // errors > 5 then errors < 3 — no value satisfies both, so the newer one wins.
+    expect(upsertPredicate([gt("errors", 5)], lt("errors", 3))).toEqual([lt("errors", 3)]);
+  });
+
+  it("a new lower bound that contradicts the upper bound supersedes it", () => {
+    // errors < 3 then errors > 5 — the newer lower bound wins.
+    expect(upsertPredicate([lt("errors", 3)], gt("errors", 5))).toEqual([gt("errors", 5)]);
+  });
+
+  it("treats equal bounds as an empty range (>= is inclusive, < is strict)", () => {
+    // errors > 5 then errors < 5 — 5 <= x < 5 is empty, so the newer one wins.
+    expect(upsertPredicate([gt("errors", 5)], lt("errors", 5))).toEqual([lt("errors", 5)]);
+  });
+
+  it("keeps a valid (non-empty) opposite bound: lower < upper", () => {
+    expect(upsertPredicate([gt("duration_ms", 3)], lt("duration_ms", 5))).toEqual([
+      gt("duration_ms", 3),
+      lt("duration_ms", 5),
+    ]);
+  });
+
+  it("an exact `equals` (both bounds equal) supersedes both range bounds", () => {
+    const start = [gt("cost", 1), lt("cost", 5)];
+    expect(upsertPredicate(start, buildBetweenPredicate("cost", 3, 3))).toEqual([
+      buildBetweenPredicate("cost", 3, 3),
+    ]);
+  });
+
+  it("a categorical value replaces the existing one on its field, untouched others", () => {
+    const start = [gt("cost", 1), buildInPredicate("model_name", ["gpt-4o"])];
+    expect(upsertPredicate(start, buildInPredicate("model_name", ["claude"]))).toEqual([
+      gt("cost", 1),
+      buildInPredicate("model_name", ["claude"]),
+    ]);
+  });
+
+  it("never touches predicates on other fields", () => {
+    const start = [gt("duration_ms", 5), gt("cost", 1)];
+    expect(upsertPredicate(start, lt("duration_ms", 10))).toEqual([
+      gt("duration_ms", 5),
+      gt("cost", 1),
+      lt("duration_ms", 10),
+    ]);
+  });
+});

--- a/frontend/ui/src/features/filters/predicate-ui.test.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.test.ts
@@ -19,12 +19,12 @@ describe("predicateLabel", () => {
     ).toBe("model_name in [claude-opus-4.8, gpt-4]");
   });
 
-  it("renders an open lower bound as greater-than", () => {
-    expect(predicateLabel({ field: "cost", op: "between", value: [0.5, null] })).toBe("cost > 0.5");
+  it("renders an open lower bound as inclusive ≥", () => {
+    expect(predicateLabel({ field: "cost", op: "between", value: [0.5, null] })).toBe("cost ≥ 0.5");
   });
 
-  it("renders an open upper bound as less-than", () => {
-    expect(predicateLabel({ field: "cost", op: "between", value: [null, 10] })).toBe("cost < 10");
+  it("renders an open upper bound as inclusive ≤", () => {
+    expect(predicateLabel({ field: "cost", op: "between", value: [null, 10] })).toBe("cost ≤ 10");
   });
 
   it("renders a closed range as between", () => {
@@ -40,7 +40,7 @@ describe("predicateLabel", () => {
   it("uses the supplied display name in place of the raw field key", () => {
     expect(
       predicateLabel({ field: "duration_ms", op: "between", value: [5, null] }, "latency"),
-    ).toBe("latency > 5");
+    ).toBe("latency ≥ 5");
     expect(predicateLabel({ field: "model_name", op: "in", value: ["gpt-4"] }, "model")).toBe(
       "model = gpt-4",
     );
@@ -66,66 +66,69 @@ describe("predicate builders", () => {
 });
 
 describe("upsertPredicate", () => {
-  const gt = (f: string, lo: number) => buildBetweenPredicate(f, lo, null);
-  const lt = (f: string, hi: number) => buildBetweenPredicate(f, null, hi);
+  const gte = (f: string, lo: number) => buildBetweenPredicate(f, lo, null);
+  const lte = (f: string, hi: number) => buildBetweenPredicate(f, null, hi);
 
   it("keeps a lower and an upper bound on the same field to form a range", () => {
-    const afterLower = upsertPredicate([], gt("duration_ms", 5));
-    const afterRange = upsertPredicate(afterLower, lt("duration_ms", 10));
-    expect(afterRange).toEqual([gt("duration_ms", 5), lt("duration_ms", 10)]);
+    const afterLower = upsertPredicate([], gte("duration_ms", 5));
+    const afterRange = upsertPredicate(afterLower, lte("duration_ms", 10));
+    expect(afterRange).toEqual([gte("duration_ms", 5), lte("duration_ms", 10)]);
   });
 
   it("replaces a same-direction bound rather than stacking two lower bounds", () => {
-    const start = [gt("duration_ms", 5), lt("duration_ms", 10)];
-    expect(upsertPredicate(start, gt("duration_ms", 8))).toEqual([
-      lt("duration_ms", 10),
-      gt("duration_ms", 8),
+    const start = [gte("duration_ms", 5), lte("duration_ms", 10)];
+    expect(upsertPredicate(start, gte("duration_ms", 8))).toEqual([
+      lte("duration_ms", 10),
+      gte("duration_ms", 8),
     ]);
   });
 
   it("a new upper bound that contradicts the lower bound supersedes it (empty range)", () => {
-    // errors > 5 then errors < 3 — no value satisfies both, so the newer one wins.
-    expect(upsertPredicate([gt("errors", 5)], lt("errors", 3))).toEqual([lt("errors", 3)]);
+    // errors ≥ 5 then errors ≤ 3 — no value satisfies both, so the newer one wins.
+    expect(upsertPredicate([gte("errors", 5)], lte("errors", 3))).toEqual([lte("errors", 3)]);
   });
 
   it("a new lower bound that contradicts the upper bound supersedes it", () => {
-    // errors < 3 then errors > 5 — the newer lower bound wins.
-    expect(upsertPredicate([lt("errors", 3)], gt("errors", 5))).toEqual([gt("errors", 5)]);
+    // errors ≤ 3 then errors ≥ 5 — the newer lower bound wins.
+    expect(upsertPredicate([lte("errors", 3)], gte("errors", 5))).toEqual([gte("errors", 5)]);
   });
 
-  it("treats equal bounds as an empty range (>= is inclusive, < is strict)", () => {
-    // errors > 5 then errors < 5 — 5 <= x < 5 is empty, so the newer one wins.
-    expect(upsertPredicate([gt("errors", 5)], lt("errors", 5))).toEqual([lt("errors", 5)]);
+  it("keeps equal bounds as an exact-value range (both inclusive: ≥ x AND ≤ x matches x)", () => {
+    // errors ≥ 5 then errors ≤ 5 — 5 <= x <= 5 matches exactly 5, a valid non-empty range.
+    expect(upsertPredicate([gte("errors", 5)], lte("errors", 5))).toEqual([
+      gte("errors", 5),
+      lte("errors", 5),
+    ]);
   });
 
   it("keeps a valid (non-empty) opposite bound: lower < upper", () => {
-    expect(upsertPredicate([gt("duration_ms", 3)], lt("duration_ms", 5))).toEqual([
-      gt("duration_ms", 3),
-      lt("duration_ms", 5),
+    expect(upsertPredicate([gte("duration_ms", 3)], lte("duration_ms", 5))).toEqual([
+      gte("duration_ms", 3),
+      lte("duration_ms", 5),
     ]);
   });
 
   it("an exact `equals` (both bounds equal) supersedes both range bounds", () => {
-    const start = [gt("cost", 1), lt("cost", 5)];
+    const start = [gte("cost", 1), lte("cost", 5)];
     expect(upsertPredicate(start, buildBetweenPredicate("cost", 3, 3))).toEqual([
       buildBetweenPredicate("cost", 3, 3),
     ]);
   });
 
   it("a categorical value replaces the existing one on its field, untouched others", () => {
-    const start = [gt("cost", 1), buildInPredicate("model_name", ["gpt-4o"])];
+    const start = [gte("cost", 1), buildInPredicate("model_name", ["gpt-4o"])];
     expect(upsertPredicate(start, buildInPredicate("model_name", ["claude"]))).toEqual([
-      gt("cost", 1),
+      gte("cost", 1),
       buildInPredicate("model_name", ["claude"]),
     ]);
   });
 
   it("never touches predicates on other fields", () => {
-    const start = [gt("duration_ms", 5), gt("cost", 1)];
-    expect(upsertPredicate(start, lt("duration_ms", 10))).toEqual([
-      gt("duration_ms", 5),
-      gt("cost", 1),
-      lt("duration_ms", 10),
+    const start = [gte("duration_ms", 5), gte("cost", 1)];
+    expect(upsertPredicate(start, lte("duration_ms", 10))).toEqual([
+      gte("duration_ms", 5),
+      gte("cost", 1),
+      lte("duration_ms", 10),
     ]);
   });
 });

--- a/frontend/ui/src/features/filters/predicate-ui.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.ts
@@ -8,8 +8,8 @@ import type { Predicate } from "@/types/api";
 /**
  * Human-readable label for an active-filter chip. Mirrors how the predicate reads:
  * a single `in` value shows as `=`, multiple as `in [...]`; a `between` with a null
- * bound shows as `>` (the "greater than" operator, an INCLUSIVE >= bound — see
- * translate.py) or `<` (the strict "less than" bound); both bounds as `between … and …`.
+ * bound shows as `≥` (the inclusive "greater than or equal to" bound) or `≤` (the
+ * inclusive "less than or equal to" bound); both bounds as `between … and …`.
  *
  * `name` is the field's display name (its registry label, lowercased — e.g. `latency`
  * for `duration_ms`); it defaults to the raw field key when a label isn't available.
@@ -23,8 +23,8 @@ export function predicateLabel(p: Predicate, name: string = p.field): string {
   if (lo !== null && hi !== null) {
     return lo === hi ? `${name} = ${lo}` : `${name} between ${lo} and ${hi}`;
   }
-  if (lo !== null) return `${name} > ${lo}`;
-  if (hi !== null) return `${name} < ${hi}`;
+  if (lo !== null) return `${name} ≥ ${lo}`;
+  if (hi !== null) return `${name} ≤ ${hi}`;
   return name;
 }
 
@@ -56,10 +56,10 @@ function slotOf(p: Predicate): Slot {
 
 /**
  * Add `next` to the active filter set, merging by slot so a range can be built from
- * two one-sided filters: a lower bound (`greater than`) and an upper bound (`less
- * than`) on the same field coexist (e.g. `latency > 5` AND `latency < 10`, which the
- * backend AND-combines). A same-direction bound, an exact `equals`, a full range, or a
- * categorical value replaces the matching predicate on that field rather than stacking.
+ * two one-sided filters: a lower bound (`greater than or equal to`) and an upper bound
+ * (`less than or equal to`) on the same field coexist (e.g. `latency ≥ 5` AND `latency
+ * ≤ 10`, which the backend AND-combines). A same-direction bound, an exact `equals`, a
+ * full range, or a categorical value replaces the matching predicate rather than stacking.
  */
 export function upsertPredicate(filters: Predicate[], next: Predicate): Predicate[] {
   const ns = slotOf(next);
@@ -69,7 +69,7 @@ export function upsertPredicate(filters: Predicate[], next: Predicate): Predicat
     if (ns === "in" || ns === "exact" || ns === "full") return false;
     // A new one-sided bound keeps the opposite existing bound ONLY if the two form a
     // non-empty range; a same-direction bound, or a contradictory opposite bound (e.g.
-    // errors > 5 then errors < 3, which no value satisfies), is superseded by the
+    // errors ≥ 5 then errors ≤ 3, which no value satisfies), is superseded by the
     // just-entered predicate.
     const es = slotOf(e);
     if (ns === "lower" && es === "upper") return boundsFormRange(next, e);
@@ -80,11 +80,12 @@ export function upsertPredicate(filters: Predicate[], next: Predicate): Predicat
 }
 
 // Whether a lower bound (`[lo, null]`, inclusive `>=`) and an upper bound (`[null, hi]`,
-// strict `<`) describe a non-empty range — i.e. `lo < hi`. A contradictory pair
-// (`lo >= hi`) must not coexist; the newer predicate wins instead.
+// inclusive `<=`) describe a non-empty range. Both bounds are inclusive, so `lo === hi`
+// is a valid one-value range (`>= x AND <= x` matches exactly x) — non-empty iff
+// `lo <= hi`. A contradictory pair (`lo > hi`) must not coexist; the newer predicate wins.
 function boundsFormRange(lower: Predicate, upper: Predicate): boolean {
   if (lower.op !== "between" || upper.op !== "between") return false;
   const lo = lower.value[0];
   const hi = upper.value[1];
-  return lo !== null && hi !== null && lo < hi;
+  return lo !== null && hi !== null && lo <= hi;
 }

--- a/frontend/ui/src/features/filters/predicate-ui.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.ts
@@ -1,0 +1,90 @@
+/**
+ * Builder-side predicate helpers for the filter UI: rendering a predicate
+ * as a readable chip label, and constructing predicates from raw inputs. Framework-free
+ * and unit-tested; kept separate from `predicate.ts` (serialization/canonicalization).
+ */
+import type { Predicate } from "@/types/api";
+
+/**
+ * Human-readable label for an active-filter chip. Mirrors how the predicate reads:
+ * a single `in` value shows as `=`, multiple as `in [...]`; a `between` with a null
+ * bound shows as `>` (the "greater than" operator, an INCLUSIVE >= bound — see
+ * translate.py) or `<` (the strict "less than" bound); both bounds as `between … and …`.
+ *
+ * `name` is the field's display name (its registry label, lowercased — e.g. `latency`
+ * for `duration_ms`); it defaults to the raw field key when a label isn't available.
+ */
+export function predicateLabel(p: Predicate, name: string = p.field): string {
+  if (p.op === "in") {
+    if (p.value.length === 1) return `${name} = ${p.value[0]}`;
+    return `${name} in [${p.value.join(", ")}]`;
+  }
+  const [lo, hi] = p.value;
+  if (lo !== null && hi !== null) {
+    return lo === hi ? `${name} = ${lo}` : `${name} between ${lo} and ${hi}`;
+  }
+  if (lo !== null) return `${name} > ${lo}`;
+  if (hi !== null) return `${name} < ${hi}`;
+  return name;
+}
+
+/** Construct a categorical membership predicate from selected values. */
+export function buildInPredicate(field: string, values: string[]): Predicate {
+  return { field, op: "in", value: values };
+}
+
+/** Construct a numeric aggregate predicate; either bound may be null (open range). */
+export function buildBetweenPredicate(
+  field: string,
+  min: number | null,
+  max: number | null,
+): Predicate {
+  return { field, op: "between", value: [min, max] };
+}
+
+// Which "slot" a predicate occupies on its field, so we know what a new predicate
+// replaces vs. coexists with. A field can hold at most one lower + one upper bound.
+type Slot = "in" | "lower" | "upper" | "exact" | "full";
+function slotOf(p: Predicate): Slot {
+  if (p.op === "in") return "in";
+  const [lo, hi] = p.value;
+  if (lo !== null && hi !== null) return lo === hi ? "exact" : "full";
+  if (lo !== null) return "lower";
+  if (hi !== null) return "upper";
+  return "full";
+}
+
+/**
+ * Add `next` to the active filter set, merging by slot so a range can be built from
+ * two one-sided filters: a lower bound (`greater than`) and an upper bound (`less
+ * than`) on the same field coexist (e.g. `latency > 5` AND `latency < 10`, which the
+ * backend AND-combines). A same-direction bound, an exact `equals`, a full range, or a
+ * categorical value replaces the matching predicate on that field rather than stacking.
+ */
+export function upsertPredicate(filters: Predicate[], next: Predicate): Predicate[] {
+  const ns = slotOf(next);
+  const keep = (e: Predicate): boolean => {
+    if (e.field !== next.field) return true;
+    // A categorical value, an exact point, or a full range supersedes everything on the field.
+    if (ns === "in" || ns === "exact" || ns === "full") return false;
+    // A new one-sided bound keeps the opposite existing bound ONLY if the two form a
+    // non-empty range; a same-direction bound, or a contradictory opposite bound (e.g.
+    // errors > 5 then errors < 3, which no value satisfies), is superseded by the
+    // just-entered predicate.
+    const es = slotOf(e);
+    if (ns === "lower" && es === "upper") return boundsFormRange(next, e);
+    if (ns === "upper" && es === "lower") return boundsFormRange(e, next);
+    return false;
+  };
+  return [...filters.filter(keep), next];
+}
+
+// Whether a lower bound (`[lo, null]`, inclusive `>=`) and an upper bound (`[null, hi]`,
+// strict `<`) describe a non-empty range — i.e. `lo < hi`. A contradictory pair
+// (`lo >= hi`) must not coexist; the newer predicate wins instead.
+function boundsFormRange(lower: Predicate, upper: Predicate): boolean {
+  if (lower.op !== "between" || upper.op !== "between") return false;
+  const lo = lower.value[0];
+  const hi = upper.value[1];
+  return lo !== null && hi !== null && lo < hi;
+}

--- a/frontend/ui/src/features/filters/predicate.test.ts
+++ b/frontend/ui/src/features/filters/predicate.test.ts
@@ -21,6 +21,14 @@ describe("canonicalizeFilters", () => {
   it("maps empty and undefined to the same stable key", () => {
     expect(canonicalizeFilters([])).toBe(canonicalizeFilters(undefined));
   });
+
+  it("folds an `in` value list that differs only in order to one key", () => {
+    // The matched-value set is order-independent, so hover-prefetch and the list hook
+    // must produce the same cache entry regardless of value order.
+    const a = canonicalizeFilters([{ field: "model_name", op: "in", value: ["a", "b"] }]);
+    const b = canonicalizeFilters([{ field: "model_name", op: "in", value: ["b", "a"] }]);
+    expect(a).toBe(b);
+  });
 });
 
 describe("serializeFiltersParam", () => {
@@ -33,6 +41,19 @@ describe("serializeFiltersParam", () => {
     const raw = serializeFiltersParam([modelFilter, costFilter]);
     expect(raw).not.toBeNull();
     expect(parseFiltersParam(raw)).toEqual([modelFilter, costFilter]);
+  });
+
+  it("drops invalid predicates on the way out (symmetric with parse)", () => {
+    const emptyIn = { field: "model_name", op: "in", value: [] } as unknown as Predicate;
+    // Assert the RAW serialized output — NOT laundered back through parseFiltersParam,
+    // which would re-drop the empty `in` itself and make the test pass even if serialize
+    // failed to filter. A serialize that kept it would yield a two-element array here.
+    expect(JSON.parse(serializeFiltersParam([modelFilter, emptyIn])!)).toEqual([modelFilter]);
+  });
+
+  it("returns null when every predicate is invalid (no param emitted)", () => {
+    const emptyIn = { field: "model_name", op: "in", value: [] } as unknown as Predicate;
+    expect(serializeFiltersParam([emptyIn])).toBeNull();
   });
 });
 
@@ -50,6 +71,11 @@ describe("parseFiltersParam", () => {
       { field: "cost", op: "between", value: [1] }, // wrong arity
       { field: "model_name", op: "in", value: "notarray" }, // wrong value type
     ]);
+    expect(parseFiltersParam(raw)).toEqual([modelFilter]);
+  });
+
+  it("drops an empty `in` predicate (matches nothing; backend would 422 the list)", () => {
+    const raw = JSON.stringify([modelFilter, { field: "model_name", op: "in", value: [] }]);
     expect(parseFiltersParam(raw)).toEqual([modelFilter]);
   });
 

--- a/frontend/ui/src/features/filters/predicate.test.ts
+++ b/frontend/ui/src/features/filters/predicate.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import type { Predicate } from "@/types/api";
+import { canonicalizeFilters, serializeFiltersParam, parseFiltersParam } from "./predicate";
+
+const modelFilter: Predicate = { field: "model_name", op: "in", value: ["a", "b"] };
+const costFilter: Predicate = { field: "cost", op: "between", value: [0.5, null] };
+
+describe("canonicalizeFilters", () => {
+  it("is independent of predicate order — order-only differences collapse to one key", () => {
+    const a = canonicalizeFilters([modelFilter, costFilter]);
+    const b = canonicalizeFilters([costFilter, modelFilter]);
+    expect(a).toBe(b);
+  });
+
+  it("distinguishes genuinely different filter sets", () => {
+    const a = canonicalizeFilters([modelFilter]);
+    const b = canonicalizeFilters([{ ...modelFilter, value: ["a", "c"] }]);
+    expect(a).not.toBe(b);
+  });
+
+  it("maps empty and undefined to the same stable key", () => {
+    expect(canonicalizeFilters([])).toBe(canonicalizeFilters(undefined));
+  });
+});
+
+describe("serializeFiltersParam", () => {
+  it("returns null for empty/undefined (no URL param emitted)", () => {
+    expect(serializeFiltersParam(undefined)).toBeNull();
+    expect(serializeFiltersParam([])).toBeNull();
+  });
+
+  it("round-trips a non-empty array through parse", () => {
+    const raw = serializeFiltersParam([modelFilter, costFilter]);
+    expect(raw).not.toBeNull();
+    expect(parseFiltersParam(raw)).toEqual([modelFilter, costFilter]);
+  });
+});
+
+describe("parseFiltersParam", () => {
+  it("returns [] for null or malformed JSON", () => {
+    expect(parseFiltersParam(null)).toEqual([]);
+    expect(parseFiltersParam("not json")).toEqual([]);
+    expect(parseFiltersParam("{}")).toEqual([]); // not an array
+  });
+
+  it("drops predicates with an unknown operator or malformed value", () => {
+    const raw = JSON.stringify([
+      modelFilter,
+      { field: "x", op: "like", value: ["y"] }, // unknown op
+      { field: "cost", op: "between", value: [1] }, // wrong arity
+      { field: "model_name", op: "in", value: "notarray" }, // wrong value type
+    ]);
+    expect(parseFiltersParam(raw)).toEqual([modelFilter]);
+  });
+
+  it("accepts a between predicate with nullable open bounds", () => {
+    const open: Predicate = { field: "cost", op: "between", value: [null, 10] };
+    expect(parseFiltersParam(JSON.stringify([open]))).toEqual([open]);
+  });
+
+  it("drops a between predicate with a non-finite bound (1e999 -> Infinity)", () => {
+    // JSON.parse turns 1e999 into Infinity; it must not survive validation — it would
+    // JSON.stringify back to null, silently converting the bound to an open range.
+    expect(parseFiltersParam('[{"field":"cost","op":"between","value":[1e999, null]}]')).toEqual(
+      [],
+    );
+  });
+});

--- a/frontend/ui/src/features/filters/predicate.ts
+++ b/frontend/ui/src/features/filters/predicate.ts
@@ -1,0 +1,64 @@
+/**
+ * Pure helpers for the trace-list filter predicate IR (`{field, op, value}`).
+ *
+ * Kept framework-free so the canonicalization, URL serialization, and validation
+ * are unit-testable without React or the DOM, and reused by both the query-key
+ * builder and the URL-synced state hook.
+ */
+import type { Predicate } from "@/types/api";
+
+const VALID_OPS = new Set<Predicate["op"]>(["in", "between"]);
+
+/** Shape-guard for a single predicate parsed from untrusted input (e.g. a URL). */
+export function isValidPredicate(p: unknown): p is Predicate {
+  if (typeof p !== "object" || p === null) return false;
+  const { field, op, value } = p as Record<string, unknown>;
+  if (typeof field !== "string" || !VALID_OPS.has(op as Predicate["op"])) return false;
+  if (op === "in") {
+    return Array.isArray(value) && value.every((v) => typeof v === "string");
+  }
+  // between: exactly two bounds, each a FINITE number or null (nullable open range).
+  // Number.isFinite rejects Infinity/NaN — e.g. a hand-edited `1e999` parses to Infinity,
+  // which JSON.stringify would silently coerce to null (corrupting the key/payload).
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    value.every((v) => v === null || Number.isFinite(v))
+  );
+}
+
+/**
+ * A deterministic string key for a set of filters that is independent of predicate
+ * order, so two arrays differing only in order fold to one React Query cache entry
+ * (otherwise hover-prefetch and the list hook would key differently and miss).
+ */
+export function canonicalizeFilters(filters?: Predicate[]): string {
+  if (!filters || filters.length === 0) return "";
+  return filters
+    .map((p) => JSON.stringify({ field: p.field, op: p.op, value: p.value }))
+    .sort()
+    .join("|");
+}
+
+/** Serialize filters for the `?filters=` URL param; null when there is nothing to add. */
+export function serializeFiltersParam(filters?: Predicate[]): string | null {
+  if (!filters || filters.length === 0) return null;
+  return JSON.stringify(filters);
+}
+
+/**
+ * Parse the `?filters=` param into validated predicates. Defensive against
+ * hand-edited URLs: malformed JSON or a non-array yields `[]`, and individual
+ * predicates that fail the shape guard are dropped rather than poisoning the list.
+ */
+export function parseFiltersParam(raw: string | null): Predicate[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(isValidPredicate);
+}

--- a/frontend/ui/src/features/filters/predicate.ts
+++ b/frontend/ui/src/features/filters/predicate.ts
@@ -15,7 +15,9 @@ export function isValidPredicate(p: unknown): p is Predicate {
   const { field, op, value } = p as Record<string, unknown>;
   if (typeof field !== "string" || !VALID_OPS.has(op as Predicate["op"])) return false;
   if (op === "in") {
-    return Array.isArray(value) && value.every((v) => typeof v === "string");
+    // Non-empty: an empty `in` matches nothing and the backend 422s it, so a
+    // hand-edited/degenerate empty-`in` is dropped here rather than sinking the fetch.
+    return Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === "string");
   }
   // between: exactly two bounds, each a FINITE number or null (nullable open range).
   // Number.isFinite rejects Infinity/NaN — e.g. a hand-edited `1e999` parses to Infinity,
@@ -35,15 +37,25 @@ export function isValidPredicate(p: unknown): p is Predicate {
 export function canonicalizeFilters(filters?: Predicate[]): string {
   if (!filters || filters.length === 0) return "";
   return filters
-    .map((p) => JSON.stringify({ field: p.field, op: p.op, value: p.value }))
+    .map((p) => {
+      // Sort the `in` values so ["a","b"] and ["b","a"] fold to one key — the set of
+      // matched values is order-independent, so hover-prefetch and the list hook must
+      // agree on the same cache entry. `between` bounds are positional; leave them.
+      const value = p.op === "in" && Array.isArray(p.value) ? [...p.value].sort() : p.value;
+      return JSON.stringify({ field: p.field, op: p.op, value });
+    })
     .sort()
     .join("|");
 }
 
-/** Serialize filters for the `?filters=` URL param; null when there is nothing to add. */
+/**
+ * Serialize filters for the `?filters=` URL param; null when there is nothing to add.
+ * Drops invalid predicates on the way out (symmetric with `parseFiltersParam` on the way
+ * in), so a malformed shape — e.g. an empty `in` — can't reach the URL/backend and 422.
+ */
 export function serializeFiltersParam(filters?: Predicate[]): string | null {
-  if (!filters || filters.length === 0) return null;
-  return JSON.stringify(filters);
+  const valid = (filters ?? []).filter(isValidPredicate);
+  return valid.length === 0 ? null : JSON.stringify(valid);
 }
 
 /**

--- a/frontend/ui/src/features/filters/registry.test.ts
+++ b/frontend/ui/src/features/filters/registry.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { STATIC_FILTER_FIELDS } from "./registry";
+
+describe("STATIC_FILTER_FIELDS fallback", () => {
+  it("covers the membership + aggregate tiers", () => {
+    expect(STATIC_FILTER_FIELDS.map((f) => f.field).sort()).toEqual(
+      ["cost", "duration_ms", "environment", "errors", "model_name", "total_tokens"].sort(),
+    );
+  });
+
+  it("categorical fields take `in`, numeric fields take `between`", () => {
+    for (const f of STATIC_FILTER_FIELDS) {
+      expect(f.operators).toEqual([f.type === "categorical" ? "in" : "between"]);
+    }
+  });
+
+  it("distinct-query categorical fields carry no static values", () => {
+    const model = STATIC_FILTER_FIELDS.find((f) => f.field === "model_name")!;
+    expect(model.value_source).toBe("distinct_query");
+    expect(model.enum_values).toEqual([]);
+  });
+});

--- a/frontend/ui/src/features/filters/registry.ts
+++ b/frontend/ui/src/features/filters/registry.ts
@@ -1,0 +1,95 @@
+/**
+ * Frontend filter-field registry: the type mirroring the backend `/filter-fields`
+ * payload, plus a static fallback list so the filter builder paints instantly
+ * before the live fetch resolves. The live payload (Python source of truth) overrides
+ * this; the fallback only needs to be shape-correct, not authoritative.
+ */
+
+export interface FilterFieldDef {
+  field: string;
+  label: string;
+  type: "categorical" | "numeric";
+  level: string;
+  operators: string[];
+  value_source: "static_enum" | "distinct_query" | "range";
+  enum_values: string[];
+  /** Integer-typed numeric field (tokens/latency/errors) — restrict input to whole numbers. */
+  integer?: boolean;
+}
+
+/** GET /traces/filter-fields response. */
+export interface FilterFieldsResponse {
+  fields: FilterFieldDef[];
+}
+
+/** One distinct categorical value with its frequency. */
+export interface FilterValue {
+  value: string;
+  count: number;
+}
+
+/** GET /traces/filter-values/{field} response. */
+export interface FilterValuesResponse {
+  field: string;
+  values: FilterValue[];
+}
+
+export const STATIC_FILTER_FIELDS: FilterFieldDef[] = [
+  {
+    field: "model_name",
+    label: "Model",
+    type: "categorical",
+    level: "SPAN_MEMBERSHIP",
+    operators: ["in"],
+    value_source: "distinct_query",
+    enum_values: [],
+  },
+  {
+    field: "environment",
+    label: "Environment",
+    type: "categorical",
+    level: "SPAN_MEMBERSHIP",
+    operators: ["in"],
+    value_source: "distinct_query",
+    enum_values: [],
+  },
+  {
+    field: "cost",
+    label: "Cost",
+    type: "numeric",
+    level: "SPAN_AGGREGATE",
+    operators: ["between"],
+    value_source: "range",
+    enum_values: [],
+  },
+  {
+    field: "total_tokens",
+    label: "Tokens",
+    type: "numeric",
+    level: "SPAN_AGGREGATE",
+    operators: ["between"],
+    value_source: "range",
+    enum_values: [],
+    integer: true,
+  },
+  {
+    field: "duration_ms",
+    label: "Latency",
+    type: "numeric",
+    level: "SPAN_AGGREGATE",
+    operators: ["between"],
+    value_source: "range",
+    enum_values: [],
+    integer: true,
+  },
+  {
+    field: "errors",
+    label: "Errors",
+    type: "numeric",
+    level: "SPAN_AGGREGATE",
+    operators: ["between"],
+    value_source: "range",
+    enum_values: [],
+    integer: true,
+  },
+];

--- a/frontend/ui/src/lib/api/traces.filter-meta.test.ts
+++ b/frontend/ui/src/lib/api/traces.filter-meta.test.ts
@@ -15,15 +15,23 @@ describe("filter meta API", () => {
     expect(mockFetch.mock.calls[0][0]).toBe("/projects/p1/traces/filter-fields");
   });
 
-  it("getFilterValues encodes the field and omits the query when no start_after", async () => {
-    await getFilterValues("p1", "model_name", undefined);
+  it("getFilterValues encodes the field and omits the query when no window", async () => {
+    await getFilterValues("p1", "model_name", undefined, undefined);
     expect(mockFetch.mock.calls[0][0]).toBe("/projects/p1/traces/filter-values/model_name");
   });
 
   it("getFilterValues appends an encoded start_after when present", async () => {
-    await getFilterValues("p1", "model_name", "2026-06-01T00:00:00Z");
+    await getFilterValues("p1", "model_name", "2026-06-01T00:00:00Z", undefined);
     expect(mockFetch.mock.calls[0][0]).toBe(
       "/projects/p1/traces/filter-values/model_name?start_after=2026-06-01T00%3A00%3A00Z",
+    );
+  });
+
+  it("getFilterValues appends both bounds so options match the active window", async () => {
+    await getFilterValues("p1", "model_name", "2026-06-01T00:00:00Z", "2026-06-02T00:00:00Z");
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "/projects/p1/traces/filter-values/model_name" +
+        "?start_after=2026-06-01T00%3A00%3A00Z&end_before=2026-06-02T00%3A00%3A00Z",
     );
   });
 });

--- a/frontend/ui/src/lib/api/traces.filter-meta.test.ts
+++ b/frontend/ui/src/lib/api/traces.filter-meta.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./client", () => ({ fetchTraceApi: vi.fn().mockResolvedValue({ fields: [] }) }));
+
+import { fetchTraceApi } from "./client";
+import { getFilterFields, getFilterValues } from "./traces";
+
+const mockFetch = vi.mocked(fetchTraceApi);
+
+beforeEach(() => mockFetch.mockClear());
+
+describe("filter meta API", () => {
+  it("getFilterFields hits the filter-fields endpoint", async () => {
+    await getFilterFields("p1");
+    expect(mockFetch.mock.calls[0][0]).toBe("/projects/p1/traces/filter-fields");
+  });
+
+  it("getFilterValues encodes the field and omits the query when no start_after", async () => {
+    await getFilterValues("p1", "model_name", undefined);
+    expect(mockFetch.mock.calls[0][0]).toBe("/projects/p1/traces/filter-values/model_name");
+  });
+
+  it("getFilterValues appends an encoded start_after when present", async () => {
+    await getFilterValues("p1", "model_name", "2026-06-01T00:00:00Z");
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "/projects/p1/traces/filter-values/model_name?start_after=2026-06-01T00%3A00%3A00Z",
+    );
+  });
+});

--- a/frontend/ui/src/lib/api/traces.test.ts
+++ b/frontend/ui/src/lib/api/traces.test.ts
@@ -5,7 +5,8 @@ vi.mock("@/lib/auth-client", () => ({
   authClient: { getSession: vi.fn().mockResolvedValue({ data: null }) },
 }));
 
-import { getSpanIO } from "./traces";
+import { getSpanIO, getTraces } from "./traces";
+import type { Predicate } from "@/types/api";
 
 describe("getSpanIO", () => {
   beforeEach(() => {
@@ -58,5 +59,44 @@ describe("getSpanIO", () => {
     await expect(getSpanIO("proj-1", "trace-9", "missing", { id: "user-1" })).rejects.toThrow(
       "Span not found",
     );
+  });
+});
+
+describe("getTraces filters serialization", () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("serializes filters as one URL-encoded JSON param that round-trips", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [], meta: { page: 0, limit: 50, total: 0 } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const filters: Predicate[] = [
+      { field: "model_name", op: "in", value: ["claude-opus-4.8"] },
+      { field: "cost", op: "between", value: [0.5, null] },
+    ];
+    await getTraces("proj-1", "", { filters }, { id: "user-1" });
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string, "http://x");
+    const raw = url.searchParams.get("filters");
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toEqual(filters);
+  });
+
+  it("omits the filters param entirely when there are no filters", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [], meta: { page: 0, limit: 50, total: 0 } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await getTraces("proj-1", "", { filters: [] }, { id: "user-1" });
+
+    const url = new URL(fetchMock.mock.calls[0][0] as string, "http://x");
+    expect(url.searchParams.has("filters")).toBe(false);
   });
 });

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -56,9 +56,13 @@ export async function getFilterValues(
   projectId: string,
   field: string,
   startAfter: string | undefined,
+  endBefore: string | undefined,
   user?: TraceApiUser,
 ): Promise<FilterValuesResponse> {
-  const query = startAfter ? `?start_after=${encodeURIComponent(startAfter)}` : "";
+  const params = new URLSearchParams();
+  if (startAfter) params.set("start_after", startAfter);
+  if (endBefore) params.set("end_before", endBefore);
+  const query = params.toString() ? `?${params.toString()}` : "";
   return fetchTraceApi<FilterValuesResponse>(
     `/projects/${projectId}/traces/filter-values/${encodeURIComponent(field)}${query}`,
     {},

--- a/frontend/ui/src/lib/api/traces.ts
+++ b/frontend/ui/src/lib/api/traces.ts
@@ -3,6 +3,8 @@
  */
 import { fetchTraceApi, type TraceApiUser } from "./client";
 import type { SpanIO, TraceDetail, TraceListResponse, TraceQueryOptions } from "@/types/api";
+import { serializeFiltersParam } from "@/features/filters/predicate";
+import type { FilterFieldsResponse, FilterValuesResponse } from "@/features/filters/registry";
 
 export async function getTraces(
   projectId: string,
@@ -19,6 +21,8 @@ export async function getTraces(
   if (options.start_after) params.set("start_after", options.start_after);
   if (options.end_before) params.set("end_before", options.end_before);
   if (options.search_query) params.set("search_query", options.search_query);
+  const filtersParam = serializeFiltersParam(options.filters);
+  if (filtersParam) params.set("filters", filtersParam);
 
   const query = params.toString();
   const endpoint = `/projects/${projectId}/traces${query ? `?${query}` : ""}`;
@@ -33,6 +37,33 @@ export async function getTrace(
   user?: TraceApiUser,
 ): Promise<TraceDetail> {
   return fetchTraceApi<TraceDetail>(`/projects/${projectId}/traces/${traceId}`, {}, user);
+}
+
+/** Registry of filterable fields driving the filter dropdown (Python source of truth). */
+export async function getFilterFields(
+  projectId: string,
+  user?: TraceApiUser,
+): Promise<FilterFieldsResponse> {
+  return fetchTraceApi<FilterFieldsResponse>(
+    `/projects/${projectId}/traces/filter-fields`,
+    {},
+    user,
+  );
+}
+
+/** Distinct values for one categorical field, time-bounded by the active window. */
+export async function getFilterValues(
+  projectId: string,
+  field: string,
+  startAfter: string | undefined,
+  user?: TraceApiUser,
+): Promise<FilterValuesResponse> {
+  const query = startAfter ? `?start_after=${encodeURIComponent(startAfter)}` : "";
+  return fetchTraceApi<FilterValuesResponse>(
+    `/projects/${projectId}/traces/filter-values/${encodeURIComponent(field)}${query}`,
+    {},
+    user,
+  );
 }
 
 /**

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -183,6 +183,17 @@ export interface TraceListResponse {
   };
 }
 
+/**
+ * A single trace-list filter predicate `{field, op, value}` — the frontend mirror
+ * of the backend predicate IR, serialized into the `?filters=` JSON array.
+ * Discriminated on `op`: categorical fields use `in` (the UI selects one value, so the
+ * array carries a single element), numeric fields use `between` with nullable bounds
+ * (`[0.5, null]` = ≥ 0.5, `[null, 10]` = < 10, a strict upper bound).
+ */
+export type Predicate =
+  | { field: string; op: "in"; value: string[] }
+  | { field: string; op: "between"; value: [number | null, number | null] };
+
 export interface TraceQueryOptions {
   page?: number;
   limit?: number;
@@ -194,6 +205,8 @@ export interface TraceQueryOptions {
   end_before?: string; // ISO timestamp - filter traces before this time
   // Multi-field keyword search (searches trace_id, name, session_id, user_id)
   search_query?: string;
+  // Structured attribute filters, serialized as one URL-encoded JSON array.
+  filters?: Predicate[];
 }
 
 // Session types


### PR DESCRIPTION
Part of #1374

Frontend data layer (PR 3/5; base `feat/trace-filter-api`).

- Predicate IR — framework-free serialization/canonicalization plus builder helpers: chip labels, predicate construction, and `upsertPredicate` (merges a lower + upper bound on one field into a range, replaces same-direction/exact/categorical, and supersedes a **contradictory** opposite bound that would make an empty range).
- API client for the filter endpoints + response types.
- Field registry type and static fallback list (incl. the `integer` hint).

Unit-tested (predicate, predicate-ui, registry, client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a framework-free filter predicate IR, UI helpers, API client endpoints, and a field registry for trace filtering. Filters are sent as one URL‑encoded JSON param with a stable, order‑independent key, and labels/parsing are hardened with inclusive bounds and stricter validation.

- **New Features**
  - Predicate IR: shape guard rejects empty `in` and non‑finite numbers; `canonicalizeFilters` sorts `in` values; URL serialize/parse for `in` and `between` (nullable bounds) with defensive parsing.
  - UI helpers: chip labels use inclusive ≥ / ≤; builders; `upsertPredicate` merges lower+upper into ranges, treats equal bounds as exact, replaces same‑slot or full/exact ranges, and supersedes contradictory pairs with the newer bound.
  - API: `getTraces` appends a `filters` JSON param when non‑empty; new `getFilterFields` and `getFilterValues` (path‑encodes `field`, accepts `start_after` and `end_before`) with typed responses.
  - Field registry: types plus a static fallback list (incl. `integer` hints) for instant render before the live fetch.

<sup>Written for commit 2a853f17a1e68cee9bd82ee1bb083109311a149b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

