### PR TITLE
Refactor Google auth readiness check

### DIFF
--- a/frontend/ui/src/app/auth/google-auth-pages.test.tsx
+++ b/frontend/ui/src/app/auth/google-auth-pages.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import SignInPage from "./sign-in/page";
+import { SignInClient } from "./sign-in/sign-in-client";
+import SignUpPage from "./sign-up/page";
+import { SignUpClient } from "./sign-up/sign-up-client";
+
+vi.mock("@/env", () => ({
+  env: {
+    AUTH_GOOGLE_CLIENT_ID: " client-id ",
+    AUTH_GOOGLE_CLIENT_SECRET: " client-secret ",
+  },
+}));
+
+vi.mock("./sign-in/sign-in-client", () => ({
+  SignInClient: function MockSignInClient() {
+    return null;
+  },
+}));
+
+vi.mock("./sign-up/sign-up-client", () => ({
+  SignUpClient: function MockSignUpClient() {
+    return null;
+  },
+}));
+
+describe("auth pages", () => {
+  it("passes Google auth readiness into the sign-in client", () => {
+    expect(SignInPage()).toMatchObject({
+      type: SignInClient,
+      props: { googleAuthConfigured: true },
+    });
+  });
+
+  it("passes Google auth readiness into the sign-up client", () => {
+    expect(SignUpPage()).toMatchObject({
+      type: SignUpClient,
+      props: { googleAuthConfigured: true },
+    });
+  });
+});

--- a/frontend/ui/src/app/auth/sign-in/page.tsx
+++ b/frontend/ui/src/app/auth/sign-in/page.tsx
@@ -1,11 +1,13 @@
 import { env } from "@/env";
+import { isGoogleAuthConfigured } from "@/lib/auth-config";
 import { SignInClient } from "./sign-in-client";
 
 export const dynamic = "force-dynamic";
 
 export default function SignInPage() {
-  const googleAuthConfigured = Boolean(
-    env.AUTH_GOOGLE_CLIENT_ID.trim() && env.AUTH_GOOGLE_CLIENT_SECRET.trim(),
+  const googleAuthConfigured = isGoogleAuthConfigured(
+    env.AUTH_GOOGLE_CLIENT_ID,
+    env.AUTH_GOOGLE_CLIENT_SECRET,
   );
 
   return <SignInClient googleAuthConfigured={googleAuthConfigured} />;

--- a/frontend/ui/src/app/auth/sign-up/page.tsx
+++ b/frontend/ui/src/app/auth/sign-up/page.tsx
@@ -1,11 +1,13 @@
 import { env } from "@/env";
+import { isGoogleAuthConfigured } from "@/lib/auth-config";
 import { SignUpClient } from "./sign-up-client";
 
 export const dynamic = "force-dynamic";
 
 export default function SignUpPage() {
-  const googleAuthConfigured = Boolean(
-    env.AUTH_GOOGLE_CLIENT_ID.trim() && env.AUTH_GOOGLE_CLIENT_SECRET.trim(),
+  const googleAuthConfigured = isGoogleAuthConfigured(
+    env.AUTH_GOOGLE_CLIENT_ID,
+    env.AUTH_GOOGLE_CLIENT_SECRET,
   );
 
   return <SignUpClient googleAuthConfigured={googleAuthConfigured} />;

--- a/frontend/ui/src/lib/auth-config.test.ts
+++ b/frontend/ui/src/lib/auth-config.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { isGoogleAuthConfigured } from "./auth-config";
+
+describe("isGoogleAuthConfigured", () => {
+  it("requires both Google auth credentials", () => {
+    expect(isGoogleAuthConfigured("client-id", "client-secret")).toBe(true);
+    expect(isGoogleAuthConfigured("", "client-secret")).toBe(false);
+    expect(isGoogleAuthConfigured("client-id", "")).toBe(false);
+  });
+
+  it("treats whitespace-only credentials as missing", () => {
+    expect(isGoogleAuthConfigured("  ", "client-secret")).toBe(false);
+    expect(isGoogleAuthConfigured("client-id", "\t")).toBe(false);
+  });
+});

--- a/frontend/ui/src/lib/auth-config.ts
+++ b/frontend/ui/src/lib/auth-config.ts
@@ -1,0 +1,3 @@
+export function isGoogleAuthConfigured(clientId: string, clientSecret: string): boolean {
+  return Boolean(clientId.trim() && clientSecret.trim());
+}


### PR DESCRIPTION
## Summary

- add a small `isGoogleAuthConfigured` helper for the Google auth UI readiness rule
- use the helper from both sign-in and sign-up pages
- cover the helper and both auth pages so the changed diff is covered

Closes #1472

## Why

The sign-in and sign-up pages each carried the same check for whether both Google auth credentials are present after trimming. Naming that policy keeps the two pages from drifting while preserving the current UI behavior.

This PR intentionally does not change Better Auth provider registration; it only centralizes the UI-facing readiness rule.

## Validation

Passed:

- `/opt/homebrew/bin/pnpm --dir frontend/ui exec vitest run src/app/auth/google-auth-pages.test.tsx src/lib/auth-config.test.ts`
- `/opt/homebrew/bin/pnpm --dir frontend/ui exec vitest run src/app/auth/google-auth-pages.test.tsx src/lib/auth-config.test.ts --coverage --coverage.reporter=text --coverage.include=src/app/auth/sign-in/page.tsx --coverage.include=src/app/auth/sign-up/page.tsx --coverage.include=src/lib/auth-config.ts`
- `/opt/homebrew/bin/pnpm --dir frontend/ui exec eslint src/app/auth/google-auth-pages.test.tsx src/lib/auth-config.ts src/lib/auth-config.test.ts src/app/auth/sign-in/page.tsx src/app/auth/sign-up/page.tsx`
- `/opt/homebrew/bin/pnpm --dir frontend/ui exec prettier --check src/app/auth/google-auth-pages.test.tsx src/lib/auth-config.ts src/lib/auth-config.test.ts src/app/auth/sign-in/page.tsx src/app/auth/sign-up/page.tsx`
- `cd frontend && /opt/homebrew/bin/pnpm exec lint-staged`
- `scip-query diff-gate --json`
- `scip-query recent-duplicates --json --full`

Notes:

- `/opt/homebrew/bin/pnpm --dir frontend/ui test` currently fails outside this change because the local environment is missing the generated Prisma client (`Cannot find module '.prisma/client/default'`) and one existing jsdom/localStorage setup fails in `GitHubStarWidget.test.tsx`.
- `/opt/homebrew/bin/pnpm --dir frontend/ui exec tsc --noEmit` also fails on existing Prisma-generated type issues and unrelated repo-wide type errors.
