### PR TITLE
feat: add Grok 4.5 to BYOK model catalog

### DIFF
--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -188,6 +188,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "deepseek-chat", label: "deepseek-chat" },
   ],
   xai: [
+    { id: "grok-4.5", label: "grok-4.5" },
     { id: "grok-4.20", label: "grok-4.20" },
     { id: "grok-4", label: "grok-4" },
   ],


### PR DESCRIPTION
Closes #1485

## Summary

xAI released Grok 4.5 on 2026-07-08 as its newest flagship model for coding, agentic tasks, and knowledge work. Traceroot's curated xAI BYOK dropdown didn't list it, so users couldn't pick it from Settings → Model Providers → xAI without falling through to the `(Unsupported)` path from #610.

## What Changed

`frontend/packages/core/src/llm-providers.ts`

- Added one entry to `ADAPTER_MODELS.xai` at index 0: `{ id: "grok-4.5", label: "grok-4.5" }`.
- Newest-first ordering, consistent with #703 (Kimi K2.6), #757 (DeepSeek V4), and #912 (Gemini 3.5 Flash).
- No `apiProtocol` override — `grok-4.5` inherits `openai-completions` from `ADAPTER_API_PROTOCOL["xai"]`, same base URL as before.
- No `SYSTEM_MODELS`, `PROVIDER_PRIORITY`, or docs changes — xAI remains BYOK-only.

## References

- xAI announcement: [https://x.ai/news/grok-4-5](https://x.ai/news/grok-4-5)
- Pricing: $2 / 1M input tokens, $6 / 1M output tokens
- API console: [https://console.x.ai/](https://console.x.ai/)

## Type of Change

- [x] feat – new model in BYOK catalog

## Screenshots / Recordings
<img width="1519" height="960" alt="image" src="https://github.com/user-attachments/assets/35de4b9e-b0e3-407f-a4b0-fa8c171de7cf" />

## Checklist

- [x] I have read the CONTRIBUTING.md
- [ ] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `grok-4.5` to the xAI BYOK model catalog so users can select it in Settings → Model Providers → xAI instead of hitting the unsupported path. Uses the existing `openai-completions` protocol and keeps newest-first ordering; addresses #1485.

<sup>Written for commit 1d45437611d2dce42815197cbc8c91ec065d7b15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

