### PR TITLE
feat(ui): widget chart renderers

### DIFF
--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -1,0 +1,349 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { cloneElement, isValidElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WidgetQueryResult } from "../types";
+import {
+  ChartTip,
+  QueryWidgetRenderer,
+  bucketLabel,
+  fmtStatNumber,
+  seriesNameFormatter,
+} from "./renderers";
+
+// jsdom reports 0x0 for the container recharts measures against, so
+// ResponsiveContainer renders nothing. Stub it with a fixed-size div and, like
+// the real ResponsiveContainer, clone the chart child with explicit
+// width/height props so it actually mounts and produces SVG output.
+vi.mock("recharts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("recharts")>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({
+      children,
+    }: {
+      children:
+        | React.ReactElement
+        | ((size: { width: number; height: number }) => React.ReactElement);
+    }) => {
+      const size = { width: 800, height: 400 };
+      const chart = typeof children === "function" ? children(size) : children;
+      return (
+        <div style={{ width: size.width, height: size.height }}>
+          {isValidElement(chart) ? cloneElement(chart, size) : chart}
+        </div>
+      );
+    },
+  };
+});
+
+function makeResult(
+  columns: string[],
+  rows: WidgetQueryResult["rows"],
+  meta: WidgetQueryResult["meta"] = {},
+): WidgetQueryResult {
+  return { columns, rows, meta };
+}
+
+describe("QueryWidgetRenderer", () => {
+  afterEach(cleanup);
+
+  describe("number display", () => {
+    it("renders the formatted stat, coercing a Decimal string from the query engine", () => {
+      const result = makeResult(["value"], [["12.3456"]]);
+      render(<QueryWidgetRenderer display="number" result={result} />);
+      expect(screen.getByText("12.3456")).toBeTruthy();
+    });
+
+    it("shows the empty state instead of a stat when there are no rows", () => {
+      const result = makeResult(["value"], []);
+      render(<QueryWidgetRenderer display="number" result={result} />);
+      expect(screen.getByText("No data in range")).toBeTruthy();
+    });
+  });
+
+  describe("table display", () => {
+    it("renders a header per column and a formatted cell per row value", () => {
+      const result = makeResult(
+        ["model_name", "count"],
+        [
+          ["gpt-4o", 10],
+          ["haiku", "5.5000"],
+        ],
+      );
+      render(<QueryWidgetRenderer display="table" result={result} />);
+      expect(screen.getByText("model_name")).toBeTruthy();
+      expect(screen.getByText("count")).toBeTruthy();
+      expect(screen.getByText("gpt-4o")).toBeTruthy();
+      expect(screen.getByText("haiku")).toBeTruthy();
+      expect(screen.getByText("10")).toBeTruthy();
+      // Decimal string cell is formatted like fmtNumber would format it.
+      expect(screen.getByText("5.5")).toBeTruthy();
+    });
+
+    it("renders dimension cells verbatim and only formats the metric column", () => {
+      const result = makeResult(
+        ["user_id", "value"],
+        [
+          // Numeric-looking identifiers must not be reformatted: past 2^53
+          // Number() loses the final digits, and "0123" would drop its zero.
+          ["9007199254740993", "5.5000"],
+          ["0123", 10],
+        ],
+      );
+      render(<QueryWidgetRenderer display="table" result={result} />);
+      expect(screen.getByText("9007199254740993")).toBeTruthy();
+      expect(screen.getByText("0123")).toBeTruthy();
+      // The metric column keeps fmtNumber formatting.
+      expect(screen.getByText("5.5")).toBeTruthy();
+      expect(screen.getByText("10")).toBeTruthy();
+    });
+
+    it("shows the empty state instead of a table when there are no rows", () => {
+      const result = makeResult(["model_name", "count"], []);
+      render(<QueryWidgetRenderer display="table" result={result} />);
+      expect(screen.getByText("No data in range")).toBeTruthy();
+      expect(screen.queryByRole("table")).toBeNull();
+    });
+  });
+
+  describe("line/area (timeseries) display", () => {
+    const bucketedRows: WidgetQueryResult["rows"] = [
+      ["2026-06-01T00:00:00", "gpt-4o", 1],
+      ["2026-06-01T00:00:00", "haiku", 2],
+      ["2026-06-02T00:00:00", "gpt-4o", 3],
+    ];
+
+    it("renders a line chart with one series per breakdown value (hour granularity)", () => {
+      const result = makeResult(["bucket", "model_name", "value"], bucketedRows, {
+        granularity: "hour",
+      });
+      const { container } = render(<QueryWidgetRenderer display="line" result={result} />);
+      // Two breakdown series -> two <path class="recharts-line-curve">.
+      const lines = container.querySelectorAll(".recharts-line-curve");
+      expect(lines.length).toBe(2);
+      // Hour granularity keeps the "T" separator swapped for a space.
+      const ticks = Array.from(container.querySelectorAll(".recharts-cartesian-axis-tick-value"));
+      expect(ticks.some((t) => t.textContent?.includes(" ") && !t.textContent?.includes("T"))).toBe(
+        true,
+      );
+    });
+
+    it("renders an area chart for a plain (no-breakdown) bucketed series (day granularity)", () => {
+      const result = makeResult(
+        ["bucket", "value"],
+        [
+          ["2026-06-01T00:00:00", 5],
+          ["2026-06-02T00:00:00", 8],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(<QueryWidgetRenderer display="area" result={result} />);
+      const areas = container.querySelectorAll(".recharts-area-area");
+      expect(areas.length).toBe(1);
+      // Day granularity ticks are sliced to MM-DD (5 chars), no time component.
+      const ticks = Array.from(container.querySelectorAll(".recharts-cartesian-axis-tick-value"));
+      expect(ticks.some((t) => t.textContent === "06-01")).toBe(true);
+    });
+
+    it("shows the empty state instead of a chart when there are no rows", () => {
+      const result = makeResult(["bucket", "value"], [], { granularity: "hour" });
+      const { container } = render(<QueryWidgetRenderer display="line" result={result} />);
+      expect(screen.getByText("No data in range")).toBeTruthy();
+      expect(container.querySelectorAll(".recharts-line-curve").length).toBe(0);
+    });
+  });
+
+  describe("line/area empty-breakdown fallback", () => {
+    it("shows the empty state when every row is a WITH FILL gap row", () => {
+      const result = makeResult(
+        ["bucket", "model_name", "value"],
+        [
+          ["2026-06-01T00:00:00", "", 0],
+          ["2026-06-02T00:00:00", "", 0],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(<QueryWidgetRenderer display="line" result={result} />);
+      expect(screen.getByText("No data in range")).toBeTruthy();
+      expect(container.querySelectorAll(".recharts-line-curve").length).toBe(0);
+    });
+
+    it("keeps the flat zero line for a no-breakdown window of gap rows", () => {
+      const result = makeResult(
+        ["bucket", "value"],
+        [
+          ["2026-06-01T00:00:00", 0],
+          ["2026-06-02T00:00:00", 0],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(<QueryWidgetRenderer display="line" result={result} />);
+      expect(screen.queryByText("No data in range")).toBeNull();
+      expect(container.querySelectorAll(".recharts-line-curve").length).toBe(1);
+    });
+  });
+
+  describe("bar display", () => {
+    it("renders one bar cell per categorical group", () => {
+      const result = makeResult(
+        ["service", "value"],
+        [
+          ["api", 10],
+          ["worker", 20],
+          ["frontend", 5],
+        ],
+      );
+      const { container } = render(<QueryWidgetRenderer display="bar" result={result} />);
+      const cells = container.querySelectorAll(".recharts-bar-rectangle");
+      expect(cells.length).toBe(3);
+      expect(screen.getByText("api")).toBeTruthy();
+      expect(screen.getByText("worker")).toBeTruthy();
+      expect(screen.getByText("frontend")).toBeTruthy();
+    });
+  });
+
+  describe("pie display", () => {
+    // recharts v3's Pie derives its sectors from an internal store selector
+    // keyed off a measured chart offset; under jsdom (no real layout/
+    // ResizeObserver) that selector never resolves, so no <path> sectors
+    // materialize even with the ResponsiveContainer stub above (verified with
+    // a ResizeObserver polyfill and a getBoundingClientRect stub — neither
+    // unblocks it). What is verifiable is that the pie mounts without
+    // crashing and produces its chart surface and layer group.
+    it("mounts the pie chart surface for a categorical result without crashing", () => {
+      const result = makeResult(
+        ["service", "value"],
+        [
+          ["api", 10],
+          ["worker", 20],
+        ],
+      );
+      const { container } = render(<QueryWidgetRenderer display="pie" result={result} />);
+      expect(container.querySelector(".recharts-surface")).toBeTruthy();
+      expect(container.querySelector(".recharts-pie")).toBeTruthy();
+    });
+  });
+
+  describe("histogram display", () => {
+    it("renders bucket-range labels from lo/hi/height row tuples", () => {
+      const result = makeResult(
+        ["lo", "hi", "height"],
+        [
+          [0, 10, 3],
+          [10, 20, 7],
+        ],
+      );
+      const { container } = render(<QueryWidgetRenderer display="histogram" result={result} />);
+      const bars = container.querySelectorAll(".recharts-bar-rectangle");
+      expect(bars.length).toBe(2);
+      // Scoped to the container: recharts also parks a hidden text-measurement
+      // span with the same content directly on document.body.
+      expect(within(container).getByText("0–10")).toBeTruthy();
+      expect(within(container).getByText("10–20")).toBeTruthy();
+    });
+
+    it("shows the empty state instead of a chart when there are no rows", () => {
+      const result = makeResult(["lo", "hi", "height"], []);
+      render(<QueryWidgetRenderer display="histogram" result={result} />);
+      expect(screen.getByText("No data in range")).toBeTruthy();
+    });
+  });
+});
+
+describe("NumberView units", () => {
+  afterEach(cleanup);
+  const result = { columns: ["value"], rows: [["12.5"]], meta: {} };
+
+  it("prefixes cost values with the dollar sign", () => {
+    render(<QueryWidgetRenderer display="number" result={result} unit={{ prefix: "$" }} />);
+    expect(screen.getByText("$12.5")).toBeTruthy();
+  });
+
+  it("suffixes latency values with ms", () => {
+    render(<QueryWidgetRenderer display="number" result={result} unit={{ suffix: "ms" }} />);
+    expect(screen.getByText("12.5")).toBeTruthy();
+    expect(screen.getByText("ms")).toBeTruthy();
+  });
+
+  it("renders bare numbers when the measure has no unit", () => {
+    render(<QueryWidgetRenderer display="number" result={result} />);
+    expect(screen.getByText("12.5")).toBeTruthy();
+    expect(screen.queryByText("$12.5")).toBeNull();
+    expect(screen.queryByText("ms")).toBeNull();
+  });
+});
+
+describe("ChartTip", () => {
+  afterEach(cleanup);
+
+  it("renders nothing when inactive or when the payload is empty", () => {
+    const { container: inactive } = render(
+      <ChartTip active={false} payload={[{ name: "a", value: 1 }]} />,
+    );
+    expect(inactive.firstChild).toBeNull();
+
+    const { container: empty } = render(<ChartTip active payload={[]} />);
+    expect(empty.firstChild).toBeNull();
+  });
+
+  it("renders the label header and one swatch+name+value row per series", () => {
+    const { container } = render(
+      <ChartTip
+        active
+        label="2026-06-01T00:00:00"
+        labelFormatter={bucketLabel}
+        payload={[
+          { name: "gpt-4o", value: 10, color: "#a78bfa" },
+          { name: "haiku", value: "5.5000", payload: { fill: "#60a5fa" } },
+        ]}
+      />,
+    );
+
+    // Bucket label header with the "T" separator swapped for a space.
+    expect(screen.getByText("2026-06-01 00:00:00")).toBeTruthy();
+
+    expect(screen.getByText("gpt-4o")).toBeTruthy();
+    expect(screen.getByText("10")).toBeTruthy();
+    expect(screen.getByText("haiku")).toBeTruthy();
+    // Decimal strings from the query engine format like fmtNumber.
+    expect(screen.getByText("5.5")).toBeTruthy();
+
+    // Swatch color: the row's data fill wins over the series color.
+    const swatches = Array.from(container.querySelectorAll("div[style]")).map(
+      (el) => (el as HTMLElement).style.backgroundColor,
+    );
+    expect(swatches).toContain("rgb(167, 139, 250)");
+    expect(swatches).toContain("rgb(96, 165, 250)");
+  });
+
+  it("maps the synthetic single-series name to the spec's measure via the name formatter", () => {
+    render(
+      <ChartTip
+        active
+        payload={[{ name: "value", value: 3 }]}
+        nameFormatter={seriesNameFormatter("cost")}
+      />,
+    );
+    expect(screen.getByText("cost")).toBeTruthy();
+    expect(screen.queryByText("value")).toBeNull();
+  });
+
+  it("keeps breakdown names untouched and shows the raw name without a measure label", () => {
+    expect(seriesNameFormatter("cost")("gpt-4o")).toBe("gpt-4o");
+    expect(seriesNameFormatter(undefined)("value")).toBe("value");
+  });
+});
+
+describe("fmtStatNumber", () => {
+  it("compacts large magnitudes so tiles stay bounded", () => {
+    expect(fmtStatNumber(705877)).toBe("705.9K");
+    expect(fmtStatNumber("12345678")).toBe("12.3M");
+    expect(fmtStatNumber(-250000)).toBe("-250K");
+  });
+  it("keeps small values in full precision", () => {
+    expect(fmtStatNumber("12.5")).toBe("12.5");
+    expect(fmtStatNumber(99999)).toBe("99,999");
+    expect(fmtStatNumber(0.0004)).toBe("0.0004");
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/renderers.test.ts
+++ b/frontend/ui/src/features/dashboards/components/renderers.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import { fmtNumber, pivotRows } from "./renderers";
+
+describe("fmtNumber", () => {
+  it("formats a numeric string (Decimal from ClickHouse) as a formatted number", () => {
+    expect(fmtNumber("0.379846500")).toBe("0.3798");
+  });
+
+  it("returns non-numeric strings unchanged", () => {
+    expect(fmtNumber("not-a-number")).toBe("not-a-number");
+  });
+
+  it("returns an em dash for null", () => {
+    expect(fmtNumber(null)).toBe("—");
+  });
+});
+
+describe("pivotRows", () => {
+  it("pivots bucket+breakdown rows into one series per breakdown value, zero-filling missing combos", () => {
+    const out = pivotRows(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt-4o", 1],
+        ["2026-06-01T00:00:00", "haiku", 2],
+        ["2026-06-02T00:00:00", "gpt-4o", 3],
+      ],
+    );
+    expect(out.seriesKeys).toEqual(["gpt-4o", "haiku"]);
+    // haiku is missing from the second bucket — zero-filled to 0
+    expect(out.data).toEqual([
+      { bucket: "2026-06-01T00:00:00", "gpt-4o": 1, haiku: 2 },
+      { bucket: "2026-06-02T00:00:00", "gpt-4o": 3, haiku: 0 },
+    ]);
+  });
+
+  it("registers WITH FILL gap rows (empty dim, zero value) as buckets without creating a series", () => {
+    const out = pivotRows(
+      ["bucket", "model_name", "value"],
+      [
+        // Leading empty buckets synthesized by the query's WITH FILL.
+        ["2026-06-01T00:00:00", "", 0],
+        ["2026-06-02T00:00:00", "", "0"],
+        ["2026-06-03T00:00:00", "gpt-4o", 3],
+      ],
+    );
+    expect(out.seriesKeys).toEqual(["gpt-4o"]);
+    // The empty buckets extend the x-axis domain, zero-filled for the series.
+    expect(out.data).toEqual([
+      { bucket: "2026-06-01T00:00:00", "gpt-4o": 0 },
+      { bucket: "2026-06-02T00:00:00", "gpt-4o": 0 },
+      { bucket: "2026-06-03T00:00:00", "gpt-4o": 3 },
+    ]);
+  });
+
+  it("registers NULL gap rows as buckets too (a Nullable expr slipping the type pin)", () => {
+    const out = pivotRows(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", null, 0],
+        ["2026-06-02T00:00:00", "gpt-4o", 3],
+      ],
+    );
+    expect(out.seriesKeys).toEqual(["gpt-4o"]);
+    expect(out.data).toEqual([
+      { bucket: "2026-06-01T00:00:00", "gpt-4o": 0 },
+      { bucket: "2026-06-02T00:00:00", "gpt-4o": 3 },
+    ]);
+  });
+
+  it("keeps a genuine empty-string dim with a nonzero value as a real series", () => {
+    const out = pivotRows(["bucket", "model_name", "value"], [["2026-06-01T00:00:00", "", 2]]);
+    expect(out.seriesKeys).toEqual([""]);
+    expect(out.data).toEqual([{ bucket: "2026-06-01T00:00:00", "": 2 }]);
+  });
+
+  it("handles no-breakdown shape (bucket+value)", () => {
+    const out = pivotRows(["bucket", "value"], [["2026-06-01", 5]]);
+    expect(out.seriesKeys).toEqual(["value"]);
+    expect(out.data).toEqual([{ bucket: "2026-06-01", value: 5 }]);
+  });
+
+  it("coerces Decimal strings from the query engine to numbers in every shape", () => {
+    // recharts (the pie especially) can't plot string values.
+    expect(pivotRows(["bucket", "value"], [["2026-06-01", "5.5000"]]).data).toEqual([
+      { bucket: "2026-06-01", value: 5.5 },
+    ]);
+    expect(pivotRows(["model_name", "value"], [["gpt-4o", "1.2345"]]).data).toEqual([
+      { name: "gpt-4o", value: 1.2345 },
+    ]);
+    expect(
+      pivotRows(["bucket", "model_name", "value"], [["2026-06-01", "gpt-4o", "2.5"]]).data,
+    ).toEqual([{ bucket: "2026-06-01", "gpt-4o": 2.5 }]);
+  });
+
+  it("handles categorical [dim, value] shape (no bucket)", () => {
+    const out = pivotRows(
+      ["service", "value"],
+      [
+        ["api", 10],
+        ["worker", 20],
+        ["frontend", 5],
+      ],
+    );
+    expect(out.seriesKeys).toEqual(["api", "worker", "frontend"]);
+    expect(out.data).toEqual([
+      { name: "api", value: 10 },
+      { name: "worker", value: 20 },
+      { name: "frontend", value: 5 },
+    ]);
+  });
+
+  it("treats null dim values as the string 'null' in the bucketed branch", () => {
+    const out = pivotRows(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", null, 7],
+        ["2026-06-01T00:00:00", "haiku", 3],
+      ],
+    );
+    expect(out.seriesKeys).toContain("null");
+    expect(out.data[0]).toMatchObject({ null: 7, haiku: 3 });
+  });
+
+  it("prefixes dim values that collide with row shape keys (e.g. 'bucket')", () => {
+    // A dimension value literally named "bucket" must be stored as "series:bucket"
+    // so it does not overwrite the pivot row's own `bucket` timestamp key.
+    const out = pivotRows(
+      ["bucket", "model", "value"],
+      [
+        ["2026-06-01T00:00:00", "bucket", 10],
+        ["2026-06-01T00:00:00", "gpt-4o", 20],
+      ],
+    );
+    expect(out.seriesKeys).toContain("series:bucket");
+    expect((out.data[0] as Record<string, unknown>)["bucket"]).toBe("2026-06-01T00:00:00");
+  });
+
+  it("zero-fills a series that only appears in the middle bucket for first and last buckets", () => {
+    // "rare-model" only has data in the second of three buckets; the first and
+    // last must be zero-filled so chart lines are continuous and honest.
+    const out = pivotRows(
+      ["bucket", "model", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt-4o", 1],
+        ["2026-06-02T00:00:00", "gpt-4o", 2],
+        ["2026-06-02T00:00:00", "rare-model", 5],
+        ["2026-06-03T00:00:00", "gpt-4o", 3],
+      ],
+    );
+    expect(out.seriesKeys).toContain("rare-model");
+    const d = out.data as Record<string, unknown>[];
+    expect(d[0]["rare-model"]).toBe(0); // first bucket: zero-filled
+    expect(d[2]["rare-model"]).toBe(0); // last bucket: zero-filled
+    expect(d[1]["rare-model"]).toBe(5); // middle bucket: real value
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -1,0 +1,459 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { DisplayType, FieldUnit, WidgetQueryResult } from "../types";
+
+// Pastel series palette mirroring the span-kind tints
+// (violet=llm, blue=agent, amber=tool, slate=span), then softened extras.
+export const SERIES_COLORS = [
+  "#a78bfa",
+  "#60a5fa",
+  "#fbbf24",
+  "#94a3b8",
+  "#34d399",
+  "#f472b6",
+  "#22d3ee",
+  "#fb923c",
+];
+
+const seriesColor = (i: number) => SERIES_COLORS[i % SERIES_COLORS.length];
+
+// Recharts marks its wrapper and SVG internals keyboard-focusable, so clicking
+// anywhere in a chart paints the browser's focus outline around the clicked
+// wrapper/layer/sector — suppress it on every chart surface.
+const CHART_FOCUS_RESET =
+  "[&_.recharts-wrapper]:outline-none [&_.recharts-surface]:outline-none " +
+  "[&_.recharts-layer]:outline-none [&_.recharts-sector]:outline-none";
+
+// ClickHouse returns Decimal columns as strings; coerce them before charting
+// or formatting — recharts (the pie especially) can't plot string values.
+const coerceNumeric = (v: unknown): unknown =>
+  typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v)) ? Number(v) : v;
+
+export function pivotRows(columns: string[], rows: WidgetQueryResult["rows"]) {
+  // Shapes: [value] | [bucket, value] | [dim, value] | [bucket, dim, value]
+  const valueIdx = columns.length - 1;
+  const hasBucket = columns[0] === "bucket";
+  const dimIdx = hasBucket ? (columns.length === 3 ? 1 : -1) : columns.length === 2 ? 0 : -1;
+
+  if (dimIdx === -1) {
+    const key = hasBucket ? "bucket" : columns[0];
+    return {
+      seriesKeys: ["value"],
+      data: rows.map((r) => ({
+        [key]: r[0],
+        value: coerceNumeric(r[valueIdx]),
+      })) as Record<string, unknown>[],
+    };
+  }
+
+  if (!hasBucket) {
+    // categorical: one row per dimension value
+    return {
+      seriesKeys: rows.map((r) => String(r[dimIdx] ?? "null")),
+      data: rows.map((r) => ({
+        name: String(r[dimIdx] ?? "null"),
+        value: coerceNumeric(r[valueIdx]),
+      })),
+    };
+  }
+
+  const seriesKeys: string[] = [];
+  // O(1) membership check alongside the ordered array
+  const seriesKeySet = new Set<string>();
+  const byBucket = new Map<string, Record<string, unknown>>();
+
+  for (const r of rows) {
+    const bucket = String(r[0]);
+    const rawDim = r[dimIdx];
+    // The query's WITH FILL synthesizes rows for empty buckets, carrying the
+    // breakdown column's default ('' — or NULL if a Nullable expr ever slips
+    // past the compiler's type pin) and a zero value. They extend the x-axis
+    // domain but are not a series: register the bucket and move on.
+    if ((rawDim === "" || rawDim == null) && !Number(r[valueIdx])) {
+      if (!byBucket.has(bucket)) byBucket.set(bucket, { bucket });
+      continue;
+    }
+    // Guard against key collisions with internal properties: if a dim value is
+    // "bucket" or "__proto__", prefix it so it doesn't stomp on the pivot row shape.
+    const dim =
+      rawDim === "bucket" || rawDim === "__proto__" ? `series:${rawDim}` : String(rawDim ?? "null");
+
+    if (!seriesKeySet.has(dim)) {
+      seriesKeys.push(dim);
+      seriesKeySet.add(dim);
+    }
+    if (!byBucket.has(bucket)) byBucket.set(bucket, { bucket });
+    byBucket.get(bucket)![dim] = coerceNumeric(r[valueIdx]);
+  }
+
+  // Uniform zero-fill: missing series keys per bucket are set to 0 so
+  // line/area charts tell the same story. Honest for count/sum (the dominant
+  // dashboard aggregations), slightly lossy for percentile gaps — accepted tradeoff.
+  const data = [...byBucket.values()].map((row) => {
+    const filled = { ...row };
+    for (const k of seriesKeys) {
+      if (!Object.hasOwn(filled, k)) filled[k] = 0;
+    }
+    return filled;
+  });
+
+  return { seriesKeys, data };
+}
+
+export const fmtNumber = (v: unknown) => {
+  const n = coerceNumeric(v);
+  if (typeof n !== "number") return String(n ?? "—");
+  const abs = Math.abs(n);
+  // Tiny non-zero values (e.g. sub-millidollar costs) would round to "0" with
+  // maximumFractionDigits:4; fall back to significant-digit formatting instead.
+  if (abs > 0 && abs < 0.001) {
+    return Intl.NumberFormat("en", { maximumSignificantDigits: 2 }).format(n);
+  }
+  return Intl.NumberFormat("en", { maximumFractionDigits: 4 }).format(n);
+};
+
+// The query engine aliases the metric column literally as "value", which is
+// also the single-series dataKey recharts reports as the tooltip name. When
+// the caller passes the spec's measure name, show that instead; breakdown
+// series keep their own names.
+export const seriesNameFormatter = (seriesLabel?: string) => (name: string) =>
+  name === "value" && seriesLabel ? seriesLabel : name;
+
+// Bucket keys come back ISO-ish ("2026-06-01T00:00:00"); a space reads better
+// in the tooltip header than the "T" separator.
+export const bucketLabel = (label: unknown) => String(label).replace("T", " ");
+
+// Hover popup shared by every chart display: a card with an optional bold
+// label header (time bucket / category) and one row per series — a color
+// swatch square, the series name in muted text, and the value right-aligned
+// in tabular figures.
+export function ChartTip({
+  active,
+  payload,
+  label,
+  nameFormatter,
+  labelFormatter,
+}: {
+  active?: boolean;
+  payload?: {
+    name?: string | number;
+    value?: unknown;
+    color?: string;
+    payload?: { fill?: string };
+  }[];
+  label?: unknown;
+  nameFormatter?: (name: string) => string;
+  labelFormatter?: (label: unknown) => string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="grid min-w-32 gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl">
+      {label != null && label !== "" && (
+        <div className="font-medium">{labelFormatter ? labelFormatter(label) : String(label)}</div>
+      )}
+      <div className="grid gap-1.5">
+        {payload.map((item, i) => {
+          const rawName = String(item.name ?? "");
+          return (
+            <div key={i} className="flex w-full items-center gap-2">
+              <div
+                className="h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                style={{ backgroundColor: item.payload?.fill ?? item.color ?? "currentColor" }}
+              />
+              <div className="flex min-w-0 flex-1 items-center justify-between gap-x-3 leading-tight">
+                <span className="truncate text-muted-foreground">
+                  {nameFormatter ? nameFormatter(rawName) : rawName}
+                </span>
+                <span className="shrink-0 whitespace-nowrap font-mono font-medium tabular-nums text-foreground">
+                  {fmtNumber(item.value)}
+                </span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// Categorical rows tinted per-index; the `fill` on each row is also what the
+// tooltip payload reads for its swatch.
+function useColoredRows(result: WidgetQueryResult) {
+  return useMemo(
+    () =>
+      pivotRows(result.columns, result.rows).data.map((d, i) => ({
+        ...d,
+        fill: seriesColor(i),
+      })),
+    [result],
+  );
+}
+
+function TimeSeries({
+  result,
+  area,
+  seriesLabel,
+}: {
+  result: WidgetQueryResult;
+  area: boolean;
+  seriesLabel?: string;
+}) {
+  const { seriesKeys, data } = useMemo(() => pivotRows(result.columns, result.rows), [result]);
+  const Chart = area ? AreaChart : LineChart;
+  const granularity = result.meta.granularity;
+
+  // A breakdown window where every row is a WITH FILL gap row pivots to zero
+  // series — show the empty state rather than a bare grid. (No-breakdown
+  // all-zero windows keep their flat zero line: the "value" series exists.)
+  if (seriesKeys.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
+        No data in range
+      </div>
+    );
+  }
+
+  const tickFormatter =
+    granularity === "day"
+      ? (v: unknown) => String(v).slice(5, 10)
+      : granularity === "hour"
+        ? (v: unknown) => String(v).slice(5, 16).replace("T", " ")
+        : (v: unknown) => String(v).slice(5, 16);
+
+  return (
+    <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
+      <Chart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+        <CartesianGrid strokeOpacity={0.15} vertical={false} />
+        <XAxis dataKey="bucket" tick={{ fontSize: 10 }} tickFormatter={tickFormatter} />
+        <YAxis tick={{ fontSize: 10 }} width={42} />
+        <Tooltip
+          isAnimationActive={false}
+          content={
+            <ChartTip
+              nameFormatter={seriesNameFormatter(seriesLabel)}
+              labelFormatter={bucketLabel}
+            />
+          }
+        />
+        {/* isAnimationActive={false} on every mark (here and in the other
+            charts): the default ~1.4s geometry morph makes charts visibly lag
+            behind their tile during grid resizes and data refreshes. */}
+        {seriesKeys.map((k, i) =>
+          area ? (
+            <Area
+              key={k}
+              dataKey={k}
+              stackId="1"
+              stroke={seriesColor(i)}
+              fill={seriesColor(i)}
+              fillOpacity={0.35}
+              isAnimationActive={false}
+            />
+          ) : (
+            <Line
+              key={k}
+              dataKey={k}
+              stroke={seriesColor(i)}
+              dot={false}
+              strokeWidth={1.5}
+              isAnimationActive={false}
+            />
+          ),
+        )}
+      </Chart>
+    </ResponsiveContainer>
+  );
+}
+
+function Bars({ result, seriesLabel }: { result: WidgetQueryResult; seriesLabel?: string }) {
+  const data = useColoredRows(result);
+  return (
+    <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
+      <BarChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+        <CartesianGrid strokeOpacity={0.15} vertical={false} />
+        <XAxis dataKey="name" tick={{ fontSize: 10 }} />
+        <YAxis tick={{ fontSize: 10 }} width={42} />
+        <Tooltip
+          isAnimationActive={false}
+          content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} />}
+        />
+        <Bar dataKey="value" isAnimationActive={false}>
+          {data.map((_, i) => (
+            <Cell key={i} fill={seriesColor(i)} fillOpacity={0.7} stroke={seriesColor(i)} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+function PieView({ result }: { result: WidgetQueryResult }) {
+  const data = useColoredRows(result);
+  return (
+    <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
+      <PieChart>
+        <Tooltip isAnimationActive={false} content={<ChartTip />} />
+        {/* Pie reads each sector's fill from its data row — no Cells needed. */}
+        <Pie
+          data={data}
+          dataKey="value"
+          nameKey="name"
+          innerRadius="45%"
+          outerRadius="80%"
+          isAnimationActive={false}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}
+
+// Stat values must stay inside a fixed tile no matter how many digits arrive:
+// large magnitudes compact ("706K", "12.3M") so the glyph count is bounded,
+// and the font clamps to the tile's width for narrow resizes.
+export const fmtStatNumber = (v: unknown) => {
+  const n = coerceNumeric(v);
+  if (typeof n === "number" && Math.abs(n) >= 100_000) {
+    return Intl.NumberFormat("en", { notation: "compact", maximumFractionDigits: 1 }).format(n);
+  }
+  return fmtNumber(v);
+};
+
+function NumberView({ result, unit }: { result: WidgetQueryResult; unit?: FieldUnit }) {
+  const value = result.rows[0]?.[result.columns.length - 1];
+  return (
+    <div className="flex h-full items-center justify-center overflow-hidden [container-type:inline-size]">
+      <div className="flex min-w-0 items-baseline gap-1">
+        <span
+          className="whitespace-nowrap font-semibold"
+          style={{ fontSize: "clamp(1rem, 19cqw, 1.875rem)" }}
+        >
+          {unit?.prefix}
+          {fmtStatNumber(value)}
+        </span>
+        {unit?.suffix && <span className="text-[13px] text-muted-foreground">{unit.suffix}</span>}
+      </div>
+    </div>
+  );
+}
+
+function TableView({ result }: { result: WidgetQueryResult }) {
+  // Only the metric column (always last, aliased "value" by the compiler) is
+  // numeric — formatting every cell reformats string dimensions too, and a
+  // numeric-looking identifier (user_id, session_id) silently loses digits
+  // past 2^53 or its leading zeros in Number() coercion.
+  const valueIdx = result.columns.length - 1;
+  return (
+    <div className="h-full overflow-auto">
+      <table className="w-full text-[11.5px]">
+        <thead>
+          <tr className="text-left text-[10px] uppercase tracking-wide text-muted-foreground">
+            {result.columns.map((c) => (
+              <th key={c} className="pb-1.5 pr-3 font-medium">
+                {c}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {result.rows.map((r, i) => (
+            <tr key={i} className="border-t border-border/60">
+              {r.map((v, j) => (
+                <td key={j} className="py-1 pr-3">
+                  {j === valueIdx ? fmtNumber(v) : v == null ? "—" : String(v)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function HistogramView({
+  result,
+  seriesLabel,
+}: {
+  result: WidgetQueryResult;
+  seriesLabel?: string;
+}) {
+  // rows: [lo, hi, height]
+  const data = result.rows.map((r) => ({
+    name: `${fmtNumber(r[0])}–${fmtNumber(r[1])}`,
+    value: r[2],
+    fill: "#93c5fd",
+  }));
+  return (
+    <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
+      <BarChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+        <XAxis dataKey="name" tick={{ fontSize: 9 }} interval="preserveStartEnd" />
+        <YAxis tick={{ fontSize: 10 }} width={42} />
+        <Tooltip
+          isAnimationActive={false}
+          content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} />}
+        />
+        <Bar
+          dataKey="value"
+          fill="#93c5fd"
+          fillOpacity={0.7}
+          stroke="#60a5fa"
+          isAnimationActive={false}
+        />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+export function QueryWidgetRenderer({
+  display,
+  result,
+  unit,
+  seriesLabel,
+}: {
+  display: DisplayType;
+  result: WidgetQueryResult;
+  unit?: FieldUnit;
+  /** Measure name from the widget spec, shown as the single-series tooltip row name. */
+  seriesLabel?: string;
+}) {
+  if (result.rows.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
+        No data in range
+      </div>
+    );
+  }
+  switch (display) {
+    case "line":
+      return <TimeSeries result={result} area={false} seriesLabel={seriesLabel} />;
+    case "area":
+      return <TimeSeries result={result} area seriesLabel={seriesLabel} />;
+    case "bar":
+      return <Bars result={result} seriesLabel={seriesLabel} />;
+    case "pie":
+      return <PieView result={result} />;
+    case "number":
+      return <NumberView result={result} unit={unit} />;
+    case "table":
+      return <TableView result={result} />;
+    case "histogram":
+      return <HistogramView result={result} seriesLabel={seriesLabel} />;
+  }
+}


### PR DESCRIPTION
Sixth PR in the stacked project-dashboards series (epic #1460), stacked on #1513. One self-contained renderer module, deliberately kept whole: `QueryWidgetRenderer` maps a widget query result onto its display type. No consumers yet — the widget card and grid arrive next in the stack.

## What's here
- **QueryWidgetRenderer** (`components/renderers.tsx`) — recharts line/area/bar/pie, a stat tile for number displays, a bucketed histogram, and a plain table, selected by the spec's display type.
- **pivotRows** — reshapes the engine's long-format `(bucket, series, value)` rows into recharts' wide format, coercing ClickHouse Decimal strings to numbers (recharts can't compute geometry from strings) and guarding key collisions (`__proto__`, a series literally named "bucket").
- **Shared chart chrome** — one in-place hover tooltip, number formatting with field unit prefixes/suffixes (`$`, `ms`), compact stat-tile formatting, a fixed series palette, and time-axis labels that span the query's full window (the compiler emits WITH FILL, so empty buckets render as zeros rather than a truncated axis).
- **Rendering details** — table dimension cells render verbatim (no numeric reformatting of ids), and charts remeasure instantly when their tile is resized.
- **Tests** split by environment: pivot/format logic in a node-env file; chart DOM assertions under jsdom with recharts' `ResponsiveContainer` mocked to a fixed size.

advances #1453

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `QueryWidgetRenderer` to render dashboard widgets (line, area, bar, pie, histogram, number, table) using `recharts` with a shared tooltip and number formatting. Supports full-window time axes, units, and empty states. Advances #1453 in the project dashboards epic (#1460).

- New Features
  - `pivotRows` reshapes long rows to wide for `recharts`, coerces Decimal strings to numbers, and guards key collisions.
  - Time series: one series per breakdown, stacked area option; x-axis spans the query window (WITH FILL) with day/hour tick formats.
  - Shared UI: `ChartTip`, fixed color palette, compact stat formatting with unit prefix/suffix, resize-aware charts, and focus-outline reset.
  - Table: dimension cells render verbatim; only the metric column is formatted.
  - Tests cover pivot/format logic and chart DOM with a mocked `ResponsiveContainer`.

<sup>Written for commit 5aa7e92f58dfe44e9c09e38f610dda4ce9afc0f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

