### PR TITLE
fix(rest): prefer API-counted token rollups

### DIFF
--- a/backend/rest/services/filters/columns.py
+++ b/backend/rest/services/filters/columns.py
@@ -14,6 +14,8 @@ parity test cross-checks the two once the Gateway merges.
 from dataclasses import dataclass
 from enum import StrEnum
 
+from rest.services.token_rollup import authoritative_sum_expr
+
 
 class FilterLevel(StrEnum):
     """How a predicate on the field lowers into the trace-list WHERE clause."""
@@ -154,8 +156,8 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         type=FilterType.NUMERIC,
         operators=_NUMERIC_OPS,
         value_source=ValueSource.RANGE,
-        aggregate_expr="sum(cost)",
-        source_columns=("cost",),
+        aggregate_expr=authoritative_sum_expr("cost"),
+        source_columns=("cost", "usage_details"),
     ),
     FilterColumn(
         name="total_tokens",
@@ -165,8 +167,8 @@ FILTER_COLUMNS: tuple[FilterColumn, ...] = (
         type=FilterType.NUMERIC,
         operators=_NUMERIC_OPS,
         value_source=ValueSource.RANGE,
-        aggregate_expr="sum(total_tokens)",
-        source_columns=("total_tokens",),
+        aggregate_expr=authoritative_sum_expr("total_tokens"),
+        source_columns=("total_tokens", "usage_details"),
     ),
     FilterColumn(
         name="duration_ms",

--- a/backend/rest/services/token_rollup.py
+++ b/backend/rest/services/token_rollup.py
@@ -1,0 +1,47 @@
+"""SQL helpers for trace/session/user token rollups.
+
+Span-level token columns can mix API-provided counts with text-estimated fallback
+counts. When a trace has any API-counted spans, trace-level totals should prefer
+those authoritative spans and ignore wrapper estimates that restate child usage.
+"""
+
+
+def api_token_span_predicate(usage_details_col: str = "usage_details") -> str:
+    """Return the ClickHouse predicate that marks API-provided token spans.
+
+    The ingest path writes ``usage_details`` only for instrumentor/API token-count
+    branches. Text-estimated spans leave the map empty.
+    """
+
+    return f"length(mapKeys({usage_details_col})) > 0"
+
+
+def authoritative_sum_expr(column: str, usage_details_col: str = "usage_details") -> str:
+    """Prefer API-counted spans for a group, falling back to all spans.
+
+    The expression is intended for grouped ClickHouse queries. Within each group,
+    if at least one span has API token-count metadata, sum only those spans;
+    otherwise preserve the old behavior and sum all spans.
+    """
+
+    predicate = api_token_span_predicate(usage_details_col)
+    return f"if(countIf({predicate}) > 0, sumIf({column}, {predicate}), sum({column}))"
+
+
+def authoritative_token_rollup_select(
+    *,
+    input_alias: str = "total_input_tokens",
+    output_alias: str = "total_output_tokens",
+    cost_alias: str = "total_cost",
+    source_prefix: str = "",
+) -> str:
+    """Return a SELECT fragment for input/output/cost rollups."""
+
+    usage_details_col = f"{source_prefix}usage_details"
+    return "\n".join(
+        [
+            f"{authoritative_sum_expr(f'{source_prefix}input_tokens', usage_details_col)} as {input_alias},",
+            f"{authoritative_sum_expr(f'{source_prefix}output_tokens', usage_details_col)} as {output_alias},",
+            f"{authoritative_sum_expr(f'{source_prefix}cost', usage_details_col)} as {cost_alias}",
+        ]
+    )

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 
 from db.clickhouse import get_clickhouse_client
 from rest.services.filters.translate import Predicate, build_conditions
+from rest.services.token_rollup import authoritative_token_rollup_select
 from rest.sql_utils import escape_ilike, to_utc_naive
 from worker.tokens.buckets import TokenBuckets, reconcile_cache_write_1h
 from worker.tokens.pricing import cost_breakdown_from_buckets, get_model_price
@@ -254,6 +255,7 @@ class TraceReaderService:
         # instead of FINAL), then aggregate spans for ONLY that page's trace_ids.
         # This avoids scanning/joining every span in the project on each list call,
         # and never groups by the large input/output text columns. See #963.
+        token_rollup = authoritative_token_rollup_select()
         query = f"""
             WITH page AS (
                 -- Dedup ReplacingMergeTree by latest ch_update_time FIRST (correctness),
@@ -283,12 +285,10 @@ class TraceReaderService:
                         NULL
                     ) as duration_ms,
                     countIf(status = 'ERROR') as error_count,
-                    sum(input_tokens) as total_input_tokens,
-                    sum(output_tokens) as total_output_tokens,
-                    sum(cost) as total_cost
+                    {token_rollup}
                 FROM (
                     SELECT trace_id, span_id, status, span_start_time, span_end_time,
-                           input_tokens, output_tokens, cost
+                           input_tokens, output_tokens, cost, usage_details
                     FROM spans
                     WHERE project_id = {{project_id:String}}
                       AND trace_id IN (SELECT trace_id FROM page)
@@ -613,6 +613,11 @@ class TraceReaderService:
         # instead of FINAL), then dedupe the traces for that page of sessions and
         # aggregate spans for only those trace_ids. Avoids the full traces x spans
         # FINAL join + group-by-on-text over the whole project on each call. See #963.
+        trace_token_rollup = authoritative_token_rollup_select(
+            input_alias="trace_input_tokens",
+            output_alias="trace_output_tokens",
+            cost_alias="trace_cost",
+        )
         query = f"""
             WITH session_page AS (
                 SELECT t.session_id
@@ -645,12 +650,10 @@ class TraceReaderService:
                         dateDiff('millisecond', min(span_start_time), max(span_end_time)),
                         NULL
                     ) as trace_duration_ms,
-                    sum(input_tokens) as trace_input_tokens,
-                    sum(output_tokens) as trace_output_tokens,
-                    sum(cost) as trace_cost
+                    {trace_token_rollup}
                 FROM (
                     SELECT trace_id, span_id, span_start_time, span_end_time,
-                           input_tokens, output_tokens, cost
+                           input_tokens, output_tokens, cost, usage_details
                     FROM spans
                     WHERE project_id = {{project_id:String}}
                       AND trace_id IN (SELECT trace_id FROM traces_dedup)
@@ -915,20 +918,27 @@ class TraceReaderService:
                     if self._is_empty_io(t["output"]) and not self._is_empty_io(span_io[1]):
                         t["output"] = span_io[1]
 
-        # Step 3: Get token totals from spans for all traces in this session
-        # Dedup spans without FINAL (latest per span_id), then sum tokens/cost.
-        tokens_query = """
+        # Step 3: Get token totals from spans for all traces in this session.
+        # Apply the authoritative-count preference per trace, then sum traces.
+        token_rollup = authoritative_token_rollup_select()
+        tokens_query = f"""
             SELECT
-                sum(input_tokens) as total_input_tokens,
-                sum(output_tokens) as total_output_tokens,
-                sum(cost) as total_cost
+                sum(total_input_tokens) as total_input_tokens,
+                sum(total_output_tokens) as total_output_tokens,
+                sum(total_cost) as total_cost
             FROM (
-                SELECT input_tokens, output_tokens, cost
-                FROM spans
-                WHERE project_id = {project_id:String}
-                  AND trace_id IN ({trace_ids:Array(String)})
-                ORDER BY ch_update_time DESC
-                LIMIT 1 BY span_id
+                SELECT
+                    trace_id,
+                    {token_rollup}
+                FROM (
+                    SELECT trace_id, input_tokens, output_tokens, cost, usage_details
+                    FROM spans
+                    WHERE project_id = {{project_id:String}}
+                      AND trace_id IN ({{trace_ids:Array(String)}})
+                    ORDER BY ch_update_time DESC
+                    LIMIT 1 BY project_id, trace_id, span_id
+                )
+                GROUP BY trace_id
             )
         """
         tokens_result = self._client.query(
@@ -998,6 +1008,7 @@ class TraceReaderService:
         # deduped via LIMIT 1 BY instead of FINAL), then sum span tokens/cost for only
         # that page's users' traces. Avoids the full traces x spans FINAL join over the
         # whole project on each call. See #963.
+        user_trace_token_rollup = authoritative_token_rollup_select()
         query = f"""
             WITH user_page AS (
                 SELECT
@@ -1023,21 +1034,28 @@ class TraceReaderService:
                 ORDER BY t.ch_update_time DESC
                 LIMIT 1 BY t.project_id, t.trace_id
             ),
-            span_totals AS (
+            span_trace_totals AS (
                 SELECT
-                    ut.user_id,
-                    sum(s.input_tokens) as total_input_tokens,
-                    sum(s.output_tokens) as total_output_tokens,
-                    sum(s.cost) as total_cost
-                FROM user_traces AS ut
-                LEFT JOIN (
-                    SELECT trace_id, span_id, input_tokens, output_tokens, cost
+                    trace_id,
+                    {user_trace_token_rollup}
+                FROM (
+                    SELECT trace_id, span_id, input_tokens, output_tokens, cost, usage_details
                     FROM spans
                     WHERE project_id = {{project_id:String}}
                       AND trace_id IN (SELECT trace_id FROM user_traces)
                     ORDER BY ch_update_time DESC
                     LIMIT 1 BY project_id, trace_id, span_id
-                ) AS s ON ut.trace_id = s.trace_id
+                )
+                GROUP BY trace_id
+            ),
+            span_totals AS (
+                SELECT
+                    ut.user_id,
+                    sum(stt.total_input_tokens) as total_input_tokens,
+                    sum(stt.total_output_tokens) as total_output_tokens,
+                    sum(stt.total_cost) as total_cost
+                FROM user_traces AS ut
+                LEFT JOIN span_trace_totals AS stt ON ut.trace_id = stt.trace_id
                 GROUP BY ut.user_id
             )
             SELECT

--- a/tests/rest/test_filter_columns_parity.py
+++ b/tests/rest/test_filter_columns_parity.py
@@ -11,6 +11,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 from rest.services.filters import columns as reg
+from rest.services.token_rollup import authoritative_sum_expr
 
 MEMBERSHIP_FIELDS = {"model_name", "environment"}
 AGGREGATE_FIELDS = {"cost", "total_tokens", "duration_ms", "errors"}
@@ -77,10 +78,10 @@ def test_open_ended_categoricals_use_a_distinct_query_with_no_static_values():
         assert col.enum_values == ()
 
 
-def test_duration_aggregates_via_min_max_while_cost_and_tokens_sum():
-    """duration is max(end)-min(start), NOT a sum — the lowering must differ."""
-    assert reg.get_column("cost").aggregate_expr == "sum(cost)"
-    assert reg.get_column("total_tokens").aggregate_expr == "sum(total_tokens)"
+def test_duration_aggregates_via_min_max_while_cost_and_tokens_prefer_api_counts():
+    """duration is max(end)-min(start); token/cost filters prefer API-counted spans."""
+    assert reg.get_column("cost").aggregate_expr == authoritative_sum_expr("cost")
+    assert reg.get_column("total_tokens").aggregate_expr == authoritative_sum_expr("total_tokens")
     dur = reg.get_column("duration_ms").aggregate_expr
     assert "min(span_start_time)" in dur and "max(span_end_time)" in dur
     assert "sum(" not in dur
@@ -89,8 +90,8 @@ def test_duration_aggregates_via_min_max_while_cost_and_tokens_sum():
 def test_aggregate_source_columns_name_the_referenced_spans_columns():
     """Each aggregate field declares the spans columns its aggregate_expr references, so
     the semi-join's inner projection is registry-driven. Membership fields declare none."""
-    assert reg.get_column("cost").source_columns == ("cost",)
-    assert reg.get_column("total_tokens").source_columns == ("total_tokens",)
+    assert reg.get_column("cost").source_columns == ("cost", "usage_details")
+    assert reg.get_column("total_tokens").source_columns == ("total_tokens", "usage_details")
     assert reg.get_column("duration_ms").source_columns == ("span_start_time", "span_end_time")
     assert reg.get_column("errors").source_columns == ("status",)
     for name in MEMBERSHIP_FIELDS | TRACE_FIELDS:

--- a/tests/rest/test_filter_translate.py
+++ b/tests/rest/test_filter_translate.py
@@ -17,6 +17,7 @@ from rest.services.filters.translate import (
     build_conditions,
     parse_filters_param,
 )
+from rest.services.token_rollup import authoritative_sum_expr
 
 # --- parsing ---------------------------------------------------------------
 
@@ -205,11 +206,11 @@ def test_membership_predicates_on_different_fields_emit_independent_semijoins():
 @pytest.mark.parametrize(
     "op,token",
     [
-        ("eq", "sum(cost) = {"),
-        ("gt", "sum(cost) > {"),
-        ("gte", "sum(cost) >= {"),
-        ("lt", "sum(cost) < {"),
-        ("lte", "sum(cost) <= {"),
+        ("eq", f"{authoritative_sum_expr('cost')} = {{"),
+        ("gt", f"{authoritative_sum_expr('cost')} > {{"),
+        ("gte", f"{authoritative_sum_expr('cost')} >= {{"),
+        ("lt", f"{authoritative_sum_expr('cost')} < {{"),
+        ("lte", f"{authoritative_sum_expr('cost')} <= {{"),
     ],
 )
 def test_numeric_operator_lowers_to_its_having_comparison(op, token):
@@ -251,10 +252,20 @@ def test_multiple_numeric_predicates_on_same_field_form_a_range():
     )
     assert len(conditions) == 1
     cond = conditions[0]
-    assert "sum(cost) > {" in cond
-    assert "sum(cost) <= {" in cond
+    cost_expr = authoritative_sum_expr("cost")
+    assert f"{cost_expr} > {{" in cond
+    assert f"{cost_expr} <= {{" in cond
     assert " AND " in cond
     assert 1 in params.values() and 10 in params.values()
+
+
+def test_cost_filter_projects_usage_details_for_authoritative_token_rollup():
+    params = {"project_id": "p1"}
+    cond = build_conditions([Predicate(field="cost", op="gt", value=1)], params)[0]
+
+    select_clause = cond.split("FROM spans", 1)[0]
+    assert "usage_details" in select_clause
+    assert authoritative_sum_expr("cost") in cond
 
 
 def test_duplicate_predicates_on_same_field_get_distinct_params():

--- a/tests/rest/test_token_rollup.py
+++ b/tests/rest/test_token_rollup.py
@@ -1,0 +1,29 @@
+from rest.services.token_rollup import (
+    api_token_span_predicate,
+    authoritative_sum_expr,
+    authoritative_token_rollup_select,
+)
+
+
+def test_api_token_span_predicate_uses_usage_details_map():
+    assert api_token_span_predicate() == "length(mapKeys(usage_details)) > 0"
+    assert api_token_span_predicate("s.usage_details") == "length(mapKeys(s.usage_details)) > 0"
+
+
+def test_authoritative_sum_prefers_api_counted_spans_then_falls_back():
+    expr = authoritative_sum_expr("input_tokens")
+
+    assert "countIf(length(mapKeys(usage_details)) > 0) > 0" in expr
+    assert "sumIf(input_tokens, length(mapKeys(usage_details)) > 0)" in expr
+    assert "sum(input_tokens)" in expr
+
+
+def test_authoritative_rollup_select_can_prefix_joined_span_columns():
+    select = authoritative_token_rollup_select(source_prefix="s.")
+
+    assert "sumIf(s.input_tokens, length(mapKeys(s.usage_details)) > 0)" in select
+    assert "as total_input_tokens" in select
+    assert "sumIf(s.output_tokens, length(mapKeys(s.usage_details)) > 0)" in select
+    assert "as total_output_tokens" in select
+    assert "sumIf(s.cost, length(mapKeys(s.usage_details)) > 0)" in select
+    assert "as total_cost" in select

--- a/tests/rest/test_trace_reader_filters.py
+++ b/tests/rest/test_trace_reader_filters.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
 from rest.services.filters.translate import Predicate
+from rest.services.token_rollup import authoritative_sum_expr
 from rest.services.trace_reader import DEFAULT_SPAN_SCAN_LOOKBACK_HOURS, TraceReaderService
 
 _MODEL_FILTER = [Predicate(field="model_name", op="in", value=["gpt-4"])]
@@ -116,6 +117,79 @@ def test_no_filters_adds_no_semijoin():
 
     page_sql = svc._client.query.call_args_list[0].args[0]
     assert "t.trace_id IN (" not in page_sql
+
+
+def test_list_traces_token_totals_prefer_api_counted_spans():
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_traces(project_id="p1")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    assert authoritative_sum_expr("input_tokens") in page_sql
+    assert authoritative_sum_expr("output_tokens") in page_sql
+    assert authoritative_sum_expr("cost") in page_sql
+    assert "usage_details" in page_sql
+
+
+def test_list_sessions_token_totals_prefer_api_counted_spans():
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_sessions(project_id="p1")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    assert authoritative_sum_expr("input_tokens") in page_sql
+    assert authoritative_sum_expr("output_tokens") in page_sql
+    assert authoritative_sum_expr("cost") in page_sql
+    assert "usage_details" in page_sql
+
+
+def test_get_session_sums_trace_level_authoritative_token_totals():
+    svc = _service_with_mock_client()
+    traces_res, tokens_res = MagicMock(), MagicMock()
+    traces_res.result_rows = [
+        (
+            "trace-1",
+            "trace",
+            datetime(2026, 1, 1),
+            "user-1",
+            "input",
+            "output",
+            12,
+            "ok",
+        )
+    ]
+    tokens_res.result_rows = [(10, 20, 0.03)]
+    svc._client.query.side_effect = [traces_res, tokens_res]
+
+    svc.get_session(project_id="p1", session_id="s1")
+
+    token_sql = svc._client.query.call_args_list[1].args[0]
+    assert "GROUP BY trace_id" in token_sql
+    assert "sum(total_input_tokens) as total_input_tokens" in token_sql
+    assert "sum(total_output_tokens) as total_output_tokens" in token_sql
+    assert "sum(total_cost) as total_cost" in token_sql
+    assert authoritative_sum_expr("input_tokens") in token_sql
+    assert authoritative_sum_expr("output_tokens") in token_sql
+    assert authoritative_sum_expr("cost") in token_sql
+
+
+def test_list_users_sums_trace_level_authoritative_token_totals():
+    svc = _service_with_mock_client()
+    _drive(svc)
+
+    svc.list_users(project_id="p1")
+
+    page_sql = svc._client.query.call_args_list[0].args[0]
+    assert "span_trace_totals AS" in page_sql
+    assert "GROUP BY trace_id" in page_sql
+    assert "sum(stt.total_input_tokens) as total_input_tokens" in page_sql
+    assert "sum(stt.total_output_tokens) as total_output_tokens" in page_sql
+    assert "sum(stt.total_cost) as total_cost" in page_sql
+    assert authoritative_sum_expr("input_tokens") in page_sql
+    assert authoritative_sum_expr("output_tokens") in page_sql
+    assert authoritative_sum_expr("cost") in page_sql
 
 
 def test_filtered_list_without_window_gets_default_lookback_in_both_queries():


### PR DESCRIPTION
## Summary

Fixes #1173.

- Add a shared REST read-path helper for authoritative token/cost rollups.
- For each trace, prefer spans with API token provenance (`usage_details`) and fall back to the old `sum(...)` behavior only when that trace has no API-counted spans.
- Apply the same semantics to trace lists, session lists, session detail totals, user lists, and aggregate `cost` / `total_tokens` filters.
- Keep worker ingest and per-span display behavior unchanged.

## Why

LlamaIndex can emit an `OpenAI.predict` wrapper as an LLM-kind span with text but no API token counts, wrapping an `OpenAI.chat` child that has API-provided counts. Since both spans are LLM-kind, ingest-side kind gating does not prevent trace totals from summing the wrapper estimate on top of the child API count.

The read path already has a provenance signal: API-counted spans persist a non-empty `usage_details` map, while text-estimated spans leave it empty. This PR uses that signal at trace-rollup time.

## Notes

Session and user totals intentionally roll up per trace first, then sum trace totals upward. A session/user-level `countIf(usage_details)` would incorrectly drop estimated-only traces whenever a different trace in the same session/user has API counts.

I did not run a full live ClickHouse service/compose test in this environment. After opening the PR, I also ran a local embedded ClickHouse (`chdb`) smoke against the rollup helper expressions; it passed trace-level API precedence, session/user per-trace rollup, and aggregate token filter semantics. This is still not a full REST service + live ClickHouse integration test, but it exercises the core ClickHouse-compatible SQL rather than only string-shape assertions.

## Validation

- `uv run pytest tests/rest/test_token_rollup.py tests/rest/test_filter_columns_parity.py tests/rest/test_filter_translate.py tests/rest/test_trace_reader_filters.py`
- `uv run pytest tests/rest/test_trace_reader.py tests/rest/test_traces_router.py tests/rest/test_sessions_router.py tests/rest/test_users_router.py tests/rest/test_filter_columns_parity.py tests/rest/test_filter_translate.py tests/rest/test_trace_reader_filters.py tests/rest/test_token_rollup.py`
- `uv run pytest tests/worker/test_otel_transform_estimation_gate.py tests/worker/test_otel_transform.py`
- `uv run ruff check backend/rest/services/token_rollup.py backend/rest/services/trace_reader.py backend/rest/services/filters/columns.py tests/rest/test_token_rollup.py tests/rest/test_filter_columns_parity.py tests/rest/test_filter_translate.py tests/rest/test_trace_reader_filters.py`
- `python3 -m py_compile backend/rest/services/token_rollup.py backend/rest/services/trace_reader.py backend/rest/services/filters/columns.py backend/rest/services/filters/translate.py tests/rest/test_trace_reader_filters.py`
- local embedded ClickHouse (`chdb`) smoke: trace-level API precedence, session/user per-trace rollup, and aggregate token filter semantics passed
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer API-counted token and cost totals in REST reads, falling back to sums only when a trace has no API-counted spans. Fixes #1173 and prevents double-counting when wrapper LLM spans restate child usage.

- **Bug Fixes**
  - For each trace, sum spans with `usage_details` (API counts); fall back to all spans only if none have it.
  - Apply the same logic to trace lists, session lists, session detail totals, user lists, and `cost`/`total_tokens` aggregate filters.
  - Ingest and per-span display remain unchanged.

- **Refactors**
  - Introduced SQL helpers: `api_token_span_predicate`, `authoritative_sum_expr`, and `authoritative_token_rollup_select`.
  - Switched `trace_reader` queries to the helpers and roll up per trace before session/user totals.
  - Updated filter column registry to use authoritative sums and project `usage_details`.
  - Added tests for rollup behavior and filter translation.

<sup>Written for commit df2ccc57de6f9daa1579c7d64b6af5847faca30c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


