### PR TITLE
feat(notifications): render detector digest email in shared branded card

### DIFF
--- a/frontend/packages/core/src/__tests__/email-card.test.ts
+++ b/frontend/packages/core/src/__tests__/email-card.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { escapeHtml, renderEmailCard } from "../lib/email-card.ts";
+
+describe("escapeHtml", () => {
+  it("escapes every HTML special character", () => {
+    expect(escapeHtml(`Tom & Jerry <script>alert("hi")</script> it's`)).toBe(
+      "Tom &amp; Jerry &lt;script&gt;alert(&quot;hi&quot;)&lt;/script&gt; it&#39;s",
+    );
+  });
+
+  it("returns strings without special characters unchanged", () => {
+    expect(escapeHtml("plain text 123")).toBe("plain text 123");
+  });
+});
+
+describe("renderEmailCard", () => {
+  const params = {
+    title: "Card title",
+    bodyHtml: `<tr><td><p>body row</p></td></tr>`,
+    buttonLabel: "Do the thing",
+    buttonUrl: "https://app.example.com/do",
+    footerText: "Why you got this.",
+  };
+
+  it("renders a standalone document with every section in place", () => {
+    const html = renderEmailCard(params);
+
+    expect(html.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(html).toContain("Card title");
+    expect(html).toContain("<tr><td><p>body row</p></td></tr>");
+    expect(html).toContain('href="https://app.example.com/do"');
+    expect(html).toContain("Do the thing");
+    expect(html).toContain("Why you got this.");
+    // branded logo header survives
+    expect(html).toContain('alt="TraceRoot"');
+  });
+
+  it("places the body rows between the title and the button", () => {
+    const html = renderEmailCard(params);
+    const titleAt = html.indexOf("Card title");
+    const bodyAt = html.indexOf("body row");
+    const buttonAt = html.indexOf("Do the thing");
+    expect(titleAt).toBeGreaterThan(-1);
+    expect(bodyAt).toBeGreaterThan(titleAt);
+    expect(buttonAt).toBeGreaterThan(bodyAt);
+  });
+});

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -9,6 +9,9 @@ export { encryptKey, decryptKey, maskKey } from "./lib/encryption.ts";
 // BYOK key resolution
 export { resolveWorkspaceApiKey } from "./lib/workspace-api-key.ts";
 
+// Transactional-email card template
+export { escapeHtml, renderEmailCard } from "./lib/email-card.ts";
+
 // Re-export Prisma types
 export type {
   User,

--- a/frontend/packages/core/src/lib/email-card.ts
+++ b/frontend/packages/core/src/lib/email-card.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared transactional-email card template.
+ *
+ * Single source of truth for the branded email layout used by the workspace
+ * invite (frontend/ui), the usage-quota emails, and the detector digest
+ * (frontend/worker): centered TraceRoot logo, title, caller-provided body
+ * rows, one black CTA button, divider, and a muted footer note.
+ *
+ * Table-based markup with inline styles only, so it survives Gmail/Outlook
+ * CSS stripping.
+ */
+
+const LOGO_URL =
+  process.env.NEXT_PUBLIC_LOGO_URL ||
+  "https://raw.githubusercontent.com/traceroot-ai/traceroot/main/frontend/ui/public/images/traceroot_icon.png";
+
+/** Escape HTML special characters to prevent XSS. */
+export function escapeHtml(str: string): string {
+  return str.replace(
+    /[&<>"']/g,
+    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+  );
+}
+
+/**
+ * Render the branded email card as a complete standalone HTML document.
+ *
+ * Callers must pass pre-escaped HTML.
+ *
+ * @param params.title Card headline, rendered centered under the logo.
+ * @param params.bodyHtml One or more complete `<tr>` sections placed between
+ *   the title and the button.
+ * @param params.buttonLabel CTA button text.
+ * @param params.buttonUrl CTA button destination.
+ * @param params.footerText Muted note under the divider explaining why the
+ *   recipient got this email.
+ */
+export function renderEmailCard(params: {
+  title: string;
+  bodyHtml: string;
+  buttonLabel: string;
+  buttonUrl: string;
+  footerText: string;
+}): string {
+  const { title, bodyHtml, buttonLabel, buttonUrl, footerText } = params;
+  return `
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 20px; background-color: #fafafa;">
+    <table cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width: 480px; margin: 0 auto; background: #fff; border: 1px solid #e5e5e5;">
+      <!-- Logo section -->
+      <tr>
+        <td style="padding: 40px 40px 32px 40px; text-align: center;">
+          <img src="${LOGO_URL}" alt="TraceRoot" width="72" height="72" style="display: block; margin: 0 auto; border-radius: 14px;" />
+        </td>
+      </tr>
+
+      <!-- Title -->
+      <tr>
+        <td style="padding: 0 40px 24px 40px; text-align: center;">
+          <h1 style="font-size: 24px; font-weight: 600; margin: 0; color: #000; letter-spacing: -0.5px;">
+            ${title}
+          </h1>
+        </td>
+      </tr>
+${bodyHtml}
+      <!-- Button -->
+      <tr>
+        <td style="padding: 0 40px 40px 40px; text-align: center;">
+          <table cellpadding="0" cellspacing="0" border="0" style="margin: 0 auto;">
+            <tr>
+              <td style="background-color: #000;">
+                <a href="${buttonUrl}" style="display: inline-block; padding: 10px 20px; color: #ffffff; text-decoration: none; font-weight: 500; font-size: 14px;">
+                  ${buttonLabel}
+                </a>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+
+      <!-- Divider -->
+      <tr>
+        <td style="border-top: 1px solid #e5e5e5;"></td>
+      </tr>
+
+      <!-- Footer -->
+      <tr>
+        <td style="padding: 24px 40px; background-color: #fafafa;">
+          <p style="color: #999; font-size: 12px; margin: 0; text-align: center;">
+            ${footerText}
+          </p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>
+  `.trim();
+}

--- a/frontend/ui/src/lib/email/__tests__/send-invite-email.test.ts
+++ b/frontend/ui/src/lib/email/__tests__/send-invite-email.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendMail = vi.fn();
+
+vi.mock("nodemailer", () => ({
+  default: { createTransport: () => ({ sendMail }) },
+}));
+
+vi.mock("@/env", () => ({
+  env: {
+    TRACEROOT_SMTP_URL: "smtp://user:pass@localhost:587",
+    TRACEROOT_SMTP_MAIL_FROM: "noreply@traceroot.ai",
+    BETTER_AUTH_URL: "https://app.example.com",
+  },
+}));
+
+const baseParams = {
+  to: "new.member@example.com",
+  inviterName: "Kai",
+  inviterEmail: "kai@example.com",
+  workspaceName: "Acme",
+  inviteId: "inv123",
+  role: "MEMBER",
+};
+
+describe("sendInviteEmail", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sendMail.mockReset();
+    sendMail.mockResolvedValue(undefined);
+  });
+
+  it("sends the branded invite with inviter, workspace, role, and accept link", async () => {
+    const { sendInviteEmail } = await import("../send-invite-email");
+    await sendInviteEmail(baseParams);
+
+    expect(sendMail).toHaveBeenCalledTimes(1);
+    const mail = sendMail.mock.calls[0][0];
+
+    expect(mail.to).toBe("new.member@example.com");
+    expect(mail.subject).toBe('Kai invited you to join "Acme" on TraceRoot');
+
+    expect(mail.html).toContain("Join Acme on TraceRoot");
+    expect(mail.html).toContain("kai@example.com");
+    // role is title-cased for display
+    expect(mail.html).toContain("<strong>Member</strong>");
+    expect(mail.html).toContain('href="https://app.example.com/invites/inv123"');
+    expect(mail.html).toContain("Accept Invitation");
+
+    // plain-text twin carries the same essentials
+    expect(mail.text).toContain("https://app.example.com/invites/inv123");
+    expect(mail.text).toContain("Acme");
+  });
+
+  it("escapes HTML in user-provided fields", async () => {
+    const { sendInviteEmail } = await import("../send-invite-email");
+    await sendInviteEmail({
+      ...baseParams,
+      inviterName: `<img src=x onerror=alert(1)>`,
+      workspaceName: `Acme <b>&</b>`,
+    });
+
+    const mail = sendMail.mock.calls[0][0];
+    expect(mail.html).not.toContain("<img src=x");
+    expect(mail.html).toContain("&lt;img src=x onerror=alert(1)&gt;");
+    expect(mail.html).toContain("Acme &lt;b&gt;&amp;&lt;/b&gt;");
+  });
+});

--- a/frontend/ui/src/lib/email/send-invite-email.ts
+++ b/frontend/ui/src/lib/email/send-invite-email.ts
@@ -2,17 +2,8 @@
  * Email service for sending workspace invitations
  */
 import nodemailer from "nodemailer";
+import { escapeHtml, renderEmailCard } from "@traceroot/core";
 import { env } from "@/env";
-
-/**
- * Escape HTML special characters to prevent XSS
- */
-function escapeHtml(str: string): string {
-  return str.replace(
-    /[&<>"']/g,
-    (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
-  );
-}
 
 interface SendInviteEmailParams {
   to: string;
@@ -87,31 +78,9 @@ function buildHtmlEmail(params: EmailContentParams): string {
   const safeWorkspaceName = escapeHtml(workspaceName);
   const safeRoleName = escapeHtml(roleName);
 
-  return `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  </head>
-  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 20px; background-color: #fafafa;">
-    <table cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width: 480px; margin: 0 auto; background: #fff; border: 1px solid #e5e5e5;">
-      <!-- Logo section -->
-      <tr>
-        <td style="padding: 40px 40px 32px 40px; text-align: center;">
-          <img src="${env.NEXT_PUBLIC_LOGO_URL || "https://raw.githubusercontent.com/traceroot-ai/traceroot/main/frontend/ui/public/images/traceroot_icon.png"}" alt="TraceRoot" width="72" height="72" style="display: block; margin: 0 auto; border-radius: 14px;" />
-        </td>
-      </tr>
-
-      <!-- Title -->
-      <tr>
-        <td style="padding: 0 40px 24px 40px; text-align: center;">
-          <h1 style="font-size: 24px; font-weight: 600; margin: 0; color: #000; letter-spacing: -0.5px;">
-            Join ${safeWorkspaceName} on TraceRoot
-          </h1>
-        </td>
-      </tr>
-
+  return renderEmailCard({
+    title: `Join ${safeWorkspaceName} on TraceRoot`,
+    bodyHtml: `
       <!-- Body -->
       <tr>
         <td style="padding: 0 40px 32px 40px;">
@@ -119,40 +88,11 @@ function buildHtmlEmail(params: EmailContentParams): string {
             <strong>${safeInviterName}</strong> (${safeInviterEmail}) has invited you to join the <strong>${safeWorkspaceName}</strong> workspace as a <strong>${safeRoleName}</strong>.
           </p>
         </td>
-      </tr>
-
-      <!-- Button -->
-      <tr>
-        <td style="padding: 0 40px 40px 40px; text-align: center;">
-          <table cellpadding="0" cellspacing="0" border="0" style="margin: 0 auto;">
-            <tr>
-              <td style="background-color: #000;">
-                <a href="${acceptLink}" style="display: inline-block; padding: 10px 20px; color: #ffffff; text-decoration: none; font-weight: 500; font-size: 14px;">
-                  Accept Invitation
-                </a>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-
-      <!-- Divider -->
-      <tr>
-        <td style="border-top: 1px solid #e5e5e5;"></td>
-      </tr>
-
-      <!-- Footer -->
-      <tr>
-        <td style="padding: 24px 40px; background-color: #fafafa;">
-          <p style="color: #999; font-size: 12px; margin: 0; text-align: center;">
-            If you were not expecting this invitation, you can ignore this email.
-          </p>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>
-  `.trim();
+      </tr>`,
+    buttonLabel: "Accept Invitation",
+    buttonUrl: acceptLink,
+    footerText: "If you were not expecting this invitation, you can ignore this email.",
+  });
 }
 
 function buildTextEmail(params: EmailContentParams): string {

--- a/frontend/worker/src/notifications/__tests__/email-digest.test.ts
+++ b/frontend/worker/src/notifications/__tests__/email-digest.test.ts
@@ -88,6 +88,26 @@ describe("sendDigestAlertEmail", () => {
     expect(sendMail).not.toHaveBeenCalled();
   });
 
+  it("caps the listed detectors and adds an overflow row (mirrors the Slack digest)", async () => {
+    const { sendDigestAlertEmail } = await import("../email.js");
+    const entries = Array.from({ length: 50 }, (_, i) => ({
+      detectorId: `d${i}`,
+      detectorName: `Detector ${i}`,
+      findingCount: 1,
+      latestTraceId: "",
+    }));
+    await sendDigestAlertEmail({ ...baseParams, total: 50, entries });
+
+    const mail = sendMail.mock.calls[0][0];
+    // 45 rows listed, the rest folded into the overflow note
+    expect(mail.html).toContain("Detector 44");
+    expect(mail.html).not.toContain("Detector 45");
+    expect(mail.html).toContain("+5 more detectors");
+    expect(mail.text).toContain("+5 more detectors");
+    // the subline still counts every triggered detector
+    expect(mail.html).toContain("· 50 detectors");
+  });
+
   it("omits the latest-trace segment when an entry has no latest trace", async () => {
     const { sendDigestAlertEmail } = await import("../email.js");
     await sendDigestAlertEmail({

--- a/frontend/worker/src/notifications/__tests__/email-digest.test.ts
+++ b/frontend/worker/src/notifications/__tests__/email-digest.test.ts
@@ -108,6 +108,28 @@ describe("sendDigestAlertEmail", () => {
     expect(mail.html).toContain("· 50 detectors");
   });
 
+  it("escapes HTML in detector names and displayed trace ids", async () => {
+    const { sendDigestAlertEmail } = await import("../email.js");
+    await sendDigestAlertEmail({
+      ...baseParams,
+      entries: [
+        {
+          detectorId: "d1",
+          detectorName: `<b>Bold</b> & co`,
+          findingCount: 1,
+          latestTraceId: `<script>7890`,
+        },
+      ],
+    });
+
+    const mail = sendMail.mock.calls[0][0];
+    expect(mail.html).not.toContain("<b>Bold</b>");
+    expect(mail.html).toContain("&lt;b&gt;Bold&lt;/b&gt; &amp; co");
+    // the displayed prefix is the first 8 chars ("<script>"), escaped
+    expect(mail.html).not.toContain("<script>");
+    expect(mail.html).toContain("&lt;script&gt;");
+  });
+
   it("omits the latest-trace segment when an entry has no latest trace", async () => {
     const { sendDigestAlertEmail } = await import("../email.js");
     await sendDigestAlertEmail({

--- a/frontend/worker/src/notifications/email.ts
+++ b/frontend/worker/src/notifications/email.ts
@@ -5,23 +5,18 @@ import {
   traceUrl,
   type DigestEntry,
 } from "@traceroot/slack";
-import type { UsageMeter } from "@traceroot/core";
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
-}
+import { escapeHtml, renderEmailCard, type UsageMeter } from "@traceroot/core";
 
 const SMTP_URL = process.env.TRACEROOT_SMTP_URL;
 const SMTP_FROM = process.env.TRACEROOT_SMTP_MAIL_FROM || "noreply@traceroot.ai";
 const APP_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-// Same logo source as the workspace-invite email in frontend/ui.
-const LOGO_URL =
-  process.env.NEXT_PUBLIC_LOGO_URL ||
-  "https://raw.githubusercontent.com/traceroot-ai/traceroot/main/frontend/ui/public/images/traceroot_icon.png";
+
+// Mirror the Slack digest's overflow behavior (its 50-block ceiling caps it at
+// 45 detector lines): list at most this many per-detector rows so a project
+// with many triggered detectors can't produce an unwieldy email — Gmail clips
+// messages over ~102 KB. An overflow row names how many were omitted, and the
+// View-findings button leads to the full list.
+const MAX_DIGEST_ROWS = 45;
 
 function createTransport() {
   if (!SMTP_URL) return null;
@@ -69,12 +64,15 @@ export async function sendDigestAlertEmail(params: {
     detectorFindingsUrl(APP_BASE_URL, projectId, detectorId, windowStart, windowEnd);
   const traceUrlFor = (traceId: string) => traceUrl(APP_BASE_URL, projectId, traceId);
 
+  const shown = entries.slice(0, MAX_DIGEST_ROWS);
+  const omitted = entries.length - shown.length;
+
   const textParts = [
     `${total} ${noun} in project ${projectName}.`,
     `${windowRange} · ${entries.length} detector${entries.length === 1 ? "" : "s"}`,
     ``,
   ];
-  for (const e of entries) {
+  for (const e of shown) {
     const findingNoun = e.findingCount === 1 ? "finding" : "findings";
     // Omit the trace segment when there is no latest trace (mirrors the Slack
     // builder), so we never emit a blank/broken trace link.
@@ -84,27 +82,68 @@ export async function sendDigestAlertEmail(params: {
       `  ${findingsUrlFor(e.detectorId)}`,
     );
   }
+  if (omitted > 0) textParts.push(`+${omitted} more detector${omitted === 1 ? "" : "s"}`);
 
-  const htmlRows = entries
+  const htmlRows = shown
     .map((e) => {
       const findingNoun = e.findingCount === 1 ? "finding" : "findings";
       const latest = e.latestTraceId
-        ? ` · latest <a href="${traceUrlFor(e.latestTraceId)}" style="color:#888;">${e.latestTraceId.slice(0, 8)}</a>`
+        ? ` · latest <a href="${traceUrlFor(e.latestTraceId)}" style="color: #888;">${e.latestTraceId.slice(0, 8)}</a>`
         : "";
-      return `<p style="margin:6px 0;"><a href="${findingsUrlFor(e.detectorId)}">${escapeHtml(e.detectorName)}</a> <span style="color:#888;">— ${e.findingCount} ${findingNoun}${latest}</span></p>`;
+      return `<p style="margin: 6px 0; color: #333; font-size: 14px; line-height: 1.6;"><a href="${findingsUrlFor(e.detectorId)}" style="color: #000; font-weight: 500;">${escapeHtml(e.detectorName)}</a> <span style="color: #888;">— ${e.findingCount} ${findingNoun}${latest}</span></p>`;
     })
+    .concat(
+      omitted > 0
+        ? [
+            `<p style="margin: 6px 0; color: #888; font-size: 14px; line-height: 1.6;">+${omitted} more detector${omitted === 1 ? "" : "s"}</p>`,
+          ]
+        : [],
+    )
     .join("\n");
+
+  const safeProjectName = escapeHtml(projectName);
+  const html = renderEmailCard({
+    title: "New detector findings",
+    bodyHtml: `
+      <!-- Body -->
+      <tr>
+        <td style="padding: 0 40px 8px 40px; text-align: center;">
+          <p style="margin: 0; color: #333; font-size: 15px; line-height: 1.6;">
+            <strong>${total} ${noun}</strong> in project <strong>${safeProjectName}</strong>.
+          </p>
+        </td>
+      </tr>
+
+      <!-- Window subline -->
+      <tr>
+        <td style="padding: 0 40px 24px 40px; text-align: center;">
+          <p style="margin: 0; color: #888; font-size: 12px;">${windowRange} · ${entries.length} detector${entries.length === 1 ? "" : "s"}</p>
+        </td>
+      </tr>
+
+      <!-- Per-detector rows -->
+      <tr>
+        <td style="padding: 0 40px 32px 40px;">
+          <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #fafafa; border: 1px solid #e5e5e5;">
+            <tr>
+              <td style="padding: 12px 16px;">
+${htmlRows}
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>`,
+    buttonLabel: "View findings",
+    buttonUrl: `${APP_BASE_URL}/projects/${projectId}/detectors`,
+    footerText: `You are receiving this because detector email alerts are enabled for the ${safeProjectName} project on TraceRoot.`,
+  });
 
   await transport.sendMail({
     from: SMTP_FROM,
     to: params.to.join(", "),
     subject: `[TraceRoot Alert] ${total} ${noun} — ${projectName}`,
     text: textParts.join("\n"),
-    html: `
-<p><strong>${total} ${noun}</strong> in project <strong>${escapeHtml(projectName)}</strong>.</p>
-<p style="color:#888;font-size:12px;">${windowRange} · ${entries.length} detector${entries.length === 1 ? "" : "s"}</p>
-${htmlRows}
-    `.trim(),
+    html,
   });
 }
 
@@ -226,9 +265,6 @@ export async function sendUsageQuotaEmail(params: {
   }
 }
 
-// Card layout mirrors the workspace-invite email (frontend/ui
-// send-invite-email.ts): table-based markup with inline styles only, so it
-// survives Gmail/Outlook CSS stripping.
 function buildUsageQuotaHtml(params: {
   kind: "warning" | "blocked";
   workspaceName: string;
@@ -256,49 +292,9 @@ function buildUsageQuotaHtml(params: {
   const safeWorkspaceName = escapeHtml(workspaceName);
 
   const title = kind === "warning" ? "Approaching your free plan limit" : "Free plan limit reached";
-  // Both variants carry a consequence callout: what IS paused (blocked, bold)
-  // or what WILL pause at the limit (warning, regular weight).
-  const consequenceSection = `
-      <!-- Consequence callout -->
-      <tr>
-        <td style="padding: 0 40px 24px 40px;">
-          <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #fafafa; border: 1px solid #e5e5e5;">
-            <tr>
-              <td style="padding: 12px 16px;">
-                <p style="margin: 0; color: #333; font-size: 14px; line-height: 1.6; text-align: center;">
-                  ${kind === "blocked" ? `<strong>${consequence}</strong>` : consequence}
-                </p>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>`;
-
-  return `
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  </head>
-  <body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; margin: 0; padding: 20px; background-color: #fafafa;">
-    <table cellpadding="0" cellspacing="0" border="0" width="100%" style="max-width: 480px; margin: 0 auto; background: #fff; border: 1px solid #e5e5e5;">
-      <!-- Logo section -->
-      <tr>
-        <td style="padding: 40px 40px 32px 40px; text-align: center;">
-          <img src="${LOGO_URL}" alt="TraceRoot" width="72" height="72" style="display: block; margin: 0 auto; border-radius: 14px;" />
-        </td>
-      </tr>
-
-      <!-- Title -->
-      <tr>
-        <td style="padding: 0 40px 24px 40px; text-align: center;">
-          <h1 style="font-size: 24px; font-weight: 600; margin: 0; color: #000; letter-spacing: -0.5px;">
-            ${title}
-          </h1>
-        </td>
-      </tr>
-
+  return renderEmailCard({
+    title,
+    bodyHtml: `
       <!-- Body -->
       <tr>
         <td style="padding: 0 40px 24px 40px;">
@@ -311,7 +307,23 @@ function buildUsageQuotaHtml(params: {
           </p>
         </td>
       </tr>
-${consequenceSection}
+
+      <!-- Consequence callout: what IS paused (blocked, bold) or what WILL
+           pause at the limit (warning, regular weight). -->
+      <tr>
+        <td style="padding: 0 40px 24px 40px;">
+          <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #fafafa; border: 1px solid #e5e5e5;">
+            <tr>
+              <td style="padding: 12px 16px;">
+                <p style="margin: 0; color: #333; font-size: 14px; line-height: 1.6; text-align: center;">
+                  ${kind === "blocked" ? `<strong>${consequence}</strong>` : consequence}
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+
       <!-- CTA note -->
       <tr>
         <td style="padding: 0 40px 32px 40px;">
@@ -319,38 +331,9 @@ ${consequenceSection}
             ${cta}
           </p>
         </td>
-      </tr>
-
-      <!-- Button -->
-      <tr>
-        <td style="padding: 0 40px 40px 40px; text-align: center;">
-          <table cellpadding="0" cellspacing="0" border="0" style="margin: 0 auto;">
-            <tr>
-              <td style="background-color: #000;">
-                <a href="${billingUrl}" style="display: inline-block; padding: 10px 20px; color: #ffffff; text-decoration: none; font-weight: 500; font-size: 14px;">
-                  Manage your plan
-                </a>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-
-      <!-- Divider -->
-      <tr>
-        <td style="border-top: 1px solid #e5e5e5;"></td>
-      </tr>
-
-      <!-- Footer -->
-      <tr>
-        <td style="padding: 24px 40px; background-color: #fafafa;">
-          <p style="color: #999; font-size: 12px; margin: 0; text-align: center;">
-            You are receiving this because you are an admin of the ${safeWorkspaceName} workspace on TraceRoot.
-          </p>
-        </td>
-      </tr>
-    </table>
-  </body>
-</html>
-  `.trim();
+      </tr>`,
+    buttonLabel: "Manage your plan",
+    buttonUrl: billingUrl,
+    footerText: `You are receiving this because you are an admin of the ${safeWorkspaceName} workspace on TraceRoot.`,
+  });
 }

--- a/frontend/worker/src/notifications/email.ts
+++ b/frontend/worker/src/notifications/email.ts
@@ -87,8 +87,10 @@ export async function sendDigestAlertEmail(params: {
   const htmlRows = shown
     .map((e) => {
       const findingNoun = e.findingCount === 1 ? "finding" : "findings";
+      // Trace IDs come from SDK-submitted telemetry, so escape the displayed
+      // prefix like the detector name; the href is already URL-encoded.
       const latest = e.latestTraceId
-        ? ` · latest <a href="${traceUrlFor(e.latestTraceId)}" style="color: #888;">${e.latestTraceId.slice(0, 8)}</a>`
+        ? ` · latest <a href="${traceUrlFor(e.latestTraceId)}" style="color: #888;">${escapeHtml(e.latestTraceId.slice(0, 8))}</a>`
         : "";
       return `<p style="margin: 6px 0; color: #333; font-size: 14px; line-height: 1.6;"><a href="${findingsUrlFor(e.detectorId)}" style="color: #000; font-weight: 500;">${escapeHtml(e.detectorName)}</a> <span style="color: #888;">— ${e.findingCount} ${findingNoun}${latest}</span></p>`;
     })


### PR DESCRIPTION
Closes #1507

## What

The detector digest alert email was bare HTML paragraphs, while the workspace-invite and free-plan usage-quota emails each carried their own inline copy of the branded card layout. This PR:

- Extracts the card (logo, centered title, black CTA button, divider, footer) into a shared `renderEmailCard` helper in `@traceroot/core`, importable by both `frontend/ui` and the worker; `escapeHtml` moves alongside it.
- Rebuilds the digest email on the card: title, findings lead, window subline, per-detector rows in a callout box, and a View-findings button deep-linking to the project's detectors page.
- Caps the digest at 45 detector rows with a "+N more detectors" overflow line in both the HTML and plain-text bodies, mirroring the Slack digest's 50-block cap, so a project with many triggered detectors can't produce an email large enough for Gmail to clip (~102 KB). The subline still reports the true detector count.
- Rewires the invite and usage-quota emails onto the shared card. Their rendered output is unchanged (screenshot-verified).

## Screenshots

<img width="1128" height="699" alt="image" src="https://github.com/user-attachments/assets/f191597a-482d-46b7-836d-c972960592f6" />


Digest email (new style) and overflow behavior were rendered and visually verified; invite and usage emails are pixel-identical to before.

## Verification

- Worker notification tests: 21 passing, including a new overflow test (cap, overflow note in HTML and text, un-capped subline).
- `tsc` clean in core, worker, and ui (the 4 pre-existing ui test-file errors reproduce with and without this change).
- `eslint` clean on all touched files.
- All four emails rendered in a browser from captured `sendMail` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies transactional emails on a shared branded card and rebuilds the detector digest email with that layout. Also escapes the displayed latest-trace ID in the digest and adds tests for the shared card and invite email (meets #1507).

- **New Features**
  - Added `renderEmailCard` and `escapeHtml` to `@traceroot/core` and exported from `core/index`.
  - Digest email: title, window subline, per-detector callout, and a "View findings" CTA linking to the project's detectors page; lists up to 45 detectors with a "+N more" overflow in HTML and text.
  - Rewired invite and usage-quota emails to use the shared card; visuals unchanged.

- **Bug Fixes**
  - Escaped the displayed latest-trace ID in the digest HTML; added direct tests for the shared email card and the invite email (content, links, and HTML escaping).

<sup>Written for commit 60e768e2a2b81d6c878f1cfb00a3a092f07e85c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



