### PR TITLE
Feat/GPT 5.6 Sol/Terra/Luna in TraceRoot byok

### DIFF
--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -150,6 +150,10 @@ export const PROVIDER_PRIORITY: LLMAdapter[] = [
 // Adapters NOT listed here (azure, amazon-bedrock, openrouter) use free-text input.
 export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
   openai: [
+    // Limited partner preview as of 2026-07-09 — not yet accessible via self-serve API keys.
+    { id: "gpt-5.6-sol", label: "gpt-5.6-sol" },
+    { id: "gpt-5.6-terra", label: "gpt-5.6-terra" },
+    { id: "gpt-5.6-luna", label: "gpt-5.6-luna" },
     { id: "gpt-5.5", label: "gpt-5.5" },
     { id: "gpt-5.5-pro", label: "gpt-5.5-pro" },
     { id: "gpt-5.4", label: "gpt-5.4" },

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -117,6 +117,42 @@
     }
   },
   {
+    "id": "tr-gpt-5-6-sol",
+    "modelName": "gpt-5.6-sol",
+    "matchPattern": "(?i)^(openai\\/|azure\\/)?(gpt-5\\.6-sol)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.000005,
+      "output": 0.00003,
+      "cacheRead": 0.0000005,
+      "cacheWrite": 0.00000625
+    }
+  },
+  {
+    "id": "tr-gpt-5-6-terra",
+    "modelName": "gpt-5.6-terra",
+    "matchPattern": "(?i)^(openai\\/|azure\\/)?(gpt-5\\.6-terra)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.0000025,
+      "output": 0.000015,
+      "cacheRead": 0.00000025,
+      "cacheWrite": 0.000003125
+    }
+  },
+  {
+    "id": "tr-gpt-5-6-luna",
+    "modelName": "gpt-5.6-luna",
+    "matchPattern": "(?i)^(openai\\/|azure\\/)?(gpt-5\\.6-luna)(-[\\d-]+)?$",
+    "provider": "openai",
+    "prices": {
+      "input": 0.000001,
+      "output": 0.000006,
+      "cacheRead": 0.0000001,
+      "cacheWrite": 0.00000125
+    }
+  },
+  {
     "id": "tr-gpt-5-5",
     "modelName": "gpt-5.5",
     "matchPattern": "(?i)^(openai\\/|azure\\/)?(gpt-5\\.5)(-[\\d-]+)?$",

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -60,6 +60,16 @@ def real_cache() -> list[dict]:
 
 
 OPENAI_MODEL_CASES = [
+    ("gpt-5.6-sol", "gpt-5.6-sol"),
+    ("openai/gpt-5.6-sol", "gpt-5.6-sol"),
+    ("azure/gpt-5.6-sol", "gpt-5.6-sol"),
+    ("gpt-5.6-sol-2026-07-09", "gpt-5.6-sol"),
+    ("gpt-5.6-terra", "gpt-5.6-terra"),
+    ("openai/gpt-5.6-terra", "gpt-5.6-terra"),
+    ("azure/gpt-5.6-terra", "gpt-5.6-terra"),
+    ("gpt-5.6-luna", "gpt-5.6-luna"),
+    ("openai/gpt-5.6-luna", "gpt-5.6-luna"),
+    ("azure/gpt-5.6-luna", "gpt-5.6-luna"),
     ("gpt-5.5", "gpt-5.5"),
     ("openai/gpt-5.5", "gpt-5.5"),
     ("azure/gpt-5.5", "gpt-5.5"),
@@ -211,6 +221,20 @@ class TestOpenAIModelIds:
         assert result["output_tokens"] > 0
         assert result["cost"] is not None
         assert result["cost"] > 0
+
+
+class TestGpt56CachePricing:
+    """gpt-5.6 is the first OpenAI family with non-null cacheWrite pricing."""
+
+    @pytest.mark.parametrize("model_name", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
+    def test_cache_write_is_1_25x_input_rate(self, real_cache, model_name):
+        entry = next(e for e in real_cache if e["model_name"] == model_name)
+        assert entry["prices"]["cacheWrite"] == pytest.approx(entry["prices"]["input"] * 1.25)
+
+    @pytest.mark.parametrize("model_name", ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])
+    def test_cache_read_is_90_percent_discount(self, real_cache, model_name):
+        entry = next(e for e in real_cache if e["model_name"] == model_name)
+        assert entry["prices"]["cacheRead"] == pytest.approx(entry["prices"]["input"] * 0.10)
 
 
 class TestGeminiModelIds:


### PR DESCRIPTION
## Summary
<img width="1504" height="623" alt="Screenshot 2026-07-09 at 1 01 38 PM" src="https://github.com/user-attachments/assets/5de201e4-452f-4ea6-82a6-cae312378a18" />
Adds OpenAI’s newly announced GPT-5.6 preview family (Sol, Terra, Luna — announced 2026-07-09) to the BYOK model catalog and pricing table. Scope is BYOK-only (`ADAPTER_MODELS.openai`), not the hosted `SYSTEM_MODELS` catalog. These models are still limited-partner-preview — verified live against /v1/chat/completions (all three return `model_not_found`) and `/v1/models` (absent from a real key’s 120-model catalog). Since BYOK is opt-in and per-user, it is safe to list them now; promotion to the hosted catalog is deferred until at least one ID is confirmed reachable.

Pricing: input/output rates are quoted directly from OpenAI’s preview docs. `cacheRead` (10% of input) and `cacheWrite` (1.25× input) are derived from the stated cache-read discount and cache-write multiplier. This is the first OpenAI model family with non-null cacheWrite, so a new test class covers that math specifically.

**Sources:**
- [GPT 4.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol)
- [GPT 4.6 Terra](https://developers.openai.com/api/docs/models/gpt-5.6-terra)
- [GPT 4.6 Luna](https://developers.openai.com/api/docs/models/gpt-5.6-luna)

## Type of Change

- [x] feat - A new feature

## Details
Test plan:

tsc --noEmit on packages/core — clean

pytest tests/worker/tokens/test_pricing.py — 181/181 pass

vitest run on packages/core — 63/63 pass

## Screenshots / Recordings (if applicable)
See below in comments

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAI GPT-5.6 Sol, Terra, and Luna to the BYOK model catalog with full pricing, including cache read/write rates. Hosted `SYSTEM_MODELS` stays unchanged since these are still partner-preview.

- **New Features**
  - BYOK catalog: added `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` in `ADAPTER_MODELS.openai`, with patterns covering `openai/`, `azure/`, and dated suffixes.
  - Pricing: input/output plus cache; `cacheWrite` = 1.25× input, `cacheRead` = 10% of input. Tests cover matching and pricing math.

<sup>Written for commit 4e722e1c53b6ef484ff2f4f5b81469f94f8a558b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

