### PR TITLE
refactor(tokens): remove unused CLAUDE_MODELS, TIKTOKEN_MODELS, is_openai_model

### DIFF
--- a/backend/worker/tokens/types.py
+++ b/backend/worker/tokens/types.py
@@ -1,34 +1,5 @@
 """Model type definitions and guards."""
 
-# OpenAI models that use tiktoken
-TIKTOKEN_MODELS = [
-    "gpt-4o",
-    "gpt-4o-mini",
-    "gpt-4-turbo",
-    "gpt-4",
-    "gpt-3.5-turbo",
-    "o1",
-    "o1-mini",
-    "o1-preview",
-    "o3-mini",
-]
-
-# Claude models (use char approximation)
-CLAUDE_MODELS = [
-    "claude-fable-5",
-    "claude-3-5-sonnet",
-    "claude-3-5-haiku",
-    "claude-3-opus",
-    "claude-3-sonnet",
-    "claude-3-haiku",
-    "claude-sonnet-4",
-]
-
-
-def is_openai_model(model: str) -> bool:
-    """Check if model uses tiktoken."""
-    return any(model.startswith(m) for m in TIKTOKEN_MODELS)
-
 
 def is_claude_model(model: str) -> bool:
     """Check if model is Anthropic Claude."""


### PR DESCRIPTION
## Summary

Closes #1430

Removes three dead symbols from `backend/worker/tokens/types.py`:

- `TIKTOKEN_MODELS` — defined but never imported anywhere
- `CLAUDE_MODELS` — defined but never imported anywhere
- `is_openai_model()` — defined but never called; `count_tokens()` handles non-Claude models via `tiktoken.encoding_for_model()` directly

`is_claude_model()` is unchanged — it is the only live export, used in `usage.py`.

**Verified with:**
```
grep -rn "CLAUDE_MODELS"   --include='*.py' .  # only definition
grep -rn "is_openai_model" --include='*.py' .  # only definition
grep -rn "TIKTOKEN_MODELS" --include='*.py' .  # only definition + is_openai_model
```

## Test plan

- [ ] Existing tests pass unchanged (`count_tokens()` behaviour unaffected)
- [ ] `is_claude_model()` still present and working
- [ ] No import errors anywhere in the worker

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `CLAUDE_MODELS`, `TIKTOKEN_MODELS`, and `is_openai_model()` from `backend/worker/tokens/types.py` to reduce dead code. `is_claude_model()` remains; `count_tokens()` behavior is unchanged and non-Claude models still use `tiktoken` directly.

<sup>Written for commit 6870e43059e74d90d2fcd47d0cad7ddf928d6b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

