### PR TITLE
fix(agent): persist tool result markers for session replay

### DIFF
--- a/frontend/packages/agent/src/__tests__/session.test.ts
+++ b/frontend/packages/agent/src/__tests__/session.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockPrisma = vi.hoisted(() => ({
+  aISession: {
+    findUnique: vi.fn(),
+  },
+  aIMessage: {
+    create: vi.fn(),
+  },
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: mockPrisma,
+}));
+
+import { SessionManager } from "../session.js";
+
+describe("SessionManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("persists tool results as compact tool messages with replay metadata", async () => {
+    mockPrisma.aISession.findUnique.mockResolvedValue({
+      workspaceId: "workspace-1",
+      userId: "user-1",
+    });
+
+    const manager = new SessionManager("session-1");
+
+    await manager.appendToolResult({
+      toolCallId: "call-1",
+      toolName: "download_traces",
+      args: { traceIds: ["trace-1"], label: "inspect trace" },
+      result: {
+        content: [
+          {
+            type: "text",
+            text: "Downloaded 1/1 traces:\ntrace-1 -> /workspace/traces/trace-1_demo/",
+          },
+        ],
+        details: undefined,
+      },
+      isError: false,
+    });
+
+    expect(mockPrisma.aIMessage.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        sessionId: "session-1",
+        workspaceId: "workspace-1",
+        kind: "chat",
+        role: "tool",
+        content: expect.stringContaining("/workspace/traces/trace-1_demo/"),
+        metadata: expect.objectContaining({
+          toolCallId: "call-1",
+          toolName: "download_traces",
+          args: { traceIds: ["trace-1"], label: "inspect trace" },
+          resultSummary: expect.stringContaining("Downloaded 1/1 traces"),
+          isError: false,
+        }),
+      }),
+    });
+  });
+
+  it("handles non-text tool result blocks, circular args, and long summaries", async () => {
+    mockPrisma.aISession.findUnique.mockResolvedValue({
+      workspaceId: "workspace-1",
+      userId: null,
+    });
+
+    const circularArgs: Record<string, unknown> = { traceId: "trace-1" };
+    circularArgs.self = circularArgs;
+    const longText = "x".repeat(8100);
+
+    const manager = new SessionManager("session-1");
+    await manager.appendToolResult({
+      toolCallId: "call-2",
+      toolName: "read",
+      args: circularArgs,
+      result: {
+        content: [
+          { type: "image", mimeType: "image/png", data: "base64" },
+          { type: "custom", payload: { ok: true } },
+          { type: "text", text: longText },
+        ],
+      },
+      isError: true,
+    });
+
+    const createData = mockPrisma.aIMessage.create.mock.calls[0][0].data;
+    expect(createData.kind).toBe("rca");
+    expect(createData.metadata.args).toBe("[object Object]");
+    expect(createData.metadata.resultSummary).toContain("[image: image/png]");
+    expect(createData.metadata.resultSummary).toContain('"payload"');
+    expect(createData.metadata.resultSummary).toContain("[truncated");
+    expect(createData.metadata.isError).toBe(true);
+  });
+
+  it("summarizes string tool results for older result payload shapes", async () => {
+    mockPrisma.aISession.findUnique.mockResolvedValue({
+      workspaceId: "workspace-1",
+      userId: "user-1",
+    });
+
+    const manager = new SessionManager("session-1");
+    await manager.appendToolResult({
+      toolCallId: "call-3",
+      toolName: "legacy_tool",
+      args: {},
+      result: "legacy plain text result",
+      isError: false,
+    });
+
+    const createData = mockPrisma.aIMessage.create.mock.calls[0][0].data;
+    expect(createData.content).toContain("legacy_tool");
+    expect(createData.content).toContain("legacy plain text result");
+    expect(createData.metadata.resultSummary).toBe("legacy plain text result");
+  });
+
+  it("falls back to stored tool content when replay metadata is incomplete", async () => {
+    const circularMetadata: Record<string, unknown> = { toolName: "read" };
+    circularMetadata.args = circularMetadata;
+
+    mockPrisma.aISession.findUnique.mockResolvedValue({
+      messages: [
+        {
+          role: "tool",
+          content: "raw stored tool result",
+          metadata: circularMetadata,
+          createTime: new Date("2026-07-08T00:00:03.000Z"),
+        },
+      ],
+    });
+
+    const manager = new SessionManager("session-1");
+    const context = await manager.buildContext();
+    const replayContent = context[0].role === "user" ? context[0].content : [];
+    const replayText =
+      Array.isArray(replayContent) && replayContent[0]?.type === "text"
+        ? replayContent[0].text
+        : "";
+
+    expect(replayText).toContain("read");
+    expect(replayText).toContain("[object Object]");
+    expect(replayText).toContain("raw stored tool result");
+  });
+
+  it("replays user and tool messages in database order", async () => {
+    mockPrisma.aISession.findUnique.mockResolvedValue({
+      messages: [
+        {
+          role: "user",
+          content: "Investigate this trace",
+          metadata: null,
+          createTime: new Date("2026-07-08T00:00:00.000Z"),
+        },
+        {
+          role: "tool",
+          content: "Tool succeeded: download_traces",
+          metadata: {
+            toolCallId: "call-1",
+            toolName: "download_traces",
+            args: { traceIds: ["trace-1"] },
+            resultSummary: "Downloaded to /workspace/traces/trace-1_demo/",
+            isError: false,
+          },
+          createTime: new Date("2026-07-08T00:00:01.000Z"),
+        },
+        {
+          role: "assistant",
+          content: "The failure came from the tool response.",
+          metadata: null,
+          createTime: new Date("2026-07-08T00:00:02.000Z"),
+        },
+      ],
+    });
+
+    const manager = new SessionManager("session-1");
+    const context = await manager.buildContext();
+
+    expect(context).toHaveLength(2);
+    expect(context[0]).toMatchObject({
+      role: "user",
+      timestamp: new Date("2026-07-08T00:00:00.000Z").getTime(),
+    });
+    expect(context[0].content).toEqual([{ type: "text", text: "Investigate this trace" }]);
+
+    expect(context[1]).toMatchObject({
+      role: "user",
+      timestamp: new Date("2026-07-08T00:00:01.000Z").getTime(),
+    });
+    const replayContent = context[1].role === "user" ? context[1].content : [];
+    const replayText =
+      Array.isArray(replayContent) && replayContent[0]?.type === "text"
+        ? replayContent[0].text
+        : "";
+    expect(replayText).toContain("[Previous tool result]");
+    expect(replayText).toContain("download_traces");
+    expect(replayText).toContain('"trace-1"');
+    expect(replayText).toContain("/workspace/traces/trace-1_demo/");
+    expect(replayText).toContain("rerun this tool");
+  });
+});

--- a/frontend/packages/agent/src/__tests__/tool-result-recorder.test.ts
+++ b/frontend/packages/agent/src/__tests__/tool-result-recorder.test.ts
@@ -1,0 +1,141 @@
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import { describe, expect, it, vi } from "vitest";
+
+import { createToolResultRecorder } from "../tool-result-recorder.js";
+import type { ToolResultData } from "../session.js";
+
+type TurnEndEvent = Extract<AgentEvent, { type: "turn_end" }>;
+
+const turnEnd = (toolResults: TurnEndEvent["toolResults"]): AgentEvent => ({
+  type: "turn_end",
+  message: {
+    role: "assistant",
+    content: [],
+    api: "test" as never,
+    provider: "test" as never,
+    model: "test",
+    usage: {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 0,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+    },
+    stopReason: "toolUse",
+    timestamp: 0,
+  },
+  toolResults,
+});
+
+describe("createToolResultRecorder", () => {
+  it("persists turn_end tool results with args captured from tool start events", async () => {
+    const appendToolResult = vi.fn<(_: ToolResultData) => Promise<void>>().mockResolvedValue();
+    const recorder = createToolResultRecorder({ appendToolResult });
+
+    recorder.handleEvent({
+      type: "tool_execution_start",
+      toolCallId: "call-1",
+      toolName: "download_traces",
+      args: { traceIds: ["trace-1"] },
+    });
+    recorder.handleEvent(
+      turnEnd([
+        {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "download_traces",
+          content: [{ type: "text", text: "downloaded" }],
+          details: { path: "/workspace/traces/trace-1" },
+          isError: false,
+          timestamp: 1,
+        },
+      ]),
+    );
+
+    await recorder.flush();
+
+    expect(appendToolResult).toHaveBeenCalledWith({
+      toolCallId: "call-1",
+      toolName: "download_traces",
+      args: { traceIds: ["trace-1"] },
+      result: {
+        content: [{ type: "text", text: "downloaded" }],
+        details: { path: "/workspace/traces/trace-1" },
+      },
+      isError: false,
+    });
+  });
+
+  it("falls back to toolResult fields when a start event was not observed", async () => {
+    const appendToolResult = vi.fn<(_: ToolResultData) => Promise<void>>().mockResolvedValue();
+    const recorder = createToolResultRecorder({ appendToolResult });
+
+    recorder.handleEvent(
+      turnEnd([
+        {
+          role: "toolResult",
+          toolCallId: "call-2",
+          toolName: "bash",
+          content: [{ type: "text", text: "boom" }],
+          isError: true,
+          timestamp: 1,
+        },
+      ]),
+    );
+
+    await recorder.flush();
+
+    expect(appendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolCallId: "call-2",
+        toolName: "bash",
+        args: {},
+        isError: true,
+      }),
+    );
+  });
+
+  it("logs persistence failures and continues later tool result writes", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const appendToolResult = vi
+      .fn<(_: ToolResultData) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("db down"))
+      .mockResolvedValueOnce(undefined);
+    const recorder = createToolResultRecorder({ appendToolResult });
+
+    recorder.handleEvent(
+      turnEnd([
+        {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "first" }],
+          isError: false,
+          timestamp: 1,
+        },
+      ]),
+    );
+    recorder.handleEvent(
+      turnEnd([
+        {
+          role: "toolResult",
+          toolCallId: "call-2",
+          toolName: "read",
+          content: [{ type: "text", text: "second" }],
+          isError: false,
+          timestamp: 2,
+        },
+      ]),
+    );
+
+    await recorder.flush();
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[Agent] Failed to persist tool result call-1:",
+      "db down",
+    );
+    expect(appendToolResult).toHaveBeenCalledTimes(2);
+    errorSpy.mockRestore();
+  });
+});

--- a/frontend/packages/agent/src/index.ts
+++ b/frontend/packages/agent/src/index.ts
@@ -15,6 +15,7 @@ import { getSystemPrompt } from "./prompts/system.js";
 import { createExecutor } from "./executors/index.js";
 import { createTools } from "./tools/index.js";
 import type { Executor } from "./executors/interface.js";
+import { createToolResultRecorder } from "./tool-result-recorder.js";
 
 const app = new Hono();
 
@@ -182,6 +183,7 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
   return streamSSE(c, async (stream) => {
     let assistantText = "";
     let loggedFirstUpdate = false;
+    const toolResultRecorder = createToolResultRecorder(sessionManager);
 
     // Accumulate token usage across all message_end events (tool-use loops)
     let totalInputTokens = 0;
@@ -232,6 +234,7 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
             if (msg?.model) responseModel = msg.model;
             if (msg?.provider) responseProvider = msg.provider;
           }
+          toolResultRecorder.handleEvent(event);
           // Forward all events to the frontend
           stream.writeSSE({
             event: event.type,
@@ -257,6 +260,7 @@ app.post("/api/v1/projects/:projectId/sessions/:sessionId/messages", async (c) =
         },
         onDone: async () => {
           console.log(`[Agent] Done. Assistant text length: ${assistantText.length}`);
+          await toolResultRecorder.flush();
           // Persist assistant response to DB via SessionManager
           if (assistantText) {
             // Use our pricing table if pi-ai returned 0 cost

--- a/frontend/packages/agent/src/session.ts
+++ b/frontend/packages/agent/src/session.ts
@@ -1,6 +1,6 @@
 import { prisma } from "@traceroot/core";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
-import type { UserMessage, Message } from "@earendil-works/pi-ai";
+import type { UserMessage } from "@earendil-works/pi-ai";
 
 // ============================================================
 // SessionManager — follows Mom's SessionManager pattern
@@ -17,6 +17,98 @@ export interface TokenUsageData {
   cost: number;
 }
 
+export interface ToolResultData {
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+  result: unknown;
+  isError: boolean;
+}
+
+const MAX_TOOL_RESULT_CHARS = 8000;
+const MAX_REPLAY_CHARS = 8000;
+
+function truncateText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}\n\n[truncated ${text.length - maxChars} chars]`;
+}
+
+function safeJson(value: unknown): unknown {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return String(value);
+  }
+}
+
+function formatJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function contentBlockToText(block: unknown): string {
+  if (!isRecord(block)) return formatJson(block);
+  if (block.type === "text" && typeof block.text === "string") {
+    return block.text;
+  }
+  if (block.type === "image") {
+    const mimeType = typeof block.mimeType === "string" ? block.mimeType : "unknown";
+    return `[image: ${mimeType}]`;
+  }
+  return formatJson(block);
+}
+
+function summarizeToolResult(result: unknown): string {
+  if (isRecord(result) && Array.isArray(result.content)) {
+    const text = result.content.map(contentBlockToText).join("\n");
+    return truncateText(text || "(empty tool result)", MAX_TOOL_RESULT_CHARS);
+  }
+  if (typeof result === "string") {
+    return truncateText(result, MAX_TOOL_RESULT_CHARS);
+  }
+  return truncateText(formatJson(result), MAX_TOOL_RESULT_CHARS);
+}
+
+function userMessage(content: string, timestamp: number): UserMessage {
+  return {
+    role: "user",
+    content: [{ type: "text", text: content }],
+    timestamp,
+  };
+}
+
+function formatToolReplay(content: string, metadata: unknown): string {
+  const meta = isRecord(metadata) ? metadata : {};
+  const toolName = typeof meta.toolName === "string" ? meta.toolName : "unknown_tool";
+  const args = "args" in meta ? meta.args : {};
+  const resultSummary =
+    typeof meta.resultSummary === "string" && meta.resultSummary.length > 0
+      ? meta.resultSummary
+      : content;
+  const status = meta.isError === true ? "error" : "success";
+
+  return truncateText(
+    [
+      "[Previous tool result]",
+      `Tool: ${toolName}`,
+      `Status: ${status}`,
+      `Args: ${formatJson(args)}`,
+      "Result:",
+      resultSummary,
+      "",
+      "If referenced /workspace files are missing after resume, rerun this tool with the recorded arguments.",
+    ].join("\n"),
+    MAX_REPLAY_CHARS,
+  );
+}
+
 export class SessionManager {
   constructor(private sessionId: string) {}
 
@@ -25,10 +117,12 @@ export class SessionManager {
    * Like Mom's sessionManager.buildSessionContext() — loads persisted
    * messages from DB and converts them to AgentMessage format.
    *
-   * We only restore user messages from DB. Assistant messages are not
-   * restored because they require full LLM metadata (api, provider, model,
-   * usage, stopReason). The agent will see user messages as context and
-   * generate fresh responses.
+   * We restore user messages and lightweight tool-result markers. Assistant
+   * messages are still not restored natively because they require full LLM
+   * metadata (api, provider, model, usage, stopReason). Tool markers are
+   * replayed as user-visible context so the model can recover durable file
+   * paths and rerun instructions without constructing invalid tool-result
+   * sequences.
    */
   async buildContext(): Promise<AgentMessage[]> {
     const session = await prisma.aISession.findUnique({
@@ -40,16 +134,20 @@ export class SessionManager {
       return [];
     }
 
-    // Only restore user messages — assistant messages lack required LLM metadata
-    return session.messages
-      .filter((m) => m.role === "user")
-      .map(
-        (m): UserMessage => ({
-          role: "user",
-          content: [{ type: "text", text: m.content }],
-          timestamp: m.createTime.getTime(),
-        }),
-      );
+    const context: AgentMessage[] = [];
+    for (const message of session.messages) {
+      if (message.role === "user") {
+        context.push(userMessage(message.content, message.createTime.getTime()));
+      } else if (message.role === "tool") {
+        context.push(
+          userMessage(
+            formatToolReplay(message.content, message.metadata),
+            message.createTime.getTime(),
+          ),
+        );
+      }
+    }
+    return context;
   }
 
   /**
@@ -93,6 +191,25 @@ export class SessionManager {
           cost: tokenUsage.cost,
         }),
       },
+    });
+  }
+
+  async appendToolResult(params: ToolResultData): Promise<void> {
+    const resultSummary = summarizeToolResult(params.result);
+    const args = safeJson(params.args);
+    const content = [
+      `Tool ${params.isError ? "failed" : "succeeded"}: ${params.toolName}`,
+      `Args: ${formatJson(args)}`,
+      "Result:",
+      resultSummary,
+    ].join("\n");
+
+    await this.appendMessage("tool", content, {
+      toolCallId: params.toolCallId,
+      toolName: params.toolName,
+      args,
+      resultSummary,
+      isError: params.isError,
     });
   }
 }

--- a/frontend/packages/agent/src/tool-result-recorder.ts
+++ b/frontend/packages/agent/src/tool-result-recorder.ts
@@ -1,0 +1,62 @@
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import type { SessionManager, ToolResultData } from "./session.js";
+
+type ToolCallState = Pick<ToolResultData, "toolName" | "args">;
+
+export interface ToolResultRecorder {
+  handleEvent(event: AgentEvent): void;
+  flush(): Promise<void>;
+}
+
+export function createToolResultRecorder(
+  sessionManager: Pick<SessionManager, "appendToolResult">,
+): ToolResultRecorder {
+  const toolCalls = new Map<string, ToolCallState>();
+  let persistChain = Promise.resolve();
+
+  const enqueuePersist = (params: ToolResultData) => {
+    persistChain = persistChain
+      .then(() => sessionManager.appendToolResult(params))
+      .catch((error) => {
+        console.error(
+          `[Agent] Failed to persist tool result ${params.toolCallId}:`,
+          error instanceof Error ? error.message : error,
+        );
+      });
+  };
+
+  return {
+    handleEvent(event: AgentEvent): void {
+      if (event.type === "tool_execution_start") {
+        toolCalls.set(event.toolCallId, {
+          toolName: event.toolName,
+          args: event.args ?? {},
+        });
+        return;
+      }
+
+      if (event.type !== "turn_end" || event.toolResults.length === 0) {
+        return;
+      }
+
+      for (const toolResult of event.toolResults) {
+        const toolCall = toolCalls.get(toolResult.toolCallId);
+        enqueuePersist({
+          toolCallId: toolResult.toolCallId,
+          toolName: toolResult.toolName || toolCall?.toolName || "unknown_tool",
+          args: toolCall?.args ?? {},
+          result: {
+            content: toolResult.content,
+            details: toolResult.details,
+          },
+          isError: toolResult.isError,
+        });
+        toolCalls.delete(toolResult.toolCallId);
+      }
+    },
+
+    flush(): Promise<void> {
+      return persistChain;
+    },
+  };
+}

--- a/frontend/ui/src/features/ai-assistant/hooks/message-history.test.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/message-history.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { mapPersistedMessage } from "./message-history";
+
+describe("mapPersistedMessage", () => {
+  it("maps persisted tool rows to tool_step messages", () => {
+    const mapped = mapPersistedMessage({
+      id: "msg-1",
+      role: "tool",
+      content: "fallback result",
+      createTime: "2026-07-08T00:00:00.000Z",
+      metadata: {
+        toolCallId: "call-1",
+        toolName: "download_traces",
+        args: { traceIds: ["trace-1"] },
+        resultSummary: "Downloaded to /workspace/traces/trace-1/",
+        isError: false,
+      },
+    });
+
+    expect(mapped).toEqual({
+      id: "msg-1",
+      role: "tool_step",
+      content: "",
+      timestamp: "2026-07-08T00:00:00.000Z",
+      toolStep: {
+        toolCallId: "call-1",
+        toolName: "download_traces",
+        args: { traceIds: ["trace-1"] },
+        result: "Downloaded to /workspace/traces/trace-1/",
+        isError: false,
+        status: "done",
+      },
+    });
+  });
+
+  it("uses safe fallbacks for old or malformed tool metadata", () => {
+    const mapped = mapPersistedMessage({
+      id: "msg-2",
+      role: "tool",
+      content: "raw tool content",
+      createTime: "2026-07-08T00:00:01.000Z",
+      metadata: { isError: true, args: ["not", "an", "object"] },
+    });
+
+    expect(mapped.role).toBe("tool_step");
+    expect(mapped.toolStep).toMatchObject({
+      toolCallId: "msg-2",
+      toolName: "unknown_tool",
+      args: {},
+      result: "raw tool content",
+      isError: true,
+      status: "error",
+    });
+  });
+
+  it("preserves assistant usage fields from persisted rows", () => {
+    const mapped = mapPersistedMessage({
+      id: "msg-3",
+      role: "assistant",
+      content: "answer",
+      createTime: "2026-07-08T00:00:02.000Z",
+      inputTokens: 10,
+      outputTokens: 20,
+      cost: "0.0123",
+    });
+
+    expect(mapped).toMatchObject({
+      id: "msg-3",
+      role: "assistant",
+      content: "answer",
+      timestamp: "2026-07-08T00:00:02.000Z",
+      inputTokens: 10,
+      outputTokens: 20,
+      costUsd: 0.0123,
+    });
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/hooks/message-history.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/message-history.ts
@@ -1,0 +1,61 @@
+import type { AIMessage } from "../types";
+
+export interface PersistedAIMessage {
+  id: string;
+  role: string;
+  content: string;
+  createTime: string;
+  metadata?: unknown;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  cost?: string | number | null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function mapPersistedMessage(message: PersistedAIMessage): AIMessage {
+  if (message.role === "tool") {
+    const metadata = isRecord(message.metadata) ? message.metadata : {};
+    const toolName = typeof metadata.toolName === "string" ? metadata.toolName : "unknown_tool";
+    const toolCallId = typeof metadata.toolCallId === "string" ? metadata.toolCallId : message.id;
+    const args = isRecord(metadata.args) ? metadata.args : {};
+    const isError = metadata.isError === true;
+    const result =
+      typeof metadata.resultSummary === "string" ? metadata.resultSummary : message.content;
+
+    return {
+      id: message.id,
+      role: "tool_step",
+      content: "",
+      timestamp: message.createTime,
+      toolStep: {
+        toolCallId,
+        toolName,
+        args,
+        result,
+        isError,
+        status: isError ? "error" : "done",
+      },
+    };
+  }
+
+  const role = message.role === "user" ? "user" : "assistant";
+  const costUsd =
+    message.cost == null
+      ? undefined
+      : typeof message.cost === "number"
+        ? message.cost
+        : Number(message.cost);
+
+  return {
+    id: message.id,
+    role,
+    content: message.content,
+    timestamp: message.createTime,
+    inputTokens: message.inputTokens ?? undefined,
+    outputTokens: message.outputTokens ?? undefined,
+    costUsd: Number.isFinite(costUsd) ? costUsd : undefined,
+  };
+}

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -2,7 +2,8 @@
 
 import { useRef, useState, useCallback, useEffect } from "react";
 import { useAIStream } from "./use-ai-stream";
-import type { AISession, AIMessage, AiTraceContext } from "../types";
+import { mapPersistedMessage } from "./message-history";
+import type { AISession, AiTraceContext } from "../types";
 import type { ModelSelection } from "../components/model-selector";
 
 interface UseAiChatOptions extends AiTraceContext {
@@ -59,14 +60,7 @@ export function useAiChat({
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
         if (ac.signal.aborted || !data) return;
-        const all = (data.messages || []).map(
-          (m: { id: string; role: string; content: string; createTime: string }) => ({
-            id: m.id,
-            role: m.role as "user" | "assistant",
-            content: m.content,
-            timestamp: m.createTime,
-          }),
-        );
+        const all = (data.messages || []).map(mapPersistedMessage);
         setMessages(all);
       })
       .catch((err) => {
@@ -172,12 +166,7 @@ export function useAiChat({
         const res = await fetch(`/api/projects/${projectId}/ai/sessions/${session.id}/messages`);
         if (res.ok) {
           const data = await res.json();
-          const loaded = (data.messages || []).map((m: any) => ({
-            id: m.id,
-            role: m.role as "user" | "assistant",
-            content: m.content,
-            timestamp: m.createTime,
-          }));
+          const loaded = (data.messages || []).map(mapPersistedMessage);
           setMessages(loaded);
         }
       } catch (err) {


### PR DESCRIPTION
## Summary

This is a first Option-C slice for #808, not a full fix for durable sandbox/executor state.

It persists lightweight tool-result markers so follow-up turns can recover what prior tool calls did after an agent restart, model switch, or completed RCA handoff.

## What changed

- Persist `turn_end.toolResults` as `AIMessage` rows with `role="tool"`.
- Store compact replay metadata: `toolCallId`, `toolName`, args, result summary, and error state.
- Replay persisted tool markers in `SessionManager.buildContext()` as plain user context instead of fabricating native tool-result messages without full assistant/tool-call metadata.
- Map persisted `role="tool"` rows back into the existing UI `tool_step` shape when loading session history.
- Extract the new glue into `tool-result-recorder.ts` and `message-history.ts` so the behavior is directly unit-tested.
- Add `SessionManager` coverage for tool-result persistence, replay ordering, malformed metadata, non-text content blocks, legacy string result payloads, and truncation behavior.

## Why this shape

`pi-agent-core` native tool-result replay needs the matching assistant tool-call message. TraceRoot currently stores assistant text, but not the full assistant message metadata/content needed to reconstruct a valid provider transcript.

This PR keeps replay safe by treating previous tool results as contextual markers and adding a rerun hint when referenced `/workspace` files are missing. It intentionally references #808 instead of closing it, because durable sandbox/executor rehydration remains a follow-up.

## Validation

- `corepack pnpm --filter @traceroot/agent test` — 35 passed
- `corepack pnpm --filter @traceroot/agent build` — passed
- `corepack pnpm --filter @traceroot/agent test:coverage` — 35 passed
- `corepack pnpm --filter traceroot-ui test:coverage` — 82 files / 508 tests passed
- `corepack pnpm run lint` — 0 errors, existing warnings only
- `corepack pnpm run format:check` — passed
- `git diff --check` — clean
- Local CI-style `diff-cover` over merged frontend lcov — 81%, passed the >= 80% gate

References #808.
