### PR TITLE
feat(api): trace-filter follow-ups — registry-driven translator/builder + independent membership

### DIFF
--- a/backend/rest/services/filters/columns.py
+++ b/backend/rest/services/filters/columns.py
@@ -69,6 +69,10 @@ class FilterColumn:
         aggregate_expr (str | None): For ``SPAN_AGGREGATE`` fields, the per-trace
             aggregate the HAVING clause filters on (e.g. ``sum(cost)``). ``None`` for
             non-aggregate fields.
+        source_columns (tuple[str, ...]): The spans columns ``aggregate_expr``
+            references. The aggregate semi-join derives its inner projection from these
+            (plus the structural columns), so adding an aggregate field needs no change
+            to the translator. Empty for non-aggregate fields.
     """
 
     name: str
@@ -80,6 +84,7 @@ class FilterColumn:
     value_source: str
     enum_values: tuple[str, ...] = ()
     aggregate_expr: str | None = None
+    source_columns: tuple[str, ...] = ()
 
     @property
     def is_integer(self) -> bool:
@@ -125,6 +130,7 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         operators=(FilterOperator.BETWEEN,),
         value_source=ValueSource.RANGE,
         aggregate_expr="sum(cost)",
+        source_columns=("cost",),
     ),
     FilterColumn(
         name="total_tokens",
@@ -135,6 +141,7 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         operators=(FilterOperator.BETWEEN,),
         value_source=ValueSource.RANGE,
         aggregate_expr="sum(total_tokens)",
+        source_columns=("total_tokens",),
     ),
     FilterColumn(
         name="duration_ms",
@@ -145,6 +152,7 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         operators=(FilterOperator.BETWEEN,),
         value_source=ValueSource.RANGE,
         aggregate_expr=_DURATION_EXPR,
+        source_columns=("span_start_time", "span_end_time"),
     ),
     # Per-trace error-span count, filtered like the other numeric aggregates
     # (e.g. "errors between 3 and ∞"). `errors` is derived, not a stored column —
@@ -158,6 +166,7 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         operators=(FilterOperator.BETWEEN,),
         value_source=ValueSource.RANGE,
         aggregate_expr="countIf(status = 'ERROR')",
+        source_columns=("status",),
     ),
 )
 

--- a/backend/rest/services/filters/translate.py
+++ b/backend/rest/services/filters/translate.py
@@ -7,8 +7,9 @@ BOTH the page CTE and the separate count query. Every condition is keyed on
 filter narrows the page and the total identically and safely.
 
 Structured as a per-field lowering plus a small assembler that groups predicates by
-registry level. Membership predicates merge into one span semi-join; the safety boundary
-is the per-field operator whitelist validated against the registry here, not downstream.
+registry level. Each membership predicate becomes its own span semi-join (independent
+existence); the safety boundary is the per-field operator whitelist validated against the
+registry here, not downstream.
 """
 
 import json
@@ -183,33 +184,32 @@ def _span_time_bound(params: dict) -> str:
     return ""
 
 
-def _membership_semijoin(frags: list[tuple[int, FilterColumn, Predicate]], params: dict) -> str:
-    """Merge membership predicates into one project-scoped span semi-join.
+def _membership_semijoin(idx: int, col: FilterColumn, pred: Predicate, params: dict) -> str:
+    """One project-scoped span semi-join for a single membership predicate.
 
-    Matches traces with >=1 span satisfying ALL membership predicates. Dedups
-    ReplacingMergeTree spans to the latest ``ch_update_time`` version per span BEFORE
-    applying the categorical predicates (like the aggregate/distinct paths), so a stale
-    row can't match a value the latest version no longer has. Scoped to the same
-    ``project_id`` as the outer query (tenant isolation) and keyed on ``t.trace_id`` so
-    it filters the page and the count alike. Param names carry the predicate's index so
+    Independent-existence semantics: each membership predicate becomes its OWN semi-join,
+    AND-combined by the caller, so a trace matches if it has >=1 span for EACH predicate
+    independently (NOT one span satisfying all). Cross-attribute membership thus reads as
+    "has an X span AND has an error span", not "has one span that is both". A multi-value
+    predicate on a single field stays one ``IN (...)`` (OR within the field).
+
+    Dedups ReplacingMergeTree spans to the latest ``ch_update_time`` version per span
+    BEFORE applying the categorical predicate (like the aggregate/distinct paths), so a
+    stale row can't match a value the latest version no longer has. Scoped to the same
+    ``project_id`` as the outer query (tenant isolation) and keyed on ``t.trace_id`` so it
+    filters the page and the count alike. The param name carries the predicate's index so
     two predicates on the same field don't collide.
     """
-    member_conds: list[str] = []
-    select_cols = ["project_id", "trace_id", "span_id"]
-    for i, col, pred in frags:
-        pname = f"f_{col.name}_{i}"
-        params[pname] = pred.value
-        member_conds.append(f"{col.name} IN {{{pname}:Array({col.ch_type})}}")
-        select_cols.append(col.name)
-    # dict.fromkeys dedups columns (two predicates on the same field select it once).
+    pname = f"f_{col.name}_{idx}"
+    params[pname] = pred.value
     inner = (
-        f"SELECT {', '.join(dict.fromkeys(select_cols))} "
+        f"SELECT project_id, trace_id, span_id, {col.name} "
         "FROM spans "
         "WHERE project_id = {project_id:String}" + _span_time_bound(params) + " "
         "ORDER BY ch_update_time DESC "
         "LIMIT 1 BY project_id, trace_id, span_id"
     )
-    where = " AND ".join(member_conds)
+    where = f"{col.name} IN {{{pname}:Array({col.ch_type})}}"
     return f"t.trace_id IN (SELECT trace_id FROM ({inner}) WHERE {where})"
 
 
@@ -256,9 +256,17 @@ def _aggregate_semijoin(
     having = [c for c in (_having_clause(i, col, pred, params) for i, col, pred in frags) if c]
     if not having:
         return None
+    # Project the dedup/group keys, UNIONED with the source_columns of the active aggregate
+    # predicates. Registry-driven, so a new aggregate field is one registry entry (its
+    # source_columns) with no change here. dict.fromkeys dedups with stable order.
+    # (span_start_time is filtered in the inner WHERE by _span_time_bound but needn't be
+    # projected; duration_ms's source_columns add it when that field is active.)
+    structural = ("trace_id", "span_id", "project_id")
+    select_cols = list(structural)
+    for _, col, _pred in frags:
+        select_cols.extend(col.source_columns)
     inner = (
-        "SELECT trace_id, span_id, project_id, status, cost, total_tokens, "
-        "span_start_time, span_end_time "
+        f"SELECT {', '.join(dict.fromkeys(select_cols))} "
         "FROM spans "
         "WHERE project_id = {project_id:String}" + _span_time_bound(params) + " "
         "ORDER BY ch_update_time DESC "
@@ -297,8 +305,10 @@ def build_conditions(filters: list[Predicate], params: dict) -> list[str]:
             raise NotImplementedError(f"level {col.level} not yet lowered: {col.name}")
 
     conditions: list[str] = []
-    if membership:
-        conditions.append(_membership_semijoin(membership, params))
+    # One semi-join per membership predicate (independent existence), each AND-combined via
+    # the shared conditions list so every one lands in both the page and count queries.
+    for i, col, pred in membership:
+        conditions.append(_membership_semijoin(i, col, pred, params))
     if aggregate:
         agg = _aggregate_semijoin(aggregate, params)
         if agg:

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -152,6 +152,9 @@ class TraceReaderService:
         params: dict = {"project_id": project_id}
         inner_conditions = ["project_id = {project_id:String}"]
         if normalized_start is not None:
+            # Exact bound, no lookback back-off: this is a self-contained window scan with
+            # no trace-level semi-join, so the boundary-drift false-negative reasoning that
+            # SPAN_TIME_BOUND_LOOKBACK_HOURS guards against in the filtered list doesn't apply.
             inner_conditions.append("span_start_time >= {start_after:DateTime64(3)}")
             params["start_after"] = normalized_start
         if normalized_end is not None:

--- a/frontend/ui/src/features/filters/filter-builder.test.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.test.tsx
@@ -172,6 +172,46 @@ describe("FilterBuilder (Basic row)", () => {
     expect(screen.getByText("$")).toBeTruthy();
   });
 
+  it("derives the operator set from the field's `operators` (numeric `between` → equals/gte/lte, not `is`)", () => {
+    renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.click(screen.getByRole("button", { name: "equals" })); // open operator dropdown
+    expect(screen.getByRole("option", { name: "equals" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "greater than or equal to" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "less than or equal to" })).toBeTruthy();
+    expect(screen.queryByRole("option", { name: "is" })).toBeNull();
+  });
+
+  it("derives the operator set from the field's `operators` (categorical `in` → `is`)", () => {
+    renderBuilder([STATUS]);
+    pickField(/Status/);
+    // The lone `is` operator is shown on the disabled-until-picked operator trigger.
+    expect(screen.getByRole("button", { name: "is" })).toBeTruthy();
+  });
+
+  it("yields no operators for an unknown op in `operators` (defensive)", () => {
+    // A field whose registry op isn't in the UI map contributes no UI operators,
+    // so the operator dropdown offers nothing to choose.
+    const UNKNOWN: FilterFieldDef = {
+      field: "mystery",
+      label: "Mystery",
+      type: "numeric",
+      level: "SPAN_AGGREGATE",
+      operators: ["not_a_real_op"],
+      value_source: "range",
+      enum_values: [],
+    };
+    renderBuilder([UNKNOWN]);
+    pickField(/Mystery/);
+    // DOM order of buttons: [field, operator, Add filter] — open the operator dropdown.
+    fireEvent.click(screen.getAllByRole("button")[1]);
+    expect(screen.queryAllByRole("option")).toHaveLength(0);
+    // With no operator selected, entering a value must still build nothing — "Add filter"
+    // stays disabled rather than silently falling through to a bound.
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "5" } });
+    expect(screen.getByRole("button", { name: "Add filter" })).toHaveProperty("disabled", true);
+  });
+
   it("threads both window bounds into the distinct-values query for a categorical field", () => {
     mockUseFilterValues.mockClear();
     render(

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -60,8 +60,18 @@ const OP_LABEL: Record<UiOp, string> = {
 // "between" is intentionally not offered in the UI — a range is two filters
 // (a gte and an lte on the same field). The backend still supports a two-bound
 // predicate (and `equals` uses it as `[x, x]`).
+//
+// The UI operators are derived from the registry field's `operators` whitelist
+// (the backend op names) rather than branching on `f.type`, so adding a field
+// with a new operator set is one entry in this map — no type branch to touch.
+// `between` expands into three UI ops (equals/gte/lte) that all lower to a
+// `between` predicate with the right (possibly null) bounds.
+const REGISTRY_OP_TO_UI: Record<string, UiOp[]> = {
+  in: ["is"],
+  between: ["equals", "gte", "lte"],
+};
 const opsFor = (f: FilterFieldDef): UiOp[] =>
-  f.type === "categorical" ? ["is"] : ["equals", "gte", "lte"];
+  f.operators.flatMap((op) => REGISTRY_OP_TO_UI[op] ?? []);
 
 interface FilterBuilderProps {
   projectId: string;
@@ -104,7 +114,10 @@ export function FilterBuilder({
     if (field.integer && !Number.isInteger(lo)) return null;
     if (op === "equals") return buildBetweenPredicate(field.field, lo, lo);
     if (op === "gte") return buildBetweenPredicate(field.field, lo, null);
-    return buildBetweenPredicate(field.field, null, lo); // lte
+    if (op === "lte") return buildBetweenPredicate(field.field, null, lo);
+    // No recognized operator (e.g. a field whose registry `operators` map to none) — build
+    // nothing rather than silently falling through to a bound.
+    return null;
   };
   const built = predicate();
   // Immediate apply, then clear the row so another filter can be added without the

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -188,7 +188,7 @@ export interface TraceListResponse {
  * of the backend predicate IR, serialized into the `?filters=` JSON array.
  * Discriminated on `op`: categorical fields use `in` (the UI selects one value, so the
  * array carries a single element), numeric fields use `between` with nullable bounds
- * (`[0.5, null]` = ≥ 0.5, `[null, 10]` = < 10, a strict upper bound).
+ * (`[0.5, null]` = ≥ 0.5, `[null, 10]` = ≤ 10; both bounds inclusive).
  */
 export type Predicate =
   | { field: string; op: "in"; value: string[] }

--- a/tests/rest/test_filter_columns_parity.py
+++ b/tests/rest/test_filter_columns_parity.py
@@ -66,6 +66,17 @@ def test_duration_aggregates_via_min_max_while_cost_and_tokens_sum():
     assert "sum(" not in dur
 
 
+def test_aggregate_source_columns_name_the_referenced_spans_columns():
+    """Each aggregate field declares the spans columns its aggregate_expr references, so
+    the semi-join's inner projection is registry-driven. Membership fields declare none."""
+    assert reg.get_column("cost").source_columns == ("cost",)
+    assert reg.get_column("total_tokens").source_columns == ("total_tokens",)
+    assert reg.get_column("duration_ms").source_columns == ("span_start_time", "span_end_time")
+    assert reg.get_column("errors").source_columns == ("status",)
+    for name in MEMBERSHIP_FIELDS:
+        assert reg.get_column(name).source_columns == ()
+
+
 def test_get_column_returns_none_for_unknown_field():
     assert reg.get_column("not_a_field") is None
 

--- a/tests/rest/test_filter_translate.py
+++ b/tests/rest/test_filter_translate.py
@@ -9,6 +9,7 @@ keyed on ``t.trace_id`` filters the page and the total identically.
 import pytest
 
 from rest.services.filters.translate import (
+    SPAN_TIME_BOUND_LOOKBACK_HOURS,
     Predicate,
     build_conditions,
     parse_filters_param,
@@ -172,6 +173,56 @@ def test_membership_predicate_lowers_to_a_project_scoped_span_semijoin():
     assert "claude-opus-4.8" not in cond
 
 
+def test_membership_predicates_on_different_fields_emit_independent_semijoins():
+    # Independent existence: each membership predicate is its OWN semi-join, AND-combined,
+    # so a trace matches if it has >=1 span for EACH predicate independently (NOT one span
+    # satisfying both). Two fields -> two separate t.trace_id IN (...) conditions.
+    params = {"project_id": "p1"}
+    conditions = build_conditions(
+        [
+            Predicate(field="model_name", op="in", value=["gpt-4"]),
+            Predicate(field="environment", op="in", value=["prod"]),
+        ],
+        params,
+    )
+    assert len(conditions) == 2
+    assert all(c.startswith("t.trace_id IN (") for c in conditions)
+    # Each semi-join carries only its own field's condition, not the other's (not merged).
+    model_cond = next(c for c in conditions if "model_name IN" in c)
+    env_cond = next(c for c in conditions if "environment IN" in c)
+    assert "environment IN" not in model_cond
+    assert "model_name IN" not in env_cond
+    # Per-predicate param indexing keeps the two from colliding.
+    assert params["f_model_name_0"] == ["gpt-4"]
+    assert params["f_environment_1"] == ["prod"]
+
+
+def test_aggregate_inner_projection_is_registry_driven():
+    # The aggregate inner SELECT projects the structural columns plus only the active
+    # field's source_columns — a cost filter projects cost, NOT total_tokens or status.
+    params = {"project_id": "p1"}
+    cond = build_conditions([Predicate(field="cost", op="between", value=[0.5, None])], params)[0]
+    # The inner projection is the SELECT list feeding "FROM spans" (not the outer wrapper).
+    inner_select_start = cond.index("SELECT", cond.index("SELECT") + 1)
+    select = cond[inner_select_start : cond.index("FROM spans")]
+    assert "cost" in select
+    assert "total_tokens" not in select
+    assert "status" not in select
+    # A cost filter doesn't need span_start_time projected — it's only filtered in the
+    # inner WHERE, not selected — so it isn't over-projected here.
+    assert "span_start_time" not in select
+    # The dedup/group keys are always present.
+    for structural in ("trace_id", "span_id", "project_id"):
+        assert structural in select
+    # A duration filter DOES project span_start_time + span_end_time — supplied by its
+    # source_columns, not hardcoded — confirming the projection is registry-driven.
+    dcond = build_conditions(
+        [Predicate(field="duration_ms", op="between", value=[5, None])], {"project_id": "p1"}
+    )[0]
+    dsel = dcond[dcond.index("SELECT", dcond.index("SELECT") + 1) : dcond.index("FROM spans")]
+    assert "span_start_time" in dsel and "span_end_time" in dsel
+
+
 def test_unknown_field_is_rejected():
     with pytest.raises(ValueError):
         build_conditions([Predicate(field="not_a_field", op="in", value=["x"])], {})
@@ -257,4 +308,7 @@ def test_span_time_bound_backs_off_for_boundary_drift():
     dropped — which would false-negative an otherwise-matching in-window trace."""
     params = {"project_id": "p1", "start_after": "2026-06-01 00:00:00"}
     conditions = build_conditions([Predicate(field="model_name", op="in", value=["gpt-4"])], params)
-    assert "span_start_time >= {start_after:DateTime64(3)} - INTERVAL" in conditions[0]
+    assert (
+        f"span_start_time >= {{start_after:DateTime64(3)}} - INTERVAL "
+        f"{SPAN_TIME_BOUND_LOOKBACK_HOURS} HOUR" in conditions[0]
+    )

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -48,6 +48,33 @@ def test_membership_filter_lands_in_both_page_and_count_queries():
     assert params["f_model_name_0"] == ["gpt-4"]
 
 
+def test_independent_membership_predicates_emit_two_semijoins_in_both_queries():
+    """Two membership predicates on different fields lower to TWO separate
+    ``t.trace_id IN (...)`` semi-joins (independent existence, not one merged match), and
+    both must reach the page AND the count query so page and total stay consistent."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(
+        project_id="p1",
+        filters=[
+            Predicate(field="model_name", op="in", value=["gpt-4"]),
+            Predicate(field="environment", op="in", value=["prod"]),
+        ],
+    )
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    count_sql = svc._client.query.call_args_list[1].args[0]
+    for sql in (page_sql, count_sql):
+        # Two independent semi-joins, each keyed on t.trace_id with its own field.
+        assert sql.count("t.trace_id IN (") == 2
+        assert "model_name IN" in sql
+        assert "environment IN" in sql
+    params = svc._client.query.call_args_list[0].kwargs["parameters"]
+    assert params["f_model_name_0"] == ["gpt-4"]
+    assert params["f_environment_1"] == ["prod"]
+
+
 def test_aggregate_filter_lands_in_both_page_and_count_queries():
     svc = _service_with_mock_client()
     _drive(svc)


### PR DESCRIPTION
Follow-up to the trace-list filtering series (stacked on `feat/trace-filter-ui`). Implements the P3 "future-proofing" review items 9–11 plus a few review nits carried over. Item 12 (single aggregate CTE for filter + display) is deferred — it needs the per-trace denormalization it depends on, so folding it in now would regress the pagination-first full-scan avoidance.

## Changes

- **Registry-driven builder operators** — the filter builder chose its operator set by branching on the field's `type`; it now maps the registry field's `operators` whitelist to UI operators (`in → is`; `between → equals/gte/lte`). Adding a field with a different operator set no longer needs a builder edit — the extension point is one entry in the registry-op → UI-op map. An unrecognized op builds no predicate (explicit) rather than falling through to a bound.

- **Registry-driven aggregate projection** — the aggregate semi-join's inner `SELECT` was a hardcoded column list; each `SPAN_AGGREGATE` registry column now declares its `source_columns`, and the translator projects the dedup/group keys plus the active predicates' `source_columns`. A new aggregate field is now one registry entry with no translator change.

- **Independent-existence membership** — multiple membership predicates on different fields previously required **one span** to satisfy all of them. Each membership predicate is now its own span semi-join, AND-combined, so cross-attribute membership reads as "has an X span **and** has an error span" rather than "one span that is both." This is a deliberate behavior change; for today's `model`/`environment` the practical difference is small, but it sets the correct foundation for `status`/`span_kind` joining the membership tier. A multi-value predicate on a single field still lowers to one `IN (...)`.

The pagination-correctness invariant is preserved: every emitted condition is keyed on `t.trace_id` and lands in both the page query and the count query (tested).

Also folds in review nits from the parent series' final passes: pin the span-lookback boundary test to the full interval magnitude, note why the distinct-values scan intentionally has no lookback, drop a redundant projected column, and make the builder's unrecognized-operator path explicit.

## Tests
Backend and frontend unit tests updated/added for all three items (independent-existence semi-joins, registry-driven projection incl. the duration source-columns case, registry-derived operators incl. the unknown-op guard). Full filter suites green; changed lines are 100% covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes trace filtering registry-driven and updates membership to independent existence, while deriving UI operators from the registry. This simplifies adding new fields and keeps page/count pagination consistent.

- **New Features**
  - Backend: Aggregate semi-join projection reads `source_columns` from the registry; new `FilterColumn.source_columns` added. The inner SELECT now projects only structural keys plus active aggregates’ `source_columns`.
  - Backend: Membership predicates are independent-existence; each becomes its own span semi-join keyed by `t.trace_id` and AND-combined. Multi-value on one field remains a single `IN (...)`.
  - Frontend: Filter builder derives operators from the registry `operators` whitelist (`in` → `is`; `between` → `equals`/`gte`/`lte`). Unknown ops yield no predicate (defensive).

- **Refactors**
  - Pinned the span-lookback boundary test to the full constant and documented why distinct-values scans have no lookback.
  - Dropped a redundant projected column and made the builder’s unknown-operator path explicit.
  - Expanded unit tests for independent membership, registry-driven projection (incl. duration), and operator derivation; corrected the `Predicate` type doc to note the upper bound is inclusive (≤).

<sup>Written for commit a7902558bac5e6cd16a23dd271524875af6e6e22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

