### PR TITLE
fix(worker): gate api token counts to llm spans

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -436,10 +436,12 @@ def transform_otel_to_clickhouse(
                         json.dumps(span_output) if not isinstance(span_output, str) else span_output
                     )
 
-                # Model & token fields — extract API-provided counts whenever a model
-                # name is present, not just for LLM spans. Auto-instrumentors
-                # (OpenInference, GenAI) set model/token attrs on AGENT and CHAIN spans
-                # too. Text-based ESTIMATION, however, is LLM-spans-only (see below).
+                # Model & token fields — keep model names on every span that
+                # reports them, but adopt token counts only from LLM-kind spans.
+                # Some auto-instrumentors roll child usage up onto AGENT/CHAIN
+                # wrappers; pricing those wrapper totals double-counts the
+                # underlying LLM calls. Text-based ESTIMATION is also
+                # LLM-spans-only (see below).
                 model_name = (
                     span_attrs.get("traceroot.llm.model")
                     or span_attrs.get("gen_ai.request.model")
@@ -450,17 +452,19 @@ def transform_otel_to_clickhouse(
 
                     # Try API-provided token counts first (from instrumentors).
                     # OpenInference: llm.token_count.*  ·  GenAI semconv: gen_ai.usage.*
-                    input_token_keys = [
-                        "llm.token_count.prompt",
-                        "gen_ai.usage.input_tokens",
-                        "gen_ai.usage.prompt_tokens",
-                    ]
-                    output_token_keys = [
-                        "llm.token_count.completion",
-                        "gen_ai.usage.output_tokens",
-                        "gen_ai.usage.completion_tokens",
-                    ]
+                    input_token_keys: list[str] = []
+                    output_token_keys: list[str] = []
                     if span_kind == SpanKind.LLM:
+                        input_token_keys = [
+                            "llm.token_count.prompt",
+                            "gen_ai.usage.input_tokens",
+                            "gen_ai.usage.prompt_tokens",
+                        ]
+                        output_token_keys = [
+                            "llm.token_count.completion",
+                            "gen_ai.usage.output_tokens",
+                            "gen_ai.usage.completion_tokens",
+                        ]
                         # Vercel AI SDK raw GROSS totals are the only token source it
                         # normalizes to neither llm.* nor gen_ai.*, so we read them as
                         # a fallback. But they sit on BOTH the LLM doGenerate span AND

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -734,6 +734,85 @@ class TestTransformOtelToClickhouse:
             assert (s.get("output_tokens") or 0) == 0, f"oi_kind={oi_kind}"
             assert (s.get("cost") or 0) == 0, f"oi_kind={oi_kind}"
 
+    def test_normalized_api_counts_dropped_on_explicit_non_llm_span(self):
+        """An explicitly non-LLM wrapper with a model name and normalized usage
+        must not be priced from those counts. Future instrumentors may add model
+        names to AGENT/CHAIN wrappers that already carry aggregate gen_ai/llm
+        usage; accepting those counts would price wrapper totals as real calls."""
+        from unittest.mock import patch
+
+        prices = {"input": 0.000003, "output": 0.000015, "cacheRead": 0.0, "cacheWrite": 0.0}
+        for oi_kind in ("AGENT", "CHAIN"):
+            payload = make_otel_payload(
+                [
+                    make_span(
+                        "aa" * 16,
+                        "bb" * 8,
+                        name="future.wrapper",
+                        attributes=[
+                            make_attr("openinference.span.kind", oi_kind),
+                            make_attr("llm.model_name", "gpt-4o-mini"),
+                            make_attr("llm.token_count.prompt", 1234),
+                            make_attr("gen_ai.usage.output_tokens", 567),
+                        ],
+                    )
+                ],
+                scope_name="future.instrumentor",
+            )
+            with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+                _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+            s = spans[0]
+            assert (s.get("input_tokens") or 0) == 0, f"oi_kind={oi_kind}"
+            assert (s.get("output_tokens") or 0) == 0, f"oi_kind={oi_kind}"
+            assert (s.get("cost") or 0) == 0, f"oi_kind={oi_kind}"
+
+    def test_normalized_non_llm_wrapper_does_not_double_count_llm_child(self):
+        """If a wrapper rolls child usage up into normalized token keys, trace
+        totals must still come only from the LLM child span."""
+        from unittest.mock import patch
+
+        prices = {"input": 0.000003, "output": 0.000015, "cacheRead": 0.0, "cacheWrite": 0.0}
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    name="future.agent_wrapper",
+                    attributes=[
+                        make_attr("openinference.span.kind", "AGENT"),
+                        make_attr("llm.model_name", "gpt-4o-mini"),
+                        make_attr("llm.token_count.prompt", 203),
+                        make_attr("llm.token_count.completion", 178),
+                    ],
+                ),
+                make_span(
+                    "aa" * 16,
+                    "cc" * 8,
+                    name="future.llm_call",
+                    parent_span_id_hex="bb" * 8,
+                    attributes=[
+                        make_attr("openinference.span.kind", "LLM"),
+                        make_attr("llm.model_name", "gpt-4o-mini"),
+                        make_attr("llm.token_count.prompt", 203),
+                        make_attr("llm.token_count.completion", 178),
+                    ],
+                ),
+            ],
+            scope_name="future.instrumentor",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        wrapper = next(s for s in spans if s["name"] == "future.agent_wrapper")
+        child = next(s for s in spans if s["name"] == "future.llm_call")
+        assert (wrapper.get("input_tokens") or 0) == 0
+        assert (wrapper.get("output_tokens") or 0) == 0
+        assert child["input_tokens"] == 203
+        assert child["output_tokens"] == 178
+        assert sum((s.get("input_tokens") or 0) for s in spans) == 203
+        assert sum((s.get("output_tokens") or 0) for s in spans) == 178
+
     def test_vercel_generate_object_legacy_spellings_priced_on_llm_child_only(self):
         """generateObject emits only the legacy ai.usage.promptTokens /
         completionTokens spellings. The AGENT wrapper (ai.generateObject) and its

--- a/tests/worker/test_otel_transform_estimation_gate.py
+++ b/tests/worker/test_otel_transform_estimation_gate.py
@@ -8,8 +8,9 @@ Estimating tokens from a wrapper's text fabricates a duplicate of usage its LLM
 children already report, silently doubling per-trace token totals and cost.
 
 The estimation fallback must therefore fire only for spans classified as LLM.
-API-provided token counts are unaffected: they are trusted on any span kind, because
-some instrumentors legitimately report usage at the wrapper level.
+#1206 extends the same boundary to API-provided token counts: explicitly non-LLM
+wrapper spans can carry aggregate child usage, so adopting those counts silently
+double-counts the real LLM children.
 
 Estimation tests use Claude model names: their token estimate is a deterministic,
 offline `len(text) // 4`, so the tests never depend on tiktoken downloads or pricing DB.
@@ -132,13 +133,12 @@ def test_genai_chat_operation_still_gets_estimated_tokens():
 
 
 # ---------------------------------------------------------------------------
-# API-provided counts are trusted on ANY span kind (the gate must not touch them)
+# API-provided counts are also gated to LLM-kind spans
 # ---------------------------------------------------------------------------
 
 
-def test_agent_span_with_api_counts_keeps_them():
-    """Some instrumentors report real usage at the wrapper level; API-provided
-    counts must survive on non-LLM spans — only ESTIMATION is gated."""
+def test_agent_span_with_api_counts_dropped():
+    """Explicitly non-LLM spans keep their model name but do not adopt counts."""
     spans = _transform(
         [
             _span_with(
@@ -152,12 +152,11 @@ def test_agent_span_with_api_counts_keeps_them():
         ]
     )
     assert spans[0]["span_kind"] == "AGENT"
-    assert spans[0]["input_tokens"] == 120
-    assert spans[0]["output_tokens"] == 45
-    assert spans[0]["total_tokens"] == 165
+    assert spans[0]["model_name"] == MODEL
+    _assert_no_fabricated_tokens(spans[0])
 
 
-def test_agent_span_with_api_counts_still_gets_cost():
+def test_agent_span_with_api_counts_does_not_get_cost():
     mock_prices = {"input": 0.000003, "output": 0.000015}
     with patch("worker.tokens.pricing.get_model_price", return_value=mock_prices):
         spans = _transform(
@@ -172,7 +171,8 @@ def test_agent_span_with_api_counts_still_gets_cost():
                 )
             ]
         )
-    assert spans[0]["cost"] is not None and spans[0]["cost"] > 0
+    assert spans[0]["model_name"] == MODEL
+    _assert_no_fabricated_tokens(spans[0])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1206.

## Summary

- gate API-provided token count adoption to spans classified as LLM
- keep `model_name` on explicitly non-LLM spans, but do not price their normalized `llm.token_count.*` / `gen_ai.usage.*` values
- add regressions for normalized wrapper usage both with and without an LLM child
- update the old estimation-gate tests that intentionally protected the previous non-LLM API-count behavior

## Why

The Vercel raw `ai.usage.*` path was already gated to LLM spans, but normalized keys were still read whenever a span had a model name. If an AGENT/CHAIN wrapper carries model metadata plus aggregate child usage, the wrapper gets priced on top of the real LLM child spans.

This keeps sparse emitters working because a model-bearing span with no explicit non-LLM kind is still classified as LLM by `get_span_kind()`.

## Validation

- `uv run pytest tests/worker/test_otel_transform.py -k "normalized_api_counts_dropped_on_explicit_non_llm_span or normalized_non_llm_wrapper_does_not_double_count_llm_child"` — 2 passed
- `uv run pytest tests/worker/test_otel_transform.py` — 104 passed
- `uv run pytest tests/worker/tokens/test_buckets.py tests/worker/tokens/test_pricing.py` — 184 passed
- `uv run pytest tests/worker/test_otel_transform_estimation_gate.py` — 13 passed
- `uv run pytest tests/worker/` — 343 passed
- `uv run ruff check backend/worker/otel_transform.py tests/worker/test_otel_transform.py tests/worker/test_otel_transform_estimation_gate.py` — passed
- `git diff --check` — clean


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate API-provided token counts to LLM spans to prevent double-pricing when wrapper spans report aggregated usage. Non-LLM spans keep `model_name` but no longer adopt normalized counts or accrue cost. Aligns with #1206.

- **Bug Fixes**
  - Read normalized API counts (`llm.token_count.*`, `gen_ai.usage.*`) only on LLM spans; AGENT/CHAIN wrappers with models no longer get tokens or cost from these fields. Vercel `ai.usage.*` gross totals remain an LLM-only fallback.
  - Preserve `model_name` on non-LLM spans; spans with a model and no explicit non-LLM kind still classify as LLM.
  - Added regressions to ensure wrapper totals don't double-count LLM children and updated estimation-gate tests to reflect the new boundary.

<sup>Written for commit f974c171ec07cc1f382f3c98c5d32d533b2755e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


