### PR TITLE
feat(ui): trace feed widget and filter rows with stored-value dropdowns

### DIFF
--- a/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WidgetSchemaField } from "../types";
+import { FilterRow } from "./FilterRow";
+
+vi.mock("../hooks/use-widget-data", () => ({ useWidgetFieldValues: vi.fn() }));
+import { useWidgetFieldValues } from "../hooks/use-widget-data";
+
+const stringField: WidgetSchemaField = {
+  type: "string",
+  label: "Model",
+  filterOps: ["=", "!=", "contains"],
+  groupable: true,
+  aggs: [],
+};
+const numberField: WidgetSchemaField = {
+  type: "number",
+  label: "Cost",
+  filterOps: [">", ">=", "<", "<=", "=", "!="],
+  groupable: false,
+  aggs: ["sum"],
+};
+const durationField: WidgetSchemaField = { ...numberField, label: "Duration" };
+
+const baseProps = {
+  index: 0,
+  filterableFields: [
+    ["model_name", stringField],
+    ["cost", numberField],
+    ["duration_ms", durationField],
+  ] as [string, WidgetSchemaField][],
+  fieldsMap: { model_name: stringField, cost: numberField, duration_ms: durationField },
+  onChange: vi.fn(),
+  onRemove: vi.fn(),
+  projectId: "p1",
+  view: "spans" as const,
+  range: { start: new Date("2026-06-01T00:00:00Z"), end: new Date("2026-06-02T00:00:00Z") },
+};
+
+describe("FilterRow value input", () => {
+  // RTL auto-cleanup needs vitest globals, which this config doesn't enable.
+  afterEach(cleanup);
+
+  it("offers stored values with counts for string equality, and selecting one propagates", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({
+      values: [{ value: "gpt-4o", count: 3 }],
+      isLoading: false,
+    });
+    const onChange = vi.fn();
+    render(
+      <FilterRow
+        {...baseProps}
+        onChange={onChange}
+        filter={{ field: "model_name", op: "=", value: "" }}
+      />,
+    );
+    // field + op selects; the value control is the trace-list popover dropdown
+    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    expect(screen.queryByRole("textbox")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Value" }));
+    const option = screen.getByRole("option", { name: /gpt-4o/ });
+    // the stored value's occurrence count is shown alongside it
+    expect(option.textContent).toContain("3");
+    fireEvent.click(option);
+    expect(onChange).toHaveBeenCalledWith(0, { value: "gpt-4o" });
+  });
+
+  it("keeps free text for contains", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    render(
+      <FilterRow {...baseProps} filter={{ field: "model_name", op: "contains", value: "gp" }} />,
+    );
+    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    expect(screen.getByRole("textbox")).toBeTruthy();
+    // the hook is parked while the op is not enumerable
+    expect(vi.mocked(useWidgetFieldValues).mock.lastCall?.[4]).toBe(false);
+  });
+
+  it("falls back to free text when no stored values exist", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    render(<FilterRow {...baseProps} filter={{ field: "model_name", op: "=", value: "" }} />);
+    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    expect(screen.getByRole("textbox")).toBeTruthy();
+  });
+
+  it("keeps the number input for numeric fields", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    render(<FilterRow {...baseProps} filter={{ field: "cost", op: ">", value: 5 }} />);
+    expect(screen.getByRole("spinbutton")).toBeTruthy();
+    expect(vi.mocked(useWidgetFieldValues).mock.lastCall?.[4]).toBe(false);
+  });
+
+  it("shows trace-list wording for string ops and symbols for numeric ops", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    const { unmount } = render(
+      <FilterRow {...baseProps} filter={{ field: "model_name", op: "=", value: "" }} />,
+    );
+    expect(screen.getByText("is")).toBeTruthy();
+    unmount();
+
+    render(<FilterRow {...baseProps} filter={{ field: "cost", op: ">=", value: 5 }} />);
+    expect(screen.getByText("≥")).toBeTruthy();
+  });
+
+  it("adorns cost and duration values with their unit like the trace-list builder", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    const { unmount } = render(
+      <FilterRow {...baseProps} filter={{ field: "cost", op: ">", value: 1 }} />,
+    );
+    expect(screen.getByText("$")).toBeTruthy();
+    unmount();
+
+    render(<FilterRow {...baseProps} filter={{ field: "duration_ms", op: ">", value: 100 }} />);
+    expect(screen.getByText("ms")).toBeTruthy();
+  });
+
+  it("free-text edits still propagate through onChange", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    const onChange = vi.fn();
+    render(
+      <FilterRow
+        {...baseProps}
+        onChange={onChange}
+        filter={{ field: "model_name", op: "contains", value: "" }}
+      />,
+    );
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "claude" } });
+    expect(onChange).toHaveBeenCalledWith(0, { value: "claude" });
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/FilterRow.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useMemo } from "react";
+import { X } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ValueDropdown } from "@/features/filters/filter-builder";
+import { fieldIcon } from "./field-icons";
+import { useWidgetFieldValues } from "../hooks/use-widget-data";
+import {
+  FIELD_UNIT,
+  filterOpLabel,
+  isEnumerableFilter,
+  type TimeRange,
+  type WidgetSchemaField,
+} from "../types";
+
+export function FilterRow({
+  index,
+  filter,
+  filterableFields,
+  fieldsMap,
+  onChange,
+  onRemove,
+  projectId,
+  view,
+  range,
+}: {
+  index: number;
+  filter: { field: string; op: string; value: string | number };
+  filterableFields: [string, WidgetSchemaField][];
+  fieldsMap: Record<string, WidgetSchemaField>;
+  onChange: (
+    idx: number,
+    patch: Partial<{ field: string; op: string; value: string | number }>,
+  ) => void;
+  onRemove: (idx: number) => void;
+  projectId: string;
+  view: "spans" | "traces" | undefined;
+  range: TimeRange;
+}) {
+  const fieldMeta = fieldsMap[filter.field];
+  const ops = fieldMeta?.filterOps ?? [];
+  const isNumeric = fieldMeta?.type === "number";
+
+  // Equality on a string dimension offers the field's stored values as a
+  // dropdown; contains and numeric comparisons stay free inputs.
+  const enumerable = isEnumerableFilter(fieldMeta, filter.op);
+  const { values, isLoading } = useWidgetFieldValues(
+    projectId,
+    view,
+    filter.field,
+    range,
+    enumerable,
+  );
+
+  // Keep a previously-saved value selectable even when it no longer occurs in
+  // the active window's stored values (it gets no count, marking it as stale).
+  const options = useMemo(() => {
+    const current = String(filter.value);
+    const hasCurrent = values.some((v) => v.value === current);
+    return current && !hasCurrent ? [{ value: current }, ...values] : values;
+  }, [values, filter.value]);
+
+  const showValueDropdown = enumerable && (options.length > 0 || isLoading);
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {/* field */}
+      <Select
+        value={filter.field}
+        onValueChange={(v) => onChange(index, { field: v, op: "", value: "" })}
+      >
+        <SelectTrigger className="h-7 flex-1 text-[12px]">
+          <SelectValue placeholder="Field" />
+        </SelectTrigger>
+        <SelectContent>
+          {filterableFields.map(([key, meta]) => {
+            const Icon = fieldIcon(key);
+            return (
+              <SelectItem
+                key={key}
+                value={key}
+                className="text-[12px]"
+                icon={<Icon className="h-3.5 w-3.5 text-muted-foreground" />}
+              >
+                {meta.label}
+              </SelectItem>
+            );
+          })}
+        </SelectContent>
+      </Select>
+
+      {/* op — labeled with the trace-list filter vocabulary (is / is not / ≥ / ≤ / ≠) */}
+      <Select
+        value={filter.op}
+        onValueChange={(v) => onChange(index, { op: v })}
+        disabled={!filter.field}
+      >
+        <SelectTrigger className="h-7 w-24 text-[12px]">
+          <SelectValue placeholder="Op">
+            {filter.op ? filterOpLabel(fieldMeta, filter.op) : undefined}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          {ops.map((op) => (
+            <SelectItem key={op} value={op} className="text-[12px]">
+              {filterOpLabel(fieldMeta, op)}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* value — the trace-list stored-values picker, counts included */}
+      {showValueDropdown ? (
+        <ValueDropdown
+          value={String(filter.value)}
+          options={options}
+          onValue={(v) => onChange(index, { value: v })}
+          placeholder={isLoading ? "Loading…" : "Value"}
+          triggerClassName="text-[12px]"
+        />
+      ) : (
+        <div className="flex flex-1 items-center gap-1">
+          {isNumeric && FIELD_UNIT[filter.field]?.prefix && (
+            <span className="shrink-0 text-[11px] text-muted-foreground">
+              {FIELD_UNIT[filter.field].prefix}
+            </span>
+          )}
+          <Input
+            className="h-7 flex-1 text-[12px]"
+            placeholder="Value"
+            type={isNumeric ? "number" : "text"}
+            value={String(filter.value)}
+            onChange={(e) => {
+              const raw = e.target.value;
+              onChange(index, { value: isNumeric && raw !== "" ? Number(raw) : raw });
+            }}
+            disabled={!filter.field}
+          />
+          {isNumeric && FIELD_UNIT[filter.field]?.suffix && (
+            <span className="shrink-0 text-[11px] text-muted-foreground">
+              {FIELD_UNIT[filter.field].suffix}
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* remove */}
+      <button
+        type="button"
+        onClick={() => onRemove(index)}
+        className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+        aria-label="Remove filter"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
@@ -12,11 +12,15 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+// Mutable so individual tests can put the session into its resolving state.
+const auth = {
+  data: { user: { id: "u1", email: "u@example.com" } } as {
+    user: { id: string; email: string };
+  } | null,
+  isPending: false,
+};
 vi.mock("@/lib/auth-client", () => ({
-  useSession: () => ({
-    data: { user: { id: "u1", email: "u@example.com" } },
-    isPending: false,
-  }),
+  useSession: () => auth,
 }));
 
 vi.mock("@/lib/api/traces", () => ({
@@ -28,6 +32,8 @@ import { getTraces } from "@/lib/api/traces";
 afterEach(() => {
   cleanup();
   vi.mocked(getTraces).mockReset();
+  auth.data = { user: { id: "u1", email: "u@example.com" } };
+  auth.isPending = false;
 });
 
 const RANGE: TimeRange = {
@@ -67,6 +73,15 @@ describe("TraceFeedWidget", () => {
     vi.mocked(getTraces).mockReturnValue(new Promise(() => {}));
     renderWidget();
     expect(screen.getByText("Loading…")).toBeTruthy();
+  });
+
+  it("stays loading while the auth session resolves, not the empty state", () => {
+    auth.data = null;
+    auth.isPending = true;
+    renderWidget();
+    expect(screen.getByText("Loading…")).toBeTruthy();
+    expect(screen.queryByText("No traces in this time range")).toBeNull();
+    expect(getTraces).not.toHaveBeenCalled();
   });
 
   it("shows an error state when the query fails", async () => {

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TraceListItem } from "@/types/api";
+import type { TimeRange } from "../types";
+import { TraceFeedWidget } from "./TraceFeedWidget";
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({
+    data: { user: { id: "u1", email: "u@example.com" } },
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/lib/api/traces", () => ({
+  getTraces: vi.fn(),
+}));
+
+import { getTraces } from "@/lib/api/traces";
+
+afterEach(() => {
+  cleanup();
+  vi.mocked(getTraces).mockReset();
+});
+
+const RANGE: TimeRange = {
+  start: new Date("2026-06-01T00:00:00Z"),
+  end: new Date("2026-06-02T00:00:00Z"),
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function renderWidget(spec: { limit?: number } = {}) {
+  return render(<TraceFeedWidget projectId="p1" spec={spec} range={RANGE} />, { wrapper });
+}
+
+function makeTrace(overrides: Partial<TraceListItem> = {}): TraceListItem {
+  return {
+    trace_id: "t1",
+    project_id: "p1",
+    name: "checkout-flow",
+    trace_start_time: "2026-06-01T12:00:00Z",
+    user_id: null,
+    session_id: null,
+    span_count: 3,
+    duration_ms: 1500,
+    error_count: 0,
+    input: null,
+    output: null,
+    total_cost: 0.1234,
+    ...overrides,
+  };
+}
+
+describe("TraceFeedWidget", () => {
+  it("shows a loading state while the query is pending", () => {
+    vi.mocked(getTraces).mockReturnValue(new Promise(() => {}));
+    renderWidget();
+    expect(screen.getByText("Loading…")).toBeTruthy();
+  });
+
+  it("shows an error state when the query fails", async () => {
+    vi.mocked(getTraces).mockRejectedValue(new Error("boom"));
+    renderWidget();
+    await waitFor(() => expect(screen.getByText("Failed to load traces")).toBeTruthy());
+  });
+
+  it("shows an empty state when there are no traces", async () => {
+    vi.mocked(getTraces).mockResolvedValue({
+      data: [],
+      meta: { page: 0, limit: 10, total: 0 },
+    });
+    renderWidget();
+    await waitFor(() => expect(screen.getByText("No traces in this time range")).toBeTruthy());
+  });
+
+  it("renders a populated list with status chips, cost, time and links", async () => {
+    vi.mocked(getTraces).mockResolvedValue({
+      data: [
+        makeTrace({ trace_id: "err-trace", name: "errored-run", error_count: 2, total_cost: 0.5 }),
+        makeTrace({ trace_id: "ok-trace", name: "clean-run", error_count: 0, total_cost: 0 }),
+        makeTrace({
+          trace_id: "null-cost-trace",
+          name: "no-cost-run",
+          error_count: 0,
+          total_cost: undefined,
+        }),
+      ],
+      meta: { page: 0, limit: 10, total: 3 },
+    });
+    renderWidget();
+
+    await waitFor(() => expect(screen.getByText("errored-run")).toBeTruthy());
+
+    expect(screen.getByText("ERROR")).toBeTruthy();
+    expect(screen.getAllByText("OK")).toHaveLength(2);
+
+    expect(screen.getByText("$0.5000")).toBeTruthy();
+    expect(screen.getAllByText("—")).toHaveLength(2);
+
+    const nameLink = screen.getByText("errored-run").closest("a");
+    expect(nameLink?.getAttribute("href")).toBe("/projects/p1/traces?traceId=err-trace");
+
+    const expectedTime = new Date("2026-06-01T12:00:00Z").toLocaleTimeString(undefined, {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+    const timeLinks = screen.getAllByText(expectedTime);
+    expect(timeLinks.length).toBeGreaterThan(0);
+    expect(timeLinks[0].closest("a")?.getAttribute("href")).toBe(
+      "/projects/p1/traces?traceId=err-trace",
+    );
+  });
+
+  it("passes spec.limit and the range bounds to getTraces", async () => {
+    vi.mocked(getTraces).mockResolvedValue({
+      data: [makeTrace()],
+      meta: { page: 0, limit: 25, total: 1 },
+    });
+    renderWidget({ limit: 25 });
+
+    await waitFor(() => expect(getTraces).toHaveBeenCalled());
+    expect(getTraces).toHaveBeenCalledWith(
+      "p1",
+      "",
+      {
+        page: 0,
+        limit: 25,
+        start_after: RANGE.start.toISOString(),
+        end_before: RANGE.end.toISOString(),
+      },
+      { id: "u1", email: "u@example.com" },
+    );
+  });
+
+  it("defaults the limit to 10 when spec.limit is not provided", async () => {
+    vi.mocked(getTraces).mockResolvedValue({
+      data: [makeTrace()],
+      meta: { page: 0, limit: 10, total: 1 },
+    });
+    renderWidget();
+
+    await waitFor(() => expect(getTraces).toHaveBeenCalled());
+    expect(getTraces).toHaveBeenCalledWith(
+      "p1",
+      "",
+      expect.objectContaining({ limit: 10 }),
+      expect.anything(),
+    );
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
@@ -120,8 +120,10 @@ describe("TraceFeedWidget", () => {
     expect(screen.getByText("ERROR")).toBeTruthy();
     expect(screen.getAllByText("OK")).toHaveLength(2);
 
+    // Cost renders through the shared formatCost: magnitude-adaptive
+    // precision, "-" for missing/zero — same as every other cost in the app.
     expect(screen.getByText("$0.5000")).toBeTruthy();
-    expect(screen.getAllByText("—")).toHaveLength(2);
+    expect(screen.getAllByText("-")).toHaveLength(2);
 
     const nameLink = screen.getByText("errored-run").closest("a");
     expect(nameLink?.getAttribute("href")).toBe("/projects/p1/traces?traceId=err-trace");

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@tanstack/react-query";
+import { useTraceApiUser } from "@/lib/hooks/use-trace-api-user";
+import { getTraces } from "@/lib/api/traces";
+import type { TraceListItem } from "@/types/api";
+import { formatDuration } from "@/lib/utils";
+import type { TimeRange } from "../types";
+
+interface TraceFeedWidgetProps {
+  projectId: string;
+  spec: { limit?: number };
+  range: TimeRange;
+}
+
+function StatusChip({ errorCount }: { errorCount: number }) {
+  if (errorCount > 0) {
+    return (
+      <span className="inline-flex rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
+        ERROR
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">
+      OK
+    </span>
+  );
+}
+
+function fmtCost(cost: number | null | undefined): string {
+  if (cost == null || cost === 0) return "—";
+  return `$${cost.toFixed(4)}`;
+}
+
+function fmtTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps) {
+  const limit = spec.limit ?? 10;
+  const { user, sessionReady } = useTraceApiUser();
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["trace-feed", projectId, limit, range.start.getTime(), range.end.getTime()],
+    queryFn: () =>
+      getTraces(
+        projectId,
+        "",
+        {
+          page: 0,
+          limit,
+          start_after: range.start.toISOString(),
+          end_before: range.end.toISOString(),
+        },
+        user,
+      ),
+    enabled: sessionReady && !!projectId,
+  });
+
+  if (isLoading) {
+    return <p className="text-[11.5px] text-muted-foreground">Loading…</p>;
+  }
+  if (isError) {
+    return <p className="text-[11.5px] text-red-500">Failed to load traces</p>;
+  }
+
+  const traces = data?.data ?? [];
+
+  if (traces.length === 0) {
+    return <p className="text-[11.5px] text-muted-foreground">No traces in this time range</p>;
+  }
+
+  return (
+    <div className="h-full overflow-auto">
+      <table className="w-full text-[11.5px]">
+        <thead>
+          <tr className="text-left text-[10px] uppercase tracking-wide text-muted-foreground">
+            <th className="pb-1.5 pr-3 font-medium">Time</th>
+            <th className="pb-1.5 pr-3 font-medium">Name</th>
+            <th className="pb-1.5 pr-3 font-medium">Status</th>
+            <th className="pb-1.5 pr-3 font-medium">Cost</th>
+            <th className="pb-1.5 font-medium">Latency</th>
+          </tr>
+        </thead>
+        <tbody>
+          {traces.map((trace: TraceListItem) => (
+            <tr key={trace.trace_id} className="border-t border-border/60">
+              <td className="whitespace-nowrap py-1 pr-3 text-muted-foreground">
+                <Link
+                  href={`/projects/${projectId}/traces?traceId=${trace.trace_id}`}
+                  className="hover:underline"
+                >
+                  {fmtTime(trace.trace_start_time)}
+                </Link>
+              </td>
+              <td className="max-w-[120px] truncate py-1 pr-3">
+                <Link
+                  href={`/projects/${projectId}/traces?traceId=${trace.trace_id}`}
+                  className="hover:underline"
+                  title={trace.name}
+                >
+                  {trace.name}
+                </Link>
+              </td>
+              <td className="py-1 pr-3">
+                <StatusChip errorCount={trace.error_count} />
+              </td>
+              <td className="py-1 pr-3 tabular-nums text-muted-foreground">
+                {fmtCost(trace.total_cost)}
+              </td>
+              <td className="py-1 tabular-nums text-muted-foreground">
+                {formatDuration(trace.duration_ms)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
@@ -5,7 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useTraceApiUser } from "@/lib/hooks/use-trace-api-user";
 import { getTraces } from "@/lib/api/traces";
 import type { TraceListItem } from "@/types/api";
-import { formatDuration } from "@/lib/utils";
+import { formatCost, formatDuration } from "@/lib/utils";
 import type { TimeRange } from "../types";
 
 interface TraceFeedWidgetProps {
@@ -27,11 +27,6 @@ function StatusChip({ errorCount }: { errorCount: number }) {
       OK
     </span>
   );
-}
-
-function fmtCost(cost: number | null | undefined): string {
-  if (cost == null || cost === 0) return "—";
-  return `$${cost.toFixed(4)}`;
 }
 
 function fmtTime(iso: string): string {
@@ -115,7 +110,7 @@ export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps
                 <StatusChip errorCount={trace.error_count} />
               </td>
               <td className="py-1 pr-3 tabular-nums text-muted-foreground">
-                {fmtCost(trace.total_cost)}
+                {formatCost(trace.total_cost)}
               </td>
               <td className="py-1 tabular-nums text-muted-foreground">
                 {formatDuration(trace.duration_ms)}

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
@@ -46,7 +46,7 @@ export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps
   const limit = spec.limit ?? 10;
   const { user, sessionReady } = useTraceApiUser();
 
-  const { data, isLoading, isError } = useQuery({
+  const { data, isPending, isError } = useQuery({
     queryKey: ["trace-feed", projectId, limit, range.start.getTime(), range.end.getTime()],
     queryFn: () =>
       getTraces(
@@ -63,7 +63,10 @@ export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps
     enabled: sessionReady && !!projectId,
   });
 
-  if (isLoading) {
+  // isPending (no data yet), not isLoading (pending AND fetching): while the
+  // auth session is still resolving the query is disabled — not fetching — and
+  // isLoading would fall through to the misleading "No traces" empty state.
+  if (isPending) {
     return <p className="text-[11.5px] text-muted-foreground">Loading…</p>;
   }
   if (isError) {

--- a/frontend/ui/src/features/dashboards/components/field-icons.test.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  AlertCircle,
+  Box,
+  CircleCheck,
+  CircleDollarSign,
+  CircleStop,
+  Clock,
+  Globe,
+  Hash,
+  Layers,
+  Shapes,
+  Users,
+  Workflow,
+} from "lucide-react";
+import { fieldIcon } from "./field-icons";
+
+describe("fieldIcon", () => {
+  it("mirrors the trace-list filter icons for shared fields", () => {
+    expect(fieldIcon("cost")).toBe(CircleDollarSign);
+    expect(fieldIcon("total_tokens")).toBe(CircleStop);
+    expect(fieldIcon("duration_ms")).toBe(Clock);
+    expect(fieldIcon("environment")).toBe(Globe);
+    expect(fieldIcon("model_name")).toBe(Box);
+  });
+
+  it("maps the widget registry's own spellings and token variants", () => {
+    expect(fieldIcon("error_count")).toBe(AlertCircle);
+    expect(fieldIcon("input_tokens")).toBe(CircleStop);
+    expect(fieldIcon("output_tokens")).toBe(CircleStop);
+  });
+
+  it("gives count its own symbol and mirrors the trace-page tabs for user/session", () => {
+    // count must not fall back to Box — that doubles as the model icon.
+    expect(fieldIcon("count")).toBe(Hash);
+    expect(fieldIcon("user_id")).toBe(Users);
+    expect(fieldIcon("session_id")).toBe(Layers);
+  });
+
+  it("uses the sidebar's Tracing symbol for the trace/span name field", () => {
+    expect(fieldIcon("name")).toBe(Workflow);
+  });
+
+  it("uses the shapes symbol for span kind", () => {
+    expect(fieldIcon("span_kind")).toBe(Shapes);
+  });
+
+  it("uses the check circle for status", () => {
+    expect(fieldIcon("status")).toBe(CircleCheck);
+  });
+
+  it("falls back to the generic box like the trace list does", () => {
+    expect(fieldIcon("some_future_field")).toBe(Box);
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/field-icons.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.ts
@@ -1,0 +1,36 @@
+import {
+  AlertCircle,
+  Box,
+  CircleCheck,
+  CircleStop,
+  Hash,
+  Layers,
+  Shapes,
+  Users,
+  Workflow,
+  type LucideIcon,
+} from "lucide-react";
+import { FIELD_ICONS } from "@/features/filters/filter-builder";
+
+// The trace-list filter icons, extended with the widget registry's field
+// names the trace list spells differently (errors -> error_count), the token
+// variants, a distinct count symbol (the shared map's Box doubles as the
+// model icon, so count falling back to it read as "model"), and the user /
+// session symbols the trace-page tabs use. Box stays the generic fallback.
+const WIDGET_FIELD_ICONS: Record<string, LucideIcon> = {
+  ...FIELD_ICONS,
+  error_count: AlertCircle,
+  input_tokens: CircleStop,
+  output_tokens: CircleStop,
+  count: Hash,
+  user_id: Users,
+  session_id: Layers,
+  // The sidebar's Tracing symbol; `name` is the trace/span name on both views.
+  name: Workflow,
+  // A category-of-kinds field; the per-kind glyphs (Sparkle/Bot/Wrench) would
+  // each wrongly imply one specific kind.
+  span_kind: Shapes,
+  status: CircleCheck,
+};
+
+export const fieldIcon = (field: string): LucideIcon => WIDGET_FIELD_ICONS[field] ?? Box;

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -31,8 +31,9 @@ import type { FilterFieldDef } from "./registry";
 import { buildInPredicate, buildNumericPredicate, buildTextPredicate } from "./predicate-ui";
 
 // Icons mirror the trace detail / list UI for consistency; the model and environment
-// fields, which have no trace-detail icon, use a generic one.
-const FIELD_ICONS: Record<string, LucideIcon> = {
+// fields, which have no trace-detail icon, use a generic one. Exported so the
+// dashboard widget builder shows the same symbols for the same fields.
+export const FIELD_ICONS: Record<string, LucideIcon> = {
   trace_id: Hash,
   cost: CircleDollarSign,
   total_tokens: CircleStop,
@@ -345,14 +346,35 @@ function CategoricalValue({
     ? field.enum_values.map((v) => ({ value: v }))
     : values.map((v) => ({ value: v.value, count: v.count }));
 
+  return <ValueDropdown value={value} options={options} onValue={onValue} />;
+}
+
+/**
+ * The stored-values picker: a dropdown of a field's values with per-value
+ * occurrence counts on the right. Shared by the trace-list filter builder and
+ * the dashboard widget filter rows.
+ */
+export function ValueDropdown({
+  value,
+  options,
+  onValue,
+  placeholder = "Enter value",
+  triggerClassName,
+}: {
+  value: string;
+  options: { value: string; count?: number }[];
+  onValue: (v: string) => void;
+  placeholder?: string;
+  triggerClassName?: string;
+}) {
   return (
     <Dropdown
       trigger={
         <span className={cn("truncate", !value && "text-muted-foreground")}>
-          {value || "Enter value"}
+          {value || placeholder}
         </span>
       }
-      triggerClassName="min-w-0 flex-1"
+      triggerClassName={cn("min-w-0 flex-1", triggerClassName)}
       contentClassName="w-[12rem]"
     >
       {(close) =>


### PR DESCRIPTION
Seventh PR in the stacked project-dashboards series (epic #1460), stacked on #1514. The two dashboard surfaces that reuse trace-list vocabulary directly. No consumers yet — the widget card/grid and builder arrive next in the stack.

## What's here
- **TraceFeedWidget** (`components/TraceFeedWidget.tsx`) — the canned recent-traces widget: the window's latest traces (name, status from error count, duration, cost, time) with deep links into the trace view. Reuses the existing `getTraces` API and the shared session gate.
- **FilterRow** (`components/FilterRow.tsx`) — one widget filter as three controls (field / op / value). String equality ops swap the free-text input for the trace list's stored-values picker so users choose from values that actually exist; ops render with the trace-list wording (is / is not / ≥); fields carry the same icons as the trace-list filter builder; numeric fields show their unit prefix/suffix.
- **`filter-builder.tsx`** (2 hunks) — exports its `FIELD_ICONS` map and extracts the stored-values dropdown into a reusable `ValueDropdown`. Behavior-preserving for the trace list: the extraction reproduces the old inline JSX exactly, and existing filter-builder tests still exercise it end-to-end.
- **field-icons.ts** — the widget registry's icon map, extending the shared trace-list icons with the registry's spellings (`error_count`, token variants, user/session symbols) and a distinct count symbol.

closes #1455
advances #1453

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Trace feed widget and a filter row with stored-value dropdowns for dashboards, reusing the trace-list API and vocabulary for a consistent experience. Closes #1455 and advances #1453.

- **New Features**
  - TraceFeedWidget: shows latest traces with Time, Name, Status (from error count), Cost, and Latency; deep links; respects time range and limit (default 10); loading/empty/error states.
  - FilterRow: field/op/value controls; string equality uses a stored-values picker with counts; numeric fields keep number input and show units; fields use the same icons as the trace-list builder.
  - Shared: exported `FIELD_ICONS` and a reusable `ValueDropdown`; widget icon map extends shared icons (e.g., `error_count`, token variants, `user_id`/`session_id`, `count`), with `Box` as fallback.

- **Bug Fixes**
  - TraceFeedWidget shows Loading (not Empty) while auth resolves by gating on `isPending`.
  - TraceFeedWidget costs render via shared `formatCost` for consistent precision and "-" placeholder.

<sup>Written for commit b8465e082af485199d652918af5a6c07ce4e93fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

