### PR TITLE
feat(deploy): provision sql-gateway clickhouse users via helm hook

### DIFF
--- a/backend/db/clickhouse/SQL_GATEWAY_RUNBOOK.md
+++ b/backend/db/clickhouse/SQL_GATEWAY_RUNBOOK.md
@@ -121,10 +121,12 @@ order above is the safe logical sequence for staged/manual provisioning.
   upgrade need no manual step. Confirm afterwards: `SHOW CREATE VIEW` shows the writer definer,
   and `sql_gateway_ro` is denied the physical tables (Code 497).
 
-  **Caveats to verify against a real cluster:** `CREATE USER IF NOT EXISTS` does not re-apply a
-  changed password, so rotating the writer/ro secrets needs an unconditional `ALTER USER` step;
-  and confirm the admin does not already carry access management out of the box (which would
-  make the flag redundant).
+  Secret rotation is handled in-code: the provisioning Job follows each `CREATE USER` with
+  `ALTER USER ... IDENTIFIED WITH sha256_password BY ...`, so a rerun after rotating the
+  writer/ro secrets propagates the new password.
+
+  **Caveat to verify against a real cluster:** confirm the admin does not already carry access
+  management out of the box, which would make the `usersExtraOverrides` flag redundant.
 
 ## DEFINER: explicit scoped writer
 

--- a/backend/db/clickhouse/SQL_GATEWAY_RUNBOOK.md
+++ b/backend/db/clickhouse/SQL_GATEWAY_RUNBOOK.md
@@ -98,26 +98,33 @@ order above is the safe logical sequence for staged/manual provisioning.
   `docker-compose.prod.yml` stack instead auto-provisions the `no_password` compose
   accounts via `clickhouse-init` — for a hardened host, create the users with real
   secrets out of band and do not rely on that bootstrap.
-- **Staging / production (Helm) — ⚠️ OPS BLOCKER, not yet automated.** The Helm chart
-  does **not** yet provision these users, so a deploy that reaches migration 006 without
-  them will fail (`post-install`/`pre-upgrade` hook Job → failed release). Provision them
-  as part of the ClickHouse deploy, then wire the RO env, before rolling the app:
-  1. In the ClickHouse Bitnami subchart values, declare the users/profile via
-     `clickhouse.usersExtraOverrides` (native `users.d` XML — applies to already-running
-     clusters, unlike `initdbScripts`, which only fires on a first-boot/empty data dir and
-     would silently no-op on the existing EFS volume). Back the passwords with
-     `<password from_env="...">` fed by `clickhouse.extraEnvVars` `secretKeyRef`.
-  2. Add `sql_gateway_writer` / `sql_gateway_ro` passwords as new keys in the Terraform-owned
-     secret (`deploy/terraform/aws/secrets.tf`) — mirror `random_password.clickhouse`.
-  3. Wire `CLICKHOUSE_RO_USER` / `CLICKHOUSE_RO_PASSWORD` into `deploy/helm/templates/rest/deployment.yaml`
-     (next to the existing `CLICKHOUSE_USER`/`CLICKHOUSE_PASSWORD`).
-  4. Verify the writer exists **before** the migrate Job runs — the subchart StatefulSet is
-     not hook-ordered relative to the `hook-weight: 0` migrate Job, so confirm the users are
-     live (e.g. a `pre-upgrade` hook Job at a lower weight, or a manual pre-check) rather than
-     assuming values-driven config lands first.
+- **Staging / production (Helm).** Automated by the chart:
+  - `clickhouse.usersExtraOverrides` (`deploy/helm/values.yaml`) grants the admin user
+    `access_management` via native `users.d` config, so the migration can create the
+    definer views and the provisioning Job can create users.
+  - `provision-clickhouse-users.yaml` (`post-install,pre-upgrade`, `hook-weight: -5`) runs
+    the idempotent `CREATE USER`/`GRANT`/`CREATE SETTINGS PROFILE` via `clickhouse-client`,
+    polling for ClickHouse to be reachable. Being weighted below the migrate Job
+    (`hook-weight: 0`) it always runs first, so the writer exists before the migration.
+  - Passwords come from two Terraform-generated secret keys — `clickhouse-writer-password`
+    and `clickhouse-ro-password` in the `traceroot` secret (`deploy/terraform/aws/secrets.tf`).
+  - `CLICKHOUSE_RO_USER` / `CLICKHOUSE_RO_PASSWORD` are wired into
+    `deploy/helm/templates/rest/deployment.yaml`.
 
-  TODO(ops): automate the above (tracked separately) before enabling the SQL gateway in
-  staging/prod. This change intentionally does not ship unverified Helm/Terraform changes.
+  **First rollout onto an already-running cluster — one-time manual sequencing.** Helm runs
+  `pre-upgrade` hooks *before* it updates non-hook resources (the ClickHouse StatefulSet). On
+  the very first upgrade that introduces `access_management`, the provisioning hook would run
+  against the old pod that lacks it and fail with a permissions error (no retry can fix that).
+  Do it in two steps: (1) upgrade with only the `usersExtraOverrides` change and confirm the
+  ClickHouse pod rolled with the new flag (`SHOW GRANTS` shows `ACCESS MANAGEMENT`); (2) upgrade
+  again to add the provisioning Job + enable the migration. Fresh installs and every subsequent
+  upgrade need no manual step. Confirm afterwards: `SHOW CREATE VIEW` shows the writer definer,
+  and `sql_gateway_ro` is denied the physical tables (Code 497).
+
+  **Caveats to verify against a real cluster:** `CREATE USER IF NOT EXISTS` does not re-apply a
+  changed password, so rotating the writer/ro secrets needs an unconditional `ALTER USER` step;
+  and confirm the admin does not already carry access management out of the box (which would
+  make the flag redundant).
 
 ## DEFINER: explicit scoped writer
 
@@ -166,9 +173,9 @@ SHOW CREATE VIEW <database>.spans_public_v1;
 - Under `readonly = 1`, the RO user cannot apply per-query `SETTINGS`. The query service
   therefore relies on the profile for caps and applies row limits via a `LIMIT`
   wrapper in the SQL text, never via per-query settings.
-- **TODO (public SQL endpoint):** the app service containers must receive `CLICKHOUSE_RO_USER` /
-  `CLICKHOUSE_RO_PASSWORD` before anything calls `get_readonly_clickhouse_client()`.
-  `docker-compose.prod.yml`'s `rest`/`worker` and Helm's `rest/deployment.yaml` do **not**
-  pass them yet — intentionally, since nothing reads the RO client until the public SQL
-  endpoint lands. Wire them there at that point (in cloud, `rest` defaults `ENABLE_BILLING=true`,
-  so a missing `CLICKHOUSE_RO_USER` is fatal by design).
+- **RO env wiring:** Helm's `rest/deployment.yaml` passes `CLICKHOUSE_RO_USER` /
+  `CLICKHOUSE_RO_PASSWORD` (the host that serves the SQL endpoint). Still **not** wired:
+  `docker-compose.prod.yml`'s app services and Helm's `worker` — intentionally, since nothing
+  reads the RO client there. Wire them if the public SQL endpoint ever runs outside `rest`
+  (in cloud, `rest` defaults `ENABLE_BILLING=true`, so a missing `CLICKHOUSE_RO_USER` is fatal
+  by design).

--- a/deploy/helm/templates/migrations/provision-clickhouse-users.yaml
+++ b/deploy/helm/templates/migrations/provision-clickhouse-users.yaml
@@ -1,0 +1,80 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "traceroot.fullname" . }}-provision-clickhouse-users
+  labels:
+    {{- include "traceroot.labels" . | nindent 4 }}
+  annotations:
+    # Runs in the same install/upgrade phase as migrate-clickhouse but at a lower
+    # weight, so the SQL-gateway users always exist before the migration creates the
+    # views (whose DEFINER is sql_gateway_writer).
+    "helm.sh/hook": post-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "traceroot.selectorLabels" . | nindent 8 }}
+        app: provision-clickhouse-users
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      restartPolicy: Never
+      containers:
+        - name: provision
+          image: "{{ .Values.migrations.clickhouseUsers.image.repository }}:{{ .Values.migrations.clickhouseUsers.image.tag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              set -euo pipefail
+              CH="clickhouse-client --host {{ include "traceroot.clickhouse.hostname" . }} --port 9000 --user {{ .Values.clickhouse.auth.username }} --password ${CLICKHOUSE_ADMIN_PASSWORD}"
+              # The ClickHouse pod is not guaranteed Ready before this hook fires; poll.
+              for i in $(seq 1 60); do
+                $CH --query "SELECT 1" >/dev/null 2>&1 && break
+                echo "waiting for clickhouse ($i/60)"; sleep 5
+              done
+              # Idempotent. Grants are name-based, so the read-only grants on the
+              # views are recorded even though the views are created by the later
+              # migration. ClickHouse redacts the password in query_log.
+              $CH --multiquery --query "
+                CREATE USER IF NOT EXISTS sql_gateway_writer
+                    IDENTIFIED WITH sha256_password BY '${SQL_GATEWAY_WRITER_PASSWORD}';
+                GRANT SELECT ON default.spans  TO sql_gateway_writer;
+                GRANT SELECT ON default.traces TO sql_gateway_writer;
+                CREATE SETTINGS PROFILE IF NOT EXISTS sql_readonly_profile SETTINGS
+                    readonly = 1,
+                    max_execution_time = 30 CONST,
+                    max_result_rows = 100000 CONST,
+                    max_result_bytes = 536870912 CONST,
+                    max_memory_usage = 4294967296 CONST;
+                CREATE USER IF NOT EXISTS sql_gateway_ro
+                    IDENTIFIED WITH sha256_password BY '${SQL_GATEWAY_RO_PASSWORD}'
+                    SETTINGS PROFILE 'sql_readonly_profile';
+                GRANT SELECT ON default.spans_public_v1  TO sql_gateway_ro;
+                GRANT SELECT ON default.traces_public_v1 TO sql_gateway_ro;
+              "
+          env:
+            - name: CLICKHOUSE_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.auth.existingSecret }}
+                  key: {{ .Values.clickhouse.auth.existingSecretKey }}
+            - name: SQL_GATEWAY_WRITER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.auth.existingSecret }}
+                  key: "clickhouse-writer-password"
+            - name: SQL_GATEWAY_RO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.auth.existingSecret }}
+                  key: "clickhouse-ro-password"
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "250m"
+              memory: "256Mi"

--- a/deploy/helm/templates/migrations/provision-clickhouse-users.yaml
+++ b/deploy/helm/templates/migrations/provision-clickhouse-users.yaml
@@ -35,11 +35,16 @@ spec:
                 $CH --query "SELECT 1" >/dev/null 2>&1 && break
                 echo "waiting for clickhouse ($i/60)"; sleep 5
               done
-              # Idempotent. Grants are name-based, so the read-only grants on the
-              # views are recorded even though the views are created by the later
-              # migration. ClickHouse redacts the password in query_log.
+              # Idempotent AND reconciling: the ALTER statements re-apply the password
+              # and profile on every run, so rotating the secret propagates to
+              # ClickHouse (CREATE ... IF NOT EXISTS alone would not update an existing
+              # user, leaving it on the old password). Grants are name-based, so the
+              # read-only grants on the views are recorded even though the views are
+              # created by the later migration. ClickHouse redacts passwords in query_log.
               $CH --multiquery --query "
                 CREATE USER IF NOT EXISTS sql_gateway_writer
+                    IDENTIFIED WITH sha256_password BY '${SQL_GATEWAY_WRITER_PASSWORD}';
+                ALTER USER sql_gateway_writer
                     IDENTIFIED WITH sha256_password BY '${SQL_GATEWAY_WRITER_PASSWORD}';
                 GRANT SELECT ON default.spans  TO sql_gateway_writer;
                 GRANT SELECT ON default.traces TO sql_gateway_writer;
@@ -49,7 +54,16 @@ spec:
                     max_result_rows = 100000 CONST,
                     max_result_bytes = 536870912 CONST,
                     max_memory_usage = 4294967296 CONST;
+                ALTER SETTINGS PROFILE sql_readonly_profile SETTINGS
+                    readonly = 1,
+                    max_execution_time = 30 CONST,
+                    max_result_rows = 100000 CONST,
+                    max_result_bytes = 536870912 CONST,
+                    max_memory_usage = 4294967296 CONST;
                 CREATE USER IF NOT EXISTS sql_gateway_ro
+                    IDENTIFIED WITH sha256_password BY '${SQL_GATEWAY_RO_PASSWORD}'
+                    SETTINGS PROFILE 'sql_readonly_profile';
+                ALTER USER sql_gateway_ro
                     IDENTIFIED WITH sha256_password BY '${SQL_GATEWAY_RO_PASSWORD}'
                     SETTINGS PROFILE 'sql_readonly_profile';
                 GRANT SELECT ON default.spans_public_v1  TO sql_gateway_ro;

--- a/deploy/helm/templates/rest/deployment.yaml
+++ b/deploy/helm/templates/rest/deployment.yaml
@@ -45,6 +45,13 @@ spec:
                   key: {{ .Values.clickhouse.auth.existingSecretKey }}
             - name: CLICKHOUSE_DATABASE
               value: "default"
+            - name: CLICKHOUSE_RO_USER
+              value: "sql_gateway_ro"
+            - name: CLICKHOUSE_RO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.auth.existingSecret }}
+                  key: "clickhouse-ro-password"
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -144,6 +144,18 @@ clickhouse:
     enabled: true
     size: 20Gi
     storageClass: "efs"
+  # Grants the admin user (auth.username) SQL access management so the SQL-gateway
+  # provisioning Job can CREATE USER and the ClickHouse migration can create views
+  # with an explicit DEFINER. The stock admin has broad DDL but not access
+  # management. The element name below MUST match auth.username (default `default`).
+  usersExtraOverrides: |
+    <clickhouse>
+      <users>
+        <default>
+          <access_management>1</access_management>
+        </default>
+      </users>
+    </clickhouse>
 
 # --- Migrations ---
 migrations:
@@ -155,6 +167,13 @@ migrations:
     image:
       repository: ""
       tag: "latest"
+  # One-shot Job that provisions the SQL-gateway ClickHouse users (writer + read-only
+  # + settings profile) before the ClickHouse migration runs. Needs an image that
+  # ships clickhouse-client; only has to reach the ClickHouse service.
+  clickhouseUsers:
+    image:
+      repository: clickhouse/clickhouse-server
+      tag: "24.3.18.7"
 
 # --- Secrets (managed by Terraform) ---
 secrets:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -147,13 +147,14 @@ clickhouse:
   # Grants the admin user (auth.username) SQL access management so the SQL-gateway
   # provisioning Job can CREATE USER and the ClickHouse migration can create views
   # with an explicit DEFINER. The stock admin has broad DDL but not access
-  # management. The element name below MUST match auth.username (default `default`).
+  # management. The subchart renders this value with `tpl`, so the username element
+  # tracks auth.username automatically — including a non-default admin username.
   usersExtraOverrides: |
     <clickhouse>
       <users>
-        <default>
+        <{{ .Values.auth.username }}>
           <access_management>1</access_management>
-        </default>
+        </{{ .Values.auth.username }}>
       </users>
     </clickhouse>
 

--- a/deploy/terraform/aws/secrets.tf
+++ b/deploy/terraform/aws/secrets.tf
@@ -18,6 +18,19 @@ resource "random_password" "clickhouse" {
   special = false
 }
 
+# SQL-gateway ClickHouse identities: the view-definer writer and the read-only
+# user the SQL gateway runs user queries as. Provisioned by the
+# provision-clickhouse-users Helm hook Job before the ClickHouse migration.
+resource "random_password" "clickhouse_writer" {
+  length  = 32
+  special = false
+}
+
+resource "random_password" "clickhouse_ro" {
+  length  = 32
+  special = false
+}
+
 resource "random_id" "encryption_key" {
   byte_length = 32 # 32 bytes = 64 hex characters = 256 bits
 }
@@ -44,14 +57,16 @@ resource "kubernetes_secret" "app" {
   }
 
   data = {
-    "postgres-password"   = random_password.postgres.result
-    "redis-password"      = random_password.redis.result
-    "better-auth-secret"  = random_password.better_auth_secret.result
-    "internal-api-secret" = random_password.internal_api_secret.result
-    "clickhouse-password" = random_password.clickhouse.result
-    "database-url"        = "postgresql://traceroot:${random_password.postgres.result}@${aws_rds_cluster.postgres.endpoint}:5432/${local.database_name}"
-    "redis-url"           = "rediss://:${random_password.redis.result}@${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379/0"
-    "encryption-key"      = random_id.encryption_key.hex
+    "postgres-password"          = random_password.postgres.result
+    "redis-password"             = random_password.redis.result
+    "better-auth-secret"         = random_password.better_auth_secret.result
+    "internal-api-secret"        = random_password.internal_api_secret.result
+    "clickhouse-password"        = random_password.clickhouse.result
+    "clickhouse-writer-password" = random_password.clickhouse_writer.result
+    "clickhouse-ro-password"     = random_password.clickhouse_ro.result
+    "database-url"               = "postgresql://traceroot:${random_password.postgres.result}@${aws_rds_cluster.postgres.endpoint}:5432/${local.database_name}"
+    "redis-url"                  = "rediss://:${random_password.redis.result}@${aws_elasticache_replication_group.redis.primary_endpoint_address}:6379/0"
+    "encryption-key"             = random_id.encryption_key.hex
   }
 
   depends_on = [module.eks]


### PR DESCRIPTION
## Summary

(2/2) Fixes #1336 
DB layer: #1355 
Specifically scoped to Helm Layer

Provisions the SQL-gateway ClickHouse identities on the Helm/Terraform (staging/prod) deploy path, so the gateway's read-only views migration applies cleanly there — closing the last remaining gap before the SQL gateway can be enabled in the cloud.

The read-only views are created with `SQL SECURITY DEFINER` owned by a dedicated `sql_gateway_writer`, and user SQL runs as a separate least-privileged `sql_gateway_ro`. Both accounts (plus a read-only settings profile) must exist **before** the ClickHouse migration runs, and the admin that runs the migration needs access management + set-definer rights. The compose/dev path already handles this; this change does the equivalent for Helm.

Stacked on the read-only-views branch (it provisions the users that branch's migration depends on, and mirrors its bootstrap SQL).

## How it works

```
helm upgrade
  → ClickHouse admin gets access_management via users.d config (usersExtraOverrides)
    → provision-clickhouse-users hook Job (hook-weight -5) runs FIRST
        → CREATE USER sql_gateway_writer / sql_gateway_ro + sql_readonly_profile + grants
      → migrate-clickhouse hook Job (hook-weight 0) runs
          → migration creates the DEFINER views (writer now exists)
        → app rolls with CLICKHOUSE_RO_USER / CLICKHOUSE_RO_PASSWORD set
```

The provisioning Job is weighted below the migration Job in the same hook phase, so the users always exist before the migration needs them — independent of StatefulSet readiness (the Job also polls for ClickHouse to be reachable). The provisioning SQL is idempotent and identical in shape to the compose bootstrap already verified on the pinned ClickHouse version.

## What's included

### Helm
- `deploy/helm/templates/migrations/provision-clickhouse-users.yaml` — new `post-install,pre-upgrade` hook Job at `hook-weight: -5`; runs the idempotent `CREATE USER`/`GRANT`/`CREATE SETTINGS PROFILE` via `clickhouse-client` with a readiness poll loop. Passwords injected from the `traceroot` secret; ClickHouse redacts them in `query_log`.
- `deploy/helm/values.yaml` — `clickhouse.usersExtraOverrides` grants the admin user `access_management` (needed to create users and set the view definer; the stock admin has broad DDL but not access management); `migrations.clickhouseUsers.image` for the provisioning Job.
- `deploy/helm/templates/rest/deployment.yaml` — wires `CLICKHOUSE_RO_USER` / `CLICKHOUSE_RO_PASSWORD` into the API service (the host that serves the SQL endpoint).

### Terraform
- `deploy/terraform/aws/secrets.tf` — two generated passwords (`clickhouse-writer-password`, `clickhouse-ro-password`) added to the `traceroot` secret, mirroring the existing ClickHouse password.

### Docs
- `backend/db/clickhouse/SQL_GATEWAY_RUNBOOK.md` — the staging/prod section now documents the automated flow, the one-time two-step rollout required the first time this lands on an already-running cluster, and the verification steps.

## The one operational caveat

Helm runs `pre-upgrade` hooks *before* it updates non-hook resources (the ClickHouse StatefulSet). On the **very first** upgrade that introduces the `access_management` flag onto an already-running cluster, the provisioning hook would run against the old pod that lacks the flag and fail on permissions. Fresh installs are unaffected. For that one transition, do a two-step rollout (documented in the runbook): land the flag, confirm the pod rolled, then land the provisioning Job + enable the migration. Every later upgrade needs no manual step.

## Test plan

Neither `helm` nor `terraform` is installed in the authoring environment, so this landed with local structural validation only and **must be validated against a staging cluster before enabling the gateway in production**.

- [x] `values.yaml` parses as YAML
- [x] Both migration Job templates parse structurally; provisioning Job renders at `hook-weight -5` (before migrate's `0`)
- [x] No secrets committed (passwords are Terraform-generated into the secret)
- [ ] `helm template` / `helm lint` render clean against the chart
- [ ] `terraform fmt -check` + `terraform validate` clean
- [ ] Fresh install on a staging cluster: provisioning Job succeeds, migration applies, `SHOW CREATE VIEW` shows the writer definer, `sql_gateway_ro` is denied the physical tables (Code 497)
- [ ] Two-step rollout onto an already-running cluster works as documented
- [ ] Confirm the admin does not already have access management out of the box (would make the flag redundant)
- [x] Confirm secret rotation behavior (add an unconditional `ALTER USER` if the writer/ro passwords need to rotate)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provision SQL‑gateway ClickHouse users via a Helm hook so the read‑only views migration runs cleanly in staging/prod. The hook reconciles passwords/profiles on each run, and the admin grant follows custom admin usernames.

- **New Features**
  - Adds a `post-install,pre-upgrade` Helm hook Job (weight `-5`) that creates users, settings profile, and grants before the migration, with a readiness poll and reconciling `ALTER USER` statements.
  - Grants ClickHouse admin `access_management` via `clickhouse.usersExtraOverrides`, templated to track `.Values.auth.username`.
  - Wires `CLICKHOUSE_RO_USER` and `CLICKHOUSE_RO_PASSWORD` into the `rest` deployment.
  - Adds Terraform-managed secrets for `clickhouse-writer-password` and `clickhouse-ro-password`.
  - Updates the runbook with the automated flow, one-time two-step rollout, verification steps, and in-code secret rotation behavior.

- **Migration**
  - One-time two-step rollout for existing clusters: first add `access_management` and roll ClickHouse, then add the provisioning Job + enable the migration (Helm runs pre-upgrade hooks before the StatefulSet update).
  - Password rotation is applied by the hook on upgrade (via `ALTER USER`); rotate out-of-band by running an upgrade or applying `ALTER USER` manually.

<sup>Written for commit d63476353e9ee1d5db4dac56d32682eb68759614. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



