### PR TITLE
feat(ui): trace-filter UI polish + explicit operators + trace_id filter

### DIFF
--- a/backend/rest/services/filters/columns.py
+++ b/backend/rest/services/filters/columns.py
@@ -28,21 +28,25 @@ class FilterType(StrEnum):
 
     CATEGORICAL = "categorical"  # single-select value dropdown
     NUMERIC = "numeric"  # number input
+    TEXT = "text"  # free-text input (e.g. trace_id)
 
 
 class FilterOperator(StrEnum):
-    """Operators the translator whitelists per field (safety boundary)."""
+    """Operators the translator whitelists per field (safety boundary).
 
-    IN = "in"
-    # The single numeric operator: a [min, max] range where either bound may be null,
-    # which is how the UI's "greater/less than or equal to" and "equals" are expressed
-    # without separate ops. Lowering (see translate.py:_having_clause) — both bounds
-    # inclusive:
-    #   value [0.5, null]  -> agg >= 0.5            (UI "greater than or equal to")
-    #   value [null, 10]   -> agg <= 10             (UI "less than or equal to")
-    #   value [0.5, 10]    -> agg BETWEEN 0.5 AND 10  (inclusive; "equals" uses [x, x])
-    # The translator keys off which bounds are present.
-    BETWEEN = "between"
+    Explicit scalar operators: categorical membership (``in``, a list),
+    numeric comparisons (``eq``/``gt``/``gte``/``lt``/``lte``, each a single number), and
+    text match (``eq`` exact / ``contains`` case-insensitive substring). Each lowers to a
+    literal SQL comparison in ``translate.py``; the value's shape is validated per field.
+    """
+
+    IN = "in"  # categorical membership — value is a list of strings
+    EQ = "eq"  # =   (numeric equality, or text exact match)
+    GT = "gt"  # >
+    GTE = "gte"  # >=
+    LT = "lt"  # <
+    LTE = "lte"  # <=
+    CONTAINS = "contains"  # case-insensitive substring (text)
 
 
 class ValueSource(StrEnum):
@@ -51,6 +55,7 @@ class ValueSource(StrEnum):
     STATIC_ENUM = "static_enum"  # a fixed shared StrEnum (no field uses this currently)
     DISTINCT_QUERY = "distinct_query"  # a distinct-values query (model_name, environment)
     RANGE = "range"  # numeric field — no enumerated options, a number input
+    FREE_TEXT = "free_text"  # text field — a free-text input, no options (trace_id)
 
 
 @dataclass(frozen=True)
@@ -98,9 +103,29 @@ class FilterColumn:
 # the trace's spans — the same expression the list query's span_agg already uses.
 _DURATION_EXPR = "dateDiff('millisecond', min(span_start_time), max(span_end_time))"
 
+# The comparison operators every numeric field accepts.
+_NUMERIC_OPS = (
+    FilterOperator.EQ,
+    FilterOperator.GT,
+    FilterOperator.GTE,
+    FilterOperator.LT,
+    FilterOperator.LTE,
+)
+
 # A tuple, not a list/frozenset: an immutable constant whose order is the UI render
 # / serialization order; keyed lookup is FILTER_COLUMNS_BY_NAME below.
 FILTER_COLUMNS: tuple[FilterColumn, ...] = (
+    # Trace-identifier tier — inline predicate on the traces row (t.trace_id), not a span
+    # scan. Text match: exact `=` or case-insensitive `contains` (the search-by-id path).
+    FilterColumn(
+        name="trace_id",
+        label="Trace ID",
+        ch_type="String",
+        level=FilterLevel.TRACE,
+        type=FilterType.TEXT,
+        operators=(FilterOperator.EQ, FilterOperator.CONTAINS),
+        value_source=ValueSource.FREE_TEXT,
+    ),
     # Membership tier — "trace has ≥1 span where …" (span semi-join).
     FilterColumn(
         name="model_name",
@@ -120,14 +145,14 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         operators=(FilterOperator.IN,),
         value_source=ValueSource.DISTINCT_QUERY,
     ),
-    # Aggregate tier — time-bounded GROUP BY trace_id HAVING <agg> BETWEEN ….
+    # Aggregate tier — time-bounded GROUP BY trace_id HAVING <agg> <op> <value>.
     FilterColumn(
         name="cost",
         label="Cost",
         ch_type="Decimal64(9)",
         level=FilterLevel.SPAN_AGGREGATE,
         type=FilterType.NUMERIC,
-        operators=(FilterOperator.BETWEEN,),
+        operators=_NUMERIC_OPS,
         value_source=ValueSource.RANGE,
         aggregate_expr="sum(cost)",
         source_columns=("cost",),
@@ -138,7 +163,7 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         ch_type="Int64",
         level=FilterLevel.SPAN_AGGREGATE,
         type=FilterType.NUMERIC,
-        operators=(FilterOperator.BETWEEN,),
+        operators=_NUMERIC_OPS,
         value_source=ValueSource.RANGE,
         aggregate_expr="sum(total_tokens)",
         source_columns=("total_tokens",),
@@ -149,13 +174,13 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         ch_type="Int64",
         level=FilterLevel.SPAN_AGGREGATE,
         type=FilterType.NUMERIC,
-        operators=(FilterOperator.BETWEEN,),
+        operators=_NUMERIC_OPS,
         value_source=ValueSource.RANGE,
         aggregate_expr=_DURATION_EXPR,
         source_columns=("span_start_time", "span_end_time"),
     ),
     # Per-trace error-span count, filtered like the other numeric aggregates
-    # (e.g. "errors between 3 and ∞"). `errors` is derived, not a stored column —
+    # (e.g. "errors >= 3"). `errors` is derived, not a stored column —
     # the aggregate_expr counts spans whose status is ERROR.
     FilterColumn(
         name="errors",
@@ -163,7 +188,7 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         ch_type="UInt64",
         level=FilterLevel.SPAN_AGGREGATE,
         type=FilterType.NUMERIC,
-        operators=(FilterOperator.BETWEEN,),
+        operators=_NUMERIC_OPS,
         value_source=ValueSource.RANGE,
         aggregate_expr="countIf(status = 'ERROR')",
         source_columns=("status",),

--- a/backend/rest/services/filters/translate.py
+++ b/backend/rest/services/filters/translate.py
@@ -22,8 +22,10 @@ from rest.services.filters.columns import (
     FilterColumn,
     FilterLevel,
     FilterOperator,
+    FilterType,
     get_column,
 )
+from rest.sql_utils import escape_ilike
 
 
 class Predicate(BaseModel):
@@ -32,8 +34,9 @@ class Predicate(BaseModel):
     Attributes:
         field (str): The registry column name to filter on.
         op (str): The operator (validated against the field's whitelist).
-        value (Any): The operand — a list for ``in``, a ``[min, max]`` pair for
-            ``between`` (either bound may be ``None`` for an open-ended range).
+        value (Any): The operand, shaped by the field's type — a list of strings for
+            ``in``, a single number for a numeric comparison (``eq``/``gt``/``gte``/
+            ``lt``/``lte``), or a string for a text match (``eq``/``contains``).
     """
 
     field: str
@@ -112,51 +115,57 @@ _NUMERIC_TYPE_MAX = {"Int64": 2**63 - 1, "UInt64": 2**64 - 1, "Decimal64(9)": 10
 
 
 def _validate_value(pred: Predicate, col: FilterColumn) -> None:
-    """Check the value matches the operator's shape, so a malformed (but typed) filter
-    is a 422 at the edge rather than a 500 from deep in query building.
+    """Check the value matches the field's type, so a malformed (but typed) filter is a
+    422 at the edge rather than a 500 from deep in query building. The value's shape is
+    keyed off the field type; the operator whitelist (checked in ``validate_predicate``)
+    already guaranteed the op is valid for the field.
 
     Raises:
-        ValueError: If ``in`` lacks a list of strings; if ``between`` lacks a two-element
-            ``[min, max]`` list of numbers (either bound may be ``null``); or if a bound
-            can't safely bind to the column's ClickHouse type — non-finite (NaN/inf),
-            negative (the metrics are all non-negative; a negative can't bind to a
-            ``UInt64``), fractional on an integer field, or beyond the column type's
-            range. Each of these would otherwise be a BAD_QUERY_PARAMETER 500.
+        ValueError: If a categorical ``in`` isn't a non-empty list of strings; if a text
+            value isn't a non-empty string; or if a numeric value can't bind to the
+            column's ClickHouse type (see ``_validate_numeric``).
     """
-    if pred.op == FilterOperator.IN:
+    if col.type == FilterType.CATEGORICAL:
         if (
             not isinstance(pred.value, list)
             or not pred.value  # an empty IN list matches nothing — reject it
             or not all(isinstance(v, str) for v in pred.value)
         ):
             raise ValueError(f"'in' filter on {pred.field!r} requires a non-empty list of strings")
-    elif pred.op == FilterOperator.BETWEEN:
-        v = pred.value
-        if not isinstance(v, list) or len(v) != 2 or not all(x is None or _is_number(x) for x in v):
-            raise ValueError(
-                f"'between' filter on {pred.field!r} requires [min, max] numbers "
-                "(either bound may be null)"
-            )
-        max_val = _NUMERIC_TYPE_MAX.get(col.ch_type)
-        for x in v:
-            if x is None:
-                continue
-            # A bound must bind safely to the column's type or ClickHouse 500s. Guard the
-            # float coercions: math.isfinite()/is_integer() OverflowError on an
-            # arbitrary-size JSON int, so only NaN/inf-check floats and compare ranges
-            # directly (int/Decimal alike — an oversized cost overflows Decimal64 too).
-            if isinstance(x, float) and not math.isfinite(x):
-                raise ValueError(f"'between' filter on {pred.field!r} bounds must be finite")
-            if x < 0:
-                raise ValueError(
-                    f"'between' filter on {pred.field!r} takes non-negative numbers (got {x!r})"
-                )
-            if col.is_integer and isinstance(x, float) and not x.is_integer():
-                raise ValueError(
-                    f"'between' filter on {pred.field!r} takes whole numbers only (got {x!r})"
-                )
-            if max_val is not None and x > max_val:
-                raise ValueError(f"'between' filter on {pred.field!r} exceeds its maximum value")
+    elif col.type == FilterType.TEXT:
+        # bool is not a str, so a JSON boolean is correctly rejected here.
+        if not isinstance(pred.value, str) or pred.value == "":
+            raise ValueError(f"{pred.op!r} filter on {pred.field!r} requires a non-empty string")
+    elif col.type == FilterType.NUMERIC:
+        _validate_numeric(pred.value, pred, col)
+
+
+def _validate_numeric(x: object, pred: Predicate, col: FilterColumn) -> None:
+    """Validate a single numeric comparison operand can bind to the column's type.
+
+    A value that can't bind is a BAD_QUERY_PARAMETER 500 in ClickHouse, so reject it at
+    the edge (422): not a number, non-finite (NaN/inf), negative (the metrics are all
+    non-negative; a negative can't bind to a ``UInt64``), fractional on an integer field,
+    or beyond the column type's range. Guards the float coercions — ``math.isfinite()`` /
+    ``is_integer()`` OverflowError on an arbitrary-size JSON int, so only NaN/inf-check
+    floats and compare ranges directly (int / Decimal alike; an oversized cost overflows
+    Decimal64 too).
+    """
+    if not _is_number(x):
+        raise ValueError(f"{pred.op!r} filter on {pred.field!r} requires a number (got {x!r})")
+    if isinstance(x, float) and not math.isfinite(x):
+        raise ValueError(f"{pred.op!r} filter on {pred.field!r} value must be finite")
+    if x < 0:
+        raise ValueError(
+            f"{pred.op!r} filter on {pred.field!r} takes non-negative numbers (got {x!r})"
+        )
+    if col.is_integer and isinstance(x, float) and not x.is_integer():
+        raise ValueError(
+            f"{pred.op!r} filter on {pred.field!r} takes whole numbers only (got {x!r})"
+        )
+    max_val = _NUMERIC_TYPE_MAX.get(col.ch_type)
+    if max_val is not None and x > max_val:
+        raise ValueError(f"{pred.op!r} filter on {pred.field!r} exceeds its maximum value")
 
 
 # Back off the span-scan lower bound from ``start_after`` by this much. ``start_after``
@@ -213,49 +222,58 @@ def _membership_semijoin(idx: int, col: FilterColumn, pred: Predicate, params: d
     return f"t.trace_id IN (SELECT trace_id FROM ({inner}) WHERE {where})"
 
 
-def _having_clause(idx: int, col: FilterColumn, pred: Predicate, params: dict) -> str | None:
-    """One per-trace aggregate HAVING comparison, with nullable open-ended bounds.
+# Numeric comparison operators -> their literal SQL. The operand always binds as a param.
+_COMPARISON_SQL = {
+    FilterOperator.EQ: "=",
+    FilterOperator.GT: ">",
+    FilterOperator.GTE: ">=",
+    FilterOperator.LT: "<",
+    FilterOperator.LTE: "<=",
+}
 
-    Bound semantics — both bounds are INCLUSIVE, matching the UI's "greater than or equal
-    to" / "less than or equal to" operators so the label never misrepresents the result:
-    ``[lo, None]`` -> ``>=``, ``[None, hi]`` -> ``<=``, both bounds -> inclusive ``BETWEEN``.
-    Returns ``None`` when both bounds are absent (a no-op filter). Param names carry
-    ``idx`` so duplicate predicates on the same field don't collide.
+
+def _trace_condition(idx: int, col: FilterColumn, pred: Predicate, params: dict) -> str:
+    """One inline predicate on the traces row for a TRACE-level (text) field.
+
+    Filters ``t.<col>`` directly — no span scan — keyed on the outer query so it lands in
+    both the page and count queries. ``eq`` is an exact match; ``contains`` is a
+    case-insensitive ILIKE with the search value's wildcards escaped so a literal ``%``/
+    ``_`` matches literally. The value binds as a parameter, never interpolated.
     """
-    lo, hi = pred.value[0], pred.value[1]
-    agg, ch = col.aggregate_expr, col.ch_type
+    pname = f"f_{col.name}_{idx}"
+    if pred.op == FilterOperator.CONTAINS:
+        params[pname] = f"%{escape_ilike(pred.value)}%"
+        return f"t.{col.name} ILIKE {{{pname}:String}}"
+    params[pname] = pred.value  # EQ — exact match
+    return f"t.{col.name} = {{{pname}:String}}"
+
+
+def _having_clause(idx: int, col: FilterColumn, pred: Predicate, params: dict) -> str:
+    """One per-trace aggregate HAVING comparison: ``<agg> <op> {param}``.
+
+    The operand binds as a parameter (never interpolated). Multiple predicates on the same
+    field are AND-combined by the caller, so a range is two one-sided comparisons (e.g.
+    ``> 5`` and ``<= 10``). Param names carry ``idx`` so duplicate predicates on the same
+    field don't collide.
+    """
+    val = pred.value
     if col.is_integer:
-        # Bounds are validated whole numbers; bind them as int so a JSON float like 5.0
-        # doesn't reach ClickHouse as "5.0" (unparseable as Int64/UInt64).
-        lo = int(lo) if lo is not None else None
-        hi = int(hi) if hi is not None else None
-    lo_name, hi_name = f"f_{col.name}_{idx}_min", f"f_{col.name}_{idx}_max"
-    if lo is not None and hi is not None:
-        params[lo_name] = lo
-        params[hi_name] = hi
-        return f"{agg} BETWEEN {{{lo_name}:{ch}}} AND {{{hi_name}:{ch}}}"
-    if lo is not None:
-        params[lo_name] = lo
-        return f"{agg} >= {{{lo_name}:{ch}}}"  # "greater than or equal to"
-    if hi is not None:
-        params[hi_name] = hi
-        return f"{agg} <= {{{hi_name}:{ch}}}"  # "less than or equal to" (inclusive)
-    return None
+        # Bind a validated whole number as int so a JSON float like 5.0 doesn't reach
+        # ClickHouse as "5.0" (unparseable as Int64/UInt64).
+        val = int(val)
+    pname = f"f_{col.name}_{idx}"
+    params[pname] = val
+    return f"{col.aggregate_expr} {_COMPARISON_SQL[pred.op]} {{{pname}:{col.ch_type}}}"
 
 
-def _aggregate_semijoin(
-    frags: list[tuple[int, FilterColumn, Predicate]], params: dict
-) -> str | None:
+def _aggregate_semijoin(frags: list[tuple[int, FilterColumn, Predicate]], params: dict) -> str:
     """Merge aggregate predicates into one time-bounded GROUP BY ... HAVING semi-join.
 
     Dedups ReplacingMergeTree spans (latest ``ch_update_time`` per span) within the
     active window, rolls them up per trace, and keeps traces whose aggregates satisfy
     all HAVING comparisons. Keyed on ``t.trace_id`` so it filters page and count alike.
-    Returns ``None`` if every predicate was an empty (no-bound) range.
     """
-    having = [c for c in (_having_clause(i, col, pred, params) for i, col, pred in frags) if c]
-    if not having:
-        return None
+    having = [_having_clause(i, col, pred, params) for i, col, pred in frags]
     # Project the dedup/group keys, UNIONED with the source_columns of the active aggregate
     # predicates. Registry-driven, so a new aggregate field is one registry entry (its
     # source_columns) with no change here. dict.fromkeys dedups with stable order.
@@ -295,22 +313,27 @@ def build_conditions(filters: list[Predicate], params: dict) -> list[str]:
     """
     membership: list[tuple[int, FilterColumn, Predicate]] = []
     aggregate: list[tuple[int, FilterColumn, Predicate]] = []
+    trace: list[tuple[int, FilterColumn, Predicate]] = []
     for i, pred in enumerate(filters):
         col = validate_predicate(pred)
         if col.level == FilterLevel.SPAN_MEMBERSHIP:
             membership.append((i, col, pred))
         elif col.level == FilterLevel.SPAN_AGGREGATE:
             aggregate.append((i, col, pred))
+        elif col.level == FilterLevel.TRACE:
+            trace.append((i, col, pred))
         else:
             raise NotImplementedError(f"level {col.level} not yet lowered: {col.name}")
 
     conditions: list[str] = []
+    # Inline trace-row predicates (t.*), keyed on the outer query so they land in both the
+    # page and count queries.
+    for i, col, pred in trace:
+        conditions.append(_trace_condition(i, col, pred, params))
     # One semi-join per membership predicate (independent existence), each AND-combined via
     # the shared conditions list so every one lands in both the page and count queries.
     for i, col, pred in membership:
         conditions.append(_membership_semijoin(i, col, pred, params))
     if aggregate:
-        agg = _aggregate_semijoin(aggregate, params)
-        if agg:
-            conditions.append(agg)
+        conditions.append(_aggregate_semijoin(aggregate, params))
     return conditions

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -56,7 +56,6 @@ export default function TracesPage() {
     state,
     updateDateFilter,
     updateCustomRange,
-    updateKeyword,
     updateFilters,
     updateLimit,
     goToPage,
@@ -165,8 +164,6 @@ export default function TracesPage() {
           <SearchFilterBar
             searchInput={
               <TraceSearchFilterInput
-                searchValue={state.keyword}
-                onSearchChange={updateKeyword}
                 projectId={projectId}
                 filters={state.filters}
                 onFiltersChange={updateFilters}

--- a/frontend/ui/src/features/filters/filter-builder.test.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.test.tsx
@@ -25,7 +25,7 @@ const COST: FilterFieldDef = {
   label: "Cost",
   type: "numeric",
   level: "SPAN_AGGREGATE",
-  operators: ["between"],
+  operators: ["eq", "gt", "gte", "lt", "lte"],
   value_source: "range",
   enum_values: [],
 };
@@ -34,7 +34,7 @@ const TOKENS: FilterFieldDef = {
   label: "Tokens",
   type: "numeric",
   level: "SPAN_AGGREGATE",
-  operators: ["between"],
+  operators: ["eq", "gt", "gte", "lt", "lte"],
   value_source: "range",
   enum_values: [],
   integer: true,
@@ -47,6 +47,16 @@ const MODEL: FilterFieldDef = {
   level: "SPAN_MEMBERSHIP",
   operators: ["in"],
   value_source: "distinct_query",
+  enum_values: [],
+};
+
+const TRACE_ID: FilterFieldDef = {
+  field: "trace_id",
+  label: "Trace ID",
+  type: "text",
+  level: "TRACE",
+  operators: ["eq", "contains"],
+  value_source: "free_text",
   enum_values: [],
 };
 
@@ -75,33 +85,53 @@ describe("FilterBuilder (Basic row)", () => {
     expect(onSubmit).toHaveBeenCalledWith({ field: "status", op: "in", value: ["ERROR"] });
   });
 
-  it("numeric `greater than or equal to` lowers to a between with an open upper bound", () => {
+  it("numeric `≥` emits an inclusive `gte` predicate", () => {
     const onSubmit = renderBuilder([COST]);
     pickField(/Cost/);
-    fireEvent.click(screen.getByRole("button", { name: "equals" })); // operator dropdown
-    fireEvent.click(screen.getByRole("option", { name: "greater than or equal to" }));
+    fireEvent.click(screen.getByRole("button", { name: "=" })); // operator dropdown
+    fireEvent.click(screen.getByRole("option", { name: "≥" }));
     fireEvent.change(screen.getByLabelText("value"), { target: { value: "0.5" } });
     fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
-    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "between", value: [0.5, null] });
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "gte", value: 0.5 });
   });
 
-  it("numeric `less than or equal to` lowers to a between with an open lower bound", () => {
+  it("numeric `≤` emits an inclusive `lte` predicate", () => {
     const onSubmit = renderBuilder([COST]);
     pickField(/Cost/);
-    fireEvent.click(screen.getByRole("button", { name: "equals" }));
-    fireEvent.click(screen.getByRole("option", { name: "less than or equal to" }));
+    fireEvent.click(screen.getByRole("button", { name: "=" }));
+    fireEvent.click(screen.getByRole("option", { name: "≤" }));
     fireEvent.change(screen.getByLabelText("value"), { target: { value: "10" } });
     fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
-    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "between", value: [null, 10] });
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "lte", value: 10 });
   });
 
-  it("does not offer a `between` operator", () => {
+  it("numeric `>` emits a strict `gt` predicate", () => {
+    const onSubmit = renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.click(screen.getByRole("button", { name: "=" }));
+    fireEvent.click(screen.getByRole("option", { name: ">" }));
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "gt", value: 5 });
+  });
+
+  it("numeric `<` emits a strict `lt` predicate", () => {
+    const onSubmit = renderBuilder([COST]);
+    pickField(/Cost/);
+    fireEvent.click(screen.getByRole("button", { name: "=" }));
+    fireEvent.click(screen.getByRole("option", { name: "<" }));
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "lt", value: 5 });
+  });
+
+  it("does not offer a `between` operator (a range is two one-sided filters)", () => {
     renderBuilder([COST]);
     pickField(/Cost/);
-    fireEvent.click(screen.getByRole("button", { name: "equals" }));
+    fireEvent.click(screen.getByRole("button", { name: "=" }));
     expect(screen.queryByRole("option", { name: "between" })).toBeNull();
-    expect(screen.getByRole("option", { name: "greater than or equal to" })).toBeTruthy();
-    expect(screen.getByRole("option", { name: "less than or equal to" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "≥" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "≤" })).toBeTruthy();
   });
 
   it("resets the row after adding so another filter can be entered", () => {
@@ -143,11 +173,7 @@ describe("FilterBuilder (Basic row)", () => {
     pickField(/Tokens/);
     fireEvent.change(screen.getByLabelText("value"), { target: { value: "100" } });
     fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
-    expect(onSubmit).toHaveBeenCalledWith({
-      field: "total_tokens",
-      op: "between",
-      value: [100, 100],
-    });
+    expect(onSubmit).toHaveBeenCalledWith({ field: "total_tokens", op: "eq", value: 100 });
   });
 
   it("decimal field (Cost) still accepts a fractional value", () => {
@@ -155,7 +181,7 @@ describe("FilterBuilder (Basic row)", () => {
     pickField(/Cost/);
     fireEvent.change(screen.getByLabelText("value"), { target: { value: "0.5" } });
     fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
-    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "between", value: [0.5, 0.5] });
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "eq", value: 0.5 });
   });
 
   it("creates the filter when Enter is pressed in the value field", () => {
@@ -163,7 +189,7 @@ describe("FilterBuilder (Basic row)", () => {
     pickField(/Cost/);
     fireEvent.change(screen.getByLabelText("value"), { target: { value: "5" } });
     fireEvent.keyDown(screen.getByLabelText("value"), { key: "Enter" });
-    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "between", value: [5, 5] });
+    expect(onSubmit).toHaveBeenCalledWith({ field: "cost", op: "eq", value: 5 });
   });
 
   it("shows the field's unit in the numeric value input ($ for cost)", () => {
@@ -172,14 +198,34 @@ describe("FilterBuilder (Basic row)", () => {
     expect(screen.getByText("$")).toBeTruthy();
   });
 
-  it("derives the operator set from the field's `operators` (numeric `between` → equals/gte/lte, not `is`)", () => {
+  it("derives the operator set from the field's `operators` (numeric → = > ≥ < ≤, not `is`)", () => {
     renderBuilder([COST]);
     pickField(/Cost/);
-    fireEvent.click(screen.getByRole("button", { name: "equals" })); // open operator dropdown
-    expect(screen.getByRole("option", { name: "equals" })).toBeTruthy();
-    expect(screen.getByRole("option", { name: "greater than or equal to" })).toBeTruthy();
-    expect(screen.getByRole("option", { name: "less than or equal to" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "=" })); // open operator dropdown
+    for (const sym of ["=", ">", "≥", "<", "≤"]) {
+      expect(screen.getByRole("option", { name: sym })).toBeTruthy();
+    }
     expect(screen.queryByRole("option", { name: "is" })).toBeNull();
+  });
+
+  it("a text field (Trace ID) offers `=` and `contains`, emitting string predicates", () => {
+    // `contains` -> a case-insensitive substring predicate.
+    const onContains = renderBuilder([TRACE_ID]);
+    pickField(/Trace ID/);
+    fireEvent.click(screen.getByRole("button", { name: "=" })); // operator dropdown (default `=`)
+    expect(screen.getByRole("option", { name: "contains" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("option", { name: "contains" }));
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "abc" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onContains).toHaveBeenCalledWith({ field: "trace_id", op: "contains", value: "abc" });
+
+    cleanup();
+    // `=` -> an exact string match (a string value, not a number).
+    const onEq = renderBuilder([TRACE_ID]);
+    pickField(/Trace ID/);
+    fireEvent.change(screen.getByLabelText("value"), { target: { value: "abc123" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add filter" }));
+    expect(onEq).toHaveBeenCalledWith({ field: "trace_id", op: "eq", value: "abc123" });
   });
 
   it("derives the operator set from the field's `operators` (categorical `in` → `is`)", () => {

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -18,6 +18,7 @@ import {
   CircleStop,
   Clock,
   Globe,
+  Hash,
   type LucideIcon,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
@@ -27,11 +28,12 @@ import { cn } from "@/lib/utils";
 import type { Predicate } from "@/types/api";
 import { useFilterValues } from "./hooks";
 import type { FilterFieldDef } from "./registry";
-import { buildBetweenPredicate, buildInPredicate } from "./predicate-ui";
+import { buildInPredicate, buildNumericPredicate, buildTextPredicate } from "./predicate-ui";
 
 // Icons mirror the trace detail / list UI for consistency; the model and environment
 // fields, which have no trace-detail icon, use a generic one.
 const FIELD_ICONS: Record<string, LucideIcon> = {
+  trace_id: Hash,
   cost: CircleDollarSign,
   total_tokens: CircleStop,
   duration_ms: Clock,
@@ -48,30 +50,32 @@ const FIELD_UNIT: Record<string, { prefix?: string; suffix?: string }> = {
   duration_ms: { suffix: "ms" },
 };
 
-type UiOp = "is" | "equals" | "gte" | "lte";
+type UiOp = "is" | "eq" | "gt" | "gte" | "lt" | "lte" | "contains";
 const OP_LABEL: Record<UiOp, string> = {
   is: "is",
-  equals: "equals",
-  // Verbose + honest: both bounds are inclusive (lowered to >= / <= in translate.py),
-  // so the operator name matches the actual comparison at the boundary.
-  gte: "greater than or equal to",
-  lte: "less than or equal to",
+  // Short symbols matching the chip labels and the backend comparison exactly.
+  eq: "=",
+  gt: ">",
+  gte: "≥",
+  lt: "<",
+  lte: "≤",
+  contains: "contains",
 };
-// "between" is intentionally not offered in the UI — a range is two filters
-// (a gte and an lte on the same field). The backend still supports a two-bound
-// predicate (and `equals` uses it as `[x, x]`).
-//
-// The UI operators are derived from the registry field's `operators` whitelist
-// (the backend op names) rather than branching on `f.type`, so adding a field
-// with a new operator set is one entry in this map — no type branch to touch.
-// `between` expands into three UI ops (equals/gte/lte) that all lower to a
-// `between` predicate with the right (possibly null) bounds.
-const REGISTRY_OP_TO_UI: Record<string, UiOp[]> = {
-  in: ["is"],
-  between: ["equals", "gte", "lte"],
+// The UI operators ARE the registry field's `operators` whitelist (the backend op names)
+// mapped to their UI labels — categorical `in` reads as "is". Deriving from the registry
+// (not branching on `f.type`) means adding a field with a new operator set is one entry
+// in this map, no code branch to touch. An unrecognized op contributes nothing.
+const REGISTRY_OP_TO_UI: Record<string, UiOp> = {
+  in: "is",
+  eq: "eq",
+  gt: "gt",
+  gte: "gte",
+  lt: "lt",
+  lte: "lte",
+  contains: "contains",
 };
 const opsFor = (f: FilterFieldDef): UiOp[] =>
-  f.operators.flatMap((op) => REGISTRY_OP_TO_UI[op] ?? []);
+  f.operators.map((op) => REGISTRY_OP_TO_UI[op]).filter((o): o is UiOp => o !== undefined);
 
 interface FilterBuilderProps {
   projectId: string;
@@ -106,17 +110,22 @@ export function FilterBuilder({
   const num = (s: string) => (s.trim() === "" ? null : Number(s));
   const predicate = (): Predicate | null => {
     if (!field) return null;
+    if (field.type === "text") {
+      // trace_id: a `contains` substring or an exact `=` — a string value, not a number.
+      if (value === "") return null;
+      return buildTextPredicate(field.field, op === "contains" ? "contains" : "eq", value);
+    }
     if (op === "is") return value === "" ? null : buildInPredicate(field.field, [value]);
-    const lo = num(value);
-    // Reject NaN/Infinity, and a fractional value on an integer field (e.g. "1e-1"
-    // slips past the input's decimal-point guard but can't bind as Int64).
-    if (lo === null || !Number.isFinite(lo)) return null;
-    if (field.integer && !Number.isInteger(lo)) return null;
-    if (op === "equals") return buildBetweenPredicate(field.field, lo, lo);
-    if (op === "gte") return buildBetweenPredicate(field.field, lo, null);
-    if (op === "lte") return buildBetweenPredicate(field.field, null, lo);
+    // Numeric comparison (eq/gt/gte/lt/lte). Reject NaN/Infinity, and a fractional value
+    // on an integer field (e.g. "1e-1" slips the input's decimal-point guard but can't
+    // bind as Int64).
+    const n = num(value);
+    if (n === null || !Number.isFinite(n)) return null;
+    if (field.integer && !Number.isInteger(n)) return null;
+    if (op === "eq" || op === "gt" || op === "gte" || op === "lt" || op === "lte")
+      return buildNumericPredicate(field.field, op, n);
     // No recognized operator (e.g. a field whose registry `operators` map to none) — build
-    // nothing rather than silently falling through to a bound.
+    // nothing rather than silently falling through to a comparison.
     return null;
   };
   const built = predicate();
@@ -129,13 +138,15 @@ export function FilterBuilder({
   };
 
   return (
-    <div className="flex items-center gap-1.5 p-2">
+    <div className="flex items-center gap-1 p-1.5">
       <FieldDropdown fields={fields} value={field} onPick={pickField} />
       <Dropdown
         disabled={!field}
-        trigger={<span className="truncate">{field ? OP_LABEL[op] : "is"}</span>}
-        triggerClassName="w-[7.5rem] shrink-0"
-        contentClassName="w-[10rem]"
+        trigger={<span className="whitespace-nowrap">{field ? OP_LABEL[op] : "is"}</span>}
+        // Size to the operator label with a floor for the short symbols, so a wide label
+        // (e.g. "contains") sits comfortably instead of truncating in a fixed cell.
+        triggerClassName="min-w-[3.5rem] shrink-0"
+        contentClassName="w-28"
       >
         {(close) =>
           (field ? opsFor(field) : []).map((o) => (
@@ -163,7 +174,7 @@ export function FilterBuilder({
       />
       <Button
         size="sm"
-        className="h-8 shrink-0 rounded-md px-3 text-[13px]"
+        className="h-7 shrink-0 rounded-md px-2.5 text-xs"
         disabled={!built}
         onClick={submit}
       >
@@ -197,7 +208,7 @@ function ValueControl({
         readOnly
         value=""
         placeholder="Enter value"
-        className="h-8 min-w-0 flex-1 rounded-md text-[13px]"
+        className="h-7 min-w-0 flex-1 rounded-md text-[13px]"
       />
     );
   }
@@ -213,6 +224,17 @@ function ValueControl({
       />
     );
   }
+  if (field.type === "text") {
+    return (
+      <TextField
+        ariaLabel="value"
+        placeholder="Enter value"
+        value={value}
+        onChange={onValue}
+        onEnter={onEnter}
+      />
+    );
+  }
   return (
     <NumberField
       ariaLabel="value"
@@ -222,6 +244,33 @@ function ValueControl({
       onEnter={onEnter}
       unit={FIELD_UNIT[field.field]}
       integer={Boolean(field.integer)}
+    />
+  );
+}
+
+function TextField({
+  ariaLabel,
+  placeholder,
+  value,
+  onChange,
+  onEnter,
+}: {
+  ariaLabel: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  onEnter: () => void;
+}) {
+  return (
+    <Input
+      aria-label={ariaLabel}
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") onEnter();
+      }}
+      className="h-7 min-w-0 flex-1 rounded-md text-[13px]"
     />
   );
 }
@@ -246,7 +295,7 @@ function NumberField({
   integer?: boolean;
 }) {
   return (
-    <div className="flex h-8 min-w-0 flex-1 items-center gap-1 rounded-md border border-input bg-transparent px-2.5 text-[13px] focus-within:ring-1 focus-within:ring-ring">
+    <div className="flex h-7 min-w-0 flex-1 items-center gap-1 rounded-md border border-input bg-transparent px-2 text-[13px] focus-within:ring-1 focus-within:ring-ring">
       {unit?.prefix && <span className="shrink-0 text-muted-foreground">{unit.prefix}</span>}
       <input
         type="number"
@@ -395,7 +444,7 @@ function Dropdown({
           type="button"
           disabled={disabled}
           className={cn(
-            "flex h-8 items-center justify-between gap-1.5 rounded-md border border-border bg-background px-2.5 text-[13px] font-normal transition-colors",
+            "flex h-7 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 text-[13px] font-normal transition-colors",
             "hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50",
             triggerClassName,
           )}
@@ -430,7 +479,7 @@ function DropdownItem({
       aria-selected={active}
       onClick={onClick}
       className={cn(
-        "flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[13px] transition-colors hover:bg-muted/50",
+        "flex w-full items-center gap-2 rounded px-2 py-1 text-left text-[13px] transition-colors hover:bg-muted/50",
         active && "bg-muted/40",
       )}
     >

--- a/frontend/ui/src/features/filters/predicate-ui.test.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   predicateLabel,
   buildInPredicate,
-  buildBetweenPredicate,
+  buildNumericPredicate,
+  buildTextPredicate,
   upsertPredicate,
 } from "./predicate-ui";
 
@@ -19,28 +20,27 @@ describe("predicateLabel", () => {
     ).toBe("model_name in [claude-opus-4.8, gpt-4]");
   });
 
-  it("renders an open lower bound as inclusive ≥", () => {
-    expect(predicateLabel({ field: "cost", op: "between", value: [0.5, null] })).toBe("cost ≥ 0.5");
+  it("renders numeric comparison operators as their symbols", () => {
+    expect(predicateLabel({ field: "cost", op: "eq", value: 5 })).toBe("cost = 5");
+    expect(predicateLabel({ field: "cost", op: "gt", value: 0.5 })).toBe("cost > 0.5");
+    expect(predicateLabel({ field: "cost", op: "gte", value: 0.5 })).toBe("cost ≥ 0.5");
+    expect(predicateLabel({ field: "cost", op: "lt", value: 10 })).toBe("cost < 10");
+    expect(predicateLabel({ field: "cost", op: "lte", value: 10 })).toBe("cost ≤ 10");
   });
 
-  it("renders an open upper bound as inclusive ≤", () => {
-    expect(predicateLabel({ field: "cost", op: "between", value: [null, 10] })).toBe("cost ≤ 10");
-  });
-
-  it("renders a closed range as between", () => {
-    expect(predicateLabel({ field: "cost", op: "between", value: [0.5, 10] })).toBe(
-      "cost between 0.5 and 10",
+  it("renders text `eq` as an equality and `contains` as `contains`", () => {
+    expect(predicateLabel({ field: "trace_id", op: "eq", value: "abc123" })).toBe(
+      "trace_id = abc123",
+    );
+    expect(predicateLabel({ field: "trace_id", op: "contains", value: "abc" })).toBe(
+      "trace_id contains abc",
     );
   });
 
-  it("renders equal bounds (from `equals`) as `=`", () => {
-    expect(predicateLabel({ field: "cost", op: "between", value: [5, 5] })).toBe("cost = 5");
-  });
-
   it("uses the supplied display name in place of the raw field key", () => {
-    expect(
-      predicateLabel({ field: "duration_ms", op: "between", value: [5, null] }, "latency"),
-    ).toBe("latency ≥ 5");
+    expect(predicateLabel({ field: "duration_ms", op: "gte", value: 5 }, "latency")).toBe(
+      "latency ≥ 5",
+    );
     expect(predicateLabel({ field: "model_name", op: "in", value: ["gpt-4"] }, "model")).toBe(
       "model = gpt-4",
     );
@@ -56,27 +56,38 @@ describe("predicate builders", () => {
     });
   });
 
-  it("buildBetweenPredicate makes a numeric `between` predicate with nullable bounds", () => {
-    expect(buildBetweenPredicate("cost", 0.5, null)).toEqual({
+  it("buildNumericPredicate makes a scalar numeric comparison predicate", () => {
+    expect(buildNumericPredicate("cost", "gte", 0.5)).toEqual({
       field: "cost",
-      op: "between",
-      value: [0.5, null],
+      op: "gte",
+      value: 0.5,
+    });
+  });
+
+  it("buildTextPredicate makes a scalar text predicate", () => {
+    expect(buildTextPredicate("trace_id", "contains", "abc")).toEqual({
+      field: "trace_id",
+      op: "contains",
+      value: "abc",
     });
   });
 });
 
 describe("upsertPredicate", () => {
-  const gte = (f: string, lo: number) => buildBetweenPredicate(f, lo, null);
-  const lte = (f: string, hi: number) => buildBetweenPredicate(f, null, hi);
+  const gt = (f: string, v: number) => buildNumericPredicate(f, "gt", v);
+  const gte = (f: string, v: number) => buildNumericPredicate(f, "gte", v);
+  const lt = (f: string, v: number) => buildNumericPredicate(f, "lt", v);
+  const lte = (f: string, v: number) => buildNumericPredicate(f, "lte", v);
+  const eq = (f: string, v: number) => buildNumericPredicate(f, "eq", v);
 
   it("keeps a lower and an upper bound on the same field to form a range", () => {
-    const afterLower = upsertPredicate([], gte("duration_ms", 5));
+    const afterLower = upsertPredicate([], gt("duration_ms", 5));
     const afterRange = upsertPredicate(afterLower, lte("duration_ms", 10));
-    expect(afterRange).toEqual([gte("duration_ms", 5), lte("duration_ms", 10)]);
+    expect(afterRange).toEqual([gt("duration_ms", 5), lte("duration_ms", 10)]);
   });
 
   it("replaces a same-direction bound rather than stacking two lower bounds", () => {
-    const start = [gte("duration_ms", 5), lte("duration_ms", 10)];
+    const start = [gt("duration_ms", 5), lte("duration_ms", 10)];
     expect(upsertPredicate(start, gte("duration_ms", 8))).toEqual([
       lte("duration_ms", 10),
       gte("duration_ms", 8),
@@ -89,30 +100,31 @@ describe("upsertPredicate", () => {
   });
 
   it("a new lower bound that contradicts the upper bound supersedes it", () => {
-    // errors ≤ 3 then errors ≥ 5 — the newer lower bound wins.
     expect(upsertPredicate([lte("errors", 3)], gte("errors", 5))).toEqual([gte("errors", 5)]);
   });
 
-  it("keeps equal bounds as an exact-value range (both inclusive: ≥ x AND ≤ x matches x)", () => {
-    // errors ≥ 5 then errors ≤ 5 — 5 <= x <= 5 matches exactly 5, a valid non-empty range.
+  it("keeps equal INCLUSIVE bounds as an exact-value range (≥ x AND ≤ x matches x)", () => {
     expect(upsertPredicate([gte("errors", 5)], lte("errors", 5))).toEqual([
       gte("errors", 5),
       lte("errors", 5),
     ]);
   });
 
+  it("drops equal bounds when either is STRICT (> x AND ≤ x at x is empty)", () => {
+    // gt 5 then lte 5 — nothing satisfies x > 5 AND x <= 5, so the newer one wins.
+    expect(upsertPredicate([gt("errors", 5)], lte("errors", 5))).toEqual([lte("errors", 5)]);
+  });
+
   it("keeps a valid (non-empty) opposite bound: lower < upper", () => {
-    expect(upsertPredicate([gte("duration_ms", 3)], lte("duration_ms", 5))).toEqual([
-      gte("duration_ms", 3),
-      lte("duration_ms", 5),
+    expect(upsertPredicate([gt("duration_ms", 3)], lt("duration_ms", 5))).toEqual([
+      gt("duration_ms", 3),
+      lt("duration_ms", 5),
     ]);
   });
 
-  it("an exact `equals` (both bounds equal) supersedes both range bounds", () => {
+  it("an exact `eq` supersedes both range bounds on the field", () => {
     const start = [gte("cost", 1), lte("cost", 5)];
-    expect(upsertPredicate(start, buildBetweenPredicate("cost", 3, 3))).toEqual([
-      buildBetweenPredicate("cost", 3, 3),
-    ]);
+    expect(upsertPredicate(start, eq("cost", 3))).toEqual([eq("cost", 3)]);
   });
 
   it("a categorical value replaces the existing one on its field, untouched others", () => {
@@ -120,6 +132,13 @@ describe("upsertPredicate", () => {
     expect(upsertPredicate(start, buildInPredicate("model_name", ["claude"]))).toEqual([
       gte("cost", 1),
       buildInPredicate("model_name", ["claude"]),
+    ]);
+  });
+
+  it("a text predicate replaces any existing predicate on its field", () => {
+    const start = [buildTextPredicate("trace_id", "contains", "abc")];
+    expect(upsertPredicate(start, buildTextPredicate("trace_id", "eq", "xyz"))).toEqual([
+      buildTextPredicate("trace_id", "eq", "xyz"),
     ]);
   });
 

--- a/frontend/ui/src/features/filters/predicate-ui.ts
+++ b/frontend/ui/src/features/filters/predicate-ui.ts
@@ -6,26 +6,33 @@
 import type { Predicate } from "@/types/api";
 
 /**
- * Human-readable label for an active-filter chip. Mirrors how the predicate reads:
- * a single `in` value shows as `=`, multiple as `in [...]`; a `between` with a null
- * bound shows as `≥` (the inclusive "greater than or equal to" bound) or `≤` (the
- * inclusive "less than or equal to" bound); both bounds as `between … and …`.
+ * Human-readable label for an active-filter chip. Mirrors how the predicate reads and
+ * matches the backend comparison exactly: a single `in` value shows as `=`, multiple as
+ * `in [...]`; numeric `eq/gt/gte/lt/lte` show as `= / > / ≥ / < / ≤`; text `contains`
+ * shows as `contains`.
  *
  * `name` is the field's display name (its registry label, lowercased — e.g. `latency`
  * for `duration_ms`); it defaults to the raw field key when a label isn't available.
  */
 export function predicateLabel(p: Predicate, name: string = p.field): string {
-  if (p.op === "in") {
-    if (p.value.length === 1) return `${name} = ${p.value[0]}`;
-    return `${name} in [${p.value.join(", ")}]`;
+  switch (p.op) {
+    case "in":
+      return p.value.length === 1
+        ? `${name} = ${p.value[0]}`
+        : `${name} in [${p.value.join(", ")}]`;
+    case "eq":
+      return `${name} = ${p.value}`;
+    case "gt":
+      return `${name} > ${p.value}`;
+    case "gte":
+      return `${name} ≥ ${p.value}`;
+    case "lt":
+      return `${name} < ${p.value}`;
+    case "lte":
+      return `${name} ≤ ${p.value}`;
+    case "contains":
+      return `${name} contains ${p.value}`;
   }
-  const [lo, hi] = p.value;
-  if (lo !== null && hi !== null) {
-    return lo === hi ? `${name} = ${lo}` : `${name} between ${lo} and ${hi}`;
-  }
-  if (lo !== null) return `${name} ≥ ${lo}`;
-  if (hi !== null) return `${name} ≤ ${hi}`;
-  return name;
 }
 
 /** Construct a categorical membership predicate from selected values. */
@@ -33,44 +40,57 @@ export function buildInPredicate(field: string, values: string[]): Predicate {
   return { field, op: "in", value: values };
 }
 
-/** Construct a numeric aggregate predicate; either bound may be null (open range). */
-export function buildBetweenPredicate(
+/** Construct a numeric comparison predicate (`eq/gt/gte/lt/lte`). */
+export function buildNumericPredicate(
   field: string,
-  min: number | null,
-  max: number | null,
+  op: "eq" | "gt" | "gte" | "lt" | "lte",
+  value: number,
 ): Predicate {
-  return { field, op: "between", value: [min, max] };
+  return { field, op, value };
+}
+
+/** Construct a text predicate: exact `eq` or case-insensitive `contains`. */
+export function buildTextPredicate(field: string, op: "eq" | "contains", value: string): Predicate {
+  return { field, op, value };
 }
 
 // Which "slot" a predicate occupies on its field, so we know what a new predicate
-// replaces vs. coexists with. A field can hold at most one lower + one upper bound.
-type Slot = "in" | "lower" | "upper" | "exact" | "full";
+// replaces vs. coexists with. A numeric field can hold at most one lower + one upper
+// bound (a range); everything else is single-slot per field.
+type Slot = "in" | "exact" | "text" | "lower" | "upper";
 function slotOf(p: Predicate): Slot {
-  if (p.op === "in") return "in";
-  const [lo, hi] = p.value;
-  if (lo !== null && hi !== null) return lo === hi ? "exact" : "full";
-  if (lo !== null) return "lower";
-  if (hi !== null) return "upper";
-  return "full";
+  switch (p.op) {
+    case "in":
+      return "in";
+    case "eq":
+      return "exact";
+    case "contains":
+      return "text";
+    case "gt":
+    case "gte":
+      return "lower";
+    case "lt":
+    case "lte":
+      return "upper";
+  }
 }
 
 /**
- * Add `next` to the active filter set, merging by slot so a range can be built from
- * two one-sided filters: a lower bound (`greater than or equal to`) and an upper bound
- * (`less than or equal to`) on the same field coexist (e.g. `latency ≥ 5` AND `latency
- * ≤ 10`, which the backend AND-combines). A same-direction bound, an exact `equals`, a
- * full range, or a categorical value replaces the matching predicate rather than stacking.
+ * Add `next` to the active filter set, merging by slot so a numeric range can be built
+ * from two one-sided filters: a lower bound (`>`/`≥`) and an upper bound (`<`/`≤`) on the
+ * same field coexist (e.g. `latency > 5` AND `latency ≤ 10`, which the backend
+ * AND-combines). A categorical value, an exact `=`, a text match, a same-direction bound,
+ * or a contradictory opposite bound replaces the matching predicate rather than stacking.
  */
 export function upsertPredicate(filters: Predicate[], next: Predicate): Predicate[] {
   const ns = slotOf(next);
   const keep = (e: Predicate): boolean => {
     if (e.field !== next.field) return true;
-    // A categorical value, an exact point, or a full range supersedes everything on the field.
-    if (ns === "in" || ns === "exact" || ns === "full") return false;
+    // A categorical value, an exact `=`, or a text match supersedes everything on the field.
+    if (ns === "in" || ns === "exact" || ns === "text") return false;
     // A new one-sided bound keeps the opposite existing bound ONLY if the two form a
     // non-empty range; a same-direction bound, or a contradictory opposite bound (e.g.
-    // errors ≥ 5 then errors ≤ 3, which no value satisfies), is superseded by the
-    // just-entered predicate.
+    // errors > 5 then errors < 3, which no value satisfies), is superseded by the new one.
     const es = slotOf(e);
     if (ns === "lower" && es === "upper") return boundsFormRange(next, e);
     if (ns === "upper" && es === "lower") return boundsFormRange(e, next);
@@ -79,13 +99,17 @@ export function upsertPredicate(filters: Predicate[], next: Predicate): Predicat
   return [...filters.filter(keep), next];
 }
 
-// Whether a lower bound (`[lo, null]`, inclusive `>=`) and an upper bound (`[null, hi]`,
-// inclusive `<=`) describe a non-empty range. Both bounds are inclusive, so `lo === hi`
-// is a valid one-value range (`>= x AND <= x` matches exactly x) — non-empty iff
-// `lo <= hi`. A contradictory pair (`lo > hi`) must not coexist; the newer predicate wins.
+// Whether a lower bound (`>`/`≥`) and an upper bound (`<`/`≤`) describe a non-empty range.
+// Non-empty iff `lo < hi`, or `lo === hi` with BOTH bounds inclusive (`≥ x AND ≤ x`
+// matches exactly x). A contradictory pair is dropped; the newer predicate wins instead.
 function boundsFormRange(lower: Predicate, upper: Predicate): boolean {
-  if (lower.op !== "between" || upper.op !== "between") return false;
-  const lo = lower.value[0];
-  const hi = upper.value[1];
-  return lo !== null && hi !== null && lo <= hi;
+  const lo = numericValue(lower);
+  const hi = numericValue(upper);
+  if (lo === null || hi === null) return false;
+  if (lo < hi) return true;
+  return lo === hi && lower.op === "gte" && upper.op === "lte";
+}
+
+function numericValue(p: Predicate): number | null {
+  return typeof p.value === "number" ? p.value : null;
 }

--- a/frontend/ui/src/features/filters/predicate.test.ts
+++ b/frontend/ui/src/features/filters/predicate.test.ts
@@ -3,7 +3,7 @@ import type { Predicate } from "@/types/api";
 import { canonicalizeFilters, serializeFiltersParam, parseFiltersParam } from "./predicate";
 
 const modelFilter: Predicate = { field: "model_name", op: "in", value: ["a", "b"] };
-const costFilter: Predicate = { field: "cost", op: "between", value: [0.5, null] };
+const costFilter: Predicate = { field: "cost", op: "gte", value: 0.5 };
 
 describe("canonicalizeFilters", () => {
   it("is independent of predicate order — order-only differences collapse to one key", () => {
@@ -68,7 +68,7 @@ describe("parseFiltersParam", () => {
     const raw = JSON.stringify([
       modelFilter,
       { field: "x", op: "like", value: ["y"] }, // unknown op
-      { field: "cost", op: "between", value: [1] }, // wrong arity
+      { field: "cost", op: "gt", value: [1] }, // numeric op needs a number, not an array
       { field: "model_name", op: "in", value: "notarray" }, // wrong value type
     ]);
     expect(parseFiltersParam(raw)).toEqual([modelFilter]);
@@ -79,16 +79,17 @@ describe("parseFiltersParam", () => {
     expect(parseFiltersParam(raw)).toEqual([modelFilter]);
   });
 
-  it("accepts a between predicate with nullable open bounds", () => {
-    const open: Predicate = { field: "cost", op: "between", value: [null, 10] };
-    expect(parseFiltersParam(JSON.stringify([open]))).toEqual([open]);
+  it("accepts numeric comparison and text predicates", () => {
+    const preds: Predicate[] = [
+      { field: "cost", op: "lte", value: 10 },
+      { field: "trace_id", op: "contains", value: "abc" },
+    ];
+    expect(parseFiltersParam(JSON.stringify(preds))).toEqual(preds);
   });
 
-  it("drops a between predicate with a non-finite bound (1e999 -> Infinity)", () => {
-    // JSON.parse turns 1e999 into Infinity; it must not survive validation — it would
-    // JSON.stringify back to null, silently converting the bound to an open range.
-    expect(parseFiltersParam('[{"field":"cost","op":"between","value":[1e999, null]}]')).toEqual(
-      [],
-    );
+  it("drops a numeric predicate with a non-finite value (1e999 -> Infinity)", () => {
+    // JSON.parse turns 1e999 into Infinity; it must not survive validation (JSON.stringify
+    // would coerce it back to null and corrupt the payload).
+    expect(parseFiltersParam('[{"field":"cost","op":"gt","value":1e999}]')).toEqual([]);
   });
 });

--- a/frontend/ui/src/features/filters/predicate.ts
+++ b/frontend/ui/src/features/filters/predicate.ts
@@ -7,7 +7,7 @@
  */
 import type { Predicate } from "@/types/api";
 
-const VALID_OPS = new Set<Predicate["op"]>(["in", "between"]);
+const VALID_OPS = new Set<Predicate["op"]>(["in", "eq", "gt", "gte", "lt", "lte", "contains"]);
 
 /** Shape-guard for a single predicate parsed from untrusted input (e.g. a URL). */
 export function isValidPredicate(p: unknown): p is Predicate {
@@ -15,18 +15,23 @@ export function isValidPredicate(p: unknown): p is Predicate {
   const { field, op, value } = p as Record<string, unknown>;
   if (typeof field !== "string" || !VALID_OPS.has(op as Predicate["op"])) return false;
   if (op === "in") {
-    // Non-empty: an empty `in` matches nothing and the backend 422s it, so a
-    // hand-edited/degenerate empty-`in` is dropped here rather than sinking the fetch.
+    // Non-empty list of strings: an empty `in` matches nothing and the backend 422s it,
+    // so a hand-edited/degenerate empty-`in` is dropped here rather than sinking the fetch.
     return Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === "string");
   }
-  // between: exactly two bounds, each a FINITE number or null (nullable open range).
-  // Number.isFinite rejects Infinity/NaN — e.g. a hand-edited `1e999` parses to Infinity,
-  // which JSON.stringify would silently coerce to null (corrupting the key/payload).
-  return (
-    Array.isArray(value) &&
-    value.length === 2 &&
-    value.every((v) => v === null || Number.isFinite(v))
-  );
+  if (op === "contains") {
+    return typeof value === "string" && value.length > 0;
+  }
+  if (op === "eq") {
+    // Numeric equality OR a text exact match — a finite number or a non-empty string.
+    return (
+      (typeof value === "number" && Number.isFinite(value)) ||
+      (typeof value === "string" && value.length > 0)
+    );
+  }
+  // gt/gte/lt/lte: a single FINITE number. Number.isFinite rejects Infinity/NaN — e.g. a
+  // hand-edited `1e999` parses to Infinity, which JSON.stringify would coerce to null.
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 /**
@@ -40,7 +45,7 @@ export function canonicalizeFilters(filters?: Predicate[]): string {
     .map((p) => {
       // Sort the `in` values so ["a","b"] and ["b","a"] fold to one key — the set of
       // matched values is order-independent, so hover-prefetch and the list hook must
-      // agree on the same cache entry. `between` bounds are positional; leave them.
+      // agree on the same cache entry. Scalar values (numbers/strings) are left as-is.
       const value = p.op === "in" && Array.isArray(p.value) ? [...p.value].sort() : p.value;
       return JSON.stringify({ field: p.field, op: p.op, value });
     })

--- a/frontend/ui/src/features/filters/registry.test.ts
+++ b/frontend/ui/src/features/filters/registry.test.ts
@@ -2,15 +2,25 @@ import { describe, it, expect } from "vitest";
 import { STATIC_FILTER_FIELDS } from "./registry";
 
 describe("STATIC_FILTER_FIELDS fallback", () => {
-  it("covers the membership + aggregate tiers", () => {
+  it("covers the trace + membership + aggregate tiers", () => {
     expect(STATIC_FILTER_FIELDS.map((f) => f.field).sort()).toEqual(
-      ["cost", "duration_ms", "environment", "errors", "model_name", "total_tokens"].sort(),
+      [
+        "cost",
+        "duration_ms",
+        "environment",
+        "errors",
+        "model_name",
+        "total_tokens",
+        "trace_id",
+      ].sort(),
     );
   });
 
-  it("categorical fields take `in`, numeric fields take `between`", () => {
+  it("declares the right operator set per field type", () => {
     for (const f of STATIC_FILTER_FIELDS) {
-      expect(f.operators).toEqual([f.type === "categorical" ? "in" : "between"]);
+      if (f.type === "categorical") expect(f.operators).toEqual(["in"]);
+      else if (f.type === "numeric") expect(f.operators).toEqual(["eq", "gt", "gte", "lt", "lte"]);
+      else if (f.type === "text") expect(f.operators).toEqual(["eq", "contains"]);
     }
   });
 

--- a/frontend/ui/src/features/filters/registry.ts
+++ b/frontend/ui/src/features/filters/registry.ts
@@ -8,10 +8,10 @@
 export interface FilterFieldDef {
   field: string;
   label: string;
-  type: "categorical" | "numeric";
+  type: "categorical" | "numeric" | "text";
   level: string;
   operators: string[];
-  value_source: "static_enum" | "distinct_query" | "range";
+  value_source: "static_enum" | "distinct_query" | "range" | "free_text";
   enum_values: string[];
   /** Integer-typed numeric field (tokens/latency/errors) — restrict input to whole numbers. */
   integer?: boolean;
@@ -36,6 +36,15 @@ export interface FilterValuesResponse {
 
 export const STATIC_FILTER_FIELDS: FilterFieldDef[] = [
   {
+    field: "trace_id",
+    label: "Trace ID",
+    type: "text",
+    level: "TRACE",
+    operators: ["eq", "contains"],
+    value_source: "free_text",
+    enum_values: [],
+  },
+  {
     field: "model_name",
     label: "Model",
     type: "categorical",
@@ -58,7 +67,7 @@ export const STATIC_FILTER_FIELDS: FilterFieldDef[] = [
     label: "Cost",
     type: "numeric",
     level: "SPAN_AGGREGATE",
-    operators: ["between"],
+    operators: ["eq", "gt", "gte", "lt", "lte"],
     value_source: "range",
     enum_values: [],
   },
@@ -67,7 +76,7 @@ export const STATIC_FILTER_FIELDS: FilterFieldDef[] = [
     label: "Tokens",
     type: "numeric",
     level: "SPAN_AGGREGATE",
-    operators: ["between"],
+    operators: ["eq", "gt", "gte", "lt", "lte"],
     value_source: "range",
     enum_values: [],
     integer: true,
@@ -77,7 +86,7 @@ export const STATIC_FILTER_FIELDS: FilterFieldDef[] = [
     label: "Latency",
     type: "numeric",
     level: "SPAN_AGGREGATE",
-    operators: ["between"],
+    operators: ["eq", "gt", "gte", "lt", "lte"],
     value_source: "range",
     enum_values: [],
     integer: true,
@@ -87,7 +96,7 @@ export const STATIC_FILTER_FIELDS: FilterFieldDef[] = [
     label: "Errors",
     type: "numeric",
     level: "SPAN_AGGREGATE",
-    operators: ["between"],
+    operators: ["eq", "gt", "gte", "lt", "lte"],
     value_source: "range",
     enum_values: [],
     integer: true,

--- a/frontend/ui/src/features/filters/trace-search-filter-input.test.tsx
+++ b/frontend/ui/src/features/filters/trace-search-filter-input.test.tsx
@@ -7,8 +7,13 @@ import type { Predicate } from "@/types/api";
 // Field registry drives the chip display name (registry label, lowercased).
 vi.mock("./hooks", () => ({
   useFilterFields: () => [
-    { field: "cost", label: "Cost", type: "numeric", operators: ["between"] },
-    { field: "duration_ms", label: "Latency", type: "numeric", operators: ["between"] },
+    { field: "cost", label: "Cost", type: "numeric", operators: ["eq", "gt", "gte", "lt", "lte"] },
+    {
+      field: "duration_ms",
+      label: "Latency",
+      type: "numeric",
+      operators: ["eq", "gt", "gte", "lt", "lte"],
+    },
   ],
 }));
 
@@ -16,9 +21,7 @@ vi.mock("./hooks", () => ({
 // input's add/replace wiring without driving the whole builder.
 vi.mock("./filter-builder", () => ({
   FilterBuilder: ({ onSubmit }: { onSubmit: (p: Predicate) => void }) => (
-    <button onClick={() => onSubmit({ field: "cost", op: "between", value: [1, null] })}>
-      stub-add-cost
-    </button>
+    <button onClick={() => onSubmit({ field: "cost", op: "gt", value: 1 })}>stub-add-cost</button>
   ),
 }));
 
@@ -26,25 +29,18 @@ afterEach(cleanup);
 
 function renderInput(props: Partial<React.ComponentProps<typeof TraceSearchFilterInput>> = {}) {
   return render(
-    <TraceSearchFilterInput
-      searchValue=""
-      onSearchChange={vi.fn()}
-      projectId="p1"
-      filters={[]}
-      onFiltersChange={vi.fn()}
-      {...props}
-    />,
+    <TraceSearchFilterInput projectId="p1" filters={[]} onFiltersChange={vi.fn()} {...props} />,
   );
 }
 
 describe("TraceSearchFilterInput", () => {
   it("renders a labeled chip inside the box per active filter", () => {
-    renderInput({ filters: [{ field: "cost", op: "between", value: [0.5, null] }] });
+    renderInput({ filters: [{ field: "cost", op: "gte", value: 0.5 }] });
     expect(screen.getByText("cost ≥ 0.5")).toBeTruthy();
   });
 
   it("labels a chip with the field's lowercased display name (latency, not duration_ms)", () => {
-    renderInput({ filters: [{ field: "duration_ms", op: "between", value: [5, null] }] });
+    renderInput({ filters: [{ field: "duration_ms", op: "gte", value: 5 }] });
     expect(screen.getByText("latency ≥ 5")).toBeTruthy();
     expect(screen.queryByText(/duration_ms/)).toBeNull();
   });
@@ -54,7 +50,7 @@ describe("TraceSearchFilterInput", () => {
     renderInput({
       filters: [
         { field: "status", op: "in", value: ["ERROR"] },
-        { field: "cost", op: "between", value: [0.5, null] },
+        { field: "cost", op: "gte", value: 0.5 },
       ],
       onFiltersChange,
     });
@@ -64,44 +60,25 @@ describe("TraceSearchFilterInput", () => {
 
   it("opens the builder on input focus and a submitted predicate replaces same-field", () => {
     const onFiltersChange = vi.fn();
-    renderInput({ filters: [{ field: "cost", op: "between", value: [5, null] }], onFiltersChange });
+    renderInput({ filters: [{ field: "cost", op: "gte", value: 5 }], onFiltersChange });
     // Builder is closed until the box is focused.
     expect(screen.queryByText("stub-add-cost")).toBeNull();
     fireEvent.focus(screen.getByRole("textbox"));
     fireEvent.click(screen.getByText("stub-add-cost"));
-    expect(onFiltersChange).toHaveBeenCalledWith([
-      { field: "cost", op: "between", value: [1, null] },
-    ]);
+    // The new `gt` supersedes the existing `gte` on the same field (same lower-bound slot).
+    expect(onFiltersChange).toHaveBeenCalledWith([{ field: "cost", op: "gt", value: 1 }]);
   });
 
-  it("types a keyword through the same box", () => {
-    const onSearchChange = vi.fn();
-    renderInput({ onSearchChange });
-    fireEvent.change(screen.getByRole("textbox"), { target: { value: "abc" } });
-    expect(onSearchChange).toHaveBeenCalledWith("abc");
-  });
-
-  it("backspace on the empty search field removes the last filter", () => {
+  it("backspace removes the last filter (the box is filter-only, no keyword text)", () => {
     const onFiltersChange = vi.fn();
     renderInput({
       filters: [
         { field: "status", op: "in", value: ["ERROR"] },
-        { field: "cost", op: "between", value: [0.5, null] },
+        { field: "cost", op: "gte", value: 0.5 },
       ],
       onFiltersChange,
     });
     fireEvent.keyDown(screen.getByRole("textbox"), { key: "Backspace" });
     expect(onFiltersChange).toHaveBeenCalledWith([{ field: "status", op: "in", value: ["ERROR"] }]);
-  });
-
-  it("backspace does nothing when the search field has text", () => {
-    const onFiltersChange = vi.fn();
-    renderInput({
-      searchValue: "abc",
-      filters: [{ field: "cost", op: "between", value: [0.5, null] }],
-      onFiltersChange,
-    });
-    fireEvent.keyDown(screen.getByRole("textbox"), { key: "Backspace" });
-    expect(onFiltersChange).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/features/filters/trace-search-filter-input.tsx
+++ b/frontend/ui/src/features/filters/trace-search-filter-input.tsx
@@ -1,16 +1,13 @@
 "use client";
 
 /**
- * The combined search-and-filter input: one box that holds the active-filter chips, the
- * keyword text field, and — anchored to it — the filter builder popover.
- *
- * Clicking/focusing the box opens the builder (per "a popup from the search bar"); the
- * popover keeps keyboard focus in the text field (`onOpenAutoFocus` prevented) so you can
- * still type a keyword while it's open. Chips render INSIDE the box, each removable.
- * Replaces the old separate "Add filter" button that sat beside the search bar.
+ * The trace filter input: one box holding the active-filter chips and — anchored to it —
+ * the filter builder popover. Clicking/focusing the box opens the builder; chips render
+ * INSIDE the box, each removable (or backspace removes the last). Filter-only: there is no
+ * free-text keyword search — find a trace by id via the `trace_id` = / contains filter.
  */
 import { useRef, useState } from "react";
-import { Search, X } from "lucide-react";
+import { ListFilter, X } from "lucide-react";
 import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import type { Predicate } from "@/types/api";
@@ -19,9 +16,6 @@ import { FilterBuilder } from "./filter-builder";
 import { predicateLabel, upsertPredicate } from "./predicate-ui";
 
 interface TraceSearchFilterInputProps {
-  searchValue: string;
-  onSearchChange: (value: string) => void;
-  searchPlaceholder?: string;
   projectId: string;
   filters: Predicate[];
   onFiltersChange: (filters: Predicate[]) => void;
@@ -31,9 +25,6 @@ interface TraceSearchFilterInputProps {
 }
 
 export function TraceSearchFilterInput({
-  searchValue,
-  onSearchChange,
-  searchPlaceholder = "Search or filter…",
   projectId,
   filters,
   onFiltersChange,
@@ -85,7 +76,7 @@ export function TraceSearchFilterInput({
             }
           }}
         >
-          <Search className="mr-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <ListFilter className="mr-1 h-3.5 w-3.5 shrink-0 text-muted-foreground" />
           {filters.map((p, i) => (
             <span
               key={`${p.field}-${i}`}
@@ -106,19 +97,19 @@ export function TraceSearchFilterInput({
           ))}
           <input
             ref={inputRef}
-            value={searchValue}
-            onChange={(e) => onSearchChange(e.target.value)}
+            readOnly
+            value=""
             onFocus={() => setOpen(true)}
             onClick={() => setOpen(true)}
             onKeyDown={(e) => {
-              // Backspace on an empty text field removes the last filter chip, one per
-              // press — the standard tokenized-input behavior.
-              if (e.key === "Backspace" && searchValue === "" && filters.length > 0) {
+              // Backspace removes the last filter chip, one per press (tokenized-input
+              // behavior). The box is filter-only — there's no keyword text to delete.
+              if (e.key === "Backspace" && filters.length > 0) {
                 removeAt(filters.length - 1);
               }
             }}
-            placeholder={filters.length === 0 ? searchPlaceholder : "Add filter or search…"}
-            className="h-6 min-w-[6rem] flex-1 bg-transparent text-[13px] outline-none placeholder:text-muted-foreground"
+            placeholder={filters.length === 0 ? "Filter traces…" : "Add filter…"}
+            className="h-6 min-w-[6rem] flex-1 cursor-text bg-transparent text-[13px] outline-none placeholder:text-muted-foreground"
           />
         </div>
       </PopoverAnchor>
@@ -137,7 +128,7 @@ export function TraceSearchFilterInput({
         // Width is 75% of the search bar (left-aligned, so the right ~25% stays
         // uncovered) with a min floor so the field/operator/value/Add-filter row never
         // cramps when the bar itself is narrow.
-        className="z-40 w-[calc(var(--radix-popover-trigger-width)*0.75)] min-w-[28rem] p-0"
+        className="z-40 w-[calc(var(--radix-popover-trigger-width)*0.75)] min-w-[22rem] p-0"
       >
         <FilterBuilder
           projectId={projectId}

--- a/frontend/ui/src/features/traces/hooks/traces-query-key.test.ts
+++ b/frontend/ui/src/features/traces/hooks/traces-query-key.test.ts
@@ -3,7 +3,7 @@ import { tracesQueryKey } from "./index";
 import type { Predicate } from "@/types/api";
 
 const model: Predicate = { field: "model_name", op: "in", value: ["a", "b"] };
-const cost: Predicate = { field: "cost", op: "between", value: [0.5, null] };
+const cost: Predicate = { field: "cost", op: "gte", value: 0.5 };
 
 describe("tracesQueryKey", () => {
   it("includes project id and all paging/filter fields in a stable order", () => {

--- a/frontend/ui/src/lib/api/traces.test.ts
+++ b/frontend/ui/src/lib/api/traces.test.ts
@@ -76,7 +76,7 @@ describe("getTraces filters serialization", () => {
 
     const filters: Predicate[] = [
       { field: "model_name", op: "in", value: ["claude-opus-4.8"] },
-      { field: "cost", op: "between", value: [0.5, null] },
+      { field: "cost", op: "gte", value: 0.5 },
     ];
     await getTraces("proj-1", "", { filters }, { id: "user-1" });
 

--- a/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
@@ -30,7 +30,7 @@ describe("useListPageState filters integration", () => {
 
   it("updateFilters writes the encoded param to the URL", () => {
     const { result } = renderHook(() => useListPageState());
-    const next: Predicate[] = [{ field: "cost", op: "between", value: [1, null] }];
+    const next: Predicate[] = [{ field: "cost", op: "gte", value: 0.5 }];
     act(() => result.current.updateFilters(next));
     const url = new URL(replace.mock.calls.at(-1)![0] as string, "http://x");
     expect(JSON.parse(url.searchParams.get("filters")!)).toEqual(next);

--- a/frontend/ui/src/lib/hooks/use-url-filters.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-url-filters.test.tsx
@@ -36,7 +36,7 @@ describe("useUrlFilters", () => {
   it("setFilters writes the encoded param to the URL and resets the page", () => {
     const onChange = vi.fn();
     const { result } = renderHook(() => useUrlFilters(onChange));
-    const next: Predicate[] = [{ field: "cost", op: "between", value: [0.5, null] }];
+    const next: Predicate[] = [{ field: "cost", op: "gte", value: 0.5 }];
 
     act(() => result.current.setFilters(next));
 
@@ -50,7 +50,7 @@ describe("useUrlFilters", () => {
   it("resets page_index in the same write so a filter applied on page >1 isn't lost", () => {
     currentParams = new URLSearchParams({ page_index: "2" });
     const { result } = renderHook(() => useUrlFilters());
-    const next: Predicate[] = [{ field: "cost", op: "between", value: [0.5, null] }];
+    const next: Predicate[] = [{ field: "cost", op: "gte", value: 0.5 }];
     act(() => result.current.setFilters(next));
     // A single write carries the new filter AND drops the stale page — no separate
     // page-reset write to clobber the filter from stale params.

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -184,15 +184,17 @@ export interface TraceListResponse {
 }
 
 /**
- * A single trace-list filter predicate `{field, op, value}` — the frontend mirror
- * of the backend predicate IR, serialized into the `?filters=` JSON array.
- * Discriminated on `op`: categorical fields use `in` (the UI selects one value, so the
- * array carries a single element), numeric fields use `between` with nullable bounds
- * (`[0.5, null]` = ≥ 0.5, `[null, 10]` = ≤ 10; both bounds inclusive).
+ * A single trace-list filter predicate `{field, op, value}` — the frontend mirror of the
+ * backend predicate IR, serialized into the `?filters=` JSON array. Explicit scalar
+ * operators: categorical `in` (a list of strings; the UI selects one),
+ * numeric `eq`/`gt`/`gte`/`lt`/`lte` (a single number), and text `eq`/`contains` (a string).
+ * A numeric range is two one-sided predicates the backend AND-combines.
  */
 export type Predicate =
   | { field: string; op: "in"; value: string[] }
-  | { field: string; op: "between"; value: [number | null, number | null] };
+  | { field: string; op: "gt" | "gte" | "lt" | "lte"; value: number }
+  | { field: string; op: "eq"; value: number | string }
+  | { field: string; op: "contains"; value: string };
 
 export interface TraceQueryOptions {
   page?: number;

--- a/tests/rest/test_filter_columns_parity.py
+++ b/tests/rest/test_filter_columns_parity.py
@@ -14,11 +14,14 @@ from rest.services.filters import columns as reg
 
 MEMBERSHIP_FIELDS = {"model_name", "environment"}
 AGGREGATE_FIELDS = {"cost", "total_tokens", "duration_ms", "errors"}
+TRACE_FIELDS = {"trace_id"}
 
 
-def test_registry_column_set_is_exactly_the_two_tiers():
-    """The registry holds precisely the membership + aggregate fields — nothing else."""
-    assert {c.name for c in reg.FILTER_COLUMNS} == MEMBERSHIP_FIELDS | AGGREGATE_FIELDS
+def test_registry_column_set_is_exactly_the_declared_tiers():
+    """The registry holds precisely the membership + aggregate + trace fields."""
+    assert {c.name for c in reg.FILTER_COLUMNS} == (
+        MEMBERSHIP_FIELDS | AGGREGATE_FIELDS | TRACE_FIELDS
+    )
 
 
 def test_membership_fields_are_span_membership_categorical_in():
@@ -31,14 +34,31 @@ def test_membership_fields_are_span_membership_categorical_in():
         assert col.aggregate_expr is None
 
 
-def test_aggregate_fields_are_span_aggregate_numeric_between():
-    """Aggregate fields lower to a HAVING semi-join and take a numeric ``between``."""
+def test_aggregate_fields_are_span_aggregate_numeric_comparisons():
+    """Aggregate fields lower to a HAVING semi-join and take the numeric comparison ops."""
     for name in AGGREGATE_FIELDS:
         col = reg.get_column(name)
         assert col.level is reg.FilterLevel.SPAN_AGGREGATE
         assert col.type is reg.FilterType.NUMERIC
-        assert col.operators == (reg.FilterOperator.BETWEEN,)
+        assert col.operators == (
+            reg.FilterOperator.EQ,
+            reg.FilterOperator.GT,
+            reg.FilterOperator.GTE,
+            reg.FilterOperator.LT,
+            reg.FilterOperator.LTE,
+        )
         assert col.value_source is reg.ValueSource.RANGE
+
+
+def test_trace_id_is_a_text_trace_level_field():
+    """trace_id filters the traces row inline (TRACE level) and takes text = / contains."""
+    col = reg.get_column("trace_id")
+    assert col.level is reg.FilterLevel.TRACE
+    assert col.type is reg.FilterType.TEXT
+    assert col.operators == (reg.FilterOperator.EQ, reg.FilterOperator.CONTAINS)
+    assert col.ch_type == "String"
+    assert col.aggregate_expr is None
+    assert col.source_columns == ()
 
 
 def test_errors_is_a_numeric_count_of_error_spans():
@@ -73,7 +93,7 @@ def test_aggregate_source_columns_name_the_referenced_spans_columns():
     assert reg.get_column("total_tokens").source_columns == ("total_tokens",)
     assert reg.get_column("duration_ms").source_columns == ("span_start_time", "span_end_time")
     assert reg.get_column("errors").source_columns == ("status",)
-    for name in MEMBERSHIP_FIELDS:
+    for name in MEMBERSHIP_FIELDS | TRACE_FIELDS:
         assert reg.get_column(name).source_columns == ()
 
 

--- a/tests/rest/test_filter_translate.py
+++ b/tests/rest/test_filter_translate.py
@@ -2,8 +2,11 @@
 
 The translator's contract is the load-bearing correctness piece: every condition it
 returns is appended to the shared ``conditions`` list in ``list_traces`` (the one that
-feeds BOTH the page CTE and the separate count query), so a membership/aggregate filter
-keyed on ``t.trace_id`` filters the page and the total identically.
+feeds BOTH the page CTE and the separate count query), so a membership / aggregate /
+trace-level filter keyed on ``t.trace_id`` filters the page and the total identically.
+
+Operators are explicit and scalar: categorical ``in`` (array),
+numeric ``eq/gt/gte/lt/lte`` (a single number), and text ``eq/contains`` (a string).
 """
 
 import pytest
@@ -14,6 +17,8 @@ from rest.services.filters.translate import (
     build_conditions,
     parse_filters_param,
 )
+
+# --- parsing ---------------------------------------------------------------
 
 
 def test_parse_none_or_empty_yields_no_predicates():
@@ -36,102 +41,6 @@ def test_parse_rejects_non_array():
         parse_filters_param('{"field":"model_name","op":"in","value":["x"]}')
 
 
-def test_validation_rejects_malformed_in_value():
-    # 'in' needs a list of strings, not a bare value or non-strings.
-    with pytest.raises(ValueError):
-        build_conditions([Predicate(field="model_name", op="in", value="gpt-4")], {})
-    with pytest.raises(ValueError):
-        build_conditions([Predicate(field="model_name", op="in", value=[1, 2])], {})
-
-
-def test_validation_rejects_empty_in_list():
-    # An empty IN list matches nothing — reject it rather than emit `col IN []`.
-    with pytest.raises(ValueError):
-        build_conditions([Predicate(field="model_name", op="in", value=[])], {})
-
-
-def test_validation_rejects_malformed_between_value():
-    # 'between' needs a two-element [min, max] list of numbers (either may be null).
-    for bad in (5, [5], [1, 2, 3], ["a", "b"], [True, None]):
-        with pytest.raises(ValueError):
-            build_conditions([Predicate(field="cost", op="between", value=bad)], {})
-
-
-def test_validation_rejects_fractional_bound_on_integer_field():
-    # total_tokens/errors/duration_ms are integer-typed; a fractional bound is a
-    # BAD_QUERY_PARAMETER at ClickHouse, so reject it at the edge (422, not a 500).
-    for field in ("total_tokens", "errors", "duration_ms"):
-        with pytest.raises(ValueError):
-            build_conditions([Predicate(field=field, op="between", value=[1.5, None])], {})
-        with pytest.raises(ValueError):
-            build_conditions([Predicate(field=field, op="between", value=[None, 2.5])], {})
-
-
-def test_validation_rejects_negative_bound():
-    # The metrics are all non-negative; a negative bound can't bind to UInt64 (errors)
-    # and would 500 in ClickHouse, so reject it at the edge (422) for every numeric field.
-    for field in ("errors", "total_tokens", "duration_ms", "cost"):
-        with pytest.raises(ValueError):
-            build_conditions([Predicate(field=field, op="between", value=[-5, None])], {})
-
-
-def test_validation_rejects_non_finite_bound():
-    # json.loads accepts NaN/Infinity by default; a non-finite bound would 500 at bind.
-    for bad in (float("inf"), float("-inf"), float("nan")):
-        with pytest.raises(ValueError):
-            build_conditions([Predicate(field="cost", op="between", value=[bad, None])], {})
-
-
-def test_validation_rejects_out_of_range_integer_bound():
-    # A value beyond the column's integer type can't bind — total_tokens is Int64. Include
-    # an arbitrary-size int that would OverflowError in float() coercion (must be a clean
-    # ValueError/422, not a 500).
-    for huge in (2**63, 10**400):
-        with pytest.raises(ValueError):
-            build_conditions(
-                [Predicate(field="total_tokens", op="between", value=[huge, None])], {}
-            )
-
-
-def test_validation_rejects_oversized_decimal_bound():
-    # cost is Decimal64(9); a value beyond its range would overflow at binding (500), so
-    # reject it at the edge too — the range check isn't integer-only.
-    for huge in (10**9, 10**30):
-        with pytest.raises(ValueError):
-            build_conditions([Predicate(field="cost", op="between", value=[huge, None])], {})
-
-
-def test_fractional_bound_allowed_on_decimal_cost():
-    # cost is Decimal-typed — fractional bounds are valid and must not be rejected.
-    conds = build_conditions(
-        [Predicate(field="cost", op="between", value=[0.5, None])], {"project_id": "p1"}
-    )
-    assert conds  # a condition was produced, no ValueError
-
-
-def test_integer_valued_float_bound_is_coerced_to_int():
-    # A whole-number float (e.g. 5.0 from a hand-crafted URL) is accepted and bound as an
-    # int, so it isn't sent to ClickHouse as "5.0" (unparseable as Int64).
-    params = {"project_id": "p1"}
-    build_conditions([Predicate(field="total_tokens", op="between", value=[5.0, 10.0])], params)
-    bounds = [v for k, v in params.items() if k.endswith(("_min", "_max"))]
-    assert set(bounds) == {5, 10}
-    assert all(isinstance(v, int) for v in bounds)
-
-
-def test_duplicate_predicates_on_same_field_get_distinct_params():
-    # Two predicates on one field must not clobber each other's bound params.
-    params = {"project_id": "p1"}
-    build_conditions(
-        [
-            Predicate(field="cost", op="between", value=[1, None]),
-            Predicate(field="cost", op="between", value=[None, 9]),
-        ],
-        params,
-    )
-    assert 1 in params.values() and 9 in params.values()
-
-
 def test_parse_rejects_non_object_array_element():
     with pytest.raises(ValueError):
         parse_filters_param("[123]")
@@ -148,8 +57,107 @@ def test_parse_rejects_unknown_field():
 
 
 def test_parse_rejects_bad_operator_for_field():
+    # cost is numeric — the `in` operator isn't in its whitelist.
     with pytest.raises(ValueError):
         parse_filters_param('[{"field":"cost","op":"in","value":[1]}]')
+
+
+# --- categorical `in` validation -------------------------------------------
+
+
+def test_validation_rejects_malformed_in_value():
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="model_name", op="in", value="gpt-4")], {})
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="model_name", op="in", value=[1, 2])], {})
+
+
+def test_validation_rejects_empty_in_list():
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="model_name", op="in", value=[])], {})
+
+
+# --- numeric comparison validation -----------------------------------------
+
+
+def test_numeric_op_requires_a_single_number():
+    # A numeric comparison takes one number — not a list, string, null, or bool.
+    for bad in ([1, 2], "5", None, True):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field="cost", op="gt", value=bad)], {})
+
+
+def test_numeric_rejects_negative():
+    # The metrics are all non-negative; a negative can't bind to a UInt64 and would 500.
+    for field in ("cost", "total_tokens", "duration_ms", "errors"):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field=field, op="gte", value=-5)], {})
+
+
+def test_numeric_rejects_non_finite():
+    for bad in (float("inf"), float("-inf"), float("nan")):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field="cost", op="lt", value=bad)], {})
+
+
+def test_numeric_rejects_fractional_on_integer_field():
+    for field in ("total_tokens", "errors", "duration_ms"):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field=field, op="gt", value=1.5)], {})
+
+
+def test_numeric_rejects_out_of_range():
+    # Beyond the column type's range can't bind (would OverflowError / 500).
+    for huge in (2**63, 10**400):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field="total_tokens", op="lt", value=huge)], {})
+    for huge in (10**9, 10**30):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field="cost", op="lt", value=huge)], {})
+
+
+def test_fractional_value_allowed_on_decimal_cost():
+    conds = build_conditions([Predicate(field="cost", op="gte", value=0.5)], {"project_id": "p1"})
+    assert conds  # a condition was produced, no ValueError
+
+
+def test_integer_valued_float_is_coerced_to_int():
+    # 5.0 from a hand-crafted URL is bound as int 5, not "5.0" (unparseable as Int64).
+    params = {"project_id": "p1"}
+    build_conditions([Predicate(field="total_tokens", op="gte", value=5.0)], params)
+    bound = [v for k, v in params.items() if k.startswith("f_total_tokens")]
+    assert bound == [5]
+    assert isinstance(bound[0], int)
+
+
+# --- text (trace_id) validation --------------------------------------------
+
+
+def test_text_op_requires_a_non_empty_string():
+    for bad in ("", 5, None, ["abc"]):
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field="trace_id", op="eq", value=bad)], {})
+        with pytest.raises(ValueError):
+            build_conditions([Predicate(field="trace_id", op="contains", value=bad)], {})
+
+
+# --- whitelist boundary ----------------------------------------------------
+
+
+def test_unknown_field_is_rejected():
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="not_a_field", op="eq", value=1)], {})
+
+
+def test_operator_not_in_field_whitelist_is_rejected():
+    # cost (numeric) doesn't allow `contains`; trace_id (text) doesn't allow `gt`.
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="cost", op="contains", value="x")], {})
+    with pytest.raises(ValueError):
+        build_conditions([Predicate(field="trace_id", op="gt", value=1)], {})
+
+
+# --- categorical membership lowering ---------------------------------------
 
 
 def test_membership_predicate_lowers_to_a_project_scoped_span_semijoin():
@@ -165,8 +173,6 @@ def test_membership_predicate_lowers_to_a_project_scoped_span_semijoin():
     assert "FROM spans" in cond
     assert "project_id = {project_id:String}" in cond
     assert "model_name IN" in cond
-    # Deduped to the latest ReplacingMergeTree version per span before the IN match, so a
-    # stale row can't match a value the latest span version no longer has.
     assert "LIMIT 1 BY project_id, trace_id, span_id" in cond
     # The value is bound as a parameter, never interpolated into the SQL text.
     assert ["claude-opus-4.8", "gpt-4"] in params.values()
@@ -174,9 +180,7 @@ def test_membership_predicate_lowers_to_a_project_scoped_span_semijoin():
 
 
 def test_membership_predicates_on_different_fields_emit_independent_semijoins():
-    # Independent existence: each membership predicate is its OWN semi-join, AND-combined,
-    # so a trace matches if it has >=1 span for EACH predicate independently (NOT one span
-    # satisfying both). Two fields -> two separate t.trace_id IN (...) conditions.
+    # Independent existence: each membership predicate is its OWN semi-join, AND-combined.
     params = {"project_id": "p1"}
     conditions = build_conditions(
         [
@@ -187,119 +191,156 @@ def test_membership_predicates_on_different_fields_emit_independent_semijoins():
     )
     assert len(conditions) == 2
     assert all(c.startswith("t.trace_id IN (") for c in conditions)
-    # Each semi-join carries only its own field's condition, not the other's (not merged).
     model_cond = next(c for c in conditions if "model_name IN" in c)
     env_cond = next(c for c in conditions if "environment IN" in c)
     assert "environment IN" not in model_cond
     assert "model_name IN" not in env_cond
-    # Per-predicate param indexing keeps the two from colliding.
     assert params["f_model_name_0"] == ["gpt-4"]
     assert params["f_environment_1"] == ["prod"]
 
 
-def test_aggregate_inner_projection_is_registry_driven():
-    # The aggregate inner SELECT projects the structural columns plus only the active
-    # field's source_columns — a cost filter projects cost, NOT total_tokens or status.
+# --- numeric aggregate lowering (explicit operators) -----------------------
+
+
+@pytest.mark.parametrize(
+    "op,token",
+    [
+        ("eq", "sum(cost) = {"),
+        ("gt", "sum(cost) > {"),
+        ("gte", "sum(cost) >= {"),
+        ("lt", "sum(cost) < {"),
+        ("lte", "sum(cost) <= {"),
+    ],
+)
+def test_numeric_operator_lowers_to_its_having_comparison(op, token):
+    # The trailing `{` disambiguates `>`/`>=` and `<`/`<=` (the param placeholder follows).
     params = {"project_id": "p1"}
-    cond = build_conditions([Predicate(field="cost", op="between", value=[0.5, None])], params)[0]
-    # The inner projection is the SELECT list feeding "FROM spans" (not the outer wrapper).
+    cond = build_conditions([Predicate(field="cost", op=op, value=0.5)], params)[0]
+    assert "t.trace_id IN (" in cond
+    assert "GROUP BY trace_id HAVING" in cond
+    assert token in cond
+    # The value is bound as a param, not interpolated.
+    assert 0.5 in params.values()
+    assert "0.5" not in cond
+
+
+def test_errors_aggregate_counts_error_spans_per_trace():
+    params = {"project_id": "p1"}
+    cond = build_conditions([Predicate(field="errors", op="gte", value=3)], params)[0]
+    assert "countIf(status = 'ERROR') >= {" in cond
+    assert "GROUP BY trace_id HAVING" in cond
+    assert 3 in params.values()
+
+
+def test_duration_aggregate_uses_min_max_expr_not_sum():
+    params = {"project_id": "p1"}
+    cond = build_conditions([Predicate(field="duration_ms", op="gt", value=100)], params)[0]
+    assert "min(span_start_time)" in cond and "max(span_end_time)" in cond
+    assert "sum(" not in cond
+
+
+def test_multiple_numeric_predicates_on_same_field_form_a_range():
+    # A range is two one-sided predicates AND-combined in ONE HAVING (page and count alike).
+    params = {"project_id": "p1"}
+    conditions = build_conditions(
+        [
+            Predicate(field="cost", op="gt", value=1),
+            Predicate(field="cost", op="lte", value=10),
+        ],
+        params,
+    )
+    assert len(conditions) == 1
+    cond = conditions[0]
+    assert "sum(cost) > {" in cond
+    assert "sum(cost) <= {" in cond
+    assert " AND " in cond
+    assert 1 in params.values() and 10 in params.values()
+
+
+def test_duplicate_predicates_on_same_field_get_distinct_params():
+    params = {"project_id": "p1"}
+    build_conditions(
+        [
+            Predicate(field="cost", op="gt", value=1),
+            Predicate(field="cost", op="lt", value=9),
+        ],
+        params,
+    )
+    assert 1 in params.values() and 9 in params.values()
+
+
+def test_aggregate_inner_projection_is_registry_driven():
+    # The inner SELECT projects the structural keys plus only the active field's
+    # source_columns — a cost filter projects cost, NOT total_tokens or status.
+    params = {"project_id": "p1"}
+    cond = build_conditions([Predicate(field="cost", op="gt", value=0.5)], params)[0]
     inner_select_start = cond.index("SELECT", cond.index("SELECT") + 1)
     select = cond[inner_select_start : cond.index("FROM spans")]
     assert "cost" in select
     assert "total_tokens" not in select
     assert "status" not in select
-    # A cost filter doesn't need span_start_time projected — it's only filtered in the
-    # inner WHERE, not selected — so it isn't over-projected here.
     assert "span_start_time" not in select
-    # The dedup/group keys are always present.
     for structural in ("trace_id", "span_id", "project_id"):
         assert structural in select
-    # A duration filter DOES project span_start_time + span_end_time — supplied by its
-    # source_columns, not hardcoded — confirming the projection is registry-driven.
+    # A duration filter DOES project span_start_time + span_end_time — from its
+    # source_columns, confirming the projection is registry-driven, not hardcoded.
     dcond = build_conditions(
-        [Predicate(field="duration_ms", op="between", value=[5, None])], {"project_id": "p1"}
+        [Predicate(field="duration_ms", op="gt", value=5)], {"project_id": "p1"}
     )[0]
     dsel = dcond[dcond.index("SELECT", dcond.index("SELECT") + 1) : dcond.index("FROM spans")]
     assert "span_start_time" in dsel and "span_end_time" in dsel
 
 
-def test_unknown_field_is_rejected():
-    with pytest.raises(ValueError):
-        build_conditions([Predicate(field="not_a_field", op="in", value=["x"])], {})
+# --- text (trace_id) lowering ----------------------------------------------
 
 
-def test_operator_not_in_field_whitelist_is_rejected():
-    # cost only allows BETWEEN, not IN.
-    with pytest.raises(ValueError):
-        build_conditions([Predicate(field="cost", op="in", value=[1])], {})
-
-
-def test_aggregate_between_lowers_to_a_having_semijoin_with_both_bounds():
+def test_trace_id_eq_lowers_to_an_inline_equality():
+    # TRACE-level fields filter the traces row directly (t.*), keyed on t.trace_id so
+    # they land in both the page and count queries. No span subquery.
     params = {"project_id": "p1"}
-    conditions = build_conditions([Predicate(field="cost", op="between", value=[0.5, 10])], params)
-    assert len(conditions) == 1
-    cond = conditions[0]
-    assert "t.trace_id IN (" in cond
-    assert "GROUP BY trace_id" in cond
-    assert "HAVING" in cond
-    assert "sum(cost) BETWEEN" in cond
-    assert "project_id = {project_id:String}" in cond
-    # both bounds bound as params, not interpolated
-    assert 0.5 in params.values() and 10 in params.values()
-    assert "0.5" not in cond
+    cond = build_conditions([Predicate(field="trace_id", op="eq", value="abc123")], params)[0]
+    assert cond == "t.trace_id = {f_trace_id_0:String}"
+    assert params["f_trace_id_0"] == "abc123"
+    assert "abc123" not in cond  # bound, not interpolated
 
 
-def test_aggregate_open_lower_bound_lowers_to_inclusive_gte():
+def test_trace_id_contains_lowers_to_a_parameterized_ilike():
     params = {"project_id": "p1"}
-    cond = build_conditions([Predicate(field="cost", op="between", value=[0.5, None])], params)[0]
-    assert "sum(cost) >=" in cond  # "greater than or equal to" is an inclusive >= bound
-    assert "BETWEEN" not in cond and "<" not in cond
+    cond = build_conditions([Predicate(field="trace_id", op="contains", value="abc")], params)[0]
+    assert cond == "t.trace_id ILIKE {f_trace_id_0:String}"
+    assert params["f_trace_id_0"] == "%abc%"  # case-insensitive substring
 
 
-def test_aggregate_open_upper_bound_lowers_to_inclusive_lte():
+def test_trace_id_contains_escapes_ilike_wildcards():
+    # A literal % or _ in the search must be escaped so it matches literally, not as a
+    # wildcard — otherwise "100%" would match every id containing "100".
     params = {"project_id": "p1"}
-    cond = build_conditions([Predicate(field="cost", op="between", value=[None, 10])], params)[0]
-    assert "sum(cost) <=" in cond  # "less than or equal to" is an inclusive <= bound
-    assert "BETWEEN" not in cond and ">=" not in cond
+    build_conditions([Predicate(field="trace_id", op="contains", value="a%b_c")], params)
+    assert params["f_trace_id_0"] == "%a\\%b\\_c%"
 
 
-def test_errors_aggregate_counts_error_spans_per_trace():
+def test_trace_id_condition_is_inline_not_a_semijoin():
     params = {"project_id": "p1"}
-    cond = build_conditions([Predicate(field="errors", op="between", value=[3, None])], params)[0]
-    assert "countIf(status = 'ERROR') >=" in cond
-    assert "GROUP BY trace_id HAVING" in cond
-    assert "status" in cond  # inner SELECT carries status for the count
+    cond = build_conditions([Predicate(field="trace_id", op="eq", value="x")], params)[0]
+    assert "SELECT" not in cond
+    assert "spans" not in cond
 
 
-def test_duration_aggregate_uses_min_max_expr_not_sum():
-    params = {"project_id": "p1"}
-    cond = build_conditions(
-        [Predicate(field="duration_ms", op="between", value=[100, 5000])], params
-    )[0]
-    assert "min(span_start_time)" in cond and "max(span_end_time)" in cond
-    assert "sum(" not in cond
+# --- time-window bounding --------------------------------------------------
 
 
-def test_aggregate_with_no_bounds_is_a_noop_and_emits_nothing():
-    # An empty range (both bounds absent) contributes no SQL — not an error.
-    params = {"project_id": "p1"}
-    assert (
-        build_conditions([Predicate(field="cost", op="between", value=[None, None])], params) == []
-    )
-
-
-def test_start_after_in_params_bounds_both_semijoins():
+def test_start_after_in_params_bounds_span_semijoins():
     params = {"project_id": "p1", "start_after": "2026-06-01 00:00:00"}
     conditions = build_conditions(
         [
             Predicate(field="model_name", op="in", value=["gpt-4"]),
-            Predicate(field="cost", op="between", value=[1, None]),
+            Predicate(field="cost", op="gt", value=1),
         ],
         params,
     )
     assert len(conditions) == 2  # one membership semi-join, one aggregate semi-join
     for cond in conditions:
-        assert "span_start_time >= {start_after:DateTime64(3)}" in cond
+        assert "span_start_time >=" in cond
 
 
 def test_span_time_bound_backs_off_for_boundary_drift():
@@ -312,3 +353,10 @@ def test_span_time_bound_backs_off_for_boundary_drift():
         f"span_start_time >= {{start_after:DateTime64(3)}} - INTERVAL "
         f"{SPAN_TIME_BOUND_LOOKBACK_HOURS} HOUR" in conditions[0]
     )
+
+
+def test_trace_id_condition_has_no_span_time_bound():
+    # An inline trace-row predicate doesn't scan spans, so start_after doesn't apply.
+    params = {"project_id": "p1", "start_after": "2026-06-01 00:00:00"}
+    cond = build_conditions([Predicate(field="trace_id", op="contains", value="x")], params)[0]
+    assert "span_start_time" not in cond

--- a/tests/rest/test_trace_filter_meta.py
+++ b/tests/rest/test_trace_filter_meta.py
@@ -66,7 +66,7 @@ class TestFilterFields:
 
         cost = fields["cost"]
         assert cost["type"] == "numeric"
-        assert cost["operators"] == ["between"]
+        assert cost["operators"] == ["eq", "gt", "gte", "lt", "lte"]
         assert cost["value_source"] == "range"
         # Integer-typed fields are flagged so the UI restricts them to whole numbers;
         # cost (Decimal) and model (String) are not.

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -81,13 +81,31 @@ def test_aggregate_filter_lands_in_both_page_and_count_queries():
 
     svc.list_traces(
         project_id="p1",
-        filters=[Predicate(field="cost", op="between", value=[0.5, None])],
+        filters=[Predicate(field="cost", op="gt", value=0.5)],
     )
 
     page_sql = svc._client.query.call_args_list[0].args[0]
     count_sql = svc._client.query.call_args_list[1].args[0]
     assert "GROUP BY trace_id HAVING" in page_sql
     assert "GROUP BY trace_id HAVING" in count_sql
+
+
+def test_trace_id_filter_lands_in_both_page_and_count_queries():
+    """A trace-level trace_id filter is an inline t.trace_id predicate that must reach
+    BOTH the page and count queries so the total stays consistent with the visible rows."""
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(
+        project_id="p1",
+        filters=[Predicate(field="trace_id", op="contains", value="abc")],
+    )
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    count_sql = svc._client.query.call_args_list[1].args[0]
+    assert "t.trace_id ILIKE" in page_sql
+    assert "t.trace_id ILIKE" in count_sql
+    assert svc._client.query.call_args_list[0].kwargs["parameters"]["f_trace_id_0"] == "%abc%"
 
 
 def test_no_filters_adds_no_semijoin():


### PR DESCRIPTION
Follow-up to the trace-filter series, **stacked on `feat/trace-filter-followups`** (#1429). Refinements gathered from local e2e testing on ~300 seeded traces.

## Changes

- **Compact filter builder** — the popover row uses `h-7` controls with tighter padding, sized to match the surrounding search bar; the operator cell now sizes to its label so a wide operator (`contains`) sits comfortably instead of truncating in a fixed cell.
- **Explicit numeric operators** — `= > >= < <=` for numeric fields, each lowering to a literal parameterized SQL comparison, replacing the null-bounded `between` encoding. Strict `>`/`<` and inclusive `>=`/`<=` are all offered and honest end to end (builder → chip label → SQL). A numeric range is two one-sided predicates the backend AND-combines.
- **`trace_id` filter** — a new text field (TRACE level, inline `t.trace_id`) with an exact `=` and a case-insensitive `contains` (parameterized `ILIKE` with the search value's wildcards escaped). Replaces the removed keyword search as the find-a-trace-by-id path.
- **Keyword search removed** — the traces bar is filter-only now.

## Correctness

The pagination invariant is preserved: every filter condition is keyed on `t.trace_id` and lands in **both** the page query and the count query.

- Backend: 78 filter unit tests pass (translator, registry parity, reader page/count, meta endpoints).
- Frontend: 85 filter unit tests pass (predicate IR, canonicalize, range-merge, builder, filter-only input).
- Local stress e2e over ~300 seeded traces: 13/13 filter cases correct, and paging through every page under each filter returned exactly the reported total with no dupes/gaps.

`tsc`, prettier, and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the trace filter UI, added explicit numeric operators (=, >, ≥, <, ≤), and introduced a `trace_id` filter with exact and case-insensitive contains. Removed the old keyword search; the search box is now filter-only.

- **New Features**
  - Compact builder popover (h-7 controls) with an operator button that sizes to its label.
  - Numeric fields now use `eq`, `gt`, `gte`, `lt`, `lte`; the backend emits parameterized comparisons.
  - New `trace_id` text filter on `t.trace_id`: `=` or case-insensitive `contains` (wildcards escaped).
  - All filters land in both the page and the total count queries.

- **Migration**
  - To find a trace by id, use the `trace_id` filter (`=` for exact, `contains` for substring).
  - Build numeric ranges with two predicates (e.g., “cost ≥ 5” and “cost ≤ 10”); `between` is not offered.
  - Update any saved URLs or API clients from `between: [min,max]` to scalar ops (`eq/gt/gte/lt/lte`).

<sup>Written for commit 06bc7f720b0c4ec7603ee6f7e2b209dd791e2d69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

