### PR TITLE
fix: improve BYOK test connection error display

### DIFF
--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -55,7 +55,7 @@ vi.mock("@/lib/auth-helpers", () => ({
 }));
 
 import { POST } from "./route";
-import { withTimeout, resolveTimeoutMs } from "./timeout";
+import { TimeoutError, withTimeout, resolveTimeoutMs } from "./timeout";
 
 const fetchMock = vi.fn();
 vi.stubGlobal("fetch", fetchMock);
@@ -133,15 +133,19 @@ describe("withTimeout", () => {
   });
 
   it("throws a timeout error when the operation never settles", async () => {
-    await expect(
-      withTimeout(
-        (signal) =>
-          new Promise((_resolve, reject) => {
-            signal.addEventListener("abort", () => reject(new Error("aborted")));
-          }),
-        20,
-      ),
-    ).rejects.toThrow(/timed out after 20ms/);
+    const err = await withTimeout(
+      (signal) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener("abort", () => reject(new Error("aborted")));
+        }),
+      20,
+    ).catch((e: unknown) => e);
+
+    // A distinct type lets callers tell a deadline breach from a transport
+    // failure; the name carries that distinction into serialized logs too.
+    expect(err).toBeInstanceOf(TimeoutError);
+    expect((err as Error).name).toBe("TimeoutError");
+    expect((err as Error).message).toMatch(/timed out after 20ms/);
   });
 
   it("stays armed across multiple awaits (e.g. a hanging body read)", async () => {

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -284,7 +284,8 @@ describe("POST model-providers/test - error responses", () => {
       const res = await POST(makeRequest(body), makeParams());
       expect(await res.json()).toEqual({
         success: false,
-        error: "HTTP 500: Internal Server Error",
+        error: "Connection failed",
+        detail: "HTTP 500: Internal Server Error",
       });
     });
   }
@@ -320,7 +321,11 @@ describe("POST model-providers/test - error responses", () => {
       json: async () => ({ error: { message: "Malformed request body" } }),
     });
     const res = await POST(makeRequest({ adapter: "openai", apiKey: "k" }), makeParams());
-    expect(await res.json()).toEqual({ success: false, error: "Malformed request body" });
+    expect(await res.json()).toEqual({
+      success: false,
+      error: "Connection failed",
+      detail: "Malformed request body",
+    });
   });
 
   it("anthropic 401 always normalizes to Invalid API key, ignoring the provider's own message", async () => {
@@ -387,7 +392,11 @@ describe("POST model-providers/test - error responses", () => {
       json: async () => ({ error: "Model not found: grok-beta" }),
     });
     const res = await POST(makeRequest({ adapter: "xai", apiKey: "k" }), makeParams());
-    expect(await res.json()).toEqual({ success: false, error: "Model not found: grok-beta" });
+    expect(await res.json()).toEqual({
+      success: false,
+      error: "Connection failed",
+      detail: "Model not found: grok-beta",
+    });
   });
 
   it("azure without baseUrl fails before any network call", async () => {

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -295,7 +295,7 @@ describe("POST model-providers/test - error responses", () => {
     expect(await res.json()).toEqual({ success: false, error: "Invalid API key" });
   });
 
-  it("anthropic non-401 errors are treated as connectable (success)", async () => {
+  it("anthropic non-auth (non-401/403) errors are treated as connectable (success)", async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 400, statusText: "Bad Request" });
     const res = await POST(makeRequest({ adapter: "anthropic", apiKey: "k" }), makeParams());
     expect(await res.json()).toEqual({ success: true });
@@ -351,7 +351,16 @@ describe("POST model-providers/test - error responses", () => {
       ok: false,
       status: 400,
       statusText: "Bad Request",
-      json: async () => ({ error: { message: "API key not valid. Reason: API_KEY_INVALID" } }),
+      json: async () => ({
+        error: {
+          code: 400,
+          message: "API key not valid. Please pass a valid API key.",
+          status: "INVALID_ARGUMENT",
+          details: [
+            { "@type": "type.googleapis.com/google.rpc.ErrorInfo", reason: "API_KEY_INVALID" },
+          ],
+        },
+      }),
     });
     const res = await POST(makeRequest({ adapter: "google", apiKey: "bad" }), makeParams());
     expect(await res.json()).toEqual({ success: false, error: "Invalid API key" });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -334,16 +334,51 @@ describe("POST model-providers/test - error responses", () => {
     expect(await res.json()).toEqual({ success: false, error: "Invalid API key" });
   });
 
-  it("anthropic 403 is treated as connectable (success), not an invalid key", async () => {
+  it("anthropic 403 maps to API lacks permission", async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 403, statusText: "Forbidden" });
     const res = await POST(makeRequest({ adapter: "anthropic", apiKey: "k" }), makeParams());
-    expect(await res.json()).toEqual({ success: true });
+    expect(await res.json()).toEqual({ success: false, error: "API lacks permission" });
   });
 
-  it("openai/azure-style 403 is not normalized to Invalid API key (401 only)", async () => {
+  it("openai 403 maps to API lacks permission", async () => {
     fetchMock.mockResolvedValue({ ok: false, status: 403, statusText: "Forbidden" });
     const res = await POST(makeRequest({ adapter: "openai", apiKey: "k" }), makeParams());
-    expect(await res.json()).toEqual({ success: false, error: "HTTP 403: Forbidden" });
+    expect(await res.json()).toEqual({ success: false, error: "API lacks permission" });
+  });
+
+  it("google 400 API_KEY_INVALID maps to Invalid API key", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({ error: { message: "API key not valid. Reason: API_KEY_INVALID" } }),
+    });
+    const res = await POST(makeRequest({ adapter: "google", apiKey: "bad" }), makeParams());
+    expect(await res.json()).toEqual({ success: false, error: "Invalid API key" });
+  });
+
+  it("xai 400 incorrect API key maps to Invalid API key", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({
+        error: "Incorrect API key provided. You can obtain an API key from https://console.x.ai.",
+      }),
+    });
+    const res = await POST(makeRequest({ adapter: "xai", apiKey: "bad" }), makeParams());
+    expect(await res.json()).toEqual({ success: false, error: "Invalid API key" });
+  });
+
+  it("xai 400 with an unrelated error surfaces the raw message", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({ error: "Model not found: grok-beta" }),
+    });
+    const res = await POST(makeRequest({ adapter: "xai", apiKey: "k" }), makeParams());
+    expect(await res.json()).toEqual({ success: false, error: "Model not found: grok-beta" });
   });
 
   it("azure without baseUrl fails before any network call", async () => {

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -301,7 +301,7 @@ describe("POST model-providers/test - error responses", () => {
     expect(await res.json()).toEqual({ success: true });
   });
 
-  it("surfaces the provider's own error message when the body has one", async () => {
+  it("openai 401 normalizes to Invalid API key, ignoring the provider's own message", async () => {
     fetchMock.mockResolvedValue({
       ok: false,
       status: 401,
@@ -309,10 +309,21 @@ describe("POST model-providers/test - error responses", () => {
       json: async () => ({ error: { message: "Incorrect API key provided" } }),
     });
     const res = await POST(makeRequest({ adapter: "openai", apiKey: "bad" }), makeParams());
-    expect(await res.json()).toEqual({ success: false, error: "Incorrect API key provided" });
+    expect(await res.json()).toEqual({ success: false, error: "Invalid API key" });
   });
 
-  it("anthropic 401 surfaces the provider error message when present", async () => {
+  it("openai surfaces the provider's own error message on non-401 statuses", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({ error: { message: "Malformed request body" } }),
+    });
+    const res = await POST(makeRequest({ adapter: "openai", apiKey: "k" }), makeParams());
+    expect(await res.json()).toEqual({ success: false, error: "Malformed request body" });
+  });
+
+  it("anthropic 401 always normalizes to Invalid API key, ignoring the provider's own message", async () => {
     fetchMock.mockResolvedValue({
       ok: false,
       status: 401,
@@ -320,7 +331,19 @@ describe("POST model-providers/test - error responses", () => {
       json: async () => ({ error: { message: "invalid x-api-key" } }),
     });
     const res = await POST(makeRequest({ adapter: "anthropic", apiKey: "bad" }), makeParams());
-    expect(await res.json()).toEqual({ success: false, error: "invalid x-api-key" });
+    expect(await res.json()).toEqual({ success: false, error: "Invalid API key" });
+  });
+
+  it("anthropic 403 is treated as connectable (success), not an invalid key", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 403, statusText: "Forbidden" });
+    const res = await POST(makeRequest({ adapter: "anthropic", apiKey: "k" }), makeParams());
+    expect(await res.json()).toEqual({ success: true });
+  });
+
+  it("openai/azure-style 403 is not normalized to Invalid API key (401 only)", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 403, statusText: "Forbidden" });
+    const res = await POST(makeRequest({ adapter: "openai", apiKey: "k" }), makeParams());
+    expect(await res.json()).toEqual({ success: false, error: "HTTP 403: Forbidden" });
   });
 
   it("azure without baseUrl fails before any network call", async () => {
@@ -450,9 +473,9 @@ describe("POST model-providers/test - timeout (acceptance criteria)", () => {
     expect(body.error).toMatch(/timed out/i);
   });
 
-  it("times out when the anthropic 401 body read stalls", async () => {
-    // The anthropic branch has its own inline withTimeout + body read; a 401
-    // whose body never finishes must still abort at the deadline.
+  it("anthropic 401 short-circuits without reading the body, so it cannot time out", async () => {
+    // The anthropic branch hardcodes "Invalid API key" on 401 without touching
+    // the response body at all, so a stalled body read is a non-issue here.
     fetchMock.mockImplementation((_url: string, init?: { signal?: AbortSignal }) =>
       Promise.resolve({
         ok: false,
@@ -468,7 +491,6 @@ describe("POST model-providers/test - timeout (acceptance criteria)", () => {
     );
     const res = await POST(makeRequest({ adapter: "anthropic", apiKey: "bad" }), makeParams());
     const body = (await res.json()) as { success: boolean; error: string };
-    expect(body.success).toBe(false);
-    expect(body.error).toMatch(/timed out/i);
+    expect(body).toEqual({ success: false, error: "Invalid API key" });
   });
 });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -494,12 +494,13 @@ describe("POST model-providers/test - timeout (acceptance criteria)", () => {
     expect(elapsed).toBeLessThan(2000);
   });
 
-  it("surfaces an ordinary fetch rejection as a non-timeout failure", async () => {
+  it("demotes an ordinary fetch rejection to the detail line under a normalized headline", async () => {
     fetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
     const res = await POST(makeRequest({ adapter: "openai", apiKey: "k" }), makeParams());
-    const body = (await res.json()) as { success: boolean; error: string };
+    const body = (await res.json()) as { success: boolean; error: string; detail?: string };
     expect(body.success).toBe(false);
-    expect(body.error).toBe("ECONNREFUSED");
+    expect(body.error).toBe("Connection failed");
+    expect(body.detail).toBe("ECONNREFUSED");
     expect(body.error).not.toMatch(/timed out/i);
   });
 
@@ -546,4 +547,34 @@ describe("POST model-providers/test - timeout (acceptance criteria)", () => {
     const body = (await res.json()) as { success: boolean; error: string };
     expect(body).toEqual({ success: false, error: "Invalid API key" });
   });
+
+  it.each([
+    [401, "Invalid API key"],
+    [403, "API lacks permission"],
+  ])(
+    "checkEndpoint short-circuits a %i before reading the body, so a stalled body cannot time it out",
+    async (status, expected) => {
+      // checkEndpoint is the path every provider except anthropic/bedrock takes.
+      // It must decide on the status alone: a provider that returns auth-failure
+      // headers and then stalls the body would otherwise report a timeout, hiding
+      // the real cause from the user.
+      fetchMock.mockImplementation((_url: string, init?: { signal?: AbortSignal }) =>
+        Promise.resolve({
+          ok: false,
+          status,
+          statusText: "Auth failure",
+          json: () =>
+            new Promise((_resolve, reject) => {
+              init?.signal?.addEventListener("abort", () =>
+                reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+              );
+            }),
+        }),
+      );
+
+      const res = await POST(makeRequest({ adapter: "openai", apiKey: "bad" }), makeParams());
+      const body = (await res.json()) as { success: boolean; error: string };
+      expect(body).toEqual({ success: false, error: expected });
+    },
+  );
 });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -70,15 +70,17 @@ async function checkEndpoint(
   return withTimeout(async (signal) => {
     const res = await fetch(url, { headers, signal });
     if (res.ok) return { ok: true as const };
+
     const message = await readErrorMessage(res, signal);
+    const isGoogleInvalidKey = /api key not valid/i.test(message ?? "");
 
     let normalizedError: string;
     if (res.status === 401) {
       normalizedError = "Invalid API key";
     } else if (res.status === 403) {
       normalizedError = "API lacks permission";
-    } else if (res.status === 400 && message && /API_KEY_INVALID/i.test(message)) {
-      // Google returns 400 with reason API_KEY_INVALID instead of 401.
+    } else if (res.status === 400 && isGoogleInvalidKey) {
+      // Google returns 400 with reason API_KEY_INVALID in error.details[].reason, not in message.
       normalizedError = "Invalid API key";
     } else if (res.status === 400 && message && /incorrect api key/i.test(message)) {
       // xAI returns 400 with a plain-string error mentioning "Incorrect API key".

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -47,8 +47,14 @@ type RouteParams = { params: Promise<{ workspaceId: string }> };
 // timeout; a merely unparseable/empty body falls back to the HTTP status line.
 async function readErrorMessage(res: Response, signal: AbortSignal): Promise<string | undefined> {
   try {
-    const body = (await res.json()) as { error?: { message?: unknown } };
-    return body?.error?.message ? String(body.error.message) : undefined;
+    const body = (await res.json()) as { error?: { message?: unknown } | string };
+    if (body?.error && typeof body.error === "object" && "message" in body.error) {
+      return body.error.message ? String(body.error.message) : undefined;
+    }
+    if (typeof body?.error === "string") {
+      return body.error;
+    }
+    return undefined;
   } catch (err) {
     if (signal.aborted) throw err;
     return undefined;
@@ -66,8 +72,20 @@ async function checkEndpoint(
     if (res.ok) return { ok: true as const };
     const message = await readErrorMessage(res, signal);
 
-    const normalizedError =
-      res.status === 401 ? "Invalid API key" : (message ?? `HTTP ${res.status}: ${res.statusText}`);
+    let normalizedError: string;
+    if (res.status === 401) {
+      normalizedError = "Invalid API key";
+    } else if (res.status === 403) {
+      normalizedError = "API lacks permission";
+    } else if (res.status === 400 && message && /API_KEY_INVALID/i.test(message)) {
+      // Google returns 400 with reason API_KEY_INVALID instead of 401.
+      normalizedError = "Invalid API key";
+    } else if (res.status === 400 && message && /incorrect api key/i.test(message)) {
+      // xAI returns 400 with a plain-string error mentioning "Incorrect API key".
+      normalizedError = "Invalid API key";
+    } else {
+      normalizedError = message ?? `HTTP ${res.status}: ${res.statusText}`;
+    }
     return { ok: false as const, error: normalizedError };
   });
 }
@@ -142,8 +160,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
             }),
             signal,
           });
-          if (res.ok || res.status !== 401) return { invalid: false as const };
-          return { invalid: true as const, error: "Invalid API key" };
+          if (res.ok) return { invalid: false as const };
+          if (res.status === 401) return { invalid: true as const, error: "Invalid API key" };
+          if (res.status === 403) return { invalid: true as const, error: "API lacks permission" };
+          return { invalid: false as const };
         });
         if (check.invalid) return successResponse({ success: false, error: check.error });
         break;

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -71,16 +71,20 @@ async function checkEndpoint(
     const res = await fetch(url, { headers, signal });
     if (res.ok) return { ok: true as const };
 
+    // Check status before reading the body — 401/403 never need the provider's message.
+    if (res.status === 401) {
+      return { ok: false as const, error: "Invalid API key" };
+    }
+    if (res.status === 403) {
+      return { ok: false as const, error: "API lacks permission" };
+    }
+
     const message = await readErrorMessage(res, signal);
     const isGoogleInvalidKey = /api key not valid/i.test(message ?? "");
 
     let normalizedError: string;
     let errorDetail: string | undefined;
-    if (res.status === 401) {
-      normalizedError = "Invalid API key";
-    } else if (res.status === 403) {
-      normalizedError = "API lacks permission";
-    } else if (res.status === 400 && isGoogleInvalidKey) {
+    if (res.status === 400 && isGoogleInvalidKey) {
       // Google returns 400 with reason API_KEY_INVALID in error.details[].reason, not in message.
       normalizedError = "Invalid API key";
     } else if (res.status === 400 && message && /incorrect api key/i.test(message)) {
@@ -170,8 +174,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           if (res.status === 403) return { invalid: true as const, error: "API lacks permission" };
           return { invalid: false as const };
         });
-        if (check.invalid)
-          return successResponse({ success: false, error: check.error, detail: check.detail });
+        if (check.invalid) return successResponse({ success: false, error: check.error });
         break;
       }
 

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -65,7 +65,13 @@ async function checkEndpoint(
     const res = await fetch(url, { headers, signal });
     if (res.ok) return { ok: true as const };
     const message = await readErrorMessage(res, signal);
-    return { ok: false as const, error: message ?? `HTTP ${res.status}: ${res.statusText}` };
+    
+    const normalizedError =
+      res.status === 401 || res.status === 403
+        ? "Invalid API key"
+        : message ?? `HTTP ${res.status}: ${res.statusText}`;
+    return { ok: false as const, error: normalizedError };
+
   });
 }
 

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -66,7 +66,7 @@ async function readErrorMessage(res: Response, signal: AbortSignal): Promise<str
 async function checkEndpoint(
   url: string,
   headers: Record<string, string>,
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<{ ok: true } | { ok: false; error: string; detail?: string }> {
   return withTimeout(async (signal) => {
     const res = await fetch(url, { headers, signal });
     if (res.ok) return { ok: true as const };
@@ -75,6 +75,7 @@ async function checkEndpoint(
     const isGoogleInvalidKey = /api key not valid/i.test(message ?? "");
 
     let normalizedError: string;
+    let errorDetail: string | undefined;
     if (res.status === 401) {
       normalizedError = "Invalid API key";
     } else if (res.status === 403) {
@@ -86,9 +87,10 @@ async function checkEndpoint(
       // xAI returns 400 with a plain-string error mentioning "Incorrect API key".
       normalizedError = "Invalid API key";
     } else {
-      normalizedError = message ?? `HTTP ${res.status}: ${res.statusText}`;
+      normalizedError = "Connection failed";
+      errorDetail = message ?? `HTTP ${res.status}: ${res.statusText}`;
     }
-    return { ok: false as const, error: normalizedError };
+    return { ok: false as const, error: normalizedError, detail: errorDetail };
   });
 }
 
@@ -140,7 +142,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           ? `${baseUrl.replace(/\/$/, "")}/v1/models`
           : "https://api.openai.com/v1/models";
         const check = await checkEndpoint(url, { Authorization: `Bearer ${apiKey}` });
-        if (!check.ok) return successResponse({ success: false, error: check.error });
+        if (!check.ok)
+          return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
       }
 
@@ -167,7 +170,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           if (res.status === 403) return { invalid: true as const, error: "API lacks permission" };
           return { invalid: false as const };
         });
-        if (check.invalid) return successResponse({ success: false, error: check.error });
+        if (check.invalid)
+          return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
       }
 
@@ -176,7 +180,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           "https://generativelanguage.googleapis.com/v1beta/models",
           { "x-goog-api-key": apiKey || "" },
         );
-        if (!check.ok) return successResponse({ success: false, error: check.error });
+        if (!check.ok)
+          return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
       }
 
@@ -192,7 +197,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           `${baseUrl.replace(/\/$/, "")}/models?api-version=${apiVersion}`,
           { "api-key": apiKey || "" },
         );
-        if (!check.ok) return successResponse({ success: false, error: check.error });
+        if (!check.ok)
+          return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
       }
 
@@ -223,7 +229,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         const check = await checkEndpoint(`${deepseekBase.replace(/\/$/, "")}/models`, {
           Authorization: `Bearer ${apiKey}`,
         });
-        if (!check.ok) return successResponse({ success: false, error: check.error });
+        if (!check.ok)
+          return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
       }
 
@@ -231,7 +238,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         const check = await checkEndpoint("https://openrouter.ai/api/v1/models", {
           Authorization: `Bearer ${apiKey}`,
         });
-        if (!check.ok) return successResponse({ success: false, error: check.error });
+        if (!check.ok)
+          return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
       }
 
@@ -240,7 +248,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         const check = await checkEndpoint(`${xaiBase.replace(/\/$/, "")}/models`, {
           Authorization: `Bearer ${apiKey}`,
         });
-        if (!check.ok) return successResponse({ success: false, error: check.error });
+        if (!check.ok)
+          return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
       }
 
@@ -249,7 +258,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         const check = await checkEndpoint(`${moonshotBase.replace(/\/$/, "")}/models`, {
           Authorization: `Bearer ${apiKey}`,
         });
-        if (!check.ok) return successResponse({ success: false, error: check.error });
+        if (!check.ok)
+          return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
       }
 
@@ -258,7 +268,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         const check = await checkEndpoint(`${zaiBase.replace(/\/$/, "")}/models`, {
           Authorization: `Bearer ${apiKey}`,
         });
-        if (!check.ok) return successResponse({ success: false, error: check.error });
+        if (!check.ok)
+          return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
       }
     }

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -65,13 +65,12 @@ async function checkEndpoint(
     const res = await fetch(url, { headers, signal });
     if (res.ok) return { ok: true as const };
     const message = await readErrorMessage(res, signal);
-    
+
     const normalizedError =
       res.status === 401 || res.status === 403
         ? "Invalid API key"
-        : message ?? `HTTP ${res.status}: ${res.statusText}`;
+        : (message ?? `HTTP ${res.status}: ${res.statusText}`);
     return { ok: false as const, error: normalizedError };
-
   });
 }
 

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -67,9 +67,7 @@ async function checkEndpoint(
     const message = await readErrorMessage(res, signal);
 
     const normalizedError =
-      res.status === 401 || res.status === 403
-        ? "Invalid API key"
-        : (message ?? `HTTP ${res.status}: ${res.statusText}`);
+      res.status === 401 ? "Invalid API key" : (message ?? `HTTP ${res.status}: ${res.statusText}`);
     return { ok: false as const, error: normalizedError };
   });
 }
@@ -145,8 +143,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
             signal,
           });
           if (res.ok || res.status !== 401) return { invalid: false as const };
-          const message = await readErrorMessage(res, signal);
-          return { invalid: true as const, error: message ?? "Invalid API key" };
+          return { invalid: true as const, error: "Invalid API key" };
         });
         if (check.invalid) return successResponse({ success: false, error: check.error });
         break;

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -11,7 +11,7 @@ import {
 // baseUrl — that accepts the socket but never responds would otherwise leave
 // this handler hanging. `withTimeout` keeps the deadline armed across the whole
 // provider check (including the error-body reads below).
-import { withTimeout } from "./timeout";
+import { TimeoutError, withTimeout } from "./timeout";
 
 const ADAPTER_VALUES = [
   LLMAdapter.OPENAI,
@@ -85,7 +85,8 @@ async function checkEndpoint(
     let normalizedError: string;
     let errorDetail: string | undefined;
     if (res.status === 400 && isGoogleInvalidKey) {
-      // Google returns 400 with reason API_KEY_INVALID in error.details[].reason, not in message.
+      // Google's machine-readable API_KEY_INVALID lives in error.details[].reason, which
+      // readErrorMessage does not surface — so match the prose in error.message instead.
       normalizedError = "Invalid API key";
     } else if (res.status === 400 && message && /incorrect api key/i.test(message)) {
       // xAI returns 400 with a plain-string error mentioning "Incorrect API key".
@@ -279,9 +280,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     return successResponse({ success: true });
   } catch (err) {
+    // A timeout message stands on its own as a headline. Transport failures
+    // ("fetch failed", "ECONNREFUSED") are raw runtime text, so they belong in
+    // the detail line under a normalized headline.
+    if (err instanceof TimeoutError) {
+      return successResponse({ success: false, error: err.message });
+    }
     return successResponse({
       success: false,
-      error: err instanceof Error ? err.message : "Connection failed",
+      error: "Connection failed",
+      detail: err instanceof Error ? err.message : undefined,
     });
   }
 }

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/timeout.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/timeout.ts
@@ -21,6 +21,11 @@ export const TEST_CONNECTION_TIMEOUT_MS = resolveTimeoutMs(
   process.env.MODEL_PROVIDER_TEST_TIMEOUT_MS,
 );
 
+// A deadline breach, as opposed to a transport failure. Callers surface the two
+// differently: a timeout message is meaningful on its own, while a transport
+// error's raw text belongs in the detail line rather than the headline.
+export class TimeoutError extends Error {}
+
 // Run the full logical provider check under a single deadline. The timer stays
 // armed until `operation` settles, so it bounds not just the initial fetch() but
 // any subsequent response-body reads the operation performs.
@@ -34,7 +39,7 @@ export async function withTimeout<T>(
     return await operation(controller.signal);
   } catch (err) {
     if (controller.signal.aborted) {
-      throw new Error(`Connection timed out after ${timeoutMs}ms`);
+      throw new TimeoutError(`Connection timed out after ${timeoutMs}ms`);
     }
     throw err;
   } finally {

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/timeout.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/timeout.ts
@@ -24,7 +24,14 @@ export const TEST_CONNECTION_TIMEOUT_MS = resolveTimeoutMs(
 // A deadline breach, as opposed to a transport failure. Callers surface the two
 // differently: a timeout message is meaningful on its own, while a transport
 // error's raw text belongs in the detail line rather than the headline.
-export class TimeoutError extends Error {}
+export class TimeoutError extends Error {
+  constructor(message?: string) {
+    super(message);
+    // Without this, `name` inherits "Error" and serialized logs/stack traces read
+    // "Error: Connection timed out ...", indistinguishable from any other failure.
+    this.name = "TimeoutError";
+  }
+}
 
 // Run the full logical provider check under a single deadline. The timer stays
 // armed until `operation` settles, so it bounds not just the initial fetch() but

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const mocks = vi.hoisted(() => ({
+  testModelProvider: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getModelProviders: vi.fn().mockResolvedValue({ byokEnabled: true, providers: [] }),
+  createModelProvider: vi.fn(),
+  updateModelProvider: vi.fn(),
+  deleteModelProvider: vi.fn(),
+  testModelProvider: (...a: unknown[]) => mocks.testModelProvider(...a),
+}));
+
+// Radix Select renders through a portal and is flaky in jsdom; mock it to a
+// native <select> so we can drive onValueChange directly, matching the
+// pattern used in DetectorsTab.test.tsx.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (v: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select
+      aria-label="adapter"
+      role="combobox"
+      value={value}
+      onChange={(e) => onValueChange(e.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+import { ModelProvidersTab } from "./ModelProvidersTab";
+
+function renderTab() {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <ModelProvidersTab workspaceId="ws-1" />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.testModelProvider.mockReset();
+});
+
+describe("ModelProvidersTab - Test Connection error display", () => {
+  it("renders the error in its own block below the button on failure, not inline", async () => {
+    mocks.testModelProvider.mockResolvedValue({ success: false, error: "Invalid API key" });
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("button", { name: /add provider/i }));
+    fireEvent.change(screen.getByRole("combobox", { name: /adapter/i }), {
+      target: { value: "openai" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("sk-..."), {
+      target: { value: "bad-key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /test connection/i }));
+
+    const errorText = await screen.findByText("Invalid API key");
+    // The error lives in its own block, not the same inline row as the button.
+    const button = screen.getByRole("button", { name: /test connection/i });
+    expect(button.parentElement?.contains(errorText)).toBe(false);
+  });
+
+  it("shows Connected inline next to the button on success, not the error block", async () => {
+    mocks.testModelProvider.mockResolvedValue({ success: true });
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("button", { name: /add provider/i }));
+    fireEvent.change(screen.getByRole("combobox", { name: /adapter/i }), {
+      target: { value: "openai" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("sk-..."), {
+      target: { value: "good-key" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /test connection/i }));
+
+    await waitFor(() => expect(screen.getByText("Connected")).toBeTruthy());
+    expect(screen.queryByText(/invalid api key/i)).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
@@ -81,6 +81,43 @@ describe("ModelProvidersTab - Test Connection error display", () => {
     expect(button.parentElement?.contains(errorText)).toBe(false);
   });
 
+  it("renders a non-auth failure as a headline with the raw provider text demoted to a detail line", async () => {
+    mocks.testModelProvider.mockResolvedValue({
+      success: false,
+      error: "Connection failed",
+      detail: "HTTP 500: Internal Server Error",
+    });
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("button", { name: /add provider/i }));
+    fireEvent.change(screen.getByRole("combobox", { name: /adapter/i }), {
+      target: { value: "openai" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("sk-..."), { target: { value: "k" } });
+    fireEvent.click(screen.getByRole("button", { name: /test connection/i }));
+
+    const headline = await screen.findByText("Connection failed");
+    const detail = screen.getByText("HTTP 500: Internal Server Error");
+    // The raw provider text is a sibling of the headline, styled as secondary.
+    expect(detail).not.toBe(headline);
+    expect(detail.className).toContain("text-muted-foreground");
+  });
+
+  it("surfaces a failed request itself, rather than leaving the user with no result", async () => {
+    mocks.testModelProvider.mockRejectedValue(new Error("Failed to fetch"));
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("button", { name: /add provider/i }));
+    fireEvent.change(screen.getByRole("combobox", { name: /adapter/i }), {
+      target: { value: "openai" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("sk-..."), { target: { value: "k" } });
+    fireEvent.click(screen.getByRole("button", { name: /test connection/i }));
+
+    expect(await screen.findByText("Connection failed")).toBeTruthy();
+    expect(screen.getByText("Failed to fetch")).toBeTruthy();
+  });
+
   it("shows Connected inline next to the button on success, not the error block", async () => {
     mocks.testModelProvider.mockResolvedValue({ success: true });
     renderTab();

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.test.tsx
@@ -95,6 +95,9 @@ describe("ModelProvidersTab - Test Connection error display", () => {
     fireEvent.click(screen.getByRole("button", { name: /test connection/i }));
 
     await waitFor(() => expect(screen.getByText("Connected")).toBeTruthy());
+    const button = screen.getByRole("button", { name: /test connection/i });
+    const connectedText = screen.getByText("Connected");
+    expect(button.parentElement?.contains(connectedText)).toBe(true);
     expect(screen.queryByText(/invalid api key/i)).toBeNull();
   });
 });

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -110,6 +110,14 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
     mutationFn: (input: Parameters<typeof testModelProvider>[1]) =>
       testModelProvider(workspaceId, input),
     onSuccess: (result) => setTestResult(result),
+    // The request itself can fail (expired session, offline, 500). Without this
+    // the spinner would just stop and the user would see no result at all.
+    onError: (err) =>
+      setTestResult({
+        success: false,
+        error: "Connection failed",
+        detail: err instanceof Error ? err.message : undefined,
+      }),
   });
 
   function closeDialog() {
@@ -644,7 +652,9 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                     <span className="min-w-0 break-words">{testResult.error}</span>
                   </div>
                   {testResult.detail && (
-                    <span className="pl-4.5 min-w-0 break-words text-muted-foreground">
+                    // Indent past the icon (h-3.5) and its gap-1 so the detail
+                    // aligns under the headline text.
+                    <span className="min-w-0 break-words pl-[1.125rem] text-muted-foreground">
                       {testResult.detail}
                     </span>
                   )}

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -614,33 +614,33 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
             )}
 
             {/* Test Connection */}
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={!canTest || testMutation.isPending}
-                onClick={handleTest}
-              >
-                {testMutation.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
-                Test Connection
-              </Button>
-              {testResult && (
-                <span className="flex items-center gap-1 text-xs">
-                  {testResult.success ? (
-                    <>
-                      <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
-                      <span className="text-green-600">Connected</span>
-                    </>
-                  ) : (
-                    <>
-                      <XCircle className="h-3.5 w-3.5 text-destructive" />
-                      <span className="text-destructive">{testResult.error}</span>
-                    </>
-                  )}
-                </span>
-              )}
-            </div>
+<div className="flex flex-col gap-2">
+  <div className="flex items-center gap-2">
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={!canTest || testMutation.isPending}
+      onClick={handleTest}
+    >
+      {testMutation.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+      Test Connection
+    </Button>
+    {testResult?.success && (
+      <span className="flex items-center gap-1 text-xs">
+        <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
+        <span className="text-green-600">Connected</span>
+      </span>
+    )}
+  </div>
+  {testResult && !testResult.success && (
+    <div className="flex items-start gap-1 text-xs text-destructive">
+      <XCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+      <span>{testResult.error}</span>
+    </div>
+  )}
+</div>
+
           </div>
 
           {saveError && (

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -56,7 +56,11 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
   const [apiKey, setApiKey] = useState("");
   const [baseUrl, setBaseUrl] = useState("");
   const [customModels, setCustomModels] = useState<string[]>([]);
-  const [testResult, setTestResult] = useState<{ success: boolean; error?: string } | null>(null);
+  const [testResult, setTestResult] = useState<{
+    success: boolean;
+    error?: string;
+    detail?: string;
+  } | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   // Per-model API protocol overrides: modelId -> protocol
   const [modelProtocols, setModelProtocols] = useState<Record<string, string>>({});
@@ -634,9 +638,16 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
                 )}
               </div>
               {testResult && !testResult.success && (
-                <div className="flex items-start gap-1 text-xs text-destructive">
-                  <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                  <span>{testResult.error}</span>
+                <div className="flex min-w-0 flex-col gap-0.5 text-xs text-destructive">
+                  <div className="flex items-start gap-1">
+                    <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span className="min-w-0 break-words">{testResult.error}</span>
+                  </div>
+                  {testResult.detail && (
+                    <span className="pl-4.5 min-w-0 break-words text-muted-foreground">
+                      {testResult.detail}
+                    </span>
+                  )}
                 </div>
               )}
             </div>

--- a/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/ModelProvidersTab.tsx
@@ -614,33 +614,32 @@ export function ModelProvidersTab({ workspaceId }: ModelProvidersTabProps) {
             )}
 
             {/* Test Connection */}
-<div className="flex flex-col gap-2">
-  <div className="flex items-center gap-2">
-    <Button
-      type="button"
-      variant="outline"
-      size="sm"
-      disabled={!canTest || testMutation.isPending}
-      onClick={handleTest}
-    >
-      {testMutation.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
-      Test Connection
-    </Button>
-    {testResult?.success && (
-      <span className="flex items-center gap-1 text-xs">
-        <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
-        <span className="text-green-600">Connected</span>
-      </span>
-    )}
-  </div>
-  {testResult && !testResult.success && (
-    <div className="flex items-start gap-1 text-xs text-destructive">
-      <XCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-      <span>{testResult.error}</span>
-    </div>
-  )}
-</div>
-
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={!canTest || testMutation.isPending}
+                  onClick={handleTest}
+                >
+                  {testMutation.isPending && <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />}
+                  Test Connection
+                </Button>
+                {testResult?.success && (
+                  <span className="flex items-center gap-1 text-xs">
+                    <CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
+                    <span className="text-green-600">Connected</span>
+                  </span>
+                )}
+              </div>
+              {testResult && !testResult.success && (
+                <div className="flex items-start gap-1 text-xs text-destructive">
+                  <XCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>{testResult.error}</span>
+                </div>
+              )}
+            </div>
           </div>
 
           {saveError && (

--- a/frontend/ui/src/lib/api/model-providers.ts
+++ b/frontend/ui/src/lib/api/model-providers.ts
@@ -114,7 +114,7 @@ export async function testModelProvider(
     awsRegion?: string;
     useDefaultCredentials?: boolean;
   },
-): Promise<{ success: boolean; error?: string }> {
+): Promise<{ success: boolean; error?: string; detail?: string }> {
   return fetchNextApi(`/workspaces/${workspaceId}/model-providers/test`, {
     method: "POST",
     body: JSON.stringify(data),


### PR DESCRIPTION
## Summary
Fixes two issues with the BYOK "Test Connection" error display.

**Layout fix** (`ModelProvidersTab.tsx`):
- Error result was a bare inline `<span>` inside the button's flex 
  row — long messages overflowed and pushed the button around
- Moved error to its own block below the button so text wraps cleanly
- Success ("Connected") stays inline with the button

**Message normalization** (`model-providers/test/route.ts`):
- 401/403 auth failures now return "Invalid API key" consistently 
  across all providers (Azure/OpenRouter returned bare `HTTP 401: Unauthorized`, 
  OpenAI returned verbose prose with the key fragment)
- Unexpected failures still surface raw provider detail

## Demo
See Files Changed tab for the diff — UI change moves error from 
inline with button to its own block below it.
<img width="1470" height="956" alt="Screenshot 2026-07-02 at 3 18 39 PM" src="https://github.com/user-attachments/assets/fe9648af-c007-434d-87fd-5fd008f28b43" />
<img width="1470" height="956" alt="Screenshot 2026-07-02 at 3 18 32 PM" src="https://github.com/user-attachments/assets/0cfe3505-1a33-4f95-a14d-3c463e8cfc43" />
<img width="1470" height="956" alt="Screenshot 2026-07-02 at 3 18 29 PM" src="https://github.com/user-attachments/assets/ec5d6f08-5fec-4056-b706-a1bd2f613eb3" />


Fixes #1412

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the BYOK Test Connection UX by moving errors below the button and normalizing auth/connection failures with a clear headline and optional detail. Adds status‑first handling to avoid bogus timeouts and clearly separates timeouts from transport errors (fixes #1412).

- **Bug Fixes**
  - Layout: Error shows in its own block under the button with wrapping; “Connected” stays inline.
  - Auth: 401 → “Invalid API key”; 403 → “API lacks permission”; Google 400 API_KEY_INVALID and xAI 400 “Incorrect API key” → “Invalid API key”.
  - Non-auth/transport: Use “Connection failed” as the headline with a muted detail (provider message or HTTP status); fetch rejections show in detail; timeouts surface as a standalone headline. 401/403 are short‑circuited before reading bodies to avoid body‑stall timeouts; timeout errors use a named `TimeoutError` for clearer logs.
  - Tests: Added UI tests for placement and success state; expanded API tests for 401/403 and Google/xAI cases; replaced the Anthropic 401 body‑stall timeout with short‑circuit coverage.

<sup>Written for commit 440f670c547313cade49a82663fa7e0f29547aa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

