### PR TITLE
feat(api): public read API for detectors and detector findings

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -21,6 +21,7 @@ from slowapi.errors import RateLimitExceeded
 from rest.rate_limit import limiter, rate_limit_exceeded_handler
 from rest.routers.internal import router as internal_router
 from rest.routers.live import router as live_router
+from rest.routers.public.detectors_read import router as public_detectors_read_router
 from rest.routers.public.traces import router as public_traces_router
 from rest.routers.public.traces_read import router as public_traces_read_router
 from rest.routers.public.whoami import router as public_whoami_router
@@ -71,6 +72,7 @@ app.include_router(public_traces_router, prefix="/api/v1")
 # Public read API for API-key clients (e.g. the CLI)
 app.include_router(public_whoami_router, prefix="/api/v1")
 app.include_router(public_traces_read_router, prefix="/api/v1")
+app.include_router(public_detectors_read_router, prefix="/api/v1")
 
 # Internal API for worker/service communication (protected by secret)
 app.include_router(internal_router, prefix="/api/v1")

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1,6 +1,41 @@
 {
   "components": {
     "schemas": {
+      "DetectorItem": {
+        "description": "A detector from the project's catalog (Postgres ``detectors``).\n\n``detector_id`` is the value to pass to ``findings list --detector`` to filter\nfindings to this detector.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "detector_id": {
+            "title": "Detector Id",
+            "type": "string"
+          },
+          "enabled": {
+            "title": "Enabled",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "template": {
+            "title": "Template",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detector_id",
+          "name",
+          "template",
+          "enabled",
+          "created_at"
+        ],
+        "title": "DetectorItem",
+        "type": "object"
+      },
       "DetectorResultItem": {
         "description": "One detector's result within a finding, normalized from the stored payload.\n\nThe stored finding ``payload`` uses camelCase keys (``detectorId`` /\n``detectorName``); the public API exposes snake_case. Only triggered detectors\nare persisted, so ``identified`` is always ``True`` for a present item. ``data``\nis the detector's opaque output, passed through verbatim. ``template`` is looked\nup from the Postgres ``detectors`` row and is ``None`` when that row is absent\n(e.g. a deleted detector).",
         "properties": {
@@ -334,6 +369,27 @@
           "total"
         ],
         "title": "PaginationMeta",
+        "type": "object"
+      },
+      "PublicDetectorListResponse": {
+        "description": "Paginated list of the project's detectors for the public API.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/DetectorItem"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "PublicDetectorListResponse",
         "type": "object"
       },
       "PublicFindingListResponse": {
@@ -1051,6 +1107,104 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/public/detectors": {
+      "get": {
+        "description": "List the detectors in the API key's project (newest first).",
+        "operationId": "list_detectors_api_v1_public_detectors_get",
+        "parameters": [
+          {
+            "description": "Items per page",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Items per page",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicDetectorListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to list detectors"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List Detectors",
+        "tags": [
+          "Detectors (Public)"
+        ]
+      }
+    },
     "/api/v1/public/detectors/findings": {
       "get": {
         "description": "List recent detector findings for the API key's project (newest first).",

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1,6 +1,57 @@
 {
   "components": {
     "schemas": {
+      "DetectorResultItem": {
+        "description": "One detector's result within a finding, normalized from the stored payload.\n\nThe stored finding ``payload`` uses camelCase keys (``detectorId`` /\n``detectorName``); the public API exposes snake_case. Only triggered detectors\nare persisted, so ``identified`` is always ``True`` for a present item. ``data``\nis the detector's opaque output, passed through verbatim. ``template`` is looked\nup from the Postgres ``detectors`` row and is ``None`` when that row is absent\n(e.g. a deleted detector).",
+        "properties": {
+          "data": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "detector_id": {
+            "title": "Detector Id",
+            "type": "string"
+          },
+          "detector_name": {
+            "title": "Detector Name",
+            "type": "string"
+          },
+          "identified": {
+            "title": "Identified",
+            "type": "boolean"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "template": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Template"
+          }
+        },
+        "required": [
+          "detector_id",
+          "detector_name",
+          "template",
+          "summary",
+          "identified",
+          "data"
+        ],
+        "title": "DetectorResultItem",
+        "type": "object"
+      },
       "ExportManifest": {
         "description": "manifest.json: index of the bundle's parts.",
         "properties": {
@@ -31,6 +82,111 @@
           "files"
         ],
         "title": "ExportManifest",
+        "type": "object"
+      },
+      "FindingDetail": {
+        "description": "A finding plus its per-detector results and optional free-text RCA.",
+        "properties": {
+          "detectors": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "finding_id": {
+            "title": "Finding Id",
+            "type": "string"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "string"
+          },
+          "rca": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RCAResult"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/DetectorResultItem"
+            },
+            "title": "Results",
+            "type": "array"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "finding_id",
+          "project_id",
+          "trace_id",
+          "summary",
+          "timestamp",
+          "detectors",
+          "results",
+          "rca"
+        ],
+        "title": "FindingDetail",
+        "type": "object"
+      },
+      "FindingSummary": {
+        "description": "A detector finding row for the list view; ``detectors`` are display labels.",
+        "properties": {
+          "detectors": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Detectors",
+            "type": "array"
+          },
+          "finding_id": {
+            "title": "Finding Id",
+            "type": "string"
+          },
+          "project_id": {
+            "title": "Project Id",
+            "type": "string"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "timestamp": {
+            "format": "date-time",
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "finding_id",
+          "project_id",
+          "trace_id",
+          "summary",
+          "timestamp",
+          "detectors"
+        ],
+        "title": "FindingSummary",
         "type": "object"
       },
       "GitContext": {
@@ -178,6 +334,27 @@
           "total"
         ],
         "title": "PaginationMeta",
+        "type": "object"
+      },
+      "PublicFindingListResponse": {
+        "description": "Paginated list of detector findings for the public API.",
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/FindingSummary"
+            },
+            "title": "Data",
+            "type": "array"
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ],
+        "title": "PublicFindingListResponse",
         "type": "object"
       },
       "PublicTraceDetailResponse": {
@@ -496,6 +673,32 @@
           "meta"
         ],
         "title": "PublicTraceListResponse",
+        "type": "object"
+      },
+      "RCAResult": {
+        "description": "Free-text root-cause analysis for a finding (Postgres ``detector_rcas``).",
+        "properties": {
+          "result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Result"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "result"
+        ],
+        "title": "RCAResult",
         "type": "object"
       },
       "SpanResponse": {
@@ -848,6 +1051,319 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/api/v1/public/detectors/findings": {
+      "get": {
+        "description": "List recent detector findings for the API key's project (newest first).",
+        "operationId": "list_findings_api_v1_public_detectors_findings_get",
+        "parameters": [
+          {
+            "description": "Items per page",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 50,
+              "description": "Items per page",
+              "maximum": 200,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Only findings at or after this time (inclusive, ISO 8601)",
+            "in": "query",
+            "name": "start_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only findings at or after this time (inclusive, ISO 8601)",
+              "title": "Start After"
+            }
+          },
+          {
+            "description": "Only findings before this time (exclusive, ISO 8601)",
+            "in": "query",
+            "name": "end_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only findings before this time (exclusive, ISO 8601)",
+              "title": "End Before"
+            }
+          },
+          {
+            "description": "Filter by detector id, name, or template",
+            "in": "query",
+            "name": "detector",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by detector id, name, or template",
+              "title": "Detector"
+            }
+          },
+          {
+            "description": "Filter to a single trace",
+            "in": "query",
+            "name": "trace_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to a single trace",
+              "title": "Trace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicFindingListResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List Findings",
+        "tags": [
+          "Detectors (Public)"
+        ]
+      }
+    },
+    "/api/v1/public/detectors/findings/{finding_id}": {
+      "get": {
+        "description": "Get a single finding by id for the key's project.",
+        "operationId": "get_finding_api_v1_public_detectors_findings__finding_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "finding_id",
+            "required": true,
+            "schema": {
+              "title": "Finding Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FindingDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get Finding",
+        "tags": [
+          "Detectors (Public)"
+        ]
+      }
+    },
+    "/api/v1/public/detectors/traces/{trace_id}/finding": {
+      "get": {
+        "description": "Get the finding for a single trace (findings are 1-per-trace).",
+        "operationId": "get_finding_by_trace_api_v1_public_detectors_traces__trace_id__finding_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "trace_id",
+            "required": true,
+            "schema": {
+              "title": "Trace Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FindingDetail"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Get Finding By Trace",
+        "tags": [
+          "Detectors (Public)"
+        ]
+      }
+    },
     "/api/v1/public/traces": {
       "get": {
         "description": "List recent traces for the API key's project (newest first).",

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1125,6 +1125,44 @@
               "title": "Limit",
               "type": "integer"
             }
+          },
+          {
+            "description": "Only detectors created at or after this time (inclusive, ISO 8601)",
+            "in": "query",
+            "name": "start_after",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only detectors created at or after this time (inclusive, ISO 8601)",
+              "title": "Start After"
+            }
+          },
+          {
+            "description": "Only detectors created before this time (exclusive, ISO 8601)",
+            "in": "query",
+            "name": "end_before",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "date-time",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Only detectors created before this time (exclusive, ISO 8601)",
+              "title": "End Before"
+            }
           }
         ],
         "responses": {

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1181,6 +1181,21 @@
             },
             "description": "Validation Error"
           },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to list findings"
+          },
           "503": {
             "content": {
               "application/json": {
@@ -1249,6 +1264,21 @@
             },
             "description": "Authentication failed"
           },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Finding not found"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -1258,6 +1288,21 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to read finding"
           },
           "503": {
             "content": {
@@ -1327,6 +1372,21 @@
             },
             "description": "Authentication failed"
           },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Finding not found"
+          },
           "422": {
             "content": {
               "application/json": {
@@ -1336,6 +1396,21 @@
               }
             },
             "description": "Validation Error"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Failed to read finding"
           },
           "503": {
             "content": {

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -84,6 +84,19 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
             op["responses"].setdefault("404", _error_response("Trace not found"))
             op["responses"].setdefault("500", _error_response("Failed to get trace"))
 
+    # Detector findings read error contract (matches the route code).
+    findings_list_op = schema["paths"].get("/api/v1/public/detectors/findings", {}).get("get")
+    if findings_list_op is not None:
+        findings_list_op["responses"].setdefault("500", _error_response("Failed to list findings"))
+    for path in (
+        "/api/v1/public/detectors/findings/{finding_id}",
+        "/api/v1/public/detectors/traces/{trace_id}/finding",
+    ):
+        op = schema["paths"].get(path, {}).get("get")
+        if op is not None:
+            op["responses"].setdefault("404", _error_response("Finding not found"))
+            op["responses"].setdefault("500", _error_response("Failed to read finding"))
+
 
 def _collect_refs(node: Any, acc: set[str]) -> None:
     """Collect component schema names referenced by `$ref` anywhere under `node`."""

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -84,6 +84,13 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
             op["responses"].setdefault("404", _error_response("Trace not found"))
             op["responses"].setdefault("500", _error_response("Failed to get trace"))
 
+    # Detector catalog list error contract (matches the route code).
+    detectors_list_op = schema["paths"].get("/api/v1/public/detectors", {}).get("get")
+    if detectors_list_op is not None:
+        detectors_list_op["responses"].setdefault(
+            "500", _error_response("Failed to list detectors")
+        )
+
     # Detector findings read error contract (matches the route code).
     findings_list_op = schema["paths"].get("/api/v1/public/detectors/findings", {}).get("get")
     if findings_list_op is not None:

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -20,12 +20,42 @@ from rest.rate_limit import (
 )
 from rest.routers.public.deps import StampedAuth
 from rest.schemas.common import PaginationMeta
-from rest.schemas.public import FindingDetail, PublicFindingListResponse
+from rest.schemas.public import (
+    FindingDetail,
+    PublicDetectorListResponse,
+    PublicFindingListResponse,
+)
 from rest.services.detector_reader import DetectorReaderService, get_detector_reader_service
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/public/detectors", tags=["Detectors (Public)"])
+
+
+@router.get("", response_model=PublicDetectorListResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_detectors(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+):
+    """List the detectors in the API key's project (newest first)."""
+    try:
+        items, total = service.list_detectors(project_id=auth.project_id, limit=limit)
+    except Exception as e:
+        logger.exception(f"Error listing detectors: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list detectors",
+        ) from e
+
+    return PublicDetectorListResponse(
+        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    )
 
 
 @router.get("/findings", response_model=PublicFindingListResponse)

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -1,0 +1,114 @@
+"""Public, API-key-authenticated read API for detector findings.
+
+Mirrors the public traces read stack (StampedAuth, READ-bucket rate limiting,
+project-scoped reads). All access is scoped to the project resolved from the API
+key; a finding outside that project simply isn't found (404).
+"""
+
+import logging
+from collections.abc import Callable
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
+
+from rest.rate_limit import (
+    BUCKET_READ,
+    is_request_rate_limit_exempt,
+    key_read,
+    limiter,
+    resolve_limit,
+)
+from rest.routers.public.deps import StampedAuth
+from rest.schemas.common import PaginationMeta
+from rest.schemas.public import FindingDetail, PublicFindingListResponse
+from rest.services.detector_reader import DetectorReaderService, get_detector_reader_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/public/detectors", tags=["Detectors (Public)"])
+
+
+@router.get("/findings", response_model=PublicFindingListResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def list_findings(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+    limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    start_after: datetime | None = Query(
+        None, description="Only findings at or after this time (inclusive, ISO 8601)"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only findings before this time (exclusive, ISO 8601)"
+    ),
+    detector: str | None = Query(None, description="Filter by detector id, name, or template"),
+    trace_id: str | None = Query(None, description="Filter to a single trace"),
+):
+    """List recent detector findings for the API key's project (newest first)."""
+    try:
+        items, total = service.list_findings(
+            project_id=auth.project_id,
+            limit=limit,
+            start_after=start_after,
+            end_before=end_before,
+            detector=detector,
+            trace_id=trace_id,
+        )
+    except Exception as e:
+        logger.exception(f"Error listing detector findings: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list findings",
+        ) from e
+
+    return PublicFindingListResponse(
+        data=items, meta=PaginationMeta(page=0, limit=limit, total=total)
+    )
+
+
+@router.get("/findings/{finding_id}", response_model=FindingDetail)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def get_finding(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    finding_id: str,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+):
+    """Get a single finding by id for the key's project."""
+    return _require_finding(lambda: service.get_finding(auth.project_id, finding_id))
+
+
+@router.get("/traces/{trace_id}/finding", response_model=FindingDetail)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def get_finding_by_trace(
+    request: Request,
+    response: Response,
+    auth: StampedAuth,
+    trace_id: str,
+    service: DetectorReaderService = Depends(get_detector_reader_service),
+):
+    """Get the finding for a single trace (findings are 1-per-trace)."""
+    return _require_finding(lambda: service.get_finding_by_trace(auth.project_id, trace_id))
+
+
+def _require_finding(fetch: Callable[[], FindingDetail | None]) -> FindingDetail:
+    """Run a reader fetch, mapping None -> 404 and reader errors -> a clean 500."""
+    try:
+        finding = fetch()
+    except Exception as e:
+        logger.exception(f"Error reading detector finding: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to read finding",
+        ) from e
+    if finding is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Finding not found")
+    return finding

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -42,10 +42,21 @@ async def list_detectors(
     auth: StampedAuth,
     service: DetectorReaderService = Depends(get_detector_reader_service),
     limit: int = Query(50, ge=1, le=200, description="Items per page"),
+    start_after: datetime | None = Query(
+        None, description="Only detectors created at or after this time (inclusive, ISO 8601)"
+    ),
+    end_before: datetime | None = Query(
+        None, description="Only detectors created before this time (exclusive, ISO 8601)"
+    ),
 ):
     """List the detectors in the API key's project (newest first)."""
     try:
-        items, total = service.list_detectors(project_id=auth.project_id, limit=limit)
+        items, total = service.list_detectors(
+            project_id=auth.project_id,
+            limit=limit,
+            start_after=start_after,
+            end_before=end_before,
+        )
     except Exception as e:
         logger.exception(f"Error listing detectors: {e}")
         raise HTTPException(

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -134,3 +134,24 @@ class PublicFindingListResponse(BaseModel):
 
     data: list[FindingSummary]
     meta: PaginationMeta
+
+
+class DetectorItem(BaseModel):
+    """A detector from the project's catalog (Postgres ``detectors``).
+
+    ``detector_id`` is the value to pass to ``findings list --detector`` to filter
+    findings to this detector.
+    """
+
+    detector_id: str
+    name: str
+    template: str
+    enabled: bool
+    created_at: datetime
+
+
+class PublicDetectorListResponse(BaseModel):
+    """Paginated list of the project's detectors for the public API."""
+
+    data: list[DetectorItem]
+    meta: PaginationMeta

--- a/backend/rest/schemas/public.py
+++ b/backend/rest/schemas/public.py
@@ -1,5 +1,8 @@
 """Response schemas for the public, API-key-authenticated API."""
 
+from datetime import datetime
+from typing import Any
+
 from pydantic import BaseModel
 
 from rest.schemas.common import PaginationMeta
@@ -80,3 +83,54 @@ class PublicTraceExportResponse(BaseModel):
     # null. See rest.projection and the export endpoint's default `fields`.
     spans: list[SpanResponse]
     git_context: GitContext
+
+
+class DetectorResultItem(BaseModel):
+    """One detector's result within a finding, normalized from the stored payload.
+
+    The stored finding ``payload`` uses camelCase keys (``detectorId`` /
+    ``detectorName``); the public API exposes snake_case. Only triggered detectors
+    are persisted, so ``identified`` is always ``True`` for a present item. ``data``
+    is the detector's opaque output, passed through verbatim. ``template`` is looked
+    up from the Postgres ``detectors`` row and is ``None`` when that row is absent
+    (e.g. a deleted detector).
+    """
+
+    detector_id: str
+    detector_name: str
+    template: str | None
+    summary: str
+    identified: bool
+    data: Any | None
+
+
+class RCAResult(BaseModel):
+    """Free-text root-cause analysis for a finding (Postgres ``detector_rcas``)."""
+
+    status: str
+    result: str | None
+
+
+class FindingSummary(BaseModel):
+    """A detector finding row for the list view; ``detectors`` are display labels."""
+
+    finding_id: str
+    project_id: str
+    trace_id: str
+    summary: str
+    timestamp: datetime
+    detectors: list[str]
+
+
+class FindingDetail(FindingSummary):
+    """A finding plus its per-detector results and optional free-text RCA."""
+
+    results: list[DetectorResultItem]
+    rca: RCAResult | None
+
+
+class PublicFindingListResponse(BaseModel):
+    """Paginated list of detector findings for the public API."""
+
+    data: list[FindingSummary]
+    meta: PaginationMeta

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -20,6 +20,7 @@ import psycopg2
 
 from db.clickhouse import get_clickhouse_client
 from rest.schemas.public import (
+    DetectorItem,
     DetectorResultItem,
     FindingDetail,
     FindingSummary,
@@ -69,6 +70,38 @@ class DetectorReaderService:
             for item in self._parse_payload(payload)
             if isinstance(item, dict) and item.get("detectorName") is not None
         ]
+
+    # ------------------------------------------------------------------ #
+    # detector catalog
+    # ------------------------------------------------------------------ #
+    def list_detectors(self, project_id: str, limit: int) -> tuple[list[DetectorItem], int]:
+        """List the project's detectors (Postgres catalog), newest first.
+
+        Returns the page of items plus the total match count. Unlike the RCA /
+        template enrichment reads, a catalog-read failure is NOT swallowed — it
+        propagates so the router can return a controlled 500.
+        """
+        count_rows = self._pg_rows(
+            "SELECT count(*) FROM detectors WHERE project_id = %s", (project_id,)
+        )
+        total = count_rows[0][0] if count_rows else 0
+
+        rows = self._pg_rows(
+            "SELECT id, name, template, enabled, create_time FROM detectors "
+            "WHERE project_id = %s ORDER BY create_time DESC LIMIT %s",
+            (project_id, limit),
+        )
+        items = [
+            DetectorItem(
+                detector_id=row[0],
+                name=row[1],
+                template=row[2],
+                enabled=row[3],
+                created_at=row[4],
+            )
+            for row in rows
+        ]
+        return items, total
 
     # ------------------------------------------------------------------ #
     # list

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -74,22 +74,38 @@ class DetectorReaderService:
     # ------------------------------------------------------------------ #
     # detector catalog
     # ------------------------------------------------------------------ #
-    def list_detectors(self, project_id: str, limit: int) -> tuple[list[DetectorItem], int]:
+    def list_detectors(
+        self,
+        project_id: str,
+        limit: int,
+        start_after: datetime | None = None,
+        end_before: datetime | None = None,
+    ) -> tuple[list[DetectorItem], int]:
         """List the project's detectors (Postgres catalog), newest first.
 
-        Returns the page of items plus the total match count. Unlike the RCA /
-        template enrichment reads, a catalog-read failure is NOT swallowed — it
-        propagates so the router can return a controlled 500.
+        The optional ``start_after`` / ``end_before`` bounds filter on the
+        detector's creation time (inclusive lower, exclusive upper), mirroring the
+        findings/traces list windows. Returns the page of items plus the total
+        match count. Unlike the RCA / template enrichment reads, a catalog-read
+        failure is NOT swallowed — it propagates so the router returns a 500.
         """
-        count_rows = self._pg_rows(
-            "SELECT count(*) FROM detectors WHERE project_id = %s", (project_id,)
-        )
+        conditions = ["project_id = %s"]
+        params: list[Any] = [project_id]
+        if start_after is not None:
+            conditions.append("create_time >= %s")
+            params.append(to_utc_naive(start_after))
+        if end_before is not None:
+            conditions.append("create_time < %s")
+            params.append(to_utc_naive(end_before))
+        where = " AND ".join(conditions)
+
+        count_rows = self._pg_rows(f"SELECT count(*) FROM detectors WHERE {where}", tuple(params))
         total = count_rows[0][0] if count_rows else 0
 
         rows = self._pg_rows(
-            "SELECT id, name, template, enabled, create_time FROM detectors "
-            "WHERE project_id = %s ORDER BY create_time DESC LIMIT %s",
-            (project_id, limit),
+            f"SELECT id, name, template, enabled, create_time FROM detectors "
+            f"WHERE {where} ORDER BY create_time DESC LIMIT %s",
+            (*params, limit),
         )
         items = [
             DetectorItem(

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -81,13 +81,22 @@ class DetectorReaderService:
         start_after: datetime | None = None,
         end_before: datetime | None = None,
     ) -> tuple[list[DetectorItem], int]:
-        """List the project's detectors (Postgres catalog), newest first.
+        """List the project's detectors from the Postgres catalog, newest first.
 
-        The optional ``start_after`` / ``end_before`` bounds filter on the
-        detector's creation time (inclusive lower, exclusive upper), mirroring the
-        findings/traces list windows. Returns the page of items plus the total
-        match count. Unlike the RCA / template enrichment reads, a catalog-read
-        failure is NOT swallowed — it propagates so the router returns a 500.
+        Args:
+            project_id: Owning project; every query is scoped to it.
+            limit: Max items in the returned page (already validated by the router).
+            start_after: Inclusive lower bound on the detector's ``create_time``.
+            end_before: Exclusive upper bound on the detector's ``create_time``.
+
+        Returns:
+            ``(items, total)`` — the page of :class:`DetectorItem` ordered by
+            ``create_time`` DESC, plus the total number of catalog rows matching the
+            filters (for pagination).
+
+        The ``start_after`` / ``end_before`` window mirrors the findings/traces list
+        windows. Unlike the best-effort RCA/template enrichment reads, a failure
+        here is NOT swallowed: it propagates so the router returns a controlled 500.
         """
         conditions = ["project_id = %s"]
         params: list[Any] = [project_id]
@@ -131,17 +140,40 @@ class DetectorReaderService:
         detector: str | None,
         trace_id: str | None,
     ) -> tuple[list[FindingSummary], int]:
-        """List findings for a project, newest first, with the total match count."""
+        """List a project's detector findings, newest first, with the total match count.
+
+        Args:
+            project_id: Owning project; every query is scoped to it.
+            limit: Max findings in the returned page (already validated by the router).
+            start_after: Inclusive lower bound on a finding's (latest) ``timestamp``.
+            end_before: Exclusive upper bound on a finding's ``timestamp``.
+            detector: Optional selector (id / name / template); resolved server-side
+                to the set of matching detector names+ids and matched against the
+                stored payload. An unresolved token simply matches nothing.
+            trace_id: Optional restriction to a single trace's finding.
+
+        Returns:
+            ``(items, total)`` — the page of :class:`FindingSummary` ordered by
+            ``timestamp`` DESC, plus the total number of distinct findings matching
+            the filters.
+
+        ``detector_findings`` is a ``ReplacingMergeTree(timestamp)``, so every query
+        first dedups to the latest row per ``finding_id`` (``LIMIT 1 BY``), and
+        filter placement is both correctness- and cost-critical:
+
+        * ``project_id`` / ``trace_id`` (immutable across re-ingested versions) and
+          ``start_after`` are applied BEFORE the dedup. ``start_after`` is safe
+          there because a finding's latest version carries the max timestamp, so it
+          survives ``timestamp >= start`` iff its latest version does — this scopes
+          the expensive dedup + count to the window instead of all history.
+        * ``end_before`` and the payload-based ``detector`` predicate are
+          version-sensitive and applied AFTER the dedup; on raw pre-merge rows an
+          older version ``< end_before`` (or an outdated payload) could otherwise
+          resurface a finding whose latest version no longer matches.
+        """
         params: dict[str, Any] = {"project_id": project_id, "limit": limit}
 
-        # Filters safe to apply BEFORE dedup — they scope the (expensive) dedup +
-        # count aggregation to fewer rows instead of the project's full finding
-        # history. project_id/trace_id are immutable across re-ingested versions.
-        # start_after is safe too: a finding's LATEST version has the MAX timestamp,
-        # so the finding survives `timestamp >= start` in the pre-dedup scan iff its
-        # latest version does — no stale version can slip through the lower bound.
-        # Since `--since` sets only start_after, the common windowed query is now
-        # bounded to the window rather than deduping every finding ever produced.
+        # Pre-dedup filters (see the docstring: safe here + they prune the scan).
         base_conditions = ["project_id = {project_id:String}"]
         if trace_id is not None:
             base_conditions.append("trace_id = {trace_id:String}")
@@ -150,12 +182,7 @@ class DetectorReaderService:
             base_conditions.append("timestamp >= {start_after:DateTime64(3)}")
             params["start_after"] = to_utc_naive(start_after)
 
-        # Version-sensitive filters — applied AFTER dedup, to the latest version
-        # only. detector_findings is a ReplacingMergeTree(timestamp); an UPPER time
-        # bound or the payload-based detector predicate on raw pre-merge rows could
-        # surface a stale finding whose latest version no longer matches (an older
-        # version < end_before, or an outdated payload). So we dedup to the latest
-        # row per finding first, then filter.
+        # Post-dedup, version-sensitive filters (see the docstring).
         outer_conditions: list[str] = []
         if end_before is not None:
             outer_conditions.append("timestamp < {end_before:DateTime64(3)}")

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -97,12 +97,15 @@ class DetectorReaderService:
             params["trace_id"] = trace_id
         if detector is not None:
             # Backend-owned resolution: match a finding whose payload contains any
-            # of the resolved detector names. The raw token is always included, so
-            # an unresolved token simply matches nothing (empty list, not an error).
+            # of the resolved tokens by detectorName OR detectorId. The raw token is
+            # always included, so `detector=<id>` matches a payload detectorId even
+            # when Postgres resolves nothing; an unresolved token matches nothing
+            # (empty list, not an error).
             params["detector_names"] = self._resolve_detector_names(project_id, detector)
             conditions.append(
                 "arrayExists("
-                "x -> JSONExtractString(x, 'detectorName') IN {detector_names:Array(String)}, "
+                "x -> JSONExtractString(x, 'detectorName') IN {detector_names:Array(String)} "
+                "OR JSONExtractString(x, 'detectorId') IN {detector_names:Array(String)}, "
                 "JSONExtractArrayRaw(payload))"
             )
 

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -1,0 +1,263 @@
+"""Service for reading detector findings from ClickHouse + Postgres.
+
+Findings live in ClickHouse (`detector_findings`, a `ReplacingMergeTree` keyed by
+`timestamp`); the free-text RCA (`detector_rcas`) and the detector catalog
+(`detectors`, used to resolve the `--detector` selector and look up templates)
+live in Postgres. All reads are scoped to the caller's `project_id`.
+
+Postgres is best-effort for enrichment: an RCA or template lookup that is missing
+or fails degrades to ``None`` and never prevents a finding from being returned. A
+ClickHouse failure on the finding read itself propagates (the router maps it to a
+controlled 500).
+"""
+
+import json
+import logging
+from datetime import datetime
+from typing import Any
+
+import psycopg2
+
+from db.clickhouse import get_clickhouse_client
+from rest.schemas.public import (
+    DetectorResultItem,
+    FindingDetail,
+    FindingSummary,
+    RCAResult,
+)
+from rest.sql_utils import to_utc_naive
+from shared.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class DetectorReaderService:
+    """Read detector findings (ClickHouse) plus RCA/templates (Postgres)."""
+
+    def __init__(self):
+        self._client = get_clickhouse_client()
+
+    # ------------------------------------------------------------------ #
+    # Postgres boundary (single read-only seam; mocked in unit tests)
+    # ------------------------------------------------------------------ #
+    def _pg_rows(self, sql: str, params: tuple) -> list[tuple]:
+        """Run a read-only Postgres query and return all rows."""
+        conn = psycopg2.connect(settings.database_url)
+        try:
+            with conn.cursor() as cur:
+                cur.execute(sql, params)
+                return cur.fetchall()
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------ #
+    # payload helpers
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _parse_payload(payload: str) -> list[dict]:
+        """Parse the stored finding payload JSON array; [] on any malformed input."""
+        try:
+            data = json.loads(payload) if payload else []
+        except (ValueError, TypeError):
+            return []
+        return data if isinstance(data, list) else []
+
+    def _detector_labels(self, payload: str) -> list[str]:
+        """Display labels (`detectorName`) for the DETECTORS column."""
+        return [
+            str(item["detectorName"])
+            for item in self._parse_payload(payload)
+            if isinstance(item, dict) and item.get("detectorName") is not None
+        ]
+
+    # ------------------------------------------------------------------ #
+    # list
+    # ------------------------------------------------------------------ #
+    def list_findings(
+        self,
+        project_id: str,
+        limit: int,
+        start_after: datetime | None,
+        end_before: datetime | None,
+        detector: str | None,
+        trace_id: str | None,
+    ) -> tuple[list[FindingSummary], int]:
+        """List findings for a project, newest first, with the total match count."""
+        conditions = ["project_id = {project_id:String}"]
+        params: dict[str, Any] = {"project_id": project_id, "limit": limit}
+
+        if start_after is not None:
+            conditions.append("timestamp >= {start_after:DateTime64(3)}")
+            params["start_after"] = to_utc_naive(start_after)
+        if end_before is not None:
+            conditions.append("timestamp < {end_before:DateTime64(3)}")
+            params["end_before"] = to_utc_naive(end_before)
+        if trace_id is not None:
+            conditions.append("trace_id = {trace_id:String}")
+            params["trace_id"] = trace_id
+        if detector is not None:
+            # Backend-owned resolution: match a finding whose payload contains any
+            # of the resolved detector names. The raw token is always included, so
+            # an unresolved token simply matches nothing (empty list, not an error).
+            params["detector_names"] = self._resolve_detector_names(project_id, detector)
+            conditions.append(
+                "arrayExists("
+                "x -> JSONExtractString(x, 'detectorName') IN {detector_names:Array(String)}, "
+                "JSONExtractArrayRaw(payload))"
+            )
+
+        where = " AND ".join(conditions)
+
+        count_query = f"""
+            SELECT count(DISTINCT finding_id)
+            FROM detector_findings
+            WHERE {where}
+        """
+        count_result = self._client.query(count_query, parameters=params)
+        total = count_result.result_rows[0][0] if count_result.result_rows else 0
+
+        # Dedup the ReplacingMergeTree rows (latest per finding_id) BEFORE limiting.
+        list_query = f"""
+            SELECT finding_id, project_id, trace_id, summary, payload, timestamp
+            FROM (
+                SELECT finding_id, project_id, trace_id, summary, payload, timestamp
+                FROM detector_findings
+                WHERE {where}
+                ORDER BY timestamp DESC
+                LIMIT 1 BY finding_id
+            )
+            ORDER BY timestamp DESC
+            LIMIT {{limit:UInt32}}
+        """
+        result = self._client.query(list_query, parameters=params)
+        items = [
+            FindingSummary(
+                finding_id=row[0],
+                project_id=row[1],
+                trace_id=row[2],
+                summary=row[3],
+                timestamp=row[5],
+                detectors=self._detector_labels(row[4]),
+            )
+            for row in result.result_rows
+        ]
+        return items, total
+
+    def _resolve_detector_names(self, project_id: str, token: str) -> list[str]:
+        """Resolve a `--detector` token to the set of matching detector names.
+
+        Always includes the raw token (so a name typed directly still matches the
+        payload), plus any project detector whose id, name, or template equals the
+        token. A Postgres failure degrades to just the raw token.
+        """
+        names = {token}
+        try:
+            rows = self._pg_rows(
+                "SELECT name FROM detectors "
+                "WHERE project_id = %s AND (id = %s OR name = %s OR template = %s)",
+                (project_id, token, token, token),
+            )
+            names.update(r[0] for r in rows if r and r[0] is not None)
+        except Exception:
+            logger.warning("detector resolution failed; using raw token", exc_info=True)
+        return list(names)
+
+    # ------------------------------------------------------------------ #
+    # detail
+    # ------------------------------------------------------------------ #
+    def get_finding(self, project_id: str, finding_id: str) -> FindingDetail | None:
+        row = self._fetch_finding(
+            "finding_id = {finding_id:String}",
+            {"project_id": project_id, "finding_id": finding_id},
+        )
+        return self._build_detail(project_id, row) if row else None
+
+    def get_finding_by_trace(self, project_id: str, trace_id: str) -> FindingDetail | None:
+        row = self._fetch_finding(
+            "trace_id = {trace_id:String}",
+            {"project_id": project_id, "trace_id": trace_id},
+        )
+        return self._build_detail(project_id, row) if row else None
+
+    def _fetch_finding(self, predicate: str, params: dict) -> tuple | None:
+        query = f"""
+            SELECT finding_id, project_id, trace_id, summary, payload, timestamp
+            FROM detector_findings
+            WHERE project_id = {{project_id:String}} AND {predicate}
+            ORDER BY timestamp DESC
+            LIMIT 1
+        """
+        result = self._client.query(query, parameters=params)
+        rows = result.result_rows
+        return rows[0] if rows else None
+
+    def _build_detail(self, project_id: str, row: tuple) -> FindingDetail:
+        finding_id, _project_id, trace_id, summary, payload, timestamp = row
+        parsed = self._parse_payload(payload)
+        templates = self._read_templates(
+            project_id, [item.get("detectorId") for item in parsed if isinstance(item, dict)]
+        )
+        results = [
+            DetectorResultItem(
+                detector_id=item.get("detectorId") or "",
+                detector_name=item.get("detectorName") or "",
+                template=templates.get(item.get("detectorId")),
+                summary=item.get("summary") or "",
+                identified=True,
+                data=item.get("data"),
+            )
+            for item in parsed
+            if isinstance(item, dict)
+        ]
+        return FindingDetail(
+            finding_id=finding_id,
+            project_id=project_id,
+            trace_id=trace_id,
+            summary=summary,
+            timestamp=timestamp,
+            detectors=[r.detector_name for r in results],
+            results=results,
+            rca=self._read_rca(project_id, finding_id),
+        )
+
+    def _read_templates(self, project_id: str, detector_ids: list[str]) -> dict[str, str | None]:
+        """Map detector_id -> template from Postgres; {} on missing/failed lookup."""
+        ids = [d for d in detector_ids if d]
+        if not ids:
+            return {}
+        try:
+            rows = self._pg_rows(
+                "SELECT id, template FROM detectors WHERE project_id = %s AND id = ANY(%s)",
+                (project_id, ids),
+            )
+            return {r[0]: r[1] for r in rows}
+        except Exception:
+            logger.warning("template lookup failed; templates will be null", exc_info=True)
+            return {}
+
+    def _read_rca(self, project_id: str, finding_id: str) -> RCAResult | None:
+        """Read the finding's free-text RCA from Postgres; None if missing/failed."""
+        try:
+            rows = self._pg_rows(
+                "SELECT status, result FROM detector_rcas "
+                "WHERE project_id = %s AND finding_id = %s LIMIT 1",
+                (project_id, finding_id),
+            )
+        except Exception:
+            logger.warning("RCA lookup failed; returning rca=None", exc_info=True)
+            return None
+        if not rows:
+            return None
+        return RCAResult(status=rows[0][0], result=rows[0][1])
+
+
+# Singleton instance
+_service: DetectorReaderService | None = None
+
+
+def get_detector_reader_service() -> DetectorReaderService:
+    """Get or create the singleton DetectorReaderService."""
+    global _service
+    if _service is None:
+        _service = DetectorReaderService()
+    return _service

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -134,22 +134,29 @@ class DetectorReaderService:
         """List findings for a project, newest first, with the total match count."""
         params: dict[str, Any] = {"project_id": project_id, "limit": limit}
 
-        # Immutable filters — safe to apply BEFORE dedup because a finding's
-        # project_id and trace_id never change across re-ingested versions.
+        # Filters safe to apply BEFORE dedup — they scope the (expensive) dedup +
+        # count aggregation to fewer rows instead of the project's full finding
+        # history. project_id/trace_id are immutable across re-ingested versions.
+        # start_after is safe too: a finding's LATEST version has the MAX timestamp,
+        # so the finding survives `timestamp >= start` in the pre-dedup scan iff its
+        # latest version does — no stale version can slip through the lower bound.
+        # Since `--since` sets only start_after, the common windowed query is now
+        # bounded to the window rather than deduping every finding ever produced.
         base_conditions = ["project_id = {project_id:String}"]
         if trace_id is not None:
             base_conditions.append("trace_id = {trace_id:String}")
             params["trace_id"] = trace_id
+        if start_after is not None:
+            base_conditions.append("timestamp >= {start_after:DateTime64(3)}")
+            params["start_after"] = to_utc_naive(start_after)
 
         # Version-sensitive filters — applied AFTER dedup, to the latest version
-        # only. detector_findings is a ReplacingMergeTree(timestamp); filtering the
-        # time window or the payload-based detector predicate on raw pre-merge rows
-        # could surface a stale finding version whose latest version no longer
-        # matches. So we dedup to the latest row per finding first, then filter.
+        # only. detector_findings is a ReplacingMergeTree(timestamp); an UPPER time
+        # bound or the payload-based detector predicate on raw pre-merge rows could
+        # surface a stale finding whose latest version no longer matches (an older
+        # version < end_before, or an outdated payload). So we dedup to the latest
+        # row per finding first, then filter.
         outer_conditions: list[str] = []
-        if start_after is not None:
-            outer_conditions.append("timestamp >= {start_after:DateTime64(3)}")
-            params["start_after"] = to_utc_naive(start_after)
         if end_before is not None:
             outer_conditions.append("timestamp < {end_before:DateTime64(3)}")
             params["end_before"] = to_utc_naive(end_before)

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -83,20 +83,20 @@ class DetectorReaderService:
     ) -> tuple[list[DetectorItem], int]:
         """List the project's detectors from the Postgres catalog, newest first.
 
-        Args:
-            project_id: Owning project; every query is scoped to it.
-            limit: Max items in the returned page (already validated by the router).
-            start_after: Inclusive lower bound on the detector's ``create_time``.
-            end_before: Exclusive upper bound on the detector's ``create_time``.
-
-        Returns:
-            ``(items, total)`` — the page of :class:`DetectorItem` ordered by
-            ``create_time`` DESC, plus the total number of catalog rows matching the
-            filters (for pagination).
-
         The ``start_after`` / ``end_before`` window mirrors the findings/traces list
         windows. Unlike the best-effort RCA/template enrichment reads, a failure
         here is NOT swallowed: it propagates so the router returns a controlled 500.
+
+        Args:
+            project_id (str): Owning project; every query is scoped to it.
+            limit (int): Max items in the returned page (already validated by the router).
+            start_after (datetime | None): Inclusive lower bound on ``create_time``.
+            end_before (datetime | None): Exclusive upper bound on ``create_time``.
+
+        Returns:
+            tuple[list[DetectorItem], int]: The page of :class:`DetectorItem` ordered
+            by ``create_time`` DESC, plus the total number of catalog rows matching
+            the filters (for pagination).
         """
         conditions = ["project_id = %s"]
         params: list[Any] = [project_id]
@@ -142,21 +142,6 @@ class DetectorReaderService:
     ) -> tuple[list[FindingSummary], int]:
         """List a project's detector findings, newest first, with the total match count.
 
-        Args:
-            project_id: Owning project; every query is scoped to it.
-            limit: Max findings in the returned page (already validated by the router).
-            start_after: Inclusive lower bound on a finding's (latest) ``timestamp``.
-            end_before: Exclusive upper bound on a finding's ``timestamp``.
-            detector: Optional selector (id / name / template); resolved server-side
-                to the set of matching detector names+ids and matched against the
-                stored payload. An unresolved token simply matches nothing.
-            trace_id: Optional restriction to a single trace's finding.
-
-        Returns:
-            ``(items, total)`` — the page of :class:`FindingSummary` ordered by
-            ``timestamp`` DESC, plus the total number of distinct findings matching
-            the filters.
-
         ``detector_findings`` is a ``ReplacingMergeTree(timestamp)``, so every query
         first dedups to the latest row per ``finding_id`` (``LIMIT 1 BY``), and
         filter placement is both correctness- and cost-critical:
@@ -170,6 +155,21 @@ class DetectorReaderService:
           version-sensitive and applied AFTER the dedup; on raw pre-merge rows an
           older version ``< end_before`` (or an outdated payload) could otherwise
           resurface a finding whose latest version no longer matches.
+
+        Args:
+            project_id (str): Owning project; every query is scoped to it.
+            limit (int): Max findings in the returned page (already validated by the router).
+            start_after (datetime | None): Inclusive lower bound on ``timestamp``.
+            end_before (datetime | None): Exclusive upper bound on ``timestamp``.
+            detector (str | None): Optional selector (id / name / template); resolved
+                server-side to the matching detector names+ids and matched against
+                the stored payload. An unresolved token simply matches nothing.
+            trace_id (str | None): Optional restriction to a single trace's finding.
+
+        Returns:
+            tuple[list[FindingSummary], int]: The page of :class:`FindingSummary`
+            ordered by ``timestamp`` DESC, plus the total number of distinct findings
+            matching the filters.
         """
         params: dict[str, Any] = {"project_id": project_id, "limit": limit}
 

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -83,18 +83,27 @@ class DetectorReaderService:
         trace_id: str | None,
     ) -> tuple[list[FindingSummary], int]:
         """List findings for a project, newest first, with the total match count."""
-        conditions = ["project_id = {project_id:String}"]
         params: dict[str, Any] = {"project_id": project_id, "limit": limit}
 
+        # Immutable filters — safe to apply BEFORE dedup because a finding's
+        # project_id and trace_id never change across re-ingested versions.
+        base_conditions = ["project_id = {project_id:String}"]
+        if trace_id is not None:
+            base_conditions.append("trace_id = {trace_id:String}")
+            params["trace_id"] = trace_id
+
+        # Version-sensitive filters — applied AFTER dedup, to the latest version
+        # only. detector_findings is a ReplacingMergeTree(timestamp); filtering the
+        # time window or the payload-based detector predicate on raw pre-merge rows
+        # could surface a stale finding version whose latest version no longer
+        # matches. So we dedup to the latest row per finding first, then filter.
+        outer_conditions: list[str] = []
         if start_after is not None:
-            conditions.append("timestamp >= {start_after:DateTime64(3)}")
+            outer_conditions.append("timestamp >= {start_after:DateTime64(3)}")
             params["start_after"] = to_utc_naive(start_after)
         if end_before is not None:
-            conditions.append("timestamp < {end_before:DateTime64(3)}")
+            outer_conditions.append("timestamp < {end_before:DateTime64(3)}")
             params["end_before"] = to_utc_naive(end_before)
-        if trace_id is not None:
-            conditions.append("trace_id = {trace_id:String}")
-            params["trace_id"] = trace_id
         if detector is not None:
             # Backend-owned resolution: match a finding whose payload contains any
             # of the resolved tokens by detectorName OR detectorId. The raw token is
@@ -102,33 +111,32 @@ class DetectorReaderService:
             # when Postgres resolves nothing; an unresolved token matches nothing
             # (empty list, not an error).
             params["detector_names"] = self._resolve_detector_names(project_id, detector)
-            conditions.append(
+            outer_conditions.append(
                 "arrayExists("
                 "x -> JSONExtractString(x, 'detectorName') IN {detector_names:Array(String)} "
                 "OR JSONExtractString(x, 'detectorId') IN {detector_names:Array(String)}, "
                 "JSONExtractArrayRaw(payload))"
             )
 
-        where = " AND ".join(conditions)
+        base_where = " AND ".join(base_conditions)
+        outer_where = (" WHERE " + " AND ".join(outer_conditions)) if outer_conditions else ""
 
-        count_query = f"""
-            SELECT count(DISTINCT finding_id)
+        # Dedup the ReplacingMergeTree rows to the latest per finding_id first.
+        deduped = f"""
+            SELECT finding_id, project_id, trace_id, summary, payload, timestamp
             FROM detector_findings
-            WHERE {where}
+            WHERE {base_where}
+            ORDER BY timestamp DESC
+            LIMIT 1 BY finding_id
         """
+
+        count_query = f"SELECT count() FROM ({deduped}){outer_where}"
         count_result = self._client.query(count_query, parameters=params)
         total = count_result.result_rows[0][0] if count_result.result_rows else 0
 
-        # Dedup the ReplacingMergeTree rows (latest per finding_id) BEFORE limiting.
         list_query = f"""
             SELECT finding_id, project_id, trace_id, summary, payload, timestamp
-            FROM (
-                SELECT finding_id, project_id, trace_id, summary, payload, timestamp
-                FROM detector_findings
-                WHERE {where}
-                ORDER BY timestamp DESC
-                LIMIT 1 BY finding_id
-            )
+            FROM ({deduped}){outer_where}
             ORDER BY timestamp DESC
             LIMIT {{limit:UInt32}}
         """

--- a/backend/rest/services/detector_reader.py
+++ b/backend/rest/services/detector_reader.py
@@ -46,7 +46,7 @@ class DetectorReaderService:
         try:
             with conn.cursor() as cur:
                 cur.execute(sql, params)
-                return cur.fetchall()
+                return list(cur.fetchall())
         finally:
             conn.close()
 
@@ -193,21 +193,19 @@ class DetectorReaderService:
 
     def _build_detail(self, project_id: str, row: tuple) -> FindingDetail:
         finding_id, _project_id, trace_id, summary, payload, timestamp = row
-        parsed = self._parse_payload(payload)
-        templates = self._read_templates(
-            project_id, [item.get("detectorId") for item in parsed if isinstance(item, dict)]
-        )
+        items = [item for item in self._parse_payload(payload) if isinstance(item, dict)]
+        detector_ids = [str(item.get("detectorId") or "") for item in items]
+        templates = self._read_templates(project_id, [d for d in detector_ids if d])
         results = [
             DetectorResultItem(
-                detector_id=item.get("detectorId") or "",
-                detector_name=item.get("detectorName") or "",
-                template=templates.get(item.get("detectorId")),
-                summary=item.get("summary") or "",
+                detector_id=detector_id,
+                detector_name=str(item.get("detectorName") or ""),
+                template=templates.get(detector_id),
+                summary=str(item.get("summary") or ""),
                 identified=True,
                 data=item.get("data"),
             )
-            for item in parsed
-            if isinstance(item, dict)
+            for item, detector_id in zip(items, detector_ids)
         ]
         return FindingDetail(
             finding_id=finding_id,

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -126,7 +126,7 @@ def test_list_findings_detector_filter_matches_detector_id_without_resolution(re
     assert names == ["d1"]
 
 
-def test_list_findings_deduplicates_before_version_sensitive_filters(reader, monkeypatch):
+def test_list_findings_places_time_filters_for_dedup_correctness(reader, monkeypatch):
     reader._client.rows = []
     reader._client.count_rows = [(0,)]
     monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
@@ -135,18 +135,23 @@ def test_list_findings_deduplicates_before_version_sensitive_filters(reader, mon
         project_id="p1",
         limit=50,
         start_after=datetime(2026, 6, 1),
-        end_before=None,
+        end_before=datetime(2026, 6, 30),
         detector="hallucination",
         trace_id=None,
     )
 
-    # The version-sensitive filters (timestamp window + payload predicate) must be
-    # applied to the deduped subquery, i.e. AFTER `LIMIT 1 BY finding_id` — otherwise
-    # a stale finding version could be surfaced on a ReplacingMergeTree table.
+    # Filter placement is correctness- AND performance-critical on a
+    # ReplacingMergeTree(timestamp):
+    #   - start_after (lower bound) goes BEFORE `LIMIT 1 BY finding_id` so the
+    #     dedup + count only process the window's rows; it's safe because a
+    #     finding's latest version has the max timestamp.
+    #   - end_before (upper bound) and the payload predicate go AFTER dedup, or a
+    #     stale version could resurface a finding whose latest version is excluded.
     for query, _ in reader._client.calls:
-        assert "LIMIT 1 BY finding_id" in query
-        assert query.index("LIMIT 1 BY finding_id") < query.index("arrayExists")
-        assert query.index("LIMIT 1 BY finding_id") < query.index("timestamp >=")
+        dedup = query.index("LIMIT 1 BY finding_id")
+        assert query.index("timestamp >=") < dedup
+        assert query.index("timestamp <") > dedup
+        assert query.index("arrayExists") > dedup
 
 
 def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -101,6 +101,31 @@ def test_list_findings_detector_filter_includes_token_and_resolved_names(reader,
     assert "p1" in captured["params"]  # resolution scoped to the project
 
 
+def test_list_findings_detector_filter_matches_detector_id_without_resolution(reader, monkeypatch):
+    reader._client.rows = []
+    reader._client.count_rows = [(0,)]
+    monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])  # Postgres resolves nothing
+
+    reader.list_findings(
+        project_id="p1",
+        limit=50,
+        start_after=None,
+        end_before=None,
+        detector="d1",
+        trace_id=None,
+    )
+
+    # The raw token is the only resolved name, and the predicate checks detectorId too,
+    # so `detector=d1` can match a payload entry whose detectorId is "d1".
+    queries_with_names = [q for q, p in reader._client.calls if p and "detector_names" in p]
+    assert queries_with_names
+    assert "detectorId" in queries_with_names[0]
+    names = next(
+        p["detector_names"] for _, p in reader._client.calls if p and "detector_names" in p
+    )
+    assert names == ["d1"]
+
+
 def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):
     payload = json.dumps(
         [{"detectorId": "d1", "detectorName": "hallucination", "summary": "s", "data": {"x": 1}}]

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -1,0 +1,183 @@
+"""Unit tests for the detector findings reader service.
+
+ClickHouse is faked (dispatches by SQL content) and the Postgres boundary
+(`_pg_rows`) is monkeypatched, so these run with no live databases.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _ch_result(rows):
+    r = MagicMock()
+    r.result_rows = rows
+    return r
+
+
+class FakeCH:
+    """Fake ClickHouse client: count queries get count_rows, others get rows."""
+
+    def __init__(self):
+        self.calls: list[tuple] = []
+        self.count_rows = [(0,)]
+        self.rows: list[tuple] = []
+
+    def query(self, query, parameters=None):
+        self.calls.append((query, parameters))
+        if "count(" in query.lower():
+            return _ch_result(self.count_rows)
+        return _ch_result(self.rows)
+
+
+@pytest.fixture()
+def reader(monkeypatch):
+    import rest.services.detector_reader as mod
+
+    fake = FakeCH()
+    monkeypatch.setattr(mod, "get_clickhouse_client", lambda: fake)
+    svc = mod.DetectorReaderService()
+    return svc
+
+
+def test_list_findings_parses_payload_into_summaries(reader):
+    payload = json.dumps(
+        [
+            {
+                "detectorId": "d1",
+                "detectorName": "hallucination",
+                "summary": "s1",
+                "data": {"a": 1},
+            },
+            {"detectorId": "d2", "detectorName": "logic", "summary": "s2", "data": None},
+        ]
+    )
+    reader._client.rows = [("f1", "p1", "t1", "combined", payload, datetime(2026, 6, 29, 10, 42))]
+    reader._client.count_rows = [(1,)]
+
+    items, total = reader.list_findings(
+        project_id="p1", limit=50, start_after=None, end_before=None, detector=None, trace_id=None
+    )
+
+    assert total == 1
+    assert len(items) == 1
+    assert items[0].finding_id == "f1"
+    assert items[0].detectors == ["hallucination", "logic"]
+    # every query is project-scoped
+    assert all(p and p.get("project_id") == "p1" for _, p in reader._client.calls)
+
+
+def test_list_findings_detector_filter_includes_token_and_resolved_names(reader, monkeypatch):
+    reader._client.rows = []
+    reader._client.count_rows = [(0,)]
+    captured = {}
+
+    def fake_pg(sql, params):
+        if "from detectors" in sql.lower():
+            captured["params"] = params
+            return [("My Hallucination Detector",)]
+        return []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    reader.list_findings(
+        project_id="p1",
+        limit=50,
+        start_after=None,
+        end_before=None,
+        detector="hallucination",
+        trace_id=None,
+    )
+
+    name_params = [
+        p["detector_names"] for _, p in reader._client.calls if p and "detector_names" in p
+    ]
+    assert name_params, "expected detector_names passed to ClickHouse"
+    names = name_params[0]
+    assert "hallucination" in names  # raw token always included
+    assert "My Hallucination Detector" in names  # resolved via Postgres
+    assert "p1" in captured["params"]  # resolution scoped to the project
+
+
+def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):
+    payload = json.dumps(
+        [{"detectorId": "d1", "detectorName": "hallucination", "summary": "s", "data": {"x": 1}}]
+    )
+    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+
+    def fake_pg(sql, params):
+        s = sql.lower()
+        if "from detectors" in s:
+            return [("d1", "hallucination")]  # id, template
+        if "from detector_rcas" in s:
+            return [("done", "root cause text")]  # status, result
+        return []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    detail = reader.get_finding("p1", "f1")
+
+    assert detail is not None
+    item = detail.results[0]
+    assert (item.detector_id, item.detector_name) == ("d1", "hallucination")
+    assert item.template == "hallucination"
+    assert item.identified is True
+    assert item.data == {"x": 1}
+    assert detail.detectors == ["hallucination"]
+    assert detail.rca.status == "done"
+    assert detail.rca.result == "root cause text"
+
+
+def test_get_finding_returns_none_when_missing(reader):
+    reader._client.rows = []
+    assert reader.get_finding("p1", "missing") is None
+
+
+def test_get_finding_absent_rca_yields_none(reader, monkeypatch):
+    payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
+    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+    monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
+
+    detail = reader.get_finding("p1", "f1")
+
+    assert detail.rca is None
+    assert detail.results[0].template is None
+
+
+def test_get_finding_rca_lookup_failure_still_returns_finding(reader, monkeypatch):
+    payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
+    reader._client.rows = [("f1", "p1", "t1", "sum", payload, datetime(2026, 6, 29))]
+
+    def boom(sql, params):
+        raise RuntimeError("postgres down")
+
+    monkeypatch.setattr(reader, "_pg_rows", boom)
+
+    detail = reader.get_finding("p1", "f1")  # must not raise
+
+    assert detail is not None
+    assert detail.rca is None
+    assert detail.results[0].template is None
+
+
+def test_get_finding_by_trace_is_project_and_trace_scoped(reader, monkeypatch):
+    payload = json.dumps([{"detectorId": "d1", "detectorName": "x", "summary": "s", "data": None}])
+    reader._client.rows = [("f1", "p1", "t9", "sum", payload, datetime(2026, 6, 29))]
+    monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
+
+    detail = reader.get_finding_by_trace("p1", "t9")
+
+    assert detail.trace_id == "t9"
+    _, params = reader._client.calls[-1]
+    assert params["project_id"] == "p1"
+    assert params["trace_id"] == "t9"
+
+
+def test_get_detector_reader_service_is_singleton(monkeypatch):
+    import rest.services.detector_reader as mod
+
+    monkeypatch.setattr(mod, "get_clickhouse_client", lambda: MagicMock())
+    mod._service = None
+    assert mod.get_detector_reader_service() is mod.get_detector_reader_service()

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -126,6 +126,29 @@ def test_list_findings_detector_filter_matches_detector_id_without_resolution(re
     assert names == ["d1"]
 
 
+def test_list_findings_deduplicates_before_version_sensitive_filters(reader, monkeypatch):
+    reader._client.rows = []
+    reader._client.count_rows = [(0,)]
+    monkeypatch.setattr(reader, "_pg_rows", lambda sql, params: [])
+
+    reader.list_findings(
+        project_id="p1",
+        limit=50,
+        start_after=datetime(2026, 6, 1),
+        end_before=None,
+        detector="hallucination",
+        trace_id=None,
+    )
+
+    # The version-sensitive filters (timestamp window + payload predicate) must be
+    # applied to the deduped subquery, i.e. AFTER `LIMIT 1 BY finding_id` — otherwise
+    # a stale finding version could be surfaced on a ReplacingMergeTree table.
+    for query, _ in reader._client.calls:
+        assert "LIMIT 1 BY finding_id" in query
+        assert query.index("LIMIT 1 BY finding_id") < query.index("arrayExists")
+        assert query.index("LIMIT 1 BY finding_id") < query.index("timestamp >=")
+
+
 def test_get_finding_normalizes_results_and_attaches_rca(reader, monkeypatch):
     payload = json.dumps(
         [{"detectorId": "d1", "detectorName": "hallucination", "summary": "s", "data": {"x": 1}}]

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -223,6 +223,53 @@ def test_get_finding_by_trace_is_project_and_trace_scoped(reader, monkeypatch):
     assert params["trace_id"] == "t9"
 
 
+def test_list_detectors_returns_items_and_total(reader, monkeypatch):
+    def fake_pg(sql, params):
+        if "count(" in sql.lower():
+            return [(2,)]
+        return [
+            (
+                "d1",
+                "My Hallucination Detector",
+                "hallucination",
+                True,
+                datetime(2026, 6, 29, 10, 42),
+            ),
+            ("d2", "Failure Watch", "failure", False, datetime(2026, 6, 28, 9, 0)),
+        ]
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    items, total = reader.list_detectors(project_id="p1", limit=50)
+
+    assert total == 2
+    assert [i.detector_id for i in items] == ["d1", "d2"]
+    assert items[0].name == "My Hallucination Detector"
+    assert items[0].template == "hallucination"
+    assert items[0].enabled is True
+    assert items[1].enabled is False
+
+
+def test_list_detectors_is_project_scoped_limited_and_newest_first(reader, monkeypatch):
+    captured: list[tuple] = []
+
+    def fake_pg(sql, params):
+        captured.append((sql, params))
+        return [(0,)] if "count(" in sql.lower() else []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    reader.list_detectors(project_id="p1", limit=25)
+
+    assert captured, "expected Postgres queries"
+    assert all("p1" in params for _, params in captured)  # every query project-scoped
+    list_calls = [(sql, params) for sql, params in captured if "count(" not in sql.lower()]
+    assert list_calls
+    sql, params = list_calls[0]
+    assert 25 in params  # limit forwarded
+    assert "order by create_time desc" in sql.lower()  # newest first
+
+
 def test_get_detector_reader_service_is_singleton(monkeypatch):
     import rest.services.detector_reader as mod
 

--- a/tests/rest/test_detector_reader.py
+++ b/tests/rest/test_detector_reader.py
@@ -270,6 +270,30 @@ def test_list_detectors_is_project_scoped_limited_and_newest_first(reader, monke
     assert "order by create_time desc" in sql.lower()  # newest first
 
 
+def test_list_detectors_applies_create_time_window(reader, monkeypatch):
+    captured: list[tuple] = []
+
+    def fake_pg(sql, params):
+        captured.append((sql.lower(), params))
+        return [(0,)] if "count(" in sql.lower() else []
+
+    monkeypatch.setattr(reader, "_pg_rows", fake_pg)
+
+    reader.list_detectors(
+        project_id="p1",
+        limit=50,
+        start_after=datetime(2026, 6, 1),
+        end_before=datetime(2026, 6, 30),
+    )
+
+    # Both the count and list queries carry the inclusive-lower / exclusive-upper
+    # create_time window, so pagination totals match the returned page.
+    assert captured
+    for sql, _params in captured:
+        assert "create_time >= %s" in sql
+        assert "create_time < %s" in sql
+
+
 def test_get_detector_reader_service_is_singleton(monkeypatch):
     import rest.services.detector_reader as mod
 

--- a/tests/rest/test_public_detector_schemas.py
+++ b/tests/rest/test_public_detector_schemas.py
@@ -1,0 +1,92 @@
+"""Schema contract tests for the public detector findings API."""
+
+from datetime import datetime
+
+from rest.schemas.common import PaginationMeta
+from rest.schemas.public import (
+    DetectorResultItem,
+    FindingDetail,
+    FindingSummary,
+    PublicFindingListResponse,
+    RCAResult,
+)
+
+
+def test_detector_result_item_fields_are_snake_case():
+    item = DetectorResultItem(
+        detector_id="d1",
+        detector_name="hallucination",
+        template="hallucination",
+        summary="unsupported claims",
+        identified=True,
+        data={"k": "v"},
+    )
+    assert item.model_dump() == {
+        "detector_id": "d1",
+        "detector_name": "hallucination",
+        "template": "hallucination",
+        "summary": "unsupported claims",
+        "identified": True,
+        "data": {"k": "v"},
+    }
+
+
+def test_detector_result_item_allows_null_template_and_data():
+    item = DetectorResultItem(
+        detector_id="d1",
+        detector_name="hallucination",
+        template=None,
+        summary="s",
+        identified=True,
+        data=None,
+    )
+    assert item.template is None
+    assert item.data is None
+
+
+def test_rca_result_result_is_optional():
+    assert RCAResult(status="pending", result=None).result is None
+    assert RCAResult(status="done", result="root cause").result == "root cause"
+
+
+def test_finding_detail_allows_null_rca():
+    detail = FindingDetail(
+        finding_id="f1",
+        project_id="p1",
+        trace_id="t1",
+        summary="x",
+        timestamp=datetime(2026, 6, 29, 10, 42),
+        detectors=["hallucination"],
+        results=[
+            DetectorResultItem(
+                detector_id="d1",
+                detector_name="hallucination",
+                template="hallucination",
+                summary="s",
+                identified=True,
+                data=None,
+            )
+        ],
+        rca=None,
+    )
+    assert detail.rca is None
+    assert detail.detectors == ["hallucination"]
+    assert detail.results[0].detector_id == "d1"
+
+
+def test_public_finding_list_response_wraps_summaries_with_pagination():
+    resp = PublicFindingListResponse(
+        data=[
+            FindingSummary(
+                finding_id="f1",
+                project_id="p1",
+                trace_id="t1",
+                summary="x",
+                timestamp=datetime(2026, 6, 29),
+                detectors=["failure", "logic"],
+            )
+        ],
+        meta=PaginationMeta(page=0, limit=50, total=1),
+    )
+    assert resp.meta.page == 0
+    assert resp.data[0].detectors == ["failure", "logic"]

--- a/tests/rest/test_public_detector_schemas.py
+++ b/tests/rest/test_public_detector_schemas.py
@@ -4,12 +4,47 @@ from datetime import datetime
 
 from rest.schemas.common import PaginationMeta
 from rest.schemas.public import (
+    DetectorItem,
     DetectorResultItem,
     FindingDetail,
     FindingSummary,
+    PublicDetectorListResponse,
     PublicFindingListResponse,
     RCAResult,
 )
+
+
+def test_detector_item_fields_are_snake_case():
+    item = DetectorItem(
+        detector_id="d1",
+        name="My Hallucination Detector",
+        template="hallucination",
+        enabled=True,
+        created_at=datetime(2026, 6, 29, 10, 42),
+    )
+    dumped = item.model_dump()
+    assert dumped["detector_id"] == "d1"
+    assert dumped["name"] == "My Hallucination Detector"
+    assert dumped["template"] == "hallucination"
+    assert dumped["enabled"] is True
+
+
+def test_public_detector_list_response_wraps_items_with_pagination():
+    resp = PublicDetectorListResponse(
+        data=[
+            DetectorItem(
+                detector_id="d1",
+                name="n",
+                template="failure",
+                enabled=False,
+                created_at=datetime(2026, 6, 29),
+            )
+        ],
+        meta=PaginationMeta(page=0, limit=50, total=1),
+    )
+    assert resp.meta.total == 1
+    assert resp.data[0].detector_id == "d1"
+    assert resp.data[0].enabled is False
 
 
 def test_detector_result_item_fields_are_snake_case():

--- a/tests/rest/test_public_detectors_read.py
+++ b/tests/rest/test_public_detectors_read.py
@@ -1,0 +1,194 @@
+"""API tests for the public detector findings read endpoints.
+
+Auth is overridden and the reader service is replaced with a fake, so these run
+with no live databases.
+"""
+
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from rest.routers.public.deps import AuthResult, authenticate_api_key
+from rest.schemas.public import (
+    DetectorResultItem,
+    FindingDetail,
+    FindingSummary,
+    RCAResult,
+)
+from rest.services.detector_reader import get_detector_reader_service
+
+
+def make_auth(project_id: str = "proj-A") -> AuthResult:
+    return AuthResult(
+        project_id=project_id,
+        workspace_id="ws-1",
+        billing_plan="pro",
+        ingestion_blocked=False,
+    )
+
+
+class FakeReader:
+    def __init__(self):
+        self.list_args: dict | None = None
+        self.list_return: tuple = ([], 0)
+        self.raise_on_list = False
+        self.finding: FindingDetail | None = None
+        self.by_trace: FindingDetail | None = None
+        self.last_get: tuple | None = None
+        self.last_by_trace: tuple | None = None
+
+    def list_findings(self, **kwargs):
+        self.list_args = kwargs
+        if self.raise_on_list:
+            raise RuntimeError("boom")
+        return self.list_return
+
+    def get_finding(self, project_id, finding_id):
+        self.last_get = (project_id, finding_id)
+        return self.finding
+
+    def get_finding_by_trace(self, project_id, trace_id):
+        self.last_by_trace = (project_id, trace_id)
+        return self.by_trace
+
+
+@pytest.fixture()
+def reader():
+    return FakeReader()
+
+
+@pytest.fixture()
+def client(reader):
+    # conftest's autouse fixture clears app.dependency_overrides after each test.
+    app.dependency_overrides[authenticate_api_key] = lambda: make_auth()
+    app.dependency_overrides[get_detector_reader_service] = lambda: reader
+    return TestClient(app)
+
+
+def _summary(**over):
+    base = dict(
+        finding_id="f1",
+        project_id="proj-A",
+        trace_id="t1",
+        summary="s",
+        timestamp=datetime(2026, 6, 29, 10, 42),
+        detectors=["hallucination"],
+    )
+    base.update(over)
+    return FindingSummary(**base)
+
+
+def _detail(**over):
+    base = dict(
+        finding_id="f1",
+        project_id="proj-A",
+        trace_id="t1",
+        summary="s",
+        timestamp=datetime(2026, 6, 29, 10, 42),
+        detectors=["hallucination"],
+        results=[
+            DetectorResultItem(
+                detector_id="d1",
+                detector_name="hallucination",
+                template="hallucination",
+                summary="x",
+                identified=True,
+                data={"k": "v"},
+            )
+        ],
+        rca=RCAResult(status="done", result="rc"),
+    )
+    base.update(over)
+    return FindingDetail(**base)
+
+
+def test_list_returns_findings_with_pagination_meta(client, reader):
+    reader.list_return = ([_summary()], 1)
+    resp = client.get("/api/v1/public/detectors/findings")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["meta"] == {"page": 0, "limit": 50, "total": 1}
+    assert body["data"][0]["finding_id"] == "f1"
+    assert body["data"][0]["detectors"] == ["hallucination"]
+
+
+def test_list_empty_returns_200_with_empty_data(client, reader):
+    reader.list_return = ([], 0)
+    resp = client.get("/api/v1/public/detectors/findings")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["data"] == []
+    assert body["meta"] == {"page": 0, "limit": 50, "total": 0}
+
+
+def test_list_forwards_filters_and_project_scope(client, reader):
+    client.get(
+        "/api/v1/public/detectors/findings"
+        "?limit=10&detector=hallucination&trace_id=t9"
+        "&start_after=2026-06-01T00:00:00Z&end_before=2026-06-30T00:00:00Z"
+    )
+    args = reader.list_args
+    assert args["project_id"] == "proj-A"
+    assert args["limit"] == 10
+    assert args["detector"] == "hallucination"
+    assert args["trace_id"] == "t9"
+    assert args["start_after"] is not None
+    assert args["end_before"] is not None
+
+
+@pytest.mark.parametrize("limit", [0, 500])
+def test_list_rejects_out_of_range_limit(client, limit):
+    assert client.get(f"/api/v1/public/detectors/findings?limit={limit}").status_code == 422
+
+
+def test_list_reader_failure_returns_sanitized_500(client, reader):
+    reader.raise_on_list = True
+    resp = client.get("/api/v1/public/detectors/findings")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to list findings"
+    assert "boom" not in resp.text
+
+
+def test_detail_by_finding_id_returns_results_and_rca(client, reader):
+    reader.finding = _detail()
+    resp = client.get("/api/v1/public/detectors/findings/f1")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert reader.last_get == ("proj-A", "f1")
+    assert body["results"][0]["detector_id"] == "d1"
+    assert body["results"][0]["identified"] is True
+    assert body["rca"] == {"status": "done", "result": "rc"}
+
+
+def test_detail_without_rca_returns_null(client, reader):
+    reader.finding = _detail(rca=None, results=[])
+    body = client.get("/api/v1/public/detectors/findings/f1").json()
+    assert body["rca"] is None
+
+
+def test_detail_404_when_missing(client, reader):
+    reader.finding = None
+    assert client.get("/api/v1/public/detectors/findings/nope").status_code == 404
+
+
+def test_detail_by_trace_returns_finding(client, reader):
+    reader.by_trace = _detail(trace_id="t9", results=[], rca=None)
+    resp = client.get("/api/v1/public/detectors/traces/t9/finding")
+    assert resp.status_code == 200
+    assert reader.last_by_trace == ("proj-A", "t9")
+    assert resp.json()["trace_id"] == "t9"
+
+
+def test_detail_by_trace_404_when_none(client, reader):
+    reader.by_trace = None
+    assert client.get("/api/v1/public/detectors/traces/none/finding").status_code == 404
+
+
+def test_auth_required_without_key(reader):
+    # Only the service is overridden; with no auth override the real key check runs
+    # and a request without a key is rejected before reaching the reader.
+    app.dependency_overrides[get_detector_reader_service] = lambda: reader
+    resp = TestClient(app).get("/api/v1/public/detectors/findings")
+    assert resp.status_code in (401, 403)

--- a/tests/rest/test_public_detectors_read.py
+++ b/tests/rest/test_public_detectors_read.py
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from rest.main import app
 from rest.routers.public.deps import AuthResult, authenticate_api_key
 from rest.schemas.public import (
+    DetectorItem,
     DetectorResultItem,
     FindingDetail,
     FindingSummary,
@@ -34,6 +35,9 @@ class FakeReader:
         self.list_args: dict | None = None
         self.list_return: tuple = ([], 0)
         self.raise_on_list = False
+        self.detectors_args: dict | None = None
+        self.detectors_return: tuple = ([], 0)
+        self.raise_on_detectors = False
         self.finding: FindingDetail | None = None
         self.by_trace: FindingDetail | None = None
         self.last_get: tuple | None = None
@@ -44,6 +48,12 @@ class FakeReader:
         if self.raise_on_list:
             raise RuntimeError("boom")
         return self.list_return
+
+    def list_detectors(self, **kwargs):
+        self.detectors_args = kwargs
+        if self.raise_on_detectors:
+            raise RuntimeError("boom")
+        return self.detectors_return
 
     def get_finding(self, project_id, finding_id):
         self.last_get = (project_id, finding_id)
@@ -102,6 +112,55 @@ def _detail(**over):
     )
     base.update(over)
     return FindingDetail(**base)
+
+
+def _detector(**over):
+    base = dict(
+        detector_id="d1",
+        name="My Hallucination Detector",
+        template="hallucination",
+        enabled=True,
+        created_at=datetime(2026, 6, 29, 10, 42),
+    )
+    base.update(over)
+    return DetectorItem(**base)
+
+
+def test_list_detectors_returns_items_with_pagination_meta(client, reader):
+    reader.detectors_return = ([_detector()], 1)
+    resp = client.get("/api/v1/public/detectors")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["meta"] == {"page": 0, "limit": 50, "total": 1}
+    assert body["data"][0]["detector_id"] == "d1"
+    assert body["data"][0]["template"] == "hallucination"
+    assert body["data"][0]["enabled"] is True
+
+
+def test_list_detectors_forwards_limit_and_project_scope(client, reader):
+    client.get("/api/v1/public/detectors?limit=10")
+    args = reader.detectors_args
+    assert args["project_id"] == "proj-A"
+    assert args["limit"] == 10
+
+
+@pytest.mark.parametrize("limit", [0, 500])
+def test_list_detectors_rejects_out_of_range_limit(client, limit):
+    assert client.get(f"/api/v1/public/detectors?limit={limit}").status_code == 422
+
+
+def test_list_detectors_reader_failure_returns_sanitized_500(client, reader):
+    reader.raise_on_detectors = True
+    resp = client.get("/api/v1/public/detectors")
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Failed to list detectors"
+    assert "boom" not in resp.text
+
+
+def test_list_detectors_auth_required_without_key(reader):
+    app.dependency_overrides[get_detector_reader_service] = lambda: reader
+    resp = TestClient(app).get("/api/v1/public/detectors")
+    assert resp.status_code in (401, 403)
 
 
 def test_list_returns_findings_with_pagination_meta(client, reader):

--- a/tests/rest/test_public_detectors_read.py
+++ b/tests/rest/test_public_detectors_read.py
@@ -144,6 +144,15 @@ def test_list_detectors_forwards_limit_and_project_scope(client, reader):
     assert args["limit"] == 10
 
 
+def test_list_detectors_forwards_time_window(client, reader):
+    client.get(
+        "/api/v1/public/detectors?start_after=2026-06-01T00:00:00Z&end_before=2026-06-30T00:00:00Z"
+    )
+    args = reader.detectors_args
+    assert args["start_after"] is not None
+    assert args["end_before"] is not None
+
+
 @pytest.mark.parametrize("limit", [0, 500])
 def test_list_detectors_rejects_out_of_range_limit(client, limit):
     assert client.get(f"/api/v1/public/detectors?limit={limit}").status_code == 422

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -152,3 +152,10 @@ def test_read_endpoints_document_error_responses():
         responses = paths[p]["get"]["responses"]
         assert set(responses) >= {"200", "401", "404", "500"}
         assert responses["404"]["description"] == "Trace not found"
+
+
+def test_detectors_list_route_documents_error_responses():
+    paths = _schema()["paths"]
+    assert "get" in paths["/api/v1/public/detectors"]
+    responses = paths["/api/v1/public/detectors"]["get"]["responses"]
+    assert set(responses) >= {"200", "401", "500"}


### PR DESCRIPTION
## Summary

(1/2) Closes #1382

Adds a public, API-key-authenticated, project-scoped **read API** for the detector catalog and detector findings — the backend that powers the new `traceroot detectors` / `traceroot findings` CLI commands. Four `GET` endpoints under `/api/v1/public/detectors`, mirroring the existing public traces read stack 1:1 (`StampedAuth`, READ-bucket rate limiting, project scoping). Read-only over data that already exists — no severity, no structured RCA packets, no write paths, no new tables.

This is the aggregate of the reviewed sub-PRs #1388 (schemas + reader service) and #1393 (router + wiring), integrated into the epic branch. The CLI half ships separately in `traceroot-cli`; it only vendors this repo's public OpenAPI schema, so the two land independently.

## How it works

```
GET /api/v1/public/detectors*  (Authorization: Bearer <api_key>)
  → StampedAuth resolves project_id server-side + stamps the READ rate-limit identity
    → DetectorReaderService (Depends-injected, project-scoped, read-only)
        ├── Postgres detectors        catalog list + resolve --detector (id/name/template) + template
        ├── ClickHouse detector_findings  findings (deduped ReplacingMergeTree)
        └── Postgres detector_rcas    free-text RCA for finding detail (best-effort)
      → list  -> {data, meta(page=0, limit, total)}
        detail -> FindingDetail | 404
  errors: reader None -> 404; reader exception -> sanitized 500; empty list -> 200
```

## Endpoints

| Method | Path | Response | Purpose |
|--------|------|----------|---------|
| GET | `/api/v1/public/detectors` | `PublicDetectorListResponse` | The project's detector catalog |
| GET | `/api/v1/public/detectors/findings` | `PublicFindingListResponse` | Detector findings (filtered) |
| GET | `/api/v1/public/detectors/findings/{finding_id}` | `FindingDetail` | Finding detail by id |
| GET | `/api/v1/public/detectors/traces/{trace_id}/finding` | `FindingDetail` | Finding detail by trace (1-per-trace) |

List params: `limit` (`Query(50, ge=1, le=200)`), `start_after` / `end_before` (creation-time window for detectors, finding-timestamp window for findings), plus `detector` and `trace_id` on findings. Every query is constrained to the key's `project_id`; the client never supplies one, so cross-project reads return no rows / 404. Pagination follows the traces model: `PaginationMeta(page=0, limit, total)`, no cursors.

## Data model (read-only; nothing new added)
- **ClickHouse** `detector_findings` — `ReplacingMergeTree(timestamp)`, one row per trace where ≥1 detector fired; `summary` + JSON `payload` array of `{detectorId, detectorName, summary, data}`.
- **Postgres** `detectors` — the catalog list, plus `--detector` resolution and `template` lookup.
- **Postgres** `detector_rcas` — free-text RCA (`status`, `result`), keyed by `finding_id`.

## What's included

### Schemas — `backend/rest/schemas/public.py`
`DetectorItem`, `PublicDetectorListResponse`, `DetectorResultItem`, `RCAResult`, `FindingSummary`, `FindingDetail`, `PublicFindingListResponse` (snake_case, normalized from the camelCase payload; `data` opaque passthrough).

### Reader service — `backend/rest/services/detector_reader.py` (new)
`DetectorReaderService` + `get_detector_reader_service()` singleton (sync; ClickHouse client + a single read-only psycopg2 seam): `list_detectors`, `list_findings`, `get_finding`, `get_finding_by_trace`, plus `_resolve_detector_names`, `_read_templates`, `_read_rca`.

### Router — `backend/rest/routers/public/detectors_read.py` (new) + `main.py`
`APIRouter(prefix="/public/detectors")`; the four routes use `StampedAuth` + the existing READ-bucket limiter; `None → 404`, reader exception → sanitized `500`; wired via a 2-line `main.py` include.

### OpenAPI — `backend/rest/openapi_public.py` + `backend/rest/openapi/public.json`
`_apply_public_contract` documents the per-route error responses (401/503 on all, 500 on the lists, 404/500 on the details); `public.json` regenerated by `scripts/sync_public_openapi.py` (this is the artifact the CLI vendors).

## Correctness & performance notes
- **`--detector` is backend-owned:** the token matches a payload `detectorName`/`detectorId` directly, and also resolves against Postgres `detectors` by `id`/`name`/`template`; an unresolved token matches nothing (empty list, not an error).
- **ReplacingMergeTree filter placement:** findings dedup to the latest row per `finding_id` (`LIMIT 1 BY`) before applying version-sensitive filters. `start_after` (lower bound) is applied **before** the dedup — safe (a finding's latest version has the max timestamp) and it scopes the expensive dedup + count to the window; `end_before` and the payload `detector` predicate stay **after** the dedup, or a stale version could resurface a finding whose latest version no longer matches. (Verified empirically against real un-merged parts.)
- **RCA never blocks a finding:** a missing `detector_rcas` row or a Postgres lookup failure degrades to `rca = null`; the finding still returns. `template` is `null` for a deleted detector. A catalog-read failure in `list_detectors`, by contrast, propagates → a controlled 500.
- **Tenant isolation:** every ClickHouse and Postgres query is constrained to `auth.project_id`; no client-supplied project id.

## Test plan
- [x] Schema contract tests — `tests/rest/test_public_detector_schemas.py`
- [x] Reader unit tests — `tests/rest/test_detector_reader.py` (payload parse/normalize, `template`/RCA present/absent/failure, project scoping, `--detector` resolution, dedup filter placement, `list_detectors` window)
- [x] Router/API tests — `tests/rest/test_public_detectors_read.py` (auth, project scope, filters, `422` on bad `limit`, sanitized `500`, `404`s, detail by id/trace)
- [x] OpenAPI tests — `tests/rest/test_public_openapi.py` (paths present, error responses documented, drift guard)
- [x] Full REST suite green; `ruff` + `ruff format` + `mypy` clean on the new/changed modules
- [x] Perf fix (`start_after` before dedup) verified against a seeded 2-version finding: lower-bound results identical pre/post dedup; upper-bound correctly excludes a stale version

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public, API‑key read API for the detector catalog and detector findings, powering the new `traceroot detectors` and `traceroot findings` CLI commands. All routes are project‑scoped, read‑only, and rate‑limited like the existing public traces API.

- **New Features**
  - Four `GET` routes under `/api/v1/public/detectors`:
    - `/` — list detectors with `limit` (1–200), optional `start_after`/`end_before`.
    - `/findings` — list findings with `limit`, time window, optional `detector` (id/name/template) and `trace_id`.
    - `/findings/{finding_id}` — get a finding by id.
    - `/traces/{trace_id}/finding` — get a finding by trace.
  - Auth via `StampedAuth`; READ bucket rate limiting; results constrained to the key’s project.
  - Data sources: ClickHouse `detector_findings` (dedup to latest per finding), Postgres `detectors` (catalog, template) and `detector_rcas` (free‑text RCA, best‑effort).
  - `--detector` filter matches `detectorId` and `detectorName`; resolves against Postgres by id/name/template (unresolved token → no matches, not an error).
  - OpenAPI updated (`backend/rest/openapi/public.json`), new router wired in `backend/rest/main.py`, reader service and schemas added, tests included.

<sup>Written for commit 6a9fae7706ce836c204ba1f2fea10236c099c1c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

