### PR TITLE
feat(ui): filter builder popover + traces-page integration

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -7,6 +7,7 @@ import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
 import { Workflow, Users, Layers, X } from "lucide-react";
 import { SearchFilterBar } from "@/components/search-filter-bar";
+import { TraceSearchFilterInput } from "@/features/filters/trace-search-filter-input";
 import { ListPagination } from "@/components/list-pagination";
 import { ProjectBreadcrumb } from "@/features/projects/components";
 import {
@@ -56,6 +57,7 @@ export default function TracesPage() {
     updateDateFilter,
     updateCustomRange,
     updateKeyword,
+    updateFilters,
     updateLimit,
     goToPage,
     queryOptions,
@@ -161,9 +163,16 @@ export default function TracesPage() {
         {/* Filters bar — hidden during onboarding or while checking */}
         {!checking && !showGettingStarted && (
           <SearchFilterBar
-            searchValue={state.keyword}
-            onSearchChange={updateKeyword}
-            searchPlaceholder="Search..."
+            searchInput={
+              <TraceSearchFilterInput
+                searchValue={state.keyword}
+                onSearchChange={updateKeyword}
+                projectId={projectId}
+                filters={state.filters}
+                onFiltersChange={updateFilters}
+                startAfter={queryOptions.start_after}
+              />
+            }
             dateFilter={state.dateFilter}
             customStartDate={state.customStartDate}
             customEndDate={state.customEndDate}

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -171,6 +171,7 @@ export default function TracesPage() {
                 filters={state.filters}
                 onFiltersChange={updateFilters}
                 startAfter={queryOptions.start_after}
+                endBefore={queryOptions.end_before}
               />
             }
             dateFilter={state.dateFilter}

--- a/frontend/ui/src/components/search-filter-bar.tsx
+++ b/frontend/ui/src/components/search-filter-bar.tsx
@@ -11,9 +11,12 @@ import { DATE_FILTER_OPTIONS, formatDateRange, type DateFilterOption } from "@/l
 
 interface SearchFilterBarProps {
   // Search
-  searchValue: string;
-  onSearchChange: (value: string) => void;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
   searchPlaceholder?: string;
+  // Optional replacement for the default search input (e.g. a combined
+  // search-and-filter input). When provided, the plain input is not rendered.
+  searchInput?: React.ReactNode;
   // Date filter
   dateFilter: DateFilterOption;
   customStartDate: Date | null;
@@ -28,6 +31,7 @@ export function SearchFilterBar({
   searchValue,
   onSearchChange,
   searchPlaceholder = "Search...",
+  searchInput,
   dateFilter,
   customStartDate,
   customEndDate,
@@ -58,15 +62,17 @@ export function SearchFilterBar({
   return (
     <div className="border-b border-border bg-background px-3 py-1.5">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-        <div className="relative min-w-[12rem] max-w-md flex-1">
-          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            placeholder={searchPlaceholder}
-            value={searchValue}
-            onChange={(e) => onSearchChange(e.target.value)}
-            className="h-8 pl-8 text-[13px]"
-          />
-        </div>
+        {searchInput ?? (
+          <div className="relative min-w-[12rem] max-w-md flex-1">
+            <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              placeholder={searchPlaceholder}
+              value={searchValue ?? ""}
+              onChange={(e) => onSearchChange?.(e.target.value)}
+              className="h-8 pl-8 text-[13px]"
+            />
+          </div>
+        )}
         {children}
         <Popover
           open={dateFilterOpen}

--- a/frontend/ui/src/features/filters/filter-builder.test.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.test.tsx
@@ -4,10 +4,10 @@ import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 import { FilterBuilder } from "./filter-builder";
 import type { FilterFieldDef } from "./registry";
 
-// Distinct-values hook is irrelevant here (status is a static enum); stub it.
-vi.mock("./hooks", () => ({
-  useFilterValues: () => ({ values: [], isLoading: false }),
-}));
+// Stub the distinct-values hook; keep it as a spy so we can assert the window bounds
+// are threaded through to it for a distinct-query categorical field.
+const mockUseFilterValues = vi.hoisted(() => vi.fn(() => ({ values: [], isLoading: false })));
+vi.mock("./hooks", () => ({ useFilterValues: mockUseFilterValues }));
 
 afterEach(cleanup);
 
@@ -38,6 +38,16 @@ const TOKENS: FilterFieldDef = {
   value_source: "range",
   enum_values: [],
   integer: true,
+};
+
+const MODEL: FilterFieldDef = {
+  field: "model_name",
+  label: "Model",
+  type: "categorical",
+  level: "SPAN_MEMBERSHIP",
+  operators: ["in"],
+  value_source: "distinct_query",
+  enum_values: [],
 };
 
 function renderBuilder(fields: FilterFieldDef[], onSubmit = vi.fn()) {
@@ -150,5 +160,27 @@ describe("FilterBuilder (Basic row)", () => {
     renderBuilder([COST]);
     pickField(/Cost/);
     expect(screen.getByText("$")).toBeTruthy();
+  });
+
+  it("threads both window bounds into the distinct-values query for a categorical field", () => {
+    mockUseFilterValues.mockClear();
+    render(
+      <FilterBuilder
+        projectId="p1"
+        fields={[MODEL]}
+        startAfter="2026-06-01T00:00:00Z"
+        endBefore="2026-06-02T00:00:00Z"
+        onSubmit={vi.fn()}
+      />,
+    );
+    pickField(/Model/);
+    // The distinct-query field enables the lazy fetch, bounded on BOTH ends.
+    expect(mockUseFilterValues).toHaveBeenCalledWith(
+      "p1",
+      "model_name",
+      "2026-06-01T00:00:00Z",
+      "2026-06-02T00:00:00Z",
+      true,
+    );
   });
 });

--- a/frontend/ui/src/features/filters/filter-builder.test.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { FilterBuilder } from "./filter-builder";
+import type { FilterFieldDef } from "./registry";
+
+// Distinct-values hook is irrelevant here (status is a static enum); stub it.
+vi.mock("./hooks", () => ({
+  useFilterValues: () => ({ values: [], isLoading: false }),
+}));
+
+afterEach(cleanup);
+
+const STATUS: FilterFieldDef = {
+  field: "status",
+  label: "Status",
+  type: "categorical",
+  level: "SPAN_MEMBERSHIP",
+  operators: ["in"],
+  value_source: "static_enum",
+  enum_values: ["OK", "ERROR"],
+};
+const COST: FilterFieldDef = {
+  field: "cost",
+  label: "Cost",
+  type: "numeric",
+  level: "SPAN_AGGREGATE",
+  operators: ["between"],
+  value_source: "range",
+  enum_values: [],
+};
+const TOKENS: FilterFieldDef = {
+  field: "total_tokens",
+  label: "Tokens",
+  type: "numeric",
+  level: "SPAN_AGGREGATE",
+  operators: ["between"],
+  value_source: "range",
+  enum_values: [],
+  integer: true,
+};
+
+function renderBuilder(fields: FilterFieldDef[], onSubmit = vi.fn()) {
+  render(<FilterBuilder projectId="p1" fields={fields} onSubmit={onSubmit} />);
+  return onSubmit;
+}
+
+const pickField = (label: string | RegExp) => {
+  fireEvent.click(screen.getByRole("button", { name: "Field" }));
+  fireEvent.click(screen.getByRole("option", { name: label }));
+};
+
+describe("FilterBuilder (Basic row)", () => {
+  it("Add filter is disabled until a field and value are chosen", () => {
+    renderBuilder([STATUS]);
+    expect(screen.getByRole("button", { name: "Add filter" })).toHaveProperty("disabled", true);
+  });
+
+  it("categorical: pick field + value, emit a single-value `in` predicate", () => {
+    const onSubmit = renderBuilder([STATUS]);
+    pickField(/Status/);
+    fireEvent.click(screen.getByRole("button", { name: /Enter value/ }));
+    fireEvent.click(screen.getByRole("option", { name: /ERROR/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({ field: "status", op: "in", value: ["ERROR"] });
+  });
+
+  it("numeric `greater than` lowers to a between with an open upper bound", () => {
+    const onSubmit = renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.click(screen.getByRole("button", { name: "equals" })); // operator dropdown
+    fireEvent.click(screen.getByRole("option", { name: "greater than" }));
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "0.5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "between", value: [0.5, null] });
+  });
+
+  it("does not offer a `between` operator", () => {
+    renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.click(screen.getByRole("button", { name: "equals" }));
+    expect(screen.queryByRole("option", { name: "between" })).toBeNull();
+    expect(screen.getByRole("option", { name: "greater than" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "less than" })).toBeTruthy();
+  });
+
+  it("resets the row after adding so another filter can be entered", () => {
+    renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    // Field is back to the unset placeholder, ready for the next filter.
+    expect(screen.getByRole("button", { name: "Field" })).toBeTruthy();
+  });
+
+  it("rejects negative numeric input", () => {
+    renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "-5" } });
+    // Negative is dropped → no value set → Add filter stays disabled.
+    expect(screen.getByRole("button", { name: "Add filter" })).toHaveProperty("disabled", true);
+  });
+
+  it("integer field (Tokens) drops a fractional value", () => {
+    renderBuilder([TOKENS]);
+    pickField(/Tokens/);
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "1.5" } });
+    // Fractional is dropped for an Int64 field → no value → Add stays disabled.
+    expect(screen.getByRole("button", { name: "Add filter" })).toHaveProperty("disabled", true);
+  });
+
+  it("integer field (Tokens) rejects a fractional value in scientific notation", () => {
+    renderBuilder([TOKENS]);
+    pickField(/Tokens/);
+    // "1e-1" (=0.1) has no decimal point, so it slips past the input guard — the
+    // predicate builder must still reject it for an integer field.
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "1e-1" } });
+    expect(screen.getByRole("button", { name: "Add filter" })).toHaveProperty("disabled", true);
+  });
+
+  it("integer field (Tokens) accepts a whole number", () => {
+    const onSubmit = renderBuilder([TOKENS]);
+    pickField(/Tokens/);
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "100" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({
+      field: "total_tokens",
+      op: "between",
+      value: [100, 100],
+    });
+  });
+
+  it("decimal field (Cost) still accepts a fractional value", () => {
+    const onSubmit = renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "0.5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "between", value: [0.5, 0.5] });
+  });
+
+  it("creates the filter when Enter is pressed in the value field", () => {
+    const onSubmit = renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "5" } });
+    fireEvent.keyDown(screen.getByLabelText("value"), { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "between", value: [5, 5] });
+  });
+
+  it("shows the field's unit in the numeric value input ($ for cost)", () => {
+    renderBuilder([COST]);
+    pickField(/Cost/);
+    expect(screen.getByText("$")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/features/filters/filter-builder.test.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.test.tsx
@@ -75,14 +75,24 @@ describe("FilterBuilder (Basic row)", () => {
     expect(onSubmit).toHaveBeenCalledWith({ field: "status", op: "in", value: ["ERROR"] });
   });
 
-  it("numeric `greater than` lowers to a between with an open upper bound", () => {
+  it("numeric `greater than or equal to` lowers to a between with an open upper bound", () => {
     const onSubmit = renderBuilder([COST]);
     pickField(/Cost/);
     fireEvent.click(screen.getByRole("button", { name: "equals" })); // operator dropdown
-    fireEvent.click(screen.getByRole("option", { name: "greater than" }));
+    fireEvent.click(screen.getByRole("option", { name: "greater than or equal to" }));
     fireEvent.change(screen.getByLabelText("value"), { target: { value: "0.5" } });
     fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
     expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "between", value: [0.5, null] });
+  });
+
+  it("numeric `less than or equal to` lowers to a between with an open lower bound", () => {
+    const onSubmit = renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.click(screen.getByRole("button", { name: "equals" }));
+    fireEvent.click(screen.getByRole("option", { name: "less than or equal to" }));
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "10" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "between", value: [null, 10] });
   });
 
   it("does not offer a `between` operator", () => {
@@ -90,8 +100,8 @@ describe("FilterBuilder (Basic row)", () => {
     pickField(/Cost/);
     fireEvent.click(screen.getByRole("button", { name: "equals" }));
     expect(screen.queryByRole("option", { name: "between" })).toBeNull();
-    expect(screen.getByRole("option", { name: "greater than" })).toBeTruthy();
-    expect(screen.getByRole("option", { name: "less than" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "greater than or equal to" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "less than or equal to" })).toBeTruthy();
   });
 
   it("resets the row after adding so another filter can be entered", () => {

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+/**
+ * The filter builder (the search-bar popup's content): one row —
+ * [ field ▾ ] [ operator ▾ ] [ value ] [ Add filter ].
+ *
+ * Friendly operators lower to the backend `in`/`between` predicates: numeric
+ * equals/greater-than/less-than all emit a `between` predicate with the right (possibly
+ * null) bounds, and categorical `is` emits a one-element `in`. "Add filter" emits one
+ * predicate (the parent appends it as a chip) and resets the row so another can be added.
+ */
+import { useState } from "react";
+import {
+  AlertCircle,
+  Box,
+  ChevronDown,
+  CircleDollarSign,
+  CircleStop,
+  Clock,
+  Globe,
+  type LucideIcon,
+} from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { Predicate } from "@/types/api";
+import { useFilterValues } from "./hooks";
+import type { FilterFieldDef } from "./registry";
+import { buildBetweenPredicate, buildInPredicate } from "./predicate-ui";
+
+// Icons mirror the trace detail / list UI for consistency; the model and environment
+// fields, which have no trace-detail icon, use a generic one.
+const FIELD_ICONS: Record<string, LucideIcon> = {
+  cost: CircleDollarSign,
+  total_tokens: CircleStop,
+  duration_ms: Clock,
+  errors: AlertCircle,
+  model_name: Box,
+  environment: Globe,
+};
+
+// Unit shown inside the value input so it's clear what a numeric filter is measured in.
+// Only the short units ($ and ms) are shown; a "tokens" suffix is long enough to crowd
+// out the "Enter value" placeholder, and the Tokens field name already makes it clear.
+const FIELD_UNIT: Record<string, { prefix?: string; suffix?: string }> = {
+  cost: { prefix: "$" },
+  duration_ms: { suffix: "ms" },
+};
+
+type UiOp = "is" | "equals" | "gt" | "lt";
+const OP_LABEL: Record<UiOp, string> = {
+  is: "is",
+  equals: "equals",
+  // "greater than" is an INCLUSIVE >= bound (lowered to >= in translate.py); "less
+  // than" is a strict < bound. Labels are kept short; the semantics live in the comment.
+  gt: "greater than",
+  lt: "less than",
+};
+// "between" is intentionally not offered in the UI — a range is two filters
+// ("greater than X" and "less than Y"). The backend still supports a two-bound
+// predicate (and `equals` uses it as `[x, x]`).
+const opsFor = (f: FilterFieldDef): UiOp[] =>
+  f.type === "categorical" ? ["is"] : ["equals", "gt", "lt"];
+
+interface FilterBuilderProps {
+  projectId: string;
+  fields: FilterFieldDef[];
+  startAfter?: string;
+  onSubmit: (predicate: Predicate) => void;
+}
+
+export function FilterBuilder({ projectId, fields, startAfter, onSubmit }: FilterBuilderProps) {
+  const [field, setField] = useState<FilterFieldDef | null>(null);
+  const [op, setOp] = useState<UiOp>("is");
+  const [value, setValue] = useState("");
+
+  const reset = () => {
+    setField(null);
+    setOp("is");
+    setValue("");
+  };
+  const pickField = (f: FilterFieldDef) => {
+    setField(f);
+    setOp(opsFor(f)[0]);
+    setValue("");
+  };
+
+  const num = (s: string) => (s.trim() === "" ? null : Number(s));
+  const predicate = (): Predicate | null => {
+    if (!field) return null;
+    if (op === "is") return value === "" ? null : buildInPredicate(field.field, [value]);
+    const lo = num(value);
+    // Reject NaN/Infinity, and a fractional value on an integer field (e.g. "1e-1"
+    // slips past the input's decimal-point guard but can't bind as Int64).
+    if (lo === null || !Number.isFinite(lo)) return null;
+    if (field.integer && !Number.isInteger(lo)) return null;
+    if (op === "equals") return buildBetweenPredicate(field.field, lo, lo);
+    if (op === "gt") return buildBetweenPredicate(field.field, lo, null);
+    return buildBetweenPredicate(field.field, null, lo); // lt
+  };
+  const built = predicate();
+  // Immediate apply, then clear the row so another filter can be added without the
+  // popover closing ("add another row").
+  const submit = () => {
+    if (!built) return;
+    onSubmit(built);
+    reset();
+  };
+
+  return (
+    <div className="flex items-center gap-1.5 p-2">
+      <FieldDropdown fields={fields} value={field} onPick={pickField} />
+      <Dropdown
+        disabled={!field}
+        trigger={<span className="truncate">{field ? OP_LABEL[op] : "is"}</span>}
+        triggerClassName="w-[7.5rem] shrink-0"
+        contentClassName="w-[10rem]"
+      >
+        {(close) =>
+          (field ? opsFor(field) : []).map((o) => (
+            <DropdownItem
+              key={o}
+              active={o === op}
+              onClick={() => {
+                setOp(o);
+                close();
+              }}
+            >
+              {OP_LABEL[o]}
+            </DropdownItem>
+          ))
+        }
+      </Dropdown>
+      <ValueControl
+        projectId={projectId}
+        field={field}
+        startAfter={startAfter}
+        value={value}
+        onValue={setValue}
+        onEnter={submit}
+      />
+      <Button
+        size="sm"
+        className="h-8 shrink-0 rounded-md px-3 text-[13px]"
+        disabled={!built}
+        onClick={submit}
+      >
+        Add filter
+      </Button>
+    </div>
+  );
+}
+
+function ValueControl({
+  projectId,
+  field,
+  startAfter,
+  value,
+  onValue,
+  onEnter,
+}: {
+  projectId: string;
+  field: FilterFieldDef | null;
+  startAfter?: string;
+  value: string;
+  onValue: (v: string) => void;
+  onEnter: () => void;
+}) {
+  if (!field) {
+    return (
+      <Input
+        disabled
+        readOnly
+        value=""
+        placeholder="Enter value"
+        className="h-8 min-w-0 flex-1 rounded-md text-[13px]"
+      />
+    );
+  }
+  if (field.type === "categorical") {
+    return (
+      <CategoricalValue
+        projectId={projectId}
+        field={field}
+        startAfter={startAfter}
+        value={value}
+        onValue={onValue}
+      />
+    );
+  }
+  return (
+    <NumberField
+      ariaLabel="value"
+      placeholder="Enter value"
+      value={value}
+      onChange={onValue}
+      onEnter={onEnter}
+      unit={FIELD_UNIT[field.field]}
+      integer={Boolean(field.integer)}
+    />
+  );
+}
+
+function NumberField({
+  ariaLabel,
+  placeholder,
+  value,
+  onChange,
+  onEnter,
+  unit,
+  integer = false,
+}: {
+  ariaLabel: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  onEnter: () => void;
+  unit?: { prefix?: string; suffix?: string };
+  // Integer-typed fields (tokens/latency/errors) can't bind a fractional value in
+  // ClickHouse, so restrict the input to whole numbers.
+  integer?: boolean;
+}) {
+  return (
+    <div className="flex h-8 min-w-0 flex-1 items-center gap-1 rounded-md border border-input bg-transparent px-2.5 text-[13px] focus-within:ring-1 focus-within:ring-ring">
+      {unit?.prefix && <span className="shrink-0 text-muted-foreground">{unit.prefix}</span>}
+      <input
+        type="number"
+        min={0}
+        step={integer ? 1 : "any"}
+        aria-label={ariaLabel}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => {
+          // The filterable metrics are all non-negative — reject negative input; and for
+          // integer fields, reject a fractional value (it can't bind as Int64/UInt64).
+          const v = e.target.value;
+          if (v.startsWith("-") || Number(v) < 0) return;
+          if (integer && v.includes(".")) return;
+          onChange(v);
+        }}
+        onKeyDown={(e) => {
+          // Block a minus sign always, and a decimal point on integer fields.
+          if (e.key === "-" || (integer && e.key === ".")) e.preventDefault();
+          else if (e.key === "Enter") onEnter();
+        }}
+        className="min-w-0 flex-1 bg-transparent text-[13px] outline-none [appearance:textfield] placeholder:text-muted-foreground [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+      />
+      {unit?.suffix && <span className="shrink-0 text-muted-foreground">{unit.suffix}</span>}
+    </div>
+  );
+}
+
+function CategoricalValue({
+  projectId,
+  field,
+  startAfter,
+  value,
+  onValue,
+}: {
+  projectId: string;
+  field: FilterFieldDef;
+  startAfter?: string;
+  value: string;
+  onValue: (v: string) => void;
+}) {
+  const isStatic = field.value_source === "static_enum";
+  const { values } = useFilterValues(projectId, field.field, startAfter, !isStatic);
+  const options: { value: string; count?: number }[] = isStatic
+    ? field.enum_values.map((v) => ({ value: v }))
+    : values.map((v) => ({ value: v.value, count: v.count }));
+
+  return (
+    <Dropdown
+      trigger={
+        <span className={cn("truncate", !value && "text-muted-foreground")}>
+          {value || "Enter value"}
+        </span>
+      }
+      triggerClassName="min-w-0 flex-1"
+      contentClassName="w-[12rem]"
+    >
+      {(close) =>
+        options.length === 0 ? (
+          <div className="px-2 py-1.5 text-[13px] text-muted-foreground">No options</div>
+        ) : (
+          options.map((opt) => (
+            <DropdownItem
+              key={opt.value}
+              active={opt.value === value}
+              onClick={() => {
+                onValue(opt.value);
+                close();
+              }}
+            >
+              <span className="flex-1 truncate">{opt.value}</span>
+              {opt.count !== undefined && (
+                <span className="text-[11px] text-muted-foreground">{opt.count}</span>
+              )}
+            </DropdownItem>
+          ))
+        )
+      }
+    </Dropdown>
+  );
+}
+
+function FieldDropdown({
+  fields,
+  value,
+  onPick,
+}: {
+  fields: FilterFieldDef[];
+  value: FilterFieldDef | null;
+  onPick: (f: FilterFieldDef) => void;
+}) {
+  const Icon = value ? (FIELD_ICONS[value.field] ?? Box) : null;
+  return (
+    <Dropdown
+      trigger={
+        <span className="flex min-w-0 items-center gap-1.5">
+          {Icon && <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+          <span className="truncate">{value ? value.label : "Field"}</span>
+        </span>
+      }
+      triggerClassName="w-[8.5rem] shrink-0"
+      contentClassName="w-[13rem]"
+    >
+      {(close) =>
+        fields.map((f) => {
+          const FIcon = FIELD_ICONS[f.field] ?? Box;
+          return (
+            <DropdownItem
+              key={f.field}
+              active={f.field === value?.field}
+              onClick={() => {
+                onPick(f);
+                close();
+              }}
+            >
+              <FIcon className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="flex-1 truncate">{f.label}</span>
+            </DropdownItem>
+          );
+        })
+      }
+    </Dropdown>
+  );
+}
+
+function Dropdown({
+  trigger,
+  children,
+  triggerClassName,
+  contentClassName,
+  disabled,
+}: {
+  trigger: React.ReactNode;
+  children: (close: () => void) => React.ReactNode;
+  triggerClassName?: string;
+  contentClassName?: string;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "flex h-8 items-center justify-between gap-1.5 rounded-md border border-border bg-background px-2.5 text-[13px] font-normal transition-colors",
+            "hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50",
+            triggerClassName,
+          )}
+        >
+          {trigger}
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className={cn("max-h-64 overflow-y-auto p-1", contentClassName)}
+      >
+        {children(() => setOpen(false))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function DropdownItem({
+  active,
+  onClick,
+  children,
+}: {
+  active?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-muted/50",
+        active && "bg-muted/40",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -5,9 +5,9 @@
  * [ field ▾ ] [ operator ▾ ] [ value ] [ Add filter ].
  *
  * Friendly operators lower to the backend `in`/`between` predicates: numeric
- * equals/greater-than/less-than all emit a `between` predicate with the right (possibly
- * null) bounds, and categorical `is` emits a one-element `in`. "Add filter" emits one
- * predicate (the parent appends it as a chip) and resets the row so another can be added.
+ * equals / greater-than-or-equal / less-than-or-equal all emit a `between` predicate with
+ * the right (possibly null) bounds, and categorical `is` emits a one-element `in`. "Add
+ * filter" emits one predicate (the parent appends it as a chip) and resets the row.
  */
 import { useState } from "react";
 import {
@@ -48,20 +48,20 @@ const FIELD_UNIT: Record<string, { prefix?: string; suffix?: string }> = {
   duration_ms: { suffix: "ms" },
 };
 
-type UiOp = "is" | "equals" | "gt" | "lt";
+type UiOp = "is" | "equals" | "gte" | "lte";
 const OP_LABEL: Record<UiOp, string> = {
   is: "is",
   equals: "equals",
-  // "greater than" is an INCLUSIVE >= bound (lowered to >= in translate.py); "less
-  // than" is a strict < bound. Labels are kept short; the semantics live in the comment.
-  gt: "greater than",
-  lt: "less than",
+  // Verbose + honest: both bounds are inclusive (lowered to >= / <= in translate.py),
+  // so the operator name matches the actual comparison at the boundary.
+  gte: "greater than or equal to",
+  lte: "less than or equal to",
 };
 // "between" is intentionally not offered in the UI — a range is two filters
-// ("greater than X" and "less than Y"). The backend still supports a two-bound
+// (a gte and an lte on the same field). The backend still supports a two-bound
 // predicate (and `equals` uses it as `[x, x]`).
 const opsFor = (f: FilterFieldDef): UiOp[] =>
-  f.type === "categorical" ? ["is"] : ["equals", "gt", "lt"];
+  f.type === "categorical" ? ["is"] : ["equals", "gte", "lte"];
 
 interface FilterBuilderProps {
   projectId: string;
@@ -103,8 +103,8 @@ export function FilterBuilder({
     if (lo === null || !Number.isFinite(lo)) return null;
     if (field.integer && !Number.isInteger(lo)) return null;
     if (op === "equals") return buildBetweenPredicate(field.field, lo, lo);
-    if (op === "gt") return buildBetweenPredicate(field.field, lo, null);
-    return buildBetweenPredicate(field.field, null, lo); // lt
+    if (op === "gte") return buildBetweenPredicate(field.field, lo, null);
+    return buildBetweenPredicate(field.field, null, lo); // lte
   };
   const built = predicate();
   // Immediate apply, then clear the row so another filter can be added without the

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -67,10 +67,17 @@ interface FilterBuilderProps {
   projectId: string;
   fields: FilterFieldDef[];
   startAfter?: string;
+  endBefore?: string;
   onSubmit: (predicate: Predicate) => void;
 }
 
-export function FilterBuilder({ projectId, fields, startAfter, onSubmit }: FilterBuilderProps) {
+export function FilterBuilder({
+  projectId,
+  fields,
+  startAfter,
+  endBefore,
+  onSubmit,
+}: FilterBuilderProps) {
   const [field, setField] = useState<FilterFieldDef | null>(null);
   const [op, setOp] = useState<UiOp>("is");
   const [value, setValue] = useState("");
@@ -136,6 +143,7 @@ export function FilterBuilder({ projectId, fields, startAfter, onSubmit }: Filte
         projectId={projectId}
         field={field}
         startAfter={startAfter}
+        endBefore={endBefore}
         value={value}
         onValue={setValue}
         onEnter={submit}
@@ -156,6 +164,7 @@ function ValueControl({
   projectId,
   field,
   startAfter,
+  endBefore,
   value,
   onValue,
   onEnter,
@@ -163,6 +172,7 @@ function ValueControl({
   projectId: string;
   field: FilterFieldDef | null;
   startAfter?: string;
+  endBefore?: string;
   value: string;
   onValue: (v: string) => void;
   onEnter: () => void;
@@ -184,6 +194,7 @@ function ValueControl({
         projectId={projectId}
         field={field}
         startAfter={startAfter}
+        endBefore={endBefore}
         value={value}
         onValue={onValue}
       />
@@ -255,17 +266,19 @@ function CategoricalValue({
   projectId,
   field,
   startAfter,
+  endBefore,
   value,
   onValue,
 }: {
   projectId: string;
   field: FilterFieldDef;
   startAfter?: string;
+  endBefore?: string;
   value: string;
   onValue: (v: string) => void;
 }) {
   const isStatic = field.value_source === "static_enum";
-  const { values } = useFilterValues(projectId, field.field, startAfter, !isStatic);
+  const { values } = useFilterValues(projectId, field.field, startAfter, endBefore, !isStatic);
   const options: { value: string; count?: number }[] = isStatic
     ? field.enum_values.map((v) => ({ value: v }))
     : values.map((v) => ({ value: v.value, count: v.count }));

--- a/frontend/ui/src/features/filters/trace-search-filter-input.test.tsx
+++ b/frontend/ui/src/features/filters/trace-search-filter-input.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { TraceSearchFilterInput } from "./trace-search-filter-input";
+import type { Predicate } from "@/types/api";
+
+// Field registry drives the chip display name (registry label, lowercased).
+vi.mock("./hooks", () => ({
+  useFilterFields: () => [
+    { field: "cost", label: "Cost", type: "numeric", operators: ["between"] },
+    { field: "duration_ms", label: "Latency", type: "numeric", operators: ["between"] },
+  ],
+}));
+
+// Stub the builder: clicking it submits a `cost` predicate, so we can assert the
+// input's add/replace wiring without driving the whole builder.
+vi.mock("./filter-builder", () => ({
+  FilterBuilder: ({ onSubmit }: { onSubmit: (p: Predicate) => void }) => (
+    <button onClick={() => onSubmit({ field: "cost", op: "between", value: [1, null] })}>
+      stub-add-cost
+    </button>
+  ),
+}));
+
+afterEach(cleanup);
+
+function renderInput(props: Partial<React.ComponentProps<typeof TraceSearchFilterInput>> = {}) {
+  return render(
+    <TraceSearchFilterInput
+      searchValue=""
+      onSearchChange={vi.fn()}
+      projectId="p1"
+      filters={[]}
+      onFiltersChange={vi.fn()}
+      {...props}
+    />,
+  );
+}
+
+describe("TraceSearchFilterInput", () => {
+  it("renders a labeled chip inside the box per active filter", () => {
+    renderInput({ filters: [{ field: "cost", op: "between", value: [0.5, null] }] });
+    expect(screen.getByText("cost > 0.5")).toBeTruthy();
+  });
+
+  it("labels a chip with the field's lowercased display name (latency, not duration_ms)", () => {
+    renderInput({ filters: [{ field: "duration_ms", op: "between", value: [5, null] }] });
+    expect(screen.getByText("latency > 5")).toBeTruthy();
+    expect(screen.queryByText(/duration_ms/)).toBeNull();
+  });
+
+  it("removes a filter when its chip ✕ is clicked", () => {
+    const onFiltersChange = vi.fn();
+    renderInput({
+      filters: [
+        { field: "status", op: "in", value: ["ERROR"] },
+        { field: "cost", op: "between", value: [0.5, null] },
+      ],
+      onFiltersChange,
+    });
+    fireEvent.click(screen.getByLabelText("Remove cost filter"));
+    expect(onFiltersChange).toHaveBeenCalledWith([{ field: "status", op: "in", value: ["ERROR"] }]);
+  });
+
+  it("opens the builder on input focus and a submitted predicate replaces same-field", () => {
+    const onFiltersChange = vi.fn();
+    renderInput({ filters: [{ field: "cost", op: "between", value: [5, null] }], onFiltersChange });
+    // Builder is closed until the box is focused.
+    expect(screen.queryByText("stub-add-cost")).toBeNull();
+    fireEvent.focus(screen.getByRole("textbox"));
+    fireEvent.click(screen.getByText("stub-add-cost"));
+    expect(onFiltersChange).toHaveBeenCalledWith([
+      { field: "cost", op: "between", value: [1, null] },
+    ]);
+  });
+
+  it("types a keyword through the same box", () => {
+    const onSearchChange = vi.fn();
+    renderInput({ onSearchChange });
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "abc" } });
+    expect(onSearchChange).toHaveBeenCalledWith("abc");
+  });
+
+  it("backspace on the empty search field removes the last filter", () => {
+    const onFiltersChange = vi.fn();
+    renderInput({
+      filters: [
+        { field: "status", op: "in", value: ["ERROR"] },
+        { field: "cost", op: "between", value: [0.5, null] },
+      ],
+      onFiltersChange,
+    });
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Backspace" });
+    expect(onFiltersChange).toHaveBeenCalledWith([{ field: "status", op: "in", value: ["ERROR"] }]);
+  });
+
+  it("backspace does nothing when the search field has text", () => {
+    const onFiltersChange = vi.fn();
+    renderInput({
+      searchValue: "abc",
+      filters: [{ field: "cost", op: "between", value: [0.5, null] }],
+      onFiltersChange,
+    });
+    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Backspace" });
+    expect(onFiltersChange).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/features/filters/trace-search-filter-input.test.tsx
+++ b/frontend/ui/src/features/filters/trace-search-filter-input.test.tsx
@@ -40,12 +40,12 @@ function renderInput(props: Partial<React.ComponentProps<typeof TraceSearchFilte
 describe("TraceSearchFilterInput", () => {
   it("renders a labeled chip inside the box per active filter", () => {
     renderInput({ filters: [{ field: "cost", op: "between", value: [0.5, null] }] });
-    expect(screen.getByText("cost > 0.5")).toBeTruthy();
+    expect(screen.getByText("cost ≥ 0.5")).toBeTruthy();
   });
 
   it("labels a chip with the field's lowercased display name (latency, not duration_ms)", () => {
     renderInput({ filters: [{ field: "duration_ms", op: "between", value: [5, null] }] });
-    expect(screen.getByText("latency > 5")).toBeTruthy();
+    expect(screen.getByText("latency ≥ 5")).toBeTruthy();
     expect(screen.queryByText(/duration_ms/)).toBeNull();
   });
 

--- a/frontend/ui/src/features/filters/trace-search-filter-input.tsx
+++ b/frontend/ui/src/features/filters/trace-search-filter-input.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+/**
+ * The combined search-and-filter input: one box that holds the active-filter chips, the
+ * keyword text field, and — anchored to it — the filter builder popover.
+ *
+ * Clicking/focusing the box opens the builder (per "a popup from the search bar"); the
+ * popover keeps keyboard focus in the text field (`onOpenAutoFocus` prevented) so you can
+ * still type a keyword while it's open. Chips render INSIDE the box, each removable.
+ * Replaces the old separate "Add filter" button that sat beside the search bar.
+ */
+import { useRef, useState } from "react";
+import { Search, X } from "lucide-react";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import type { Predicate } from "@/types/api";
+import { useFilterFields } from "./hooks";
+import { FilterBuilder } from "./filter-builder";
+import { predicateLabel, upsertPredicate } from "./predicate-ui";
+
+interface TraceSearchFilterInputProps {
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  searchPlaceholder?: string;
+  projectId: string;
+  filters: Predicate[];
+  onFiltersChange: (filters: Predicate[]) => void;
+  /** Active-window lower bound, threaded to the lazy distinct-values query. */
+  startAfter?: string;
+}
+
+export function TraceSearchFilterInput({
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = "Search or filter…",
+  projectId,
+  filters,
+  onFiltersChange,
+  startAfter,
+}: TraceSearchFilterInputProps) {
+  const fields = useFilterFields(projectId);
+  const [open, setOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const anchorRef = useRef<HTMLDivElement>(null);
+
+  const addPredicate = (p: Predicate) => {
+    // Merge into the active set: a lower bound (`greater than`) and an upper bound
+    // (`less than`) on the same field coexist to form a range (e.g. latency > 5 and
+    // latency < 10, AND-combined by the backend); a same-direction bound, an exact
+    // `equals`, a categorical value, or a contradictory opposite bound that would make
+    // an empty range (e.g. errors > 5 then errors < 3) is superseded by the new one. The
+    // popover stays open and the builder resets, so another filter can be added at once.
+    onFiltersChange(upsertPredicate(filters, p));
+  };
+  const removeAt = (index: number) => onFiltersChange(filters.filter((_, i) => i !== index));
+
+  // Chips show the field's display name (its registry label, lowercased — e.g. `latency`
+  // rather than the raw `duration_ms`), falling back to the field key if it isn't loaded.
+  const fieldName = (field: string) =>
+    fields.find((f) => f.field === field)?.label.toLowerCase() ?? field;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverAnchor asChild>
+        <div
+          ref={anchorRef}
+          className={cn(
+            // Match the default SearchFilterBar input exactly: its absolute icon sits at
+            // left-2.5 (10px) with text at pl-8 (32px). Here the box has a 1px border, so
+            // pl-[9px] (1px border + 9px) puts the icon at the same 10px; mr-1 + gap-1
+            // (8px) then lands the text at 32px. Keeps the traces bar identical to
+            // users/sessions.
+            "flex min-h-8 min-w-[16rem] max-w-2xl flex-1 flex-wrap items-center gap-1 rounded-md",
+            "border border-input bg-transparent py-0.5 pl-[9px] pr-2 shadow-sm",
+            "focus-within:ring-1 focus-within:ring-ring",
+          )}
+          onMouseDown={(e) => {
+            // Clicking the empty area of the box focuses the text field (which opens the
+            // builder); let chip ✕ buttons and the field itself handle their own clicks.
+            if (e.target === e.currentTarget) {
+              e.preventDefault();
+              inputRef.current?.focus();
+            }
+          }}
+        >
+          <Search className="mr-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          {filters.map((p, i) => (
+            <span
+              key={`${p.field}-${i}`}
+              className="flex items-center gap-1 rounded bg-muted/70 py-0.5 pl-1.5 pr-1 text-[12px]"
+            >
+              <span className="font-medium text-foreground">
+                {predicateLabel(p, fieldName(p.field))}
+              </span>
+              <button
+                type="button"
+                aria-label={`Remove ${p.field} filter`}
+                onClick={() => removeAt(i)}
+                className="rounded p-0.5 transition-colors hover:bg-muted"
+              >
+                <X className="h-3 w-3 text-muted-foreground" />
+              </button>
+            </span>
+          ))}
+          <input
+            ref={inputRef}
+            value={searchValue}
+            onChange={(e) => onSearchChange(e.target.value)}
+            onFocus={() => setOpen(true)}
+            onClick={() => setOpen(true)}
+            onKeyDown={(e) => {
+              // Backspace on an empty text field removes the last filter chip, one per
+              // press — the standard tokenized-input behavior.
+              if (e.key === "Backspace" && searchValue === "" && filters.length > 0) {
+                removeAt(filters.length - 1);
+              }
+            }}
+            placeholder={filters.length === 0 ? searchPlaceholder : "Add filter or search…"}
+            className="h-6 min-w-[6rem] flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+      </PopoverAnchor>
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onInteractOutside={(e) => {
+          // Clicking the search box (the anchor, not the content) must NOT close the
+          // popover — Radix would otherwise close-then-reopen it, remounting the
+          // builder and wiping the user's in-progress selections.
+          if (anchorRef.current?.contains(e.target as Node)) e.preventDefault();
+        }}
+        // z-40 keeps the filter menu above the list but BELOW the trace detail panel
+        // (fixed z-50), so it never overlaps on top of an open detail view.
+        // Width is 75% of the search bar (left-aligned, so the right ~25% stays
+        // uncovered) with a min floor so the field/operator/value/Add-filter row never
+        // cramps when the bar itself is narrow.
+        className="z-40 w-[calc(var(--radix-popover-trigger-width)*0.75)] min-w-[28rem] p-0"
+      >
+        <FilterBuilder
+          projectId={projectId}
+          fields={fields}
+          startAfter={startAfter}
+          onSubmit={addPredicate}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/ui/src/features/filters/trace-search-filter-input.tsx
+++ b/frontend/ui/src/features/filters/trace-search-filter-input.tsx
@@ -46,11 +46,11 @@ export function TraceSearchFilterInput({
   const anchorRef = useRef<HTMLDivElement>(null);
 
   const addPredicate = (p: Predicate) => {
-    // Merge into the active set: a lower bound (`greater than`) and an upper bound
-    // (`less than`) on the same field coexist to form a range (e.g. latency > 5 and
-    // latency < 10, AND-combined by the backend); a same-direction bound, an exact
-    // `equals`, a categorical value, or a contradictory opposite bound that would make
-    // an empty range (e.g. errors > 5 then errors < 3) is superseded by the new one. The
+    // Merge into the active set: a lower bound (`greater than or equal to`) and an upper
+    // bound (`less than or equal to`) on the same field coexist to form a range (e.g.
+    // latency ≥ 5 and latency ≤ 10, AND-combined by the backend); a same-direction bound,
+    // an exact `equals`, a categorical value, or a contradictory opposite bound that would
+    // make an empty range (e.g. errors ≥ 5 then errors ≤ 3) is superseded by the new one. The
     // popover stays open and the builder resets, so another filter can be added at once.
     onFiltersChange(upsertPredicate(filters, p));
   };

--- a/frontend/ui/src/features/filters/trace-search-filter-input.tsx
+++ b/frontend/ui/src/features/filters/trace-search-filter-input.tsx
@@ -25,8 +25,9 @@ interface TraceSearchFilterInputProps {
   projectId: string;
   filters: Predicate[];
   onFiltersChange: (filters: Predicate[]) => void;
-  /** Active-window lower bound, threaded to the lazy distinct-values query. */
+  /** Active-window bounds, threaded to the lazy distinct-values query. */
   startAfter?: string;
+  endBefore?: string;
 }
 
 export function TraceSearchFilterInput({
@@ -37,6 +38,7 @@ export function TraceSearchFilterInput({
   filters,
   onFiltersChange,
   startAfter,
+  endBefore,
 }: TraceSearchFilterInputProps) {
   const fields = useFilterFields(projectId);
   const [open, setOpen] = useState(false);
@@ -141,6 +143,7 @@ export function TraceSearchFilterInput({
           projectId={projectId}
           fields={fields}
           startAfter={startAfter}
+          endBefore={endBefore}
           onSubmit={addPredicate}
         />
       </PopoverContent>


### PR DESCRIPTION
Closes #1375

The user-facing filter builder and its wiring (PR 5/5; base `feat/trace-filter-state`). Turns the feature on.

- Popover builder: field ▾ / operator ▾ / value row. Categorical single-select; numeric `equals`/`greater than`/`less than` that compose into ranges via two one-sided filters; integer-typed fields restrict input to whole numbers; non-negative guard.
- Tokenized search-and-filter input (active-filter chips + keyword) wired into the traces page search bar.

Tested: filter-builder, search-filter-input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Video

https://github.com/user-attachments/assets/513b5645-462c-41bf-9979-67d3c707aa37




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a popover filter builder anchored to the traces search bar and replaces the old button with a combined search-and-filter input for faster, in-place filtering.

- **New Features**
  - Filter builder: field ▾ / operator ▾ / value; categorical “is” and numeric equals/greater‑than‑or‑equal/less‑than‑or‑equal lower to backend `in`/`between`; non‑negative + integer‑only guards (incl. scientific notation); unit hints (`$`, `ms`); Enter to add; stays open and resets for multi‑add.
  - Combined input: chips + keyword in one box; opens builder on focus while keeping typing; chip ✕ removes; backspace on empty removes last; chip labels use the field’s display name (e.g., “latency”); merges/replaces same‑field predicates so ranges compose. Integrated on traces via `TraceSearchFilterInput` passed as `searchInput` to `SearchFilterBar` (`projectId`, `startAfter`, `endBefore`, keyword, `filters`); tests added.

- **Bug Fixes**
  - Categorical value dropdowns (e.g., model/environment) now bound by both `startAfter` and `endBefore` to match the active window and avoid zero‑result picks.
  - Operator labels clarified to “greater than or equal to” / “less than or equal to” so UI, chip text, and backend comparisons are inclusive and consistent.

<sup>Written for commit 7a4268714c61511a26c35a8ce92659a0b4c86733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1418?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




