### PR TITLE
fix(ui): preserve default-tracking detector model on edit

### DIFF
--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   models: undefined as
@@ -90,6 +90,72 @@ describe("ModelSelector", () => {
       provider: "anthropic",
       source: "system",
       adapter: "anthropic",
+    });
+  });
+
+  it("shows a labeled default option without auto-picking when auto selection is disabled", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        autoSelectDefault={false}
+        emptySelectionLabel="System default detector model"
+      />,
+    );
+
+    expect(screen.getByRole("button").textContent).toContain("System default detector model");
+    expect(mocks.onChange).not.toHaveBeenCalled();
+  });
+
+  it("lets callers clear back to the labeled default option", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{
+          model: "claude-4",
+          provider: "anthropic",
+          source: "system",
+          adapter: "anthropic",
+        }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        autoSelectDefault={false}
+        emptySelectionLabel="System default detector model"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(screen.getByRole("button", { name: "System default detector model" }));
+
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: "",
+      provider: "",
+      source: "system",
+      adapter: "",
     });
   });
 });

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -20,13 +20,21 @@ interface ModelSelectorProps {
   value: ModelSelection;
   onChange: (selection: ModelSelection) => void;
   workspaceId?: string;
+  autoSelectDefault?: boolean;
+  emptySelectionLabel?: string;
 }
 
 function modelKey(m: { id?: string; model?: string; source: string; provider: string }) {
   return `${m.source}:${m.provider}:${m.id ?? m.model}`;
 }
 
-export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorProps) {
+export function ModelSelector({
+  value,
+  onChange,
+  workspaceId,
+  autoSelectDefault = true,
+  emptySelectionLabel,
+}: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
 
   const { data } = useQuery({
@@ -58,6 +66,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
 
     if (!match) {
       if (!value.model) {
+        if (!autoSelectDefault) return;
         const pick = pickDefaultModel(models);
         if (pick) {
           onChange({
@@ -87,10 +96,12 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
         adapter: match.adapter,
       });
     }
-  }, [models, value, onChange]);
+  }, [models, value, onChange, autoSelectDefault]);
 
   const selectedKey = modelKey({ id: value.model, source: value.source, provider: value.provider });
   const selectedModel = models.find((m) => modelKey(m) === selectedKey);
+  const selectedLabel =
+    selectedModel?.label || value.model || emptySelectionLabel || "Select model";
 
   return (
     <div className="flex items-center">
@@ -101,7 +112,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
             size="sm"
             className="h-7 gap-1 rounded-sm px-2 text-[11px] text-muted-foreground hover:text-foreground"
           >
-            {selectedModel?.label || value.model || "Select model"}
+            {selectedLabel}
             <ChevronDown className="h-3 w-3" />
           </Button>
         </PopoverTrigger>
@@ -111,6 +122,28 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
           className="z-[70] max-h-[320px] w-[280px] overflow-y-auto p-1"
           sideOffset={4}
         >
+          {emptySelectionLabel && (
+            <button
+              className={cn(
+                "flex w-full items-center justify-between rounded-md px-2.5 py-2 text-left text-[12px] transition-colors hover:bg-muted/50",
+                !value.model && "font-medium text-foreground",
+              )}
+              onClick={() => {
+                onChange({
+                  model: "",
+                  provider: "",
+                  source: "system",
+                  adapter: "",
+                });
+                setOpen(false);
+              }}
+            >
+              <span className="flex items-center gap-1.5">
+                {!value.model && <span className="text-[11px]">&#10003;</span>}
+                {emptySelectionLabel}
+              </span>
+            </button>
+          )}
           {models.map((m) => {
             const key = modelKey(m);
             const isSelected = key === selectedKey;

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -6,6 +6,19 @@ import type { Detector } from "../hooks/use-detectors";
 const mocks = vi.hoisted(() => ({
   detector: undefined as Detector | undefined,
   mutate: vi.fn(),
+  modelSelectorProps: undefined as
+    | {
+        autoSelectDefault?: boolean;
+        emptySelectionLabel?: string;
+        onChange: (value: {
+          model: string;
+          provider: string;
+          source: "system" | "byok";
+          adapter: string;
+        }) => void;
+        value: { model: string; provider: string; source: string; adapter: string };
+      }
+    | undefined,
 }));
 
 vi.mock("../hooks/use-detectors", () => ({
@@ -22,7 +35,51 @@ vi.mock("./agent-model-link", () => ({
   AgentModelLink: () => null,
 }));
 vi.mock("@/features/ai-assistant/components/model-selector", () => ({
-  ModelSelector: () => null,
+  ModelSelector: (props: {
+    autoSelectDefault?: boolean;
+    emptySelectionLabel?: string;
+    onChange: (value: {
+      model: string;
+      provider: string;
+      source: "system" | "byok";
+      adapter: string;
+    }) => void;
+    value: { model: string; provider: string; source: string; adapter: string };
+  }) => {
+    mocks.modelSelectorProps = props;
+    return (
+      <>
+        <button
+          type="button"
+          data-testid="select-system-model"
+          onClick={() =>
+            props.onChange({
+              model: "model-b",
+              provider: "provider-b",
+              source: "system",
+              adapter: "anthropic",
+            })
+          }
+        >
+          Select system model
+        </button>
+        <button
+          type="button"
+          data-testid="select-default-model"
+          onClick={() =>
+            props.onChange({
+              model: "",
+              provider: "",
+              source: "system",
+              adapter: "",
+            })
+          }
+        >
+          Select default model
+        </button>
+      </>
+    );
+  },
 }));
 vi.mock("./rca-toggle", () => ({
   RcaToggle: ({
@@ -80,6 +137,7 @@ const saveButton = () => screen.getByRole("button", { name: "Save" });
 afterEach(() => {
   cleanup();
   mocks.detector = undefined;
+  mocks.modelSelectorProps = undefined;
   mocks.mutate.mockReset();
 });
 
@@ -116,6 +174,65 @@ describe("DetectorPanel", () => {
     const options = mocks.mutate.mock.calls[0][1] as { onSuccess: () => void };
     options.onSuccess();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not auto-pin a model when saving a default-tracking detector edit", () => {
+    mocks.detector = {
+      ...baseDetector,
+      detectionModel: null,
+      detectionProvider: null,
+      detectionSource: null,
+    };
+    renderPanel();
+
+    expect(mocks.modelSelectorProps?.autoSelectDefault).toBe(false);
+    expect(mocks.modelSelectorProps?.emptySelectionLabel).toBe("System default detector model");
+    expect(mocks.modelSelectorProps?.value).toMatchObject({
+      model: "",
+      provider: "",
+      source: "system",
+    });
+
+    fireEvent.change(promptBox(), { target: { value: "new prompt" } });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({ prompt: "new prompt" });
+  });
+
+  it("sends a complete selector tuple when pinning a model from default tracking", () => {
+    mocks.detector = {
+      ...baseDetector,
+      detectionModel: null,
+      detectionProvider: null,
+      detectionSource: null,
+    };
+    renderPanel();
+
+    fireEvent.click(screen.getByTestId("select-system-model"));
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({
+      detectionModel: "model-b",
+      detectionProvider: "provider-b",
+      detectionSource: "system",
+    });
+  });
+
+  it("clears model and provider when returning a pinned detector to default tracking", () => {
+    mocks.detector = baseDetector;
+    renderPanel();
+
+    fireEvent.click(screen.getByTestId("select-default-model"));
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toEqual({
+      detectionModel: "",
+      detectionProvider: "",
+      detectionSource: "system",
+    });
   });
 
   it("closes without a network call when nothing changed", () => {

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -237,9 +237,12 @@ export function DetectorPanel({
                 value={editModelSelection}
                 onChange={setEditModelSelection}
                 workspaceId={workspaceId}
+                autoSelectDefault={false}
+                emptySelectionLabel="System default detector model"
               />
               <p className="mt-1 text-[11px] text-muted-foreground">
-                Used to evaluate each trace for this detector.
+                Used to evaluate each trace. Unpinned detectors use the system default detector
+                model, separate from the Agent Model.
               </p>
             </div>
             {/* Agent Model — project-scoped, click to configure in settings */}

--- a/frontend/ui/src/features/detectors/hooks/use-detectors.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-detectors.ts
@@ -92,7 +92,7 @@ export interface UpdateDetectorInput {
   triggerConditions?: Array<{ field: string; op: string; value: unknown }>;
   detectionModel?: string;
   detectionProvider?: string;
-  detectionSource?: "system" | "byok";
+  detectionSource?: "system" | "byok" | "";
 }
 
 async function updateDetector(

--- a/frontend/ui/src/features/detectors/utils/index.test.ts
+++ b/frontend/ui/src/features/detectors/utils/index.test.ts
@@ -70,9 +70,17 @@ describe("buildDetectorPatch", () => {
     expect(patch).toEqual({ prompt: "New prompt" });
   });
 
-  it("omits a model cleared to empty (omission means leave unchanged)", () => {
-    const patch = buildDetectorPatch(baseForm, { ...baseForm, detectionModel: "" });
-    expect(patch).toEqual({});
+  it("clears model and provider while retaining the system default source", () => {
+    const patch = buildDetectorPatch(baseForm, {
+      ...baseForm,
+      detectionModel: "",
+      detectionProvider: "",
+    });
+    expect(patch).toEqual({
+      detectionModel: "",
+      detectionProvider: "",
+      detectionSource: "system",
+    });
   });
 
   it("includes a changed detection model, provider, and source", () => {
@@ -86,6 +94,26 @@ describe("buildDetectorPatch", () => {
       detectionModel: "model-b",
       detectionProvider: "provider-b",
       detectionSource: "byok",
+    });
+  });
+
+  it("includes detectionSource when pinning a model from default tracking", () => {
+    const loaded = {
+      ...baseForm,
+      detectionModel: "",
+      detectionProvider: "",
+      detectionSource: "system" as const,
+    };
+    const patch = buildDetectorPatch(loaded, {
+      ...loaded,
+      detectionModel: "model-b",
+      detectionProvider: "provider-b",
+      detectionSource: "system",
+    });
+    expect(patch).toEqual({
+      detectionModel: "model-b",
+      detectionProvider: "provider-b",
+      detectionSource: "system",
     });
   });
 

--- a/frontend/ui/src/features/detectors/utils/index.ts
+++ b/frontend/ui/src/features/detectors/utils/index.ts
@@ -40,8 +40,9 @@ function conditionsEqual(
  * Diff the form against the last-loaded server snapshot and return only the
  * fields the user actually changed. Saving a partial body means a stale tab
  * can no longer silently revert fields it never touched (the PATCH route
- * leaves omitted fields unchanged). A model/provider cleared to "" is omitted
- * rather than sent, matching the previous save behavior.
+ * leaves omitted fields unchanged). Detection model/provider/source move as an
+ * atomic selector tuple so pinning a model also records its source, and choosing
+ * the empty/default option clears all three fields together.
  */
 export function buildDetectorPatch(
   loaded: DetectorFormValues,
@@ -62,13 +63,13 @@ export function buildDetectorPatch(
   if (!conditionsEqual(form.conditions, loaded.conditions)) {
     patch.triggerConditions = form.conditions;
   }
-  if (form.detectionModel !== loaded.detectionModel && form.detectionModel !== "") {
+  const selectorChanged =
+    form.detectionModel !== loaded.detectionModel ||
+    form.detectionProvider !== loaded.detectionProvider ||
+    form.detectionSource !== loaded.detectionSource;
+  if (selectorChanged) {
     patch.detectionModel = form.detectionModel;
-  }
-  if (form.detectionProvider !== loaded.detectionProvider && form.detectionProvider !== "") {
     patch.detectionProvider = form.detectionProvider;
-  }
-  if (form.detectionSource !== loaded.detectionSource) {
     patch.detectionSource = form.detectionSource;
   }
   return patch;


### PR DESCRIPTION
## Summary

Default-tracking detectors can load with empty model/provider fields in the edit panel. The shared model selector previously auto-selected a concrete default for empty values, so saving an unrelated edit could accidentally pin the detector to that model tuple.

This adds an explicit non-auto-select mode for detector editing, shows that inherited state as `System default detector model`, and treats detector model/provider/source as one atomic selector tuple when a user intentionally changes or clears it.

## Changes

- Add `autoSelectDefault` and `emptySelectionLabel` options to `ModelSelector`, preserving existing auto-selection behavior by default.
- Disable automatic default selection in the detector edit panel and show `System default detector model` for unpinned/default-tracking detectors.
- Allow the detector edit selector to clear back to default and send an empty selector tuple for that intentional clear.
- Update detector patch building so model, provider, and source are patched together for intentional selector changes.
- Add regression coverage for no-op saves, explicit pinning from default tracking, clear-to-default UI behavior, and pure patch generation.

## Why this matters

Default-tracking detector configuration should keep following the runtime default unless a user intentionally changes the model selector. This prevents prompt/name-only edits from silently changing runtime model behavior, and it avoids leaving source attribution ambiguous when a user does pin a model.

## Tests

Commands run:

- `cd frontend/ui && pnpm vitest run src/features/ai-assistant/components/model-selector.test.tsx src/features/detectors/components/detector-panel.test.tsx src/features/detectors/utils/index.test.ts --reporter=verbose` — passed, 3 files / 27 tests
- `cd frontend/ui && pnpm lint` — passed with existing warning baseline, 49 warnings / 0 errors
- `cd frontend/ui && pnpm format:check` — passed
- `cd frontend && pnpm format:check` — passed
- `git diff --check origin/main...HEAD` — passed
- `git diff --check` — passed

## Risk

Risk level: low/medium

The new selector props default to existing behavior, so current callers continue to auto-select defaults. The detector edit panel opts out because preserving an intentionally unpinned/default-tracking state is the safer behavior. The PATCH behavior changes only when the model selector tuple changes; ordinary field edits still produce partial patches.

Rollback is straightforward by reverting the selector props, detector panel prop usage, and patch-builder tuple change.

## Issue

No existing issue. This was discovered during repository review while preparing the detector model default-label follow-up.

## Notes for maintainers

This does not change detector creation defaults or server validation. The PATCH route already accepts empty string detection fields as clears; this PR uses that existing behavior only when the user explicitly chooses the default selector option.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the detector edit panel so default‑tracking detectors keep using the system default model unless the user intentionally changes it. Adds an opt‑out for auto-selection in `ModelSelector` and updates patching to avoid accidental pinning.

- **Bug Fixes**
  - Added `autoSelectDefault` and `emptySelectionLabel` to `ModelSelector`; detector panel sets `autoSelectDefault=false` and displays “System default detector model”.
  - Selector now lets users clear back to the default option and sends an empty selector tuple on clear.
  - Patch builder treats `detectionModel`/`detectionProvider`/`detectionSource` as an atomic tuple; clearing sets model/provider to "" and `detectionSource` to "system".
  - Regression tests cover no-op saves, pinning from default tracking, clear-to-default behavior, and tuple patch generation.

<sup>Written for commit ab9ace20204e461dc4e2bbb270bb2500015282cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

