### PR TITLE
fix: rate-limit get_span_io endpoint (join shared read bucket)

### DIFF
--- a/backend/rest/routers/traces.py
+++ b/backend/rest/routers/traces.py
@@ -19,7 +19,7 @@ from rest.rate_limit import (
     limiter,
     resolve_limit,
 )
-from rest.routers.deps import ProjectAccess, RateLimitedProjectAccess
+from rest.routers.deps import RateLimitedProjectAccess
 from rest.schemas.traces import SpanIOResponse, TraceDetailResponse, TraceListResponse
 from rest.services.trace_reader import get_trace_reader_service
 
@@ -123,11 +123,16 @@ async def get_trace(
 
 
 @router.get("/{trace_id}/spans/{span_id}/io", response_model=SpanIOResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def get_span_io(
+    request: Request,
+    response: Response,
     project_id: str,
     trace_id: str,
     span_id: str,
-    _access: ProjectAccess,  # Validates user has access to project
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
 ):
     """Get full input/output/metadata for a single span on demand."""
     service = get_trace_reader_service()


### PR DESCRIPTION
## Summary

`get_span_io` was the only read endpoint in `traces.py` not enrolled in the shared read-rate-limit bucket, leaving it unthrottled on cloud/billing-enabled deployments.

- Add `@limiter.shared_limit(resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt)` decorator
- Swap `_access: ProjectAccess` → `_access: RateLimitedProjectAccess` so `workspace_id`/`billing_plan` are stamped on the request for `key_read`
- Add `request: Request` and `response: Response` parameters required by the limiter

Both changes are required together — the decorator alone leaves the request unstamped and collapses callers into a degenerate key.

## What changed

`backend/rest/routers/traces.py` — `get_span_io` now matches the sibling endpoints `list_traces` and `get_trace` exactly.

## Validation

- No behaviour change on self-host (limiter is disabled)
- On cloud, a burst against `.../spans/{span_id}/io` will now return `429` after the per-plan read limit, sharing the bucket with `list_traces`/`get_trace`
- All pre-commit hooks (ruff lint + format) pass

## Notes

No existing REST-layer test infrastructure is present in the repo (`backend/rest/` has no test directory). The acceptance criterion for a rate-limit integration test can be addressed in a follow-up once a test harness is established.

Closes #1411

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rate-limit the `get_span_io` endpoint by joining the shared read bucket, aligning it with `list_traces` and `get_trace` to prevent unthrottled reads on cloud. Added `@limiter.shared_limit(...)`, switched `_access` to `RateLimitedProjectAccess`, and included `request`/`response` for proper keying; no change for self-hosted deployments.

<sup>Written for commit e8b4febd29f73c08e342494cb098c961e8bc0525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

