### PR TITLE
fix(db): use the native port for goose ClickHouse migrations

### DIFF
--- a/backend/db/clickhouse/migrate.py
+++ b/backend/db/clickhouse/migrate.py
@@ -8,9 +8,14 @@ import shutil
 import subprocess
 from pathlib import Path
 
+# goose speaks ClickHouse's native protocol (tcp://), so it needs the native
+# port — CLICKHOUSE_NATIVE_PORT (9000), not CLICKHOUSE_PORT (8123, the HTTP port
+# used by the app's clickhouse-connect client). These are distinct env vars in
+# shared.config.ClickHouseSettings; using CLICKHOUSE_PORT here would point goose
+# at the HTTP port and break migrations.
 DEFAULTS = {
     "CLICKHOUSE_HOST": "localhost",
-    "CLICKHOUSE_PORT": "9000",
+    "CLICKHOUSE_NATIVE_PORT": "9000",
     "CLICKHOUSE_USER": "clickhouse",
     "CLICKHOUSE_PASSWORD": "clickhouse",
     "CLICKHOUSE_DATABASE": "default",
@@ -52,7 +57,7 @@ def goose_dbstring(env: dict[str, str] | None = None) -> str:
     values = {**DEFAULTS, **(env or {})}
     return (
         "tcp://"
-        f"{values['CLICKHOUSE_HOST']}:{values['CLICKHOUSE_PORT']}"
+        f"{values['CLICKHOUSE_HOST']}:{values['CLICKHOUSE_NATIVE_PORT']}"
         f"?username={values['CLICKHOUSE_USER']}"
         f"&password={values['CLICKHOUSE_PASSWORD']}"
         f"&database={values['CLICKHOUSE_DATABASE']}"

--- a/backend/worker/celery_app.py
+++ b/backend/worker/celery_app.py
@@ -74,7 +74,7 @@ def on_worker_ready(**kwargs):
             env={
                 **os.environ,
                 "CLICKHOUSE_HOST": ch.host,
-                "CLICKHOUSE_PORT": str(ch.native_port),
+                "CLICKHOUSE_NATIVE_PORT": str(ch.native_port),
                 "CLICKHOUSE_USER": ch.user,
                 "CLICKHOUSE_PASSWORD": ch.password,
                 "CLICKHOUSE_DATABASE": ch.database,

--- a/tests/db/test_clickhouse_migrate.py
+++ b/tests/db/test_clickhouse_migrate.py
@@ -11,7 +11,7 @@ def test_goose_command_uses_env_overrides():
         "up",
         env={
             "CLICKHOUSE_HOST": "clickhouse.internal",
-            "CLICKHOUSE_PORT": "9440",
+            "CLICKHOUSE_NATIVE_PORT": "9440",
             "CLICKHOUSE_USER": "trace",
             "CLICKHOUSE_PASSWORD": "secret",
             "CLICKHOUSE_DATABASE": "events",
@@ -24,6 +24,24 @@ def test_goose_command_uses_env_overrides():
         == "tcp://clickhouse.internal:9440?username=trace&password=secret&database=events"
     )
     assert command[5] == "up"
+
+
+def test_goose_dbstring_uses_native_port_default():
+    # No port supplied -> the native default (9000), never the HTTP default.
+    assert migrate.goose_dbstring() == (
+        "tcp://localhost:9000?username=clickhouse&password=clickhouse&database=default"
+    )
+
+
+def test_goose_dbstring_ignores_http_port():
+    # goose speaks the native protocol, so CLICKHOUSE_PORT (the HTTP port) must
+    # not leak into the DSN — only CLICKHOUSE_NATIVE_PORT controls the port.
+    dbstring = migrate.goose_dbstring(
+        env={"CLICKHOUSE_PORT": "8123", "CLICKHOUSE_NATIVE_PORT": "9000"}
+    )
+
+    assert ":9000?" in dbstring
+    assert "8123" not in dbstring
 
 
 def test_goose_command_create_requires_name():


### PR DESCRIPTION
## What

`goose_dbstring()` builds the goose migration DSN — which uses ClickHouse's
**native** protocol (`tcp://`) — from `CLICKHOUSE_PORT`. But `CLICKHOUSE_PORT`
is the **HTTP** port: it defaults to `8123` in
`shared.config.ClickHouseSettings` and is set to `8123` in `.env.example`. The
native port is a separate variable, `CLICKHOUSE_NATIVE_PORT` (`9000`).

This PR makes the migration runner read `CLICKHOUSE_NATIVE_PORT`.

## Why

Because goose was reading the HTTP port, it dialed `8123` with the native
protocol. Two call sites diverged around this:

- **Worker startup** (`backend/worker/celery_app.py`) *worked around* it by
  remapping `CLICKHOUSE_PORT = ch.native_port` before calling `run_goose`.
- **`make dev`** (`tmux_tools/launcher.py:110`) calls `run_goose` with **no
  remap**. So after the documented setup — `cp .env.example .env` (which sets
  `CLICKHOUSE_PORT=8123`) + installing goose per `CONTRIBUTING.md` — host-side
  `goose up` builds `tcp://localhost:8123` and migrations fail against the HTTP
  port.

The fact that the worker already remaps the port is the tell that the DSN should
have been keyed on the native port all along.

## Fix

- `goose_dbstring` now reads `CLICKHOUSE_NATIVE_PORT` (default `9000`), matching
  `shared.config.ClickHouseSettings`. No caller has to remember to remap.
- `celery_app.py` now sets `CLICKHOUSE_NATIVE_PORT` in the migration env so both
  call sites agree.

Defaults are unchanged (`9000`), so existing working setups produce an identical
DSN. `CLICKHOUSE_PORT` (HTTP) is untouched and still used by the app's
clickhouse-connect client.

## How validated

- `test_goose_dbstring_uses_native_port_default` — no port supplied → `:9000`.
- `test_goose_dbstring_ignores_http_port` — `CLICKHOUSE_PORT=8123` no longer
  leaks into the DSN; only `CLICKHOUSE_NATIVE_PORT` controls the port.
- `test_goose_command_uses_env_overrides` updated to key on the native port.
- `pytest tests/db/test_clickhouse_migrate.py` → 9 passed; `ruff check` /
  `ruff format --check` clean.

## Note

Lightly overlaps #1439 (same `goose_dbstring` function / test file). They're
independent fixes; happy to rebase whichever merges second.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes goose ClickHouse migrations to use the native port for the tcp:// DSN. This prevents dialing the HTTP port and failing migrations.

- **Bug Fixes**
  - `goose_dbstring()` now reads `CLICKHOUSE_NATIVE_PORT` (default `9000`) and ignores `CLICKHOUSE_PORT` for the native `tcp://` DSN.
  - Worker sets `CLICKHOUSE_NATIVE_PORT` in the migration env so both worker and host paths use the same port.

<sup>Written for commit 2ef4c1103bdfd5c0dc035a4646fbd6522f879cc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

