### PR TITLE
refactor: break tmux tools import cycle

### DIFF
--- a/tmux_tools/tmux.py
+++ b/tmux_tools/tmux.py
@@ -144,21 +144,20 @@ class TmuxSession:
         )
 
     def verify_installation(self) -> bool:
-        from tmux_tools.schema import Prerequisite
-
-        dep = Prerequisite(
-            name="tmux is installed",
-            command="tmux -V",
-            expected_output="tmux 3.",
-            instructions="""
+        name = "tmux is installed"
+        command = "tmux -V"
+        instructions = """
 Please install tmux version 3 or above.
 
     Mac:   brew install tmux
     Linux: sudo apt install tmux
-""",
-        )
-        print("Checking prerequisite:", dep.name)
-        result = dep.check()
-        if not result.succeeded:
-            print(result.message)
-        return result.succeeded
+"""
+        print("Checking prerequisite:", name)
+        output = _shell(command)
+        if output.returncode == 0 and "tmux 3." in output.stdout:
+            return True
+
+        print(f"Failed to check: {name}")
+        print(_format_error(command, output))
+        print(instructions)
+        return False


### PR DESCRIPTION
## Summary
- move tmux prerequisite checks into `tmux_tools.prerequisites`
- move shared shell helpers into `tmux_tools.shell`
- keep `schema.Prerequisite` and `schema.CheckResult` available while removing the schema/tmux import cycle

## Why
`tmux_tools.schema` and `tmux_tools.tmux` imported each other. Splitting the lower-level shell and prerequisite helpers gives both modules one-way dependencies and removes the cycle reported by SCIP.

Closes #1464

## Validation
- `uv run python -m py_compile tmux_tools/schema.py tmux_tools/tmux.py tmux_tools/launcher.py tmux_tools/prerequisites.py tmux_tools/shell.py`
- `uv run pytest tests/tmux_tools/test_schema.py -q`
- `scip-query reindex && scip-query cycles --json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Breaks the import cycle between `tmux_tools.schema` and `tmux_tools.tmux` by extracting prerequisites and shell helpers into dedicated modules and refactoring `verify_installation` to run a direct shell check. This simplifies dependencies, unblocks SCIP indexing, and keeps the public API stable (closes #1464).

- **Refactors**
  - Moved prerequisite types to `tmux_tools.prerequisites` (`Prerequisite`, `CheckResult`).
  - Moved shell helpers to `tmux_tools.shell`; `tmux_tools.tmux.verify_installation` now calls `tmux -V` via shell helpers and no longer depends on `schema.Prerequisite`.
  - Updated `tmux_tools.schema` to import from `tmux_tools.prerequisites`, removing the `schema` <-> `tmux` cycle.
  - Kept `schema.Prerequisite` and `schema.CheckResult` as aliases for compatibility.

<sup>Written for commit fdedbb2724314d7a1e1d1785f20823c48aef4645. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

