### PR TITLE
fix(agent): pass env through docker executor

### DIFF
--- a/frontend/packages/agent/src/executors/__tests__/docker.test.ts
+++ b/frontend/packages/agent/src/executors/__tests__/docker.test.ts
@@ -1,0 +1,65 @@
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockSpawn } = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  spawn: mockSpawn,
+  execFile: vi.fn(),
+}));
+
+import { DockerExecutor } from "../docker.js";
+
+function mockDockerExecClose(code = 0) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  queueMicrotask(() => child.emit("close", code));
+  mockSpawn.mockReturnValueOnce(child);
+}
+
+describe("DockerExecutor", () => {
+  let executor: DockerExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new DockerExecutor();
+    (executor as unknown as { containerId: string }).containerId = "container-123";
+  });
+
+  describe("exec()", () => {
+    it("passes ExecOptions.env through docker exec -e args", async () => {
+      mockDockerExecClose();
+
+      await executor.exec("printenv SECRET_TOKEN", {
+        env: {
+          SECRET_TOKEN: "token with spaces",
+          GIT_TERMINAL_PROMPT: "0",
+        },
+      });
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "docker",
+        [
+          "exec",
+          "-e",
+          "SECRET_TOKEN=token with spaces",
+          "-e",
+          "GIT_TERMINAL_PROMPT=0",
+          "container-123",
+          "sh",
+          "-c",
+          "printenv SECRET_TOKEN",
+        ],
+        { stdio: ["ignore", "pipe", "pipe"] },
+      );
+    });
+  });
+});

--- a/frontend/packages/agent/src/executors/docker.ts
+++ b/frontend/packages/agent/src/executors/docker.ts
@@ -49,7 +49,11 @@ export class DockerExecutor implements Executor {
     if (!this.containerId) throw new Error("Container not initialized");
 
     return new Promise((resolve) => {
-      const child = spawn("docker", ["exec", this.containerId!, "sh", "-c", command], {
+      const envArgs = Object.entries(options?.env ?? {}).flatMap(([key, value]) => [
+        "-e",
+        `${key}=${value}`,
+      ]);
+      const child = spawn("docker", ["exec", ...envArgs, this.containerId!, "sh", "-c", command], {
         stdio: ["ignore", "pipe", "pipe"],
       });
 


### PR DESCRIPTION
## Summary
- pass `ExecOptions.env` through Docker with `docker exec -e KEY=value` arguments
- add a DockerExecutor unit test for the spawn args

## Why
The shared executor contract exposes `ExecOptions.env`, and Daytona already honors it. Docker was silently dropping those values even though Docker is the default sandbox provider.

Closes #1461

## Validation
- `/opt/homebrew/bin/pnpm --dir frontend/packages/agent test`
- `cd frontend && /opt/homebrew/bin/pnpm exec lint-staged`

Note: the local pre-commit `frontend-lint` bootstrap tried to run a bundled pnpm install and failed on lockfile/runtime config before linting. I ran the equivalent `lint-staged` command directly with the repo pnpm, and it passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward environment variables from `ExecOptions.env` through the Docker executor by adding `-e KEY=value` to `docker exec`, so commands receive the expected env inside the container. Adds a unit test to verify the exact spawn arguments and order.

<sup>Written for commit 223c4269fd3c4089d85d98480d56ceab2d10c24c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

