### PR TITLE
fix: add environment field to ClickHouse insert functions

### DIFF
--- a/backend/db/clickhouse/client.py
+++ b/backend/db/clickhouse/client.py
@@ -57,6 +57,7 @@ class ClickHouseClient:
                     t.get("input"),
                     t.get("output"),
                     t.get("metadata"),
+                    t.get("environment"),
                     now,  # ch_create_time
                     now,  # ch_update_time
                 ]
@@ -77,6 +78,7 @@ class ClickHouseClient:
                 "input",
                 "output",
                 "metadata",
+                "environment",
                 "ch_create_time",
                 "ch_update_time",
             ],
@@ -114,6 +116,7 @@ class ClickHouseClient:
                     s.get("git_source_file"),
                     s.get("git_source_line"),
                     s.get("git_source_function"),
+                    s.get("environment"),
                     now,  # ch_create_time
                     now,  # ch_update_time
                 ]
@@ -145,6 +148,7 @@ class ClickHouseClient:
                 "git_source_file",
                 "git_source_line",
                 "git_source_function",
+                "environment",
                 "ch_create_time",
                 "ch_update_time",
             ],

--- a/tests/db/test_client.py
+++ b/tests/db/test_client.py
@@ -50,10 +50,35 @@ class TestInsertTracesBatch:
         assert row[8] == "hello"  # input
         assert row[9] == "world"  # output
         assert row[10] is None  # metadata
+        assert row[11] is None  # environment (not set in this trace)
         # ch_create_time and ch_update_time are auto-set
-        assert isinstance(row[11], datetime)
         assert isinstance(row[12], datetime)
-        assert len(columns) == 13
+        assert isinstance(row[13], datetime)
+        assert len(columns) == 14
+
+    def test_environment_field_in_row(self):
+        """Verify environment value is passed through at the correct column position."""
+        mock_internal = MagicMock()
+        client = ClickHouseClient(mock_internal)
+
+        traces = [
+            {
+                "trace_id": "trace-1",
+                "project_id": "proj-1",
+                "trace_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                "name": "test-trace",
+                "environment": "production",
+            }
+        ]
+        client.insert_traces_batch(traces)
+
+        call_args = mock_internal.insert.call_args
+        rows = call_args[0][1]
+        columns = call_args[1]["column_names"]
+        row = rows[0]
+
+        env_index = columns.index("environment")
+        assert row[env_index] == "production"
 
     def test_empty_batch_no_insert(self):
         """Empty list -> no _client.insert() call."""
@@ -113,8 +138,35 @@ class TestInsertSpansBatch:
         assert row[13] == 50  # output_tokens
         assert row[14] == 150  # total_tokens
         # 3 fixed breakdown columns collapsed into one usage_details map (net -2).
-        assert len(columns) == 24
+        assert len(columns) == 25
         assert "usage_details" in columns
+        assert "environment" in columns
+
+    def test_environment_field_in_row(self):
+        """Verify environment value is passed through at the correct column position."""
+        mock_internal = MagicMock()
+        client = ClickHouseClient(mock_internal)
+
+        spans = [
+            {
+                "span_id": "span-1",
+                "trace_id": "trace-1",
+                "project_id": "proj-1",
+                "span_start_time": datetime(2024, 1, 15, 12, 0, 0),
+                "name": "test-span",
+                "span_kind": "LLM",
+                "environment": "staging",
+            }
+        ]
+        client.insert_spans_batch(spans)
+
+        call_args = mock_internal.insert.call_args
+        rows = call_args[0][1]
+        columns = call_args[1]["column_names"]
+        row = rows[0]
+
+        env_index = columns.index("environment")
+        assert row[env_index] == "staging"
 
     def test_optional_fields_none(self):
         """None values for optional fields (cost, tokens)."""


### PR DESCRIPTION
## Summary

`insert_traces_batch` and `insert_spans_batch` in `backend/db/clickhouse/client.py` use explicit column lists where every field must be manually added. The `environment` column — added to the `spans` and `traces` tables in migration `003_create_detector_tables.sql` — was never included, so it was silently dropped before reaching ClickHouse and always stored as `NULL`.

`otel_transform.py` already correctly extracts the value and conditionally sets it on the record dict; this fix wires the final step so it actually gets persisted.

## Changes

`backend/db/clickhouse/client.py` — 4 lines added:

- `insert_traces_batch`: add `t.get("environment")` to the row and `"environment"` to `column_names`
- `insert_spans_batch`: add `s.get("environment")` to the row and `"environment"` to `column_names`

Row position and column name are kept in sync in both functions.

## Impact

With this fix, when the SDK sets `traceroot.environment` on a span, the value flows through `otel_transform.py` → `insert_spans_batch` → ClickHouse correctly. The `environment` trigger condition in the Detectors UI (`environment = production`) can then evaluate against a real value instead of always receiving `NULL`.

## Notes

The SDK (`traceroot-py`) must also be fixed to actually read `TRACEROOT_ENVIRONMENT` and stamp `traceroot.environment` on spans — tracked in #1407. Both fixes are needed end-to-end; this PR covers the backend half.

All pre-commit hooks (ruff lint + format) pass.

Closes #1408

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the environment field for traces and spans in ClickHouse by adding it to the explicit column and value lists in `insert_traces_batch` and `insert_spans_batch`. This prevents NULLs and enables environment-based detectors (e.g., environment = production) to work as expected.

- **Bug Fixes**
  - Updated `tests/db/test_client.py` to cover environment column insertion, adjust column counts (traces 13→14, spans 24→25), and verify the value is passed through at the correct position.

<sup>Written for commit 96fb1767b1695b3e033109205161fbcaf1228c05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

