### PR TITLE
fix(agent): fail sandbox init on tool install errors

### DIFF
--- a/frontend/packages/agent/src/executors/__tests__/daytona.test.ts
+++ b/frontend/packages/agent/src/executors/__tests__/daytona.test.ts
@@ -69,6 +69,18 @@ describe("DaytonaExecutor", () => {
       expect(apt).toContain("ca-certificates");
       expect(apt).toContain("git");
     });
+
+    it("fails init and resets readiness when required tool installation fails", async () => {
+      mockSandbox.process.executeCommand
+        .mockResolvedValueOnce({ exitCode: 0, result: "" })
+        .mockResolvedValueOnce({ exitCode: 100, result: "apt failed" });
+
+      await expect(executor.init()).rejects.toThrow(
+        "Failed to install required sandbox tools: apt failed",
+      );
+      expect(mockSandbox.delete).toHaveBeenCalled();
+      expect(executor.isReady()).toBe(false);
+    });
   });
 
   describe("exec()", () => {

--- a/frontend/packages/agent/src/executors/__tests__/docker-init.test.ts
+++ b/frontend/packages/agent/src/executors/__tests__/docker-init.test.ts
@@ -1,0 +1,68 @@
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockExecFile, mockExecFileAsync, mockSpawn } = vi.hoisted(() => {
+  return {
+    mockExecFile: vi.fn(),
+    mockExecFileAsync: vi.fn(),
+    mockSpawn: vi.fn(),
+  };
+});
+
+vi.mock("child_process", () => ({
+  spawn: mockSpawn,
+  execFile: mockExecFile,
+}));
+
+vi.mock("util", () => ({
+  promisify: () => mockExecFileAsync,
+}));
+
+import { DockerExecutor } from "../docker.js";
+
+function mockDockerRun(containerId = "container-123") {
+  mockExecFileAsync.mockResolvedValueOnce({ stdout: `${containerId}\n`, stderr: "" });
+}
+
+function mockDockerRm() {
+  mockExecFileAsync.mockResolvedValueOnce({ stdout: "", stderr: "" });
+}
+
+function mockDockerExecClose(code = 0, stderr = "") {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  setTimeout(() => {
+    if (stderr) child.stderr.emit("data", Buffer.from(stderr));
+    child.emit("close", code);
+  }, 0);
+  mockSpawn.mockReturnValueOnce(child);
+}
+
+describe("DockerExecutor init()", () => {
+  let executor: DockerExecutor;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executor = new DockerExecutor();
+  });
+
+  it("fails init and resets readiness when required tool installation fails", async () => {
+    mockDockerRun();
+    mockDockerExecClose(); // mkdir
+    mockDockerExecClose(100, "apt failed"); // install tools
+    mockDockerRm();
+
+    await expect(executor.init()).rejects.toThrow(
+      "Failed to install required container tools: apt failed",
+    );
+
+    expect(executor.isReady()).toBe(false);
+    expect(mockExecFileAsync).toHaveBeenLastCalledWith("docker", ["rm", "-f", "container-123"]);
+  });
+});

--- a/frontend/packages/agent/src/executors/daytona.ts
+++ b/frontend/packages/agent/src/executors/daytona.ts
@@ -40,9 +40,15 @@ export class DaytonaExecutor implements Executor {
     // certs must be present before any HTTPS clone. We intentionally do NOT rely
     // on Daytona's native go-git here — its daemon caches an empty cert pool at
     // boot on this image, so its in-process TLS can't be fixed by a later apt.
-    await this.sandbox.process.executeCommand(
-      "apt-get update -qq && apt-get install -y -qq ca-certificates git jq curl > /dev/null 2>&1 || true",
+    const installResult = await this.sandbox.process.executeCommand(
+      "apt-get update -qq && apt-get install -y -qq ca-certificates git jq curl",
     );
+    if ((installResult.exitCode ?? 1) !== 0) {
+      const output = installResult.result?.trim() || "no output";
+      await Promise.resolve(this.sandbox.delete()).catch(() => {});
+      this.sandbox = null;
+      throw new Error(`Failed to install required sandbox tools: ${output}`);
+    }
 
     console.log(`[DaytonaExecutor] Sandbox ready, workDir: ${this.workDir}`);
   }

--- a/frontend/packages/agent/src/executors/docker.ts
+++ b/frontend/packages/agent/src/executors/docker.ts
@@ -33,9 +33,14 @@ export class DockerExecutor implements Executor {
     await this.exec(`mkdir -p ${WORKSPACE_DIR}/traces ${WORKSPACE_DIR}/notes`);
 
     // Install basic tools if not in image
-    await this.exec(
-      "apt-get update -qq && apt-get install -y -qq git jq curl > /dev/null 2>&1 || true",
+    const installResult = await this.exec(
+      "apt-get update -qq && apt-get install -y -qq git jq curl",
     );
+    if (installResult.code !== 0) {
+      const output = `${installResult.stderr || installResult.stdout || ""}`.trim() || "no output";
+      await this.destroy();
+      throw new Error(`Failed to install required container tools: ${output}`);
+    }
 
     console.log(`[DockerExecutor] Container ready: ${this.containerId.slice(0, 12)}`);
   }


### PR DESCRIPTION
## Summary
- make Daytona init fail if required tool installation returns non-zero
- make Docker init fail and clean up the container if required tool installation returns non-zero
- add executor tests that prove failed installs do not leave the executor ready

## Why
Both executors previously used `apt-get ... || true`, so `init()` could report readiness even when required tools like git/curl/jq/certificates were unavailable.

Closes #1462

## Validation
- `/opt/homebrew/bin/pnpm --dir frontend/packages/agent test`
- `cd frontend && /opt/homebrew/bin/pnpm exec lint-staged`

Note: the local pre-commit `frontend-lint` bootstrap tried to run a bundled pnpm install and failed before linting. I ran the equivalent `lint-staged` command directly with the repo pnpm, and it passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail executor init when required tool installation fails, and clean up the sandbox/container so we never report ready with missing dependencies. Addresses #1462.

- **Bug Fixes**
  - Daytona: check `apt-get` for `ca-certificates`, `git`, `jq`, `curl`; on failure, delete sandbox and reset readiness.
  - Docker: check `apt-get` for `git`, `jq`, `curl`; on failure, remove container and reset readiness.
  - Tests: added unit tests to ensure failed installs prevent readiness in both executors.

<sup>Written for commit 9990bec0002f7c7a0364b136ce4533d91b9da106. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

