### PR TITLE
feat(ui): widget card and drag/resize dashboard grid

### DIFF
--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
@@ -1,0 +1,319 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LayoutItem, TimeRange, Widget } from "../types";
+import { DashboardGrid } from "./DashboardGrid";
+
+// DashboardGrid only cares about the layout it hands to react-grid-layout and
+// the onLayoutChange callback it wires up — stub the library component so the
+// test can capture both without exercising the real drag/resize engine.
+const gridLayoutMock = vi.fn(
+  (props: {
+    children?: React.ReactNode;
+    layout: LayoutItem[];
+    onLayoutChange: (l: LayoutItem[]) => void;
+  }) => <div data-testid="grid-layout">{props.children}</div>,
+);
+vi.mock("react-grid-layout", () => ({
+  GridLayout: (props: unknown) => gridLayoutMock(props as never),
+}));
+
+// WidgetCard pulls in its own data hooks; the layout logic under test doesn't
+// need a real widget body.
+vi.mock("./WidgetCard", () => ({
+  WidgetCard: ({ widget }: { widget: Widget }) => <div>{widget.id}</div>,
+}));
+
+const RANGE: TimeRange = {
+  start: new Date("2026-06-01T00:00:00Z"),
+  end: new Date("2026-06-02T00:00:00Z"),
+};
+
+function widget(id: string): Widget {
+  return {
+    id,
+    dashboardId: "d1",
+    title: id,
+    type: "trace_feed",
+    spec: {},
+    displayConfig: {},
+  };
+}
+
+function latestProps() {
+  const calls = gridLayoutMock.mock.calls;
+  return calls[calls.length - 1][0] as {
+    layout: LayoutItem[];
+    onLayoutChange: (l: LayoutItem[]) => void;
+  };
+}
+
+describe("DashboardGrid", () => {
+  afterEach(() => {
+    cleanup();
+    gridLayoutMock.mockClear();
+  });
+
+  describe("fullLayout mapping", () => {
+    it("keeps known layout entries as-is, appends missing widgets at the bottom, and ignores stale entries", () => {
+      const widgets = [widget("w1"), widget("w2"), widget("w3")];
+      const layout: LayoutItem[] = [
+        { i: "w1", x: 2, y: 5, w: 6, h: 3 },
+        // Stale entry for a widget that no longer exists — its y+h still
+        // factors into the "append at the bottom" watermark.
+        { i: "w-deleted", x: 0, y: 20, w: 4, h: 4 },
+      ];
+
+      render(
+        <DashboardGrid
+          projectId="p1"
+          widgets={widgets}
+          layout={layout}
+          range={RANGE}
+          width={1000}
+          onLayoutChange={vi.fn()}
+          onEdit={vi.fn()}
+          onDuplicate={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+
+      const fullLayout = latestProps().layout;
+      expect(fullLayout).toEqual([
+        { i: "w1", x: 2, y: 5, w: 6, h: 3, minW: 2, minH: 2 },
+        { i: "w2", x: 0, y: 24, w: 4, h: 4, minW: 2, minH: 2 },
+        { i: "w3", x: 0, y: 28, w: 4, h: 4, minW: 2, minH: 2 },
+      ]);
+      // The deleted widget's stale layout entry never surfaces.
+      expect(fullLayout.some((l) => l.i === "w-deleted")).toBe(false);
+    });
+
+    it("starts fresh widgets at y:0 when there is no stored layout", () => {
+      const widgets = [widget("w1")];
+      render(
+        <DashboardGrid
+          projectId="p1"
+          widgets={widgets}
+          layout={[]}
+          range={RANGE}
+          width={1000}
+          onLayoutChange={vi.fn()}
+          onEdit={vi.fn()}
+          onDuplicate={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+
+      expect(latestProps().layout).toEqual([{ i: "w1", x: 0, y: 0, w: 4, h: 4, minW: 2, minH: 2 }]);
+    });
+
+    it("marks every item static and never persists layout changes when read-only", () => {
+      vi.useFakeTimers();
+      const onLayoutChange = vi.fn();
+      render(
+        <DashboardGrid
+          projectId="p1"
+          widgets={[widget("w1")]}
+          layout={[{ i: "w1", x: 0, y: 0, w: 4, h: 4 }]}
+          range={RANGE}
+          width={1000}
+          readOnly
+          onLayoutChange={onLayoutChange}
+          onEdit={vi.fn()}
+          onDuplicate={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+
+      const { layout: fullLayout, onLayoutChange: onChange } = latestProps();
+      expect(fullLayout).toEqual([
+        { i: "w1", x: 0, y: 0, w: 4, h: 4, minW: 2, minH: 2, static: true },
+      ]);
+
+      // Even if the grid fires (e.g. mount-fire compaction), nothing goes upstream.
+      onChange([{ i: "w1", x: 2, y: 0, w: 4, h: 4 }]);
+      vi.advanceTimersByTime(600);
+      expect(onLayoutChange).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it("stamps the minimum size on every item so widgets can't be shrunk into clipping", () => {
+      const widgets = [widget("w1"), widget("w2")];
+      render(
+        <DashboardGrid
+          projectId="p1"
+          widgets={widgets}
+          layout={[{ i: "w1", x: 0, y: 0, w: 6, h: 3 }]}
+          range={RANGE}
+          width={1000}
+          onLayoutChange={vi.fn()}
+          onEdit={vi.fn()}
+          onDuplicate={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+
+      for (const item of latestProps().layout) {
+        expect(item).toMatchObject({ minW: 2, minH: 2 });
+      }
+    });
+  });
+
+  describe("handleChange debounce", () => {
+    const widgets = [widget("w1"), widget("w2")];
+    const initialLayout: LayoutItem[] = [
+      { i: "w1", x: 0, y: 0, w: 4, h: 4 },
+      { i: "w2", x: 4, y: 0, w: 4, h: 4 },
+    ];
+
+    function renderGrid(onLayoutChange: (l: LayoutItem[]) => void) {
+      const utils = render(
+        <DashboardGrid
+          projectId="p1"
+          widgets={widgets}
+          layout={initialLayout}
+          range={RANGE}
+          width={1000}
+          onLayoutChange={onLayoutChange}
+          onEdit={vi.fn()}
+          onDuplicate={vi.fn()}
+          onDelete={vi.fn()}
+        />,
+      );
+      return { ...utils, onChange: latestProps().onLayoutChange };
+    }
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("never calls upstream for the mount-fire, even after the debounce elapses", () => {
+      vi.useFakeTimers();
+      const onLayoutChange = vi.fn();
+      const { onChange } = renderGrid(onLayoutChange);
+
+      // react-grid-layout fires onLayoutChange on mount with the same layout
+      // it was given.
+      onChange(initialLayout);
+      vi.advanceTimersByTime(600);
+
+      expect(onLayoutChange).not.toHaveBeenCalled();
+    });
+
+    it("calls upstream once, 600ms after a genuine layout change", () => {
+      vi.useFakeTimers();
+      const onLayoutChange = vi.fn();
+      const { onChange } = renderGrid(onLayoutChange);
+
+      onChange(initialLayout); // mount-fire, lazily initializes the sent snapshot
+      vi.advanceTimersByTime(600);
+      expect(onLayoutChange).not.toHaveBeenCalled();
+
+      const moved: LayoutItem[] = [
+        { i: "w1", x: 2, y: 0, w: 4, h: 4 },
+        { i: "w2", x: 4, y: 0, w: 4, h: 4 },
+      ];
+      onChange(moved);
+      expect(onLayoutChange).not.toHaveBeenCalled();
+      vi.advanceTimersByTime(600);
+
+      expect(onLayoutChange).toHaveBeenCalledTimes(1);
+      expect(onLayoutChange).toHaveBeenCalledWith(moved);
+    });
+
+    it("dedupes an identical repeat of a layout already sent", () => {
+      vi.useFakeTimers();
+      const onLayoutChange = vi.fn();
+      const { onChange } = renderGrid(onLayoutChange);
+
+      const moved: LayoutItem[] = [
+        { i: "w1", x: 2, y: 0, w: 4, h: 4 },
+        { i: "w2", x: 4, y: 0, w: 4, h: 4 },
+      ];
+      onChange(initialLayout);
+      onChange(moved);
+      vi.advanceTimersByTime(600);
+      expect(onLayoutChange).toHaveBeenCalledTimes(1);
+
+      // Same layout content again (new array identity, same values).
+      onChange([...moved.map((l) => ({ ...l }))]);
+      vi.advanceTimersByTime(600);
+
+      expect(onLayoutChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("collapses rapid successive changes into a single call for the latest layout", () => {
+      vi.useFakeTimers();
+      const onLayoutChange = vi.fn();
+      const { onChange } = renderGrid(onLayoutChange);
+
+      onChange(initialLayout); // mount-fire
+      const v1: LayoutItem[] = [
+        { i: "w1", x: 1, y: 0, w: 4, h: 4 },
+        { i: "w2", x: 4, y: 0, w: 4, h: 4 },
+      ];
+      const v2: LayoutItem[] = [
+        { i: "w1", x: 2, y: 0, w: 4, h: 4 },
+        { i: "w2", x: 4, y: 0, w: 4, h: 4 },
+      ];
+      const v3: LayoutItem[] = [
+        { i: "w1", x: 3, y: 0, w: 4, h: 4 },
+        { i: "w2", x: 4, y: 0, w: 4, h: 4 },
+      ];
+      onChange(v1);
+      onChange(v2);
+      onChange(v3);
+
+      vi.advanceTimersByTime(600);
+
+      expect(onLayoutChange).toHaveBeenCalledTimes(1);
+      expect(onLayoutChange).toHaveBeenCalledWith(v3);
+    });
+
+    it("does not flush the suppressed mount-fire layout on unmount", () => {
+      vi.useFakeTimers();
+      const onLayoutChange = vi.fn();
+      const { onChange, unmount } = renderGrid(onLayoutChange);
+
+      // Mount-fire arrives, then the user navigates away before the debounce
+      // fires: the pending snapshot equals what was lazily marked as sent, so
+      // nothing may go upstream.
+      onChange(initialLayout);
+      unmount();
+
+      expect(onLayoutChange).not.toHaveBeenCalled();
+    });
+
+    it("does not flush on unmount after the dedupe path already handled the timer", () => {
+      vi.useFakeTimers();
+      const onLayoutChange = vi.fn();
+      const { onChange, unmount } = renderGrid(onLayoutChange);
+
+      // Mount-fire, timer fires and takes the dedupe skip — refs must be
+      // cleared there, or this unmount would resend the mount layout.
+      onChange(initialLayout);
+      vi.advanceTimersByTime(600);
+      unmount();
+
+      expect(onLayoutChange).not.toHaveBeenCalled();
+    });
+
+    it("flushes a pending debounced change synchronously on unmount", () => {
+      vi.useFakeTimers();
+      const onLayoutChange = vi.fn();
+      const { onChange, unmount } = renderGrid(onLayoutChange);
+
+      onChange(initialLayout); // mount-fire
+      const moved: LayoutItem[] = [
+        { i: "w1", x: 2, y: 0, w: 4, h: 4 },
+        { i: "w2", x: 4, y: 0, w: 4, h: 4 },
+      ];
+      onChange(moved); // pending debounce, not yet flushed
+
+      unmount();
+
+      expect(onLayoutChange).toHaveBeenCalledTimes(1);
+      expect(onLayoutChange).toHaveBeenCalledWith(moved);
+    });
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { GridLayout } from "react-grid-layout";
+import type { Layout, LayoutItem as RGLLayoutItem } from "react-grid-layout";
+import "react-grid-layout/css/styles.css";
+import type { LayoutItem, TimeRange, Widget } from "../types";
+import { WidgetCard } from "./WidgetCard";
+
+const COLS = 12;
+const ROW_HEIGHT = 56;
+// Floor for widget resizing: below 2x2 grid units a tile's title and body get
+// clipped into illegibility, so react-grid-layout refuses to shrink past it.
+const MIN_W = 2;
+const MIN_H = 2;
+
+export function DashboardGrid({
+  projectId,
+  widgets,
+  layout,
+  range,
+  width,
+  readOnly = false,
+  onLayoutChange,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: {
+  projectId: string;
+  widgets: Widget[];
+  layout: LayoutItem[];
+  range: TimeRange;
+  width: number;
+  /** Read-only dashboards (the seeded default) can't be rearranged or resized. */
+  readOnly?: boolean;
+  onLayoutChange: (layout: LayoutItem[]) => void;
+  onEdit: (w: Widget) => void;
+  onDuplicate: (w: Widget) => void;
+  onDelete: (w: Widget) => void;
+}) {
+  // Widgets missing from layout (e.g. just created) get appended at the bottom.
+  // Stale layout entries for deleted widgets are tolerated: fullLayout maps
+  // from widgets, so extras in the stored layout are simply ignored.
+  const fullLayout: RGLLayoutItem[] = useMemo(() => {
+    const known = new Map(layout.map((l) => [l.i, l]));
+    let maxY = Math.max(0, ...layout.map((l) => l.y + l.h));
+    // `static` items can't be dragged or resized.
+    const constraints = readOnly
+      ? { minW: MIN_W, minH: MIN_H, static: true }
+      : { minW: MIN_W, minH: MIN_H };
+    return widgets.map((w) => {
+      const item = known.get(w.id);
+      if (item) return { ...item, ...constraints };
+      const fresh: RGLLayoutItem = { i: w.id, x: 0, y: maxY, w: 4, h: 4, ...constraints };
+      maxY += 4;
+      return fresh;
+    });
+  }, [widgets, layout, readOnly]);
+
+  // Snapshot of the last layout sent upstream, used to skip no-op PATCH calls.
+  // react-grid-layout fires onLayoutChange on mount with the initial layout, so
+  // we lazy-init lastSentRef on the first handleChange call to the incoming
+  // layout's JSON — that way the mount-fire only triggers an upstream call if
+  // the layout genuinely differs (e.g. real compaction), not unconditionally.
+  const lastSentRef = useRef<string | null>(null);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Holds the most-recently-computed mapped layout so the unmount cleanup can
+  // flush it synchronously if a debounce timer is still pending.
+  const pendingMappedRef = useRef<LayoutItem[] | null>(null);
+
+  // On unmount: if a debounce is still pending, cancel the timer and flush the
+  // pending layout change synchronously so the last drag is never silently
+  // lost. The flush re-checks against lastSentRef: without that, the
+  // mount-fire layout (deliberately suppressed by the lazy-init below) would
+  // be PATCHed on every visit-then-navigate — including stale mount-time
+  // layouts overwriting a teammate's saved arrangement, or a PATCH against a
+  // dashboard the user just deleted.
+  useEffect(
+    () => () => {
+      if (debounceTimer.current) {
+        clearTimeout(debounceTimer.current);
+        const pending = pendingMappedRef.current;
+        if (pending && JSON.stringify(pending) !== lastSentRef.current) {
+          onLayoutChange(pending);
+        }
+      }
+    },
+    [],
+  );
+
+  const handleChange = (next: Layout) => {
+    // Static items can still be re-compacted on mount; never persist from a
+    // read-only grid.
+    if (readOnly) return;
+    const mapped: LayoutItem[] = next.map(({ i, x, y, w, h }) => ({ i, x, y, w, h }));
+
+    // Lazy-init: on the first call (mount-fire from react-grid-layout) treat the
+    // incoming layout as already-sent so we don't PATCH unless it truly changed.
+    if (lastSentRef.current === null) {
+      lastSentRef.current = JSON.stringify(mapped);
+    }
+
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    pendingMappedRef.current = mapped;
+    debounceTimer.current = setTimeout(() => {
+      // Clear both refs on every firing — including the dedupe skip below —
+      // so the unmount flush can't resend a layout that was already handled.
+      debounceTimer.current = null;
+      pendingMappedRef.current = null;
+      const json = JSON.stringify(mapped);
+      if (json === lastSentRef.current) return;
+      lastSentRef.current = json;
+      onLayoutChange(mapped);
+    }, 600);
+  };
+
+  return (
+    <GridLayout
+      className="layout"
+      layout={fullLayout}
+      gridConfig={{ cols: COLS, rowHeight: ROW_HEIGHT }}
+      dragConfig={{ handle: ".drag-handle" }}
+      width={width}
+      onLayoutChange={handleChange}
+    >
+      {widgets.map((w) => (
+        <div key={w.id} className="group">
+          <WidgetCard
+            projectId={projectId}
+            widget={w}
+            range={range}
+            readOnly={readOnly}
+            onEdit={() => onEdit(w)}
+            onDuplicate={() => onDuplicate(w)}
+            onDelete={() => onDelete(w)}
+          />
+        </div>
+      ))}
+    </GridLayout>
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
@@ -82,7 +82,7 @@ describe("WidgetCard menu gating", () => {
   afterEach(cleanup);
 
   it("shows Edit for a query widget and wires it to onEdit", async () => {
-    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    useWidgetData.mockReturnValue({ data: undefined, isPending: false, error: null });
     const { onEdit } = renderCard(makeWidget());
 
     await openMenu();
@@ -93,7 +93,7 @@ describe("WidgetCard menu gating", () => {
   });
 
   it("hides the options menu and drag handle entirely when read-only", () => {
-    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    useWidgetData.mockReturnValue({ data: undefined, isPending: false, error: null });
     renderCard(makeWidget(), {}, true);
 
     expect(screen.queryByRole("button", { name: "Widget options" })).toBeNull();
@@ -110,7 +110,7 @@ describe("WidgetCard menu gating", () => {
   });
 
   it("always shows Duplicate and Delete, wired to their callbacks", async () => {
-    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    useWidgetData.mockReturnValue({ data: undefined, isPending: false, error: null });
     const { onDuplicate, onDelete } = renderCard(makeWidget());
 
     await openMenu();
@@ -143,7 +143,7 @@ describe("WidgetCard body dispatch", () => {
   it("renders a query widget's data via useWidgetData", () => {
     useWidgetData.mockReturnValue({
       data: { columns: ["value"], rows: [[42]], meta: {} },
-      isLoading: false,
+      isPending: false,
       error: null,
     });
 
@@ -153,7 +153,7 @@ describe("WidgetCard body dispatch", () => {
   });
 
   it("shows a loading state while the query is in flight", () => {
-    useWidgetData.mockReturnValue({ data: undefined, isLoading: true, error: null });
+    useWidgetData.mockReturnValue({ data: undefined, isPending: true, error: null });
 
     renderCard(makeWidget());
 
@@ -161,7 +161,7 @@ describe("WidgetCard body dispatch", () => {
   });
 
   it("shows a query error message", () => {
-    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: new Error("boom") });
+    useWidgetData.mockReturnValue({ data: undefined, isPending: false, error: new Error("boom") });
 
     renderCard(makeWidget());
 
@@ -169,7 +169,7 @@ describe("WidgetCard body dispatch", () => {
   });
 
   it("shows an invalid-spec message and disables the query when the spec fails to parse", () => {
-    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    useWidgetData.mockReturnValue({ data: undefined, isPending: false, error: null });
 
     renderCard(makeWidget({ spec: { view: "spans" } }));
 

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
@@ -1,0 +1,187 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TimeRange, Widget } from "../types";
+import { WidgetCard } from "./WidgetCard";
+
+// Radix DropdownMenu opens on pointerdown and relies on pointer-capture APIs
+// jsdom doesn't implement.
+window.HTMLElement.prototype.hasPointerCapture = vi.fn();
+window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+const useWidgetData = vi.fn();
+vi.mock("../hooks/use-widget-data", () => ({
+  useWidgetData: (...args: unknown[]) => useWidgetData(...args),
+}));
+
+vi.mock("./TraceFeedWidget", () => ({
+  TraceFeedWidget: (props: { projectId: string; spec: { limit?: number }; range: TimeRange }) => (
+    <div data-testid="trace-feed-widget">
+      {props.projectId}:{JSON.stringify(props.spec)}
+    </div>
+  ),
+}));
+
+const RANGE: TimeRange = {
+  start: new Date("2026-06-01T00:00:00Z"),
+  end: new Date("2026-06-02T00:00:00Z"),
+};
+
+const VALID_SPEC = {
+  view: "spans",
+  filters: [],
+  metric: { measure: "count", agg: "count" },
+  breakdown: null,
+  display: { type: "number" },
+};
+
+function makeWidget(overrides: Partial<Widget> = {}): Widget {
+  return {
+    id: "w1",
+    dashboardId: "d1",
+    title: "My widget",
+    type: "query",
+    spec: VALID_SPEC,
+    displayConfig: {},
+    ...overrides,
+  };
+}
+
+function renderCard(
+  widget: Widget,
+  callbacks: Partial<{ onEdit: () => void; onDuplicate: () => void; onDelete: () => void }> = {},
+  readOnly = false,
+) {
+  const onEdit = callbacks.onEdit ?? vi.fn();
+  const onDuplicate = callbacks.onDuplicate ?? vi.fn();
+  const onDelete = callbacks.onDelete ?? vi.fn();
+  render(
+    <WidgetCard
+      projectId="p1"
+      widget={widget}
+      range={RANGE}
+      readOnly={readOnly}
+      onEdit={onEdit}
+      onDuplicate={onDuplicate}
+      onDelete={onDelete}
+    />,
+  );
+  return { onEdit, onDuplicate, onDelete };
+}
+
+async function openMenu() {
+  fireEvent.pointerDown(screen.getByRole("button", { name: "Widget options" }), {
+    button: 0,
+    pointerType: "mouse",
+  });
+  await screen.findByRole("menu");
+}
+
+describe("WidgetCard menu gating", () => {
+  afterEach(cleanup);
+
+  it("shows Edit for a query widget and wires it to onEdit", async () => {
+    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    const { onEdit } = renderCard(makeWidget());
+
+    await openMenu();
+    const edit = screen.getByRole("menuitem", { name: "Edit" });
+    fireEvent.click(edit);
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the options menu and drag handle entirely when read-only", () => {
+    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    renderCard(makeWidget(), {}, true);
+
+    expect(screen.queryByRole("button", { name: "Widget options" })).toBeNull();
+    expect(screen.queryByText("⠿")).toBeNull();
+    // The widget body still renders.
+    expect(screen.getByText("My widget")).toBeTruthy();
+  });
+
+  it("hides Edit for a non-query widget", async () => {
+    renderCard(makeWidget({ type: "trace_feed", spec: { limit: 5 } }));
+
+    await openMenu();
+    expect(screen.queryByRole("menuitem", { name: "Edit" })).toBeNull();
+  });
+
+  it("always shows Duplicate and Delete, wired to their callbacks", async () => {
+    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    const { onDuplicate, onDelete } = renderCard(makeWidget());
+
+    await openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
+    expect(onDuplicate).toHaveBeenCalledTimes(1);
+
+    await openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("still shows Duplicate and Delete for a non-query widget", async () => {
+    const { onDuplicate, onDelete } = renderCard(
+      makeWidget({ type: "trace_feed", spec: { limit: 5 } }),
+    );
+
+    await openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
+    expect(onDuplicate).toHaveBeenCalledTimes(1);
+
+    await openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("WidgetCard body dispatch", () => {
+  afterEach(cleanup);
+
+  it("renders a query widget's data via useWidgetData", () => {
+    useWidgetData.mockReturnValue({
+      data: { columns: ["value"], rows: [[42]], meta: {} },
+      isLoading: false,
+      error: null,
+    });
+
+    renderCard(makeWidget());
+
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  it("shows a loading state while the query is in flight", () => {
+    useWidgetData.mockReturnValue({ data: undefined, isLoading: true, error: null });
+
+    renderCard(makeWidget());
+
+    expect(screen.getByText("Loading…")).toBeTruthy();
+  });
+
+  it("shows a query error message", () => {
+    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: new Error("boom") });
+
+    renderCard(makeWidget());
+
+    expect(screen.getByText("Query failed: boom")).toBeTruthy();
+  });
+
+  it("shows an invalid-spec message and disables the query when the spec fails to parse", () => {
+    useWidgetData.mockReturnValue({ data: undefined, isLoading: false, error: null });
+
+    renderCard(makeWidget({ spec: { view: "spans" } }));
+
+    expect(screen.getByText("Invalid widget spec — edit to fix")).toBeTruthy();
+    const [, , , , enabled] = useWidgetData.mock.calls[useWidgetData.mock.calls.length - 1];
+    expect(enabled).toBe(false);
+  });
+
+  it("dispatches trace_feed widgets to TraceFeedWidget", () => {
+    renderCard(makeWidget({ type: "trace_feed", spec: { limit: 5 } }));
+
+    const body = screen.getByTestId("trace-feed-widget");
+    expect(body.textContent).toBe('p1:{"limit":5}');
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -25,7 +25,7 @@ function QueryWidgetBody({
 
   // Hooks cannot be conditional — pass a placeholder spec when invalid, but
   // gate the query with enabled=false so no request is actually sent.
-  const { data, isLoading, error } = useWidgetData(
+  const { data, isPending, error } = useWidgetData(
     projectId,
     widget.id,
     spec ?? {
@@ -42,7 +42,10 @@ function QueryWidgetBody({
   if (!spec) {
     return <div className="p-2 text-[12px] text-red-600">Invalid widget spec — edit to fix</div>;
   }
-  if (isLoading) {
+  // isPending (no data yet), not isLoading (pending AND fetching): while the
+  // auth session is still resolving the query is disabled — not fetching — and
+  // isLoading would fall through to a blank body on every dashboard load.
+  if (isPending) {
     return <div className="p-2 text-[12px] text-muted-foreground">Loading…</div>;
   }
   if (error) {

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { MoreVertical } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useWidgetData } from "../hooks/use-widget-data";
+import { FIELD_UNIT, parseSpec, type TimeRange, type Widget } from "../types";
+import { QueryWidgetRenderer } from "./renderers";
+import { TraceFeedWidget } from "./TraceFeedWidget";
+
+function QueryWidgetBody({
+  projectId,
+  widget,
+  range,
+}: {
+  projectId: string;
+  widget: Widget;
+  range: TimeRange;
+}) {
+  const spec = parseSpec(widget.spec);
+
+  // Hooks cannot be conditional — pass a placeholder spec when invalid, but
+  // gate the query with enabled=false so no request is actually sent.
+  const { data, isLoading, error } = useWidgetData(
+    projectId,
+    widget.id,
+    spec ?? {
+      view: "spans",
+      filters: [],
+      metric: { measure: "count", agg: "count" },
+      breakdown: null,
+      display: { type: "number" },
+    },
+    range,
+    spec !== null,
+  );
+
+  if (!spec) {
+    return <div className="p-2 text-[12px] text-red-600">Invalid widget spec — edit to fix</div>;
+  }
+  if (isLoading) {
+    return <div className="p-2 text-[12px] text-muted-foreground">Loading…</div>;
+  }
+  if (error) {
+    return (
+      <div className="p-2 text-[12px] text-red-600">
+        Query failed{error instanceof Error ? `: ${error.message}` : ""}
+      </div>
+    );
+  }
+  if (!data) return null;
+  return (
+    <QueryWidgetRenderer
+      display={spec.display.type}
+      result={data}
+      unit={FIELD_UNIT[spec.metric.measure]}
+      seriesLabel={spec.metric.measure}
+    />
+  );
+}
+
+export function WidgetCard({
+  projectId,
+  widget,
+  range,
+  readOnly = false,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: {
+  projectId: string;
+  widget: Widget;
+  range: TimeRange;
+  /** Read-only dashboards (the seeded default) hide the drag handle and menu. */
+  readOnly?: boolean;
+  onEdit: () => void;
+  onDuplicate: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col rounded-md border bg-background p-3">
+      {/* Header: drag handle + title + menu */}
+      <div className="mb-2 flex items-center gap-1.5">
+        {!readOnly && (
+          <span className="drag-handle cursor-move select-none text-muted-foreground/50">⠿</span>
+        )}
+        <span className="flex-1 truncate text-[12px] font-medium" title={widget.title}>
+          {widget.title}
+        </span>
+        {!readOnly && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted focus:opacity-100 group-hover:opacity-100"
+                aria-label="Widget options"
+              >
+                <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {widget.type === "query" && (
+                <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>
+              )}
+              <DropdownMenuItem onSelect={onDuplicate}>Duplicate</DropdownMenuItem>
+              <DropdownMenuItem onSelect={onDelete} className="text-red-600 focus:text-red-600">
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="min-h-0 flex-1">
+        {widget.type === "query" && (
+          <QueryWidgetBody projectId={projectId} widget={widget} range={range} />
+        )}
+        {widget.type === "trace_feed" && (
+          <TraceFeedWidget
+            projectId={projectId}
+            spec={widget.spec as { limit?: number }}
+            range={range}
+          />
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Eighth PR in the stacked project-dashboards series (epic #1460), stacked on #1515. The composition layer between the dashboard page (coming in the stack's last PR) and the renderers.

## What's here
- **WidgetCard** — frames one widget: title, kebab menu (edit/duplicate/delete; edit only for query widgets), and the body dispatched by widget type — query widgets run their stored spec through `useWidgetData` into `QueryWidgetRenderer`, `trace_feed` renders the feed. Invalid stored specs surface "Invalid widget spec — edit to fix" instead of rendering blank, and the query never fires for them. Read-only dashboards (the seeded Overview) drop the drag handle and menu.
- **DashboardGrid** — react-grid-layout wrapper: drag/resize with a 2×2 minimum tile, layout changes debounced and deduped before the parent's save callback, charts reshape immediately during a resize, and the unmount flush no longer resends layouts the grid was told to suppress. Read-only renders a static grid.
- Follow-up commit: widget cards gate their loading state on `isPending` so the body shows "Loading…" instead of flashing blank while the auth session resolves (same fix as the trace feed in #1515).

closes #1453

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `WidgetCard` and a drag/resize `DashboardGrid` to compose dashboard widgets. Users can arrange widgets with debounced, safe layout saves; read-only dashboards render static and hide controls.

- New Features
  - `WidgetCard`: title, drag handle, and options (Edit for `query` widgets; Duplicate/Delete). Renders `query` via `useWidgetData` -> `QueryWidgetRenderer`, and `trace_feed` with the feed. Invalid specs show “Invalid widget spec” and skip querying.
  - `DashboardGrid`: `react-grid-layout` wrapper (12 cols, 56px rows) with a 2×2 minimum tile. Preserves known positions, appends missing widgets at the bottom, and ignores stale entries. Debounced (600ms) layout saves with dedupe. Read-only marks items static.

- Bug Fixes
  - Widget cards no longer render blank during auth; they show a loading state by gating on isPending.
  - Fix layout persistence edge cases: flush a pending change on unmount and never resend the grid’s mount-fire layout.

<sup>Written for commit a00100d40afa0ea179801a25af8a5a44f1fb6010. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

