### PR TITLE
feat(ui): dashboard CRUD routes with a lazily seeded Overview

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock responses don't carry NextResponse's full type — cast at call sites.
+type MockResponse = { status: number; json: () => Promise<unknown> };
+
+vi.mock("next/server", () => ({ NextRequest: class {} }));
+
+vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
+
+const dashboardFindFirstMock = vi.fn();
+const dashboardUpdateMock = vi.fn();
+const dashboardDeleteMock = vi.fn();
+const widgetFindFirstMock = vi.fn();
+const widgetCreateMock = vi.fn();
+const widgetUpdateMock = vi.fn();
+const widgetDeleteMock = vi.fn();
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    dashboard: {
+      findFirst: (...args: unknown[]) => dashboardFindFirstMock(...args),
+      update: (...args: unknown[]) => dashboardUpdateMock(...args),
+      delete: (...args: unknown[]) => dashboardDeleteMock(...args),
+    },
+    widget: {
+      findFirst: (...args: unknown[]) => widgetFindFirstMock(...args),
+      create: (...args: unknown[]) => widgetCreateMock(...args),
+      update: (...args: unknown[]) => widgetUpdateMock(...args),
+      delete: (...args: unknown[]) => widgetDeleteMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({
+    status,
+    json: async () => data,
+  }),
+}));
+
+import { GET, PATCH, DELETE } from "./route";
+
+function makeRequest(body?: unknown) {
+  return {
+    json: async () => body,
+  } as unknown as Parameters<typeof PATCH>[0];
+}
+
+function makeParams(projectId = "proj-1", dashboardId = "dash-1") {
+  return { params: Promise.resolve({ projectId, dashboardId }) };
+}
+
+const fakeDashboard = {
+  id: "dash-1",
+  projectId: "proj-1",
+  name: "My Dashboard",
+  description: null,
+  isDefault: false,
+  layout: [],
+  widgets: [],
+};
+
+const fakeWidget = {
+  id: "widget-1",
+  dashboardId: "dash-1",
+  title: "My Widget",
+  type: "query",
+  spec: { sql: "SELECT 1" },
+  displayConfig: {},
+};
+
+beforeEach(() => {
+  dashboardFindFirstMock.mockReset();
+  dashboardUpdateMock.mockReset();
+  dashboardDeleteMock.mockReset();
+  widgetFindFirstMock.mockReset();
+  widgetCreateMock.mockReset();
+  widgetUpdateMock.mockReset();
+  widgetDeleteMock.mockReset();
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  // Default: authenticated with project access.
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+});
+
+// ---------------------------------------------------------------------------
+// GET /dashboards/[dashboardId]
+// ---------------------------------------------------------------------------
+describe("GET /dashboards/[dashboardId]", () => {
+  it("returns 404 when dashboard is not found in the project", async () => {
+    dashboardFindFirstMock.mockResolvedValue(null);
+
+    const res = (await GET(makeRequest(), makeParams("proj-1", "dash-999"))) as MockResponse;
+    expect(res.status).toBe(404);
+
+    // The where clause must scope by BOTH id AND projectId
+    const [call] = dashboardFindFirstMock.mock.calls;
+    const where = (call[0] as { where: Record<string, unknown> }).where;
+    expect(where.id).toBe("dash-999");
+    expect(where.projectId).toBe("proj-1");
+  });
+
+  it("returns 200 with dashboard including widgets ordered by createTime", async () => {
+    const dashboardWithWidgets = { ...fakeDashboard, widgets: [fakeWidget] };
+    dashboardFindFirstMock.mockResolvedValue(dashboardWithWidgets);
+
+    const res = (await GET(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { dashboard: typeof dashboardWithWidgets };
+    expect(body.dashboard).toEqual(dashboardWithWidgets);
+    expect(body.dashboard.widgets).toHaveLength(1);
+
+    // Verify include clause includes widgets ordered by createTime asc
+    const [call] = dashboardFindFirstMock.mock.calls;
+    const include = (call[0] as { include?: Record<string, unknown> }).include;
+    expect(include?.widgets).toMatchObject({ orderBy: { createTime: "asc" } });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = (await GET(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(401);
+    expect(dashboardFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user lacks project access", async () => {
+    requireProjectAccessMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    const res = (await GET(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(403);
+    expect(dashboardFindFirstMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /dashboards/[dashboardId]
+// ---------------------------------------------------------------------------
+describe("PATCH /dashboards/[dashboardId]", () => {
+  it("updates layout and returns 200", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const updatedLayout = [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }];
+    dashboardUpdateMock.mockResolvedValue({ ...fakeDashboard, layout: updatedLayout });
+
+    const res = (await PATCH(makeRequest({ layout: updatedLayout }), makeParams())) as MockResponse;
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { dashboard: Record<string, unknown> };
+    expect(body.dashboard.layout).toEqual(updatedLayout);
+
+    const [call] = dashboardUpdateMock.mock.calls;
+    const data = (call[0] as { data: Record<string, unknown> }).data;
+    expect(data.layout).toEqual(updatedLayout);
+    // isDefault must never be settable via PATCH
+    expect(data.isDefault).toBeUndefined();
+  });
+
+  it("returns 400 for empty body (no fields to update)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await PATCH(makeRequest({}), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for non-object body (array)", async () => {
+    const req = { json: async () => ["a", "b"] } as unknown as Parameters<typeof PATCH>[0];
+    const res = (await PATCH(req, makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(dashboardFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for non-object body (null)", async () => {
+    const req = { json: async () => null } as unknown as Parameters<typeof PATCH>[0];
+    const res = (await PATCH(req, makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(dashboardFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  it("does not accept isDefault from request body", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    dashboardUpdateMock.mockResolvedValue({ ...fakeDashboard, name: "Renamed" });
+
+    await PATCH(makeRequest({ name: "Renamed", isDefault: true }), makeParams());
+
+    const [call] = dashboardUpdateMock.mock.calls;
+    const data = (call[0] as { data: Record<string, unknown> }).data;
+    expect(data.isDefault).toBeUndefined();
+    expect(data.name).toBe("Renamed");
+  });
+
+  it("returns 400 for non-string name", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await PATCH(makeRequest({ name: 42 }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for empty name", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await PATCH(makeRequest({ name: "  " }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for non-array layout", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await PATCH(makeRequest({ layout: { i: "w1" } }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when dashboard not found in project", async () => {
+    dashboardFindFirstMock.mockResolvedValue(null);
+    const res = (await PATCH(
+      makeRequest({ name: "New" }),
+      makeParams("proj-1", "dash-999"),
+    )) as MockResponse;
+    expect(res.status).toBe(404);
+    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+
+    const [call] = dashboardFindFirstMock.mock.calls;
+    const where = (call[0] as { where: Record<string, unknown> }).where;
+    expect(where.id).toBe("dash-999");
+    expect(where.projectId).toBe("proj-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /dashboards/[dashboardId]
+// ---------------------------------------------------------------------------
+describe("DELETE /dashboards/[dashboardId]", () => {
+  it("returns 200 with deleted: true after scoped findFirst", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    dashboardDeleteMock.mockResolvedValue({});
+
+    const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deleted: boolean };
+    expect(body.deleted).toBe(true);
+
+    // Ensure the findFirst used both id and projectId
+    const [call] = dashboardFindFirstMock.mock.calls;
+    const where = (call[0] as { where: Record<string, unknown> }).where;
+    expect(where.id).toBe("dash-1");
+    expect(where.projectId).toBe("proj-1");
+  });
+
+  it("returns 404 when dashboard not found in project", async () => {
+    dashboardFindFirstMock.mockResolvedValue(null);
+    const res = (await DELETE(makeRequest(), makeParams("proj-1", "dash-999"))) as MockResponse;
+    expect(res.status).toBe(404);
+    expect(dashboardDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(401);
+    expect(dashboardFindFirstMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Default dashboard is read-only
+// ---------------------------------------------------------------------------
+describe("default dashboard is read-only", () => {
+  const defaultDashboard = { ...fakeDashboard, isDefault: true };
+
+  it("PATCH /dashboards/[dashboardId] returns 403", async () => {
+    dashboardFindFirstMock.mockResolvedValue(defaultDashboard);
+    const res = (await PATCH(makeRequest({ name: "renamed" }), makeParams())) as MockResponse;
+    expect(res.status).toBe(403);
+    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("DELETE /dashboards/[dashboardId] returns 403", async () => {
+    dashboardFindFirstMock.mockResolvedValue(defaultDashboard);
+    const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(403);
+    expect(dashboardDeleteMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("PATCH /dashboards/[dashboardId] — name length cap", () => {
+  it("rejects a rename longer than 100 characters", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await PATCH(makeRequest({ name: "x".repeat(101) }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import { errorResponse, successResponse } from "@/lib/auth-helpers";
+import { parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
+import { DASHBOARD_NAME_MAX } from "@/features/dashboards/types";
+
+type RouteParams = { params: Promise<{ projectId: string; dashboardId: string }> };
+
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const auth = await requireProjectAuth(params);
+  if (auth.error) return auth.error;
+  const { projectId, dashboardId } = auth.params;
+
+  const dashboard = await prisma.dashboard.findFirst({
+    where: { id: dashboardId, projectId },
+    include: { widgets: { orderBy: { createTime: "asc" } } },
+  });
+  if (!dashboard) return errorResponse("Dashboard not found", 404);
+  return successResponse({ dashboard });
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  const auth = await requireProjectAuth(params);
+  if (auth.error) return auth.error;
+  const { projectId, dashboardId } = auth.params;
+
+  // Parse and validate body before hitting the DB — fail fast on bad input.
+  const parsed = await parseJsonObject(req);
+  if (parsed.error) return parsed.error;
+  const { name, description, layout } = parsed.body;
+
+  const data: Record<string, unknown> = {};
+  if (name !== undefined) {
+    if (typeof name !== "string" || name.trim().length === 0) {
+      return errorResponse("name must be a non-empty string", 400);
+    }
+    if (name.trim().length > DASHBOARD_NAME_MAX) {
+      return errorResponse(`name must be at most ${DASHBOARD_NAME_MAX} characters`, 400);
+    }
+    data.name = name.trim();
+  }
+  if (description !== undefined) {
+    if (description !== null && typeof description !== "string") {
+      return errorResponse("description must be a string or null", 400);
+    }
+    data.description = description;
+  }
+  if (layout !== undefined) {
+    if (!Array.isArray(layout)) return errorResponse("layout must be an array", 400);
+    data.layout = layout;
+  }
+  if (Object.keys(data).length === 0) return errorResponse("No fields to update", 400);
+
+  const existing = await prisma.dashboard.findFirst({
+    where: { id: dashboardId, projectId },
+  });
+  if (!existing) return errorResponse("Dashboard not found", 404);
+  if (existing.isDefault) return errorResponse("The default dashboard is read-only", 403);
+
+  const dashboard = await prisma.dashboard.update({
+    where: { id: dashboardId },
+    data,
+  });
+  return successResponse({ dashboard });
+}
+
+export async function DELETE(_req: NextRequest, { params }: RouteParams) {
+  const auth = await requireProjectAuth(params);
+  if (auth.error) return auth.error;
+  const { projectId, dashboardId } = auth.params;
+
+  const existing = await prisma.dashboard.findFirst({
+    where: { id: dashboardId, projectId },
+  });
+  if (!existing) return errorResponse("Dashboard not found", 404);
+  if (existing.isDefault) return errorResponse("The default dashboard is read-only", 403);
+
+  await prisma.dashboard.delete({ where: { id: dashboardId } });
+  return successResponse({ deleted: true });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Prisma } from "@prisma/client";
+
+vi.mock("next/server", () => ({ NextRequest: class {} }));
+
+vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
+
+const dashboardFindManyMock = vi.fn();
+const dashboardCreateMock = vi.fn();
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    dashboard: {
+      findMany: (...args: unknown[]) => dashboardFindManyMock(...args),
+      create: (...args: unknown[]) => dashboardCreateMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({
+    status,
+    json: async () => data,
+  }),
+}));
+
+import { GET, POST } from "./route";
+
+function makeGetRequest() {
+  return {} as Parameters<typeof GET>[0];
+}
+
+function makePostRequest(body: unknown) {
+  return {
+    json: async () => body,
+  } as unknown as Parameters<typeof POST>[0];
+}
+
+function makeParams(projectId = "proj-1") {
+  return { params: Promise.resolve({ projectId }) };
+}
+
+beforeEach(() => {
+  dashboardFindManyMock.mockReset();
+  dashboardCreateMock.mockReset();
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  // Default: authenticated with project access.
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+});
+
+describe("GET /dashboards — existing dashboards", () => {
+  it("returns existing dashboards without seeding when dashboards already exist", async () => {
+    const existing = [
+      {
+        id: "dash-1",
+        name: "Overview",
+        description: null,
+        isDefault: true,
+        updateTime: new Date(),
+      },
+    ];
+    dashboardFindManyMock.mockResolvedValue(existing);
+
+    const res = await GET(makeGetRequest(), makeParams());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: unknown[] };
+    expect(body.data).toHaveLength(1);
+    // create must never have been called
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+    // findMany called exactly once (no re-read needed)
+    expect(dashboardFindManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = await GET(makeGetRequest(), makeParams());
+    expect(res.status).toBe(401);
+    expect(dashboardFindManyMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user lacks project access", async () => {
+    requireProjectAccessMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    const res = await GET(makeGetRequest(), makeParams());
+    expect(res.status).toBe(403);
+    expect(dashboardFindManyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /dashboards — lazy seeding (no existing dashboards)", () => {
+  it("seeds default dashboard: create called once with correct id, isDefault=true, >=7 widgets, layout[i].i === widgets.create[i].id", async () => {
+    // First findMany returns empty (triggers seed); second returns seeded list.
+    dashboardFindManyMock.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: "default_proj-1",
+        name: "Overview",
+        description: null,
+        isDefault: true,
+        updateTime: new Date(),
+      },
+    ]);
+    dashboardCreateMock.mockResolvedValue({});
+
+    const res = await GET(makeGetRequest(), makeParams("proj-1"));
+    expect(res.status).toBe(200);
+
+    expect(dashboardCreateMock).toHaveBeenCalledTimes(1);
+    const { data } = dashboardCreateMock.mock.calls[0][0] as {
+      data: {
+        id: string;
+        isDefault: boolean;
+        layout: Array<{ i: string }>;
+        widgets: { create: Array<{ id: string }> };
+      };
+    };
+
+    expect(data.id).toBe("default_proj-1");
+    expect(data.isDefault).toBe(true);
+    expect(data.widgets.create.length).toBeGreaterThanOrEqual(7);
+
+    // Every layout[i].i must equal widgets.create[i].id
+    data.layout.forEach((layoutItem, idx) => {
+      expect(layoutItem.i).toBe(data.widgets.create[idx].id);
+    });
+
+    // Re-read happens after creation
+    expect(dashboardFindManyMock).toHaveBeenCalledTimes(2);
+    const body = (await res.json()) as { data: unknown[] };
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("swallows PK conflict (P2002) and still returns dashboards", async () => {
+    dashboardFindManyMock.mockResolvedValueOnce([]).mockResolvedValueOnce([
+      {
+        id: "default_proj-1",
+        name: "Overview",
+        description: null,
+        isDefault: true,
+        updateTime: new Date(),
+      },
+    ]);
+    dashboardCreateMock.mockRejectedValue(
+      new Prisma.PrismaClientKnownRequestError("Unique constraint failed on the fields: (`id`)", {
+        code: "P2002",
+        clientVersion: "5.22.0",
+      }),
+    );
+
+    const res = await GET(makeGetRequest(), makeParams("proj-1"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: unknown[] };
+    expect(body.data).toHaveLength(1);
+  });
+
+  it("propagates non-PK-clash errors from dashboard.create", async () => {
+    dashboardFindManyMock.mockResolvedValueOnce([]);
+    dashboardCreateMock.mockRejectedValue(new Error("Database connection lost"));
+
+    await expect(GET(makeGetRequest(), makeParams("proj-1"))).rejects.toThrow(
+      "Database connection lost",
+    );
+  });
+});
+
+describe("POST /dashboards — create a named dashboard", () => {
+  it("rejects empty name with 400", async () => {
+    const res = await POST(makePostRequest({ name: "" }), makeParams());
+    expect(res.status).toBe(400);
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects whitespace-only name with 400", async () => {
+    const res = await POST(makePostRequest({ name: "   " }), makeParams());
+    expect(res.status).toBe(400);
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing name with 400", async () => {
+    const res = await POST(makePostRequest({}), makeParams());
+    expect(res.status).toBe(400);
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("creates and returns 201 with a valid name", async () => {
+    const created = {
+      id: "dash-new",
+      name: "My Dashboard",
+      description: null,
+      projectId: "proj-1",
+      isDefault: false,
+    };
+    dashboardCreateMock.mockResolvedValue(created);
+
+    const res = await POST(makePostRequest({ name: "My Dashboard" }), makeParams());
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { dashboard: typeof created };
+    expect(body.dashboard).toEqual(created);
+    expect(dashboardCreateMock).toHaveBeenCalledTimes(1);
+
+    const { data } = dashboardCreateMock.mock.calls[0][0] as { data: Record<string, unknown> };
+    // isDefault must NOT be accepted from the request body
+    expect(data.isDefault).toBeUndefined();
+    expect(data.name).toBe("My Dashboard");
+  });
+
+  it("trims leading/trailing whitespace from name", async () => {
+    dashboardCreateMock.mockResolvedValue({ id: "dash-x", name: "Trimmed" });
+
+    await POST(makePostRequest({ name: "  Trimmed  " }), makeParams());
+
+    const { data } = dashboardCreateMock.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(data.name).toBe("Trimmed");
+  });
+
+  it("rejects non-string description with 400", async () => {
+    const res = await POST(makePostRequest({ name: "Valid", description: 123 }), makeParams());
+    expect(res.status).toBe(400);
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts null description", async () => {
+    dashboardCreateMock.mockResolvedValue({ id: "dash-y", name: "Valid" });
+    const res = await POST(makePostRequest({ name: "Valid", description: null }), makeParams());
+    expect(res.status).toBe(201);
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = await POST(makePostRequest({ name: "x" }), makeParams());
+    expect(res.status).toBe(401);
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user lacks project access", async () => {
+    requireProjectAccessMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    const res = await POST(makePostRequest({ name: "x" }), makeParams());
+    expect(res.status).toBe(403);
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a null body (non-object JSON)", async () => {
+    const req = {
+      json: async () => null,
+    } as unknown as Parameters<typeof POST>[0];
+    const res = await POST(req, makeParams());
+    expect(res.status).toBe(400);
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an array body (non-object JSON)", async () => {
+    const req = {
+      json: async () => ["a", "b"],
+    } as unknown as Parameters<typeof POST>[0];
+    const res = await POST(req, makeParams());
+    expect(res.status).toBe(400);
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /dashboards — name length cap", () => {
+  it("rejects a name longer than 50 characters", async () => {
+    const res = (await POST(
+      makePostRequest({ name: "x".repeat(51) }),
+      makeParams(),
+    )) as unknown as { status: number; json: () => Promise<unknown> };
+    expect(res.status).toBe(400);
+    expect(dashboardCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("accepts a name of exactly 50 characters", async () => {
+    dashboardCreateMock.mockResolvedValue({ id: "d-new" });
+    const res = (await POST(
+      makePostRequest({ name: "x".repeat(50) }),
+      makeParams(),
+    )) as unknown as { status: number; json: () => Promise<unknown> };
+    expect(res.status).toBe(201);
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest } from "next/server";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@traceroot/core";
+import { errorResponse, successResponse } from "@/lib/auth-helpers";
+import { parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
+import { defaultDashboardId, seedWidgets } from "@/lib/dashboard-seed";
+import { DASHBOARD_NAME_MAX } from "@/features/dashboards/types";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+const listArgs = (projectId: string) => ({
+  where: { projectId },
+  orderBy: [{ isDefault: "desc" as const }, { createTime: "asc" as const }],
+  select: { id: true, name: true, description: true, isDefault: true, updateTime: true },
+});
+
+// GET /api/projects/[projectId]/dashboards — list; lazily seeds the default
+// "Overview" dashboard the first time a project's dashboards are fetched.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const auth = await requireProjectAuth(params);
+  if (auth.error) return auth.error;
+  const { user } = auth;
+  const { projectId } = auth.params;
+
+  let dashboards = await prisma.dashboard.findMany(listArgs(projectId));
+
+  if (dashboards.length === 0) {
+    const widgets = seedWidgets();
+    const seeded = widgets.map((w, i) => ({ ...w, id: `seed-${i}-${projectId}` }));
+    try {
+      await prisma.dashboard.create({
+        data: {
+          id: defaultDashboardId(projectId),
+          projectId,
+          name: "Overview",
+          isDefault: true,
+          createdBy: user.id,
+          // layout keys MUST equal widget ids (react-grid-layout matches on `i`)
+          layout: seeded.map((w) => ({ i: w.id, ...w.layout })),
+          widgets: {
+            create: seeded.map((w) => ({ id: w.id, title: w.title, type: w.type, spec: w.spec })),
+          },
+        },
+      });
+    } catch (e) {
+      // Concurrent first-visit: another request already created it (PK clash).
+      if (!(e instanceof Prisma.PrismaClientKnownRequestError) || e.code !== "P2002") throw e;
+    }
+    dashboards = await prisma.dashboard.findMany(listArgs(projectId));
+  }
+
+  return successResponse({ data: dashboards });
+}
+
+// POST /api/projects/[projectId]/dashboards — create a named dashboard
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const auth = await requireProjectAuth(params);
+  if (auth.error) return auth.error;
+  const { user } = auth;
+  const { projectId } = auth.params;
+
+  const parsed = await parseJsonObject(req);
+  if (parsed.error) return parsed.error;
+  const { name, description } = parsed.body;
+  if (typeof name !== "string" || name.trim().length === 0) {
+    return errorResponse("name must be a non-empty string", 400);
+  }
+  if (name.trim().length > DASHBOARD_NAME_MAX) {
+    return errorResponse(`name must be at most ${DASHBOARD_NAME_MAX} characters`, 400);
+  }
+  if (description !== undefined && description !== null && typeof description !== "string") {
+    return errorResponse("description must be a string", 400);
+  }
+
+  const dashboard = await prisma.dashboard.create({
+    data: {
+      projectId,
+      name: name.trim(),
+      description: (description as string) ?? null,
+      createdBy: user.id,
+    },
+  });
+  return successResponse({ dashboard }, 201);
+}

--- a/frontend/ui/src/lib/dashboard-seed.ts
+++ b/frontend/ui/src/lib/dashboard-seed.ts
@@ -1,0 +1,104 @@
+// Widget definitions for the lazily-created default "Overview" dashboard.
+// Created once per project on first dashboards fetch, then fully user-owned —
+// never re-seeded or force-updated.
+
+type SeedWidget = {
+  title: string;
+  type: "query" | "trace_feed";
+  spec: object;
+  layout: { x: number; y: number; w: number; h: number };
+};
+
+export function defaultDashboardId(projectId: string): string {
+  // Deterministic id makes lazy creation idempotent across concurrent requests
+  // (second insert fails the PK constraint and is swallowed).
+  return `default_${projectId}`;
+}
+
+export function seedWidgets(): SeedWidget[] {
+  const stat = (title: string, spec: object, x: number): SeedWidget => ({
+    title,
+    type: "query",
+    spec,
+    layout: { x, y: 0, w: 3, h: 2 },
+  });
+
+  const widgets: SeedWidget[] = [
+    stat(
+      "Trace count",
+      {
+        view: "traces",
+        filters: [],
+        metric: { measure: "count", agg: "count" },
+        breakdown: null,
+        display: { type: "number" },
+      },
+      0,
+    ),
+    stat(
+      "Total cost",
+      {
+        view: "traces",
+        filters: [],
+        metric: { measure: "cost", agg: "sum" },
+        breakdown: null,
+        display: { type: "number" },
+      },
+      3,
+    ),
+    stat(
+      "Tokens",
+      {
+        view: "traces",
+        filters: [],
+        metric: { measure: "total_tokens", agg: "sum" },
+        breakdown: null,
+        display: { type: "number" },
+      },
+      6,
+    ),
+    stat(
+      "p95 latency",
+      {
+        view: "traces",
+        filters: [],
+        metric: { measure: "duration_ms", agg: "p95" },
+        breakdown: null,
+        display: { type: "number" },
+      },
+      9,
+    ),
+    {
+      title: "Cost over time · by model",
+      type: "query",
+      spec: {
+        view: "spans",
+        filters: [{ field: "span_kind", op: "=", value: "LLM" }],
+        metric: { measure: "cost", agg: "sum" },
+        breakdown: "model_name",
+        display: { type: "line" },
+      },
+      layout: { x: 0, y: 2, w: 8, h: 6 },
+    },
+    {
+      title: "Tokens by model",
+      type: "query",
+      spec: {
+        view: "spans",
+        filters: [{ field: "span_kind", op: "=", value: "LLM" }],
+        metric: { measure: "total_tokens", agg: "sum" },
+        breakdown: "model_name",
+        display: { type: "bar" },
+      },
+      layout: { x: 8, y: 2, w: 4, h: 6 },
+    },
+    {
+      title: "Recent traces",
+      type: "trace_feed",
+      spec: { filters: [], limit: 10 },
+      layout: { x: 0, y: 8, w: 12, h: 4 },
+    },
+  ];
+
+  return widgets;
+}

--- a/frontend/ui/src/lib/route-helpers.ts
+++ b/frontend/ui/src/lib/route-helpers.ts
@@ -1,0 +1,47 @@
+import type { NextResponse } from "next/server";
+import {
+  errorResponse,
+  requireAuth,
+  requireProjectAccess,
+  type AuthenticatedUser,
+} from "@/lib/auth-helpers";
+
+/**
+ * Require an authenticated user with access to the project named in the
+ * route's params. Resolves the params promise so callers can destructure any
+ * additional route segments off `params`.
+ */
+export async function requireProjectAuth<P extends { projectId: string }>(
+  params: Promise<P>,
+): Promise<
+  | { user: AuthenticatedUser; params: P; error?: never }
+  | { user?: never; params?: never; error: NextResponse }
+> {
+  const authResult = await requireAuth();
+  if (authResult.error) return { error: authResult.error };
+  const resolved = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, resolved.projectId);
+  if (accessResult.error) return { error: accessResult.error };
+  return { user: authResult.user, params: resolved };
+}
+
+/**
+ * Parse a request body as a JSON object. Rejects invalid JSON and payloads
+ * that aren't destructure-friendly (null, arrays, scalars).
+ */
+export async function parseJsonObject(
+  req: Request,
+): Promise<
+  { body: Record<string, unknown>; error?: never } | { body?: never; error: NextResponse }
+> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return { error: errorResponse("Invalid JSON", 400) };
+  }
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return { error: errorResponse("Body must be a JSON object", 400) };
+  }
+  return { body: body as Record<string, unknown> };
+}


### PR DESCRIPTION
Ninth PR in the stacked project-dashboards series (epic #1460), stacked on #1516. The Next.js persistence routes for dashboards themselves — widget CRUD routes follow in the next PR, and a dedicated hardening PR (role gates, layout entry validation, title/description caps, P2025→404 mapping) lands after both as its own reviewable diff.

## What's here
- **`GET`/`POST /api/projects/{id}/dashboards`** — list and create. The first list call lazily seeds the project's read-only **Overview** dashboard from `lib/dashboard-seed.ts`: seven deterministic widgets (trace count / total cost / tokens / p95 latency stat tiles, cost over time and by model, tokens by model, recent-trace feed) so a new project's dashboard tab is never empty. Seeding is race-safe: deterministic PK, swallowed unique-violation, re-read; the nested widget create is transactional so no partial seed can leak. Names cap at 50 chars.
- **`GET`/`PATCH`/`DELETE /api/projects/{id}/dashboards/{dashboardId}`** — detail (widgets joined in, ordered by create time), rename/description/layout updates (`isDefault` is never accepted from the body), and deletion (project-scoped lookup; cascade removes widgets). The seeded default is read-only — mutations against it return 403.
- **`lib/route-helpers.ts`** — `requireProjectAuth` and `parseJsonObject`, shared by these routes and the widget routes that follow.

Note for reviewers: the detail route's test file also covers the widget routes on the feature branch; this slice carries the dashboards-scope subset, and the widget-routes PR restores the full file.

advances #1451

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project-scoped dashboard CRUD API routes and lazily seeds a read-only “Overview” dashboard on first fetch so new projects aren’t empty. Includes input validation and shared auth helpers.

- New Features
  - GET/POST `/api/projects/{id}/dashboards`: lists dashboards (default first). First list seeds “Overview” with seven deterministic widgets; race-safe with a deterministic id and re-read; layout ids match widget ids; name length cap enforced.
  - GET/PATCH/DELETE `/api/projects/{id}/dashboards/{dashboardId}`: returns details with widgets ordered by create time; updates name/description/layout (ignores `isDefault`); default dashboard blocks mutations with 403; 404 when not found.
  - Utilities: `lib/route-helpers.ts` adds `requireProjectAuth` and `parseJsonObject`; `lib/dashboard-seed.ts` defines seed widgets and `defaultDashboardId()`.

<sup>Written for commit 8da3f61b3fc6ec80dc8eeb17304978c71e7d98c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

