### PR TITLE
docs(byok): sync Default Models table with SYSTEM_MODELS

### DIFF
--- a/docs/ai-agent/byok.mdx
+++ b/docs/ai-agent/byok.mdx
@@ -12,6 +12,8 @@ By default, TraceRoot provides system models for the AI agent. With BYOK, you ca
 | Anthropic | `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-opus-4-5`, `claude-sonnet-4-5`, `claude-haiku-4-5` |
 | OpenAI | `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5`, `gpt-5-mini`, `o3`, `o4-mini`, `gpt-5.3-codex` |
 
+See [Supported Models](/integrations/internal-models) for a description of each system model.
+
 ## Supported Providers
 
 OpenAI, Anthropic, Azure OpenAI, Google (Gemini), Amazon Bedrock, xAI, DeepSeek, OpenRouter, Kimi, GLM.

--- a/docs/ai-agent/byok.mdx
+++ b/docs/ai-agent/byok.mdx
@@ -7,10 +7,10 @@ By default, TraceRoot provides system models for the AI agent. With BYOK, you ca
 
 ## Default Models
 
-| Provider | Models |
-|----------|--------|
-| Anthropic | Claude Opus 4.6, Sonnet 4.6, Opus 4.5, Sonnet 4.5, Haiku 4.5 |
-| OpenAI | GPT-5, GPT-5 Mini, GPT-5.3 Codex, o3, o4-mini |
+| Provider | Models (first entry is the default) |
+|----------|--------------------------------------|
+| Anthropic | claude-opus-4-8, claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6, claude-opus-4-5, claude-sonnet-4-5, claude-haiku-4-5 |
+| OpenAI | gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5, gpt-5-mini, o3, o4-mini, gpt-5.3-codex |
 
 ## Supported Providers
 

--- a/docs/ai-agent/byok.mdx
+++ b/docs/ai-agent/byok.mdx
@@ -9,8 +9,8 @@ By default, TraceRoot provides system models for the AI agent. With BYOK, you ca
 
 | Provider | Models (first entry is the default) |
 |----------|--------------------------------------|
-| Anthropic | claude-opus-4-8, claude-opus-4-7, claude-opus-4-6, claude-sonnet-4-6, claude-opus-4-5, claude-sonnet-4-5, claude-haiku-4-5 |
-| OpenAI | gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5, gpt-5-mini, o3, o4-mini, gpt-5.3-codex |
+| Anthropic | `claude-opus-4-8`, `claude-opus-4-7`, `claude-opus-4-6`, `claude-sonnet-5`, `claude-sonnet-4-6`, `claude-opus-4-5`, `claude-sonnet-4-5`, `claude-haiku-4-5` |
+| OpenAI | `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5`, `gpt-5-mini`, `o3`, `o4-mini`, `gpt-5.3-codex` |
 
 ## Supported Providers
 

--- a/docs/integrations/internal-models.mdx
+++ b/docs/integrations/internal-models.mdx
@@ -28,9 +28,9 @@ TraceRoot Cloud provides the following models out of the box — no API key requ
 | `gpt-5.4-nano`  | Smallest, lowest-cost GPT-5.4 variant  |
 | `gpt-5`         | Previous flagship model                |
 | `gpt-5-mini`    | Fast and cost-efficient GPT-5 variant  |
-| `gpt-5.3-codex` | Code-optimized model via Responses API |
 | `o3`            | Advanced reasoning model               |
 | `o4-mini`       | Lightweight reasoning model            |
+| `gpt-5.3-codex` | Code-optimized model via Responses API |
 
 ## Bring Your Own Key (BYOK)
 

--- a/frontend/packages/core/src/__tests__/llm-providers.test.ts
+++ b/frontend/packages/core/src/__tests__/llm-providers.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, it, expect } from "vitest";
 import {
   ADAPTER_MODELS,
@@ -145,4 +146,30 @@ describe("ADAPTER_MODELS", () => {
       }
     });
   });
+});
+
+describe("docs stay in sync with SYSTEM_MODELS", () => {
+  // The BYOK docs table is a hand-maintained copy of SYSTEM_MODELS. Without this
+  // check, adding a model here silently leaves the docs stale (see #1431).
+  const BYOK_DOC = new URL("../../../../../docs/ai-agent/byok.mdx", import.meta.url);
+
+  it.each(SYSTEM_MODELS.map((s) => [s.provider, s.models.map((m) => m.id)] as const))(
+    "the byok.mdx Default Models table lists %s's models in SYSTEM_MODELS order",
+    (provider, expectedIds) => {
+      const row = readFileSync(BYOK_DOC, "utf8")
+        .split("\n")
+        .find((line) => line.startsWith(`| ${provider} |`));
+
+      expect(
+        row,
+        `no "${provider}" row in the Default Models table of docs/ai-agent/byok.mdx`,
+      ).toBeDefined();
+
+      const documentedIds = [...row!.matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+      expect(
+        documentedIds,
+        `docs/ai-agent/byok.mdx is out of sync with SYSTEM_MODELS for ${provider} — update the table`,
+      ).toEqual([...expectedIds]);
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Closes #1431

The Default Models table in `docs/ai-agent/byok.mdx` was out of sync with `SYSTEM_MODELS` in `llm-providers.ts`. It listed Opus 4.6 and GPT-5 as the first entries (implying they were defaults) and was missing the newest models entirely.

The actual default is `SYSTEM_MODELS[provider].models[0]` per `getDefaultSystemModel()` in `model-resolver.ts`.

**Before → After:**

| Provider | Before | After |
|---|---|---|
| Anthropic default | Opus 4.6 ❌ | claude-opus-4-8 ✅ |
| OpenAI default | GPT-5 ❌ | gpt-5.5 ✅ |
| Anthropic missing | opus-4-8, opus-4-7 | Added ✅ |
| OpenAI missing | gpt-5.5, gpt-5.4 family | Added ✅ |

Also updated the column header to clarify that the first entry per row is the real default.

## Test plan

- [ ] Table entries match `SYSTEM_MODELS` in `llm-providers.ts` exactly, in the same order
- [ ] First entry per provider row matches `getDefaultSystemModel()` output

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the BYOK Default Models table with `SYSTEM_MODELS` so defaults and order match the system config, and adds a test to catch future drift. Sets correct defaults (Anthropic: `claude-opus-4-8`, OpenAI: `gpt-5.5`), adds missing models (incl. `claude-sonnet-5` and the `gpt-5.4` family), clarifies the first entry is the default, code-formats model IDs, links to the Supported Models page, and aligns the `internal-models` table order (closes #1431).

<sup>Written for commit 32789168fa6040789ae4781fc21208349da60ee1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

