### PR TITLE
docs(cli): document detector and findings commands

### DIFF
--- a/docs/cli/get-started.mdx
+++ b/docs/cli/get-started.mdx
@@ -3,7 +3,7 @@ title: Get Started
 description: Bring TraceRoot to your terminal
 ---
 
-The TraceRoot CLI wraps the TraceRoot API so you can work with your project directly from the terminal — list, inspect, and export traces, then pipe the JSON into whatever comes next. It is built for AI coding agents and power users who prefer the command line.
+The TraceRoot CLI wraps the TraceRoot API so you can work with your project directly from the terminal — list, inspect, and export traces, query detectors, and retrieve findings. It is built for AI coding agents and power users who prefer the command line.
 
 Full source and reference live in the [`traceroot-cli`](https://github.com/traceroot-ai/traceroot-cli) repo.
 
@@ -40,12 +40,41 @@ traceroot status
 # List recent traces, newest first
 traceroot traces list --limit 10
 
+# Filter by time range
+traceroot traces list --since 24h
+traceroot traces list --from 2025-01-01T00:00:00Z --to 2025-01-02T00:00:00Z
+
 # Inspect one: span tree, duration, I/O preview, and a link to open it in TraceRoot
 traceroot traces get <trace-id>
 
 # Write a full trace bundle to disk to share or feed into another tool
 traceroot traces export <trace-id> --output ./my-trace
 ```
+
+## Query detectors and findings
+
+[Detectors](/detectors/get-started) run continuously on your traces and emit findings whenever the LLM-as-a-judge flags a problem.
+
+```bash
+# List all detectors in your project
+traceroot detectors list
+
+# List recent findings across all detectors
+traceroot findings list --since 24h
+
+# Filter findings by detector and time window
+traceroot findings list --detector <detector-id> --since 7d
+
+# Retrieve a specific finding
+traceroot findings get <finding-id>
+
+# Retrieve the finding tied to a specific trace
+traceroot findings get --trace <trace-id>
+```
+
+### Time-range syntax
+
+`--since` accepts a plain duration: `30m`, `6h`, `24h`, `7d`, `2w`. `--from` and `--to` accept ISO 8601 timestamps (`2025-01-01T00:00:00Z`). `--since` and `--from`/`--to` are mutually exclusive.
 
 ## Command reference
 
@@ -55,13 +84,19 @@ Add `--json` to any command for machine-readable output, or run `traceroot <comm
 | :-- | :-- |
 | `login` | Validate an API key and save credentials. |
 | `status` | Show the identity your credentials resolve to — workspace, project, host, and key hint. |
-| `traces list` | List traces for your project, newest first. Flag: `--limit <n>`. |
+| `traces list` | List traces for your project, newest first. Flags: `--limit <n>`, `--since <duration>`, `--from <ISO>`, `--to <ISO>`. |
 | `traces get <id>` | Show one trace: header, span tree, duration, and I/O preview. `--json` emits the full trace. |
 | `traces export <id>` | Write `trace.json`, `spans.json`, `git_context.json`, and a `manifest.json` index to a directory. Flags: `--output <dir>`, `--force`. |
+| `detectors list` | List all detectors in your project with their IDs, names, and enabled status. |
+| `findings list` | List recent findings. Flags: `--detector <id>`, `--since <duration>`, `--from <ISO>`, `--to <ISO>`, `--limit <n>`. |
+| `findings get <id>` | Show one finding: detector name, judge summary, RCA, and a link to the trace. `--trace <trace-id>` looks up by trace instead of finding ID. |
 
 ## What's next
 
 <CardGroup cols={2}>
+  <Card title="Detectors" icon="shield-halved" href="/detectors/get-started">
+    Create detectors and understand the findings the CLI surfaces.
+  </Card>
   <Card title="Tracing" icon="route" href="/tracing/get-started">
     Instrument your app so traces show up for the CLI to read.
   </Card>

--- a/docs/detectors/get-started.mdx
+++ b/docs/detectors/get-started.mdx
@@ -58,4 +58,7 @@ Both stages of the pipeline — the LLM-as-a-judge and the AI agent — run on a
   <Card title="AI Agent" icon="brain" href="/ai-agent/overview">
     Learn how the RCA agent behind every finding works.
   </Card>
+  <Card title="CLI" icon="terminal" href="/cli/get-started">
+    Query detectors and findings from the terminal with `traceroot detectors list` and `traceroot findings list`.
+  </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary

- Adds `detectors list`, `findings list`, and `findings get` to the CLI get-started page with usage examples
- Documents time-range flags (`--since`, `--from`, `--to`) with duration syntax (`30m`, `6h`, `7d`, `2w`) and ISO 8601 for `--from`/`--to`
- Expands the `traces list` command reference to include the new time-range flags
- Adds a CLI card to the detectors get-started "Next steps" section so detector users discover the commands

## Test plan

- [ ] Verify all command examples in `docs/cli/get-started.mdx` match the actual `traceroot-cli` flags
- [ ] Confirm cross-link `/cli/get-started` renders correctly from the detectors page
- [ ] Check docs site preview renders the new command reference table and code blocks

Closes #1445

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for new CLI commands to query detectors and findings, and updates `traces list` with time-range flags. Makes it easier to list detectors, filter findings by time, and fetch a specific finding from the terminal.

- **New Features**
  - Added `detectors list`, `findings list`, and `findings get` to `/cli/get-started` with examples.
  - Documented `--since`, `--from`, and `--to` flags (durations like `30m`, `6h`, `7d`, `2w`; ISO 8601 for `--from`/`--to`).
  - Expanded command reference for `traces list` and new findings commands to include time-range flags.
  - Added cross-links: CLI card on detectors page and Detectors card on the CLI page.

<sup>Written for commit 12f28e99aa93d3d45e719d05695d3b80006fa974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

