### PR TITLE
feat(ui): dashboard and widget data hooks

### DIFF
--- a/frontend/ui/src/features/dashboards/hooks/use-dashboards.test.tsx
+++ b/frontend/ui/src/features/dashboards/hooks/use-dashboards.test.tsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
+import * as api from "../api";
+import { useDashboard, useDashboardMutations, useDashboards } from "./use-dashboards";
+import type { DashboardDetail, DashboardSummary, Widget } from "../types";
+
+vi.mock("../api");
+const broadcastMock = vi.fn();
+vi.mock("@/lib/cross-tab-sync", () => ({
+  broadcastQueryInvalidation: (...args: unknown[]) => broadcastMock(...args),
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, invalidateSpy, queryClient };
+}
+
+const fakeSummary: DashboardSummary = {
+  id: "dash-1",
+  name: "Overview",
+  description: null,
+  isDefault: true,
+  updateTime: "2026-06-01T00:00:00Z",
+};
+
+const fakeDetail: DashboardDetail = {
+  ...fakeSummary,
+  layout: [],
+  widgets: [],
+};
+
+const fakeWidget: Widget = {
+  id: "widget-1",
+  dashboardId: "dash-1",
+  title: "My Widget",
+  type: "query",
+  spec: {},
+  displayConfig: {},
+};
+
+beforeEach(() => {
+  vi.mocked(api.listDashboards).mockReset();
+  vi.mocked(api.getDashboard).mockReset();
+  vi.mocked(api.createDashboard).mockReset();
+  vi.mocked(api.updateDashboard).mockReset();
+  vi.mocked(api.deleteDashboard).mockReset();
+  vi.mocked(api.createWidget).mockReset();
+  vi.mocked(api.updateWidget).mockReset();
+  vi.mocked(api.deleteWidget).mockReset();
+  broadcastMock.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// useDashboards / useDashboard
+// ---------------------------------------------------------------------------
+describe("useDashboards", () => {
+  it("unwraps the data array from the list response", async () => {
+    vi.mocked(api.listDashboards).mockResolvedValue({ data: [fakeSummary] });
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useDashboards("proj-1"), { wrapper });
+    await waitFor(() => expect(result.current.data).toEqual([fakeSummary]));
+    expect(api.listDashboards).toHaveBeenCalledWith("proj-1");
+  });
+
+  it("stays disabled when projectId is empty", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDashboards(""), { wrapper });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(api.listDashboards).not.toHaveBeenCalled();
+  });
+});
+
+describe("useDashboard", () => {
+  it("unwraps the dashboard from the detail response", async () => {
+    vi.mocked(api.getDashboard).mockResolvedValue({ dashboard: fakeDetail });
+    const { wrapper } = makeWrapper();
+
+    const { result } = renderHook(() => useDashboard("proj-1", "dash-1"), { wrapper });
+    await waitFor(() => expect(result.current.data).toEqual(fakeDetail));
+    expect(api.getDashboard).toHaveBeenCalledWith("proj-1", "dash-1");
+  });
+
+  it("stays disabled when dashboardId is empty", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDashboard("proj-1", ""), { wrapper });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(api.getDashboard).not.toHaveBeenCalled();
+  });
+
+  it("stays disabled when projectId is empty", () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDashboard("", "dash-1"), { wrapper });
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(api.getDashboard).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useDashboardMutations
+// ---------------------------------------------------------------------------
+describe("useDashboardMutations", () => {
+  it("createDashboard: calls api.createDashboard and invalidates the list only (no dashboardId scope)", async () => {
+    vi.mocked(api.createDashboard).mockResolvedValue({ dashboard: fakeSummary });
+    const { wrapper, invalidateSpy } = makeWrapper();
+
+    const { result } = renderHook(() => useDashboardMutations("proj-1"), { wrapper });
+    result.current.createDashboard.mutate({ name: "New Dash" });
+    await waitFor(() => expect(result.current.createDashboard.isSuccess).toBe(true));
+
+    expect(api.createDashboard).toHaveBeenCalledWith("proj-1", { name: "New Dash" });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "proj-1"] });
+    expect(broadcastMock).toHaveBeenCalledWith(["dashboards", "proj-1"]);
+    // No dashboardId was passed to the hook, so no detail-scoped invalidation.
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: expect.arrayContaining(["dashboard"]),
+    });
+  });
+
+  it("updateLayout: calls api.updateDashboard with the layout and invalidates list + detail", async () => {
+    vi.mocked(api.updateDashboard).mockResolvedValue({ dashboard: fakeSummary });
+    const { wrapper, invalidateSpy } = makeWrapper();
+    const layout = [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }];
+
+    const { result } = renderHook(() => useDashboardMutations("proj-1", "dash-1"), { wrapper });
+    result.current.updateLayout.mutate(layout);
+    await waitFor(() => expect(result.current.updateLayout.isSuccess).toBe(true));
+
+    expect(api.updateDashboard).toHaveBeenCalledWith("proj-1", "dash-1", { layout });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "proj-1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "proj-1", "dash-1"] });
+    expect(broadcastMock).toHaveBeenCalledWith(["dashboards", "proj-1"]);
+    expect(broadcastMock).toHaveBeenCalledWith(["dashboard", "proj-1", "dash-1"]);
+  });
+
+  it("updateLayout: writes the layout into the detail cache optimistically", async () => {
+    // Never-resolving PATCH: the cache must already hold the new layout while
+    // the request is in flight, so a poll response can't revert the grid.
+    vi.mocked(api.updateDashboard).mockReturnValue(new Promise(() => {}));
+    const { wrapper, queryClient } = makeWrapper();
+    const key = ["dashboard", "proj-1", "dash-1"];
+    queryClient.setQueryData(key, { dashboard: { ...fakeSummary, layout: [], widgets: [] } });
+
+    const layout = [{ i: "w1", x: 2, y: 0, w: 4, h: 4 }];
+    const { result } = renderHook(() => useDashboardMutations("proj-1", "dash-1"), { wrapper });
+    result.current.updateLayout.mutate(layout);
+
+    await waitFor(() => {
+      const cached = queryClient.getQueryData(key) as { dashboard: { layout: unknown } };
+      expect(cached.dashboard.layout).toEqual(layout);
+    });
+  });
+
+  it("updateLayout: refetches the truth when the PATCH fails", async () => {
+    vi.mocked(api.updateDashboard).mockRejectedValue(new Error("boom"));
+    const { wrapper, invalidateSpy } = makeWrapper();
+
+    const { result } = renderHook(() => useDashboardMutations("proj-1", "dash-1"), { wrapper });
+    result.current.updateLayout.mutate([{ i: "w1", x: 0, y: 0, w: 4, h: 4 }]);
+    await waitFor(() => expect(result.current.updateLayout.isError).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "proj-1", "dash-1"] });
+  });
+
+  it("renameDashboard: calls api.updateDashboard with name/description and invalidates list + detail", async () => {
+    vi.mocked(api.updateDashboard).mockResolvedValue({ dashboard: fakeSummary });
+    const { wrapper, invalidateSpy } = makeWrapper();
+
+    const { result } = renderHook(() => useDashboardMutations("proj-1", "dash-1"), { wrapper });
+    result.current.renameDashboard.mutate({ name: "Renamed", description: null });
+    await waitFor(() => expect(result.current.renameDashboard.isSuccess).toBe(true));
+
+    expect(api.updateDashboard).toHaveBeenCalledWith("proj-1", "dash-1", {
+      name: "Renamed",
+      description: null,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "proj-1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "proj-1", "dash-1"] });
+  });
+
+  it("removeDashboard: calls api.deleteDashboard with the given id and invalidates list + that dashboard's detail", async () => {
+    vi.mocked(api.deleteDashboard).mockResolvedValue({ deleted: true });
+    const { wrapper, invalidateSpy } = makeWrapper();
+
+    // Hook-level dashboardId differs from the id passed to mutate — the
+    // mutation should scope invalidation to the id it was called with.
+    const { result } = renderHook(() => useDashboardMutations("proj-1", "dash-1"), { wrapper });
+    result.current.removeDashboard.mutate("dash-2");
+    await waitFor(() => expect(result.current.removeDashboard.isSuccess).toBe(true));
+
+    expect(api.deleteDashboard).toHaveBeenCalledWith("proj-1", "dash-2");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "proj-1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "proj-1", "dash-2"] });
+  });
+
+  it("createWidget: calls api.createWidget scoped to the dashboard and invalidates list + detail", async () => {
+    vi.mocked(api.createWidget).mockResolvedValue({ widget: fakeWidget });
+    const { wrapper, invalidateSpy } = makeWrapper();
+    const input = { title: "New Widget", type: "query" as const, spec: { view: "spans" } };
+
+    const { result } = renderHook(() => useDashboardMutations("proj-1", "dash-1"), { wrapper });
+    result.current.createWidget.mutate(input);
+    await waitFor(() => expect(result.current.createWidget.isSuccess).toBe(true));
+
+    expect(api.createWidget).toHaveBeenCalledWith("proj-1", "dash-1", input);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "proj-1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "proj-1", "dash-1"] });
+  });
+
+  it("updateWidget: calls api.updateWidget with widgetId split out of the input and invalidates list + detail", async () => {
+    vi.mocked(api.updateWidget).mockResolvedValue({ widget: fakeWidget });
+    const { wrapper, invalidateSpy } = makeWrapper();
+
+    const { result } = renderHook(() => useDashboardMutations("proj-1", "dash-1"), { wrapper });
+    result.current.updateWidget.mutate({ widgetId: "widget-1", title: "Updated" });
+    await waitFor(() => expect(result.current.updateWidget.isSuccess).toBe(true));
+
+    expect(api.updateWidget).toHaveBeenCalledWith("proj-1", "dash-1", "widget-1", {
+      title: "Updated",
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "proj-1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "proj-1", "dash-1"] });
+  });
+
+  it("removeWidget: calls api.deleteWidget with the widgetId and invalidates list + detail", async () => {
+    vi.mocked(api.deleteWidget).mockResolvedValue({ deleted: true });
+    const { wrapper, invalidateSpy } = makeWrapper();
+
+    const { result } = renderHook(() => useDashboardMutations("proj-1", "dash-1"), { wrapper });
+    result.current.removeWidget.mutate("widget-1");
+    await waitFor(() => expect(result.current.removeWidget.isSuccess).toBe(true));
+
+    expect(api.deleteWidget).toHaveBeenCalledWith("proj-1", "dash-1", "widget-1");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "proj-1"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboard", "proj-1", "dash-1"] });
+  });
+});

--- a/frontend/ui/src/features/dashboards/hooks/use-dashboards.ts
+++ b/frontend/ui/src/features/dashboards/hooks/use-dashboards.ts
@@ -1,0 +1,117 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { broadcastQueryInvalidation } from "@/lib/cross-tab-sync";
+import * as api from "../api";
+import type { LayoutItem, Widget } from "../types";
+
+export function useDashboards(projectId: string) {
+  return useQuery({
+    queryKey: ["dashboards", projectId],
+    queryFn: () => api.listDashboards(projectId),
+    select: (data) => data.data,
+    enabled: !!projectId,
+  });
+}
+
+export function useDashboard(projectId: string, dashboardId: string) {
+  return useQuery({
+    queryKey: ["dashboard", projectId, dashboardId],
+    queryFn: () => api.getDashboard(projectId, dashboardId),
+    select: (data) => data.dashboard,
+    enabled: !!projectId && !!dashboardId,
+    // Teammates' edits have no push channel and cross-tab sync only covers
+    // one browser, so an open dashboard would otherwise show another user's
+    // changes only on focus/navigation. Polling pauses while the tab is
+    // hidden (react-query default).
+    refetchInterval: 30_000,
+  });
+}
+
+function invalidateDashboards(
+  queryClient: ReturnType<typeof useQueryClient>,
+  projectId: string,
+  dashboardId?: string,
+) {
+  void queryClient.invalidateQueries({ queryKey: ["dashboards", projectId] });
+  broadcastQueryInvalidation(["dashboards", projectId]);
+  if (dashboardId) {
+    void queryClient.invalidateQueries({ queryKey: ["dashboard", projectId, dashboardId] });
+    broadcastQueryInvalidation(["dashboard", projectId, dashboardId]);
+  }
+}
+
+export function useDashboardMutations(projectId: string, dashboardId?: string) {
+  const queryClient = useQueryClient();
+
+  const createDashboard = useMutation({
+    mutationFn: (input: { name: string; description?: string }) =>
+      api.createDashboard(projectId, input),
+    onSuccess: () => invalidateDashboards(queryClient, projectId),
+  });
+
+  const updateLayout = useMutation({
+    mutationFn: (layout: LayoutItem[]) => api.updateDashboard(projectId, dashboardId!, { layout }),
+    // A 30s-poll (or focus-refetch) response carrying the pre-save layout can
+    // land between the drag's PATCH and its refetch, reverting the grid and
+    // re-PATCHing the old layout. Cancel in-flight reads and write the new
+    // layout into the cache up front so that window doesn't exist.
+    onMutate: async (layout) => {
+      const key = ["dashboard", projectId, dashboardId];
+      await queryClient.cancelQueries({ queryKey: key });
+      queryClient.setQueryData(key, (prev: { dashboard: { layout: LayoutItem[] } } | undefined) =>
+        prev ? { ...prev, dashboard: { ...prev.dashboard, layout } } : prev,
+      );
+    },
+    // On failure the optimistic layout is wrong — refetch the truth.
+    onError: () => invalidateDashboards(queryClient, projectId, dashboardId),
+    onSuccess: () => invalidateDashboards(queryClient, projectId, dashboardId),
+  });
+
+  const renameDashboard = useMutation({
+    mutationFn: (input: { name?: string; description?: string | null }) =>
+      api.updateDashboard(projectId, dashboardId!, input),
+    onSuccess: () => invalidateDashboards(queryClient, projectId, dashboardId),
+  });
+
+  const removeDashboard = useMutation({
+    mutationFn: (id: string) => api.deleteDashboard(projectId, id),
+    onSuccess: (_data, id) => invalidateDashboards(queryClient, projectId, id),
+  });
+
+  const createWidget = useMutation({
+    mutationFn: (input: {
+      title: string;
+      type: Widget["type"];
+      spec: object;
+      displayConfig?: object;
+    }) => api.createWidget(projectId, dashboardId!, input),
+    onSuccess: () => invalidateDashboards(queryClient, projectId, dashboardId),
+  });
+
+  const updateWidget = useMutation({
+    mutationFn: ({
+      widgetId,
+      ...input
+    }: {
+      widgetId: string;
+      title?: string;
+      spec?: object;
+      displayConfig?: object;
+    }) => api.updateWidget(projectId, dashboardId!, widgetId, input),
+    onSuccess: () => invalidateDashboards(queryClient, projectId, dashboardId),
+  });
+
+  const removeWidget = useMutation({
+    mutationFn: (widgetId: string) => api.deleteWidget(projectId, dashboardId!, widgetId),
+    onSuccess: () => invalidateDashboards(queryClient, projectId, dashboardId),
+  });
+
+  return {
+    createDashboard,
+    updateLayout,
+    renameDashboard,
+    removeDashboard,
+    createWidget,
+    updateWidget,
+    removeWidget,
+  };
+}

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "../api";
+import type { DraftSpec, TimeRange, WidgetSpec } from "../types";
+import {
+  useWidgetData,
+  useWidgetFieldValues,
+  useWidgetPreview,
+  useWidgetSchema,
+} from "./use-widget-data";
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({
+    data: { user: { id: "u1", email: "u@example.com" } },
+    isPending: false,
+  }),
+}));
+vi.mock("../api");
+
+const RANGE: TimeRange = {
+  start: new Date("2026-06-01T00:00:00Z"),
+  end: new Date("2026-06-02T00:00:00Z"),
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("useWidgetFieldValues", () => {
+  beforeEach(() => {
+    vi.mocked(api.fetchWidgetFieldValues).mockReset();
+  });
+
+  it("fetches stored values once enabled", async () => {
+    vi.mocked(api.fetchWidgetFieldValues).mockResolvedValue({
+      field: "model_name",
+      values: [{ value: "gpt-4o", count: 3 }],
+    });
+    const { result } = renderHook(
+      () => useWidgetFieldValues("p1", "spans", "model_name", RANGE, true),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.values).toHaveLength(1));
+    expect(result.current.values[0]).toEqual({ value: "gpt-4o", count: 3 });
+    expect(api.fetchWidgetFieldValues).toHaveBeenCalledWith("p1", "spans", "model_name", RANGE, {
+      id: "u1",
+      email: "u@example.com",
+    });
+  });
+
+  it("stays idle while disabled — no fetch, no values", async () => {
+    const { result } = renderHook(
+      () => useWidgetFieldValues("p1", "spans", "model_name", RANGE, false),
+      { wrapper },
+    );
+    expect(result.current).toEqual({ values: [], isLoading: false });
+    expect(api.fetchWidgetFieldValues).not.toHaveBeenCalled();
+  });
+
+  it("stays idle until a field is picked", () => {
+    const { result } = renderHook(() => useWidgetFieldValues("p1", "spans", "", RANGE, true), {
+      wrapper,
+    });
+    expect(result.current).toEqual({ values: [], isLoading: false });
+    expect(api.fetchWidgetFieldValues).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWidgetSchema", () => {
+  beforeEach(() => {
+    vi.mocked(api.fetchWidgetSchema).mockReset();
+  });
+
+  it("fetches the schema once the session is ready", async () => {
+    const schema = { spans: { fields: {} }, traces: { fields: {} } };
+    vi.mocked(api.fetchWidgetSchema).mockResolvedValue(schema);
+    const { result } = renderHook(() => useWidgetSchema("p1"), { wrapper });
+    await waitFor(() => expect(result.current.data).toEqual(schema));
+    expect(api.fetchWidgetSchema).toHaveBeenCalledWith("p1", { id: "u1", email: "u@example.com" });
+  });
+
+  it("stays disabled without a projectId", () => {
+    renderHook(() => useWidgetSchema(""), { wrapper });
+    expect(api.fetchWidgetSchema).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWidgetData", () => {
+  const SPEC: WidgetSpec = {
+    view: "spans",
+    filters: [],
+    metric: { measure: "count", agg: "count" },
+    breakdown: null,
+    display: { type: "number" },
+  };
+
+  beforeEach(() => {
+    vi.mocked(api.runWidgetQuery).mockReset();
+  });
+
+  it("fetches when enabled with a complete spec, passing the user through", async () => {
+    const queryResult = { columns: ["count"], rows: [[1]], meta: {} };
+    vi.mocked(api.runWidgetQuery).mockResolvedValue(queryResult);
+    const { result } = renderHook(() => useWidgetData("p1", "w1", SPEC, RANGE), { wrapper });
+    await waitFor(() => expect(result.current.data).toEqual(queryResult));
+    expect(api.runWidgetQuery).toHaveBeenCalledWith("p1", SPEC, RANGE, {
+      id: "u1",
+      email: "u@example.com",
+    });
+  });
+
+  it("stays disabled when enabled=false", () => {
+    renderHook(() => useWidgetData("p1", "w1", SPEC, RANGE, false), { wrapper });
+    expect(api.runWidgetQuery).not.toHaveBeenCalled();
+  });
+
+  it("stays disabled without a widgetId", () => {
+    renderHook(() => useWidgetData("p1", "", SPEC, RANGE), { wrapper });
+    expect(api.runWidgetQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe("useWidgetPreview", () => {
+  beforeEach(() => {
+    vi.mocked(api.runWidgetQuery).mockReset();
+  });
+
+  it("never queries for an incomplete draft", () => {
+    const draft: DraftSpec = { view: "spans", metric: { measure: "count" } };
+    renderHook(() => useWidgetPreview("p1", draft, RANGE), { wrapper });
+    expect(api.runWidgetQuery).not.toHaveBeenCalled();
+  });
+
+  it("queries with the parsed spec once the draft is complete", async () => {
+    const draft: DraftSpec = {
+      view: "spans",
+      metric: { measure: "count", agg: "count" },
+      display: { type: "number" },
+    };
+    const queryResult = { columns: ["count"], rows: [[1]], meta: {} };
+    vi.mocked(api.runWidgetQuery).mockResolvedValue(queryResult);
+    const { result } = renderHook(() => useWidgetPreview("p1", draft, RANGE), { wrapper });
+    await waitFor(() => expect(result.current.data).toEqual(queryResult));
+    expect(api.runWidgetQuery).toHaveBeenCalledWith(
+      "p1",
+      {
+        view: "spans",
+        filters: [],
+        metric: { measure: "count", agg: "count" },
+        breakdown: null,
+        display: { type: "number" },
+      },
+      RANGE,
+      { id: "u1", email: "u@example.com" },
+    );
+  });
+});

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
@@ -1,0 +1,98 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { useTraceApiUser } from "@/lib/hooks/use-trace-api-user";
+import * as api from "../api";
+import {
+  isSpecComplete,
+  parseSpec,
+  type TimeRange,
+  type WidgetFieldValue,
+  type WidgetSpec,
+} from "../types";
+
+export function useWidgetSchema(projectId: string) {
+  const { user, sessionReady } = useTraceApiUser();
+
+  return useQuery({
+    queryKey: ["widget-schema", projectId],
+    queryFn: () => api.fetchWidgetSchema(projectId, user),
+    enabled: sessionReady && !!projectId,
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+export function useWidgetData(
+  projectId: string,
+  widgetId: string,
+  spec: WidgetSpec,
+  range: TimeRange,
+  enabled = true,
+) {
+  const { user, sessionReady } = useTraceApiUser();
+
+  return useQuery({
+    queryKey: [
+      "widget-data",
+      projectId,
+      widgetId,
+      JSON.stringify(spec),
+      range.start.getTime(),
+      range.end.getTime(),
+    ],
+    queryFn: () => api.runWidgetQuery(projectId, spec, range, user),
+    enabled: enabled && sessionReady && !!projectId && !!widgetId,
+    retry: 1,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/**
+ * Distinct stored values for a string filter field, fetched lazily (only for an
+ * enumerable filter, once a field is picked) and bounded by the dashboard window.
+ * Backed by the same cached distinct-values scan as the trace-list filter dropdown.
+ */
+export function useWidgetFieldValues(
+  projectId: string,
+  view: "spans" | "traces" | undefined,
+  field: string,
+  range: TimeRange,
+  enabled: boolean,
+): { values: WidgetFieldValue[]; isLoading: boolean } {
+  const { user, sessionReady } = useTraceApiUser();
+
+  const active = enabled && sessionReady && !!projectId && !!view && !!field;
+  const { data, isLoading } = useQuery({
+    queryKey: [
+      "widget-field-values",
+      projectId,
+      view ?? null,
+      field,
+      range.start.getTime(),
+      range.end.getTime(),
+    ],
+    queryFn: () => api.fetchWidgetFieldValues(projectId, view!, field, range, user),
+    enabled: active,
+    staleTime: 30_000,
+  });
+  // Mask React Query's retained cache while inactive so a row that switched field
+  // or to a non-enumerable op reports no values rather than a stale list.
+  return active ? { values: data?.values ?? [], isLoading } : { values: [], isLoading: false };
+}
+
+export function useWidgetPreview(projectId: string, draft: unknown, range: TimeRange) {
+  const { user, sessionReady } = useTraceApiUser();
+
+  return useQuery({
+    queryKey: [
+      "widget-preview",
+      projectId,
+      JSON.stringify(draft),
+      range.start.getTime(),
+      range.end.getTime(),
+    ],
+    queryFn: () => api.runWidgetQuery(projectId, parseSpec(draft)!, range, user),
+    enabled: sessionReady && !!projectId && isSpecComplete(draft),
+    staleTime: 10_000,
+    retry: false,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/frontend/ui/src/lib/hooks/use-trace-api-user.ts
+++ b/frontend/ui/src/lib/hooks/use-trace-api-user.ts
@@ -1,0 +1,15 @@
+import { useSession as useAuthSession } from "@/lib/auth-client";
+import type { TraceApiUser } from "@/lib/api/client";
+
+/**
+ * Session-derived identity for trace-api calls: `user` for the request
+ * headers and `sessionReady` to gate queries until auth has resolved.
+ */
+export function useTraceApiUser(): { user: TraceApiUser | undefined; sessionReady: boolean } {
+  const { data: authSession, isPending } = useAuthSession();
+  const sessionReady = !isPending && !!authSession?.user;
+  const user = authSession?.user
+    ? { id: authSession.user.id, email: authSession.user.email }
+    : undefined;
+  return { user, sessionReady };
+}


### PR DESCRIPTION
Fifth PR in the stacked project-dashboards series (epic #1460), stacked on #1512. The react-query hooks layer between the PR-4 data layer and the coming UI — no components in this slice; consumers (renderers, cards/grid, builder, pages) arrive next.

## What's here
- **useDashboards / useDashboard / useDashboardMutations** (`hooks/use-dashboards.ts`) — list and detail queries plus create/update/delete/layout mutations. The open dashboard refetches on a 30s interval so teammates' edits appear without a refocus, and mutations broadcast query invalidation across browser tabs.
- **useWidgetSchema / useWidgetData / useWidgetFieldValues / useWidgetPreview** (`hooks/use-widget-data.ts`) — builder registry fetch, widget query execution (previous data kept while a new time window loads), stored-value dropdowns, and a draft preview that only fires once the spec parses complete.
- **useTraceApiUser** (`lib/hooks/use-trace-api-user.ts`) — session-derived identity for trace-api calls: user for request headers plus a `sessionReady` gate so queries wait for auth to resolve.

advances #1453, advances #1454

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `@tanstack/react-query` hooks for dashboards and widgets, with polling, optimistic updates, and cross-tab invalidation to power the upcoming UI. Queries are gated on session state for reliable auth. Progress toward Linear #1453 and #1454.

- New Features
  - Dashboards: `useDashboards`, `useDashboard`, `useDashboardMutations`
    - 30s refetch on open dashboards, optimistic layout writes, and cross-tab query invalidation.
  - Widgets: `useWidgetSchema`, `useWidgetData`, `useWidgetFieldValues`, `useWidgetPreview`
    - Keeps previous data while time windows change, lazy field-value fetches scoped to range, and preview only when the draft spec is complete.
  - Auth: `useTraceApiUser`
    - Provides `{ user, sessionReady }` so all trace-API queries wait for auth before firing.

<sup>Written for commit 59c9c5588288c711d034a6020cb4bb58d8d74d59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

