### PR TITLE
fix(ui): stop detector model selector from auto-pinning opus

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -155,6 +156,8 @@ export default function NewDetectorPage() {
                     value={modelSelection}
                     onChange={setModelSelection}
                     workspaceId={project?.workspace_id}
+                    autoSelectDefault={false}
+                    defaultLabel={`${DETECTOR_SYSTEM_DEFAULT_MODEL_ID} (default)`}
                   />
                   <p className="mt-1 text-[11px] text-muted-foreground">
                     Used to evaluate each trace for this detector.

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -92,4 +92,55 @@ describe("ModelSelector", () => {
       adapter: "anthropic",
     });
   });
+
+  it("does not auto-pick a default when autoSelectDefault is false", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        autoSelectDefault={false}
+      />,
+    );
+
+    expect(mocks.onChange).not.toHaveBeenCalled();
+  });
+
+  it("shows defaultLabel as a placeholder when nothing is selected and autoSelectDefault is false", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        autoSelectDefault={false}
+        defaultLabel="claude-haiku-4-5 (default)"
+      />,
+    );
+
+    expect(screen.getByRole("button").textContent).toContain("claude-haiku-4-5 (default)");
+  });
 });

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -20,13 +20,29 @@ interface ModelSelectorProps {
   value: ModelSelection;
   onChange: (selection: ModelSelection) => void;
   workspaceId?: string;
+  /**
+   * When false, skip auto-picking a default model into form state when
+   * `value.model` is empty — the caller wants an explicit user choice
+   * before anything is written (e.g. a persisted setting where "unset"
+   * has real meaning, like a detector's screening model). Defaults to
+   * true to preserve the existing chat/RCA auto-pick behavior.
+   */
+  autoSelectDefault?: boolean;
+  /** Placeholder shown on the button when nothing is selected and autoSelectDefault is false. */
+  defaultLabel?: string;
 }
 
 function modelKey(m: { id?: string; model?: string; source: string; provider: string }) {
   return `${m.source}:${m.provider}:${m.id ?? m.model}`;
 }
 
-export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorProps) {
+export function ModelSelector({
+  value,
+  onChange,
+  workspaceId,
+  autoSelectDefault = true,
+  defaultLabel,
+}: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
 
   const { data } = useQuery({
@@ -57,7 +73,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
     const match = exact ?? modelOnly;
 
     if (!match) {
-      if (!value.model) {
+      if (!value.model && autoSelectDefault) {
         const pick = pickDefaultModel(models);
         if (pick) {
           onChange({
@@ -87,7 +103,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
         adapter: match.adapter,
       });
     }
-  }, [models, value, onChange]);
+  }, [models, value, onChange, autoSelectDefault]);
 
   const selectedKey = modelKey({ id: value.model, source: value.source, provider: value.provider });
   const selectedModel = models.find((m) => modelKey(m) === selectedKey);
@@ -101,7 +117,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
             size="sm"
             className="h-7 gap-1 rounded-sm px-2 text-[11px] text-muted-foreground hover:text-foreground"
           >
-            {selectedModel?.label || value.model || "Select model"}
+            {selectedModel?.label || value.model || defaultLabel || "Select model"}
             <ChevronDown className="h-3 w-3" />
           </Button>
         </PopoverTrigger>

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -132,4 +132,44 @@ describe("DetectorPanel", () => {
     expect(promptBox().value).toBe("");
     expect((saveButton() as HTMLButtonElement).disabled).toBe(true);
   });
+
+  it("does not pin detectionModel in the patch when the detector has no model selected", () => {
+    const detectorWithoutModel: Detector = {
+      ...baseDetector,
+      detectionModel: null,
+      detectionProvider: null,
+      detectionSource: null,
+    };
+    mocks.detector = detectorWithoutModel;
+    const { onClose } = renderPanel();
+    fireEvent.click(saveButton());
+
+    // When nothing changed and model is unset, the patch should not
+    // include detectionModel (it stays absent, allowing system default)
+    expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not include detectionModel in patch when model is empty even after editing other fields", () => {
+    const detectorWithoutModel: Detector = {
+      ...baseDetector,
+      detectionModel: null,
+      detectionProvider: null,
+      detectionSource: null,
+    };
+    mocks.detector = detectorWithoutModel;
+    const { onClose } = renderPanel();
+    fireEvent.change(promptBox(), { target: { value: "updated prompt" } });
+    fireEvent.click(saveButton());
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    // The patch should contain the prompt change but NOT detectionModel
+    const patch = mocks.mutate.mock.calls[0][0];
+    expect(patch).toEqual({ prompt: "updated prompt" });
+    expect(patch.detectionModel).toBeUndefined();
+
+    const options = mocks.mutate.mock.calls[0][1] as { onSuccess: () => void };
+    options.onSuccess();
+    expect(onClose).toHaveBeenCalled();
+  });
 });

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import { Eye, X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
 import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
 import { DEFAULT_DETECTOR_SAMPLE_RATE } from "../templates";
@@ -237,6 +238,8 @@ export function DetectorPanel({
                 value={editModelSelection}
                 onChange={setEditModelSelection}
                 workspaceId={workspaceId}
+                autoSelectDefault={false}
+                defaultLabel={`${DETECTOR_SYSTEM_DEFAULT_MODEL_ID} (default)`}
               />
               <p className="mt-1 text-[11px] text-muted-foreground">
                 Used to evaluate each trace for this detector.


### PR DESCRIPTION
## What

`ModelSelector` (`frontend/ui/src/features/ai-assistant/components/model-selector.tsx`) silently auto-picked the highest-priority model (opus-first, via `pickDefaultModel()`) into form stattion was empty, and persisted it as soon as the formwas submitted or saved.

Adds an opt-out `autoSelectDefault?: boolean` prop (default `true`, preserving existing behavior everywhere) and a `defaultLabel?:string` display-only placeholder prop. Wires `autoSeltLabel="claude-haiku-4-5 (default)"` into the twodetector call sites:
- `app/projects/[projectId]/detectors/new/page.tsx` (create form)
- `features/detectors/components/detector-panel.tsx` (edit panel)

## Why

Detection screening runs an LLM eval per sampled trace at ingestion — the highest-volume LLM workload in the system — and is meant to default to the cheap `DETECTOR_SYSTEM_DEFAULT_MODEL_Iuse `ModelSelector` is shared with the AI assistantchat surface (where auto-picking a smart default on first render is correct — `message-input.tsx` even gates the send button on a model being selected), the same auto-pick logic was silentle-opus-4-8` the moment a create form was submitted oran edit panel was saved for any reason (even just adjusting the sample rate), since `buildDetectorPatch` can't distinguish an auto-write from a real user pick.

Chat (`message-input.tsx`) and the project settings "torsTab.tsx`, maps to the separate `rca_model` field)are untouched — both are out of scope for this issue and still get `autoSelectDefault`'s default of `true`.

`buildDetectorPatch` needed no changes: once the phantom write stops, its existing diff logic (`form.detectionModel !== loaded.detectionModel && form.detectionModel !== ""`)detectionModel` from the patch correctly.

## Screenshots of the fix
<img width="1462" height="640" alt="image" src="https://github.com/user-attachments/assets/50442bc5-e78e-4b60-a197-a9545a3c5140" />
<img width="1463" height="654" alt="image" src="https://github.com/user-attachments/assets/e972f7eb-57ef-4ba4-a048-12f53ef741cd" />

## How validated

cd frontend && pnpm run lint          # pass, 0 new errors
pnpm run format:check                 # pass
pnpm --filter traceroot-ui test       # 508/509 pass (1 pre-existing, unrelated locale/ICU fs, not touched by this diff)

Reproduced the CI coverage gate locally against `origin/main` using the exact command from `.github/workflows/`: diff-cover frontend/ui/coverage/lcov.info
  --compare-branch=origin/main 
  --exclude "**/*vitest.config.ts" --exclude "**/next
  --fail-under=80
Result: **100%** coverage on changed lines (16/16).

Pre-commit hooks (ruff/eslint/prettier via lint-staged) ran clean on commit.

Closes #1465 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops detector forms from auto-pinning a high-cost model; they now leave the model unset and use the system default until the user explicitly picks one. Adds an opt-out to `ModelSelector` so detectors show a default label without persisting it.

- Bug Fixes
  - Added `autoSelectDefault?: boolean` (default true) and `defaultLabel?: string` to `ModelSelector`.
  - Detectors create/edit pass `autoSelectDefault={false}` and show `${DETECTOR_SYSTEM_DEFAULT_MODEL_ID} (default)` from `@traceroot/core/llm-providers`.
  - Unchanged chat/RCA behavior; only detectors opt out of auto-pick.
  - Tests cover no auto-pick, placeholder label, and omission of `detectionModel` from patches when unset.

<sup>Written for commit 591106823e3c481f55ca57d45636789d93593d48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

