### PR TITLE
fix(detector): make eval timeout durable in Helm (default 180s)

### DIFF
--- a/deploy/helm/templates/detector/deployment.yaml
+++ b/deploy/helm/templates/detector/deployment.yaml
@@ -99,6 +99,8 @@ spec:
                   key: {{ .Values.smtp.keys.mailFrom }}
             {{- end }}
             {{- end }}
+            - name: DETECTOR_EVAL_TIMEOUT_MS
+              value: {{ .Values.detector.evalTimeoutMs | default "180000" | quote }}
             {{- with .Values.additionalEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -89,6 +89,9 @@ detector:
     repository: ""
     tag: "latest"
   replicas: 1
+  # Per-attempt LLM eval timeout (ms). High enough to absorb slow/throttled
+  # BYOK providers (e.g. Z.AI glm) so their evals complete instead of timing out.
+  evalTimeoutMs: "180000"
   resources:
     requests:
       cpu: "250m"


### PR DESCRIPTION
## Problem
The detector worker's per-attempt LLM eval timeout (`DETECTOR_EVAL_TIMEOUT_MS`) was only ever applied as a **live `kubectl set env` patch** on the running deployment. It was never in the Helm chart — so **every `helm upgrade` / `terraform apply` silently reverted it to the 60s code default**, and it had to be re-applied by hand after each deploy.

## Why it matters
60s is too tight for slow / rate-throttled BYOK providers, whose evals can take 60–150s under load. When the timeout reverts to 60s, those evals fail with false timeouts (~18% of evals exceeded 60s on real large-trace traffic). 180s absorbs the slow tail so evals complete instead of failing.

## Change
- Add `DETECTOR_EVAL_TIMEOUT_MS` to the detector deployment env, sourced from `.Values.detector.evalTimeoutMs` with a built-in `default "180000"` — correct in **every environment** even if nothing is passed.
- Document the knob in `values.yaml` (`detector.evalTimeoutMs: "180000"`) for per-env override.

Net: 180s is durable across deploys; no more ephemeral kubectl patch. No behavior change vs. what prod runs today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the detector eval timeout persistent in Helm with a 180s default. This prevents upgrades from resetting it to 60s and avoids false timeouts on slow BYOK providers.

Adds DETECTOR_EVAL_TIMEOUT_MS to the detector deployment from .Values.detector.evalTimeoutMs (documented in values.yaml).

<sup>Written for commit 2b05a79bd02b3edd0a44a8b67ac89e090bc41c6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

