### PR TITLE
Add LiveKit TraceRoot example

### DIFF
--- a/examples/python/livekit-agent/.env.example
+++ b/examples/python/livekit-agent/.env.example
@@ -1,0 +1,9 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# LiveKit
+LIVEKIT_URL=your_livekit_url_here
+LIVEKIT_API_KEY=your_livekit_api_key_here
+LIVEKIT_API_SECRET=your_livekit_api_secret_here

--- a/examples/python/livekit-agent/README.md
+++ b/examples/python/livekit-agent/README.md
@@ -1,0 +1,42 @@
+# LiveKit Voice Agent
+
+LiveKit Agents voice agent, instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+
+```bash
+cp .env.example .env  # fill in your API keys
+```
+
+With `uv` (recommended):
+
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+```
+
+To talk to the agent from your terminal:
+
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py console
+```
+
+## What it does
+
+Starts a LiveKit agent and routes LiveKit's native OpenTelemetry spans through
+TraceRoot. The agent uses LiveKit Inference for STT, TTS, and LLM calls, plus
+LiveKit Agents' default bundled VAD and default turn detection for voice
+interaction.
+
+The TraceRoot setup is intentionally small:
+
+- `traceroot.initialize(integrations=[Integration.LIVEKIT])` gives TraceRoot's
+  tracer provider to LiveKit.
+- `using_attributes(session_id=ctx.room.name)` groups all spans from the room
+  into one TraceRoot session.
+- `ctx.add_shutdown_callback(traceroot.flush)` flushes spans before the job exits.
+- `record={"traces": False}` avoids LiveKit Cloud re-binding the tracer provider
+  away from TraceRoot.
+
+LiveKit currently emits an `agent_turn` span for each completed turn. The user's
+voice input is emitted as a `user_turn` span, and the assistant response is
+emitted as an `agent_turn` span.

--- a/examples/python/livekit-agent/README.md
+++ b/examples/python/livekit-agent/README.md
@@ -34,8 +34,6 @@ The TraceRoot setup is intentionally small:
 - `using_attributes(session_id=ctx.room.name)` groups all spans from the room
   into one TraceRoot session.
 - `ctx.add_shutdown_callback(traceroot.flush)` flushes spans before the job exits.
-- `record={"traces": False}` avoids LiveKit Cloud re-binding the tracer provider
-  away from TraceRoot.
 
 LiveKit currently emits an `agent_turn` span for each completed turn. The user's
 voice input is emitted as a `user_turn` span, and the assistant response is

--- a/examples/python/livekit-agent/README.md
+++ b/examples/python/livekit-agent/README.md
@@ -40,3 +40,7 @@ The TraceRoot setup is intentionally small:
 LiveKit currently emits an `agent_turn` span for each completed turn. The user's
 voice input is emitted as a `user_turn` span, and the assistant response is
 emitted as an `agent_turn` span.
+
+The demo agent also exposes an `add_numbers` function tool. Ask something like
+"what is 12 plus 30?" to generate a tool call span during an apple-to-apple
+comparison run.

--- a/examples/python/livekit-agent/README.md
+++ b/examples/python/livekit-agent/README.md
@@ -20,17 +20,18 @@ grep -v '^traceroot' requirements.txt > /tmp/livekit-agent-requirements-pr.txt
 uv run --no-project --python 3.13 \
   --with-requirements /tmp/livekit-agent-requirements-pr.txt \
   --with /path/to/traceroot-py/dist/traceroot-*.whl \
-  python main.py smoke
+  python main.py
 
 # Or use a local SDK source checkout:
 uv run --no-project --python 3.13 \
   --with-requirements /tmp/livekit-agent-requirements-pr.txt \
   --with "traceroot @ file:///path/to/traceroot-py" \
-  python main.py smoke
+  python main.py
 ```
 
-The `smoke` command runs one text-only turn, calls the `add_numbers` tool, flushes
-TraceRoot, and exits. To talk to the voice agent from your terminal:
+The default command runs one real text-only LiveKit turn, calls the `add_numbers`
+tool, flushes TraceRoot, and exits. To talk to the voice agent from your
+terminal:
 
 ```bash
 uv run --no-project --python 3.13 \
@@ -43,7 +44,7 @@ After `traceroot>=0.1.12` is published to PyPI, you can use
 `requirements.txt` directly:
 
 ```bash
-uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py smoke
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
 uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py dev
 uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py start
 uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py console
@@ -52,10 +53,10 @@ uv run --no-project --python 3.13 --with-requirements requirements.txt python ma
 ## What it does
 
 Starts a LiveKit agent and routes LiveKit's native OpenTelemetry spans through
-TraceRoot. The default `smoke` path runs a text-only turn with LiveKit Inference
-LLM and exits. The `console`, `dev`, and `start` paths use LiveKit Inference for
-STT, TTS, and LLM calls, plus LiveKit Agents' default bundled VAD and default
-turn detection for voice interaction.
+TraceRoot. The default path runs a text-only turn with LiveKit Inference LLM and
+exits. The `console`, `dev`, and `start` paths use LiveKit Inference for STT,
+TTS, and LLM calls, plus LiveKit Agents' default bundled VAD and default turn
+detection for voice interaction.
 
 The TraceRoot setup is intentionally small:
 
@@ -69,6 +70,6 @@ The TraceRoot setup is intentionally small:
 LiveKit currently emits an `agent_turn` span for each completed turn. Voice runs
 also emit `user_turn` spans for user input.
 
-The demo agent exposes an `add_numbers` function tool. The `smoke` command asks
+The demo agent exposes an `add_numbers` function tool. The default command asks
 "what is 12 plus 30?" automatically to generate a tool call span during an
 apple-to-apple comparison run.

--- a/examples/python/livekit-agent/README.md
+++ b/examples/python/livekit-agent/README.md
@@ -10,13 +10,40 @@ cp .env.example .env  # fill in your API keys
 
 With `uv` (recommended):
 
+For PR review before `traceroot>=0.1.12` is published, install the other
+requirements plus a local TraceRoot SDK wheel or source checkout:
+
 ```bash
-uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py
+grep -v '^traceroot' requirements.txt > /tmp/livekit-agent-requirements-pr.txt
+
+# Use a locally built SDK wheel:
+uv run --no-project --python 3.13 \
+  --with-requirements /tmp/livekit-agent-requirements-pr.txt \
+  --with /path/to/traceroot-py/dist/traceroot-*.whl \
+  python main.py dev
+
+# Or use a local SDK source checkout:
+uv run --no-project --python 3.13 \
+  --with-requirements /tmp/livekit-agent-requirements-pr.txt \
+  --with "traceroot @ file:///path/to/traceroot-py" \
+  python main.py dev
 ```
 
 To talk to the agent from your terminal:
 
 ```bash
+uv run --no-project --python 3.13 \
+  --with-requirements /tmp/livekit-agent-requirements-pr.txt \
+  --with /path/to/traceroot-py/dist/traceroot-*.whl \
+  python main.py console
+```
+
+After `traceroot>=0.1.12` is published to PyPI, you can use
+`requirements.txt` directly:
+
+```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py dev
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py start
 uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py console
 ```
 

--- a/examples/python/livekit-agent/README.md
+++ b/examples/python/livekit-agent/README.md
@@ -33,7 +33,8 @@ The TraceRoot setup is intentionally small:
   tracer provider to LiveKit.
 - `using_attributes(session_id=ctx.room.name)` groups all spans from the room
   into one TraceRoot session.
-- `ctx.add_shutdown_callback(traceroot.flush)` flushes spans before the job exits.
+- `ctx.add_shutdown_callback(traceroot.flush_async)` flushes spans before the
+  job exits.
 
 LiveKit currently emits an `agent_turn` span for each completed turn. The user's
 voice input is emitted as a `user_turn` span, and the assistant response is

--- a/examples/python/livekit-agent/README.md
+++ b/examples/python/livekit-agent/README.md
@@ -20,16 +20,17 @@ grep -v '^traceroot' requirements.txt > /tmp/livekit-agent-requirements-pr.txt
 uv run --no-project --python 3.13 \
   --with-requirements /tmp/livekit-agent-requirements-pr.txt \
   --with /path/to/traceroot-py/dist/traceroot-*.whl \
-  python main.py dev
+  python main.py smoke
 
 # Or use a local SDK source checkout:
 uv run --no-project --python 3.13 \
   --with-requirements /tmp/livekit-agent-requirements-pr.txt \
   --with "traceroot @ file:///path/to/traceroot-py" \
-  python main.py dev
+  python main.py smoke
 ```
 
-To talk to the agent from your terminal:
+The `smoke` command runs one text-only turn, calls the `add_numbers` tool, flushes
+TraceRoot, and exits. To talk to the voice agent from your terminal:
 
 ```bash
 uv run --no-project --python 3.13 \
@@ -42,6 +43,7 @@ After `traceroot>=0.1.12` is published to PyPI, you can use
 `requirements.txt` directly:
 
 ```bash
+uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py smoke
 uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py dev
 uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py start
 uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py console
@@ -50,9 +52,10 @@ uv run --no-project --python 3.13 --with-requirements requirements.txt python ma
 ## What it does
 
 Starts a LiveKit agent and routes LiveKit's native OpenTelemetry spans through
-TraceRoot. The agent uses LiveKit Inference for STT, TTS, and LLM calls, plus
-LiveKit Agents' default bundled VAD and default turn detection for voice
-interaction.
+TraceRoot. The default `smoke` path runs a text-only turn with LiveKit Inference
+LLM and exits. The `console`, `dev`, and `start` paths use LiveKit Inference for
+STT, TTS, and LLM calls, plus LiveKit Agents' default bundled VAD and default
+turn detection for voice interaction.
 
 The TraceRoot setup is intentionally small:
 
@@ -63,10 +66,9 @@ The TraceRoot setup is intentionally small:
 - `ctx.add_shutdown_callback(traceroot.flush_async)` flushes spans before the
   job exits.
 
-LiveKit currently emits an `agent_turn` span for each completed turn. The user's
-voice input is emitted as a `user_turn` span, and the assistant response is
-emitted as an `agent_turn` span.
+LiveKit currently emits an `agent_turn` span for each completed turn. Voice runs
+also emit `user_turn` spans for user input.
 
-The demo agent also exposes an `add_numbers` function tool. Ask something like
-"what is 12 plus 30?" to generate a tool call span during an apple-to-apple
-comparison run.
+The demo agent exposes an `add_numbers` function tool. The `smoke` command asks
+"what is 12 plus 30?" automatically to generate a tool call span during an
+apple-to-apple comparison run.

--- a/examples/python/livekit-agent/main.py
+++ b/examples/python/livekit-agent/main.py
@@ -3,7 +3,11 @@ LiveKit Agents with TraceRoot observability.
 
 Usage:
     cp .env.example .env
-    uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py console
+    python main.py dev
+    python main.py start
+    python main.py console
+
+See README.md for PR-review installation commands using a local TraceRoot SDK.
 """
 
 from dotenv import find_dotenv, load_dotenv

--- a/examples/python/livekit-agent/main.py
+++ b/examples/python/livekit-agent/main.py
@@ -14,7 +14,7 @@ if dotenv_path:
 else:
     print("No .env file found. Using process environment variables.")
 
-from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli, function_tool
 
 import traceroot
 from traceroot import Integration, using_attributes
@@ -23,8 +23,17 @@ from traceroot import Integration, using_attributes
 class Assistant(Agent):
     def __init__(self) -> None:
         super().__init__(
-            instructions="You are a helpful voice AI assistant.",
+            instructions=(
+                "You are a helpful voice AI assistant. Keep replies short. "
+                "When the user asks you to add two numbers, call add_numbers "
+                "before answering."
+            ),
         )
+
+    @function_tool(description="Add two numbers and return the sum.")
+    async def add_numbers(self, a: float, b: float) -> str:
+        """Return a deterministic addition result for tool tracing."""
+        return f"{a} + {b} = {a + b}"
 
 
 server = AgentServer()

--- a/examples/python/livekit-agent/main.py
+++ b/examples/python/livekit-agent/main.py
@@ -1,0 +1,58 @@
+"""
+LiveKit Agents with TraceRoot observability.
+
+Usage:
+    cp .env.example .env
+    uv run --no-project --python 3.13 --with-requirements requirements.txt python main.py console
+"""
+
+from dotenv import find_dotenv, load_dotenv
+
+dotenv_path = find_dotenv()
+if dotenv_path:
+    load_dotenv(dotenv_path)
+else:
+    print("No .env file found. Using process environment variables.")
+
+from livekit.agents import Agent, AgentServer, AgentSession, JobContext, cli
+
+import traceroot
+from traceroot import Integration, using_attributes
+
+
+class Assistant(Agent):
+    def __init__(self) -> None:
+        super().__init__(
+            instructions="You are a helpful voice AI assistant.",
+        )
+
+
+server = AgentServer()
+
+
+@server.rtc_session(agent_name="traceroot-livekit-agent")
+async def entrypoint(ctx: JobContext) -> None:
+    traceroot.initialize(integrations=[Integration.LIVEKIT])
+
+    async def flush_trace() -> None:
+        traceroot.flush()
+
+    ctx.add_shutdown_callback(flush_trace)
+
+    session = AgentSession(
+        stt="deepgram/nova-3:en",
+        llm="openai/chat-latest",
+        tts="cartesia/sonic-3",
+    )
+
+    with using_attributes(session_id=ctx.room.name):
+        await session.start(
+            agent=Assistant(),
+            room=ctx.room,
+            record={"traces": False},
+        )
+        await ctx.connect()
+
+
+if __name__ == "__main__":
+    cli.run_app(server)

--- a/examples/python/livekit-agent/main.py
+++ b/examples/python/livekit-agent/main.py
@@ -3,12 +3,16 @@ LiveKit Agents with TraceRoot observability.
 
 Usage:
     cp .env.example .env
+    python main.py smoke
     python main.py dev
     python main.py start
     python main.py console
 
 See README.md for PR-review installation commands using a local TraceRoot SDK.
 """
+
+import asyncio
+import sys
 
 from dotenv import find_dotenv, load_dotenv
 
@@ -43,16 +47,37 @@ class Assistant(Agent):
 server = AgentServer()
 
 
+def _new_session(*, voice: bool) -> AgentSession:
+    if not voice:
+        return AgentSession(llm="openai/chat-latest")
+
+    return AgentSession(
+        stt="deepgram/nova-3:en",
+        llm="openai/chat-latest",
+        tts="cartesia/sonic-3",
+    )
+
+
+async def run_smoke() -> None:
+    traceroot.initialize(integrations=[Integration.LIVEKIT])
+
+    session = _new_session(voice=False)
+    try:
+        with using_attributes(session_id="livekit-smoke"):
+            await session.start(agent=Assistant())
+            result = session.run(user_input="What is 12 plus 30? Use the add_numbers tool.")
+            await result
+    finally:
+        await session.aclose()
+        await traceroot.flush_async()
+
+
 @server.rtc_session(agent_name="traceroot-livekit-agent")
 async def entrypoint(ctx: JobContext) -> None:
     traceroot.initialize(integrations=[Integration.LIVEKIT])
     ctx.add_shutdown_callback(traceroot.flush_async)
 
-    session = AgentSession(
-        stt="deepgram/nova-3:en",
-        llm="openai/chat-latest",
-        tts="cartesia/sonic-3",
-    )
+    session = _new_session(voice=True)
 
     with using_attributes(session_id=ctx.room.name):
         await session.start(
@@ -63,4 +88,7 @@ async def entrypoint(ctx: JobContext) -> None:
 
 
 if __name__ == "__main__":
-    cli.run_app(server)
+    if len(sys.argv) == 1 or sys.argv[1] == "smoke":
+        asyncio.run(run_smoke())
+    else:
+        cli.run_app(server)

--- a/examples/python/livekit-agent/main.py
+++ b/examples/python/livekit-agent/main.py
@@ -42,11 +42,7 @@ server = AgentServer()
 @server.rtc_session(agent_name="traceroot-livekit-agent")
 async def entrypoint(ctx: JobContext) -> None:
     traceroot.initialize(integrations=[Integration.LIVEKIT])
-
-    async def flush_trace() -> None:
-        traceroot.flush()
-
-    ctx.add_shutdown_callback(flush_trace)
+    ctx.add_shutdown_callback(traceroot.flush_async)
 
     session = AgentSession(
         stt="deepgram/nova-3:en",

--- a/examples/python/livekit-agent/main.py
+++ b/examples/python/livekit-agent/main.py
@@ -58,7 +58,6 @@ async def entrypoint(ctx: JobContext) -> None:
         await session.start(
             agent=Assistant(),
             room=ctx.room,
-            record={"traces": False},
         )
         await ctx.connect()
 

--- a/examples/python/livekit-agent/main.py
+++ b/examples/python/livekit-agent/main.py
@@ -3,7 +3,8 @@ LiveKit Agents with TraceRoot observability.
 
 Usage:
     cp .env.example .env
-    python main.py smoke
+    python main.py
+    python main.py demo
     python main.py dev
     python main.py start
     python main.py console
@@ -58,12 +59,12 @@ def _new_session(*, voice: bool) -> AgentSession:
     )
 
 
-async def run_smoke() -> None:
+async def run_demo() -> None:
     traceroot.initialize(integrations=[Integration.LIVEKIT])
 
     session = _new_session(voice=False)
     try:
-        with using_attributes(session_id="livekit-smoke"):
+        with using_attributes(session_id="livekit-demo"):
             await session.start(agent=Assistant())
             result = session.run(user_input="What is 12 plus 30? Use the add_numbers tool.")
             await result
@@ -88,7 +89,7 @@ async def entrypoint(ctx: JobContext) -> None:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) == 1 or sys.argv[1] == "smoke":
-        asyncio.run(run_smoke())
+    if len(sys.argv) == 1 or sys.argv[1] == "demo":
+        asyncio.run(run_demo())
     else:
         cli.run_app(server)

--- a/examples/python/livekit-agent/requirements.txt
+++ b/examples/python/livekit-agent/requirements.txt
@@ -1,0 +1,5 @@
+python-dotenv>=1.0.0
+
+livekit-agents>=1.0.0
+
+traceroot>=0.1.12


### PR DESCRIPTION
## Summary

Add a Python LiveKit voice-agent example instrumented with TraceRoot.

This example demonstrates:

- `traceroot.initialize(integrations=[Integration.LIVEKIT])`
- `using_attributes(session_id=ctx.room.name)` for room/session grouping
- `ctx.add_shutdown_callback(traceroot.flush_async)` for shutdown flushing
- pre-release PR review commands that install a local TraceRoot SDK wheel or source checkout
- LiveKit STT/LLM/TTS setup through LiveKit Inference
- a simple `add_numbers` function tool so comparison runs include a tool-call span

## Notes

- This example depends on the LiveKit integration in the TraceRoot Python SDK.
- `requirements.txt` currently points at `traceroot>=0.1.12`, which is expected to include the SDK-side LiveKit integration.
- Until that release is published, the README shows PR-review commands using a local SDK wheel or local SDK source checkout.

## Testing

Current verification on this branch:

- `uv run --no-project --python 3.13 --with ruff ruff check examples/python/livekit-agent` -> passed
- `uv run --no-project --python 3.13 --with ruff ruff format --check examples/python/livekit-agent` -> passed
- `uv run --no-project --python 3.13 python -m py_compile examples/python/livekit-agent/main.py` -> passed
- Verified against the local SDK wheel that `traceroot.flush_async` is available and awaitable.

I did not run the example through `--with-requirements requirements.txt` in this branch because `traceroot>=0.1.12` is not published yet.

## Result

<img width="1507" height="848" alt="image" src="https://github.com/user-attachments/assets/c7c466d9-f405-47c1-bb59-a6bc24a4e9c7" />
