### PR TITLE
fix(agent): create parent dir before Daytona writeFile

### DIFF
--- a/frontend/packages/agent/src/executors/__tests__/daytona.test.ts
+++ b/frontend/packages/agent/src/executors/__tests__/daytona.test.ts
@@ -132,6 +132,55 @@ describe("DaytonaExecutor", () => {
       expect(mockSandbox.fs.uploadFile).toHaveBeenCalledWith(Buffer.from("hello"), "/tmp/test.txt");
     });
 
+    it("creates the parent directory before uploading a nested path", async () => {
+      // The download tools write into per-item subdirs that init() never creates
+      // (e.g. /workspace/traces/<id>_<name>/); uploadFile does not create parents,
+      // so writeFile must mkdir -p the parent first — and before the upload.
+      await executor.init();
+      vi.clearAllMocks();
+
+      await executor.writeFile("/workspace/traces/t1_name/spans.jsonl", "{}\n");
+
+      const mkdir = mockSandbox.process.executeCommand.mock.calls.find((c: [string]) =>
+        c[0].startsWith("mkdir -p"),
+      );
+      expect(mkdir).toBeTruthy();
+      expect(mkdir![0]).toBe("mkdir -p '/workspace/traces/t1_name'");
+      // mkdir runs before the upload
+      const mkdirOrder = mockSandbox.process.executeCommand.mock.invocationCallOrder[0];
+      const uploadOrder = mockSandbox.fs.uploadFile.mock.invocationCallOrder[0];
+      expect(mkdirOrder).toBeLessThan(uploadOrder);
+      expect(mockSandbox.fs.uploadFile).toHaveBeenCalledWith(
+        Buffer.from("{}\n"),
+        "/workspace/traces/t1_name/spans.jsonl",
+      );
+    });
+
+    it("does not mkdir for a root-level path", async () => {
+      await executor.init();
+      vi.clearAllMocks();
+
+      await executor.writeFile("/foo.txt", "x");
+
+      const mkdir = mockSandbox.process.executeCommand.mock.calls.find((c: [string]) =>
+        c[0].startsWith("mkdir -p"),
+      );
+      expect(mkdir).toBeUndefined();
+      expect(mockSandbox.fs.uploadFile).toHaveBeenCalledWith(Buffer.from("x"), "/foo.txt");
+    });
+
+    it("shell-escapes a parent dir containing single quotes", async () => {
+      await executor.init();
+      vi.clearAllMocks();
+
+      await executor.writeFile("/workspace/traces/o'brien/spans.jsonl", "{}\n");
+
+      const mkdir = mockSandbox.process.executeCommand.mock.calls.find((c: [string]) =>
+        c[0].startsWith("mkdir -p"),
+      );
+      expect(mkdir![0]).toBe("mkdir -p '/workspace/traces/o'\\''brien'");
+    });
+
     it("throws if not initialized", async () => {
       await expect(executor.writeFile("/tmp/x", "y")).rejects.toThrow("not initialized");
     });

--- a/frontend/packages/agent/src/executors/daytona.ts
+++ b/frontend/packages/agent/src/executors/daytona.ts
@@ -70,6 +70,15 @@ export class DaytonaExecutor implements Executor {
 
   async writeFile(path: string, content: string): Promise<void> {
     if (!this.sandbox) throw new Error("Sandbox not initialized");
+    // fs.uploadFile does not create missing parent directories, so writing into
+    // a nested path fails unless the parent already exists. The download tools
+    // write into per-item subdirs that init() never creates —
+    // /workspace/traces/<id>_<name>/ and /workspace/sessions/<id>/... — so
+    // create the parent first, mirroring DockerExecutor.writeFile.
+    const dir = path.includes("/") ? path.substring(0, path.lastIndexOf("/")) : "";
+    if (dir) {
+      await this.sandbox.process.executeCommand(`mkdir -p ${shellEscape(dir)}`);
+    }
     await this.sandbox.fs.uploadFile(Buffer.from(content), path);
   }
 
@@ -218,4 +227,8 @@ export async function setupGhCliDaytona(
     : "agent@traceroot.ai";
   await executor.exec(`git config --global user.name "${name}"`);
   await executor.exec(`git config --global user.email "${email}"`);
+}
+
+function shellEscape(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
 }


### PR DESCRIPTION
## What

`DaytonaExecutor.writeFile` calls `sandbox.fs.uploadFile` directly, which does
not create missing parent directories. This PR creates the parent directory
first (mirroring `DockerExecutor.writeFile`).

## Why

`init()` only creates `/workspace/{repos,traces,notes}`, but the download tools
write into nested per-item subdirs it never creates:

- `download_traces` → `/workspace/traces/<traceId>_<name>/{trace.jsonl,tree.json,spans.jsonl}`
- `download_session` → `/workspace/sessions/<id>/…`

So on the Daytona sandbox, `download_session` fails outright and
`download_traces` fails on each trace's subdir. `DockerExecutor.writeFile`
already guards against this with `mkdir -p <parent>` before writing
([docker.ts](../blob/main/frontend/packages/agent/src/executors/docker.ts)); the
Daytona path was missing the equivalent, which is the download failure reported
in #618.

## Fix

Before `uploadFile`, derive the parent directory from the path and
`mkdir -p` it via `sandbox.process.executeCommand`, mirroring
`DockerExecutor.writeFile`. Root-level paths skip the `mkdir`; the parent is
shell-escaped (same helper as the Docker executor).

## How validated

New unit tests in `daytona.test.ts` (mocked sandbox — no live Daytona):

- nested path issues `mkdir -p <parent>` **before** the upload
- a root-level path does **not** `mkdir`
- a parent dir containing a single quote is shell-escaped

`pnpm --filter @traceroot/agent test` → 25 passed; `eslint` / `tsc` / `prettier`
clean.

## Scope note

This fixes the missing-parent-directory failure, which is a total outage for
`download_session` and nested `download_traces` writes on Daytona. If a very
large `spans.jsonl` additionally hits Daytona's upload/proxy body-size limit,
that's a separate concern and a good follow-up — this PR deliberately keeps to
the parent-dir parity fix with `DockerExecutor`.

Refs #618


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create parent directories before `DaytonaExecutor.writeFile` uploads to prevent failures when writing to nested paths. This mirrors `DockerExecutor` and fixes broken `download_session` and nested `download_traces` writes on Daytona.

- **Bug Fixes**
  - `DaytonaExecutor.writeFile` now runs `mkdir -p <parent>` (shell-escaped) via `sandbox.process.executeCommand` before `fs.uploadFile`; skipped for root-level paths.
  - Tests added to confirm mkdir runs before upload, root-level skip, and single-quote escaping.

<sup>Written for commit 98a2e24abf3e80efff508e0ea1b6789f3de951ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

