### PR TITLE
fix(db): url-encode credentials in the goose ClickHouse DSN

### DIFF
--- a/backend/db/clickhouse/migrate.py
+++ b/backend/db/clickhouse/migrate.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from urllib.parse import quote
 
 DEFAULTS = {
     "CLICKHOUSE_HOST": "localhost",
@@ -50,12 +51,21 @@ def migrations_dir() -> Path:
 
 def goose_dbstring(env: dict[str, str] | None = None) -> str:
     values = {**DEFAULTS, **(env or {})}
+    # goose parses the DSN as a URL, so credential and database values must be
+    # percent-encoded. A password (or user/database) containing a URL-reserved
+    # character such as '&', '=', '?', '#', '+', '/', or a space would otherwise
+    # corrupt the query string — splitting the password early or bleeding into
+    # the next parameter — and silently break the migration connection. quote()
+    # with safe="" encodes every reserved character, including '&' and '='.
+    username = quote(values["CLICKHOUSE_USER"], safe="")
+    password = quote(values["CLICKHOUSE_PASSWORD"], safe="")
+    database = quote(values["CLICKHOUSE_DATABASE"], safe="")
     return (
         "tcp://"
         f"{values['CLICKHOUSE_HOST']}:{values['CLICKHOUSE_PORT']}"
-        f"?username={values['CLICKHOUSE_USER']}"
-        f"&password={values['CLICKHOUSE_PASSWORD']}"
-        f"&database={values['CLICKHOUSE_DATABASE']}"
+        f"?username={username}"
+        f"&password={password}"
+        f"&database={database}"
     )
 
 

--- a/tests/db/test_clickhouse_migrate.py
+++ b/tests/db/test_clickhouse_migrate.py
@@ -26,6 +26,46 @@ def test_goose_command_uses_env_overrides():
     assert command[5] == "up"
 
 
+def test_goose_dbstring_percent_encodes_credentials():
+    # A password with URL-reserved characters must not corrupt the DSN query
+    # string: '&' and '=' would otherwise split the password or start a new
+    # parameter, so goose would connect with truncated/wrong credentials.
+    dbstring = migrate.goose_dbstring(
+        env={
+            "CLICKHOUSE_HOST": "clickhouse.internal",
+            "CLICKHOUSE_PORT": "9000",
+            "CLICKHOUSE_USER": "trace user",
+            "CLICKHOUSE_PASSWORD": "p@ss:w/rd&x=1?#+",
+            "CLICKHOUSE_DATABASE": "events/prod",
+        }
+    )
+
+    assert dbstring == (
+        "tcp://clickhouse.internal:9000"
+        "?username=trace%20user"
+        "&password=p%40ss%3Aw%2Frd%26x%3D1%3F%23%2B"
+        "&database=events%2Fprod"
+    )
+
+
+def test_goose_dbstring_leaves_plain_credentials_unchanged():
+    # Values without reserved characters must round-trip verbatim so existing
+    # deployments see an identical DSN.
+    dbstring = migrate.goose_dbstring(
+        env={
+            "CLICKHOUSE_HOST": "localhost",
+            "CLICKHOUSE_PORT": "9000",
+            "CLICKHOUSE_USER": "clickhouse",
+            "CLICKHOUSE_PASSWORD": "clickhouse",
+            "CLICKHOUSE_DATABASE": "default",
+        }
+    )
+
+    assert dbstring == (
+        "tcp://localhost:9000?username=clickhouse&password=clickhouse&database=default"
+    )
+
+
 def test_goose_command_create_requires_name():
     with pytest.raises(ValueError, match="required"):
         migrate.goose_command("create")


### PR DESCRIPTION
## What

`goose_dbstring()` builds the goose migration DSN by interpolating
`CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, and `CLICKHOUSE_DATABASE` **raw** into
the URL query string. This PR percent-encodes those three components.

## Why

goose parses the DSN as a URL (`tcp://host:port?username=..&password=..&database=..`).
Any credential value containing a URL-reserved character — `&`, `=`, `?`, `#`,
`+`, `/`, or a space — corrupts the query string. For example a password of
`p@ss&x=1` produces:

```
tcp://...?username=trace&password=p@ss&x=1&database=default
```

goose reads `password=p@ss`, then treats `x=1` as another parameter — so the
migration connects with **truncated/wrong credentials** or fails to connect.
Special characters in DB passwords are common (and often mandated by password
policies), so this silently breaks `goose up`/`down`/`status` for many
self-hosted and production deployments — with a confusing "authentication
failed" rather than an obvious config error.

## Fix

Encode each credential/database component with `urllib.parse.quote(safe="")`,
which escapes every reserved character (including `&` and `=`). Host and port
are left as-is. Plain values without reserved characters round-trip verbatim, so
existing deployments get a byte-identical DSN — no migration or config changes
needed.

## How validated

- New unit tests:
  - `test_goose_dbstring_percent_encodes_credentials` — a password/user/database
    full of reserved characters encodes correctly.
  - `test_goose_dbstring_leaves_plain_credentials_unchanged` — regression guard
    that plain values are unchanged.
- The existing `test_goose_command_uses_env_overrides` still passes unchanged.
- `pytest tests/db/test_clickhouse_migrate.py` → 9 passed.
- `ruff check` and `ruff format --check` clean.

No linked issue — found while auditing the migration path; happy to open one if
preferred.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Percent-encode ClickHouse user, password, and database in the `goose` DSN to prevent query-string corruption with special characters. Fixes failed/truncated auth when credentials include `&`, `=`, `?`, `#`, `+`, `/`, or spaces.

- **Bug Fixes**
  - Encode `CLICKHOUSE_USER`, `CLICKHOUSE_PASSWORD`, and `CLICKHOUSE_DATABASE` with `urllib.parse.quote(safe="")`.
  - Keep host and port unchanged; plain values produce the same DSN.
  - Add tests for reserved-character encoding and plain-value round-tripping.

<sup>Written for commit 503c716057a72f3869a150c9c16055eece8fef32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1439?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

