### PR TITLE
feat: add claude-fable-5 as BYOK-only model

### DIFF
--- a/backend/worker/tokens/types.py
+++ b/backend/worker/tokens/types.py
@@ -15,6 +15,7 @@ TIKTOKEN_MODELS = [
 
 # Claude models (use char approximation)
 CLAUDE_MODELS = [
+    "claude-fable-5",
     "claude-3-5-sonnet",
     "claude-3-5-haiku",
     "claude-3-opus",

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -154,6 +154,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "o4-mini", label: "o4-mini" },
   ],
   anthropic: [
+    { id: "claude-fable-5", label: "claude-fable-5" },
     { id: "claude-opus-4-8", label: "claude-opus-4-8" },
     { id: "claude-opus-4-7", label: "claude-opus-4-7" },
     { id: "claude-opus-4-6", label: "claude-opus-4-6" },

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -154,7 +154,6 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "o4-mini", label: "o4-mini" },
   ],
   anthropic: [
-    { id: "claude-fable-5", label: "claude-fable-5" },
     { id: "claude-opus-4-8", label: "claude-opus-4-8" },
     { id: "claude-opus-4-7", label: "claude-opus-4-7" },
     { id: "claude-opus-4-6", label: "claude-opus-4-6" },
@@ -162,6 +161,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "claude-opus-4-5", label: "claude-opus-4-5" },
     { id: "claude-sonnet-4-5", label: "claude-sonnet-4-5" },
     { id: "claude-haiku-4-5", label: "claude-haiku-4-5" },
+    { id: "claude-fable-5", label: "claude-fable-5" },
   ],
   google: [
     { id: "gemini-3.5-flash", label: "gemini-3.5-flash" },

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "tr-claude-fable-5",
+    "modelName": "claude-fable-5",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-fable-5(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-fable-5(-[\\d-]+)?(-v\\d+:\\d+)?)$",
+    "provider": "anthropic",
+    "prices": {
+      "input": 0.00001,
+      "output": 0.00005,
+      "cacheRead": 0.000001,
+      "cacheWrite": 0.0000125,
+      "cacheWrite1h": 0.00002
+    }
+  },
+  {
     "id": "tr-claude-opus-4-8",
     "modelName": "claude-opus-4-8",
     "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-8(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-8-opus(@[\\d-]+)?)$",

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -313,6 +313,11 @@ class TestCalculateCost:
 
 # (model_id, expected modelName) for IDs the worker must price correctly.
 CLAUDE_BEDROCK_VERTEX_CASES = [
+    # Fable 5 — plain, [1m] variant, anthropic/ prefix, Bedrock (no Vertex reversed-alias)
+    ("claude-fable-5", "claude-fable-5"),
+    ("claude-fable-5[1m]", "claude-fable-5"),
+    ("anthropic/claude-fable-5", "claude-fable-5"),
+    ("us.anthropic.claude-fable-5-20260701-v1:0", "claude-fable-5"),
     # Opus 4.8 — plain, [1m] variant, Bedrock, Vertex
     ("claude-opus-4-8", "claude-opus-4-8"),
     ("claude-opus-4-8[1m]", "claude-opus-4-8"),


### PR DESCRIPTION
## Summary

Closes #1421

Adds Claude Fable 5 (`claude-fable-5`) to the BYOK catalog. Fable 5 is **not** added to `SYSTEM_MODELS` — its $10/$50 per MTok pricing and mandatory 30-day data retention make it unsuitable as a TraceRoot-hosted model. Users who bring their own Anthropic key will see it in the BYOK dropdown and can run it at their own cost and retention tradeoff.

**Changes:**
- `frontend/packages/core/src/llm-providers.ts` — added `claude-fable-5` to `ADAPTER_MODELS.anthropic` only (not `SYSTEM_MODELS`)
- `frontend/packages/core/src/standard-model-prices.json` — added pricing entry at $10/$50 per MTok input/output with Anthropic-standard cache multipliers (read 0.1×, write-5m 1.25×, write-1h 2×)
- `backend/worker/tokens/types.py` — added `"claude-fable-5"` to `CLAUDE_MODELS`
- `tests/worker/tokens/test_pricing.py` — added plain, `[1m]`, `anthropic/` prefix, and Bedrock CRIS cases to `CLAUDE_BEDROCK_VERTEX_CASES`; no Vertex reversed-alias case (Fable 5 uses plain `claude-fable-5` on GCP)

## Test plan

- [ ] With an Anthropic BYOK key, `claude-fable-5` appears in the model dropdown (BYOK section) and is selectable
- [ ] `claude-fable-5` does not appear as a hosted/system model
- [ ] Pricing test cases pass (`TestClaudeBedrockAndVertexIds`)
- [ ] `test_anthropic_entries_have_2x_input_1h_cache_rate` passes (cacheWrite1h = 2× input = 0.00002)
- [ ] Hosted default model (Opus 4.8) is unchanged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `claude-fable-5` as a BYOK-only model so users with their own Anthropic key can use it. Keeps `claude-opus-4-8` as the BYOK default by placing Fable 5 at the end of the Anthropic list.

- New Features
  - Added to `ADAPTER_MODELS.anthropic` (BYOK only); not in `SYSTEM_MODELS`.
  - Pricing entry: input $0.00001, output $0.00005; cache read 0.1×, write‑5m 1.25×, write‑1h 2×. Pattern matches plain, `[1m]`, `anthropic/` prefix, and Bedrock CRIS IDs.
  - Included in `CLAUDE_MODELS` for cost estimation; tests added for ID mapping and pricing/cache.

- Bug Fixes
  - Moved `claude-fable-5` to the end of `ADAPTER_MODELS.anthropic` to avoid becoming the default via first-item fallback, preserving `claude-opus-4-8` as the BYOK default.

<sup>Written for commit af12d1be0245a86de81b9cf06ad7fca7fab8403d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

