### PR TITLE
docs: add Star History chart to README

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -206,6 +206,16 @@ Agentic Debugging Runtime의 기반을 제공하는 [pi-mono](https://github.com
   <img src="https://contrib.rocks/image?repo=traceroot-ai/traceroot" />
 </a>
 
+## ⭐️ Star History
+
+<a href="https://star-history.com/#traceroot-ai/traceroot&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
+ </picture>
+</a>
+
 <!-- Links -->
 [discord-image]: https://img.shields.io/discord/1395844148568920114?logo=discord&labelColor=%235462eb&logoColor=%23f5f5f5&color=%235462eb
 [discord-url]: https://discord.gg/TM2m3CtKuC

--- a/README.ko.md
+++ b/README.ko.md
@@ -200,13 +200,7 @@ Agentic Debugging Runtime의 기반을 제공하는 [pi-mono](https://github.com
 
 이 프로젝트는 [Apache 2.0 라이선스](LICENSE)를 기반으로 제공되며, 추가 [Enterprise 기능](./ee/LICENSE)을 포함합니다.
 
-## Contributors
-
-<a href="https://github.com/traceroot-ai/traceroot/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=traceroot-ai/traceroot" />
-</a>
-
-## ⭐️ Star History
+## Star History
 
 <a href="https://star-history.com/#traceroot-ai/traceroot&Date">
  <picture>
@@ -214,6 +208,12 @@ Agentic Debugging Runtime의 기반을 제공하는 [pi-mono](https://github.com
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" />
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
  </picture>
+</a>
+
+## Contributors
+
+<a href="https://github.com/traceroot-ai/traceroot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=traceroot-ai/traceroot" />
 </a>
 
 <!-- Links -->

--- a/README.md
+++ b/README.md
@@ -200,13 +200,7 @@ Special Thanks for [pi-mono](https://github.com/badlogic/pi-mono) project, which
 
 This project is licensed under [Apache 2.0](LICENSE) with additional [Enterprise features](./ee/LICENSE).
 
-## Contributors
-
-<a href="https://github.com/traceroot-ai/traceroot/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=traceroot-ai/traceroot" />
-</a>
-
-## ⭐️ Star History
+## Star History
 
 <a href="https://star-history.com/#traceroot-ai/traceroot&Date">
  <picture>
@@ -214,6 +208,12 @@ This project is licensed under [Apache 2.0](LICENSE) with additional [Enterprise
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" />
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
  </picture>
+</a>
+
+## Contributors
+
+<a href="https://github.com/traceroot-ai/traceroot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=traceroot-ai/traceroot" />
 </a>
 
 <!-- Links -->

--- a/README.md
+++ b/README.md
@@ -206,6 +206,16 @@ This project is licensed under [Apache 2.0](LICENSE) with additional [Enterprise
   <img src="https://contrib.rocks/image?repo=traceroot-ai/traceroot" />
 </a>
 
+## ⭐️ Star History
+
+<a href="https://star-history.com/#traceroot-ai/traceroot&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
+ </picture>
+</a>
+
 <!-- Links -->
 [discord-image]: https://img.shields.io/discord/1395844148568920114?logo=discord&labelColor=%235462eb&logoColor=%23f5f5f5&color=%235462eb
 [discord-url]: https://discord.gg/TM2m3CtKuC

--- a/README.zh.md
+++ b/README.zh.md
@@ -200,13 +200,7 @@ main().catch(console.error);
 
 本项目基于 [Apache 2.0](LICENSE) 许可证，并包含额外的[企业版功能](./ee/LICENSE)。
 
-## 贡献者
-
-<a href="https://github.com/traceroot-ai/traceroot/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=traceroot-ai/traceroot" />
-</a>
-
-## ⭐️ Star 趋势
+## Star 趋势
 
 <a href="https://star-history.com/#traceroot-ai/traceroot&Date">
  <picture>
@@ -214,6 +208,12 @@ main().catch(console.error);
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" />
    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
  </picture>
+</a>
+
+## 贡献者
+
+<a href="https://github.com/traceroot-ai/traceroot/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=traceroot-ai/traceroot" />
 </a>
 
 <!-- Links -->

--- a/README.zh.md
+++ b/README.zh.md
@@ -206,6 +206,16 @@ main().catch(console.error);
   <img src="https://contrib.rocks/image?repo=traceroot-ai/traceroot" />
 </a>
 
+## ⭐️ Star 趋势
+
+<a href="https://star-history.com/#traceroot-ai/traceroot&Date">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=traceroot-ai/traceroot&type=Date" style="border-radius: 15px;" />
+ </picture>
+</a>
+
 <!-- Links -->
 [discord-image]: https://img.shields.io/discord/1395844148568920114?logo=discord&labelColor=%235462eb&logoColor=%23f5f5f5&color=%235462eb
 [discord-url]: https://discord.gg/TM2m3CtKuC


### PR DESCRIPTION
## Summary

Adds a Star History chart to the bottom of the README (English, Chinese, Korean), placed just after the Contributors section.

- Live light/dark `<picture>` block backed by `api.star-history.com` for `traceroot-ai/traceroot`, so the chart stays current automatically.
- Heading localized per file: `⭐️ Star History` (EN/KO), `⭐️ Star 趋势` (ZH).

## Notes

The chart renders live and reflects real star growth as-is. Preview: https://star-history.com/#traceroot-ai/traceroot&Date

Closes #1423

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a live Star History chart to the English, Chinese, and Korean READMEs, placed above the Contributors section. It uses a light/dark <picture> that pulls the current SVG from `api.star-history.com` for `traceroot-ai/traceroot`, with localized headings and no emoji.

<sup>Written for commit b6c8ff6d451ca5f4841a0315f5dc66be87ad6563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

