### PR TITLE
fix(ui): show resolved default detector model

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -35,7 +35,7 @@ RUN cd packages/core && npx prisma generate \
 # `.js` with explicit relative-import extensions, so no tsconfig patching is needed.
 RUN cd packages/core && \
     pnpm build && \
-    node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'},'./model-resolver':{types:'./dist/model-resolver.d.ts',import:'./dist/model-resolver.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
+    node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'},'./model-resolver':{types:'./dist/model-resolver.d.ts',import:'./dist/model-resolver.js'},'./llm-providers':{types:'./dist/llm-providers.d.ts',import:'./dist/llm-providers.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 RUN cd packages/agent && pnpm build
 
 FROM node:20-alpine AS runner

--- a/docker/Dockerfile.billing
+++ b/docker/Dockerfile.billing
@@ -37,7 +37,7 @@ RUN cd packages/core && npx prisma generate \
 # `.js` with explicit relative-import extensions, so no tsconfig patching is needed.
 RUN cd packages/core && \
     pnpm build && \
-    node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'},'./model-resolver':{types:'./dist/model-resolver.d.ts',import:'./dist/model-resolver.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
+    node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'},'./model-resolver':{types:'./dist/model-resolver.d.ts',import:'./dist/model-resolver.js'},'./llm-providers':{types:'./dist/llm-providers.d.ts',import:'./dist/llm-providers.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 # Build slack package (also ESM) — patch package.json to point at dist/ so the
 # worker's import resolves to compiled JS at runtime.
 RUN cd packages/slack && \

--- a/docker/Dockerfile.detector
+++ b/docker/Dockerfile.detector
@@ -37,7 +37,7 @@ RUN cd packages/core && npx prisma generate \
 # `.js` with explicit relative-import extensions, so no tsconfig patching is needed.
 RUN cd packages/core && \
     pnpm build && \
-    node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'},'./model-resolver':{types:'./dist/model-resolver.d.ts',import:'./dist/model-resolver.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
+    node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.main='./dist/index.js'; p.exports={'.':{types:'./dist/index.d.ts',import:'./dist/index.js'},'./model-resolver':{types:'./dist/model-resolver.d.ts',import:'./dist/model-resolver.js'},'./llm-providers':{types:'./dist/llm-providers.d.ts',import:'./dist/llm-providers.js'}}; fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
 # Build slack package (also ESM) — patch package.json to point at dist/ so the
 # worker's import resolves to compiled JS at runtime.
 RUN cd packages/slack && \

--- a/frontend/packages/core/package.json
+++ b/frontend/packages/core/package.json
@@ -10,6 +10,10 @@
       "types": "./src/index.ts",
       "default": "./src/index.ts"
     },
+    "./llm-providers": {
+      "types": "./src/llm-providers.ts",
+      "default": "./src/llm-providers.ts"
+    },
     "./model-resolver": {
       "types": "./src/model-resolver.ts",
       "default": "./src/model-resolver.ts"

--- a/frontend/packages/core/src/__tests__/llm-providers.test.ts
+++ b/frontend/packages/core/src/__tests__/llm-providers.test.ts
@@ -4,6 +4,7 @@ import {
   SYSTEM_MODELS,
   ADAPTER_API_PROTOCOL,
   LLMAdapter,
+  DETECTOR_SYSTEM_DEFAULT_MODEL_ID,
 } from "../llm-providers.ts";
 
 describe("ADAPTER_MODELS", () => {
@@ -35,6 +36,14 @@ describe("ADAPTER_MODELS", () => {
         ).toBe(model.id);
       }
     }
+  });
+
+  it("keeps the detector system default in the system model catalog", () => {
+    const systemModelIds = SYSTEM_MODELS.flatMap((system) =>
+      system.models.map((model) => model.id),
+    );
+
+    expect(systemModelIds).toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
 
   describe("apiProtocol consistency with SYSTEM_MODELS", () => {

--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -76,6 +76,15 @@ export interface LLMModelDef {
 // ──────────────────────────────────────────────
 // System models — always available via env vars.
 // ──────────────────────────────────────────────
+/**
+ * Detector-specific hosted screening model.
+ *
+ * This is intentionally not `resolvePiModel(undefined, null)`: detector evals
+ * use a stable cheap-and-fast model instead of the general provider-priority
+ * fallback used by other model resolution paths.
+ */
+export const DETECTOR_SYSTEM_DEFAULT_MODEL_ID = "claude-haiku-4-5";
+
 export const SYSTEM_MODELS: {
   provider: string;
   envVar: string;

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 
 const mocks = vi.hoisted(() => ({ push: vi.fn() }));
 
@@ -31,12 +32,58 @@ vi.mock("@/features/detectors/hooks/use-detectors", () => ({
           name: "My Detector",
           template: "failure",
           detectionModel: null,
+          detectionProvider: null,
+          detectionSource: "system",
           sampleRate: 25,
           createTime: "2026-06-15T00:00:00.000Z",
           updateTime: "2026-06-15T00:00:00.000Z",
         },
+        {
+          id: "det-2",
+          name: "Pinned Detector",
+          template: "failure",
+          detectionModel: "gpt-5.4",
+          detectionProvider: "OpenAI",
+          detectionSource: "system",
+          sampleRate: 100,
+          createTime: "2026-06-16T00:00:00.000Z",
+          updateTime: "2026-06-16T00:00:00.000Z",
+        },
+        {
+          id: "det-3",
+          name: "BYOK Detector",
+          template: "failure",
+          detectionModel: null,
+          detectionProvider: "Anthropic BYOK",
+          detectionSource: "byok",
+          sampleRate: 100,
+          createTime: "2026-06-17T00:00:00.000Z",
+          updateTime: "2026-06-17T00:00:00.000Z",
+        },
+        {
+          id: "det-4",
+          name: "Pinned BYOK Detector",
+          template: "failure",
+          detectionModel: "gpt-5.4",
+          detectionProvider: "OpenAI BYOK",
+          detectionSource: "byok",
+          sampleRate: 100,
+          createTime: "2026-06-18T00:00:00.000Z",
+          updateTime: "2026-06-18T00:00:00.000Z",
+        },
+        {
+          id: "det-5",
+          name: "Legacy Detector",
+          template: "failure",
+          detectionModel: null,
+          detectionProvider: null,
+          detectionSource: null,
+          sampleRate: 100,
+          createTime: "2026-06-19T00:00:00.000Z",
+          updateTime: "2026-06-19T00:00:00.000Z",
+        },
       ],
-      meta: { total: 1 },
+      meta: { total: 5 },
     },
     isLoading: false,
     error: null,
@@ -62,6 +109,56 @@ afterEach(() => {
 });
 
 describe("DetectorsPage", () => {
+  it("shows the resolved detector default model with a default marker", () => {
+    render(<DetectorsPage />);
+
+    const defaultRow = screen.getByText("My Detector").closest("tr");
+    expect(defaultRow).not.toBeNull();
+    expect(defaultRow?.textContent).toContain("System default:");
+    expect(defaultRow?.textContent).toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
+    expect(defaultRow?.textContent).toContain("(default)");
+  });
+
+  it("does not label BYOK detectors without a model as a default", () => {
+    render(<DetectorsPage />);
+
+    const byokRow = screen.getByText("BYOK Detector").closest("tr");
+    expect(byokRow).not.toBeNull();
+    expect(byokRow?.textContent).toContain("BYOK provider: Anthropic BYOK");
+    expect(byokRow?.textContent).not.toContain("(default)");
+    expect(byokRow?.textContent).not.toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
+  });
+
+  it("keeps legacy null-source detector labels availability-aware", () => {
+    render(<DetectorsPage />);
+
+    const legacyRow = screen.getByText("Legacy Detector").closest("tr");
+    expect(legacyRow).not.toBeNull();
+    expect(legacyRow?.textContent).toContain("Auto-selected default");
+    expect(legacyRow?.textContent).toContain("(default)");
+    expect(legacyRow?.textContent).not.toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
+  });
+
+  it("shows pinned detector models without the default marker", () => {
+    render(<DetectorsPage />);
+
+    const pinnedRow = screen.getByText("Pinned Detector").closest("tr");
+    expect(pinnedRow).not.toBeNull();
+    expect(pinnedRow?.textContent).toContain("System pinned:");
+    expect(pinnedRow?.textContent).toContain("gpt-5.4");
+    expect(pinnedRow?.textContent).not.toContain("System default:");
+    expect(pinnedRow?.textContent).not.toContain("(default)");
+  });
+
+  it("shows source context for pinned BYOK detector models", () => {
+    render(<DetectorsPage />);
+
+    const pinnedByokRow = screen.getByText("Pinned BYOK Detector").closest("tr");
+    expect(pinnedByokRow).not.toBeNull();
+    expect(pinnedByokRow?.textContent).toContain("BYOK (OpenAI BYOK): gpt-5.4");
+    expect(pinnedByokRow?.textContent).not.toContain("(default)");
+  });
+
   it("carries the selected time range into the detector detail URL on row click", () => {
     render(<DetectorsPage />);
 

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
@@ -114,8 +114,8 @@ describe("DetectorsPage", () => {
 
     const defaultRow = screen.getByText("My Detector").closest("tr");
     expect(defaultRow).not.toBeNull();
-    expect(defaultRow?.textContent).toContain("System default:");
     expect(defaultRow?.textContent).toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
+    expect(defaultRow?.textContent).not.toContain("System default:");
     expect(defaultRow?.textContent).toContain("(default)");
   });
 
@@ -124,7 +124,8 @@ describe("DetectorsPage", () => {
 
     const byokRow = screen.getByText("BYOK Detector").closest("tr");
     expect(byokRow).not.toBeNull();
-    expect(byokRow?.textContent).toContain("BYOK provider: Anthropic BYOK");
+    expect(byokRow?.textContent).toContain("Anthropic BYOK");
+    expect(byokRow?.textContent).not.toContain("BYOK provider:");
     expect(byokRow?.textContent).not.toContain("(default)");
     expect(byokRow?.textContent).not.toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
@@ -134,7 +135,8 @@ describe("DetectorsPage", () => {
 
     const legacyRow = screen.getByText("Legacy Detector").closest("tr");
     expect(legacyRow).not.toBeNull();
-    expect(legacyRow?.textContent).toContain("Auto-selected default");
+    expect(legacyRow?.textContent).toContain("Auto-selected");
+    expect(legacyRow?.textContent).not.toContain("Auto-selected default");
     expect(legacyRow?.textContent).toContain("(default)");
     expect(legacyRow?.textContent).not.toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
@@ -144,18 +146,19 @@ describe("DetectorsPage", () => {
 
     const pinnedRow = screen.getByText("Pinned Detector").closest("tr");
     expect(pinnedRow).not.toBeNull();
-    expect(pinnedRow?.textContent).toContain("System pinned:");
     expect(pinnedRow?.textContent).toContain("gpt-5.4");
+    expect(pinnedRow?.textContent).not.toContain("System pinned:");
     expect(pinnedRow?.textContent).not.toContain("System default:");
     expect(pinnedRow?.textContent).not.toContain("(default)");
   });
 
-  it("shows source context for pinned BYOK detector models", () => {
+  it("shows pinned BYOK detector models without source prefixes", () => {
     render(<DetectorsPage />);
 
     const pinnedByokRow = screen.getByText("Pinned BYOK Detector").closest("tr");
     expect(pinnedByokRow).not.toBeNull();
-    expect(pinnedByokRow?.textContent).toContain("BYOK (OpenAI BYOK): gpt-5.4");
+    expect(pinnedByokRow?.textContent).toContain("gpt-5.4");
+    expect(pinnedByokRow?.textContent).not.toContain("BYOK (OpenAI BYOK):");
     expect(pinnedByokRow?.textContent).not.toContain("(default)");
   });
 

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Eye, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SearchFilterBar } from "@/components/search-filter-bar";
@@ -20,6 +21,36 @@ import { useProject } from "@/features/projects/hooks";
 import { DeleteDetectorDialog } from "@/features/detectors/components/delete-detector-dialog";
 import { DetectorPanel } from "@/features/detectors/components/detector-panel";
 import { getTemplate } from "@/features/detectors/templates";
+
+function formatDetectorModel(detector: {
+  detectionModel: string | null;
+  detectionProvider: string | null;
+  detectionSource: "system" | "byok" | null;
+}) {
+  const providerLabel = detector.detectionProvider ?? "configured provider";
+
+  if (detector.detectionModel) {
+    if (detector.detectionSource === "byok") {
+      return { label: `BYOK (${providerLabel}): ${detector.detectionModel}`, isDefault: false };
+    }
+
+    if (detector.detectionSource === "system") {
+      return { label: `System pinned: ${detector.detectionModel}`, isDefault: false };
+    }
+
+    return { label: detector.detectionModel, isDefault: false };
+  }
+
+  if (detector.detectionSource === "byok") {
+    return { label: `BYOK provider: ${providerLabel}`, isDefault: false };
+  }
+
+  if (detector.detectionSource === "system") {
+    return { label: `System default: ${DETECTOR_SYSTEM_DEFAULT_MODEL_ID}`, isDefault: true };
+  }
+
+  return { label: "Auto-selected default", isDefault: true };
+}
 
 export default function DetectorsPage() {
   const params = useParams();
@@ -199,6 +230,7 @@ export default function DetectorsPage() {
               <tbody>
                 {detectors.map((detector) => {
                   const template = getTemplate(detector.template);
+                  const detectorModel = formatDetectorModel(detector);
                   const c = counts?.[detector.id];
                   const findingCount = c?.finding_count ?? 0;
                   const runCount = c?.run_count ?? 0;
@@ -222,7 +254,12 @@ export default function DetectorsPage() {
                         {template?.label ?? detector.template}
                       </td>
                       <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
-                        {detector.detectionModel ?? "Default"}
+                        {detectorModel.label}
+                        {detectorModel.isDefault && (
+                          <span className="ml-1 text-[11px] text-muted-foreground/70">
+                            (default)
+                          </span>
+                        )}
                       </td>
                       <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                         {detector.sampleRate}%

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -27,29 +27,19 @@ function formatDetectorModel(detector: {
   detectionProvider: string | null;
   detectionSource: "system" | "byok" | null;
 }) {
-  const providerLabel = detector.detectionProvider ?? "configured provider";
-
   if (detector.detectionModel) {
-    if (detector.detectionSource === "byok") {
-      return { label: `BYOK (${providerLabel}): ${detector.detectionModel}`, isDefault: false };
-    }
-
-    if (detector.detectionSource === "system") {
-      return { label: `System pinned: ${detector.detectionModel}`, isDefault: false };
-    }
-
     return { label: detector.detectionModel, isDefault: false };
   }
 
   if (detector.detectionSource === "byok") {
-    return { label: `BYOK provider: ${providerLabel}`, isDefault: false };
+    return { label: detector.detectionProvider ?? "configured provider", isDefault: false };
   }
 
   if (detector.detectionSource === "system") {
-    return { label: `System default: ${DETECTOR_SYSTEM_DEFAULT_MODEL_ID}`, isDefault: true };
+    return { label: DETECTOR_SYSTEM_DEFAULT_MODEL_ID, isDefault: true };
   }
 
-  return { label: "Auto-selected default", isDefault: true };
+  return { label: "Auto-selected", isDefault: true };
 }
 
 export default function DetectorsPage() {

--- a/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
+++ b/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
@@ -31,6 +31,7 @@ import {
   DEFAULT_DETECTOR_EVAL_TIMEOUT_MS,
   MAX_DETECTOR_EVAL_TIMEOUT_MS,
 } from "../sandbox-eval.js";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 
 const DETECTOR = {
   id: "det-1",
@@ -45,6 +46,13 @@ const ANTHROPIC_MODEL = {
   provider: "anthropic",
   baseUrl: "",
   cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+};
+
+const BYOK_PROVIDER_CONFIG = {
+  adapter: "anthropic",
+  key: "byok-key",
+  baseUrl: null,
+  config: null,
 };
 
 const ZERO_USAGE = {
@@ -105,6 +113,75 @@ describe("runDetectionForTrace", () => {
     expect(result.data).toEqual({ category: "tool_error" });
     expect(result.error).toBeUndefined();
     expect(mockComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves the shared detector default for unpinned system detectors", async () => {
+    mockComplete.mockResolvedValueOnce({
+      content: [
+        {
+          type: "toolCall",
+          name: "submit_result",
+          arguments: { identified: false, summary: "Clean trace", data: {} },
+        },
+      ],
+      usage: ZERO_USAGE,
+      stopReason: "toolUse",
+    });
+
+    await runDetectionForTrace({
+      traceId: "trace-abc",
+      spansJsonl: "{}",
+      detector: { ...DETECTOR, detectionSource: "system", detectionModel: null },
+      workspaceId: "ws-1",
+    });
+
+    expect(mockResolvePiModel).toHaveBeenCalledWith(DETECTOR_SYSTEM_DEFAULT_MODEL_ID, null);
+  });
+
+  it("keeps legacy null-source detectors on the availability-aware resolver default", async () => {
+    mockComplete.mockResolvedValueOnce({
+      content: [
+        {
+          type: "toolCall",
+          name: "submit_result",
+          arguments: { identified: false, summary: "Clean trace", data: {} },
+        },
+      ],
+      usage: ZERO_USAGE,
+      stopReason: "toolUse",
+    });
+
+    await runDetectionForTrace({
+      traceId: "trace-abc",
+      spansJsonl: "{}",
+      detector: { ...DETECTOR, detectionSource: null, detectionModel: null },
+      workspaceId: "ws-1",
+    });
+
+    expect(mockResolvePiModel).toHaveBeenCalledWith(undefined, null);
+  });
+
+  it("passes pinned system detector models through to the resolver", async () => {
+    mockComplete.mockResolvedValueOnce({
+      content: [
+        {
+          type: "toolCall",
+          name: "submit_result",
+          arguments: { identified: false, summary: "Clean trace", data: {} },
+        },
+      ],
+      usage: ZERO_USAGE,
+      stopReason: "toolUse",
+    });
+
+    await runDetectionForTrace({
+      traceId: "trace-abc",
+      spansJsonl: "{}",
+      detector: { ...DETECTOR, detectionSource: "system", detectionModel: "claude-opus-4-8" },
+      workspaceId: "ws-1",
+    });
+
+    expect(mockResolvePiModel).toHaveBeenCalledWith("claude-opus-4-8", null);
   });
 
   it("retries on plain-text response and succeeds on second attempt", async () => {
@@ -416,11 +493,7 @@ describe("runDetectionForTrace", () => {
     });
 
     it("captures BYOK source attribution with positive cost", async () => {
-      mockFetchProviderConfig.mockResolvedValueOnce({
-        key: "byok-key",
-        provider: "anthropic",
-        model: "claude-haiku-4-5",
-      });
+      mockFetchProviderConfig.mockResolvedValueOnce(BYOK_PROVIDER_CONFIG);
       mockComplete.mockResolvedValueOnce({
         content: [
           {
@@ -446,6 +519,7 @@ describe("runDetectionForTrace", () => {
 
       expect(result.inferenceSource).toBe("byok");
       expect(result.inferenceCost).toBeCloseTo(0.005, 6);
+      expect(mockResolvePiModel).toHaveBeenCalledWith(undefined, BYOK_PROVIDER_CONFIG);
     });
 
     it("preserves source on error path with cost=0 (early-exit, BYOK provider missing)", async () => {

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -6,6 +6,7 @@ import {
   resolvePiModel,
   type ProviderModelConfig,
 } from "@traceroot/core/model-resolver";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import { buildSubmitResultTool, type SubmitResultInput } from "./submit-result-tool.js";
 
 export interface DetectorConfig {
@@ -47,8 +48,6 @@ const MAX_ATTEMPTS = 2;
  * about traces being truncated. For now, rely on this hard cap.
  */
 const SAFETY_TRUNCATE_CHARS = 150_000;
-/** Default screening model for system source — cheap-and-fast, not the agent default. */
-const SYSTEM_DEFAULT_MODEL = "claude-haiku-4-5";
 /** Fallback per-attempt timeout when DETECTOR_EVAL_TIMEOUT_MS is unset or invalid. */
 export const DEFAULT_DETECTOR_EVAL_TIMEOUT_MS = 60_000;
 /** Node's setTimeout max delay; larger values clamp to 1ms (an instant abort). */
@@ -156,7 +155,7 @@ export async function runDetectionForTrace(params: {
 
   // 2. Resolve model
   const modelId =
-    detector.detectionModel ?? (source === "system" ? SYSTEM_DEFAULT_MODEL : undefined);
+    detector.detectionModel ?? (source === "system" ? DETECTOR_SYSTEM_DEFAULT_MODEL_ID : undefined);
   const model = resolvePiModel(modelId, providerConfig);
 
   // 3. Resolve API key (BYOK row → env var → workspace BYOK scan)


### PR DESCRIPTION
Fixes #1410

## Summary

Detectors that explicitly track the hosted system default currently show `Default` in the list page's Model column. This replaces that opaque label with `System default: claude-haiku-4-5 (default)` and adds configured-source context for BYOK rows so users can distinguish detector configuration paths in the list.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Adds a shared `DETECTOR_SYSTEM_DEFAULT_MODEL_ID` constant in `@traceroot/core` and exposes the side-effect-light `@traceroot/core/llm-providers` subpath.
- Keeps explicit system detector worker evaluation on the same default by using the shared constant in `sandbox-eval`.
- Updates the detectors list Model column to render clearer default labels:
  - explicit system default rows: `System default: claude-haiku-4-5 (default)`
  - BYOK rows without a pinned model: `BYOK provider: <provider>`
  - legacy null-source rows: `Auto-selected default (default)` so the UI does not claim a concrete model while runtime keeps its existing availability-aware fallback
  - pinned system rows: `System pinned: <model>`
  - pinned BYOK rows: `BYOK (<provider>): <model>`
- Adds UI regression coverage for system-default, BYOK provider, legacy default-tracking, pinned system, and pinned BYOK detector rows.
- Adds a core invariant test so the detector default must stay present in the system model catalog.

## Screenshots / Recordings (if applicable)

Not captured locally. The rendered text behavior is covered by the detector list component test.

## Validation

- `cd frontend/ui && pnpm vitest run 'src/app/projects/[projectId]/detectors/page.test.tsx' --reporter=verbose` — passed, 1 file / 6 tests.
- `cd frontend/worker && pnpm vitest run src/detection/__tests__/sandbox-eval.test.ts --reporter=verbose` — passed, 1 file / 27 tests.
- `cd frontend/packages/core && pnpm test -- src/__tests__/llm-providers.test.ts --reporter=verbose && pnpm build` — passed, Vitest selected 7 files / 55 tests; build passed.
- `cd frontend/ui && pnpm lint && pnpm format:check` — passed with existing 49 warnings / 0 errors; format passed.
- `cd frontend/worker && pnpm build && pnpm lint && pnpm format:check` — passed; lint has existing 53 warnings / 0 errors; format passed.
- `cd frontend && pnpm format:check` — passed.
- `git diff --check` — passed.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the actual detector default in the list as "claude-haiku-4-5 (default)" and align worker evaluation to the same default. Fixes #1410.

- **Bug Fixes**
  - Lean labels in the Model column:
    - System default (unpinned): "claude-haiku-4-5 (default)"
    - Pinned models (system or BYOK): "<model>"
    - BYOK without model: "<provider>"
    - Legacy null-source: "Auto-selected (default)"
  - Worker uses the shared detector default for unpinned system detectors; legacy null-source stays on availability-aware fallback.

- **Refactors**
  - Adds `DETECTOR_SYSTEM_DEFAULT_MODEL_ID` in `@traceroot/core` and exposes `@traceroot/core/llm-providers`; updates Docker build-time `package.json` patch to include the new subpath.
  - Adds tests: UI label cases; worker model-resolution paths (system default, pinned, legacy, BYOK); core invariant to keep the detector default in `SYSTEM_MODELS`.

<sup>Written for commit 82f68acedcd89ea0181976cab86a771280d0d4eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

