### PR TITLE
test: guard evaluator delay parity

### DIFF
--- a/tests/worker/test_evaluator_delay_parity.py
+++ b/tests/worker/test_evaluator_delay_parity.py
@@ -1,0 +1,20 @@
+"""Parity guard for the detector quiescence delay shared across runtimes."""
+
+import re
+from pathlib import Path
+
+from worker.detector_tasks import EVALUATOR_DELAY as PYTHON_EVALUATOR_DELAY
+
+ROOT = Path(__file__).resolve().parents[2]
+TS_QUEUE_FILE = ROOT / "frontend/worker/src/queues/detector-run-queue.ts"
+
+
+def test_python_and_typescript_evaluator_delay_match():
+    """Python enqueues with the same delay the TypeScript worker waits for."""
+    source = TS_QUEUE_FILE.read_text()
+    match = re.search(r"export\s+const\s+EVALUATOR_DELAY\s*=\s*([\d_]+)", source)
+
+    assert match is not None, "Could not find TypeScript EVALUATOR_DELAY export"
+    typescript_delay = int(match.group(1).replace("_", ""))
+
+    assert typescript_delay == PYTHON_EVALUATOR_DELAY


### PR DESCRIPTION
## Summary
- add a Python parity test that compares the backend detector enqueue delay with the TypeScript detector worker delay
- fail fast if the mirrored `EVALUATOR_DELAY` constants drift

## Why
The Python enqueue path and TypeScript worker path both depend on the same quiescence delay. Keeping them aligned prevents detector timing from silently diverging.

Closes #1463

## Validation
- `env BETTER_AUTH_URL=http://localhost:3000 NEXT_PUBLIC_APP_URL=http://localhost:3000 TRACEROOT_UI_URL=http://localhost:3000 TRACEROOT_PUBLIC_UI_URL=http://localhost:3000 BACKEND_INTERNAL_URL=http://localhost:8000 CORS_ORIGINS='["http://localhost:3000"]' uv run pytest tests/worker/test_evaluator_delay_parity.py tests/rest/test_internal_trace_time_since_last_span.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a test that verifies the Python backend’s `EVALUATOR_DELAY` matches the TypeScript worker’s value and fails if they diverge, keeping detector quiescence timing consistent across runtimes (closes #1463).

<sup>Written for commit 3aa92a95f32ab6558db3b08cde27757af16bba0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

