### PR TITLE
fix(ui): pressing Enter should confirm the delete workspace/project dialogs

### DIFF
--- a/frontend/ui/src/features/settings/project/components/GeneralTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/GeneralTab.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent, waitFor, within } from "@testing-library/react";
+
+type ProjectUpdatePayload = { name: string };
 
 const mocks = vi.hoisted(() => ({
   project: {
@@ -8,8 +10,12 @@ const mocks = vi.hoisted(() => ({
     name: "Acme Project",
     workspace_id: "w1",
   },
-  deleteProject: vi.fn().mockResolvedValue(void 0),
-  updateProject: vi.fn().mockResolvedValue(void 0),
+  deleteProject: vi
+    .fn<(workspaceId: string, projectId: string) => Promise<void>>()
+    .mockResolvedValue(void 0),
+  updateProject: vi
+    .fn<(workspaceId: string, projectId: string, data: ProjectUpdatePayload) => Promise<void>>()
+    .mockResolvedValue(void 0),
 }));
 
 vi.mock("@/features/projects/hooks", () => ({
@@ -17,8 +23,10 @@ vi.mock("@/features/projects/hooks", () => ({
 }));
 
 vi.mock("@/lib/api", () => ({
-  updateProject: (...a: any[]) => mocks.updateProject(...a),
-  deleteProject: (...a: any[]) => mocks.deleteProject(...a),
+  updateProject: (workspaceId: string, projectId: string, data: ProjectUpdatePayload) =>
+    mocks.updateProject(workspaceId, projectId, data),
+  deleteProject: (workspaceId: string, projectId: string) =>
+    mocks.deleteProject(workspaceId, projectId),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -50,9 +58,8 @@ describe("GeneralTab project delete dialog", () => {
     // Open the delete dialog
     fireEvent.click(screen.getByRole("button", { name: /delete project/i }));
 
-    // Get the input from the dialog (the last one with this placeholder)
-    const inputs = screen.getAllByPlaceholderText("Project name");
-    const input = inputs[inputs.length - 1];
+    const dialog = screen.getByRole("dialog");
+    const input = within(dialog).getByPlaceholderText("Project name");
     fireEvent.change(input, { target: { value: "Acme Project" } });
 
     // Press Enter
@@ -70,16 +77,12 @@ describe("GeneralTab project delete dialog", () => {
     // Open the delete dialog
     fireEvent.click(screen.getByRole("button", { name: /delete project/i }));
 
-    // Get the input from the dialog (the last one with this placeholder)
-    const inputs = screen.getAllByPlaceholderText("Project name");
-    const input = inputs[inputs.length - 1];
+    const dialog = screen.getByRole("dialog");
+    const input = within(dialog).getByPlaceholderText("Project name");
     fireEvent.change(input, { target: { value: "Wrong Project" } });
 
     // Press Enter
     fireEvent.keyDown(input, { key: "Enter" });
-
-    // Give it a moment to process
-    await new Promise((r) => setTimeout(r, 50));
 
     // Verify delete was NOT called
     expect(mocks.deleteProject).not.toHaveBeenCalled();
@@ -94,18 +97,16 @@ describe("GeneralTab project delete dialog", () => {
     // Open the delete dialog
     fireEvent.click(screen.getByRole("button", { name: /delete project/i }));
 
-    // Get the input from the dialog (the last one with this placeholder)
-    const inputs = screen.getAllByPlaceholderText("Project name");
-    const input = inputs[inputs.length - 1];
+    const dialog = screen.getByRole("dialog");
+    const input = within(dialog).getByPlaceholderText("Project name");
     fireEvent.change(input, { target: { value: "Acme Project" } });
 
     // Press Enter twice
     fireEvent.keyDown(input, { key: "Enter" });
-    await new Promise((r) => setTimeout(r, 50));
+    await waitFor(() => {
+      expect(within(dialog).getByRole("button", { name: /deleting/i }).disabled).toBe(true);
+    });
     fireEvent.keyDown(input, { key: "Enter" });
-
-    // Give it a moment to process
-    await new Promise((r) => setTimeout(r, 50));
 
     // Verify delete was called exactly once
     expect(mocks.deleteProject).toHaveBeenCalledTimes(1);

--- a/frontend/ui/src/features/settings/project/components/GeneralTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/GeneralTab.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  project: {
+    id: "p1",
+    name: "Acme Project",
+    workspace_id: "w1",
+  },
+  deleteProject: vi.fn().mockResolvedValue(void 0),
+  updateProject: vi.fn().mockResolvedValue(void 0),
+}));
+
+vi.mock("@/features/projects/hooks", () => ({
+  useProject: () => ({ data: mocks.project, isLoading: false }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  updateProject: (...a: any[]) => mocks.updateProject(...a),
+  deleteProject: (...a: any[]) => mocks.deleteProject(...a),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { GeneralTab } from "./GeneralTab";
+
+function renderTab() {
+  const qc = new QueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <GeneralTab projectId="p1" />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.deleteProject.mockReset().mockResolvedValue(void 0);
+  mocks.updateProject.mockReset().mockResolvedValue(void 0);
+});
+
+describe("GeneralTab project delete dialog", () => {
+  it("pressing Enter with the exact project name triggers delete", async () => {
+    renderTab();
+
+    // Open the delete dialog
+    fireEvent.click(screen.getByRole("button", { name: /delete project/i }));
+
+    // Get the input from the dialog (the last one with this placeholder)
+    const inputs = screen.getAllByPlaceholderText("Project name");
+    const input = inputs[inputs.length - 1];
+    fireEvent.change(input, { target: { value: "Acme Project" } });
+
+    // Press Enter
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Verify delete was called with workspace_id and projectId
+    await waitFor(() => {
+      expect(mocks.deleteProject).toHaveBeenCalledWith("w1", "p1");
+    });
+  });
+
+  it("pressing Enter with a non-matching name does not trigger delete", async () => {
+    renderTab();
+
+    // Open the delete dialog
+    fireEvent.click(screen.getByRole("button", { name: /delete project/i }));
+
+    // Get the input from the dialog (the last one with this placeholder)
+    const inputs = screen.getAllByPlaceholderText("Project name");
+    const input = inputs[inputs.length - 1];
+    fireEvent.change(input, { target: { value: "Wrong Project" } });
+
+    // Press Enter
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Give it a moment to process
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify delete was NOT called
+    expect(mocks.deleteProject).not.toHaveBeenCalled();
+  });
+
+  it("pressing Enter while a delete is already pending does not double-submit", async () => {
+    // Make deleteProject return a promise that never resolves
+    mocks.deleteProject.mockReturnValue(new Promise(() => {}));
+
+    renderTab();
+
+    // Open the delete dialog
+    fireEvent.click(screen.getByRole("button", { name: /delete project/i }));
+
+    // Get the input from the dialog (the last one with this placeholder)
+    const inputs = screen.getAllByPlaceholderText("Project name");
+    const input = inputs[inputs.length - 1];
+    fireEvent.change(input, { target: { value: "Acme Project" } });
+
+    // Press Enter twice
+    fireEvent.keyDown(input, { key: "Enter" });
+    await new Promise((r) => setTimeout(r, 50));
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Give it a moment to process
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify delete was called exactly once
+    expect(mocks.deleteProject).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteProject).toHaveBeenCalledWith("w1", "p1");
+  });
+});

--- a/frontend/ui/src/features/settings/project/components/GeneralTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/GeneralTab.tsx
@@ -68,7 +68,7 @@ export function GeneralTab({ projectId }: GeneralTabProps) {
   };
 
   const handleDelete = () => {
-    if (deleteConfirmText === project?.name) {
+    if (deleteConfirmText === project?.name && !deleteMutation.isPending) {
       deleteMutation.mutate();
     }
   };
@@ -138,6 +138,7 @@ export function GeneralTab({ projectId }: GeneralTabProps) {
             <Input
               value={deleteConfirmText}
               onChange={(e) => setDeleteConfirmText(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleDelete()}
               placeholder="Project name"
             />
           </div>

--- a/frontend/ui/src/features/settings/project/components/GeneralTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/GeneralTab.tsx
@@ -138,7 +138,7 @@ export function GeneralTab({ projectId }: GeneralTabProps) {
             <Input
               value={deleteConfirmText}
               onChange={(e) => setDeleteConfirmText(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleDelete()}
+              onKeyDown={(e) => e.key === "Enter" && !e.nativeEvent.isComposing && handleDelete()}
               placeholder="Project name"
             />
           </div>

--- a/frontend/ui/src/features/settings/workspace/components/GeneralTab.test.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/GeneralTab.test.tsx
@@ -1,15 +1,18 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import type { Role as WorkspaceRole } from "@traceroot/core";
 
 const mocks = vi.hoisted(() => ({
   workspace: {
     id: "w1",
     name: "Acme Corp",
-    role: "ADMIN" as any,
+    role: "ADMIN" satisfies WorkspaceRole,
   },
-  deleteWorkspace: vi.fn().mockResolvedValue(void 0),
-  updateWorkspace: vi.fn().mockResolvedValue(void 0),
+  deleteWorkspace: vi.fn<(workspaceId: string) => Promise<void>>().mockResolvedValue(void 0),
+  updateWorkspace: vi
+    .fn<(workspaceId: string, name: string) => Promise<void>>()
+    .mockResolvedValue(void 0),
 }));
 
 vi.mock("../hooks", () => ({
@@ -17,8 +20,8 @@ vi.mock("../hooks", () => ({
 }));
 
 vi.mock("@/lib/api", () => ({
-  updateWorkspace: (...a: any[]) => mocks.updateWorkspace(...a),
-  deleteWorkspace: (...a: any[]) => mocks.deleteWorkspace(...a),
+  updateWorkspace: (workspaceId: string, name: string) => mocks.updateWorkspace(workspaceId, name),
+  deleteWorkspace: (workspaceId: string) => mocks.deleteWorkspace(workspaceId),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -54,9 +57,8 @@ describe("GeneralTab workspace delete dialog", () => {
     // Open the delete dialog
     fireEvent.click(screen.getByRole("button", { name: /delete workspace/i }));
 
-    // Get the input from the dialog (the last one with this placeholder)
-    const inputs = screen.getAllByPlaceholderText("Workspace name");
-    const input = inputs[inputs.length - 1];
+    const dialog = screen.getByRole("dialog");
+    const input = within(dialog).getByPlaceholderText("Workspace name");
     fireEvent.change(input, { target: { value: "Acme Corp" } });
 
     // Press Enter
@@ -74,16 +76,12 @@ describe("GeneralTab workspace delete dialog", () => {
     // Open the delete dialog
     fireEvent.click(screen.getByRole("button", { name: /delete workspace/i }));
 
-    // Get the input from the dialog (the last one with this placeholder)
-    const inputs = screen.getAllByPlaceholderText("Workspace name");
-    const input = inputs[inputs.length - 1];
+    const dialog = screen.getByRole("dialog");
+    const input = within(dialog).getByPlaceholderText("Workspace name");
     fireEvent.change(input, { target: { value: "Wrong Name" } });
 
     // Press Enter
     fireEvent.keyDown(input, { key: "Enter" });
-
-    // Give it a moment to process
-    await new Promise((r) => setTimeout(r, 50));
 
     // Verify delete was NOT called
     expect(mocks.deleteWorkspace).not.toHaveBeenCalled();
@@ -98,18 +96,16 @@ describe("GeneralTab workspace delete dialog", () => {
     // Open the delete dialog
     fireEvent.click(screen.getByRole("button", { name: /delete workspace/i }));
 
-    // Get the input from the dialog (the last one with this placeholder)
-    const inputs = screen.getAllByPlaceholderText("Workspace name");
-    const input = inputs[inputs.length - 1];
+    const dialog = screen.getByRole("dialog");
+    const input = within(dialog).getByPlaceholderText("Workspace name");
     fireEvent.change(input, { target: { value: "Acme Corp" } });
 
     // Press Enter twice
     fireEvent.keyDown(input, { key: "Enter" });
-    await new Promise((r) => setTimeout(r, 50));
+    await waitFor(() => {
+      expect(within(dialog).getByRole("button", { name: /deleting/i }).disabled).toBe(true);
+    });
     fireEvent.keyDown(input, { key: "Enter" });
-
-    // Give it a moment to process
-    await new Promise((r) => setTimeout(r, 50));
 
     // Verify delete was called exactly once
     expect(mocks.deleteWorkspace).toHaveBeenCalledTimes(1);

--- a/frontend/ui/src/features/settings/workspace/components/GeneralTab.test.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/GeneralTab.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  workspace: {
+    id: "w1",
+    name: "Acme Corp",
+    role: "ADMIN" as any,
+  },
+  deleteWorkspace: vi.fn().mockResolvedValue(void 0),
+  updateWorkspace: vi.fn().mockResolvedValue(void 0),
+}));
+
+vi.mock("../hooks", () => ({
+  useWorkspace: () => ({ data: mocks.workspace, isLoading: false }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  updateWorkspace: (...a: any[]) => mocks.updateWorkspace(...a),
+  deleteWorkspace: (...a: any[]) => mocks.deleteWorkspace(...a),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Role } from "@traceroot/core";
+import { GeneralTab } from "./GeneralTab";
+
+function renderTab() {
+  const qc = new QueryClient();
+  // Delete section only renders for ADMIN role -- ensure it's set before each render.
+  mocks.workspace.role = Role.ADMIN;
+
+  return render(
+    <QueryClientProvider client={qc}>
+      <GeneralTab workspaceId="w1" />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.deleteWorkspace.mockReset().mockResolvedValue(void 0);
+  mocks.updateWorkspace.mockReset().mockResolvedValue(void 0);
+});
+
+describe("GeneralTab workspace delete dialog", () => {
+  it("pressing Enter with the exact workspace name triggers delete", async () => {
+    renderTab();
+
+    // Open the delete dialog
+    fireEvent.click(screen.getByRole("button", { name: /delete workspace/i }));
+
+    // Get the input from the dialog (the last one with this placeholder)
+    const inputs = screen.getAllByPlaceholderText("Workspace name");
+    const input = inputs[inputs.length - 1];
+    fireEvent.change(input, { target: { value: "Acme Corp" } });
+
+    // Press Enter
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Verify delete was called
+    await waitFor(() => {
+      expect(mocks.deleteWorkspace).toHaveBeenCalledWith("w1");
+    });
+  });
+
+  it("pressing Enter with a non-matching name does not trigger delete", async () => {
+    renderTab();
+
+    // Open the delete dialog
+    fireEvent.click(screen.getByRole("button", { name: /delete workspace/i }));
+
+    // Get the input from the dialog (the last one with this placeholder)
+    const inputs = screen.getAllByPlaceholderText("Workspace name");
+    const input = inputs[inputs.length - 1];
+    fireEvent.change(input, { target: { value: "Wrong Name" } });
+
+    // Press Enter
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Give it a moment to process
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify delete was NOT called
+    expect(mocks.deleteWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("pressing Enter while a delete is already pending does not double-submit", async () => {
+    // Make deleteWorkspace return a promise that never resolves
+    mocks.deleteWorkspace.mockReturnValue(new Promise(() => {}));
+
+    renderTab();
+
+    // Open the delete dialog
+    fireEvent.click(screen.getByRole("button", { name: /delete workspace/i }));
+
+    // Get the input from the dialog (the last one with this placeholder)
+    const inputs = screen.getAllByPlaceholderText("Workspace name");
+    const input = inputs[inputs.length - 1];
+    fireEvent.change(input, { target: { value: "Acme Corp" } });
+
+    // Press Enter twice
+    fireEvent.keyDown(input, { key: "Enter" });
+    await new Promise((r) => setTimeout(r, 50));
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    // Give it a moment to process
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Verify delete was called exactly once
+    expect(mocks.deleteWorkspace).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteWorkspace).toHaveBeenCalledWith("w1");
+  });
+});

--- a/frontend/ui/src/features/settings/workspace/components/GeneralTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/GeneralTab.tsx
@@ -135,7 +135,7 @@ export function GeneralTab({ workspaceId }: GeneralTabProps) {
             <Input
               value={deleteConfirmText}
               onChange={(e) => setDeleteConfirmText(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleDelete()}
+              onKeyDown={(e) => e.key === "Enter" && !e.nativeEvent.isComposing && handleDelete()}
               placeholder="Workspace name"
             />
             {deleteMutation.isError && (

--- a/frontend/ui/src/features/settings/workspace/components/GeneralTab.tsx
+++ b/frontend/ui/src/features/settings/workspace/components/GeneralTab.tsx
@@ -61,7 +61,7 @@ export function GeneralTab({ workspaceId }: GeneralTabProps) {
   };
 
   const handleDelete = () => {
-    if (deleteConfirmText === workspace?.name) {
+    if (deleteConfirmText === workspace?.name && !deleteMutation.isPending) {
       deleteMutation.mutate();
     }
   };
@@ -135,6 +135,7 @@ export function GeneralTab({ workspaceId }: GeneralTabProps) {
             <Input
               value={deleteConfirmText}
               onChange={(e) => setDeleteConfirmText(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleDelete()}
               placeholder="Workspace name"
             />
             {deleteMutation.isError && (


### PR DESCRIPTION
## What Changed
Both the workspace and project "Delete" confirmation dialogs required a mouse click on the destructive button even after the confirmation name matched — pressing Enter did nothing, unlike the Create API Key dialog elsewhere in Settings which already supports Enter-to-submit.

## Root Cause
In both `frontend/ui/src/features/settings/{workspace,project}/components/GeneralTab.tsx`, `handleDelete` only checked `deleteConfirmText === name`; it never checked `deleteMutation.isPending`, and the confirm `<Input>` had no `onKeyDown` handler at all.

## Approach
- Added `&& !deleteMutation.isPending` inside `handleDelete` in both files, so the guard lives in the function itself rather than only on the button's `disabled` prop (which a keyboard path would otherwise bypass).
- Wired `onKeyDown={(e) => e.key === "Enter" && handleDelete()}` on both confirm inputs, mirroring the existing idiom already used in `AccessKeysTab.tsx`.

## How Validated
- Added `GeneralTab.test.tsx` next to each component (6 tests total): exact name + Enter deletes; non-matching name + Enter no-ops; pending delete + Enter does not double-submit.
- `pnpm vitest run` — 6/6 new tests pass; full suite 510/511 pass (1 pre-existing unrelated failure in `usage-labels.test.ts`, confirmed failing on `main` without this change too).
- `diff-cover` on changed lines: 100% (gate is 80%).
- `eslint` / `prettier` clean.
- Manually verified in the running app: typing the exact name and pressing Enter deletes without touching the button; a non-matching name + Enter is a no-op; pending delete + repeated Enter doesn't double-submit. See attached recording.

## For UI Changes Only

https://github.com/user-attachments/assets/047b85dd-89e9-4655-9e4c-672e507df107

## Additional Notes
- Closes #1483
- Pre-commit hook passed (not skipped)
- Branch based on latest `main`



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pressing Enter now confirms the delete dialogs for workspaces and projects, matching the API Key dialog behavior. Closes #1483.

- **Bug Fixes**
  - Added an Enter key handler on the confirm inputs in both General tabs; submit when the typed name matches and ignore IME composition.
  - Guarded against double-submits by checking `!deleteMutation.isPending` inside `handleDelete`.
  - Added 6 Vitest tests for correct/incorrect names and pending-state blocking.

<sup>Written for commit 12979ff4ade3ed99bfea80b92c0b25c93ec8fb3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



