### PR TITLE
feat(ui): URL-synced filter state + query-key wiring

### DIFF
--- a/frontend/ui/src/features/filters/hooks.test.tsx
+++ b/frontend/ui/src/features/filters/hooks.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { render, cleanup, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useFilterFields, useFilterValues } from "./hooks";
+import { STATIC_FILTER_FIELDS } from "./registry";
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "u1", email: "e@x.com" } }, isPending: false }),
+}));
+vi.mock("@/lib/api/traces", () => ({
+  getFilterFields: vi.fn().mockResolvedValue({
+    fields: [
+      {
+        field: "x",
+        label: "X",
+        type: "categorical",
+        level: "SPAN_MEMBERSHIP",
+        operators: ["in"],
+        value_source: "static_enum",
+        enum_values: [],
+      },
+    ],
+  }),
+  getFilterValues: vi.fn().mockResolvedValue({
+    field: "model_name",
+    values: [{ value: "gpt-4", count: 2 }],
+  }),
+}));
+
+afterEach(cleanup);
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function FieldsProbe() {
+  const fields = useFilterFields("p1");
+  return <div data-testid="fields">{fields.map((f) => f.field).join(",")}</div>;
+}
+
+function ValuesProbe({ enabled }: { enabled: boolean }) {
+  const { values } = useFilterValues("p1", "model_name", undefined, enabled);
+  return <div data-testid="values">{values.map((v) => v.value).join(",")}</div>;
+}
+
+describe("useFilterFields", () => {
+  it("starts with the static fallback then swaps in the fetched registry", async () => {
+    render(<FieldsProbe />, { wrapper: wrapper() });
+    // Synchronous first render shows the static fallback.
+    expect(screen.getByTestId("fields").textContent).toBe(
+      STATIC_FILTER_FIELDS.map((f) => f.field).join(","),
+    );
+    await waitFor(() => expect(screen.getByTestId("fields").textContent).toBe("x"));
+  });
+});
+
+describe("useFilterValues", () => {
+  it("returns fetched distinct values when enabled", async () => {
+    render(<ValuesProbe enabled />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByTestId("values").textContent).toBe("gpt-4"));
+  });
+
+  it("stays empty while disabled (lazy until the field is picked)", () => {
+    render(<ValuesProbe enabled={false} />, { wrapper: wrapper() });
+    expect(screen.getByTestId("values").textContent).toBe("");
+  });
+});

--- a/frontend/ui/src/features/filters/hooks.test.tsx
+++ b/frontend/ui/src/features/filters/hooks.test.tsx
@@ -4,6 +4,7 @@ import { render, cleanup, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useFilterFields, useFilterValues } from "./hooks";
 import { STATIC_FILTER_FIELDS } from "./registry";
+import { getFilterValues } from "@/lib/api/traces";
 
 vi.mock("@/lib/auth-client", () => ({
   useSession: () => ({ data: { user: { id: "u1", email: "e@x.com" } }, isPending: false }),
@@ -42,8 +43,16 @@ function FieldsProbe() {
   return <div data-testid="fields">{fields.map((f) => f.field).join(",")}</div>;
 }
 
-function ValuesProbe({ enabled }: { enabled: boolean }) {
-  const { values } = useFilterValues("p1", "model_name", undefined, enabled);
+function ValuesProbe({
+  enabled,
+  startAfter,
+  endBefore,
+}: {
+  enabled: boolean;
+  startAfter?: string;
+  endBefore?: string;
+}) {
+  const { values } = useFilterValues("p1", "model_name", startAfter, endBefore, enabled);
   return <div data-testid="values">{values.map((v) => v.value).join(",")}</div>;
 }
 
@@ -67,5 +76,23 @@ describe("useFilterValues", () => {
   it("stays empty while disabled (lazy until the field is picked)", () => {
     render(<ValuesProbe enabled={false} />, { wrapper: wrapper() });
     expect(screen.getByTestId("values").textContent).toBe("");
+  });
+
+  it("passes both window bounds to the distinct-values request", async () => {
+    render(
+      <ValuesProbe enabled startAfter="2026-06-01T00:00:00Z" endBefore="2026-06-02T00:00:00Z" />,
+      {
+        wrapper: wrapper(),
+      },
+    );
+    await waitFor(() =>
+      expect(getFilterValues).toHaveBeenCalledWith(
+        "p1",
+        "model_name",
+        "2026-06-01T00:00:00Z",
+        "2026-06-02T00:00:00Z",
+        expect.anything(),
+      ),
+    );
   });
 });

--- a/frontend/ui/src/features/filters/hooks.ts
+++ b/frontend/ui/src/features/filters/hooks.ts
@@ -43,13 +43,14 @@ export function useFilterValues(
   projectId: string,
   field: string | null,
   startAfter: string | undefined,
+  endBefore: string | undefined,
   enabled: boolean,
 ): { values: FilterValue[]; isLoading: boolean } {
   const { user, sessionReady } = useApiUser();
   const active = sessionReady && !!projectId && !!field && enabled;
   const { data, isLoading } = useQuery({
-    queryKey: ["filter-values", projectId, field, startAfter ?? null],
-    queryFn: () => getFilterValues(projectId, field!, startAfter, user),
+    queryKey: ["filter-values", projectId, field, startAfter ?? null, endBefore ?? null],
+    queryFn: () => getFilterValues(projectId, field!, startAfter, endBefore, user),
     enabled: active,
     staleTime: 30_000,
   });

--- a/frontend/ui/src/features/filters/hooks.ts
+++ b/frontend/ui/src/features/filters/hooks.ts
@@ -1,0 +1,59 @@
+"use client";
+
+/**
+ * Data hooks for the filter builder: the field registry that drives the pill list,
+ * and the lazy distinct-values for a categorical field (fetched only once that field
+ * is picked). Both mirror the trace-list hook conventions (auth session + React Query).
+ */
+import { useQuery } from "@tanstack/react-query";
+import { useSession as useAuthSession } from "@/lib/auth-client";
+import type { TraceApiUser } from "@/lib/api/client";
+import { getFilterFields, getFilterValues } from "@/lib/api/traces";
+import { STATIC_FILTER_FIELDS, type FilterFieldDef, type FilterValue } from "./registry";
+
+function useApiUser() {
+  const { data: authSession, isPending } = useAuthSession();
+  const sessionReady = !isPending && !!authSession?.user;
+  const user: TraceApiUser | undefined = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
+  return { user, sessionReady };
+}
+
+/**
+ * The filterable-field registry. Falls back to the static list (so the builder paints
+ * immediately) until the live `/filter-fields` payload resolves, then uses that.
+ */
+export function useFilterFields(projectId: string): FilterFieldDef[] {
+  const { user, sessionReady } = useApiUser();
+  const { data } = useQuery({
+    queryKey: ["filter-fields", projectId],
+    queryFn: () => getFilterFields(projectId, user),
+    enabled: sessionReady && !!projectId,
+    staleTime: Infinity,
+  });
+  return data?.fields ?? STATIC_FILTER_FIELDS;
+}
+
+/**
+ * Distinct values for a categorical field, fetched lazily (only when `enabled`, i.e.
+ * once the field is picked) and bounded by the active time window.
+ */
+export function useFilterValues(
+  projectId: string,
+  field: string | null,
+  startAfter: string | undefined,
+  enabled: boolean,
+): { values: FilterValue[]; isLoading: boolean } {
+  const { user, sessionReady } = useApiUser();
+  const active = sessionReady && !!projectId && !!field && enabled;
+  const { data, isLoading } = useQuery({
+    queryKey: ["filter-values", projectId, field, startAfter ?? null],
+    queryFn: () => getFilterValues(projectId, field!, startAfter, user),
+    enabled: active,
+    staleTime: 30_000,
+  });
+  // Mask React Query's retained cache while disabled so the lazy contract holds: a
+  // not-yet-active field reports no values rather than a previously-fetched field's.
+  return active ? { values: data?.values ?? [], isLoading } : { values: [], isLoading: false };
+}

--- a/frontend/ui/src/features/traces/hooks/index.ts
+++ b/frontend/ui/src/features/traces/hooks/index.ts
@@ -9,6 +9,7 @@ import { getSessions, getSession, type SessionDetailOptions } from "@/lib/api/se
 import { getUsers, type UserQueryOptions } from "@/lib/api/users";
 import type { SessionQueryOptions, TraceQueryOptions } from "@/types/api";
 import type { TraceApiUser } from "@/lib/api/client";
+import { canonicalizeFilters } from "@/features/filters/predicate";
 
 // Composed state hooks
 export { useTraceListState } from "./use-trace-list-state";
@@ -32,6 +33,9 @@ export function tracesQueryKey(projectId: string, options: TraceQueryOptions = {
     options.end_before,
     options.user_id,
     options.session_id,
+    // Canonical (order-independent) filter key so two equivalent filter sets share
+    // one cache entry and hover-prefetch lands under the key the list hook reads.
+    canonicalizeFilters(options.filters),
   ] as const;
 }
 

--- a/frontend/ui/src/features/traces/hooks/traces-query-key.test.ts
+++ b/frontend/ui/src/features/traces/hooks/traces-query-key.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { tracesQueryKey } from "./index";
+import type { Predicate } from "@/types/api";
+
+const model: Predicate = { field: "model_name", op: "in", value: ["a", "b"] };
+const cost: Predicate = { field: "cost", op: "between", value: [0.5, null] };
 
 describe("tracesQueryKey", () => {
   it("includes project id and all paging/filter fields in a stable order", () => {
@@ -13,7 +17,8 @@ describe("tracesQueryKey", () => {
         user_id: "u",
         session_id: "s",
       }),
-    ).toEqual(["traces", "p1", 2, 50, "x", "S", "E", "u", "s"]);
+      // trailing "" is the canonical (empty) filter key — see canonicalizeFilters.
+    ).toEqual(["traces", "p1", 2, 50, "x", "S", "E", "u", "s", ""]);
   });
 
   it("fills undefined for omitted options so keys stay positionally stable", () => {
@@ -27,6 +32,17 @@ describe("tracesQueryKey", () => {
       undefined,
       undefined,
       undefined,
+      "",
     ]);
+  });
+
+  it("is identical for filter arrays that differ only in order (one cache entry)", () => {
+    expect(tracesQueryKey("p", { filters: [model, cost] })).toEqual(
+      tracesQueryKey("p", { filters: [cost, model] }),
+    );
+  });
+
+  it("differs once a filter is applied vs none", () => {
+    expect(tracesQueryKey("p", { filters: [model] })).not.toEqual(tracesQueryKey("p", {}));
   });
 });

--- a/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { Predicate } from "@/types/api";
+
+let currentParams = new URLSearchParams();
+const replace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => currentParams,
+  useRouter: () => ({ replace }),
+  usePathname: () => "/traces",
+}));
+
+import { useListPageState } from "./use-list-page-state";
+
+beforeEach(() => {
+  currentParams = new URLSearchParams();
+  replace.mockClear();
+});
+
+describe("useListPageState filters integration", () => {
+  it("surfaces URL filters in both queryOptions and combined state", () => {
+    const f: Predicate[] = [{ field: "status", op: "in", value: ["ERROR"] }];
+    currentParams = new URLSearchParams({ filters: JSON.stringify(f) });
+    const { result } = renderHook(() => useListPageState());
+    expect(result.current.queryOptions.filters).toEqual(f);
+    expect(result.current.state.filters).toEqual(f);
+  });
+
+  it("updateFilters writes the encoded param to the URL", () => {
+    const { result } = renderHook(() => useListPageState());
+    const next: Predicate[] = [{ field: "cost", op: "between", value: [1, null] }];
+    act(() => result.current.updateFilters(next));
+    const url = new URL(replace.mock.calls.at(-1)![0] as string, "http://x");
+    expect(JSON.parse(url.searchParams.get("filters")!)).toEqual(next);
+  });
+});

--- a/frontend/ui/src/lib/hooks/use-list-page-state.ts
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.ts
@@ -9,6 +9,8 @@ import { useMemo } from "react";
 import { useUrlPagination } from "./use-url-pagination";
 import { useUrlDateFilter } from "./use-url-date-filter";
 import { useKeywordSearch } from "./use-keyword-search";
+import { useUrlFilters } from "./use-url-filters";
+import type { Predicate } from "@/types/api";
 
 interface QueryOptions {
   page: number;
@@ -16,6 +18,7 @@ interface QueryOptions {
   search_query?: string;
   start_after?: string;
   end_before?: string;
+  filters?: Predicate[];
 }
 
 interface UseListPageStateReturn {
@@ -33,6 +36,9 @@ interface UseListPageStateReturn {
   // Search
   keyword: string;
   updateKeyword: ReturnType<typeof useKeywordSearch>["setKeyword"];
+  // Structured attribute filters (URL-synced)
+  filters: Predicate[];
+  updateFilters: ReturnType<typeof useUrlFilters>["setFilters"];
   // Combined state for convenience
   state: {
     page: number;
@@ -41,6 +47,7 @@ interface UseListPageStateReturn {
     customStartDate: Date | null;
     customEndDate: Date | null;
     keyword: string;
+    filters: Predicate[];
   };
   // Ready-to-use query options for API
   queryOptions: QueryOptions;
@@ -61,6 +68,11 @@ export function useListPageState(
   // Search hook - resets page on change
   const { keyword, setKeyword, searchQuery } = useKeywordSearch(pagination.resetPage);
 
+  // Structured filters (URL-synced). setFilters resets page_index inside its own URL
+  // write, so it takes the state-only page reset (a second URL write would clobber the
+  // just-set filter from stale params).
+  const { filters, setFilters } = useUrlFilters(pagination.resetPageState);
+
   // Build query options for API call
   const queryOptions = useMemo<QueryOptions>(
     () => ({
@@ -69,8 +81,16 @@ export function useListPageState(
       search_query: searchQuery,
       start_after: timestamps.startAfter,
       end_before: timestamps.endBefore,
+      filters,
     }),
-    [pagination.page, pagination.limit, searchQuery, timestamps.startAfter, timestamps.endBefore],
+    [
+      pagination.page,
+      pagination.limit,
+      searchQuery,
+      timestamps.startAfter,
+      timestamps.endBefore,
+      filters,
+    ],
   );
 
   return {
@@ -88,6 +108,9 @@ export function useListPageState(
     // Search
     keyword,
     updateKeyword: setKeyword,
+    // Filters
+    filters,
+    updateFilters: setFilters,
     // Combined state
     state: {
       page: pagination.page,
@@ -96,6 +119,7 @@ export function useListPageState(
       customStartDate,
       customEndDate,
       keyword,
+      filters,
     },
     // API options
     queryOptions,

--- a/frontend/ui/src/lib/hooks/use-url-filters.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-url-filters.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { Predicate } from "@/types/api";
+
+let currentParams = new URLSearchParams();
+const replace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => currentParams,
+  useRouter: () => ({ replace }),
+  usePathname: () => "/traces",
+}));
+
+import { useUrlFilters } from "./use-url-filters";
+
+beforeEach(() => {
+  currentParams = new URLSearchParams();
+  replace.mockClear();
+});
+
+describe("useUrlFilters", () => {
+  it("reads and validates the initial filters from the URL", () => {
+    const f: Predicate[] = [{ field: "model_name", op: "in", value: ["a"] }];
+    currentParams = new URLSearchParams({ filters: JSON.stringify(f) });
+    const { result } = renderHook(() => useUrlFilters());
+    expect(result.current.filters).toEqual(f);
+  });
+
+  it("ignores a malformed URL value and falls back to an empty list", () => {
+    currentParams = new URLSearchParams({ filters: "not json" });
+    const { result } = renderHook(() => useUrlFilters());
+    expect(result.current.filters).toEqual([]);
+  });
+
+  it("setFilters writes the encoded param to the URL and resets the page", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() => useUrlFilters(onChange));
+    const next: Predicate[] = [{ field: "cost", op: "between", value: [0.5, null] }];
+
+    act(() => result.current.setFilters(next));
+
+    expect(result.current.filters).toEqual(next);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const url = replace.mock.calls[0][0] as string;
+    const raw = new URL(url, "http://x").searchParams.get("filters");
+    expect(JSON.parse(raw as string)).toEqual(next);
+  });
+
+  it("resets page_index in the same write so a filter applied on page >1 isn't lost", () => {
+    currentParams = new URLSearchParams({ page_index: "2" });
+    const { result } = renderHook(() => useUrlFilters());
+    const next: Predicate[] = [{ field: "cost", op: "between", value: [0.5, null] }];
+    act(() => result.current.setFilters(next));
+    // A single write carries the new filter AND drops the stale page — no separate
+    // page-reset write to clobber the filter from stale params.
+    const url = new URL(replace.mock.calls[0][0] as string, "http://x");
+    expect(JSON.parse(url.searchParams.get("filters")!)).toEqual(next);
+    expect(url.searchParams.has("page_index")).toBe(false);
+  });
+
+  it("setFilters([]) removes the param from the URL", () => {
+    currentParams = new URLSearchParams({
+      filters: JSON.stringify([{ field: "model_name", op: "in", value: ["a"] }]),
+    });
+    const { result } = renderHook(() => useUrlFilters());
+    act(() => result.current.setFilters([]));
+    const url = new URL(replace.mock.calls[0][0] as string, "http://x");
+    expect(url.searchParams.has("filters")).toBe(false);
+  });
+
+  it("does not re-sync from the URL after its own write (ref guard)", () => {
+    const { result, rerender } = renderHook(() => useUrlFilters());
+    const mine: Predicate[] = [{ field: "model_name", op: "in", value: ["a"] }];
+    act(() => result.current.setFilters(mine));
+
+    // The next searchParams change is the echo of our own replace(); the guard
+    // must skip it so our just-set value isn't clobbered by a re-parse.
+    currentParams = new URLSearchParams({
+      filters: JSON.stringify([{ field: "status", op: "in", value: ["ERROR"] }]),
+    });
+    rerender();
+
+    expect(result.current.filters).toEqual(mine);
+  });
+});

--- a/frontend/ui/src/lib/hooks/use-url-filters.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-url-filters.test.tsx
@@ -69,18 +69,34 @@ describe("useUrlFilters", () => {
     expect(url.searchParams.has("filters")).toBe(false);
   });
 
-  it("does not re-sync from the URL after its own write (ref guard)", () => {
+  it("skips the echo of its own write so it isn't re-parsed and clobbered", () => {
     const { result, rerender } = renderHook(() => useUrlFilters());
     const mine: Predicate[] = [{ field: "model_name", op: "in", value: ["a"] }];
     act(() => result.current.setFilters(mine));
 
-    // The next searchParams change is the echo of our own replace(); the guard
-    // must skip it so our just-set value isn't clobbered by a re-parse.
-    currentParams = new URLSearchParams({
-      filters: JSON.stringify([{ field: "status", op: "in", value: ["ERROR"] }]),
-    });
+    // Echo our OWN write back through searchParams (the real value we just wrote,
+    // not an unrelated one). The guard must skip it so `mine` isn't re-parsed away.
+    currentParams = new URL(replace.mock.calls[0][0] as string, "http://x").searchParams;
     rerender();
 
     expect(result.current.filters).toEqual(mine);
+  });
+
+  it("re-applying an identical filter set is a no-op that keeps back/forward working", () => {
+    const f: Predicate[] = [{ field: "model_name", op: "in", value: ["a"] }];
+    currentParams = new URLSearchParams({ filters: JSON.stringify(f) });
+    const { result, rerender } = renderHook(() => useUrlFilters());
+
+    // Same predicates → identical URL → no write. The guard must NOT be left armed
+    // (an unchanged router.replace would never fire the sync effect to reset it).
+    act(() => result.current.setFilters(f));
+    expect(replace).not.toHaveBeenCalled();
+
+    // A genuine back/forward must still sync into state — it would be swallowed if
+    // the guard were stuck armed from the no-op write above.
+    const external: Predicate[] = [{ field: "status", op: "in", value: ["ERROR"] }];
+    currentParams = new URLSearchParams({ filters: JSON.stringify(external) });
+    rerender();
+    expect(result.current.filters).toEqual(external);
   });
 });

--- a/frontend/ui/src/lib/hooks/use-url-filters.ts
+++ b/frontend/ui/src/lib/hooks/use-url-filters.ts
@@ -53,6 +53,12 @@ export function useUrlFilters(onFiltersChange?: () => void): UseUrlFiltersReturn
       // searchParams and drop the filter we just set (refresh/share/back would lose it).
       params.delete("page_index");
 
+      // If the URL wouldn't actually change (re-applying an identical filter set),
+      // router.replace is a no-op, so the sync effect never runs and the guard would
+      // stay armed — silently swallowing the NEXT real back/forward. Only arm the
+      // guard and write when the query string actually changes.
+      if (params.toString() === searchParams.toString()) return;
+
       isProgrammaticUpdate.current = true;
       router.replace(`${pathname}?${params.toString()}`, { scroll: false });
 

--- a/frontend/ui/src/lib/hooks/use-url-filters.ts
+++ b/frontend/ui/src/lib/hooks/use-url-filters.ts
@@ -1,0 +1,66 @@
+/**
+ * Hook for managing the structured trace filters synchronized with URL parameters,
+ * so a filtered list is shareable and survives refresh / back-forward.
+ *
+ * URL param: filters (one URL-encoded JSON predicate array)
+ */
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import type { Predicate } from "@/types/api";
+import { parseFiltersParam, serializeFiltersParam } from "@/features/filters/predicate";
+
+interface UseUrlFiltersReturn {
+  filters: Predicate[];
+  setFilters: (filters: Predicate[]) => void;
+}
+
+export function useUrlFilters(onFiltersChange?: () => void): UseUrlFiltersReturn {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [filters, setFiltersState] = useState<Predicate[]>(() =>
+    parseFiltersParam(searchParams.get("filters")),
+  );
+
+  // Skip the URL→state sync for our own writes (mirrors the pagination hook).
+  const isProgrammaticUpdate = useRef(false);
+  const onFiltersChangeRef = useRef(onFiltersChange);
+  onFiltersChangeRef.current = onFiltersChange;
+
+  // Sync state from the URL on external changes (e.g. browser back/forward).
+  useEffect(() => {
+    if (isProgrammaticUpdate.current) {
+      isProgrammaticUpdate.current = false;
+      return;
+    }
+    setFiltersState(parseFiltersParam(searchParams.get("filters")));
+  }, [searchParams]);
+
+  const setFilters = useCallback(
+    (next: Predicate[]) => {
+      setFiltersState(next);
+
+      const params = new URLSearchParams(searchParams.toString());
+      const serialized = serializeFiltersParam(next);
+      if (serialized) {
+        params.set("filters", serialized);
+      } else {
+        params.delete("filters");
+      }
+      // Reset to the first page in the SAME mutation, so a filter applied while on page
+      // >1 lands in the URL. A separate page-reset write would rebuild from this stale
+      // searchParams and drop the filter we just set (refresh/share/back would lose it).
+      params.delete("page_index");
+
+      isProgrammaticUpdate.current = true;
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+
+      // State-only page reset — the URL page reset already happened in the write above.
+      onFiltersChangeRef.current?.();
+    },
+    [searchParams, router, pathname],
+  );
+
+  return { filters, setFilters };
+}

--- a/frontend/ui/src/lib/hooks/use-url-pagination.ts
+++ b/frontend/ui/src/lib/hooks/use-url-pagination.ts
@@ -13,6 +13,7 @@ interface UseUrlPaginationReturn {
   goToPage: (page: number) => void;
   setLimit: (limit: number) => void;
   resetPage: () => void;
+  resetPageState: () => void;
 }
 
 const DEFAULT_PAGE = 0;
@@ -105,11 +106,17 @@ export function useUrlPagination(defaultLimit = DEFAULT_LIMIT): UseUrlPagination
     });
   }, [limit, updateUrl]);
 
+  // Reset only the page STATE to the first page, WITHOUT writing the URL — for callers
+  // (e.g. filters) that reset page_index inside their own single URL mutation, so a
+  // second write here can't clobber it from a stale searchParams closure.
+  const resetPageState = useCallback(() => setPageState(DEFAULT_PAGE), []);
+
   return {
     page,
     limit,
     goToPage,
     setLimit,
     resetPage,
+    resetPageState,
   };
 }


### PR DESCRIPTION
Closes #1374

Filter state management (PR 4/5; base `feat/trace-filter-client`).

- URL-synced structured filters (shareable, refresh/back-forward safe), composed into the shared list-page state hook alongside date/keyword/pagination, resetting to page 1 on change.
- Filter data hooks — the field registry and lazily-fetched distinct categorical values.
- Filter-aware **canonical** React Query key so equivalent filter sets share one cache entry and hover-prefetch aligns.

Tested: url-filters, list-page-state, hooks, query-key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds URL‑synced structured filters to the traces list, wires them into list-page state, and canonicalizes the traces query key so equivalent filter sets share one cache entry.

- **New Features**
  - URL param `filters` via `useUrlFilters`: parses/validates on load, survives back/forward, writes the param and clears `page_index` in a single `replace`, short-circuits identical URLs, skips re-sync for its own writes, and removes the param when empty; exposed in `useListPageState` as `filters`/`updateFilters` and included in `queryOptions` (uses pagination `resetPageState` to avoid double URL writes).
  - Filter data hooks: `useFilterFields` (static fallback; swaps to fetched registry) and `useFilterValues` (lazy; query key and request include both `start_after` and `end_before`).

- **Bug Fixes**
  - Prevent URL filter guard from sticking on identical re-applies by only arming it when the query string changes, keeping back/forward in sync.
  - Bound categorical dropdown values by both `start_after` and `end_before` to match the list window.

<sup>Written for commit 0a75ef96c29596f2479d8e3875fdc6c75475b9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

