### PR TITLE
feat(ui): dashboard data layer, range presets, and a shared date-filter control

### DIFF
--- a/frontend/ui/src/components/date-filter-select.test.tsx
+++ b/frontend/ui/src/components/date-filter-select.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DATE_FILTER_OPTIONS, formatDateRange } from "@/lib/date-filter";
+import { DateFilterSelect } from "./date-filter-select";
+
+// The real range picker is a calendar widget; the boundary under test here is
+// DateFilterSelect's orchestration of the apply callback, so stub the picker
+// with a button that applies a fixed range.
+const APPLIED_START = new Date("2026-07-01T00:00:00Z");
+const APPLIED_END = new Date("2026-07-04T00:00:00Z");
+vi.mock("@/components/ui/date-time-picker", () => ({
+  DateRangePicker: ({ onApply }: { onApply: (start: Date | null, end: Date | null) => void }) => (
+    <button type="button" onClick={() => onApply(APPLIED_START, APPLIED_END)}>
+      Apply stub range
+    </button>
+  ),
+}));
+
+const PRESET_7D = DATE_FILTER_OPTIONS.find((o) => o.id === "7d")!;
+const CUSTOM = DATE_FILTER_OPTIONS.find((o) => o.isCustom)!;
+
+describe("DateFilterSelect", () => {
+  afterEach(cleanup);
+  const onDateFilterChange = vi.fn();
+  const onCustomRangeChange = vi.fn();
+  beforeEach(() => {
+    onDateFilterChange.mockReset();
+    onCustomRangeChange.mockReset();
+  });
+
+  function renderSelect(
+    dateFilter = PRESET_7D,
+    start: Date | null = null,
+    end: Date | null = null,
+  ) {
+    return render(
+      <DateFilterSelect
+        dateFilter={dateFilter}
+        customStartDate={start}
+        customEndDate={end}
+        onDateFilterChange={onDateFilterChange}
+        onCustomRangeChange={onCustomRangeChange}
+      />,
+    );
+  }
+
+  it("shows the active preset label and selects another preset from the popover", () => {
+    renderSelect();
+    const trigger = screen.getByRole("button", { name: /Last 7 days/ });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("button", { name: "Last 1 hour" }));
+    expect(onDateFilterChange).toHaveBeenCalledWith(DATE_FILTER_OPTIONS.find((o) => o.id === "1h"));
+    expect(onCustomRangeChange).not.toHaveBeenCalled();
+    // popover closed after picking a preset
+    expect(screen.queryByRole("button", { name: "Last 30 minutes" })).toBeNull();
+  });
+
+  it("applies a custom range: custom option first, then the bounds", () => {
+    renderSelect();
+    fireEvent.click(screen.getByRole("button", { name: /Last 7 days/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+    // preset list swapped for the picker
+    expect(screen.queryByRole("button", { name: "Last 1 hour" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Apply stub range" }));
+    expect(onDateFilterChange).toHaveBeenCalledWith(CUSTOM);
+    expect(onCustomRangeChange).toHaveBeenCalledWith(APPLIED_START, APPLIED_END);
+  });
+
+  it("labels an active custom filter with its formatted range", () => {
+    renderSelect(CUSTOM, APPLIED_START, APPLIED_END);
+    expect(
+      screen.getByRole("button", { name: formatDateRange(APPLIED_START, APPLIED_END) }),
+    ).toBeTruthy();
+  });
+
+  it("resets to the preset list when the popover reopens after visiting the custom picker", () => {
+    renderSelect();
+    const trigger = screen.getByRole("button", { name: /Last 7 days/ });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+    fireEvent.click(trigger); // close while the picker is showing
+    fireEvent.click(trigger); // reopen
+    expect(screen.getByRole("button", { name: "Last 1 hour" })).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/components/date-filter-select.tsx
+++ b/frontend/ui/src/components/date-filter-select.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { Calendar, ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { DateRangePicker } from "@/components/ui/date-time-picker";
+import { cn } from "@/lib/utils";
+import { DATE_FILTER_OPTIONS, formatDateRange, type DateFilterOption } from "@/lib/date-filter";
+
+// The one date-filter control: preset list + custom range picker in a popover.
+// Extracted from SearchFilterBar so every windowed surface (trace list,
+// dashboards) offers the identical presets and custom-range behavior.
+export function DateFilterSelect({
+  dateFilter,
+  customStartDate,
+  customEndDate,
+  onDateFilterChange,
+  onCustomRangeChange,
+  className,
+}: {
+  dateFilter: DateFilterOption;
+  customStartDate: Date | null;
+  customEndDate: Date | null;
+  onDateFilterChange: (option: DateFilterOption) => void;
+  onCustomRangeChange: (startDate: Date, endDate: Date) => void;
+  className?: string;
+}) {
+  const [dateFilterOpen, setDateFilterOpen] = useState(false);
+  const [showCustomPicker, setShowCustomPicker] = useState(false);
+
+  const getDateFilterLabel = () => {
+    if (dateFilter.isCustom && customStartDate && customEndDate) {
+      return formatDateRange(customStartDate, customEndDate);
+    }
+    return dateFilter.label;
+  };
+
+  const handleCustomDateApply = (startDate: Date | null, endDate: Date | null) => {
+    if (startDate && endDate) {
+      const customOption = DATE_FILTER_OPTIONS.find((o) => o.isCustom)!;
+      onDateFilterChange(customOption);
+      onCustomRangeChange(startDate, endDate);
+    }
+    setDateFilterOpen(false);
+    setShowCustomPicker(false);
+  };
+
+  return (
+    <Popover
+      open={dateFilterOpen}
+      onOpenChange={(open) => {
+        setDateFilterOpen(open);
+        if (!open) setShowCustomPicker(false);
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn(
+            "h-8 min-w-[140px] justify-between gap-2 text-[13px] font-normal",
+            className,
+          )}
+        >
+          <span>{getDateFilterLabel()}</span>
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className={cn("p-0", showCustomPicker ? "w-auto" : "w-auto min-w-[130px]")}
+      >
+        {!showCustomPicker ? (
+          <div className="py-1">
+            {DATE_FILTER_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                className={cn(
+                  "flex w-full items-center gap-1.5 px-2.5 py-1 text-left text-[13px] transition-colors",
+                  dateFilter.id === option.id && !option.isCustom
+                    ? "bg-muted/70"
+                    : "hover:bg-muted/50",
+                )}
+                onClick={() => {
+                  if (option.isCustom) {
+                    setShowCustomPicker(true);
+                  } else {
+                    onDateFilterChange(option);
+                    setDateFilterOpen(false);
+                  }
+                }}
+              >
+                {option.isCustom && <Calendar className="h-3 w-3 text-muted-foreground" />}
+                <span>{option.label}</span>
+              </button>
+            ))}
+          </div>
+        ) : (
+          <DateRangePicker
+            startDate={customStartDate}
+            endDate={customEndDate}
+            onApply={handleCustomDateApply}
+          />
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/ui/src/components/search-filter-bar.tsx
+++ b/frontend/ui/src/components/search-filter-bar.tsx
@@ -1,13 +1,9 @@
 "use client";
 
-import { useState } from "react";
-import { Search, ChevronDown, Calendar } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Search } from "lucide-react";
+import { DateFilterSelect } from "@/components/date-filter-select";
 import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { DateRangePicker } from "@/components/ui/date-time-picker";
-import { cn } from "@/lib/utils";
-import { DATE_FILTER_OPTIONS, formatDateRange, type DateFilterOption } from "@/lib/date-filter";
+import type { DateFilterOption } from "@/lib/date-filter";
 
 interface SearchFilterBarProps {
   // Search
@@ -39,26 +35,6 @@ export function SearchFilterBar({
   onCustomRangeChange,
   children,
 }: SearchFilterBarProps) {
-  const [dateFilterOpen, setDateFilterOpen] = useState(false);
-  const [showCustomPicker, setShowCustomPicker] = useState(false);
-
-  const getDateFilterLabel = () => {
-    if (dateFilter.isCustom && customStartDate && customEndDate) {
-      return formatDateRange(customStartDate, customEndDate);
-    }
-    return dateFilter.label;
-  };
-
-  const handleCustomDateApply = (startDate: Date | null, endDate: Date | null) => {
-    if (startDate && endDate) {
-      const customOption = DATE_FILTER_OPTIONS.find((o) => o.isCustom)!;
-      onDateFilterChange(customOption);
-      onCustomRangeChange(startDate, endDate);
-    }
-    setDateFilterOpen(false);
-    setShowCustomPicker(false);
-  };
-
   return (
     <div className="border-b border-border bg-background px-3 py-1.5">
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
@@ -74,61 +50,14 @@ export function SearchFilterBar({
           </div>
         )}
         {children}
-        <Popover
-          open={dateFilterOpen}
-          onOpenChange={(open) => {
-            setDateFilterOpen(open);
-            if (!open) setShowCustomPicker(false);
-          }}
-        >
-          <PopoverTrigger asChild>
-            <Button
-              variant="outline"
-              size="sm"
-              className="ml-auto h-8 min-w-[140px] justify-between gap-2 text-[13px] font-normal"
-            >
-              <span>{getDateFilterLabel()}</span>
-              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent
-            align="end"
-            className={cn("p-0", showCustomPicker ? "w-auto" : "w-auto min-w-[130px]")}
-          >
-            {!showCustomPicker ? (
-              <div className="py-1">
-                {DATE_FILTER_OPTIONS.map((option) => (
-                  <button
-                    key={option.id}
-                    className={cn(
-                      "flex w-full items-center gap-1.5 px-2.5 py-1 text-left text-[13px] transition-colors",
-                      dateFilter.id === option.id && !option.isCustom
-                        ? "bg-muted/70"
-                        : "hover:bg-muted/50",
-                    )}
-                    onClick={() => {
-                      if (option.isCustom) {
-                        setShowCustomPicker(true);
-                      } else {
-                        onDateFilterChange(option);
-                        setDateFilterOpen(false);
-                      }
-                    }}
-                  >
-                    {option.isCustom && <Calendar className="h-3 w-3 text-muted-foreground" />}
-                    <span>{option.label}</span>
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <DateRangePicker
-                startDate={customStartDate}
-                endDate={customEndDate}
-                onApply={handleCustomDateApply}
-              />
-            )}
-          </PopoverContent>
-        </Popover>
+        <DateFilterSelect
+          className="ml-auto"
+          dateFilter={dateFilter}
+          customStartDate={customStartDate}
+          customEndDate={customEndDate}
+          onDateFilterChange={onDateFilterChange}
+          onCustomRangeChange={onCustomRangeChange}
+        />
       </div>
     </div>
   );

--- a/frontend/ui/src/components/ui/select.tsx
+++ b/frontend/ui/src/components/ui/select.tsx
@@ -67,22 +67,21 @@ const SelectItem = React.forwardRef<
 >(({ className, children, icon, ...props }, ref) => (
   <SelectPrimitive.Item
     ref={ref}
+    // Text starts at the left edge for every row (icon or not); the selection
+    // check always sits in the same reserved slot on the right.
     className={cn(
-      "relative flex w-full cursor-default select-none items-center py-1.5 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      icon ? "pl-2" : "pl-8",
+      "relative flex w-full cursor-default select-none items-center py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}
   >
-    {!icon && (
-      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-        <SelectPrimitive.ItemIndicator>
-          <Check className="h-4 w-4" />
-        </SelectPrimitive.ItemIndicator>
-      </span>
-    )}
     {icon && <span className="mr-2 flex shrink-0 items-center">{icon}</span>}
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
   </SelectPrimitive.Item>
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;

--- a/frontend/ui/src/features/dashboards/api.test.ts
+++ b/frontend/ui/src/features/dashboards/api.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchNextApi, fetchTraceApi } from "@/lib/api/client";
+import {
+  createDashboard,
+  createWidget,
+  deleteDashboard,
+  deleteWidget,
+  fetchWidgetFieldValues,
+  fetchWidgetSchema,
+  getDashboard,
+  listDashboards,
+  runWidgetQuery,
+  updateDashboard,
+  updateWidget,
+} from "./api";
+import type { WidgetSpec } from "./types";
+
+vi.mock("@/lib/api/client", () => ({
+  fetchNextApi: vi.fn(),
+  fetchTraceApi: vi.fn().mockResolvedValue({ field: "model_name", values: [] }),
+}));
+
+beforeEach(() => {
+  vi.mocked(fetchNextApi).mockReset();
+  vi.mocked(fetchTraceApi).mockReset().mockResolvedValue({ field: "model_name", values: [] });
+});
+
+describe("fetchWidgetFieldValues", () => {
+  it("hits the widgets field-values route with the window bounds", async () => {
+    const range = {
+      start: new Date("2026-06-01T00:00:00Z"),
+      end: new Date("2026-06-02T00:00:00Z"),
+    };
+    await fetchWidgetFieldValues("p1", "spans", "model_name", range, {
+      id: "u1",
+      email: "u@example.com",
+    });
+    const [path, , user] = vi.mocked(fetchTraceApi).mock.calls[0];
+    expect(path).toBe(
+      "/projects/p1/widgets/field-values/spans/model_name" +
+        "?start_time=2026-06-01T00%3A00%3A00.000Z&end_time=2026-06-02T00%3A00%3A00.000Z",
+    );
+    expect(user).toEqual({ id: "u1", email: "u@example.com" });
+  });
+});
+
+describe("dashboard CRUD", () => {
+  it("listDashboards gets the project's dashboards", () => {
+    listDashboards("p1");
+    expect(fetchNextApi).toHaveBeenCalledWith("/projects/p1/dashboards");
+  });
+
+  it("getDashboard gets a single dashboard by id", () => {
+    getDashboard("p1", "d1");
+    expect(fetchNextApi).toHaveBeenCalledWith("/projects/p1/dashboards/d1");
+  });
+
+  it("createDashboard posts the name and description", () => {
+    createDashboard("p1", { name: "Overview", description: "Key metrics" });
+    expect(fetchNextApi).toHaveBeenCalledWith("/projects/p1/dashboards", {
+      method: "POST",
+      body: JSON.stringify({ name: "Overview", description: "Key metrics" }),
+    });
+  });
+
+  it("updateDashboard patches the changed fields", () => {
+    updateDashboard("p1", "d1", { name: "Renamed", layout: [{ i: "w1", x: 0, y: 0, w: 2, h: 2 }] });
+    expect(fetchNextApi).toHaveBeenCalledWith("/projects/p1/dashboards/d1", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "Renamed", layout: [{ i: "w1", x: 0, y: 0, w: 2, h: 2 }] }),
+    });
+  });
+
+  it("deleteDashboard issues a DELETE to the dashboard route", () => {
+    deleteDashboard("p1", "d1");
+    expect(fetchNextApi).toHaveBeenCalledWith("/projects/p1/dashboards/d1", {
+      method: "DELETE",
+    });
+  });
+});
+
+describe("widget CRUD", () => {
+  it("createWidget posts the widget definition under the dashboard", () => {
+    createWidget("p1", "d1", { title: "Latency", type: "query", spec: { view: "spans" } });
+    expect(fetchNextApi).toHaveBeenCalledWith("/projects/p1/dashboards/d1/widgets", {
+      method: "POST",
+      body: JSON.stringify({ title: "Latency", type: "query", spec: { view: "spans" } }),
+    });
+  });
+
+  it("updateWidget patches an existing widget", () => {
+    updateWidget("p1", "d1", "w1", { title: "Renamed" });
+    expect(fetchNextApi).toHaveBeenCalledWith("/projects/p1/dashboards/d1/widgets/w1", {
+      method: "PATCH",
+      body: JSON.stringify({ title: "Renamed" }),
+    });
+  });
+
+  it("deleteWidget issues a DELETE to the widget route", () => {
+    deleteWidget("p1", "d1", "w1");
+    expect(fetchNextApi).toHaveBeenCalledWith("/projects/p1/dashboards/d1/widgets/w1", {
+      method: "DELETE",
+    });
+  });
+});
+
+describe("fetchWidgetSchema", () => {
+  it("gets the schema for a project's widgets and passes the user through", async () => {
+    await fetchWidgetSchema("p1", { id: "u1", email: "u@example.com" });
+    expect(fetchTraceApi).toHaveBeenCalledWith(
+      "/projects/p1/widgets/schema",
+      {},
+      { id: "u1", email: "u@example.com" },
+    );
+  });
+});
+
+describe("runWidgetQuery", () => {
+  it("posts the spec and ISO window bounds, passing the user through", async () => {
+    const spec: WidgetSpec = {
+      view: "spans",
+      filters: [],
+      metric: { measure: "count", agg: "count" },
+      breakdown: null,
+      display: { type: "number" },
+    };
+    const range = {
+      start: new Date("2026-06-01T00:00:00Z"),
+      end: new Date("2026-06-02T00:00:00Z"),
+    };
+    await runWidgetQuery("p1", spec, range, { id: "u1", email: "u@example.com" });
+    expect(fetchTraceApi).toHaveBeenCalledWith(
+      "/projects/p1/widgets/query",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          spec,
+          start_time: "2026-06-01T00:00:00.000Z",
+          end_time: "2026-06-02T00:00:00.000Z",
+        }),
+      },
+      { id: "u1", email: "u@example.com" },
+    );
+  });
+});

--- a/frontend/ui/src/features/dashboards/api.ts
+++ b/frontend/ui/src/features/dashboards/api.ts
@@ -1,0 +1,119 @@
+import { fetchNextApi, fetchTraceApi, type TraceApiUser } from "@/lib/api/client";
+import type {
+  DashboardDetail,
+  DashboardSummary,
+  LayoutItem,
+  TimeRange,
+  Widget,
+  WidgetFieldValuesResponse,
+  WidgetQueryResult,
+  WidgetSchema,
+  WidgetSpec,
+} from "./types";
+
+export function listDashboards(projectId: string) {
+  return fetchNextApi<{ data: DashboardSummary[] }>(`/projects/${projectId}/dashboards`);
+}
+
+export function getDashboard(projectId: string, dashboardId: string) {
+  return fetchNextApi<{ dashboard: DashboardDetail }>(
+    `/projects/${projectId}/dashboards/${dashboardId}`,
+  );
+}
+
+export function createDashboard(projectId: string, input: { name: string; description?: string }) {
+  return fetchNextApi<{ dashboard: DashboardSummary }>(`/projects/${projectId}/dashboards`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export function updateDashboard(
+  projectId: string,
+  dashboardId: string,
+  input: { name?: string; description?: string | null; layout?: LayoutItem[] },
+) {
+  return fetchNextApi<{ dashboard: DashboardSummary }>(
+    `/projects/${projectId}/dashboards/${dashboardId}`,
+    { method: "PATCH", body: JSON.stringify(input) },
+  );
+}
+
+export function deleteDashboard(projectId: string, dashboardId: string) {
+  return fetchNextApi<{ deleted: boolean }>(`/projects/${projectId}/dashboards/${dashboardId}`, {
+    method: "DELETE",
+  });
+}
+
+export function createWidget(
+  projectId: string,
+  dashboardId: string,
+  input: { title: string; type: Widget["type"]; spec: object; displayConfig?: object },
+) {
+  return fetchNextApi<{ widget: Widget }>(
+    `/projects/${projectId}/dashboards/${dashboardId}/widgets`,
+    { method: "POST", body: JSON.stringify(input) },
+  );
+}
+
+export function updateWidget(
+  projectId: string,
+  dashboardId: string,
+  widgetId: string,
+  input: { title?: string; spec?: object; displayConfig?: object },
+) {
+  return fetchNextApi<{ widget: Widget }>(
+    `/projects/${projectId}/dashboards/${dashboardId}/widgets/${widgetId}`,
+    { method: "PATCH", body: JSON.stringify(input) },
+  );
+}
+
+export function deleteWidget(projectId: string, dashboardId: string, widgetId: string) {
+  return fetchNextApi<{ deleted: boolean }>(
+    `/projects/${projectId}/dashboards/${dashboardId}/widgets/${widgetId}`,
+    { method: "DELETE" },
+  );
+}
+
+// The TRACE_API_BASE already includes /api/v1, so paths begin with /projects/...
+export function fetchWidgetSchema(projectId: string, user?: TraceApiUser) {
+  return fetchTraceApi<WidgetSchema>(`/projects/${projectId}/widgets/schema`, {}, user);
+}
+
+export function fetchWidgetFieldValues(
+  projectId: string,
+  view: "spans" | "traces",
+  field: string,
+  range: TimeRange,
+  user?: TraceApiUser,
+) {
+  const params = new URLSearchParams({
+    start_time: range.start.toISOString(),
+    end_time: range.end.toISOString(),
+  });
+  return fetchTraceApi<WidgetFieldValuesResponse>(
+    `/projects/${projectId}/widgets/field-values/${view}/${encodeURIComponent(field)}?${params}`,
+    {},
+    user,
+  );
+}
+
+export function runWidgetQuery(
+  projectId: string,
+  spec: WidgetSpec,
+  range: TimeRange,
+  user?: TraceApiUser,
+) {
+  return fetchTraceApi<WidgetQueryResult>(
+    `/projects/${projectId}/widgets/query`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        spec,
+        start_time: range.start.toISOString(),
+        end_time: range.end.toISOString(),
+      }),
+    },
+    user,
+  );
+}

--- a/frontend/ui/src/features/dashboards/range-presets.test.ts
+++ b/frontend/ui/src/features/dashboards/range-presets.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+// range-presets is now a thin adapter over the shared date-filter module (one
+// source of truth for presets/default across trace list, dashboard, and the
+// builder preview) — these tests pin that contract rather than a local list.
+import { DATE_FILTER_OPTIONS, DEFAULT_DATE_FILTER } from "@/lib/date-filter";
+import { DEFAULT_RANGE_ID, RANGE_PRESETS, makeRange } from "./range-presets";
+
+describe("makeRange", () => {
+  it("spans exactly the preset's duration, ending now", () => {
+    const before = Date.now();
+    const r = makeRange("7d");
+    const after = Date.now();
+    expect(r.end.getTime() - r.start.getTime()).toBe(7 * 86_400_000);
+    expect(r.end.getTime()).toBeGreaterThanOrEqual(before);
+    expect(r.end.getTime()).toBeLessThanOrEqual(after);
+  });
+
+  it("falls back to the shared default window for unknown ids", () => {
+    const r = makeRange("nope");
+    expect(r.end.getTime() - r.start.getTime()).toBe(DEFAULT_DATE_FILTER.durationMinutes! * 60_000);
+  });
+});
+
+describe("RANGE_PRESETS", () => {
+  it("is exactly the shared date-filter options minus custom", () => {
+    expect(RANGE_PRESETS).toEqual(DATE_FILTER_OPTIONS.filter((o) => o.durationMinutes !== null));
+  });
+
+  it("defaults to the same option as the trace list and dashboard", () => {
+    expect(DEFAULT_RANGE_ID).toBe(DEFAULT_DATE_FILTER.id);
+  });
+});

--- a/frontend/ui/src/features/dashboards/range-presets.ts
+++ b/frontend/ui/src/features/dashboards/range-presets.ts
@@ -19,8 +19,11 @@ export function makeRange(optionId: string): TimeRange {
   // (RANGE_PRESETS filters custom out).
   const minutes =
     findDateFilterOption(optionId).durationMinutes ?? DEFAULT_DATE_FILTER.durationMinutes!;
+  // Derive start from a single clock read so the range spans exactly the
+  // preset's duration; a second read would skew it by the ms elapsed between.
+  const end = new Date();
   return {
-    start: new Date(Date.now() - minutes * 60_000),
-    end: new Date(),
+    start: new Date(end.getTime() - minutes * 60_000),
+    end,
   };
 }

--- a/frontend/ui/src/features/dashboards/range-presets.ts
+++ b/frontend/ui/src/features/dashboards/range-presets.ts
@@ -1,0 +1,26 @@
+import { DATE_FILTER_OPTIONS, DEFAULT_DATE_FILTER, findDateFilterOption } from "@/lib/date-filter";
+import type { TimeRange } from "./types";
+
+// The widget builder's preview-window presets ARE the shared trace-list
+// date-filter options (minus "custom", which needs the full range-picker UI
+// the preview doesn't have). This module used to hold its own hand-rolled
+// 24h/7d/30d list with a 7-day default, which silently diverged from the
+// 24-hour default the trace list and dashboard page share — it is now a thin
+// adapter over lib/date-filter.ts so there is exactly one source of truth for
+// presets and default across all three surfaces.
+export const RANGE_PRESETS = DATE_FILTER_OPTIONS.filter((o) => o.durationMinutes !== null);
+
+// The same default the trace list and dashboard page resolve to (24 hours).
+export const DEFAULT_RANGE_ID = DEFAULT_DATE_FILTER.id;
+
+export function makeRange(optionId: string): TimeRange {
+  // findDateFilterOption falls back to the default option for unknown ids;
+  // the ?? covers the custom option's null duration, which callers never pass
+  // (RANGE_PRESETS filters custom out).
+  const minutes =
+    findDateFilterOption(optionId).durationMinutes ?? DEFAULT_DATE_FILTER.durationMinutes!;
+  return {
+    start: new Date(Date.now() - minutes * 60_000),
+    end: new Date(),
+  };
+}

--- a/frontend/ui/src/features/dashboards/types.test.ts
+++ b/frontend/ui/src/features/dashboards/types.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import {
+  WidgetSchemaField,
+  WidgetSpecSchema,
+  filterOpLabel,
+  generateWidgetTitle,
+  isEnumerableFilter,
+  isSpecComplete,
+  parseSpec,
+} from "./types";
+
+const validSpec = {
+  view: "spans",
+  filters: [{ field: "span_kind", op: "=", value: "LLM" }],
+  metric: { measure: "cost", agg: "sum" },
+  breakdown: "model_name",
+  display: { type: "line" },
+};
+
+describe("WidgetSpecSchema", () => {
+  it("accepts a valid spec", () => {
+    expect(WidgetSpecSchema.safeParse(validSpec).success).toBe(true);
+  });
+  it("rejects unknown display type", () => {
+    const bad = { ...validSpec, display: { type: "gauge" } };
+    expect(WidgetSpecSchema.safeParse(bad).success).toBe(false);
+  });
+  it("rejects pie and bar without a breakdown — they'd have nothing to chart", () => {
+    for (const type of ["pie", "bar"]) {
+      const bad = { ...validSpec, breakdown: null, display: { type } };
+      expect(WidgetSpecSchema.safeParse(bad).success).toBe(false);
+      expect(WidgetSpecSchema.safeParse({ ...bad, breakdown: "model_name" }).success).toBe(true);
+    }
+  });
+  it("rejects a filter whose value was never picked (empty string)", () => {
+    const bad = { ...validSpec, filters: [{ field: "model_name", op: "=", value: "" }] };
+    expect(WidgetSpecSchema.safeParse(bad).success).toBe(false);
+    // Zero is a legitimate numeric filter value and must stay valid.
+    const zero = { ...validSpec, filters: [{ field: "cost", op: ">", value: 0 }] };
+    expect(WidgetSpecSchema.safeParse(zero).success).toBe(true);
+  });
+
+  it("keeps line/area/table valid without a breakdown", () => {
+    for (const type of ["line", "area", "table"]) {
+      const ok = { ...validSpec, breakdown: null, display: { type } };
+      expect(WidgetSpecSchema.safeParse(ok).success).toBe(true);
+    }
+  });
+});
+
+describe("isSpecComplete", () => {
+  it("false while view or metric missing", () => {
+    expect(isSpecComplete({ view: "spans" })).toBe(false);
+    expect(isSpecComplete({ ...validSpec, metric: undefined })).toBe(false);
+  });
+  it("true for a runnable spec", () => {
+    expect(isSpecComplete(validSpec)).toBe(true);
+  });
+});
+
+describe("parseSpec", () => {
+  it("applies defaults so filters is [] when omitted", () => {
+    const { filters: _omit, ...withoutFilters } = validSpec;
+    const result = parseSpec(withoutFilters);
+    expect(result).not.toBeNull();
+    expect(result!.filters).toEqual([]);
+  });
+});
+
+describe("isEnumerableFilter", () => {
+  const stringField = {
+    type: "string" as const,
+    label: "Model",
+    filterOps: ["=", "!=", "contains"],
+    groupable: true,
+    aggs: [],
+  };
+  const numberField = { ...stringField, type: "number" as const, label: "Cost" };
+
+  it("true for string equality ops (dropdown of stored values)", () => {
+    expect(isEnumerableFilter(stringField, "=")).toBe(true);
+    expect(isEnumerableFilter(stringField, "!=")).toBe(true);
+  });
+  it("false for contains (free text) and numeric fields", () => {
+    expect(isEnumerableFilter(stringField, "contains")).toBe(false);
+    expect(isEnumerableFilter(numberField, "=")).toBe(false);
+  });
+  it("false while no field or op picked", () => {
+    expect(isEnumerableFilter(undefined, "=")).toBe(false);
+    expect(isEnumerableFilter(stringField, "")).toBe(false);
+  });
+});
+
+describe("filterOpLabel", () => {
+  const stringField = {
+    type: "string" as const,
+    label: "Model",
+    filterOps: ["=", "!=", "contains"],
+    groupable: true,
+    aggs: [],
+  };
+  const numberField = { ...stringField, type: "number" as const, label: "Cost" };
+
+  it("words string equality like the trace-list filter builder", () => {
+    expect(filterOpLabel(stringField, "=")).toBe("is");
+    expect(filterOpLabel(stringField, "!=")).toBe("is not");
+    expect(filterOpLabel(stringField, "contains")).toBe("contains");
+  });
+  it("uses the trace-list comparison symbols for numeric ops", () => {
+    expect(filterOpLabel(numberField, ">=")).toBe("≥");
+    expect(filterOpLabel(numberField, "<=")).toBe("≤");
+    expect(filterOpLabel(numberField, "!=")).toBe("≠");
+    expect(filterOpLabel(numberField, "=")).toBe("=");
+    expect(filterOpLabel(numberField, ">")).toBe(">");
+    expect(filterOpLabel(numberField, "<")).toBe("<");
+  });
+  it("falls back to the raw op when the field is unknown", () => {
+    expect(filterOpLabel(undefined, ">=")).toBe("≥");
+    expect(filterOpLabel(undefined, "=")).toBe("=");
+  });
+});
+
+describe("generateWidgetTitle", () => {
+  const fields = {
+    cost: { type: "number", label: "Cost", filterOps: [], groupable: false, aggs: ["sum"] },
+    duration_ms: {
+      type: "number",
+      label: "Latency",
+      filterOps: [],
+      groupable: false,
+      aggs: ["p95"],
+    },
+    model_name: { type: "string", label: "Model", filterOps: [], groupable: true, aggs: [] },
+  } as Record<string, WidgetSchemaField>;
+
+  it("names agg + measure with registry labels", () => {
+    expect(
+      generateWidgetTitle({ view: "traces", metric: { measure: "cost", agg: "sum" } }, fields),
+    ).toBe("Total Cost");
+    expect(
+      generateWidgetTitle(
+        { view: "traces", metric: { measure: "duration_ms", agg: "p95" } },
+        fields,
+      ),
+    ).toBe("p95 Latency");
+  });
+
+  it("appends the breakdown label", () => {
+    expect(
+      generateWidgetTitle(
+        { view: "spans", metric: { measure: "cost", agg: "sum" }, breakdown: "model_name" },
+        fields,
+      ),
+    ).toBe("Total Cost by Model");
+  });
+
+  it("names count widgets after the view", () => {
+    expect(
+      generateWidgetTitle({ view: "spans", metric: { measure: "count", agg: "count" } }, fields),
+    ).toBe("Count of spans");
+  });
+
+  it("is empty until measure and agg are chosen", () => {
+    expect(generateWidgetTitle({ view: "spans" }, fields)).toBe("");
+    expect(generateWidgetTitle({ view: "spans", metric: { measure: "cost" } }, fields)).toBe("");
+  });
+
+  it("falls back to raw field names when the schema lacks a label", () => {
+    expect(
+      generateWidgetTitle({ view: "spans", metric: { measure: "input_tokens", agg: "avg" } }, {}),
+    ).toBe("Avg input_tokens");
+  });
+});

--- a/frontend/ui/src/features/dashboards/types.test.ts
+++ b/frontend/ui/src/features/dashboards/types.test.ts
@@ -32,6 +32,13 @@ describe("WidgetSpecSchema", () => {
       expect(WidgetSpecSchema.safeParse({ ...bad, breakdown: "model_name" }).success).toBe(true);
     }
   });
+  it("rejects an empty-string breakdown — an unpicked dropdown is not a dimension", () => {
+    const bad = { ...validSpec, breakdown: "" };
+    expect(WidgetSpecSchema.safeParse(bad).success).toBe(false);
+    for (const type of ["pie", "bar"]) {
+      expect(WidgetSpecSchema.safeParse({ ...bad, display: { type } }).success).toBe(false);
+    }
+  });
   it("rejects a filter whose value was never picked (empty string)", () => {
     const bad = { ...validSpec, filters: [{ field: "model_name", op: "=", value: "" }] };
     expect(WidgetSpecSchema.safeParse(bad).success).toBe(false);

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -1,0 +1,210 @@
+import { z } from "zod";
+
+export const DISPLAY_TYPES = [
+  "line",
+  "area",
+  "bar",
+  "pie",
+  "number",
+  "table",
+  "histogram",
+] as const;
+export type DisplayType = (typeof DISPLAY_TYPES)[number];
+
+// Enforced in the create dialog and by the dashboard API routes; sized so a
+// full-length name stays visible in the create dialog's input without
+// horizontal scrolling. Long names also display truncated in the tabs.
+export const DASHBOARD_NAME_MAX = 50;
+// Widget titles and dashboard descriptions are also route-enforced: without a
+// cap one member can persist arbitrarily large strings that every dashboard
+// read then ships to all project members.
+export const WIDGET_TITLE_MAX = 100;
+export const DASHBOARD_DESCRIPTION_MAX = 500;
+
+export const AGGS = ["count", "sum", "avg", "min", "max", "p50", "p95", "p99"] as const;
+
+export const WidgetFilterSchema = z.object({
+  field: z.string().min(1),
+  op: z.enum(["=", "!=", "contains", ">", ">=", "<", "<="]),
+  // min(1): a filter whose value was never picked (the builder's rows start
+  // at "") must keep the spec incomplete, not save a widget that silently
+  // matches only empty-valued rows.
+  value: z.union([z.string().min(1), z.number()]),
+});
+
+// Pie and bar plot one mark per category — without a breakdown dimension the
+// query collapses to a single unlabeled datum and there is nothing to chart.
+export const BREAKDOWN_REQUIRED_DISPLAYS: ReadonlySet<DisplayType> = new Set(["pie", "bar"]);
+
+export const WidgetSpecSchema = z
+  .object({
+    view: z.enum(["spans", "traces"]),
+    filters: z.array(WidgetFilterSchema).default([]),
+    metric: z.object({ measure: z.string().min(1), agg: z.enum(AGGS) }),
+    breakdown: z.string().nullable().default(null),
+    display: z.object({ type: z.enum(DISPLAY_TYPES) }),
+  })
+  .superRefine((spec, ctx) => {
+    if (BREAKDOWN_REQUIRED_DISPLAYS.has(spec.display.type) && spec.breakdown === null) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["breakdown"],
+        message: `${spec.display.type} requires a breakdown dimension`,
+      });
+    }
+  });
+export type WidgetSpec = z.infer<typeof WidgetSpecSchema>;
+
+// Partial spec held by the builder while the user fills steps.
+export type DraftSpec = Partial<Omit<WidgetSpec, "metric" | "display">> & {
+  metric?: Partial<WidgetSpec["metric"]>;
+  display?: Partial<WidgetSpec["display"]>;
+};
+
+export function parseSpec(draft: unknown): WidgetSpec | null {
+  return WidgetSpecSchema.safeParse(draft).data ?? null;
+}
+
+export function isSpecComplete(draft: unknown): draft is WidgetSpec {
+  return parseSpec(draft) !== null;
+}
+
+export interface DashboardSummary {
+  id: string;
+  name: string;
+  description: string | null;
+  isDefault: boolean;
+  updateTime: string;
+}
+
+export interface LayoutItem {
+  i: string; // widget id
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface Widget {
+  id: string;
+  dashboardId: string;
+  title: string;
+  type: "query" | "trace_feed";
+  spec: Record<string, unknown>;
+  displayConfig: Record<string, unknown>;
+}
+
+export interface DashboardDetail extends DashboardSummary {
+  layout: LayoutItem[];
+  widgets: Widget[];
+}
+
+export interface WidgetQueryResult {
+  columns: string[];
+  rows: (string | number | null)[][];
+  meta: { granularity?: "hour" | "day" };
+}
+
+export interface WidgetSchemaField {
+  type: "string" | "number";
+  label: string;
+  filterOps: string[];
+  groupable: boolean;
+  aggs: string[];
+  // Whether the query engine can histogram this measure (numeric column, not
+  // the count(*) sentinel). Optional so older cached schemas keep working;
+  // treat absence as histogrammable.
+  histogrammable?: boolean;
+}
+
+export type WidgetSchema = Record<
+  "spans" | "traces",
+  { fields: Record<string, WidgetSchemaField> }
+>;
+
+export interface WidgetFieldValue {
+  value: string;
+  count: number;
+}
+
+export interface WidgetFieldValuesResponse {
+  field: string;
+  values: WidgetFieldValue[];
+}
+
+/**
+ * Whether a filter's value is one of the field's stored values (so the builder
+ * offers a dropdown of them). Equality on a string dimension is enumerable;
+ * `contains` stays free text and numeric fields take a number input.
+ */
+export function isEnumerableFilter(field: WidgetSchemaField | undefined, op: string): boolean {
+  return !!field && field.type === "string" && (op === "=" || op === "!=");
+}
+
+export interface FieldUnit {
+  prefix?: string;
+  suffix?: string;
+}
+
+// Units for fields that carry one — shared by the builder's filter inputs and
+// the stat renderer. Moving these into the backend registry's schema is a
+// tracked follow-up; until then this map is the frontend's single copy.
+export const FIELD_UNIT: Record<string, FieldUnit> = {
+  cost: { prefix: "$" },
+  duration_ms: { suffix: "ms" },
+};
+
+// Numeric comparison symbols shared with the trace-list filter chips.
+const NUMERIC_OP_SYMBOL: Record<string, string> = { ">=": "≥", "<=": "≤", "!=": "≠" };
+
+/**
+ * Display label for a filter operator, matching the trace-list filter builder's
+ * vocabulary: string equality reads as "is" / "is not"; numeric comparisons use
+ * the same symbols (≥ ≤ ≠). Presentation only — the wire op is unchanged.
+ */
+export function filterOpLabel(field: WidgetSchemaField | undefined, op: string): string {
+  if (field?.type === "string") {
+    if (op === "=") return "is";
+    if (op === "!=") return "is not";
+    return op;
+  }
+  return NUMERIC_OP_SYMBOL[op] ?? op;
+}
+
+// Display words for aggregations in generated widget titles.
+const AGG_TITLE: Record<string, string> = {
+  count: "Count",
+  sum: "Total",
+  avg: "Avg",
+  min: "Min",
+  max: "Max",
+  p50: "p50",
+  p95: "p95",
+  p99: "p99",
+};
+
+/**
+ * Auto-generated widget name for the builder: "{Agg} {measure label}" plus
+ * " by {breakdown label}" when a breakdown is set (e.g. "p95 Latency by Model",
+ * "Count of spans"). Empty until measure and agg are chosen. The builder shows
+ * this until the user edits the name, then never overwrites their text.
+ */
+export function generateWidgetTitle(
+  draft: DraftSpec,
+  viewFields: Record<string, WidgetSchemaField>,
+): string {
+  const measure = draft.metric?.measure;
+  const agg = draft.metric?.agg;
+  if (!measure || !agg) return "";
+  const base =
+    measure === "count"
+      ? `Count of ${draft.view ?? "rows"}`
+      : `${AGG_TITLE[agg] ?? agg} ${viewFields[measure]?.label ?? measure}`;
+  if (!draft.breakdown) return base;
+  return `${base} by ${viewFields[draft.breakdown]?.label ?? draft.breakdown}`;
+}
+
+export interface TimeRange {
+  start: Date;
+  end: Date;
+}

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -41,7 +41,9 @@ export const WidgetSpecSchema = z
     view: z.enum(["spans", "traces"]),
     filters: z.array(WidgetFilterSchema).default([]),
     metric: z.object({ measure: z.string().min(1), agg: z.enum(AGGS) }),
-    breakdown: z.string().nullable().default(null),
+    // min(1): an unpicked dropdown must read as "no breakdown", not as a
+    // (bogus) empty-string dimension that slips past the pie/bar check below.
+    breakdown: z.string().min(1).nullable().default(null),
     display: z.object({ type: z.enum(DISPLAY_TYPES) }),
   })
   .superRefine((spec, ctx) => {

--- a/frontend/ui/src/lib/api/client.ts
+++ b/frontend/ui/src/lib/api/client.ts
@@ -71,7 +71,12 @@ export async function fetchTraceApi<T>(
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ detail: "Unknown error" }));
-    throw new Error(error.detail || `API error: ${response.status}`);
+    const d = (error as { detail?: unknown }).detail;
+    throw new Error(
+      typeof d === "string"
+        ? d
+        : ((d as { message?: string } | undefined)?.message ?? `API error: ${response.status}`),
+    );
   }
 
   if (response.status === 204) {

--- a/frontend/ui/vitest.config.ts
+++ b/frontend/ui/vitest.config.ts
@@ -11,7 +11,16 @@ export default defineConfig({
       reporter: ["lcov"],
       reportsDirectory: "./coverage",
       reportOnFailure: true,
-      exclude: ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.d.ts", "**/types.ts"],
+      exclude: [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.d.ts",
+        "**/types.ts",
+        // Local dev-server build output; its compiled chunks lack usable
+        // sourcemaps and crash the untested-files coverage scan.
+        "**/.next/**",
+      ],
     },
   },
   resolve: {


### PR DESCRIPTION
Fourth PR in the stacked project-dashboards series (epic #1460), stacked on #1511. First frontend slice: the typed data layer every dashboard surface builds on — no dashboard UI yet (hooks, renderers, pages follow).

## What's here
- **Spec types** (`features/dashboards/types.ts`) — zod schemas for dashboards, widgets, grid layouts, and widget specs, plus the completeness/chartability rules the builder and CRUD routes will share (pie/bar require a breakdown; an unpicked filter value keeps a spec incomplete; histogram gates on the field's histogrammable flag).
- **API client** (`features/dashboards/api.ts`) — typed wrappers over the coming Next.js dashboard/widget CRUD routes and the FastAPI widget schema/query/field-values endpoints from #1511. `fetchTraceApi` errors now surface FastAPI's structured detail message instead of stringifying the object.
- **Range presets** (`features/dashboards/range-presets.ts`) — thin adapter mapping the shared date-filter options onto widget query time ranges.
- **DateFilterSelect** (`components/date-filter-select.tsx`) — the date-filter popover extracted verbatim from `SearchFilterBar` (which now renders it), so the trace list and dashboards get identical presets + custom-range behavior.
- **Select alignment** (`components/ui/select.tsx`) — the selection check moves to a reserved right-hand slot so rows with and without leading icons align. *Intentional app-wide visual change, not dashboard-scoped.*
- **Tests** for all of the above; vitest coverage scans now skip `.next` build output.

advances #1459, advances #1453, advances #1454

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the typed dashboard data layer and a shared date filter so dashboards and the trace list use the same presets and custom ranges. Also introduces a typed API client, clearer Trace API errors, and a small select-menu alignment tweak.

- New Features
  - `zod` schemas for dashboards, widgets, layouts, and widget specs with completeness rules (pie/bar require a breakdown; empty filter values are invalid; histogram depends on field capability).
  - Typed API client for Next.js dashboard/widget CRUD and FastAPI widget schema/query/field-values; posts ISO time windows and passes through the user.
  - Range presets adapter that maps the shared date-filter options to widget query ranges; default matches the trace list (24h).
  - Reusable DateFilterSelect extracted and used by SearchFilterBar for identical presets and custom-range behavior.
  - Select items reserve a right-side slot for the checkmark to keep text aligned across rows with/without icons; tests added and `vitest` coverage now skips `.next`.

- Bug Fixes
  - Range presets now use a single clock read in `makeRange` so the span matches the exact preset duration.
  - `WidgetSpecSchema` rejects empty-string breakdowns; unpicked dropdowns are treated as no breakdown.
  - `fetchTraceApi` now surfaces FastAPI’s structured detail message instead of stringifying the error object.

<sup>Written for commit 88b88b1560f0aafb691647bcef1963936648246b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

