### PR TITLE
feat(ui): widget CRUD routes

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
@@ -506,10 +506,15 @@ describe("default dashboard is read-only", () => {
 });
 
 describe("PATCH /dashboards/[dashboardId] — name length cap", () => {
-  it("rejects a rename longer than 100 characters", async () => {
+  it("rejects a rename longer than 50 characters but allows exactly 50", async () => {
     dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
-    const res = (await PATCH(makeRequest({ name: "x".repeat(101) }), makeParams())) as MockResponse;
+    const res = (await PATCH(makeRequest({ name: "x".repeat(51) }), makeParams())) as MockResponse;
     expect(res.status).toBe(400);
     expect(dashboardUpdateMock).not.toHaveBeenCalled();
+
+    dashboardUpdateMock.mockResolvedValue({ ...fakeDashboard, name: "x".repeat(50) });
+    const ok = (await PATCH(makeRequest({ name: "x".repeat(50) }), makeParams())) as MockResponse;
+    expect(ok.status).toBe(200);
+    expect(dashboardUpdateMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
@@ -47,6 +47,8 @@ vi.mock("@/lib/auth-helpers", () => ({
 }));
 
 import { GET, PATCH, DELETE } from "./route";
+import { POST as widgetPOST } from "./widgets/route";
+import { PATCH as widgetPATCH, DELETE as widgetDELETE } from "./widgets/[widgetId]/route";
 
 function makeRequest(body?: unknown) {
   return {
@@ -56,6 +58,10 @@ function makeRequest(body?: unknown) {
 
 function makeParams(projectId = "proj-1", dashboardId = "dash-1") {
   return { params: Promise.resolve({ projectId, dashboardId }) };
+}
+
+function makeWidgetParams(projectId = "proj-1", dashboardId = "dash-1", widgetId = "widget-1") {
+  return { params: Promise.resolve({ projectId, dashboardId, widgetId }) };
 }
 
 const fakeDashboard = {
@@ -273,6 +279,185 @@ describe("DELETE /dashboards/[dashboardId]", () => {
 });
 
 // ---------------------------------------------------------------------------
+// POST /dashboards/[dashboardId]/widgets
+// ---------------------------------------------------------------------------
+describe("POST /dashboards/[dashboardId]/widgets", () => {
+  it("creates a widget and returns 201", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    widgetCreateMock.mockResolvedValue(fakeWidget);
+
+    const res = (await widgetPOST(
+      makeRequest({ title: "My Widget", type: "query", spec: { sql: "SELECT 1" } }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { widget: typeof fakeWidget };
+    expect(body.widget).toEqual(fakeWidget);
+    expect(widgetCreateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 for an invalid widget type", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await widgetPOST(
+      makeRequest({ title: "My Widget", type: "bad_type", spec: {} }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when dashboard is not in the project", async () => {
+    dashboardFindFirstMock.mockResolvedValue(null);
+    const res = (await widgetPOST(
+      makeRequest({ title: "My Widget", type: "query", spec: {} }),
+      makeParams("proj-1", "dash-999"),
+    )) as MockResponse;
+    expect(res.status).toBe(404);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+
+    // Assert the dashboard findFirst includes projectId scoping
+    const [call] = dashboardFindFirstMock.mock.calls;
+    const where = (call[0] as { where: Record<string, unknown> }).where;
+    expect(where.id).toBe("dash-999");
+    expect(where.projectId).toBe("proj-1");
+  });
+
+  it("returns 400 for missing title", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await widgetPOST(
+      makeRequest({ type: "query", spec: {} }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for non-object spec", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await widgetPOST(
+      makeRequest({ title: "W", type: "query", spec: "bad" }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid displayConfig (array)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await widgetPOST(
+      makeRequest({ title: "W", type: "query", spec: {}, displayConfig: [1, 2] }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /dashboards/[dashboardId]/widgets/[widgetId]
+// ---------------------------------------------------------------------------
+describe("PATCH /dashboards/[dashboardId]/widgets/[widgetId]", () => {
+  it("returns 404 when widget is not in the dashboard/project scope", async () => {
+    widgetFindFirstMock.mockResolvedValue(null);
+
+    const res = (await widgetPATCH(
+      makeRequest({ title: "New Title" }),
+      makeWidgetParams("proj-1", "dash-1", "widget-999"),
+    )) as MockResponse;
+    expect(res.status).toBe(404);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+
+    // Assert the nested projectId scoping in the where clause
+    const [call] = widgetFindFirstMock.mock.calls;
+    const where = (call[0] as { where: Record<string, unknown> }).where;
+    expect(where.id).toBe("widget-999");
+    expect(where.dashboardId).toBe("dash-1");
+    expect((where.dashboard as Record<string, unknown>).projectId).toBe("proj-1");
+  });
+
+  it("updates title and returns 200", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    widgetUpdateMock.mockResolvedValue({ ...fakeWidget, title: "Updated" });
+
+    const res = (await widgetPATCH(
+      makeRequest({ title: "Updated" }),
+      makeWidgetParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { widget: Record<string, unknown> };
+    expect(body.widget.title).toBe("Updated");
+  });
+
+  it("returns 400 for empty body (no fields to update)", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await widgetPATCH(makeRequest({}), makeWidgetParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for non-object spec", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await widgetPATCH(
+      makeRequest({ spec: "bad" }),
+      makeWidgetParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for empty title string", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await widgetPATCH(
+      makeRequest({ title: "  " }),
+      makeWidgetParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /dashboards/[dashboardId]/widgets/[widgetId]
+// ---------------------------------------------------------------------------
+describe("DELETE /dashboards/[dashboardId]/widgets/[widgetId]", () => {
+  it("returns 200 with deleted: true", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    widgetDeleteMock.mockResolvedValue({});
+
+    const res = (await widgetDELETE(makeRequest(), makeWidgetParams())) as MockResponse;
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deleted: boolean };
+    expect(body.deleted).toBe(true);
+
+    // Check scoped findFirst
+    const [call] = widgetFindFirstMock.mock.calls;
+    const where = (call[0] as { where: Record<string, unknown> }).where;
+    expect(where.id).toBe("widget-1");
+    expect(where.dashboardId).toBe("dash-1");
+    expect((where.dashboard as Record<string, unknown>).projectId).toBe("proj-1");
+  });
+
+  it("returns 404 when widget not found in scope", async () => {
+    widgetFindFirstMock.mockResolvedValue(null);
+    const res = (await widgetDELETE(
+      makeRequest(),
+      makeWidgetParams("proj-1", "dash-1", "w-999"),
+    )) as MockResponse;
+    expect(res.status).toBe(404);
+    expect(widgetDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = (await widgetDELETE(makeRequest(), makeWidgetParams())) as MockResponse;
+    expect(res.status).toBe(401);
+    expect(widgetFindFirstMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Default dashboard is read-only
 // ---------------------------------------------------------------------------
 describe("default dashboard is read-only", () => {
@@ -290,6 +475,33 @@ describe("default dashboard is read-only", () => {
     const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
     expect(res.status).toBe(403);
     expect(dashboardDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("POST .../widgets returns 403", async () => {
+    dashboardFindFirstMock.mockResolvedValue(defaultDashboard);
+    const res = (await widgetPOST(
+      makeRequest({ title: "t", type: "query", spec: {} }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(403);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("PATCH .../widgets/[widgetId] returns 403", async () => {
+    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: true } });
+    const res = (await widgetPATCH(
+      makeRequest({ title: "renamed" }),
+      makeWidgetParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(403);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("DELETE .../widgets/[widgetId] returns 403", async () => {
+    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: true } });
+    const res = (await widgetDELETE(makeRequest(), makeWidgetParams())) as MockResponse;
+    expect(res.status).toBe(403);
+    expect(widgetDeleteMock).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock responses don't carry NextResponse's full type — cast at call sites.
+type MockResponse = { status: number; json: () => Promise<unknown> };
+
+vi.mock("next/server", () => ({ NextRequest: class {} }));
+
+vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
+
+const widgetFindFirstMock = vi.fn();
+const widgetUpdateMock = vi.fn();
+const widgetDeleteMock = vi.fn();
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    widget: {
+      findFirst: (...args: unknown[]) => widgetFindFirstMock(...args),
+      update: (...args: unknown[]) => widgetUpdateMock(...args),
+      delete: (...args: unknown[]) => widgetDeleteMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({
+    status,
+    json: async () => data,
+  }),
+}));
+
+import { PATCH, DELETE } from "./route";
+
+function makeRequest(body?: unknown) {
+  return {
+    json: async () => body,
+  } as unknown as Parameters<typeof PATCH>[0];
+}
+
+function makeInvalidJsonRequest() {
+  return {
+    json: async () => {
+      throw new SyntaxError("Unexpected token");
+    },
+  } as unknown as Parameters<typeof PATCH>[0];
+}
+
+function makeParams(projectId = "proj-1", dashboardId = "dash-1", widgetId = "widget-1") {
+  return { params: Promise.resolve({ projectId, dashboardId, widgetId }) };
+}
+
+const fakeWidget = {
+  id: "widget-1",
+  dashboardId: "dash-1",
+  title: "My Widget",
+  type: "query",
+  spec: { view: "spans" },
+  displayConfig: {},
+};
+
+beforeEach(() => {
+  widgetFindFirstMock.mockReset();
+  widgetUpdateMock.mockReset();
+  widgetDeleteMock.mockReset();
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  // Default: authenticated with project access.
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+});
+
+// ---------------------------------------------------------------------------
+// PATCH /dashboards/[dashboardId]/widgets/[widgetId]
+// ---------------------------------------------------------------------------
+describe("PATCH /dashboards/[dashboardId]/widgets/[widgetId]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = (await PATCH(makeRequest({ title: "New" }), makeParams())) as MockResponse;
+    expect(res.status).toBe(401);
+    expect(widgetFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user lacks project access", async () => {
+    requireProjectAccessMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    const res = (await PATCH(makeRequest({ title: "New" }), makeParams())) as MockResponse;
+    expect(res.status).toBe(403);
+    expect(widgetFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the widget is not in the dashboard/project scope", async () => {
+    widgetFindFirstMock.mockResolvedValue(null);
+
+    const res = (await PATCH(
+      makeRequest({ title: "New Title" }),
+      makeParams("proj-1", "dash-1", "widget-999"),
+    )) as MockResponse;
+    expect(res.status).toBe(404);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+
+    // The lookup must scope by widget id, dashboardId AND the nested projectId.
+    const [call] = widgetFindFirstMock.mock.calls;
+    const where = (call[0] as { where: Record<string, unknown> }).where;
+    expect(where.id).toBe("widget-999");
+    expect(where.dashboardId).toBe("dash-1");
+    expect((where.dashboard as Record<string, unknown>).projectId).toBe("proj-1");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeInvalidJsonRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-object body (array)", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeRequest(["a"]), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-object body (null)", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeRequest(null), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for empty body (no fields to update)", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeRequest({}), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-string title", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeRequest({ title: 42 }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an empty (whitespace-only) title", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeRequest({ title: "   " }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-object spec", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeRequest({ spec: "bad" }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a null spec", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeRequest({ spec: null }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid displayConfig (array)", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeRequest({ displayConfig: [1, 2] }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid displayConfig (null)", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const res = (await PATCH(makeRequest({ displayConfig: null }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("updates title only and returns 200", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    widgetUpdateMock.mockResolvedValue({ ...fakeWidget, title: "Updated" });
+
+    const res = (await PATCH(makeRequest({ title: "  Updated  " }), makeParams())) as MockResponse;
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { widget: Record<string, unknown> };
+    expect(body.widget.title).toBe("Updated");
+
+    const [call] = widgetUpdateMock.mock.calls;
+    expect((call[0] as { where: { id: string } }).where.id).toBe("widget-1");
+    const data = (call[0] as { data: Record<string, unknown> }).data;
+    expect(data).toEqual({ title: "Updated" });
+  });
+
+  it("updates spec only, leaving other fields untouched in the update payload", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const newSpec = { view: "traces" };
+    widgetUpdateMock.mockResolvedValue({ ...fakeWidget, spec: newSpec });
+
+    await PATCH(makeRequest({ spec: newSpec }), makeParams());
+
+    const [call] = widgetUpdateMock.mock.calls;
+    const data = (call[0] as { data: Record<string, unknown> }).data;
+    expect(data).toEqual({ spec: newSpec });
+  });
+
+  it("updates displayConfig only", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    const newDisplayConfig = { type: "bar" };
+    widgetUpdateMock.mockResolvedValue({ ...fakeWidget, displayConfig: newDisplayConfig });
+
+    await PATCH(makeRequest({ displayConfig: newDisplayConfig }), makeParams());
+
+    const [call] = widgetUpdateMock.mock.calls;
+    const data = (call[0] as { data: Record<string, unknown> }).data;
+    expect(data).toEqual({ displayConfig: newDisplayConfig });
+  });
+
+  it("updates multiple fields together", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    widgetUpdateMock.mockResolvedValue({ ...fakeWidget, title: "Both" });
+
+    await PATCH(
+      makeRequest({ title: "Both", spec: { view: "spans" }, displayConfig: { type: "line" } }),
+      makeParams(),
+    );
+
+    const [call] = widgetUpdateMock.mock.calls;
+    const data = (call[0] as { data: Record<string, unknown> }).data;
+    expect(data).toEqual({
+      title: "Both",
+      spec: { view: "spans" },
+      displayConfig: { type: "line" },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /dashboards/[dashboardId]/widgets/[widgetId]
+// ---------------------------------------------------------------------------
+describe("DELETE /dashboards/[dashboardId]/widgets/[widgetId]", () => {
+  it("returns 401 when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(401);
+    expect(widgetFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user lacks project access", async () => {
+    requireProjectAccessMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(403);
+    expect(widgetFindFirstMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the widget is not found in the dashboard/project scope", async () => {
+    widgetFindFirstMock.mockResolvedValue(null);
+    const res = (await DELETE(
+      makeRequest(),
+      makeParams("proj-1", "dash-1", "widget-999"),
+    )) as MockResponse;
+    expect(res.status).toBe(404);
+    expect(widgetDeleteMock).not.toHaveBeenCalled();
+
+    const [call] = widgetFindFirstMock.mock.calls;
+    const where = (call[0] as { where: Record<string, unknown> }).where;
+    expect(where.id).toBe("widget-999");
+    expect(where.dashboardId).toBe("dash-1");
+    expect((where.dashboard as Record<string, unknown>).projectId).toBe("proj-1");
+  });
+
+  it("deletes the widget and returns 200 with deleted: true", async () => {
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
+    widgetDeleteMock.mockResolvedValue({});
+
+    const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deleted: boolean };
+    expect(body.deleted).toBe(true);
+
+    expect(widgetDeleteMock).toHaveBeenCalledWith({ where: { id: "widget-1" } });
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import { errorResponse, successResponse } from "@/lib/auth-helpers";
+import { parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
+
+type RouteParams = {
+  params: Promise<{ projectId: string; dashboardId: string; widgetId: string }>;
+};
+
+async function findWidget(dashboardId: string, widgetId: string, projectId: string) {
+  return prisma.widget.findFirst({
+    where: { id: widgetId, dashboardId, dashboard: { projectId } },
+    include: { dashboard: { select: { isDefault: true } } },
+  });
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  const auth = await requireProjectAuth(params);
+  if (auth.error) return auth.error;
+  const { projectId, dashboardId, widgetId } = auth.params;
+
+  const existing = await findWidget(dashboardId, widgetId, projectId);
+  if (!existing) return errorResponse("Widget not found", 404);
+  if (existing.dashboard?.isDefault) {
+    return errorResponse("The default dashboard is read-only", 403);
+  }
+
+  const parsed = await parseJsonObject(req);
+  if (parsed.error) return parsed.error;
+  const { title, spec, displayConfig } = parsed.body;
+
+  const data: Record<string, unknown> = {};
+  if (title !== undefined) {
+    if (typeof title !== "string" || title.trim().length === 0) {
+      return errorResponse("title must be a non-empty string", 400);
+    }
+    data.title = title.trim();
+  }
+  if (spec !== undefined) {
+    if (spec === null || typeof spec !== "object" || Array.isArray(spec)) {
+      return errorResponse("spec must be a JSON object", 400);
+    }
+    data.spec = spec;
+  }
+  if (displayConfig !== undefined) {
+    if (
+      displayConfig === null ||
+      typeof displayConfig !== "object" ||
+      Array.isArray(displayConfig)
+    ) {
+      return errorResponse("displayConfig must be a JSON object", 400);
+    }
+    data.displayConfig = displayConfig;
+  }
+  if (Object.keys(data).length === 0) return errorResponse("No fields to update", 400);
+
+  const widget = await prisma.widget.update({
+    where: { id: widgetId },
+    data,
+  });
+  return successResponse({ widget });
+}
+
+export async function DELETE(_req: NextRequest, { params }: RouteParams) {
+  const auth = await requireProjectAuth(params);
+  if (auth.error) return auth.error;
+  const { projectId, dashboardId, widgetId } = auth.params;
+
+  const existing = await findWidget(dashboardId, widgetId, projectId);
+  if (!existing) return errorResponse("Widget not found", 404);
+  if (existing.dashboard?.isDefault) {
+    return errorResponse("The default dashboard is read-only", 403);
+  }
+
+  await prisma.widget.delete({ where: { id: widgetId } });
+  return successResponse({ deleted: true });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock responses don't carry NextResponse's full type — cast at call sites.
+type MockResponse = { status: number; json: () => Promise<unknown> };
+
+vi.mock("next/server", () => ({ NextRequest: class {} }));
+
+vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
+
+const dashboardFindFirstMock = vi.fn();
+const widgetCreateMock = vi.fn();
+
+vi.mock("@traceroot/core", () => ({
+  prisma: {
+    dashboard: {
+      findFirst: (...args: unknown[]) => dashboardFindFirstMock(...args),
+    },
+    widget: {
+      create: (...args: unknown[]) => widgetCreateMock(...args),
+    },
+  },
+}));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  errorResponse: (msg: string, status: number) => ({
+    status,
+    json: async () => ({ error: msg }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({
+    status,
+    json: async () => data,
+  }),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body?: unknown) {
+  return {
+    json: async () => body,
+  } as unknown as Parameters<typeof POST>[0];
+}
+
+function makeInvalidJsonRequest() {
+  return {
+    json: async () => {
+      throw new SyntaxError("Unexpected token");
+    },
+  } as unknown as Parameters<typeof POST>[0];
+}
+
+function makeParams(projectId = "proj-1", dashboardId = "dash-1") {
+  return { params: Promise.resolve({ projectId, dashboardId }) };
+}
+
+const fakeDashboard = {
+  id: "dash-1",
+  projectId: "proj-1",
+  name: "My Dashboard",
+  description: null,
+  isDefault: false,
+  layout: [],
+};
+
+const fakeWidget = {
+  id: "widget-1",
+  dashboardId: "dash-1",
+  title: "My Widget",
+  type: "query",
+  spec: { view: "spans" },
+  displayConfig: {},
+};
+
+beforeEach(() => {
+  dashboardFindFirstMock.mockReset();
+  widgetCreateMock.mockReset();
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  // Default: authenticated with project access.
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({});
+});
+
+describe("POST /dashboards/[dashboardId]/widgets", () => {
+  it("returns 401 when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = (await POST(
+      makeRequest({ title: "W", type: "query", spec: {} }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(401);
+    expect(dashboardFindFirstMock).not.toHaveBeenCalled();
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when the user lacks project access", async () => {
+    requireProjectAccessMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    const res = (await POST(
+      makeRequest({ title: "W", type: "query", spec: {} }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(403);
+    expect(dashboardFindFirstMock).not.toHaveBeenCalled();
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the dashboard does not belong to the project", async () => {
+    dashboardFindFirstMock.mockResolvedValue(null);
+
+    const res = (await POST(
+      makeRequest({ title: "W", type: "query", spec: {} }),
+      makeParams("proj-1", "dash-999"),
+    )) as MockResponse;
+    expect(res.status).toBe(404);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+
+    // Scoped by both dashboard id AND projectId.
+    const [call] = dashboardFindFirstMock.mock.calls;
+    const where = (call[0] as { where: Record<string, unknown> }).where;
+    expect(where.id).toBe("dash-999");
+    expect(where.projectId).toBe("proj-1");
+  });
+
+  it("returns 400 for invalid JSON body", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(makeInvalidJsonRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-object body (array)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(makeRequest(["a", "b"]), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-object body (null)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(makeRequest(null), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for missing title", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(
+      makeRequest({ type: "query", spec: {} }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/title/i);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an empty (whitespace-only) title", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(
+      makeRequest({ title: "   ", type: "query", spec: {} }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a missing type", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(makeRequest({ title: "W", spec: {} }), makeParams())) as MockResponse;
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/type/i);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid widget type", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(
+      makeRequest({ title: "W", type: "bad_type", spec: {} }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-object spec (string)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(
+      makeRequest({ title: "W", type: "query", spec: "bad" }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-object spec (array)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(
+      makeRequest({ title: "W", type: "query", spec: [1, 2] }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a null spec", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(
+      makeRequest({ title: "W", type: "query", spec: null }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid displayConfig (array)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(
+      makeRequest({ title: "W", type: "query", spec: {}, displayConfig: [1, 2] }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for an invalid displayConfig (string)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await POST(
+      makeRequest({ title: "W", type: "query", spec: {}, displayConfig: "bad" }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(widgetCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("creates a widget scoped to the dashboard and returns 201", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    widgetCreateMock.mockResolvedValue(fakeWidget);
+
+    const res = (await POST(
+      makeRequest({
+        title: "  My Widget  ",
+        type: "query",
+        spec: { view: "spans" },
+      }),
+      makeParams("proj-1", "dash-1"),
+    )) as MockResponse;
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { widget: typeof fakeWidget };
+    expect(body.widget).toEqual(fakeWidget);
+
+    expect(widgetCreateMock).toHaveBeenCalledTimes(1);
+    const [call] = widgetCreateMock.mock.calls;
+    const data = (call[0] as { data: Record<string, unknown> }).data;
+    expect(data.dashboardId).toBe("dash-1");
+    // Title is trimmed before persisting.
+    expect(data.title).toBe("My Widget");
+    expect(data.type).toBe("query");
+    expect(data.spec).toEqual({ view: "spans" });
+    // displayConfig defaults to {} when omitted.
+    expect(data.displayConfig).toEqual({});
+  });
+
+  it("persists a provided displayConfig as-is", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    widgetCreateMock.mockResolvedValue(fakeWidget);
+
+    await POST(
+      makeRequest({
+        title: "W",
+        type: "trace_feed",
+        spec: {},
+        displayConfig: { type: "table" },
+      }),
+      makeParams(),
+    );
+
+    const [call] = widgetCreateMock.mock.calls;
+    const data = (call[0] as { data: Record<string, unknown> }).data;
+    expect(data.displayConfig).toEqual({ type: "table" });
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import { errorResponse, successResponse } from "@/lib/auth-helpers";
+import { parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string; dashboardId: string }> };
+
+const WIDGET_TYPES = new Set(["query", "trace_feed"]);
+
+// POST .../widgets — add a widget to a dashboard
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const auth = await requireProjectAuth(params);
+  if (auth.error) return auth.error;
+  const { projectId, dashboardId } = auth.params;
+
+  const dashboard = await prisma.dashboard.findFirst({
+    where: { id: dashboardId, projectId },
+  });
+  if (!dashboard) return errorResponse("Dashboard not found", 404);
+  if (dashboard.isDefault) return errorResponse("The default dashboard is read-only", 403);
+
+  const parsed = await parseJsonObject(req);
+  if (parsed.error) return parsed.error;
+  const { title, type, spec, displayConfig } = parsed.body;
+
+  if (typeof title !== "string" || title.trim().length === 0) {
+    return errorResponse("title must be a non-empty string", 400);
+  }
+  if (typeof type !== "string" || !WIDGET_TYPES.has(type)) {
+    return errorResponse(`type must be one of ${[...WIDGET_TYPES].join(", ")}`, 400);
+  }
+  // Structural check only — deep spec validation happens in the query engine
+  // at execution time, which is the single source of truth.
+  if (spec === null || typeof spec !== "object" || Array.isArray(spec)) {
+    return errorResponse("spec must be a JSON object", 400);
+  }
+  if (
+    displayConfig !== undefined &&
+    (displayConfig === null || typeof displayConfig !== "object" || Array.isArray(displayConfig))
+  ) {
+    return errorResponse("displayConfig must be a JSON object", 400);
+  }
+
+  const widget = await prisma.widget.create({
+    data: {
+      dashboardId,
+      title: title.trim(),
+      type,
+      spec: spec as object,
+      displayConfig: (displayConfig as object) ?? {},
+    },
+  });
+  return successResponse({ widget }, 201);
+}


### PR DESCRIPTION
Tenth PR in the stacked project-dashboards series (epic #1460), stacked on #1520. Completes the dashboard persistence layer; the hardening PR (role gates, caps, P2025→404, layout validation) follows as its own diff.

## What's here
- **`POST /dashboards/{id}/widgets`** — create a widget (`query` or `trace_feed`) after a project-scoped dashboard lookup; the seeded read-only default rejects additions.
- **`PATCH`/`DELETE /dashboards/{id}/widgets/{widgetId}`** — title/spec/displayConfig updates and deletion, each behind a single lookup scoped by widget id + dashboard + project; widgets of the read-only default reject mutations.
- **Restores the dashboard-detail test file to its full form** — the widget-route describes and the read-only default's widget cases return now that the handlers they exercise exist in-tree (the previous PR carried a dashboards-scope subset).
- Second commit: the dashboard rename-cap test was mistitled ("longer than 100 characters" probing 101 when the cap is 50) — retitled and now probes the exact boundary: 51 rejects, 50 saves.

closes #1451

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add widget CRUD API routes under dashboards to complete the dashboard persistence layer. Supports creating `query` and `trace_feed` widgets, updating title/spec/displayConfig, and deleting, all scoped by project and rejecting changes on the default dashboard.

- **New Features**
  - POST `/dashboards/{dashboardId}/widgets` to create widgets (`query`, `trace_feed`) after a project-scoped dashboard check.
  - PATCH/DELETE `/dashboards/{dashboardId}/widgets/{widgetId}` for scoped updates and deletion via a single widget+dashboard+project lookup.
  - Default dashboard is read-only; all widget mutations/additions return 403.
  - Validates inputs and returns clear errors (400 for invalid payloads, 404 for out-of-scope ids). Restores and adds route tests covering these cases.

- **Bug Fixes**
  - Corrected dashboard rename length cap test to the real 50-char limit (51 rejects, 50 saves).

<sup>Written for commit c60eb841538c5612165eb466d202d4cc9348566f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

