### PR TITLE
feat(api): widget spec schemas, SQL compiler, and query endpoints

### DIFF
--- a/backend/db/clickhouse/client.py
+++ b/backend/db/clickhouse/client.py
@@ -150,9 +150,14 @@ class ClickHouseClient:
             ],
         )
 
-    def query(self, query: str, parameters: dict[str, Any] | None = None):
+    def query(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+        settings: dict[str, Any] | None = None,
+    ):
         """Execute a query and return the result."""
-        return self._client.query(query, parameters=parameters)
+        return self._client.query(query, parameters=parameters, settings=settings)
 
     def close(self) -> None:
         """Close the client connection."""

--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -19,6 +19,7 @@ from fastapi.middleware.gzip import GZipMiddleware
 from slowapi.errors import RateLimitExceeded
 
 from rest.rate_limit import limiter, rate_limit_exceeded_handler
+from rest.routers.dashboards import router as dashboards_router
 from rest.routers.internal import router as internal_router
 from rest.routers.live import router as live_router
 from rest.routers.public.detectors_read import router as public_detectors_read_router
@@ -62,6 +63,7 @@ app.add_middleware(
 app.include_router(traces_router, prefix="/api/v1")
 app.include_router(users_router, prefix="/api/v1")
 app.include_router(sessions_router, prefix="/api/v1")
+app.include_router(dashboards_router, prefix="/api/v1")
 
 # Live trace streaming (SSE, user auth)
 app.include_router(live_router, prefix="/api/v1")

--- a/backend/rest/routers/dashboards.py
+++ b/backend/rest/routers/dashboards.py
@@ -8,9 +8,16 @@ the field registry that drives the builder UI.
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, Request, Response, status
 
-from rest.routers.deps import ProjectAccess
+from rest.rate_limit import (
+    BUCKET_READ,
+    is_request_rate_limit_exempt,
+    key_read,
+    limiter,
+    resolve_limit,
+)
+from rest.routers.deps import RateLimitedProjectAccess
 from rest.schemas.dashboards import WidgetQueryRequest, WidgetQueryResponse
 from rest.schemas.traces import FilterValuesResponse
 from rest.services.trace_reader import get_trace_reader_service
@@ -23,11 +30,16 @@ router = APIRouter(prefix="/projects/{project_id}/widgets", tags=["Dashboards"])
 
 
 @router.get("/field-values/{view}/{field}", response_model=FilterValuesResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def get_widget_field_values(
+    request: Request,
+    response: Response,
     project_id: str,
     view: str,
     field: str,
-    _access: ProjectAccess,
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
     start_time: datetime | None = Query(
         None, description="Only consider rows whose event time is at or after this timestamp"
     ),
@@ -45,7 +57,7 @@ async def get_widget_field_values(
         project_id (str): Project that owns the data; server-bound for isolation.
         view (str): The widget view (``spans`` or ``traces``) whose table is scanned.
         field (str): The string dimension to enumerate.
-        _access (ProjectAccess): Validates the caller's access to the project.
+        _access (RateLimitedProjectAccess): Validates access and sets rate-limit identity.
         start_time (datetime | None): Lower bound of the active dashboard window.
         end_time (datetime | None): Upper bound (exclusive) of the active window.
 
@@ -95,16 +107,29 @@ async def get_widget_field_values(
 
 
 @router.get("/schema")
-async def get_widget_schema(project_id: str, _access: ProjectAccess) -> dict:
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
+async def get_widget_schema(
+    request: Request,
+    response: Response,
+    project_id: str,
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
+) -> dict:
     """Field registry for the widget builder (views, fields, ops, aggs)."""
     return registry_schema()
 
 
 @router.post("/query", response_model=WidgetQueryResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def query_widget_data(
+    request: Request,
+    response: Response,
     project_id: str,
     body: WidgetQueryRequest,
-    _access: ProjectAccess,
+    _access: RateLimitedProjectAccess,  # Validates access + sets rate-limit identity
 ):
     """Execute a widget spec. Stateless: used by saved widgets and builder previews."""
     try:

--- a/backend/rest/routers/dashboards.py
+++ b/backend/rest/routers/dashboards.py
@@ -1,0 +1,127 @@
+"""Widget query endpoints for project dashboards.
+
+Dashboard/widget CRUD lives in Next.js API routes (Prisma/Postgres, same as
+detectors). This router only executes queries against ClickHouse and exposes
+the field registry that drives the builder UI.
+"""
+
+import logging
+from datetime import datetime
+
+from fastapi import APIRouter, HTTPException, Query, status
+
+from rest.routers.deps import ProjectAccess
+from rest.schemas.dashboards import WidgetQueryRequest, WidgetQueryResponse
+from rest.schemas.traces import FilterValuesResponse
+from rest.services.trace_reader import get_trace_reader_service
+from rest.services.widget_query import WidgetSpecError, run_widget_query
+from rest.services.widget_registry import REGISTRY, registry_schema
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/projects/{project_id}/widgets", tags=["Dashboards"])
+
+
+@router.get("/field-values/{view}/{field}", response_model=FilterValuesResponse)
+async def get_widget_field_values(
+    project_id: str,
+    view: str,
+    field: str,
+    _access: ProjectAccess,
+    start_time: datetime | None = Query(
+        None, description="Only consider rows whose event time is at or after this timestamp"
+    ),
+    end_time: datetime | None = Query(
+        None, description="Only consider rows whose event time is before this timestamp"
+    ),
+):
+    """Distinct stored values for a string field, for the builder's value dropdowns.
+
+    Reuses the trace-filter distinct-values scan (deduped, time-bounded, cached).
+    The view and field resolve through the widget registry before any SQL, so a
+    raw client-supplied column name can never reach a query.
+
+    Args:
+        project_id (str): Project that owns the data; server-bound for isolation.
+        view (str): The widget view (``spans`` or ``traces``) whose table is scanned.
+        field (str): The string dimension to enumerate.
+        _access (ProjectAccess): Validates the caller's access to the project.
+        start_time (datetime | None): Lower bound of the active dashboard window.
+        end_time (datetime | None): Upper bound (exclusive) of the active window.
+
+    Returns:
+        FilterValuesResponse: Distinct values ordered by descending frequency.
+
+    Raises:
+        HTTPException: 404 for an unknown view or field, 400 for a field that is
+            not an enumerable string dimension (numeric measures, ``count``).
+    """
+    view_def = REGISTRY.get(view)
+    if view_def is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown widget view: {view}",
+        )
+    field_def = view_def.fields.get(field)
+    if field_def is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Unknown field '{field}' for view '{view}'",
+        )
+    if field_def.type != "string":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Field '{field}' does not support distinct-value listing",
+        )
+
+    service = get_trace_reader_service()
+    # String dims declare their expr as the bare physical column name on the
+    # view's source table, so it feeds the distinct scan directly.
+    if view == "spans":
+        values = service.get_distinct_span_values(
+            project_id=project_id,
+            column=field_def.expr,
+            start_after=start_time,
+            end_before=end_time,
+        )
+    else:
+        values = service.get_distinct_trace_values(
+            project_id=project_id,
+            column=field_def.expr,
+            start_after=start_time,
+            end_before=end_time,
+        )
+    return {"field": field, "values": values}
+
+
+@router.get("/schema")
+async def get_widget_schema(project_id: str, _access: ProjectAccess) -> dict:
+    """Field registry for the widget builder (views, fields, ops, aggs)."""
+    return registry_schema()
+
+
+@router.post("/query", response_model=WidgetQueryResponse)
+async def query_widget_data(
+    project_id: str,
+    body: WidgetQueryRequest,
+    _access: ProjectAccess,
+):
+    """Execute a widget spec. Stateless: used by saved widgets and builder previews."""
+    try:
+        return run_widget_query(
+            spec=body.spec,
+            project_id=project_id,
+            start_time=body.start_time,
+            end_time=body.end_time,
+        )
+    except WidgetSpecError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail={"step": e.step, "message": e.message},
+        ) from e
+    except Exception as e:
+        logger.exception(f"Widget query failed: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Widget query failed",
+        ) from e

--- a/backend/rest/schemas/dashboards.py
+++ b/backend/rest/schemas/dashboards.py
@@ -1,0 +1,71 @@
+"""Request/response models for the widget query engine.
+
+Validation split: shape and closed enums (DisplayType, AggName, filter op
+Literals) are enforced here by Pydantic. The ``field``, ``measure``, and
+``breakdown`` names are deliberately plain strings — they are validated by
+the SQL compiler against ``rest.services.widget_registry.REGISTRY``, which
+is the single source of truth for which views and fields exist.
+"""
+
+from datetime import datetime
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+DisplayType = Literal["line", "area", "bar", "pie", "number", "table", "histogram"]
+AggName = Literal["count", "sum", "avg", "min", "max", "p50", "p95", "p99"]
+
+
+class _StrictModel(BaseModel):
+    """Base for request-side models: reject unknown fields."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class WidgetFilter(_StrictModel):
+    """A single filter predicate applied to a widget query."""
+
+    field: str
+    op: Literal["=", "!=", "contains", ">", ">=", "<", "<="]
+    # min_length mirrors the frontend schema: an empty value means the filter
+    # was never completed and would silently match only empty-valued rows.
+    value: Annotated[str, StringConstraints(min_length=1)] | float
+
+
+class WidgetMetric(_StrictModel):
+    """The measure and aggregation function that define the widget's y-axis."""
+
+    measure: str
+    agg: AggName
+
+
+class WidgetDisplay(_StrictModel):
+    """Controls how the query result is rendered on the dashboard."""
+
+    type: DisplayType
+
+
+class WidgetSpec(_StrictModel):
+    """Full declarative specification of a single dashboard widget."""
+
+    view: Literal["spans", "traces"]
+    filters: list[WidgetFilter] = Field(default_factory=list)
+    metric: WidgetMetric
+    breakdown: str | None = None
+    display: WidgetDisplay
+
+
+class WidgetQueryRequest(_StrictModel):
+    """Envelope that pairs a WidgetSpec with the dashboard time window."""
+
+    spec: WidgetSpec
+    start_time: datetime
+    end_time: datetime
+
+
+class WidgetQueryResponse(BaseModel):
+    """Query result returned to the frontend; meta carries display hints (e.g. granularity for time-series displays)."""
+
+    columns: list[str]
+    rows: list[list[Any]]
+    meta: dict[str, Any] = Field(default_factory=dict)

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -108,9 +108,9 @@ class TraceReaderService:
     ) -> list[dict]:
         """Distinct values of a span column within the active window, by frequency.
 
-        Powers the filter dropdown's categorical options (model, environment).
-        Time-bounded and briefly cached so repeatedly opening the same filter does
-        not re-scan spans.
+        Powers the filter dropdown's categorical options (model, environment) and
+        the widget builder's spans-view value dropdowns. Time-bounded and briefly
+        cached so repeatedly opening the same filter does not re-scan spans.
 
         Args:
             project_id (str): Project that scopes the span scan (tenant isolation).
@@ -127,9 +127,82 @@ class TraceReaderService:
             list[dict]: ``[{"value": str, "count": int}]`` ordered by descending
             frequency, capped at ``DISTINCT_VALUES_LIMIT``.
         """
+        return self._distinct_values(
+            table="spans",
+            time_column="span_start_time",
+            dedup_keys="project_id, trace_id, span_id",
+            project_id=project_id,
+            column=column,
+            start_after=start_after,
+            end_before=end_before,
+        )
+
+    def get_distinct_trace_values(
+        self,
+        project_id: str,
+        column: str,
+        start_after: datetime | None = None,
+        end_before: datetime | None = None,
+    ) -> list[dict]:
+        """Distinct values of a traces column within the active window, by frequency.
+
+        The traces-table sibling of ``get_distinct_span_values`` — powers the widget
+        builder's traces-view value dropdowns (trace name, user, session, environment).
+
+        Args:
+            project_id (str): Project that scopes the trace scan (tenant isolation).
+            column (str): A traces column name. MUST be a registry-resolved identifier,
+                never raw user input — it is interpolated into the SQL because column
+                names cannot be bound as query parameters.
+            start_after (datetime | None): Lower bound on ``trace_start_time``; prunes
+                monthly partitions. ``None`` defaults a lookback (never all-time).
+            end_before (datetime | None): Upper bound on ``trace_start_time``
+                (exclusive), symmetric with the widget query window.
+
+        Returns:
+            list[dict]: ``[{"value": str, "count": int}]`` ordered by descending
+            frequency, capped at ``DISTINCT_VALUES_LIMIT``.
+        """
+        return self._distinct_values(
+            table="traces",
+            time_column="trace_start_time",
+            dedup_keys="project_id, trace_id",
+            project_id=project_id,
+            column=column,
+            start_after=start_after,
+            end_before=end_before,
+        )
+
+    def _distinct_values(
+        self,
+        table: str,
+        time_column: str,
+        dedup_keys: str,
+        project_id: str,
+        column: str,
+        start_after: datetime | None,
+        end_before: datetime | None,
+    ) -> list[dict]:
+        """Shared distinct-values scan: dedup, group, count, cache.
+
+        Args:
+            table (str): Source table (``spans`` or ``traces``) — a literal chosen by
+                the public wrappers, never user input.
+            time_column (str): The table's partition/time column the window bounds.
+            dedup_keys (str): ``LIMIT 1 BY`` key list that identifies one logical row
+                in the table's ReplacingMergeTree.
+            project_id (str): Project that scopes the scan (tenant isolation).
+            column (str): Registry-resolved column to enumerate (interpolated; column
+                names cannot be bound as query parameters).
+            start_after (datetime | None): Lower window bound on ``time_column``.
+            end_before (datetime | None): Upper window bound on ``time_column``.
+
+        Returns:
+            list[dict]: ``[{"value": str, "count": int}]`` by descending frequency.
+        """
         normalized_start = to_utc_naive(start_after) if start_after is not None else None
         normalized_end = to_utc_naive(end_before) if end_before is not None else None
-        # Never scan spans unbounded (the OOM class the filtered list guards against): if no
+        # Never scan unbounded (the OOM class the filtered list guards against): if no
         # lower bound was given, default one — symmetric with the filtered trace list. The UI
         # always sends a window; this bounds a direct API caller that omits one.
         if normalized_start is None:
@@ -139,6 +212,7 @@ class TraceReaderService:
         # bypass the cache and force a fresh full-project GROUP BY on every open. The
         # 30s TTL already accepts this much staleness in the returned option list.
         cache_key = (
+            table,
             project_id,
             column,
             _floor_minute(normalized_start),
@@ -155,24 +229,25 @@ class TraceReaderService:
             # Exact bound, no lookback back-off: this is a self-contained window scan with
             # no trace-level semi-join, so the boundary-drift false-negative reasoning that
             # SPAN_TIME_BOUND_LOOKBACK_HOURS guards against in the filtered list doesn't apply.
-            inner_conditions.append("span_start_time >= {start_after:DateTime64(3)}")
+            inner_conditions.append(f"{time_column} >= {{start_after:DateTime64(3)}}")
             params["start_after"] = normalized_start
         if normalized_end is not None:
-            inner_conditions.append("span_start_time < {end_before:DateTime64(3)}")
+            inner_conditions.append(f"{time_column} < {{end_before:DateTime64(3)}}")
             params["end_before"] = normalized_end
         inner_where = " AND ".join(inner_conditions)
 
-        # Dedup ReplacingMergeTree spans to the latest version per span BEFORE counting, so
-        # a since-updated span can't inflate a value's count or surface a stale value. The
-        # column non-empty filter runs on the deduped (latest) value in the outer query.
+        # Dedup ReplacingMergeTree rows to the latest version per logical row BEFORE
+        # counting, so a since-updated row can't inflate a value's count or surface a stale
+        # value. The column non-empty filter runs on the deduped (latest) value in the
+        # outer query.
         query = f"""
             SELECT value, count() AS n
             FROM (
                 SELECT {column} AS value
-                FROM spans
+                FROM {table}
                 WHERE {inner_where}
                 ORDER BY ch_update_time DESC
-                LIMIT 1 BY project_id, trace_id, span_id
+                LIMIT 1 BY {dedup_keys}
             )
             WHERE value IS NOT NULL AND value != ''
             GROUP BY value

--- a/backend/rest/services/widget_query.py
+++ b/backend/rest/services/widget_query.py
@@ -1,0 +1,274 @@
+"""Compile validated widget specs into parameterized ClickHouse SQL.
+
+Security model: field names resolve through the static registry to fixed SQL
+expressions; every user value binds as a ClickHouse parameter. User strings
+never appear in SQL text, so injection is structurally impossible.
+"""
+
+import math
+from datetime import datetime, timedelta
+from typing import Any
+
+from db.clickhouse import get_clickhouse_client
+from rest.schemas.dashboards import WidgetSpec
+from rest.services.widget_registry import REGISTRY, FieldDef
+from rest.sql_utils import escape_ilike, to_utc_naive
+
+MAX_GROUPS = 50  # top-N breakdown groups; remainder folds into "other"
+MAX_TABLE_ROWS = 1000
+HISTOGRAM_BINS = 20
+QUERY_TIMEOUT_S = 10
+HOUR_BUCKET_MAX = timedelta(days=2)
+
+_AGG_SQL = {
+    "count": "count({expr})",
+    "sum": "sum({expr})",
+    "avg": "avg({expr})",
+    "min": "min({expr})",
+    "max": "max({expr})",
+    "p50": "quantile(0.5)({expr})",
+    "p95": "quantile(0.95)({expr})",
+    "p99": "quantile(0.99)({expr})",
+}
+
+_OP_SQL = {
+    "=": "{expr} = {{{p}:{t}}}",
+    "!=": "{expr} != {{{p}:{t}}}",
+    ">": "{expr} > {{{p}:{t}}}",
+    ">=": "{expr} >= {{{p}:{t}}}",
+    "<": "{expr} < {{{p}:{t}}}",
+    "<=": "{expr} <= {{{p}:{t}}}",
+    "contains": "{expr} ILIKE {{{p}:String}}",
+}
+
+
+class WidgetSpecError(Exception):
+    """Spec failed registry validation. `step` names the builder step at fault."""
+
+    def __init__(self, step: str, message: str):
+        self.step = step
+        self.message = message
+        super().__init__(f"{step}: {message}")
+
+
+def _resolve_field(view_fields: dict[str, FieldDef], name: str, step: str) -> FieldDef:
+    f = view_fields.get(name)
+    if f is None:
+        raise WidgetSpecError(step, f"Unknown field '{name}'. Allowed: {sorted(view_fields)}")
+    return f
+
+
+def _pick_granularity(start_time: datetime, end_time: datetime) -> str:
+    return "hour" if end_time - start_time <= HOUR_BUCKET_MAX else "day"
+
+
+def compile_widget_query(
+    spec: WidgetSpec,
+    project_id: str,
+    start_time: datetime,
+    end_time: datetime,
+) -> tuple[str, dict[str, Any]]:
+    """Return (sql, params) for the spec. Raises WidgetSpecError on bad specs."""
+    # Normalize like every other ClickHouse endpoint: mixed tz-aware/naive
+    # datetimes (both accepted by the request schema) crash subtraction in
+    # granularity picking, and a reversed window compiles a negative LIMIT
+    # that ClickHouse rejects — both surfaced as opaque 500s.
+    start_time = to_utc_naive(start_time)
+    end_time = to_utc_naive(end_time)
+    if end_time <= start_time:
+        raise WidgetSpecError("time_range", "end_time must be after start_time")
+
+    view = REGISTRY[spec.view]
+    params: dict[str, Any] = {
+        "project_id": project_id,
+        "start_time": start_time,
+        "end_time": end_time,
+    }
+
+    # --- filters ---
+    conditions: list[str] = []
+    for i, flt in enumerate(spec.filters):
+        f = _resolve_field(view.fields, flt.field, "filters")
+        if flt.op not in f.filter_ops:
+            raise WidgetSpecError(
+                "filters",
+                f"Op '{flt.op}' not allowed for '{flt.field}'. Allowed: {list(f.filter_ops)}",
+            )
+        pname = f"f{i}"
+        if f.type == "string":
+            ch_type = "String"
+            if flt.op == "contains":
+                # Escape %, _, and \ so they match literally rather than acting
+                # as ILIKE wildcards or escape characters in the user's value.
+                param_value = f"%{escape_ilike(str(flt.value))}%"
+            else:
+                param_value = flt.value
+        else:
+            ch_type = "Float64"
+            try:
+                param_value = float(flt.value)
+            except (ValueError, TypeError):
+                raise WidgetSpecError(
+                    "filters", f"Value for '{flt.field}' must be numeric"
+                ) from None
+        conditions.append(_OP_SQL[flt.op].format(expr=f.expr, p=pname, t=ch_type))
+        params[pname] = param_value
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+
+    base = f"({view.base_sql})"
+
+    # A number tile renders exactly one value, so a breakdown would silently
+    # drop every group but the first — reject it like histogram does.
+    if spec.display.type == "number" and spec.breakdown is not None:
+        raise WidgetSpecError("breakdown", "Number display does not support a breakdown dimension")
+
+    # Pie and bar plot one mark per category; without a breakdown the query
+    # collapses to a single unlabeled datum with nothing to chart.
+    if spec.display.type in ("pie", "bar") and spec.breakdown is None:
+        raise WidgetSpecError(
+            "breakdown", f"{spec.display.type} display requires a breakdown dimension"
+        )
+
+    # --- histogram compiles to its own shape ---
+    if spec.display.type == "histogram":
+        if spec.breakdown is not None:
+            raise WidgetSpecError("breakdown", "Histogram does not support a breakdown dimension")
+        measure = _resolve_field(view.fields, spec.metric.measure, "metric")
+        if measure.type != "number" or measure.expr == "*":
+            raise WidgetSpecError("metric", f"'{spec.metric.measure}' cannot be histogrammed")
+        # toFloat64 is required because histogram() rejects Decimal types (e.g. cost is Decimal64).
+        # It is a no-op for Int64/Float64/Nullable measures.
+        sql = (
+            f"SELECT tupleElement(b, 1) AS lo, tupleElement(b, 2) AS hi, tupleElement(b, 3) AS height "
+            f"FROM (SELECT arrayJoin(histogram({HISTOGRAM_BINS})(toFloat64({measure.expr}))) AS b "
+            f"FROM {base} {where})"
+        )
+        return sql, params
+
+    # --- metric ---
+    measure = _resolve_field(view.fields, spec.metric.measure, "metric")
+    if spec.metric.agg not in measure.aggs:
+        raise WidgetSpecError(
+            "metric",
+            f"Agg '{spec.metric.agg}' not allowed for '{spec.metric.measure}'."
+            f" Allowed: {list(measure.aggs)}",
+        )
+    metric_sql = _AGG_SQL[spec.metric.agg].format(expr=measure.expr)
+
+    # --- dimensions: optional time bucket + optional breakdown ---
+    select_cols: list[str] = []
+    group_cols: list[str] = []
+    order_by = ""
+
+    is_timeseries = spec.display.type in ("line", "area")
+    # Bound unconditionally: both the bucketing branch and the row-cap branch
+    # below key off is_timeseries, and an implicit binding would let them drift.
+    gran = _pick_granularity(start_time, end_time)
+    # Fill empty buckets across the whole window so the x-axis spans the
+    # selected range even when stored data starts later: missing buckets come
+    # back as zero rows instead of the chart starting at first data. WITH FILL
+    # TO is exclusive, so the bound is one step past the bucket of the last
+    # in-window instant (end_time - 1ms) — that covers the trailing straddle
+    # bucket of a misaligned window and stays exact for aligned ones.
+    # Bound unconditionally, like gran, so the two is_timeseries branches
+    # below can't drift apart.
+    bucket_fn = "toStartOfHour" if gran == "hour" else "toStartOfDay"
+    step = "INTERVAL 1 HOUR" if gran == "hour" else "INTERVAL 1 DAY"
+    fill = (
+        f" WITH FILL FROM {bucket_fn}({{start_time:DateTime64(3)}}, 'UTC')"
+        f" TO {bucket_fn}({{end_time:DateTime64(3)}} - INTERVAL 1 MILLISECOND, 'UTC')"
+        f" + {step} STEP {step}"
+    )
+    if is_timeseries:
+        # 'UTC' aligns day/hour boundaries with the UTC time-range params,
+        # regardless of the ClickHouse server's local timezone.
+        select_cols.append(f"{bucket_fn}(event_time, 'UTC') AS bucket")
+        group_cols.append("bucket")
+        order_by = f"ORDER BY bucket{fill}"
+
+    if spec.breakdown is not None:
+        bd = _resolve_field(view.fields, spec.breakdown, "breakdown")
+        if not bd.groupable:
+            raise WidgetSpecError("breakdown", f"'{spec.breakdown}' is not groupable")
+        # Top-N guard: keep the MAX_GROUPS largest groups, fold the rest into
+        # 'other' so a high-cardinality breakdown can't return unbounded rows.
+        # Note: a genuine breakdown value named "other" will merge with this fold
+        # bucket — accepted tradeoff for simplicity.
+        # NULL breakdown values also fold into 'other': NULL fails the IN
+        # membership test so the outer if() takes the else branch. Intentional —
+        # surfacing a separate NULL bucket would require extra special-casing for
+        # little benefit on the dashboard.
+        # ifNull pins the column type to plain String: for a Nullable
+        # breakdown expr the if() supertype would be Nullable(String), making
+        # WITH FILL's synthesized rows carry NULL instead of the '' the
+        # frontend pivot recognizes as a gap row. Runtime values are never
+        # NULL — NULLs fail the IN test and fold into 'other'.
+        select_cols.append(
+            f"ifNull(if({bd.expr} IN (SELECT {bd.expr} FROM {base} {where} "
+            f"GROUP BY {bd.expr} ORDER BY {metric_sql} DESC LIMIT {MAX_GROUPS}), "
+            f"toString({bd.expr}), 'other'), '') AS {spec.breakdown}"
+        )
+        group_cols.append(spec.breakdown)
+        if is_timeseries:
+            # Include breakdown in ORDER BY for deterministic ordering when
+            # multiple breakdown values share the same bucket. WITH FILL stays
+            # on the bucket sort key; filled rows carry the breakdown column's
+            # String default ('') and a zero value, which the frontend pivot
+            # treats as domain-only rows.
+            order_by = f"ORDER BY bucket{fill}, {spec.breakdown}"
+        else:
+            order_by = "ORDER BY value DESC"
+
+    select_cols.append(f"{metric_sql} AS value")
+    group_by = f"GROUP BY {', '.join(group_cols)}" if group_cols else ""
+
+    # Row cap: for table display use a fixed row limit.
+    # For timeseries or breakdown displays, derive the cap from the actual
+    # query window so that long ranges aren't silently truncated.
+    if spec.display.type == "table":
+        row_limit = MAX_TABLE_ROWS
+    elif is_timeseries:
+        # Each time bucket can have up to (MAX_GROUPS + 1) rows: one per
+        # breakdown group plus the 'other' fold bucket. Compute the number of
+        # expected buckets from the window size so every bucket is included.
+        granule_seconds = 3600 if gran == "hour" else 86400
+        window_seconds = (end_time - start_time).total_seconds()
+        # +1: misaligned windows straddle one extra bucket (half-open [start, end) over toStartOfX boundaries).
+        n_buckets = math.ceil(window_seconds / granule_seconds) + 1
+        row_limit = n_buckets * (MAX_GROUPS + 1)
+    elif spec.breakdown is not None:
+        # Pure breakdown (no time axis): one row per group + 'other'.
+        row_limit = MAX_GROUPS + 1
+    else:
+        # No dimensions: single aggregate row.
+        row_limit = 1
+
+    limit = f"LIMIT {row_limit}"
+
+    sql = f"SELECT {', '.join(select_cols)} FROM {base} {where} {group_by} {order_by} {limit}"
+    return sql, params
+
+
+def run_widget_query(
+    spec: WidgetSpec, project_id: str, start_time: datetime, end_time: datetime
+) -> dict[str, Any]:
+    """Compile and execute, returning the response contract dict."""
+    # Normalized once here; compile_widget_query re-normalizing is idempotent
+    # and keeps it safe for direct callers.
+    start_time = to_utc_naive(start_time)
+    end_time = to_utc_naive(end_time)
+    sql, params = compile_widget_query(spec, project_id, start_time, end_time)
+    client = get_clickhouse_client()
+    result = client.query(
+        sql,
+        parameters=params,
+        settings={"readonly": 1, "max_execution_time": QUERY_TIMEOUT_S},
+    )
+    meta: dict[str, Any] = {}
+    if spec.display.type in ("line", "area"):
+        meta["granularity"] = _pick_granularity(start_time, end_time)
+    return {
+        "columns": list(result.column_names),
+        "rows": [list(r) for r in result.result_rows],
+        "meta": meta,
+    }

--- a/tests/rest/test_dashboards_router.py
+++ b/tests/rest/test_dashboards_router.py
@@ -12,8 +12,15 @@ from rest.routers.deps import ProjectAccessInfo, get_project_access
 
 @pytest.fixture()
 def client():
+    # Mirror the validate-project-access contract (workspaceId + billingPlan)
+    # so get_rate_limited_project_access stamps a real workspace for the
+    # per-workspace rate limiter.
     app.dependency_overrides[get_project_access] = lambda: ProjectAccessInfo(
-        project_id="proj-1", user_id="user-1", role="admin"
+        project_id="proj-1",
+        user_id="user-1",
+        role="admin",
+        workspace_id="ws-test",
+        billing_plan="free",
     )
     yield TestClient(app)
 

--- a/tests/rest/test_dashboards_router.py
+++ b/tests/rest/test_dashboards_router.py
@@ -1,0 +1,150 @@
+"""Endpoint tests for the widget query router."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from rest.routers.deps import ProjectAccessInfo, get_project_access
+
+
+@pytest.fixture()
+def client():
+    app.dependency_overrides[get_project_access] = lambda: ProjectAccessInfo(
+        project_id="proj-1", user_id="user-1", role="admin"
+    )
+    yield TestClient(app)
+
+
+VALID_BODY = {
+    "spec": {
+        "view": "spans",
+        "filters": [],
+        "metric": {"measure": "cost", "agg": "sum"},
+        "breakdown": "model_name",
+        "display": {"type": "bar"},
+    },
+    "start_time": "2026-06-01T00:00:00Z",
+    "end_time": "2026-06-08T00:00:00Z",
+}
+
+
+def test_schema_endpoint(client):
+    resp = client.get("/api/v1/projects/proj-1/widgets/schema")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "spans" in body and "traces" in body
+    assert body["spans"]["fields"]["cost"]["aggs"]
+
+
+def test_query_endpoint_executes(client):
+    fake = {"columns": ["model_name", "value"], "rows": [["gpt-4o", 1.5]], "meta": {}}
+    with patch("rest.routers.dashboards.run_widget_query", return_value=fake) as mock_run:
+        resp = client.post("/api/v1/projects/proj-1/widgets/query", json=VALID_BODY)
+    assert resp.status_code == 200
+    assert resp.json() == fake
+    # project scoping comes from the path, never the body
+    assert mock_run.call_args.kwargs["project_id"] == "proj-1"
+
+
+def test_query_endpoint_spec_error_is_422_with_step(client):
+    bad = {**VALID_BODY, "spec": {**VALID_BODY["spec"], "breakdown": "cost"}}
+    resp = client.post("/api/v1/projects/proj-1/widgets/query", json=bad)
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["step"] == "breakdown"
+
+
+def test_query_endpoint_pydantic_error_is_422(client):
+    bad = {**VALID_BODY, "spec": {**VALID_BODY["spec"], "display": {"type": "gauge"}}}
+    resp = client.post("/api/v1/projects/proj-1/widgets/query", json=bad)
+    assert resp.status_code == 422
+
+
+def test_query_endpoint_no_auth_is_not_200():
+    """Without the dependency override, auth is enforced — must not return 200."""
+    # Don't override get_project_access — let it run for real.
+    # The real auth dep makes an httpx call that fails fast in tests.
+    test_client = TestClient(app, raise_server_exceptions=False)
+    resp = test_client.post("/api/v1/projects/proj-1/widgets/query", json=VALID_BODY)
+    assert resp.status_code in (401, 503)
+
+
+# ── field values (builder value dropdowns) ────────────────────────────────────
+
+
+@pytest.fixture()
+def mock_trace_reader():
+    reader = MagicMock()
+    with patch("rest.routers.dashboards.get_trace_reader_service", return_value=reader):
+        yield reader
+
+
+class TestWidgetFieldValues:
+    def test_spans_view_uses_the_span_distinct_query(self, client, mock_trace_reader):
+        mock_trace_reader.get_distinct_span_values.return_value = [
+            {"value": "gpt-4o", "count": 12},
+            {"value": "claude-opus-4-8", "count": 7},
+        ]
+        resp = client.get("/api/v1/projects/proj-1/widgets/field-values/spans/model_name")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["field"] == "model_name"
+        assert body["values"][0] == {"value": "gpt-4o", "count": 12}
+        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        # project scoping comes from the path; the column is registry-resolved
+        assert kw["project_id"] == "proj-1"
+        assert kw["column"] == "model_name"
+        mock_trace_reader.get_distinct_trace_values.assert_not_called()
+
+    def test_traces_view_uses_the_trace_distinct_query(self, client, mock_trace_reader):
+        mock_trace_reader.get_distinct_trace_values.return_value = [{"value": "u-1", "count": 3}]
+        resp = client.get("/api/v1/projects/proj-1/widgets/field-values/traces/user_id")
+        assert resp.status_code == 200
+        assert resp.json()["values"] == [{"value": "u-1", "count": 3}]
+        kw = mock_trace_reader.get_distinct_trace_values.call_args.kwargs
+        assert kw["project_id"] == "proj-1"
+        assert kw["column"] == "user_id"
+        mock_trace_reader.get_distinct_span_values.assert_not_called()
+
+    def test_time_window_threads_to_the_service(self, client, mock_trace_reader):
+        mock_trace_reader.get_distinct_span_values.return_value = []
+        resp = client.get(
+            "/api/v1/projects/proj-1/widgets/field-values/spans/environment"
+            "?start_time=2026-06-01T00:00:00&end_time=2026-06-02T00:00:00"
+        )
+        assert resp.status_code == 200
+        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        assert kw["start_after"] == datetime(2026, 6, 1, 0, 0, 0)
+        assert kw["end_before"] == datetime(2026, 6, 2, 0, 0, 0)
+
+    def test_no_window_passes_none_bounds(self, client, mock_trace_reader):
+        """The service itself defaults a lookback; the endpoint passes what it got."""
+        mock_trace_reader.get_distinct_span_values.return_value = []
+        resp = client.get("/api/v1/projects/proj-1/widgets/field-values/spans/status")
+        assert resp.status_code == 200
+        kw = mock_trace_reader.get_distinct_span_values.call_args.kwargs
+        assert kw["start_after"] is None
+        assert kw["end_before"] is None
+
+    def test_unknown_view_is_404(self, client, mock_trace_reader):
+        resp = client.get("/api/v1/projects/proj-1/widgets/field-values/sessions/name")
+        assert resp.status_code == 404
+        mock_trace_reader.get_distinct_span_values.assert_not_called()
+
+    def test_unknown_field_is_404(self, client, mock_trace_reader):
+        resp = client.get("/api/v1/projects/proj-1/widgets/field-values/spans/not_a_field")
+        assert resp.status_code == 404
+        mock_trace_reader.get_distinct_span_values.assert_not_called()
+
+    def test_numeric_field_is_400(self, client, mock_trace_reader):
+        resp = client.get("/api/v1/projects/proj-1/widgets/field-values/spans/cost")
+        assert resp.status_code == 400
+        mock_trace_reader.get_distinct_span_values.assert_not_called()
+
+    def test_count_field_is_400(self, client, mock_trace_reader):
+        resp = client.get("/api/v1/projects/proj-1/widgets/field-values/spans/count")
+        assert resp.status_code == 400
+        mock_trace_reader.get_distinct_span_values.assert_not_called()

--- a/tests/rest/test_trace_filter_meta.py
+++ b/tests/rest/test_trace_filter_meta.py
@@ -266,3 +266,92 @@ class TestGetDistinctSpanValues:
         for i in range(DISTINCT_VALUES_CACHE_MAX + 50):
             svc.get_distinct_span_values(project_id=f"p{i}", column="model_name")
         assert len(svc._distinct_cache) <= DISTINCT_VALUES_CACHE_MAX
+
+
+class TestGetDistinctTraceValues:
+    """The traces-table variant that powers the widget builder's traces-view dropdowns."""
+
+    def _service(self, monkeypatch, mock_client):
+        import rest.services.trace_reader as tr_mod
+
+        monkeypatch.setattr(tr_mod, "get_clickhouse_client", lambda: mock_client)
+        return tr_mod.TraceReaderService()
+
+    def test_builds_grouped_project_scoped_traces_query(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("u-1", 8), ("u-2", 3)]
+        svc = self._service(monkeypatch, mock_client)
+
+        out = svc.get_distinct_trace_values(project_id="p1", column="user_id")
+
+        assert out == [
+            {"value": "u-1", "count": 8},
+            {"value": "u-2", "count": 3},
+        ]
+        sql, kwargs = mock_client.query.call_args
+        query_text = sql[0]
+        assert "FROM traces" in query_text
+        assert "GROUP BY" in query_text
+        assert "user_id AS value" in query_text
+        assert "project_id = {project_id:String}" in query_text
+        # Deduped to the latest ReplacingMergeTree version per trace before counting.
+        assert "LIMIT 1 BY project_id, trace_id" in query_text
+        assert kwargs["parameters"]["project_id"] == "p1"
+
+    def test_no_window_defaults_a_lookback_bound_never_unbounded(self, monkeypatch):
+        """Same never-scan-all-time rule as the span variant, on trace_start_time."""
+        from datetime import UTC, timedelta
+
+        from rest.services.trace_reader import DEFAULT_SPAN_SCAN_LOOKBACK_HOURS
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        before = datetime.now(UTC).replace(tzinfo=None)
+        svc.get_distinct_trace_values(project_id="p1", column="user_id")
+        after = datetime.now(UTC).replace(tzinfo=None)
+
+        sql, kwargs = mock_client.query.call_args
+        assert "trace_start_time >= {start_after:DateTime64(3)}" in sql[0]
+        lo, hi = (
+            before - timedelta(hours=DEFAULT_SPAN_SCAN_LOOKBACK_HOURS),
+            after - timedelta(hours=DEFAULT_SPAN_SCAN_LOOKBACK_HOURS),
+        )
+        assert lo <= kwargs["parameters"]["start_after"] <= hi
+
+    def test_window_bounds_are_applied(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_trace_values(
+            project_id="p1",
+            column="environment",
+            start_after=datetime(2026, 6, 1),
+            end_before=datetime(2026, 6, 2),
+        )
+        sql, kwargs = mock_client.query.call_args
+        assert "trace_start_time >= {start_after:DateTime64(3)}" in sql[0]
+        assert "trace_start_time < {end_before:DateTime64(3)}" in sql[0]
+        assert kwargs["parameters"]["end_before"] == datetime(2026, 6, 2)
+
+    def test_span_and_trace_caches_do_not_collide(self, monkeypatch):
+        """Same column name on both tables must be two cache entries, not one."""
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("prod", 5)]
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_span_values(project_id="p1", column="environment")
+        svc.get_distinct_trace_values(project_id="p1", column="environment")
+        assert mock_client.query.call_count == 2  # one real query per table
+
+    def test_results_are_cached(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = [("prod", 5)]
+        svc = self._service(monkeypatch, mock_client)
+
+        first = svc.get_distinct_trace_values(project_id="p1", column="environment")
+        second = svc.get_distinct_trace_values(project_id="p1", column="environment")
+        assert first == second
+        mock_client.query.assert_called_once()

--- a/tests/rest/test_widget_query.py
+++ b/tests/rest/test_widget_query.py
@@ -1,0 +1,396 @@
+"""Tests for the widget spec models and the spec-to-SQL compiler."""
+
+from datetime import UTC, datetime
+from typing import get_args
+
+import pytest
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
+
+from rest.schemas.dashboards import (
+    AggName,
+    WidgetFilter,
+    WidgetQueryRequest,
+    WidgetQueryResponse,
+    WidgetSpec,
+)
+from rest.services.widget_query import WidgetSpecError, compile_widget_query
+from rest.services.widget_registry import (
+    AGGS_NUMBER,
+    FILTER_OPS_NUMBER,
+    FILTER_OPS_STRING,
+    REGISTRY,
+)
+
+
+def make_spec(**overrides) -> dict:
+    spec = {
+        "view": "spans",
+        "filters": [{"field": "span_kind", "op": "=", "value": "LLM"}],
+        "metric": {"measure": "cost", "agg": "sum"},
+        "breakdown": "model_name",
+        "display": {"type": "line"},
+    }
+    spec.update(overrides)
+    return spec
+
+
+def test_valid_spec_parses():
+    spec = WidgetSpec.model_validate(make_spec())
+    assert spec.view == "spans"
+    assert spec.metric.agg == "sum"
+
+
+def test_unknown_view_rejected():
+    with pytest.raises(ValidationError):
+        WidgetSpec.model_validate(make_spec(view="secrets"))
+
+
+def test_unknown_display_rejected():
+    with pytest.raises(ValidationError):
+        WidgetSpec.model_validate(make_spec(display={"type": "gauge"}))
+
+
+def test_request_requires_start_and_end_time():
+    with pytest.raises(ValidationError):
+        WidgetQueryRequest.model_validate({"spec": make_spec()})
+
+
+# --- Drift-guard tests ---
+
+
+def test_agg_name_matches_registry():
+    """AggName Literal must stay in sync with AGGS_NUMBER plus 'count'."""
+    assert set(get_args(AggName)) == set(AGGS_NUMBER) | {"count"}
+
+
+def test_view_literal_matches_registry():
+    """WidgetSpec.view Literal must list exactly the views in REGISTRY."""
+    view_annotation = WidgetSpec.model_fields["view"].annotation
+    assert set(get_args(view_annotation)) == set(REGISTRY)
+
+
+def test_filter_op_matches_registry():
+    """WidgetFilter.op Literal must cover all string and number filter ops."""
+    op_annotation = WidgetFilter.model_fields["op"].annotation
+    assert set(get_args(op_annotation)) == set(FILTER_OPS_STRING) | set(FILTER_OPS_NUMBER)
+
+
+# --- extra="forbid" tests ---
+
+
+def test_unknown_key_in_spec_rejected():
+    """A payload with 'filter' (singular, misspelled) must raise ValidationError."""
+    bad_payload = make_spec()
+    bad_payload["filter"] = bad_payload.pop("filters")  # misspell the key
+    with pytest.raises(ValidationError):
+        WidgetSpec.model_validate(bad_payload)
+
+
+# --- SQL compiler tests ---
+
+START = datetime(2026, 6, 1)
+END = datetime(2026, 6, 8)
+
+
+def compile_(spec_dict):
+    spec = WidgetSpec.model_validate(spec_dict)
+    return compile_widget_query(spec, project_id="proj-1", start_time=START, end_time=END)
+
+
+def test_compile_breakdown_bar():
+    sql, params = compile_(make_spec(display={"type": "bar"}))
+    assert "GROUP BY model_name" in sql
+    assert "sum(cost)" in sql
+    assert "span_kind = {f0:String}" in sql
+    assert params["f0"] == "LLM"
+    assert params["project_id"] == "proj-1"
+    # top-N cap with remainder folded into "other"
+    assert "LIMIT 50" in sql
+
+
+def test_compile_timeseries_adds_bucket():
+    sql, params = compile_(make_spec(display={"type": "line"}))
+    # 7-day range → day buckets in UTC
+    assert "toStartOfDay(event_time, 'UTC')" in sql
+    assert params["start_time"] == START
+
+
+def test_compile_hour_bucket_for_short_range():
+    spec = WidgetSpec.model_validate(make_spec(display={"type": "line"}))
+    sql, _ = compile_widget_query(
+        spec, project_id="p", start_time=datetime(2026, 6, 1), end_time=datetime(2026, 6, 2)
+    )
+    assert "toStartOfHour(event_time, 'UTC')" in sql
+
+
+def test_compile_number_no_groupby():
+    sql, _ = compile_(make_spec(display={"type": "number"}, breakdown=None))
+    assert "GROUP BY" not in sql
+
+
+def test_compile_histogram():
+    spec = make_spec(display={"type": "histogram"}, breakdown=None)
+    spec["metric"] = {"measure": "duration_ms", "agg": "avg"}  # agg ignored for histogram
+    sql, _ = compile_(spec)
+    assert "histogram(20)(toFloat64(duration_ms))" in sql
+
+
+def test_compile_traces_view_uses_span_agg():
+    spec = make_spec(view="traces", filters=[], breakdown="user_id")
+    spec["metric"] = {"measure": "error_count", "agg": "sum"}
+    spec["display"] = {"type": "bar"}
+    sql, _ = compile_(spec)
+    assert "countIf(status = 'ERROR')" in sql  # from the traces base relation
+    assert "GROUP BY user_id" in sql
+
+
+def test_unknown_field_raises_with_step():
+    with pytest.raises(WidgetSpecError) as e:
+        compile_(make_spec(filters=[{"field": "password", "op": "=", "value": "x"}]))
+    assert e.value.step == "filters"
+
+
+def test_disallowed_agg_raises():
+    spec = make_spec()
+    spec["metric"] = {"measure": "model_name", "agg": "sum"}  # string field
+    with pytest.raises(WidgetSpecError) as e:
+        compile_(spec)
+    assert e.value.step == "metric"
+
+
+def test_non_groupable_breakdown_raises():
+    with pytest.raises(WidgetSpecError) as e:
+        compile_(make_spec(breakdown="cost"))
+    assert e.value.step == "breakdown"
+
+
+def test_disallowed_op_for_type_raises():
+    with pytest.raises(WidgetSpecError) as e:
+        compile_(make_spec(filters=[{"field": "name", "op": ">", "value": "x"}]))
+    assert e.value.step == "filters"
+
+
+# --- histogram shape and value-coercion edge cases ---
+
+
+def test_histogram_cost_contains_tofloat64():
+    """cost is Decimal in ClickHouse; histogram() must receive toFloat64(cost)."""
+    spec = make_spec(display={"type": "histogram"}, breakdown=None)
+    spec["metric"] = {"measure": "cost", "agg": "sum"}
+    sql, _ = compile_(spec)
+    assert "toFloat64" in sql
+    assert "toFloat64(cost)" in sql
+
+
+def test_histogram_with_breakdown_raises():
+    """Histogram does not support a breakdown dimension."""
+    spec = make_spec(display={"type": "histogram"}, breakdown="model_name")
+    spec["metric"] = {"measure": "cost", "agg": "sum"}
+    with pytest.raises(WidgetSpecError) as e:
+        compile_(spec)
+    assert e.value.step == "breakdown"
+
+
+def test_non_numeric_filter_value_raises():
+    """A string value on a number-typed filter field must raise step='filters'."""
+    filters = [{"field": "cost", "op": ">", "value": "not-a-number"}]
+    with pytest.raises(WidgetSpecError) as e:
+        compile_(make_spec(filters=filters, breakdown=None))
+    assert e.value.step == "filters"
+
+
+def test_long_range_row_cap():
+    """A misaligned 365-day window (noon-to-noon) touches 366 day buckets; LIMIT must cover all of them."""
+    spec = WidgetSpec.model_validate(make_spec(display={"type": "line"}))
+    start = datetime(2026, 1, 1, 12, 0)
+    end = datetime(2027, 1, 1, 12, 0)  # 365 days, noon-anchored — straddles 366 day buckets
+    sql, _ = compile_widget_query(spec, project_id="p", start_time=start, end_time=end)
+    # Extract the final LIMIT clause (the outermost row cap, not LIMIT 1 BY inside base SQL)
+    import re
+
+    matches = re.findall(r"LIMIT (\d+)(?! BY)", sql)
+    assert matches, "No outermost LIMIT found in SQL"
+    assert int(matches[-1]) >= 366 * 51
+
+
+def test_breakdown_timeseries_order_by():
+    """When breakdown and timeseries are both present, ORDER BY must include both bucket and breakdown."""
+    sql, _ = compile_(make_spec(display={"type": "line"}))
+    assert "GROUP BY bucket, model_name" in sql
+    # WITH FILL sits on the bucket sort key; the breakdown sort key follows it.
+    assert "ORDER BY bucket WITH FILL" in sql
+    assert "STEP INTERVAL 1 DAY, model_name" in sql
+
+
+def test_timeseries_fills_empty_buckets_across_window():
+    """A timeseries orders by bucket WITH FILL over the full window at the picked step.
+
+    Empty buckets come back as zero rows so the chart's x-axis spans the
+    selected range even when stored data starts later.
+    """
+    sql, _ = compile_(make_spec(display={"type": "line"}, breakdown=None))
+    assert (
+        "ORDER BY bucket WITH FILL FROM toStartOfDay({start_time:DateTime64(3)}, 'UTC')"
+        " TO toStartOfDay({end_time:DateTime64(3)} - INTERVAL 1 MILLISECOND, 'UTC')"
+        " + INTERVAL 1 DAY STEP INTERVAL 1 DAY" in sql
+    )
+
+    hour_spec = WidgetSpec.model_validate(make_spec(display={"type": "line"}, breakdown=None))
+    hour_sql, _ = compile_widget_query(
+        hour_spec,
+        project_id="proj-1",
+        start_time=datetime(2026, 6, 1),
+        end_time=datetime(2026, 6, 2),
+    )
+    assert "WITH FILL FROM toStartOfHour({start_time:DateTime64(3)}, 'UTC')" in hour_sql
+    assert "STEP INTERVAL 1 HOUR" in hour_sql
+
+
+def test_breakdown_column_type_is_pinned_non_nullable():
+    """The breakdown select wraps in ifNull so WITH FILL rows default to ''.
+
+    Without the pin, a Nullable breakdown expr (e.g. model_name) would make the
+    if() supertype Nullable(String) and fill rows would carry NULL instead of
+    the '' the frontend pivot recognizes as a gap row.
+    """
+    sql, _ = compile_(make_spec(display={"type": "line"}))
+    assert "ifNull(if(model_name IN" in sql
+    assert "'other'), '') AS model_name" in sql
+
+
+def test_empty_filter_value_rejected_by_schema():
+    """A filter with value '' means the builder row was never completed."""
+    with pytest.raises(ValidationError):
+        WidgetSpec.model_validate(
+            make_spec(filters=[{"field": "model_name", "op": "=", "value": ""}])
+        )
+
+
+def test_reversed_window_rejected():
+    """start >= end would otherwise compile a negative LIMIT that CH rejects."""
+    spec = WidgetSpec.model_validate(make_spec(display={"type": "line"}))
+    with pytest.raises(WidgetSpecError):
+        compile_widget_query(spec, project_id="proj-1", start_time=END, end_time=START)
+    with pytest.raises(WidgetSpecError):
+        compile_widget_query(spec, project_id="proj-1", start_time=START, end_time=START)
+
+
+def test_mixed_timezone_awareness_normalized():
+    """Aware + naive bounds crash datetime subtraction without normalization."""
+    spec = WidgetSpec.model_validate(make_spec(display={"type": "line"}))
+    sql, params = compile_widget_query(
+        spec,
+        project_id="proj-1",
+        start_time=datetime(2026, 6, 1, tzinfo=UTC),
+        end_time=datetime(2026, 6, 8),
+    )
+    assert "WITH FILL" in sql
+    # Params are handed to ClickHouse tz-naive, matching every other endpoint.
+    assert params["start_time"].tzinfo is None
+    assert params["end_time"].tzinfo is None
+
+
+def test_pie_and_bar_require_breakdown():
+    """Pie/bar collapse to a single unlabeled datum without a breakdown."""
+    for display in ("pie", "bar"):
+        with pytest.raises(WidgetSpecError):
+            compile_(make_spec(display={"type": display}, breakdown=None))
+
+
+def test_non_timeseries_has_no_fill():
+    """Bar/table/number shapes have no time bucket, so no WITH FILL clause."""
+    for display in ({"type": "bar"}, {"type": "table"}):
+        sql, _ = compile_(make_spec(display=display))
+        assert "WITH FILL" not in sql
+
+
+def test_other_fold_shape():
+    """The 'other' fold uses a subquery with LIMIT 50 (MAX_GROUPS)."""
+    sql, _ = compile_(make_spec(display={"type": "bar"}))
+    assert "'other'" in sql
+    assert "IN (SELECT" in sql
+    assert "LIMIT 50" in sql
+
+
+def test_count_measure_with_breakdown():
+    """count measure (expr='*') must compile with count(*) and a breakdown."""
+    spec = make_spec(display={"type": "bar"})
+    spec["metric"] = {"measure": "count", "agg": "count"}
+    sql, _ = compile_(spec)
+    assert "count(*)" in sql
+    assert "GROUP BY model_name" in sql
+
+
+# --- filter escaping and serialization guards ---
+
+
+def test_contains_filter_escapes_percent():
+    """A contains filter with '%' in the value must bind an escaped ILIKE pattern.
+
+    Without escaping, '50%' would act as a wildcard matching '50' followed by
+    anything. The escaped pattern '%50\\%%' makes the '%' match literally.
+    """
+    filters = [{"field": "name", "op": "contains", "value": "50%"}]
+    _, params = compile_(make_spec(filters=filters, breakdown=None))
+    assert params["f0"] == "%50\\%%"
+
+
+def test_bucket_timestamp_serializes_as_iso8601():
+    """WidgetQueryResponse rows with datetime values must serialize to ISO-8601.
+
+    The frontend keys on the exact string 'YYYY-MM-DDTHH:MM:SS' (no timezone
+    suffix) to identify time-bucket columns. jsonable_encoder (used by FastAPI's
+    response pipeline) must produce that format.
+    """
+    response = WidgetQueryResponse(
+        columns=["bucket", "value"],
+        rows=[[datetime(2026, 6, 1), 1.0]],
+    )
+    encoded = jsonable_encoder(response)
+    assert encoded["rows"][0][0] == "2026-06-01T00:00:00"
+
+
+def test_empty_rows_validates_and_serializes():
+    """WidgetQueryResponse with no rows is valid and encodes to rows: []."""
+    response = WidgetQueryResponse(columns=["value"], rows=[])
+    encoded = jsonable_encoder(response)
+    assert encoded["rows"] == []
+
+
+def test_traces_view_null_guards_measures():
+    """The traces base relation must NULL-guard measures for span-less traces.
+
+    Rows from the LEFT JOIN where no matching spans exist have sa.trace_id = ''
+    (ClickHouse fills String join-key columns with empty string on no match).
+    The if(sa.trace_id = '', NULL, ...) pattern converts those to NULL so
+    aggregations ignore span-less traces rather than treating the default value
+    as real data.
+    """
+    spec = make_spec(view="traces", filters=[], breakdown=None)
+    spec["metric"] = {"measure": "duration_ms", "agg": "avg"}
+    spec["display"] = {"type": "number"}
+    sql, _ = compile_(spec)
+    assert "if(sa.trace_id = ''" in sql
+
+
+def test_traces_p95_compiles_to_quantile():
+    """p95 on traces must compile to quantile(0.95)(...) — pins the agg mapping."""
+    spec = make_spec(view="traces", filters=[], breakdown=None)
+    spec["metric"] = {"measure": "duration_ms", "agg": "p95"}
+    spec["display"] = {"type": "number"}
+    sql, _ = compile_(spec)
+    assert "quantile(0.95)(duration_ms)" in sql
+
+
+def test_number_display_rejects_breakdown():
+    """A number tile shows one value; a grouped spec must fail at the breakdown step."""
+    spec = WidgetSpec(
+        view="spans",
+        metric={"measure": "cost", "agg": "sum"},
+        breakdown="model_name",
+        display={"type": "number"},
+    )
+    with pytest.raises(WidgetSpecError) as exc:
+        compile_widget_query(spec, "p1", START, END)
+    assert exc.value.step == "breakdown"


### PR DESCRIPTION
Third PR in the stacked project-dashboards series (epic #1460), stacked on #1510. This is the query engine: with it, a widget spec can be validated, compiled, and executed end to end — the frontend layers come next.

## What's here
- **Spec schemas** (`schemas/dashboards.py`) — strict pydantic request models (`extra="forbid"`): filters (non-empty values), metric, display, breakdown; display/breakdown combination rules enforced (pie/bar require a breakdown, number/histogram forbid one).
- **Spec→SQL compiler** (`services/widget_query.py`) — resolves every user-supplied field name through the registry (raw input never reaches SQL), then emits fully parameterized ClickHouse: time-bucketed series with `WITH FILL` across the whole window (empty buckets render as zeros), top-50 breakdown fold into `other`, histogram shape, window-derived row caps, timezone-normalized and validated bounds.
- **Endpoints** (`routers/dashboards.py`) — three read-only, `ProjectAccess`-guarded routes: widget query execution (readonly + 10s execution cap via a new ClickHouse client `settings` passthrough), the builder schema (`registry_schema()`), and field values for the builder's value dropdowns.
- **Shared distinct-values scan** — `trace_reader`'s categorical-values query is extracted into a reusable helper so the trace-list filter dropdowns and the widget builder read identical data (behavior-preserving; existing tests unchanged).
- **Tests** — compiler suite (SQL shape, param binding, escaping, guard rails), router suite (auth, status mapping, `WidgetSpecError`→422), and the distinct-values parity/meta tests.

## Notes for review
- SQL injection surface: identifiers come from the registry only; all values bind as typed params; `contains` goes through ILIKE escaping.
- Spec validation is split deliberately: shape/enums in pydantic, field/op semantics in the compiler against the registry.

closes #1449
closes #1450
Also checks the gap-filled time-series box on #1457 (its remaining tasks stay open).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the dashboards query engine: strict widget spec schemas, a registry-backed SQL compiler, and read-only endpoints to validate, compile, and run widget queries against ClickHouse. Routes now use the shared read rate limit to protect expensive widget reads. Closes #1449 and #1450, and delivers gap-filled time-series for #1457 (remaining tasks pending) within epic #1460.

- **New Features**
  - Strict Pydantic widget spec schemas (`extra="forbid"`) with non-empty filter values and clear display/breakdown rules.
  - Registry-backed compiler that emits fully parameterized SQL: time buckets with WITH FILL, top-50 breakdown folded into "other", 20-bin histograms, window-derived row caps, UTC-normalized bounds, and escaped ILIKE; raw user input never reaches SQL.
  - Endpoints under `/api/v1/projects/{project_id}/widgets` (project-scoped, readonly, 10s timeout):
    - `POST /query` to execute specs,
    - `GET /schema` to expose the builder registry,
    - `GET /field-values/{view}/{field}` for spans/traces value dropdowns (time-bounded, cached; shared distinct-values helper for consistent options).

- **Bug Fixes**
  - Widget `query`, `schema`, and `field-values` now run under the shared read limiter via `RateLimitedProjectAccess`; trusted internal calls remain exempt.

<sup>Written for commit 304fe3b4ff55f4f247cd00ecfa49b842d4bfdba3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

