### PR TITLE
feat(api): widget field registry

### DIFF
--- a/backend/rest/services/widget_registry.py
+++ b/backend/rest/services/widget_registry.py
@@ -1,0 +1,211 @@
+"""Static field registry for the widget query engine.
+
+Declares which views and fields widget specs may reference. The compiler
+(`widget_query.py`) refuses anything not declared here, so this file is the
+single source of truth for what dashboard widgets can query. Field `expr`s
+reference aliases produced by each view's base relation (see `base_sql`),
+never raw user input.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+FILTER_OPS_STRING = ("=", "!=", "contains")
+FILTER_OPS_NUMBER = (">", ">=", "<", "<=", "=", "!=")
+AGGS_NUMBER = ("sum", "avg", "min", "max", "p50", "p95", "p99")
+
+
+@dataclass(frozen=True)
+class FieldDef:
+    expr: str  # SQL over the view's base relation aliases
+    type: Literal["string", "number"]
+    label: str
+    # filterOps: camelCase deliberate — this dict is the JSON contract consumed
+    # directly by the frontend builder UI.
+    filter_ops: tuple[str, ...] = ()
+    groupable: bool = False
+    aggs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ViewDef:
+    # Base relation: deduped (ReplacingMergeTree → LIMIT 1 BY) and ALWAYS
+    # scoped by {project_id}/{start_time}/{end_time} parameters. Exposes a
+    # stable `event_time` alias used for time bucketing.
+    base_sql: str
+    fields: dict[str, FieldDef] = field(default_factory=dict)
+
+
+_SPANS_BASE = """
+    SELECT
+        name, span_kind, status, model_name, environment,
+        span_start_time AS event_time,
+        dateDiff('millisecond', span_start_time, span_end_time) AS duration_ms,
+        cost, input_tokens, output_tokens, total_tokens
+    FROM (
+        SELECT
+            span_id, trace_id, name, span_kind, status, model_name, environment,
+            span_start_time, span_end_time, cost, input_tokens, output_tokens, total_tokens
+        FROM spans
+        WHERE project_id = {project_id:String}
+          AND span_start_time >= {start_time:DateTime64(3)}
+          AND span_start_time < {end_time:DateTime64(3)}
+        ORDER BY ch_update_time DESC
+        LIMIT 1 BY project_id, trace_id, span_id
+    )
+"""
+
+# Trace-level metrics do not exist as physical columns; they are aggregated
+# from spans per trace. The spans subquery is bounded by the same dashboard
+# time window as the traces query, so a trace whose spans extend beyond the
+# window edge will have those later spans excluded. This means duration,
+# cost, and token counts here may differ from the per-trace detail page (which
+# joins all spans for a trace). The tradeoff is a bounded, fast scan for
+# dashboards vs. exact per-trace metrics in the trace list.
+_TRACES_BASE = """
+    SELECT
+        t.name AS name, t.user_id AS user_id,
+        t.session_id AS session_id, t.environment AS environment,
+        t.trace_start_time AS event_time,
+        -- NULL out measures for non-matched LEFT JOIN rows; ClickHouse fills
+        -- String join key columns with '' (empty string) when there is no match,
+        -- so sa.trace_id = '' reliably identifies un-joined traces.
+        if(sa.trace_id = '', NULL, sa.duration_ms) AS duration_ms,
+        if(sa.trace_id = '', NULL, sa.error_count) AS error_count,
+        if(sa.trace_id = '', NULL, sa.total_cost) AS cost,
+        if(sa.trace_id = '', NULL, sa.input_tokens) AS input_tokens,
+        if(sa.trace_id = '', NULL, sa.output_tokens) AS output_tokens,
+        if(sa.trace_id = '', NULL, sa.total_tokens) AS total_tokens
+    FROM (
+        SELECT
+            trace_id, name, user_id, session_id, environment, trace_start_time
+        FROM traces
+        WHERE project_id = {project_id:String}
+          AND trace_start_time >= {start_time:DateTime64(3)}
+          AND trace_start_time < {end_time:DateTime64(3)}
+        ORDER BY ch_update_time DESC
+        LIMIT 1 BY project_id, trace_id
+    ) AS t
+    LEFT JOIN (
+        SELECT
+            trace_id,
+            if(
+                min(span_start_time) IS NOT NULL AND max(span_end_time) IS NOT NULL,
+                dateDiff('millisecond', min(span_start_time), max(span_end_time)),
+                NULL
+            ) AS duration_ms,
+            countIf(status = 'ERROR') AS error_count,
+            sum(cost) AS total_cost,
+            sum(input_tokens) AS input_tokens,
+            sum(output_tokens) AS output_tokens,
+            sum(total_tokens) AS total_tokens
+        FROM (
+            SELECT
+                trace_id, span_id, status, span_start_time, span_end_time, cost,
+                input_tokens, output_tokens, total_tokens
+            FROM spans
+            WHERE project_id = {project_id:String}
+              AND span_start_time >= {start_time:DateTime64(3)}
+              AND span_start_time < {end_time:DateTime64(3)}
+            ORDER BY ch_update_time DESC
+            LIMIT 1 BY project_id, trace_id, span_id
+        )
+        GROUP BY trace_id
+    ) AS sa ON sa.trace_id = t.trace_id
+"""
+
+
+def _string_dim(expr: str, label: str) -> FieldDef:
+    return FieldDef(
+        expr=expr,
+        type="string",
+        label=label,
+        filter_ops=FILTER_OPS_STRING,
+        groupable=True,
+    )
+
+
+def _number_measure(expr: str, label: str) -> FieldDef:
+    return FieldDef(
+        expr=expr,
+        type="number",
+        label=label,
+        filter_ops=FILTER_OPS_NUMBER,
+        aggs=AGGS_NUMBER,
+    )
+
+
+REGISTRY: dict[str, ViewDef] = {
+    "spans": ViewDef(
+        base_sql=_SPANS_BASE,
+        fields={
+            "name": _string_dim("name", "Span name"),
+            "span_kind": _string_dim("span_kind", "Span kind"),
+            # Effectively binary (OK / ERROR): useful as a filter, not worth a
+            # breakdown dimension.
+            "status": FieldDef(
+                expr="status", type="string", label="Status", filter_ops=FILTER_OPS_STRING
+            ),
+            "model_name": _string_dim("model_name", "Model"),
+            "environment": _string_dim("environment", "Environment"),
+            # Labels follow the trace-list filter vocabulary (see
+            # rest.services.filters.columns); units surface as input adornments
+            # in the builder, not in the label.
+            "duration_ms": _number_measure("duration_ms", "Duration"),
+            "cost": _number_measure("cost", "Cost"),
+            "input_tokens": _number_measure("input_tokens", "Input tokens"),
+            "output_tokens": _number_measure("output_tokens", "Output tokens"),
+            "total_tokens": _number_measure("total_tokens", "Total tokens"),
+            # expr="*" is a sentinel: the compiler translates it to count(*).
+            "count": FieldDef(expr="*", type="number", label="Count", aggs=("count",)),
+        },
+    ),
+    "traces": ViewDef(
+        base_sql=_TRACES_BASE,
+        fields={
+            "name": _string_dim("name", "Trace name"),
+            "user_id": _string_dim("user_id", "User"),
+            "session_id": _string_dim("session_id", "Session"),
+            "environment": _string_dim("environment", "Environment"),
+            # Same quantities the trace list exposes — same words (Latency,
+            # Cost, Tokens, Errors), so filtering a widget reads like
+            # filtering the trace list.
+            "duration_ms": _number_measure("duration_ms", "Latency"),
+            "cost": _number_measure("cost", "Cost"),
+            "input_tokens": _number_measure("input_tokens", "Input tokens"),
+            "output_tokens": _number_measure("output_tokens", "Output tokens"),
+            "total_tokens": _number_measure("total_tokens", "Tokens"),
+            # expr="*" is a sentinel: the compiler translates it to count(*).
+            "count": FieldDef(expr="*", type="number", label="Count", aggs=("count",)),
+            # Last, so the list reads as the spans measures plus one trailing
+            # trace-only addition when switching views.
+            "error_count": _number_measure("error_count", "Errors"),
+        },
+    ),
+}
+
+
+def registry_schema() -> dict:
+    """JSON-friendly registry for `GET /widgets/schema`. Omits SQL exprs."""
+    return {
+        view_name: {
+            "fields": {
+                fname: {
+                    "type": f.type,
+                    "label": f.label,
+                    "filterOps": list(f.filter_ops),
+                    "groupable": f.groupable,
+                    "aggs": list(f.aggs),
+                    # Mirrors the compiler's histogram rule (numeric column,
+                    # not the count(*) sentinel) so the builder can gate the
+                    # histogram display instead of saving a widget that the
+                    # query engine permanently rejects.
+                    "histogrammable": f.type == "number" and f.expr != "*",
+                }
+                for fname, f in view.fields.items()
+            }
+        }
+        for view_name, view in REGISTRY.items()
+    }

--- a/tests/rest/test_widget_filter_registry_parity.py
+++ b/tests/rest/test_widget_filter_registry_parity.py
@@ -1,0 +1,62 @@
+"""Drift test between the trace-filter and widget field registries.
+
+The trace-filter registry (``rest.services.filters.columns``) and the widget
+registry (``rest.services.widget_registry``) independently encode SQL for the
+same per-trace metrics (cost, tokens, duration, error count) and the same span
+dimensions (model, environment). They serve different query shapes — semi-join
+predicates vs. view base relations — so they stay separate modules, but the
+overlapping expressions must not silently diverge: a user filtering traces by
+``duration_ms > 500`` and a widget charting trace duration must measure the
+same thing. If one side changes an expression, this test fails and forces the
+other side (or this contract) to be updated deliberately.
+"""
+
+from rest.services.filters import columns as filter_reg
+from rest.services.widget_registry import REGISTRY
+
+WIDGET_TRACES_BASE = REGISTRY["traces"].base_sql
+WIDGET_SPANS_FIELDS = REGISTRY["spans"].fields
+
+# Filter-registry aggregate field -> the widget traces view's alias for the same
+# per-trace metric. Both sides must compute the alias with the identical aggregate
+# expression over spans.
+AGGREGATE_FIELD_TO_WIDGET_ALIAS = {
+    "cost": "total_cost",
+    "total_tokens": "total_tokens",
+    "duration_ms": "duration_ms",
+    "errors": "error_count",
+}
+
+
+def test_every_overlapping_aggregate_uses_the_same_expression():
+    """Each shared per-trace metric's aggregate SQL appears verbatim in the widget
+    traces base relation, so filters and widgets measure the same quantity."""
+    for field_name in AGGREGATE_FIELD_TO_WIDGET_ALIAS:
+        col = filter_reg.get_column(field_name)
+        assert col is not None and col.aggregate_expr, f"{field_name} lost its aggregate_expr"
+        assert col.aggregate_expr in WIDGET_TRACES_BASE, (
+            f"filter field '{field_name}' computes `{col.aggregate_expr}` but the widget "
+            "traces view no longer contains that expression — the two registries drifted"
+        )
+
+
+def test_widget_traces_view_still_exposes_the_shared_aliases():
+    """The alias mapping above is only meaningful while the widget view keeps those
+    fields; losing one silently would hollow out the expression check."""
+    traces_fields = REGISTRY["traces"].fields
+    for alias in ("cost", "total_tokens", "duration_ms", "error_count"):
+        assert alias in traces_fields, f"widget traces view dropped shared field '{alias}'"
+
+
+def test_membership_filter_fields_are_widget_span_dimensions():
+    """Span attributes filterable on the trace list (model, environment) exist in the
+    widget spans view as string dimensions over the same physical column."""
+    for col in filter_reg.FILTER_COLUMNS:
+        if col.level is not filter_reg.FilterLevel.SPAN_MEMBERSHIP:
+            continue
+        widget_field = WIDGET_SPANS_FIELDS.get(col.name)
+        assert widget_field is not None, f"widget spans view lacks filter field '{col.name}'"
+        assert widget_field.type == "string"
+        # Same physical column: the widget expr is the bare column name the filter
+        # semi-join scans, so both read identical stored values.
+        assert widget_field.expr == col.name

--- a/tests/rest/test_widget_registry.py
+++ b/tests/rest/test_widget_registry.py
@@ -1,0 +1,95 @@
+"""Tests for the widget field registry.
+
+These tests verify the contracts that the compiler and frontend depend on,
+not the internal shape of individual fields.
+"""
+
+import json
+import re
+
+from rest.services.widget_registry import REGISTRY, registry_schema
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+_REQUIRED_PARAMS = ["{project_id:String}", "{start_time:DateTime64(3)}", "{end_time:DateTime64(3)}"]
+
+
+def _exposed_in_base_sql(expr: str, base_sql: str) -> bool:
+    """Return True if `expr` appears as an alias or a bare selected column token."""
+    if expr == "*":
+        return True  # sentinel for count(*); compiler special-cases it
+    # Matches " AS expr" (alias) or "expr" as a standalone token in the SELECT list
+    return bool(re.search(rf"\bAS {re.escape(expr)}\b", base_sql)) or bool(
+        re.search(rf"(?<![.\w]){re.escape(expr)}(?![.\w])", base_sql)
+    )
+
+
+# ── invariant tests ───────────────────────────────────────────────────────────
+
+
+def test_every_field_expr_is_reachable_in_base_sql():
+    """Each field's expr must be an alias or column token exposed by the view's base_sql."""
+    for view_name, view in REGISTRY.items():
+        for fname, fdef in view.fields.items():
+            assert _exposed_in_base_sql(fdef.expr, view.base_sql), (
+                f"{view_name}.{fname}: expr={fdef.expr!r} not found in base_sql"
+            )
+
+
+def test_every_base_sql_has_required_params_and_event_time():
+    """Every base_sql must be scoped by the three query params and expose AS event_time."""
+    for view_name, view in REGISTRY.items():
+        for param in _REQUIRED_PARAMS:
+            assert param in view.base_sql, f"{view_name}: missing {param}"
+        assert "AS event_time" in view.base_sql, f"{view_name}: missing AS event_time"
+
+
+def test_registry_schema_round_trips_as_json():
+    """registry_schema() must be JSON-serialisable (no tuples, dataclasses, etc.)."""
+    schema = registry_schema()
+    serialised = json.dumps(schema)
+    assert json.loads(serialised) == schema
+
+
+def test_registry_schema_omits_expr():
+    """registry_schema() must never expose internal SQL expressions to clients."""
+    schema = registry_schema()
+    for view_name, view_schema in schema.items():
+        for fname, fschema in view_schema["fields"].items():
+            assert "expr" not in fschema, f"{view_name}.{fname}: expr leaked into schema"
+
+
+def test_each_view_has_count_field_and_structural_requirements():
+    """Every view needs a count field, at least one groupable string dim, and one aggregatable measure."""
+    for view_name, view in REGISTRY.items():
+        # count field with aggs=("count",)
+        assert "count" in view.fields, f"{view_name}: missing count field"
+        assert view.fields["count"].aggs == ("count",), f"{view_name}: count.aggs mismatch"
+
+        # at least one groupable string dimension
+        string_dims = [f for f in view.fields.values() if f.groupable and f.type == "string"]
+        assert string_dims, f"{view_name}: no groupable string dimension"
+
+        # at least one aggregatable number measure
+        number_measures = [
+            f for f in view.fields.values() if f.aggs and f.type == "number" and f.expr != "*"
+        ]
+        assert number_measures, f"{view_name}: no aggregatable number measure"
+
+
+def test_schema_histogrammable_mirrors_compiler_rule():
+    """histogrammable must be true exactly for numeric non-sentinel measures.
+
+    The builder gates its histogram display on this flag; if it drifts from
+    the compiler's rule the UI either blocks a valid widget or saves one the
+    engine permanently rejects.
+    """
+    schema = registry_schema()
+    for view_name, view in REGISTRY.items():
+        for fname, fdef in view.fields.items():
+            expected = fdef.type == "number" and fdef.expr != "*"
+            actual = schema[view_name]["fields"][fname]["histogrammable"]
+            assert actual == expected, f"{view_name}.{fname}: histogrammable={actual}"
+    # The concrete case that motivated the flag: count is not histogrammable.
+    assert schema["spans"]["fields"]["count"]["histogrammable"] is False
+    assert schema["spans"]["fields"]["cost"]["histogrammable"] is True


### PR DESCRIPTION
Second PR in the stacked project-dashboards series (epic #1460), stacked on #1508. Backend only, no runtime endpoints yet.

## What's here
- **`widget_registry.py`** — a static per-view field registry for the two queryable views (`spans`, `traces`). Each field declares its type, display label, allowed filter operators, whether it's groupable (breakdown), its aggregations, and whether it's histogrammable. Also holds each view's deduped, time-scoped base SQL and a `registry_schema()` serializer the widget builder consumes.
- The registry is the **single source of truth** for what a widget spec may reference — the spec compiler (next PR) resolves every user-supplied field name against it before any SQL is built, so raw client input never reaches a query.
- **Tests**: `test_widget_registry.py` (invariant tests — every field expr is reachable in its base SQL, required query params present, etc.) and `test_widget_filter_registry_parity.py` (drift test asserting the shared metric expressions stay identical to the pre-existing trace-list filter registry).

## Notes for review
- Pure declarations + SQL strings; the base SQL is fully ClickHouse-parameterized (no user-input interpolation).
- The pydantic spec schemas and the spec→SQL compiler intentionally ship in the next PR, alongside the tests that exercise them (keeps each PR's diff-coverage self-contained).

Part of #1449 (the query engine lands across this PR and the compiler PR).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a static widget field registry for `spans` and `traces` to define allowed fields and lock down dashboard queries. Establishes a single source of truth and provides a JSON schema for the builder.

- **New Features**
  - Added `backend/rest/services/widget_registry.py`: per-view registry with base SQL and field metadata (type, label, filter ops, groupable, aggs, histogrammable).
  - Exposes `registry_schema()` for a JSON-friendly schema; internal SQL is not surfaced.
  - Ensures safety: ClickHouse SQL is fully parameterized; the upcoming compiler resolves fields via this registry.
  - Tests cover invariants (required params, `event_time`, count field, histogrammable) and parity with the existing trace filter registry to prevent expression drift.

<sup>Written for commit cfcc9cb7e33898521174fab968675bfbed52f652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

