### PR TITLE
fix(api): harden dashboard mutation routes

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
@@ -16,6 +16,7 @@ const widgetUpdateMock = vi.fn();
 const widgetDeleteMock = vi.fn();
 
 vi.mock("@traceroot/core", () => ({
+  Role: { VIEWER: "VIEWER", MEMBER: "MEMBER", ADMIN: "ADMIN" },
   prisma: {
     dashboard: {
       findFirst: (...args: unknown[]) => dashboardFindFirstMock(...args),
@@ -516,5 +517,134 @@ describe("PATCH /dashboards/[dashboardId] — name length cap", () => {
     const ok = (await PATCH(makeRequest({ name: "x".repeat(50) }), makeParams())) as MockResponse;
     expect(ok.status).toBe(200);
     expect(dashboardUpdateMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hardening: role gate, layout entry validation, description cap, races
+// ---------------------------------------------------------------------------
+describe("mutation hardening", () => {
+  it("gates mutations on MEMBER role but leaves GET viewer-accessible", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    dashboardUpdateMock.mockResolvedValue(fakeDashboard);
+
+    await GET(makeRequest(), makeParams());
+    expect(requireProjectAccessMock).toHaveBeenLastCalledWith("user-1", "proj-1", undefined);
+
+    await PATCH(makeRequest({ name: "renamed" }), makeParams());
+    expect(requireProjectAccessMock).toHaveBeenLastCalledWith("user-1", "proj-1", "MEMBER");
+
+    await DELETE(makeRequest(), makeParams());
+    expect(requireProjectAccessMock).toHaveBeenLastCalledWith("user-1", "proj-1", "MEMBER");
+
+    await widgetPOST(makeRequest({ title: "t", type: "query", spec: {} }), makeParams());
+    expect(requireProjectAccessMock).toHaveBeenLastCalledWith("user-1", "proj-1", "MEMBER");
+
+    await widgetPATCH(makeRequest({ title: "t" }), makeWidgetParams());
+    expect(requireProjectAccessMock).toHaveBeenLastCalledWith("user-1", "proj-1", "MEMBER");
+
+    await widgetDELETE(makeRequest(), makeWidgetParams());
+    expect(requireProjectAccessMock).toHaveBeenLastCalledWith("user-1", "proj-1", "MEMBER");
+  });
+
+  it("rejects layout entries that are not {i, x, y, w, h} placements", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    for (const bad of [
+      [null],
+      ["x"],
+      [{ i: "w1", x: "a", y: 0, w: 4, h: 4 }],
+      [{ x: 0, y: 0, w: 4, h: 4 }],
+      [{ i: "w1", x: 0, y: 0, w: 4, h: Infinity }],
+    ]) {
+      const res = (await PATCH(makeRequest({ layout: bad }), makeParams())) as MockResponse;
+      expect(res.status).toBe(400);
+    }
+    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+
+    const ok = (await PATCH(
+      makeRequest({ layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }] }),
+      makeParams(),
+    )) as MockResponse;
+    expect(ok.status).toBe(200);
+  });
+
+  it("rejects negative coordinates and strips unknown keys from layout entries", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+
+    const negative = (await PATCH(
+      makeRequest({ layout: [{ i: "w1", x: -1, y: 0, w: 4, h: 4 }] }),
+      makeParams(),
+    )) as MockResponse;
+    expect(negative.status).toBe(400);
+
+    dashboardUpdateMock.mockResolvedValue(fakeDashboard);
+    await PATCH(
+      makeRequest({
+        // static/isDraggable would be honored by react-grid-layout for every
+        // member if persisted; only the placement keys may reach storage.
+        layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4, static: true, isDraggable: false }],
+      }),
+      makeParams(),
+    );
+    const [call] = dashboardUpdateMock.mock.calls;
+    expect((call[0] as { data: { layout: unknown } }).data.layout).toEqual([
+      { i: "w1", x: 0, y: 0, w: 4, h: 4 },
+    ]);
+  });
+
+  it("caps the dashboard description at 500 characters", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const res = (await PATCH(
+      makeRequest({ description: "x".repeat(501) }),
+      makeParams(),
+    )) as MockResponse;
+    expect(res.status).toBe(400);
+    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("caps the widget title at 100 characters on POST and PATCH", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    const post = (await widgetPOST(
+      makeRequest({ title: "x".repeat(101), type: "query", spec: {} }),
+      makeParams(),
+    )) as MockResponse;
+    expect(post.status).toBe(400);
+
+    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: false } });
+    const patch = (await widgetPATCH(
+      makeRequest({ title: "x".repeat(101) }),
+      makeWidgetParams(),
+    )) as MockResponse;
+    expect(patch.status).toBe(400);
+    expect(widgetUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("maps a concurrent delete (Prisma P2025) to 404 instead of 500", async () => {
+    const { Prisma } = await import("@prisma/client");
+    const gone = new Prisma.PrismaClientKnownRequestError("gone", {
+      code: "P2025",
+      clientVersion: "test",
+    });
+
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    dashboardUpdateMock.mockRejectedValue(gone);
+    const patch = (await PATCH(makeRequest({ name: "renamed" }), makeParams())) as MockResponse;
+    expect(patch.status).toBe(404);
+
+    dashboardDeleteMock.mockRejectedValue(gone);
+    const del = (await DELETE(makeRequest(), makeParams())) as MockResponse;
+    expect(del.status).toBe(404);
+
+    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: false } });
+    widgetUpdateMock.mockRejectedValue(gone);
+    const wpatch = (await widgetPATCH(
+      makeRequest({ title: "renamed" }),
+      makeWidgetParams(),
+    )) as MockResponse;
+    expect(wpatch.status).toBe(404);
+
+    widgetDeleteMock.mockRejectedValue(gone);
+    const wdel = (await widgetDELETE(makeRequest(), makeWidgetParams())) as MockResponse;
+    expect(wdel.status).toBe(404);
   });
 });

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from "next/server";
-import { prisma } from "@traceroot/core";
+import { prisma, Role } from "@traceroot/core";
 import { errorResponse, successResponse } from "@/lib/auth-helpers";
-import { parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
-import { DASHBOARD_NAME_MAX } from "@/features/dashboards/types";
+import { isRecordGone, parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
+import { DASHBOARD_DESCRIPTION_MAX, DASHBOARD_NAME_MAX } from "@/features/dashboards/types";
 
 type RouteParams = { params: Promise<{ projectId: string; dashboardId: string }> };
 
@@ -20,7 +20,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
 }
 
 export async function PATCH(req: NextRequest, { params }: RouteParams) {
-  const auth = await requireProjectAuth(params);
+  const auth = await requireProjectAuth(params, Role.MEMBER);
   if (auth.error) return auth.error;
   const { projectId, dashboardId } = auth.params;
 
@@ -43,11 +43,43 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     if (description !== null && typeof description !== "string") {
       return errorResponse("description must be a string or null", 400);
     }
+    if (typeof description === "string" && description.length > DASHBOARD_DESCRIPTION_MAX) {
+      return errorResponse(
+        `description must be at most ${DASHBOARD_DESCRIPTION_MAX} characters`,
+        400,
+      );
+    }
     data.description = description;
   }
   if (layout !== undefined) {
     if (!Array.isArray(layout)) return errorResponse("layout must be an array", 400);
-    data.layout = layout;
+    // Validate every entry: a single malformed one (null, missing keys,
+    // non-numeric coordinates) crashes the dashboard grid for every project
+    // member on the next read, with no UI path to repair it.
+    const isPlacement = (v: unknown): boolean =>
+      typeof v === "object" &&
+      v !== null &&
+      !Array.isArray(v) &&
+      typeof (v as Record<string, unknown>).i === "string" &&
+      ((v as Record<string, unknown>).i as string).length <= 128 &&
+      ["x", "y", "w", "h"].every((k) => {
+        const n = (v as Record<string, unknown>)[k];
+        return typeof n === "number" && Number.isFinite(n) && n >= 0;
+      });
+    if (!layout.every(isPlacement)) {
+      return errorResponse("layout entries must be {i, x, y, w, h} objects", 400);
+    }
+    // Store only the placement keys: the grid spreads stored entries into
+    // react-grid-layout items, so extra keys smuggled through PATCH (static,
+    // isDraggable, maxW, arbitrary payloads) would be persisted and honored
+    // for every member.
+    data.layout = (layout as Record<string, unknown>[]).map(({ i, x, y, w, h }) => ({
+      i,
+      x,
+      y,
+      w,
+      h,
+    }));
   }
   if (Object.keys(data).length === 0) return errorResponse("No fields to update", 400);
 
@@ -57,15 +89,21 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   if (!existing) return errorResponse("Dashboard not found", 404);
   if (existing.isDefault) return errorResponse("The default dashboard is read-only", 403);
 
-  const dashboard = await prisma.dashboard.update({
-    where: { id: dashboardId },
-    data,
-  });
-  return successResponse({ dashboard });
+  try {
+    const dashboard = await prisma.dashboard.update({
+      where: { id: dashboardId },
+      data,
+    });
+    return successResponse({ dashboard });
+  } catch (e) {
+    // Deleted concurrently between the scoped findFirst and this write.
+    if (isRecordGone(e)) return errorResponse("Dashboard not found", 404);
+    throw e;
+  }
 }
 
 export async function DELETE(_req: NextRequest, { params }: RouteParams) {
-  const auth = await requireProjectAuth(params);
+  const auth = await requireProjectAuth(params, Role.MEMBER);
   if (auth.error) return auth.error;
   const { projectId, dashboardId } = auth.params;
 
@@ -75,6 +113,12 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
   if (!existing) return errorResponse("Dashboard not found", 404);
   if (existing.isDefault) return errorResponse("The default dashboard is read-only", 403);
 
-  await prisma.dashboard.delete({ where: { id: dashboardId } });
+  try {
+    await prisma.dashboard.delete({ where: { id: dashboardId } });
+  } catch (e) {
+    // Deleted concurrently between the scoped findFirst and this write.
+    if (isRecordGone(e)) return errorResponse("Dashboard not found", 404);
+    throw e;
+  }
   return successResponse({ deleted: true });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.test.ts
@@ -12,6 +12,7 @@ const widgetUpdateMock = vi.fn();
 const widgetDeleteMock = vi.fn();
 
 vi.mock("@traceroot/core", () => ({
+  Role: { VIEWER: "VIEWER", MEMBER: "MEMBER", ADMIN: "ADMIN" },
   prisma: {
     widget: {
       findFirst: (...args: unknown[]) => widgetFindFirstMock(...args),

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from "next/server";
-import { prisma } from "@traceroot/core";
+import { prisma, Role } from "@traceroot/core";
 import { errorResponse, successResponse } from "@/lib/auth-helpers";
-import { parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
+import { isRecordGone, parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
+import { WIDGET_TITLE_MAX } from "@/features/dashboards/types";
 
 type RouteParams = {
   params: Promise<{ projectId: string; dashboardId: string; widgetId: string }>;
@@ -15,7 +16,7 @@ async function findWidget(dashboardId: string, widgetId: string, projectId: stri
 }
 
 export async function PATCH(req: NextRequest, { params }: RouteParams) {
-  const auth = await requireProjectAuth(params);
+  const auth = await requireProjectAuth(params, Role.MEMBER);
   if (auth.error) return auth.error;
   const { projectId, dashboardId, widgetId } = auth.params;
 
@@ -33,6 +34,9 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   if (title !== undefined) {
     if (typeof title !== "string" || title.trim().length === 0) {
       return errorResponse("title must be a non-empty string", 400);
+    }
+    if (title.trim().length > WIDGET_TITLE_MAX) {
+      return errorResponse(`title must be at most ${WIDGET_TITLE_MAX} characters`, 400);
     }
     data.title = title.trim();
   }
@@ -54,15 +58,21 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   }
   if (Object.keys(data).length === 0) return errorResponse("No fields to update", 400);
 
-  const widget = await prisma.widget.update({
-    where: { id: widgetId },
-    data,
-  });
-  return successResponse({ widget });
+  try {
+    const widget = await prisma.widget.update({
+      where: { id: widgetId },
+      data,
+    });
+    return successResponse({ widget });
+  } catch (e) {
+    // Deleted concurrently between the scoped findFirst and this write.
+    if (isRecordGone(e)) return errorResponse("Widget not found", 404);
+    throw e;
+  }
 }
 
 export async function DELETE(_req: NextRequest, { params }: RouteParams) {
-  const auth = await requireProjectAuth(params);
+  const auth = await requireProjectAuth(params, Role.MEMBER);
   if (auth.error) return auth.error;
   const { projectId, dashboardId, widgetId } = auth.params;
 
@@ -72,6 +82,12 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
     return errorResponse("The default dashboard is read-only", 403);
   }
 
-  await prisma.widget.delete({ where: { id: widgetId } });
+  try {
+    await prisma.widget.delete({ where: { id: widgetId } });
+  } catch (e) {
+    // Deleted concurrently between the scoped findFirst and this write.
+    if (isRecordGone(e)) return errorResponse("Widget not found", 404);
+    throw e;
+  }
   return successResponse({ deleted: true });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.test.ts
@@ -11,6 +11,7 @@ const dashboardFindFirstMock = vi.fn();
 const widgetCreateMock = vi.fn();
 
 vi.mock("@traceroot/core", () => ({
+  Role: { VIEWER: "VIEWER", MEMBER: "MEMBER", ADMIN: "ADMIN" },
   prisma: {
     dashboard: {
       findFirst: (...args: unknown[]) => dashboardFindFirstMock(...args),

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from "next/server";
-import { prisma } from "@traceroot/core";
+import { prisma, Role } from "@traceroot/core";
 import { errorResponse, successResponse } from "@/lib/auth-helpers";
 import { parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
+import { WIDGET_TITLE_MAX } from "@/features/dashboards/types";
 
 type RouteParams = { params: Promise<{ projectId: string; dashboardId: string }> };
 
@@ -9,7 +10,7 @@ const WIDGET_TYPES = new Set(["query", "trace_feed"]);
 
 // POST .../widgets — add a widget to a dashboard
 export async function POST(req: NextRequest, { params }: RouteParams) {
-  const auth = await requireProjectAuth(params);
+  const auth = await requireProjectAuth(params, Role.MEMBER);
   if (auth.error) return auth.error;
   const { projectId, dashboardId } = auth.params;
 
@@ -25,6 +26,9 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
 
   if (typeof title !== "string" || title.trim().length === 0) {
     return errorResponse("title must be a non-empty string", 400);
+  }
+  if (title.trim().length > WIDGET_TITLE_MAX) {
+    return errorResponse(`title must be at most ${WIDGET_TITLE_MAX} characters`, 400);
   }
   if (typeof type !== "string" || !WIDGET_TYPES.has(type)) {
     return errorResponse(`type must be one of ${[...WIDGET_TYPES].join(", ")}`, 400);

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.test.ts
@@ -8,6 +8,7 @@ vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
 const dashboardFindManyMock = vi.fn();
 const dashboardCreateMock = vi.fn();
 vi.mock("@traceroot/core", () => ({
+  Role: { VIEWER: "VIEWER", MEMBER: "MEMBER", ADMIN: "ADMIN" },
   prisma: {
     dashboard: {
       findMany: (...args: unknown[]) => dashboardFindManyMock(...args),

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest } from "next/server";
 import { Prisma } from "@prisma/client";
-import { prisma } from "@traceroot/core";
+import { prisma, Role } from "@traceroot/core";
 import { errorResponse, successResponse } from "@/lib/auth-helpers";
 import { parseJsonObject, requireProjectAuth } from "@/lib/route-helpers";
 import { defaultDashboardId, seedWidgets } from "@/lib/dashboard-seed";
-import { DASHBOARD_NAME_MAX } from "@/features/dashboards/types";
+import { DASHBOARD_DESCRIPTION_MAX, DASHBOARD_NAME_MAX } from "@/features/dashboards/types";
 
 type RouteParams = { params: Promise<{ projectId: string }> };
 
@@ -54,7 +54,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
 
 // POST /api/projects/[projectId]/dashboards — create a named dashboard
 export async function POST(req: NextRequest, { params }: RouteParams) {
-  const auth = await requireProjectAuth(params);
+  const auth = await requireProjectAuth(params, Role.MEMBER);
   if (auth.error) return auth.error;
   const { user } = auth;
   const { projectId } = auth.params;
@@ -70,6 +70,12 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
   }
   if (description !== undefined && description !== null && typeof description !== "string") {
     return errorResponse("description must be a string", 400);
+  }
+  if (typeof description === "string" && description.length > DASHBOARD_DESCRIPTION_MAX) {
+    return errorResponse(
+      `description must be at most ${DASHBOARD_DESCRIPTION_MAX} characters`,
+      400,
+    );
   }
 
   const dashboard = await prisma.dashboard.create({

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -306,12 +306,42 @@ describe("DashboardDetailPage", () => {
     expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
   });
 
-  it("redirects to the dashboard index and invalidates the list cache when the dashboard fails to load", () => {
-    mockDetail(undefined, new Error("404"));
+  it("redirects to the dashboard index and invalidates the list cache when the dashboard is gone", () => {
+    mockDetail(undefined, new Error("Dashboard not found"));
     const { invalidateSpy } = renderPage();
 
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "p1"] });
+  });
+
+  it("stays put and shows a failure notice on a transient load error", () => {
+    mockDetail(undefined, new Error("API error: 503"));
+    const { invalidateSpy } = renderPage();
+
+    expect(replace).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(screen.getByText(/Failed to load the dashboard/)).toBeTruthy();
+  });
+
+  it("keeps rendering the cached dashboard when a background poll fails", () => {
+    mockDetail(
+      { ...DASH_A, widgets: [WIDGET], layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }] },
+      new Error("API error: 503"),
+    );
+    renderPage();
+
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Failed to load the dashboard/)).toBeNull();
+    expect(lastGridProps?.widgets).toEqual([WIDGET]);
+  });
+
+  it("hides edit controls while the dashboard is still loading", () => {
+    mockDetail(undefined);
+    renderPage();
+
+    expect(screen.getByText("Loading…")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
   });
 
   it("passes widgets, layout and range to the grid and wires edit/duplicate/delete", () => {
@@ -333,6 +363,8 @@ describe("DashboardDetailPage", () => {
       title: "Cost (copy)",
       type: "query",
       spec: WIDGET.spec,
+      // A duplicate carries the display settings too, not just the query.
+      displayConfig: WIDGET.displayConfig,
     });
 
     fireEvent.click(screen.getByRole("button", { name: "delete-w1" }));

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -1,0 +1,344 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardDetail, DashboardSummary, Widget } from "@/features/dashboards/types";
+import DashboardDetailPage from "./page";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// jsdom doesn't implement ResizeObserver, which DashboardDetailPage uses to
+// track the grid body's width.
+(global as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+  ResizeObserverStub;
+
+const push = vi.fn();
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1", dashboardId: "d1" }),
+  useRouter: () => ({ push, replace }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/dashboard/d1",
+}));
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+const createDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, error: null };
+const updateLayout: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  {
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  };
+const createWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  {
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  };
+const removeWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  {
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  };
+const removeDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), isPending: false, isError: false, error: null };
+
+vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
+  useDashboards: vi.fn(),
+  useDashboard: vi.fn(),
+  useDashboardMutations: () => ({
+    createDashboard,
+    updateLayout,
+    createWidget,
+    removeWidget,
+    removeDashboard,
+  }),
+}));
+
+let lastGridProps: {
+  widgets: Widget[];
+  layout: unknown;
+  range: unknown;
+  readOnly?: boolean;
+  onEdit: (w: Widget) => void;
+  onDuplicate: (w: Widget) => void;
+  onDelete: (w: Widget) => void;
+} | null = null;
+
+vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
+  DashboardGrid: (props: {
+    widgets: Widget[];
+    layout: unknown;
+    range: unknown;
+    readOnly?: boolean;
+    onEdit: (w: Widget) => void;
+    onDuplicate: (w: Widget) => void;
+    onDelete: (w: Widget) => void;
+  }) => {
+    lastGridProps = props;
+    return (
+      <div data-testid="dashboard-grid">
+        {props.widgets.map((w) => (
+          <div key={w.id}>
+            <button onClick={() => props.onEdit(w)}>{`edit-${w.id}`}</button>
+            <button onClick={() => props.onDuplicate(w)}>{`duplicate-${w.id}`}</button>
+            <button onClick={() => props.onDelete(w)}>{`delete-${w.id}`}</button>
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+import { useDashboard, useDashboards } from "@/features/dashboards/hooks/use-dashboards";
+
+// The rendered dashboard (d1) is deliberately non-default: the default one is
+// read-only, which the dedicated tests below cover.
+const DASH_A: DashboardSummary = {
+  id: "d1",
+  name: "Custom",
+  description: null,
+  isDefault: false,
+  updateTime: "",
+};
+const DASH_B: DashboardSummary = {
+  id: "d2",
+  name: "Overview",
+  description: null,
+  isDefault: true,
+  updateTime: "",
+};
+
+const WIDGET: Widget = {
+  id: "w1",
+  dashboardId: "d1",
+  title: "Cost",
+  type: "query",
+  spec: { view: "spans" },
+  displayConfig: {},
+};
+
+function mockLists(dashboards: DashboardSummary[] | undefined) {
+  vi.mocked(useDashboards).mockReturnValue({
+    data: dashboards,
+  } as ReturnType<typeof useDashboards>);
+}
+
+function mockDetail(data: DashboardDetail | undefined, error: unknown = null) {
+  vi.mocked(useDashboard).mockReturnValue({ data, error } as ReturnType<typeof useDashboard>);
+}
+
+function renderPage() {
+  const queryClient = new QueryClient();
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardDetailPage />
+    </QueryClientProvider>,
+  );
+  return { invalidateSpy };
+}
+
+describe("DashboardDetailPage", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    push.mockReset();
+    replace.mockReset();
+    createDashboard.mutate.mockReset();
+    updateLayout.mutate.mockReset();
+    createWidget.mutate.mockReset();
+    removeWidget.mutate.mockReset();
+    removeDashboard.mutate.mockReset();
+    removeDashboard.isError = false;
+    removeDashboard.error = null;
+    lastGridProps = null;
+    mockLists([DASH_A, DASH_B]);
+    mockDetail({ ...DASH_A, layout: [], widgets: [] });
+  });
+
+  it("renders dashboard tabs with the default marked and the current one highlighted", () => {
+    renderPage();
+
+    const customTab = screen.getByRole("link", { name: "Custom" });
+    expect(customTab.textContent).not.toContain("⌂");
+    expect(customTab.getAttribute("aria-current")).toBe("page");
+
+    const overviewTab = screen.getByRole("link", { name: /Overview/ });
+    expect(overviewTab.textContent).toContain("⌂");
+    expect(overviewTab.getAttribute("aria-current")).toBeNull();
+
+    expect(screen.getByRole("button", { name: "＋ new" })).toBeTruthy();
+  });
+
+  it("opens the create-dashboard dialog and cancelling it does not create", () => {
+    renderPage();
+
+    expect(screen.queryByText("Create Dashboard")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "＋ new" }));
+    expect(screen.getByText("Create Dashboard")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(createDashboard.mutate).not.toHaveBeenCalled();
+  });
+
+  it("creates a dashboard from the dialog and navigates to it on success", () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "＋ new" }));
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "New dash" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(createDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = createDashboard.mutate.mock.calls[0];
+    expect(payload).toEqual({ name: "New dash" });
+
+    options.onSuccess({ dashboard: { id: "d9" } });
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d9");
+  });
+
+  it("shows the active range preset label", () => {
+    renderPage();
+    // Same default as the trace list (DEFAULT_DATE_FILTER = 24 hours).
+    expect(screen.getByRole("button", { name: "Last 24 hours" })).toBeTruthy();
+  });
+
+  it("pushes to the widgets/new route from the header create-widget button", () => {
+    renderPage();
+    // The empty-state CTA renders the same label, so target the header button
+    // (the first one in document order) specifically.
+    const [headerButton] = screen.getAllByRole("button", { name: "＋ Create widget" });
+    fireEvent.click(headerButton);
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1/widgets/new");
+  });
+
+  it("pushes to the widgets/new route from the empty-state CTA when there are no widgets", () => {
+    renderPage();
+    expect(screen.getByText("No widgets yet.")).toBeTruthy();
+
+    const buttons = screen.getAllByRole("button", { name: "＋ Create widget" });
+    expect(buttons.length).toBe(2);
+
+    fireEvent.click(buttons[1]);
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1/widgets/new");
+  });
+
+  it("marks the grid read-only and hides both create-widget buttons on the default dashboard", () => {
+    mockDetail({ ...DASH_B, layout: [], widgets: [WIDGET] });
+    renderPage();
+
+    expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
+    expect(lastGridProps?.readOnly).toBe(true);
+  });
+
+  it("keeps the grid editable on a non-default dashboard", () => {
+    mockDetail({ ...DASH_A, layout: [], widgets: [WIDGET] });
+    renderPage();
+
+    expect(screen.getAllByRole("button", { name: "＋ Create widget" }).length).toBe(1);
+    expect(lastGridProps?.readOnly).toBe(false);
+  });
+
+  it("deletes the dashboard through the confirm dialog and navigates to the index", () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
+    expect(screen.getByText("Delete Dashboard")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(removeDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [id, options] = removeDashboard.mutate.mock.calls[0];
+    expect(id).toBe("d1");
+
+    options.onSuccess();
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+  });
+
+  it("shows the delete error inside the dialog when the mutation fails", () => {
+    removeDashboard.isError = true;
+    removeDashboard.error = new Error("boom");
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
+    expect(screen.getByText("boom")).toBeTruthy();
+  });
+
+  it("cancelling the delete dialog does not delete", () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(removeDashboard.mutate).not.toHaveBeenCalled();
+  });
+
+  it("hides the delete button on the read-only default dashboard", () => {
+    mockDetail({ ...DASH_B, layout: [], widgets: [] });
+    renderPage();
+    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
+  });
+
+  it("redirects to the dashboard index and invalidates the list cache when the dashboard fails to load", () => {
+    mockDetail(undefined, new Error("404"));
+    const { invalidateSpy } = renderPage();
+
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "p1"] });
+  });
+
+  it("passes widgets, layout and range to the grid and wires edit/duplicate/delete", () => {
+    mockDetail({
+      ...DASH_A,
+      layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }],
+      widgets: [WIDGET],
+    });
+    renderPage();
+
+    expect(screen.queryByText("No widgets yet.")).toBeNull();
+    expect(lastGridProps?.widgets).toEqual([WIDGET]);
+    expect(lastGridProps?.layout).toEqual([{ i: "w1", x: 0, y: 0, w: 4, h: 4 }]);
+    expect(lastGridProps?.range).toHaveProperty("start");
+    expect(lastGridProps?.range).toHaveProperty("end");
+
+    fireEvent.click(screen.getByRole("button", { name: "duplicate-w1" }));
+    expect(createWidget.mutate).toHaveBeenCalledWith({
+      title: "Cost (copy)",
+      type: "query",
+      spec: WIDGET.spec,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "delete-w1" }));
+    expect(removeWidget.mutate).toHaveBeenCalledWith("w1");
+
+    fireEvent.click(screen.getByRole("button", { name: "edit-w1" }));
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1/widgets/w1/edit");
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { ProjectBreadcrumb } from "@/features/projects/components";
+import {
+  useDashboards,
+  useDashboard,
+  useDashboardMutations,
+} from "@/features/dashboards/hooks/use-dashboards";
+import { DashboardGrid } from "@/features/dashboards/components/DashboardGrid";
+import { CreateDashboardDialog } from "@/features/dashboards/components/CreateDashboardDialog";
+import type { TimeRange, Widget } from "@/features/dashboards/types";
+import { DateFilterSelect } from "@/components/date-filter-select";
+import { useUrlDateFilter } from "@/lib/hooks/use-url-date-filter";
+import { Button } from "@/components/ui/button";
+import { DeleteIconButton } from "@/components/ui/delete-button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+export default function DashboardDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const projectId = params.projectId as string;
+  const dashboardId = params.dashboardId as string;
+
+  // ── remote data ──────────────────────────────────────────────────────────────
+  const { data: dashboards } = useDashboards(projectId);
+  const { data: dashboard, error: dashboardError } = useDashboard(projectId, dashboardId);
+
+  const { updateLayout, createWidget, removeWidget, removeDashboard } = useDashboardMutations(
+    projectId,
+    dashboardId,
+  );
+
+  // ── time range — the same URL-synced filter AND default the trace list uses ──
+  const { dateFilter, customStartDate, customEndDate, setDateFilter, setCustomRange, timestamps } =
+    useUrlDateFilter();
+  const range: TimeRange = useMemo(
+    () => ({
+      // Widgets need concrete bounds. startAfter is only absent for a custom
+      // filter arriving via URL without its dates — fall back to the shared
+      // 24h default; endBefore is absent for now-anchored presets, whose end
+      // is "now" frozen at selection.
+      start: timestamps.startAfter
+        ? new Date(timestamps.startAfter)
+        : new Date(Date.now() - 86_400_000),
+      end: timestamps.endBefore ? new Date(timestamps.endBefore) : new Date(),
+    }),
+    [timestamps.startAfter, timestamps.endBefore],
+  );
+
+  // ── grid width via ResizeObserver ────────────────────────────────────────────
+  const [width, setWidth] = useState(1200);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setWidth(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // ── widget builder navigation ────────────────────────────────────────────────
+  const openCreate = () =>
+    router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/new`);
+
+  const openEdit = (w: Widget) =>
+    router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/${w.id}/edit`);
+
+  // ── deleted / missing dashboard redirect ─────────────────────────────────────
+  useEffect(() => {
+    if (dashboardError) {
+      // Invalidate the list so a stale cache can't bounce the user back here.
+      void queryClient.invalidateQueries({ queryKey: ["dashboards", projectId] });
+      router.replace(`/projects/${projectId}/dashboard`);
+    }
+  }, [dashboardError, projectId, queryClient, router]);
+
+  // useDashboard resolves to undefined while loading and throws on 404/error,
+  // so dashboardError above handles the redirect. No additional null check needed.
+
+  // ── new dashboard ────────────────────────────────────────────────────────────
+  const [createDashboardOpen, setCreateDashboardOpen] = useState(false);
+
+  // ── delete dashboard ─────────────────────────────────────────────────────────
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const handleDeleteDashboard = () => {
+    removeDashboard.mutate(dashboardId, {
+      onSuccess: () => {
+        setDeleteOpen(false);
+        // The index route resolves to the default dashboard.
+        router.replace(`/projects/${projectId}/dashboard`);
+      },
+    });
+  };
+
+  // ── layout change ────────────────────────────────────────────────────────────
+  const handleLayoutChange = useCallback(
+    (layout: Parameters<typeof updateLayout.mutate>[0]) => {
+      updateLayout.mutate(layout);
+    },
+    [updateLayout],
+  );
+
+  // ── duplicate widget ─────────────────────────────────────────────────────────
+  const handleDuplicate = useCallback(
+    (w: Widget) => {
+      createWidget.mutate({
+        title: `${w.title} (copy)`,
+        type: w.type,
+        spec: w.spec,
+      });
+    },
+    [createWidget],
+  );
+
+  // ── delete widget ────────────────────────────────────────────────────────────
+  const handleDelete = useCallback(
+    (w: Widget) => {
+      removeWidget.mutate(w.id);
+    },
+    [removeWidget],
+  );
+
+  // ── render ───────────────────────────────────────────────────────────────────
+  const widgets = dashboard?.widgets ?? [];
+  const layout = dashboard?.layout ?? [];
+  // The seeded default dashboard is read-only: custom dashboards start from
+  // "＋ new" instead. The API enforces the same rule.
+  const readOnly = dashboard?.isDefault ?? false;
+
+  return (
+    <div className="relative flex h-full text-[13px]">
+      <ProjectBreadcrumb projectId={projectId} />
+
+      <CreateDashboardDialog
+        projectId={projectId}
+        open={createDashboardOpen}
+        onOpenChange={setCreateDashboardOpen}
+      />
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Dashboard</DialogTitle>
+            <DialogDescription>
+              Permanently delete “{dashboard?.name}” and all of its widgets? This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {removeDashboard.isError && (
+            <p className="text-sm text-destructive">{removeDashboard.error.message}</p>
+          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteOpen(false)}
+              disabled={removeDashboard.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteDashboard}
+              disabled={removeDashboard.isPending}
+            >
+              {removeDashboard.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Page header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          {/* Left: title + dashboard tabs */}
+          <div className="flex items-center gap-3">
+            <h1 className="text-[13px] font-medium">Dashboard</h1>
+            <div className="flex items-center gap-0.5">
+              {dashboards?.map((d) => (
+                <Link
+                  key={d.id}
+                  href={`/projects/${projectId}/dashboard/${d.id}`}
+                  aria-current={d.id === dashboardId ? "page" : undefined}
+                  className={cn(
+                    "flex items-center gap-1 rounded px-2 py-0.5 text-[12px] transition-colors",
+                    d.id === dashboardId
+                      ? "border-b-2 border-foreground font-medium text-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  )}
+                >
+                  {d.isDefault && <span className="text-[10px]">⌂</span>}
+                  <span className="max-w-[10rem] truncate" title={d.name}>
+                    {d.name}
+                  </span>
+                </Link>
+              ))}
+              <button
+                type="button"
+                onClick={() => setCreateDashboardOpen(true)}
+                className="rounded px-2 py-0.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                ＋ new
+              </button>
+            </div>
+          </div>
+
+          {/* Right: time range, create widget */}
+          <div className="flex items-center gap-2">
+            <DateFilterSelect
+              dateFilter={dateFilter}
+              customStartDate={customStartDate}
+              customEndDate={customEndDate}
+              onDateFilterChange={setDateFilter}
+              onCustomRangeChange={setCustomRange}
+            />
+
+            {!readOnly && (
+              <>
+                <Button size="sm" className="h-7 text-[12px]" onClick={openCreate}>
+                  ＋ Create widget
+                </Button>
+                <DeleteIconButton
+                  aria-label="Delete dashboard"
+                  onClick={() => setDeleteOpen(true)}
+                />
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Body */}
+        <div ref={bodyRef} className="flex-1 overflow-auto bg-background">
+          {!dashboard ? (
+            <div className="flex h-64 items-center justify-center text-[13px] text-muted-foreground">
+              Loading…
+            </div>
+          ) : widgets.length === 0 ? (
+            <div className="flex h-64 flex-col items-center justify-center gap-3">
+              <p className="text-[13px] text-muted-foreground">No widgets yet.</p>
+              {!readOnly && (
+                <Button size="sm" className="text-[12px]" onClick={openCreate}>
+                  ＋ Create widget
+                </Button>
+              )}
+            </div>
+          ) : (
+            <DashboardGrid
+              projectId={projectId}
+              widgets={widgets}
+              layout={layout}
+              range={range}
+              width={width}
+              readOnly={readOnly}
+              onLayoutChange={handleLayoutChange}
+              onEdit={openEdit}
+              onDuplicate={handleDuplicate}
+              onDelete={handleDelete}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -83,16 +83,26 @@ export default function DashboardDetailPage() {
     router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/${w.id}/edit`);
 
   // ── deleted / missing dashboard redirect ─────────────────────────────────────
+  // fetchNextApi doesn't carry the HTTP status, so gone-ness is detected from
+  // the API's error message. The exact match keeps "Project not found" (a
+  // deleted project) and auth failures from redirecting; only a genuinely
+  // missing dashboard leaves the page. Everything else keeps the user here —
+  // the detail query's 30s poll retries, with a failure notice while empty.
+  const dashboardGone =
+    dashboardError instanceof Error &&
+    (dashboardError.message === "Dashboard not found" ||
+      /API error: 404/i.test(dashboardError.message));
   useEffect(() => {
-    if (dashboardError) {
+    if (dashboardGone) {
       // Invalidate the list so a stale cache can't bounce the user back here.
       void queryClient.invalidateQueries({ queryKey: ["dashboards", projectId] });
       router.replace(`/projects/${projectId}/dashboard`);
     }
-  }, [dashboardError, projectId, queryClient, router]);
+  }, [dashboardGone, projectId, queryClient, router]);
 
-  // useDashboard resolves to undefined while loading and throws on 404/error,
-  // so dashboardError above handles the redirect. No additional null check needed.
+  // useDashboard resolves to undefined while loading and surfaces failures via
+  // its error field; the redirect above handles gone dashboards, so the render
+  // below only needs the loading and failure branches.
 
   // ── new dashboard ────────────────────────────────────────────────────────────
   const [createDashboardOpen, setCreateDashboardOpen] = useState(false);
@@ -124,6 +134,7 @@ export default function DashboardDetailPage() {
         title: `${w.title} (copy)`,
         type: w.type,
         spec: w.spec,
+        displayConfig: w.displayConfig,
       });
     },
     [createWidget],
@@ -141,8 +152,10 @@ export default function DashboardDetailPage() {
   const widgets = dashboard?.widgets ?? [];
   const layout = dashboard?.layout ?? [];
   // The seeded default dashboard is read-only: custom dashboards start from
-  // "＋ new" instead. The API enforces the same rule.
-  const readOnly = dashboard?.isDefault ?? false;
+  // "＋ new" instead. The API enforces the same rule. Treated as read-only
+  // while the detail is still loading so edit controls never flash on the
+  // Overview before the app knows which dashboard this is.
+  const readOnly = dashboard ? dashboard.isDefault : true;
 
   return (
     <div className="relative flex h-full text-[13px]">
@@ -245,7 +258,13 @@ export default function DashboardDetailPage() {
 
         {/* Body */}
         <div ref={bodyRef} className="flex-1 overflow-auto bg-background">
-          {!dashboard ? (
+          {dashboardError && !dashboardGone && !dashboard ? (
+            // Only when there's nothing to render: a failed background poll
+            // keeps the cached dashboard, and the stale grid beats a notice.
+            <div className="flex h-64 items-center justify-center text-[13px] text-red-600">
+              Failed to load the dashboard — retrying automatically
+            </div>
+          ) : !dashboard ? (
             <div className="flex h-64 items-center justify-center text-[13px] text-muted-foreground">
               Loading…
             </div>

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import EditWidgetPage from "./page";
+
+const mounted = vi.fn();
+vi.mock("@/features/dashboards/components/WidgetBuilderPage", () => ({
+  WidgetBuilderPage: (props: { projectId: string; dashboardId: string; widgetId?: string }) => {
+    // Fires once per mount (not per update) — how the tests below tell a
+    // remounted builder from a prop-updated one.
+    useEffect(() => {
+      mounted(props.widgetId);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <div>{`builder-${props.projectId}-${props.dashboardId}-${props.widgetId}`}</div>;
+  },
+}));
+
+let widgetId = "w1";
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1", dashboardId: "d1", widgetId }),
+}));
+
+describe("EditWidgetPage", () => {
+  it("passes the route params through and remounts the builder per widget", () => {
+    const { rerender } = render(<EditWidgetPage />);
+    expect(screen.getByText("builder-p1-d1-w1")).toBeTruthy();
+
+    // A widgetId change without a segment remount (App Router keeps the
+    // subtree on same-route param changes) must reset the builder: it
+    // hydrates its draft once behind a flag, so a reused instance would show
+    // the previous widget's draft. The key makes it a fresh mount.
+    widgetId = "w2";
+    rerender(<EditWidgetPage />);
+    expect(screen.getByText("builder-p1-d1-w2")).toBeTruthy();
+    expect(mounted).toHaveBeenCalledTimes(2);
+    expect(mounted).toHaveBeenNthCalledWith(1, "w1");
+    expect(mounted).toHaveBeenNthCalledWith(2, "w2");
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { WidgetBuilderPage } from "@/features/dashboards/components/WidgetBuilderPage";
+
+export default function EditWidgetPage() {
+  const params = useParams();
+  return (
+    <WidgetBuilderPage
+      projectId={params.projectId as string}
+      dashboardId={params.dashboardId as string}
+      widgetId={params.widgetId as string}
+    />
+  );
+}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.tsx
@@ -6,7 +6,13 @@ import { WidgetBuilderPage } from "@/features/dashboards/components/WidgetBuilde
 export default function EditWidgetPage() {
   const params = useParams();
   return (
+    // Keyed by widget: the builder hydrates its draft once behind a flag (so
+    // the dashboard poll can't clobber in-progress edits), which means a
+    // widgetId change without a remount would keep the previous widget's
+    // draft. The key makes a different widget a fresh form; the same widget
+    // across polls keeps its instance.
     <WidgetBuilderPage
+      key={params.widgetId as string}
       projectId={params.projectId as string}
       dashboardId={params.dashboardId as string}
       widgetId={params.widgetId as string}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/new/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { WidgetBuilderPage } from "@/features/dashboards/components/WidgetBuilderPage";
+
+export default function NewWidgetPage() {
+  const params = useParams();
+  return (
+    <WidgetBuilderPage
+      projectId={params.projectId as string}
+      dashboardId={params.dashboardId as string}
+    />
+  );
+}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardSummary } from "@/features/dashboards/types";
+import DashboardIndexPage from "./page";
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1" }),
+  useRouter: () => ({ replace }),
+}));
+
+const refetch = vi.fn();
+vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
+  useDashboards: vi.fn(),
+}));
+
+import { useDashboards } from "@/features/dashboards/hooks/use-dashboards";
+
+function mockDashboards(data: DashboardSummary[] | undefined, error: unknown = null) {
+  vi.mocked(useDashboards).mockReturnValue({
+    data,
+    error,
+    refetch,
+  } as unknown as ReturnType<typeof useDashboards>);
+}
+
+const DASH_A: DashboardSummary = {
+  id: "d1",
+  name: "Overview",
+  description: null,
+  isDefault: false,
+  updateTime: "",
+};
+const DASH_B: DashboardSummary = {
+  id: "d2",
+  name: "Costs",
+  description: null,
+  isDefault: true,
+  updateTime: "",
+};
+
+describe("DashboardIndexPage", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    replace.mockReset();
+    refetch.mockReset();
+  });
+
+  it("shows a loading state while the dashboard list is in flight", () => {
+    mockDashboards(undefined);
+    render(<DashboardIndexPage />);
+    expect(screen.getByText("Loading dashboards…")).toBeTruthy();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the default dashboard once the list resolves", () => {
+    mockDashboards([DASH_A, DASH_B]);
+    render(<DashboardIndexPage />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d2");
+  });
+
+  it("redirects to the first dashboard when none is marked default", () => {
+    mockDashboards([
+      { ...DASH_A, isDefault: false },
+      { ...DASH_B, isDefault: false },
+    ]);
+    render(<DashboardIndexPage />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  it("shows a retry button on error and refetches on click", () => {
+    mockDashboards(undefined, new Error("boom"));
+    render(<DashboardIndexPage />);
+    expect(screen.getByText("Failed to load dashboards — retry")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
@@ -1,32 +1,42 @@
 "use client";
 
-import { useParams } from "next/navigation";
-import { LayoutDashboard } from "lucide-react";
-import { ProjectBreadcrumb } from "@/features/projects/components";
+import { useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useDashboards } from "@/features/dashboards/hooks/use-dashboards";
 
-export default function DashboardPage() {
+export default function DashboardIndexPage() {
   const params = useParams();
+  const router = useRouter();
   const projectId = params.projectId as string;
+  const { data: dashboards, error, refetch } = useDashboards(projectId);
+
+  useEffect(() => {
+    // The list endpoint lazily seeds the default Overview, so there is always
+    // at least one dashboard once the query resolves.
+    if (dashboards && dashboards.length > 0) {
+      const target = dashboards.find((d) => d.isDefault) ?? dashboards[0];
+      router.replace(`/projects/${projectId}/dashboard/${target.id}`);
+    }
+  }, [dashboards, projectId, router]);
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-[13px]">
+        <span className="text-destructive">Failed to load dashboards — retry</span>
+        <button
+          type="button"
+          onClick={() => void refetch()}
+          className="rounded border border-border px-3 py-1 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
 
   return (
-    <div className="relative flex h-full text-[13px]">
-      <ProjectBreadcrumb projectId={projectId} />
-
-      <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Page header */}
-        <div className="flex items-center justify-between border-b border-border px-4 py-2">
-          <h1 className="text-[13px] font-medium">Dashboard</h1>
-        </div>
-
-        {/* Coming soon placeholder */}
-        <div className="flex flex-1 flex-col items-center justify-center gap-3 bg-background">
-          <LayoutDashboard className="h-8 w-8 text-muted-foreground/40" />
-          <p className="text-[13px] text-muted-foreground">Coming soon</p>
-          <p className="text-[12px] text-muted-foreground">
-            The dashboard is under construction. Check back later.
-          </p>
-        </div>
-      </div>
+    <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+      Loading dashboards…
     </div>
   );
 }

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
@@ -103,6 +103,18 @@ describe("CreateDashboardDialog", () => {
     expect(createDashboard.mutate).not.toHaveBeenCalled();
   });
 
+  it("ignores Escape and other Radix close paths while a create is in flight", () => {
+    createDashboard.isPending = true;
+    const { onOpenChange } = renderDialog();
+
+    // Escape bypasses the disabled Cancel button; the dialog must stay open
+    // so the pending mutation can't be reset and resubmitted mid-request.
+    fireEvent.keyDown(screen.getByPlaceholderText("Dashboard name"), { key: "Escape" });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(createDashboard.reset).not.toHaveBeenCalled();
+  });
+
   it("shows the mutation error message and a pending Create label", () => {
     createDashboard.isPending = true;
     createDashboard.isError = true;

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+const createDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false, error: null };
+
+vi.mock("../hooks/use-dashboards", () => ({
+  useDashboardMutations: () => ({ createDashboard }),
+}));
+
+import { CreateDashboardDialog } from "./CreateDashboardDialog";
+
+describe("CreateDashboardDialog", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    push.mockReset();
+    createDashboard.mutate.mockReset();
+    createDashboard.reset.mockReset();
+    createDashboard.isPending = false;
+    createDashboard.isError = false;
+    createDashboard.error = null;
+  });
+
+  function renderDialog() {
+    const onOpenChange = vi.fn();
+    render(<CreateDashboardDialog projectId="p1" open={true} onOpenChange={onOpenChange} />);
+    return { onOpenChange };
+  }
+
+  it("autofocuses the name input when opened", () => {
+    renderDialog();
+    expect(document.activeElement).toBe(screen.getByPlaceholderText("Dashboard name"));
+  });
+
+  it("caps the name input at 50 characters", () => {
+    renderDialog();
+    expect(screen.getByPlaceholderText("Dashboard name").getAttribute("maxLength")).toBe("50");
+  });
+
+  it("disables Create until a non-blank name is entered", () => {
+    renderDialog();
+    const create = screen.getByRole("button", { name: "Create" });
+    expect(create.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "   " },
+    });
+    expect(create.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "Costs" },
+    });
+    expect(create.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("submits the trimmed name, then closes and navigates on success", () => {
+    const { onOpenChange } = renderDialog();
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "  New dash  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(createDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = createDashboard.mutate.mock.calls[0];
+    expect(payload).toEqual({ name: "New dash" });
+
+    options.onSuccess({ dashboard: { id: "d9" } });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d9");
+  });
+
+  it("clears the draft name and mutation state when closed via Cancel", () => {
+    const { onOpenChange } = renderDialog();
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "Draft" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(createDashboard.reset).toHaveBeenCalled();
+    expect((screen.getByPlaceholderText("Dashboard name") as HTMLInputElement).value).toBe("");
+  });
+
+  it("closes via Cancel without creating", () => {
+    const { onOpenChange } = renderDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(createDashboard.mutate).not.toHaveBeenCalled();
+  });
+
+  it("shows the mutation error message and a pending Create label", () => {
+    createDashboard.isPending = true;
+    createDashboard.isError = true;
+    createDashboard.error = new Error("boom");
+    renderDialog();
+
+    expect(screen.getByText("boom")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Creating..." }).hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useDashboardMutations } from "../hooks/use-dashboards";
+import { DASHBOARD_NAME_MAX } from "../types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export function CreateDashboardDialog({
+  projectId,
+  open,
+  onOpenChange,
+}: {
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [name, setName] = useState("");
+  const router = useRouter();
+  const { createDashboard } = useDashboardMutations(projectId);
+
+  // Closing discards the draft: a cancelled name or stale error must not
+  // reappear the next time the dialog opens.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setName("");
+      createDashboard.reset();
+    }
+    onOpenChange(next);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    createDashboard.mutate(
+      { name: name.trim() },
+      {
+        onSuccess: (res) => {
+          handleOpenChange(false);
+          router.push(`/projects/${projectId}/dashboard/${res.dashboard.id}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create Dashboard</DialogTitle>
+            <DialogDescription>Create a new dashboard to organize your widgets.</DialogDescription>
+          </DialogHeader>
+          <div className="py-4">
+            <Input
+              autoFocus
+              maxLength={DASHBOARD_NAME_MAX}
+              placeholder="Dashboard name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={createDashboard.isPending}
+            />
+            {createDashboard.isError && (
+              <p className="mt-2 text-sm text-destructive">{createDashboard.error.message}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={createDashboard.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim() || createDashboard.isPending}>
+              {createDashboard.isPending ? "Creating..." : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.tsx
@@ -31,6 +31,10 @@ export function CreateDashboardDialog({
   // Closing discards the draft: a cancelled name or stale error must not
   // reappear the next time the dialog opens.
   const handleOpenChange = (next: boolean) => {
+    // Radix close paths (Escape, overlay click, the X) bypass the disabled
+    // Cancel button — ignore them while a create is in flight, so the pending
+    // mutation can't be reset mid-request and resubmitted.
+    if (!next && createDashboard.isPending) return;
     if (!next) {
       setName("");
       createDashboard.reset();

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -2,6 +2,7 @@
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, Widget } from "../types";
+import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
 import { WidgetBuilderPage } from "./WidgetBuilderPage";
 
 // Radix Select opens on pointerdown and relies on pointer-capture APIs jsdom
@@ -133,8 +134,40 @@ describe("WidgetBuilderPage", () => {
     updateWidget.mutate.mockReset();
     updateWidget.isPending = false;
     updateWidget.error = null;
+    localStorage.clear();
     mockDashboard(DASHBOARD);
     mockPreview({});
+  });
+
+  it("adopts the project's persisted range and persists a picked preset", async () => {
+    localStorage.setItem(dateFilterStorageKey("p1"), JSON.stringify({ id: "7d" }));
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    // The preview dropdown adopts the stored selection after mount…
+    expect(await screen.findByText("Last 7 days")).toBeTruthy();
+
+    // …and picking a preset writes the shared store for the other pages.
+    fireEvent.pointerDown(screen.getByText("Last 7 days").closest("button") as HTMLElement, {
+      button: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.click(await screen.findByText("Last 30 days"));
+    expect(readStoredDateFilter("p1")).toEqual({ id: "30d" });
+  });
+
+  it("leaves a stored custom range untouched and previews the shared default", () => {
+    const custom = {
+      id: "custom",
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-07-02T00:00:00.000Z",
+    };
+    localStorage.setItem(dateFilterStorageKey("p1"), JSON.stringify(custom));
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    // The preset-only dropdown can't express custom: default preview window,
+    // stored preference preserved for the pages that can render it.
+    expect(screen.getByText("Last 24 hours")).toBeTruthy();
+    expect(readStoredDateFilter("p1")).toEqual(custom);
   });
 
   it("renders the two config sections with save disabled on a fresh draft", () => {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, Widget } from "../types";
 import { WidgetBuilderPage } from "./WidgetBuilderPage";
@@ -252,6 +252,15 @@ describe("WidgetBuilderPage", () => {
 
     expect(screen.getByText(/can't be histogrammed/)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+
+    // The preview is starved rather than firing a query the compiler is
+    // guaranteed to reject: the pane shows guidance immediately, and once
+    // the debounce settles the hook receives a null draft (the gate judges
+    // the same debounced value the hook consumes).
+    expect(
+      screen.getByText("Preview unavailable for this measure/display combination"),
+    ).toBeTruthy();
+    await waitFor(() => expect(vi.mocked(useWidgetPreview).mock.lastCall?.[1]).toBeNull());
   });
 
   it("warns and blocks save when pie/bar is picked without a breakdown", async () => {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -1,0 +1,437 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardDetail, Widget } from "../types";
+import { WidgetBuilderPage } from "./WidgetBuilderPage";
+
+// Radix Select opens on pointerdown and relies on pointer-capture APIs jsdom
+// doesn't implement.
+window.HTMLElement.prototype.hasPointerCapture = vi.fn();
+window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+const push = vi.fn();
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push, replace }) }));
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const createWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  { mutate: vi.fn(), isPending: false, error: null };
+const updateWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  { mutate: vi.fn(), isPending: false, error: null };
+vi.mock("../hooks/use-dashboards", () => ({
+  useDashboard: vi.fn(),
+  useDashboardMutations: () => ({ createWidget, updateWidget }),
+}));
+vi.mock("../hooks/use-widget-data", () => ({
+  useWidgetSchema: () => ({ data: SCHEMA }),
+  useWidgetPreview: vi.fn(),
+  useWidgetFieldValues: () => ({ values: [], isLoading: false }),
+}));
+import { useDashboard } from "../hooks/use-dashboards";
+import { useWidgetPreview } from "../hooks/use-widget-data";
+
+const SCHEMA = {
+  spans: {
+    fields: {
+      model_name: {
+        type: "string",
+        label: "Model",
+        filterOps: ["=", "!=", "contains"],
+        groupable: true,
+        aggs: [],
+      },
+      cost: {
+        type: "number",
+        label: "Cost",
+        filterOps: [">", ">="],
+        groupable: false,
+        aggs: ["sum", "avg"],
+      },
+      count: {
+        type: "number",
+        label: "Count",
+        filterOps: [],
+        groupable: false,
+        aggs: ["count"],
+        histogrammable: false,
+      },
+    },
+  },
+  traces: {
+    fields: {
+      cost: {
+        type: "number",
+        label: "Cost",
+        filterOps: [">", ">="],
+        groupable: false,
+        aggs: ["sum", "avg"],
+      },
+      error_count: {
+        type: "number",
+        label: "Errors",
+        filterOps: [">"],
+        groupable: false,
+        aggs: ["sum"],
+      },
+    },
+  },
+};
+
+const WIDGET: Widget = {
+  id: "w1",
+  dashboardId: "d1",
+  title: "My cost widget",
+  type: "query",
+  spec: {
+    view: "spans",
+    filters: [],
+    metric: { measure: "cost", agg: "sum" },
+    breakdown: null,
+    display: { type: "number" },
+  },
+  displayConfig: {},
+};
+
+// Non-default: the builder is only reachable for editable dashboards — the
+// default one redirects away, which its dedicated test covers.
+const DASHBOARD = {
+  id: "d1",
+  name: "Custom",
+  description: null,
+  isDefault: false,
+  updateTime: "",
+  layout: [],
+  widgets: [WIDGET],
+} as DashboardDetail;
+
+function mockDashboard(data: DashboardDetail | undefined, error: unknown = null) {
+  vi.mocked(useDashboard).mockReturnValue({ data, error } as ReturnType<typeof useDashboard>);
+}
+
+function mockPreview(state: { isPending?: boolean; error?: unknown; data?: unknown }) {
+  vi.mocked(useWidgetPreview).mockReturnValue({
+    isPending: false,
+    error: null,
+    data: undefined,
+    ...state,
+  } as ReturnType<typeof useWidgetPreview>);
+}
+
+describe("WidgetBuilderPage", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    push.mockReset();
+    replace.mockReset();
+    createWidget.mutate.mockReset();
+    createWidget.isPending = false;
+    createWidget.error = null;
+    updateWidget.mutate.mockReset();
+    updateWidget.isPending = false;
+    updateWidget.error = null;
+    mockDashboard(DASHBOARD);
+    mockPreview({});
+  });
+
+  it("renders the two config sections with save disabled on a fresh draft", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(screen.getByText("Data selection")).toBeTruthy();
+    expect(screen.getByText("Visualization")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+  });
+
+  it("links back to the dashboard by name", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    const back = screen.getByRole("link", { name: /Custom/ });
+    expect(back.getAttribute("href")).toBe("/projects/p1/dashboard/d1");
+  });
+
+  it("hydrates the form from the widget in edit mode and saves via update", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    const name = screen.getByPlaceholderText("Widget name") as HTMLInputElement;
+    expect(name.value).toBe("My cost widget");
+
+    const save = screen.getByRole("button", { name: "Save widget" });
+    expect(save).toHaveProperty("disabled", false);
+    fireEvent.click(save);
+
+    expect(updateWidget.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = updateWidget.mutate.mock.calls[0];
+    expect(payload).toMatchObject({ widgetId: "w1", title: "My cost widget" });
+    options.onSuccess();
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  it("keeps a manually edited name (lock) in edit mode", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    const name = screen.getByPlaceholderText("Widget name") as HTMLInputElement;
+    fireEvent.change(name, { target: { value: "Renamed" } });
+    expect(name.value).toBe("Renamed");
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    expect(updateWidget.mutate.mock.calls[0][0]).toMatchObject({ title: "Renamed" });
+  });
+
+  it("redirects to the dashboard when the widget is missing or not a query widget", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="nope" />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  it("redirects to the dashboard index when the dashboard failed to load", () => {
+    mockDashboard(undefined, new Error("404"));
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+  });
+
+  it("redirects back to the read-only default dashboard instead of opening the builder", () => {
+    mockDashboard({ ...DASHBOARD, isDefault: true });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  function openSelect(currentText: string) {
+    const trigger = screen.getByText(currentText).closest("button") as HTMLElement;
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: "mouse" });
+    return trigger;
+  }
+
+  it("offers Model from the traces view and switches to spans keeping a compatible measure", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Traces" }));
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Cost" }));
+
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: /Model/ }));
+
+    // The view flipped to Spans and the measure survived (cost exists there).
+    expect(screen.getByText("Spans")).toBeTruthy();
+    expect(screen.getByText("Cost")).toBeTruthy();
+    expect(screen.getByText("Model")).toBeTruthy();
+  });
+
+  it("clears a traces-only measure when Model switches the view to spans", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Traces" }));
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Errors" }));
+
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: /Model/ }));
+
+    expect(screen.getByText("Spans")).toBeTruthy();
+    // error_count doesn't exist on spans — the measure select resets.
+    expect(screen.queryByText("Errors")).toBeNull();
+    expect(screen.getByText("Measure")).toBeTruthy();
+  });
+
+  it("blocks the histogram display for a non-histogrammable measure", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Spans" }));
+
+    // Measure picked first: the histogram button itself is disabled.
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Count" }));
+    expect(screen.getByRole("button", { name: "histogram" })).toHaveProperty("disabled", true);
+
+    // Reached the other way (display first, then the measure): warn + block save.
+    openSelect("Count");
+    fireEvent.click(await screen.findByRole("option", { name: "Cost" }));
+    fireEvent.click(screen.getByRole("button", { name: "histogram" }));
+    openSelect("Cost");
+    fireEvent.click(await screen.findByRole("option", { name: "Count" }));
+
+    expect(screen.getByText(/can't be histogrammed/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+  });
+
+  it("warns and blocks save when pie/bar is picked without a breakdown", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Spans" }));
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Cost" }));
+    fireEvent.click(screen.getByRole("button", { name: "pie" }));
+
+    expect(screen.getByText("A pie chart needs a breakdown dimension")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+
+    // Picking a breakdown clears the warning and unblocks save.
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: "Model" }));
+    expect(screen.queryByText("A pie chart needs a breakdown dimension")).toBeNull();
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", false);
+  });
+
+  it("drives the form through view, measure, agg and display in create mode, then saves via create", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Spans" }));
+
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Cost" }));
+
+    // Measure auto-picks the field's first aggregation (sum); pick a different
+    // one explicitly to exercise the Agg select.
+    openSelect("sum");
+    fireEvent.click(await screen.findByRole("option", { name: "avg" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "number" }));
+
+    const save = screen.getByRole("button", { name: "Save widget" });
+    expect(save).toHaveProperty("disabled", false);
+    fireEvent.click(save);
+
+    expect(createWidget.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = createWidget.mutate.mock.calls[0];
+    expect(payload).toEqual({
+      title: "Avg Cost",
+      type: "query",
+      spec: {
+        view: "spans",
+        filters: [],
+        metric: { measure: "cost", agg: "avg" },
+        breakdown: null,
+        display: { type: "number" },
+      },
+    });
+
+    options.onSuccess();
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  it("switches the selected display type and gates breakdown for number and histogram", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    const numberBtn = screen.getByRole("button", { name: "number" });
+    const histogramBtn = screen.getByRole("button", { name: "histogram" });
+    const barBtn = screen.getByRole("button", { name: "bar" });
+    // the fixture widget is a number tile, so the gate notice shows immediately
+    expect(numberBtn.className).toContain("bg-primary");
+    expect(screen.getByText("Not available for this display type")).toBeTruthy();
+
+    fireEvent.click(barBtn);
+    expect(barBtn.className).toContain("bg-primary");
+    expect(screen.queryByText("Not available for this display type")).toBeNull();
+
+    fireEvent.click(histogramBtn);
+    expect(histogramBtn.className).toContain("bg-primary");
+    expect(numberBtn.className).not.toContain("bg-primary");
+    expect(screen.getByText("Not available for this display type")).toBeTruthy();
+  });
+
+  it("clears an existing breakdown when number is selected", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    fireEvent.click(screen.getByRole("button", { name: "bar" }));
+    openSelect("None");
+    fireEvent.click(screen.getByRole("option", { name: "Model" }));
+    fireEvent.click(screen.getByRole("button", { name: "number" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    const [payload] = updateWidget.mutate.mock.calls.at(-1)!;
+    expect(payload.spec.breakdown).toBeNull();
+  });
+
+  it("adds a filter row with '+ Add filter' and removes it via the row's remove button", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.queryByText("Field")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "＋ Add filter" }));
+    expect(screen.getByText("Field")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove filter" }));
+    expect(screen.queryByText("Field")).toBeNull();
+  });
+
+  it("changes the breakdown field and can reset it back to none", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+
+    // line allows a breakdown but doesn't require one, so both saves are valid.
+    fireEvent.click(screen.getByRole("button", { name: "line" }));
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: "Model" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    expect(updateWidget.mutate).toHaveBeenCalledTimes(1);
+    expect(updateWidget.mutate.mock.calls[0][0]).toMatchObject({
+      spec: expect.objectContaining({ breakdown: "model_name" }),
+    });
+
+    openSelect("Model");
+    fireEvent.click(await screen.findByRole("option", { name: "None" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    expect(updateWidget.mutate).toHaveBeenCalledTimes(2);
+    expect(updateWidget.mutate.mock.calls[1][0]).toMatchObject({
+      spec: expect.objectContaining({ breakdown: null }),
+    });
+  });
+
+  it("does not fall through to create when editing and the widget disappears from the dashboard", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="nope" />);
+    const save = screen.getByRole("button", { name: "Save widget" });
+    fireEvent.click(save);
+    expect(createWidget.mutate).not.toHaveBeenCalled();
+    expect(updateWidget.mutate).not.toHaveBeenCalled();
+  });
+
+  it("clears an existing breakdown when switching to histogram display before saving", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "bar" }));
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: "Model" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "histogram" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    expect(updateWidget.mutate).toHaveBeenCalledTimes(1);
+    expect(updateWidget.mutate.mock.calls[0][0]).toMatchObject({
+      spec: expect.objectContaining({ breakdown: null }),
+    });
+  });
+
+  it("shows an inline error when the save mutation fails", () => {
+    updateWidget.error = new Error("boom");
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.getByText("Failed to save widget: boom")).toBeTruthy();
+  });
+
+  it("shows a pending state while the preview query is in flight", () => {
+    mockPreview({ isPending: true });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.getByText("Running…")).toBeTruthy();
+  });
+
+  it("surfaces the preview query error message", () => {
+    mockPreview({ error: new Error("bad query") });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.getByText("bad query")).toBeTruthy();
+  });
+
+  it("renders the query result once preview data resolves", () => {
+    vi.useFakeTimers();
+    try {
+      mockPreview({ data: { columns: ["value"], rows: [[42]], meta: {} } });
+      render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+      // The preview draft is debounced 400ms before the renderer picks it up.
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+      // cost measure carries its $ unit through the preview renderer
+      expect(screen.getByText("$42")).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -54,6 +54,20 @@ type View = "spans" | "traces";
 
 const EMPTY_DRAFT: DraftSpec = { filters: [], breakdown: null };
 
+// A histogram-blocked draft (histogram display on a measure the registry says
+// can't be histogrammed) still parses complete — histogrammable is registry
+// data, not schema shape — so completeness checks alone won't catch it. Used
+// against both the live draft (warning/save UI) and the debounced draft (the
+// preview gate must judge the same value the query hook consumes, or leaving
+// the blocked state would fire the stale blocked spec once).
+function isHistogramBlocked(
+  draft: DraftSpec,
+  viewFields: Record<string, WidgetSchemaField>,
+): boolean {
+  const field = draft.metric?.measure ? viewFields[draft.metric.measure] : undefined;
+  return draft.display?.type === "histogram" && field?.histogrammable === false;
+}
+
 // Section boxes match the detector creation form: square-cornered border with
 // a muted header strip, sub-fields divided inside.
 function SectionBox({ label, children }: { label: string; children: React.ReactNode }) {
@@ -232,20 +246,28 @@ export function WidgetBuilderPage({
   // ── name (auto until edited) ──────────────────────────────────────────────
   const effectiveTitle = titleLocked ? title : generateWidgetTitle(draft, viewFields);
 
-  // ── preview ───────────────────────────────────────────────────────────────
-  const debouncedDraft = useDebounced(draft, 400);
-  const preview = useWidgetPreview(projectId, debouncedDraft, range);
-  const debouncedSpec = useMemo(() => parseSpec(debouncedDraft), [debouncedDraft]);
-
-  // ── save ──────────────────────────────────────────────────────────────────
-  const specComplete = isSpecComplete(draft);
   // The schema tells us which measures the query engine can histogram
   // (count's expr is the count(*) sentinel, which it permanently rejects) —
   // without this gate the widget saves and then renders "Query failed"
   // forever on the dashboard.
   const measureField = draft.metric?.measure ? viewFields[draft.metric.measure] : undefined;
-  const histogramBlocked =
-    draft.display?.type === "histogram" && measureField?.histogrammable === false;
+  const histogramBlocked = isHistogramBlocked(draft, viewFields);
+
+  // ── preview ───────────────────────────────────────────────────────────────
+  const debouncedDraft = useDebounced(draft, 400);
+  // The compiler is guaranteed to reject a histogram-blocked spec — starve
+  // the preview query instead of rendering its error under the inline
+  // warning that already explains the problem. Judged on the debounced
+  // draft the hook consumes, not the fresher `histogramBlocked`.
+  const preview = useWidgetPreview(
+    projectId,
+    isHistogramBlocked(debouncedDraft, viewFields) ? null : debouncedDraft,
+    range,
+  );
+  const debouncedSpec = useMemo(() => parseSpec(debouncedDraft), [debouncedDraft]);
+
+  // ── save ──────────────────────────────────────────────────────────────────
+  const specComplete = isSpecComplete(draft);
   const saving = createWidget.isPending || updateWidget.isPending;
   const canSave = specComplete && !histogramBlocked && effectiveTitle.trim().length > 0 && !saving;
   const saveError = createWidget.error ?? updateWidget.error;
@@ -531,9 +553,11 @@ export function WidgetBuilderPage({
             </DropdownMenu>
           </div>
           <div className="min-h-0 flex-1 p-4">
-            {!specComplete ? (
+            {!specComplete || histogramBlocked ? (
               <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
-                Complete the data selection and display to preview
+                {histogramBlocked
+                  ? "Preview unavailable for this measure/display combination"
+                  : "Complete the data selection and display to preview"}
               </div>
             ) : preview.isPending ? (
               <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -23,6 +23,7 @@ import {
 import { useDashboard, useDashboardMutations } from "../hooks/use-dashboards";
 import { useWidgetPreview, useWidgetSchema } from "../hooks/use-widget-data";
 import { DEFAULT_RANGE_ID, RANGE_PRESETS, makeRange } from "../range-presets";
+import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-storage";
 import {
   BREAKDOWN_REQUIRED_DISPLAYS,
   DISPLAY_TYPES,
@@ -93,12 +94,21 @@ export function WidgetBuilderPage({
   const [title, setTitle] = useState("");
   const [titleLocked, setTitleLocked] = useState(isEdit);
 
-  // The page doesn't inherit the dashboard's picked range; the preview gets
-  // its own preset dropdown. Presets and default come from the shared
-  // date-filter module (via range-presets.ts) so the preview window always
-  // matches the trace list's and dashboard page's vocabulary and 24h default.
-  // Preview-only, not persisted.
+  // The preview shares the project's persisted date-filter selection: it
+  // adopts the stored preset after mount (post-mount so hydration never
+  // mismatches) and picking a preset here writes it back, carrying to the
+  // dashboard and trace list too. The store may hold "custom", which the
+  // preview's preset-only dropdown can't express — that stays at the shared
+  // 24h default and is left untouched in the store.
   const [rangeId, setRangeId] = useState<string>(DEFAULT_RANGE_ID);
+  useEffect(() => {
+    const stored = readStoredDateFilter(projectId);
+    if (stored && RANGE_PRESETS.some((p) => p.id === stored.id)) setRangeId(stored.id);
+  }, [projectId]);
+  const handleRangePick = (id: string) => {
+    setRangeId(id);
+    writeStoredDateFilter(projectId, { id });
+  };
   const range = useMemo(() => makeRange(rangeId), [rangeId]);
 
   // ── edit mode: hydrate once the widget arrives, guard bad targets ─────────
@@ -522,7 +532,7 @@ export function WidgetBuilderPage({
                   <DropdownMenuItem
                     key={preset.id}
                     className="text-[12px]"
-                    onClick={() => setRangeId(preset.id)}
+                    onClick={() => handleRangePick(preset.id)}
                   >
                     {preset.label}
                   </DropdownMenuItem>

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -1,0 +1,559 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useDashboard, useDashboardMutations } from "../hooks/use-dashboards";
+import { useWidgetPreview, useWidgetSchema } from "../hooks/use-widget-data";
+import { DEFAULT_RANGE_ID, RANGE_PRESETS, makeRange } from "../range-presets";
+import {
+  BREAKDOWN_REQUIRED_DISPLAYS,
+  DISPLAY_TYPES,
+  FIELD_UNIT,
+  generateWidgetTitle,
+  isSpecComplete,
+  parseSpec,
+  type DraftSpec,
+  type WidgetSchemaField,
+} from "../types";
+import { fieldIcon } from "./field-icons";
+import { FilterRow } from "./FilterRow";
+import { QueryWidgetRenderer } from "./renderers";
+
+const ModelIcon = fieldIcon("model_name");
+
+function useDebounced<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(id);
+  }, [value, ms]);
+  return debounced;
+}
+
+const NONE_SENTINEL = "__none__";
+
+type View = "spans" | "traces";
+
+const EMPTY_DRAFT: DraftSpec = { filters: [], breakdown: null };
+
+// Section boxes match the detector creation form: square-cornered border with
+// a muted header strip, sub-fields divided inside.
+function SectionBox({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="border border-border">
+      <div className="border-b border-border bg-muted/50 px-3 py-1.5">
+        <span className="text-[12px] font-medium text-muted-foreground">{label}</span>
+      </div>
+      <div className="divide-y divide-border">{children}</div>
+    </div>
+  );
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <p className="mb-1.5 text-[11px] font-medium text-muted-foreground">{children}</p>;
+}
+
+export function WidgetBuilderPage({
+  projectId,
+  dashboardId,
+  widgetId,
+}: {
+  projectId: string;
+  dashboardId: string;
+  widgetId?: string;
+}) {
+  const router = useRouter();
+  const isEdit = widgetId !== undefined;
+  const dashboardUrl = `/projects/${projectId}/dashboard/${dashboardId}`;
+
+  const { data: dashboard, error: dashboardError } = useDashboard(projectId, dashboardId);
+  const { createWidget, updateWidget } = useDashboardMutations(projectId, dashboardId);
+
+  const [draft, setDraft] = useState<DraftSpec>(EMPTY_DRAFT);
+  // Auto-name: `title` holds user text once locked; until then the generated
+  // title is displayed. Edit mode starts locked — existing titles are user-owned.
+  const [title, setTitle] = useState("");
+  const [titleLocked, setTitleLocked] = useState(isEdit);
+
+  // The page doesn't inherit the dashboard's picked range; the preview gets
+  // its own preset dropdown. Presets and default come from the shared
+  // date-filter module (via range-presets.ts) so the preview window always
+  // matches the trace list's and dashboard page's vocabulary and 24h default.
+  // Preview-only, not persisted.
+  const [rangeId, setRangeId] = useState<string>(DEFAULT_RANGE_ID);
+  const range = useMemo(() => makeRange(rangeId), [rangeId]);
+
+  // ── edit mode: hydrate once the widget arrives, guard bad targets ─────────
+  const widget = isEdit ? dashboard?.widgets.find((w) => w.id === widgetId) : undefined;
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    if (!isEdit || hydrated || !widget) return;
+    setDraft(widget.spec as DraftSpec);
+    setTitle(widget.title);
+    setHydrated(true);
+  }, [isEdit, hydrated, widget]);
+
+  useEffect(() => {
+    if (dashboardError) router.replace(`/projects/${projectId}/dashboard`);
+  }, [dashboardError, projectId, router]);
+
+  useEffect(() => {
+    if (isEdit && dashboard && (!widget || widget.type !== "query")) {
+      router.replace(dashboardUrl);
+    }
+  }, [isEdit, dashboard, widget, dashboardUrl, router]);
+
+  // The default dashboard is read-only — widgets can be neither added nor
+  // edited, so bounce straight back. The API enforces the same rule.
+  useEffect(() => {
+    if (dashboard?.isDefault) router.replace(dashboardUrl);
+  }, [dashboard, dashboardUrl, router]);
+
+  // ── schema-driven field lists (same derivation as the old modal) ──────────
+  const { data: schema } = useWidgetSchema(projectId);
+  const view = draft.view as View | undefined;
+  const viewFields: Record<string, WidgetSchemaField> = view ? (schema?.[view]?.fields ?? {}) : {};
+  const pickFields = (pred: (f: WidgetSchemaField) => boolean) =>
+    Object.entries(viewFields).filter(([, f]) => pred(f)) as [string, WidgetSchemaField][];
+  const filterableFields = pickFields((f) => f.filterOps.length > 0);
+  const measurableFields = pickFields((f) => f.aggs.length > 0);
+  const groupableFields = pickFields((f) => f.groupable);
+
+  function handleViewChange(v: View) {
+    setDraft({ view: v, filters: [], breakdown: null });
+  }
+
+  // ── filters ────────────────────────────────────────────────────────────────
+  const filters = draft.filters ?? [];
+
+  // Filter rows use `op: string` while DraftSpec expects the strict op union.
+  // Rows are partial/in-progress; parseSpec/isSpecComplete validates the final
+  // shape — so we cast through unknown here to satisfy the type checker.
+  function handleFilterChange(
+    idx: number,
+    patch: Partial<{ field: string; op: string; value: string | number }>,
+  ) {
+    setDraft(
+      (d) =>
+        ({
+          ...d,
+          filters: (d.filters ?? []).map((f, i) => (i === idx ? { ...f, ...patch } : f)),
+        }) as unknown as DraftSpec,
+    );
+  }
+
+  function handleFilterRemove(idx: number) {
+    setDraft(
+      (d) =>
+        ({ ...d, filters: (d.filters ?? []).filter((_, i) => i !== idx) }) as unknown as DraftSpec,
+    );
+  }
+
+  function handleAddFilter() {
+    setDraft(
+      (d) =>
+        ({
+          ...d,
+          filters: [...(d.filters ?? []), { field: "", op: "", value: "" }],
+        }) as unknown as DraftSpec,
+    );
+  }
+
+  // ── metric / breakdown / display ──────────────────────────────────────────
+  const measure = draft.metric?.measure ?? "";
+  const agg = draft.metric?.agg ?? "";
+  const measureMeta = viewFields[measure];
+  const allowedAggs = measureMeta?.aggs ?? [];
+
+  function handleMeasureChange(m: string) {
+    const firstAgg = viewFields[m]?.aggs[0] ?? "";
+    setDraft((d) => ({ ...d, metric: { measure: m, agg: firstAgg } }) as unknown as DraftSpec);
+  }
+
+  function handleAggChange(a: string) {
+    setDraft(
+      (d) =>
+        ({ ...d, metric: { measure: d.metric?.measure ?? "", agg: a } }) as unknown as DraftSpec,
+    );
+  }
+
+  function handleBreakdownChange(v: string) {
+    const breakdown = v === NONE_SENTINEL ? null : v;
+    // Model is span-level data but the most-wanted breakdown, so it's offered
+    // from every view: picking it switches to Spans like a manual view change
+    // (filters reset), keeping the metric when the measure exists there too.
+    if (breakdown === "model_name" && view !== "spans") {
+      const spansFields = schema?.spans?.fields ?? {};
+      setDraft((d) => {
+        const spansField = d.metric?.measure ? spansFields[d.metric.measure] : undefined;
+        const metricSurvives =
+          spansField && d.metric?.agg ? spansField.aggs.includes(d.metric.agg) : false;
+        return {
+          view: "spans",
+          filters: [],
+          breakdown,
+          metric: metricSurvives ? d.metric : undefined,
+          display: d.display,
+        };
+      });
+      return;
+    }
+    setDraft((d) => ({ ...d, breakdown }));
+  }
+
+  function handleDisplayChange(t: (typeof DISPLAY_TYPES)[number]) {
+    setDraft((d) => ({
+      ...d,
+      display: { type: t },
+      // histogram has its own shape and a number tile shows a single value —
+      // neither can express a breakdown, so clear it automatically
+      ...(t === "histogram" || t === "number" ? { breakdown: null } : {}),
+    }));
+  }
+
+  // ── name (auto until edited) ──────────────────────────────────────────────
+  const effectiveTitle = titleLocked ? title : generateWidgetTitle(draft, viewFields);
+
+  // ── preview ───────────────────────────────────────────────────────────────
+  const debouncedDraft = useDebounced(draft, 400);
+  const preview = useWidgetPreview(projectId, debouncedDraft, range);
+  const debouncedSpec = useMemo(() => parseSpec(debouncedDraft), [debouncedDraft]);
+
+  // ── save ──────────────────────────────────────────────────────────────────
+  const specComplete = isSpecComplete(draft);
+  // The schema tells us which measures the query engine can histogram
+  // (count's expr is the count(*) sentinel, which it permanently rejects) —
+  // without this gate the widget saves and then renders "Query failed"
+  // forever on the dashboard.
+  const measureField = draft.metric?.measure ? viewFields[draft.metric.measure] : undefined;
+  const histogramBlocked =
+    draft.display?.type === "histogram" && measureField?.histogrammable === false;
+  const saving = createWidget.isPending || updateWidget.isPending;
+  const canSave = specComplete && !histogramBlocked && effectiveTitle.trim().length > 0 && !saving;
+  const saveError = createWidget.error ?? updateWidget.error;
+
+  function handleSave() {
+    const spec = parseSpec(draft);
+    if (!spec) return;
+    const payload = { title: effectiveTitle.trim(), spec };
+    const onSuccess = () => router.push(dashboardUrl);
+    if (isEdit) {
+      if (!widget) return; // deleted from under us — the redirect guard takes over
+      updateWidget.mutate({ widgetId: widget.id, ...payload }, { onSuccess });
+    } else {
+      createWidget.mutate({ ...payload, type: "query" }, { onSuccess });
+    }
+  }
+
+  // Fall back to the default option so an unmatched id shows the same label
+  // as the window makeRange actually builds for it.
+  const activePreset =
+    RANGE_PRESETS.find((p) => p.id === rangeId) ??
+    RANGE_PRESETS.find((p) => p.id === DEFAULT_RANGE_ID)!;
+
+  return (
+    <div className="flex h-full flex-col text-[13px]">
+      {/* header */}
+      <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+        <Link
+          href={dashboardUrl}
+          className="inline-flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          {dashboard?.name ?? "Dashboard"}
+        </Link>
+        <h1 className="text-[13px] font-medium">{isEdit ? "Edit widget" : "New widget"}</h1>
+      </div>
+
+      {/* body: config card left, preview right */}
+      <div className="flex min-h-0 flex-1 gap-4 overflow-hidden p-4">
+        {/* left: configuration column, sectioned like the detector form */}
+        <div className="flex w-1/3 min-w-[340px] max-w-[420px] flex-col">
+          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
+            <SectionBox label="Data selection">
+              <div className="p-3">
+                <FieldLabel>View</FieldLabel>
+                <Select value={view ?? ""} onValueChange={handleViewChange}>
+                  <SelectTrigger className="h-7 text-[12px]">
+                    <SelectValue placeholder="Select view" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="traces" className="text-[12px]">
+                      Traces
+                    </SelectItem>
+                    <SelectItem value="spans" className="text-[12px]">
+                      Spans
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="p-3">
+                <FieldLabel>Filters</FieldLabel>
+                <div className="flex flex-col gap-1.5">
+                  {filters.map((f, i) => (
+                    <FilterRow
+                      key={i}
+                      index={i}
+                      filter={f as { field: string; op: string; value: string | number }}
+                      filterableFields={filterableFields}
+                      fieldsMap={viewFields}
+                      onChange={handleFilterChange}
+                      onRemove={handleFilterRemove}
+                      projectId={projectId}
+                      view={view}
+                      range={range}
+                    />
+                  ))}
+                  <button
+                    type="button"
+                    disabled={!view}
+                    onClick={handleAddFilter}
+                    className="mt-0.5 self-start text-[11.5px] text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    ＋ Add filter
+                  </button>
+                </div>
+              </div>
+
+              <div className="p-3">
+                <FieldLabel>Metric</FieldLabel>
+                <div className="flex flex-col gap-1.5">
+                  <Select value={measure} onValueChange={handleMeasureChange} disabled={!view}>
+                    <SelectTrigger className="h-7 text-[12px]">
+                      <SelectValue placeholder="Measure" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {measurableFields.map(([key, meta]) => {
+                        const Icon = fieldIcon(key);
+                        return (
+                          <SelectItem
+                            key={key}
+                            value={key}
+                            className="text-[12px]"
+                            icon={<Icon className="h-3.5 w-3.5 text-muted-foreground" />}
+                          >
+                            {meta.label}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                  <Select value={agg} onValueChange={handleAggChange} disabled={!measure}>
+                    <SelectTrigger className="h-7 text-[12px]">
+                      <SelectValue placeholder="Aggregation" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {allowedAggs.map((a) => (
+                        <SelectItem key={a} value={a} className="text-[12px]">
+                          {a}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="p-3">
+                <FieldLabel>Breakdown</FieldLabel>
+                <Select
+                  value={draft.breakdown ?? NONE_SENTINEL}
+                  onValueChange={handleBreakdownChange}
+                  disabled={
+                    !view || draft.display?.type === "histogram" || draft.display?.type === "number"
+                  }
+                >
+                  <SelectTrigger className="h-7 text-[12px]">
+                    <SelectValue placeholder="None" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NONE_SENTINEL} className="text-[12px]">
+                      None
+                    </SelectItem>
+                    {groupableFields.map(([key, meta]) => {
+                      const Icon = fieldIcon(key);
+                      return (
+                        <SelectItem
+                          key={key}
+                          value={key}
+                          className="text-[12px]"
+                          icon={<Icon className="h-3.5 w-3.5 text-muted-foreground" />}
+                        >
+                          {meta.label}
+                        </SelectItem>
+                      );
+                    })}
+                    {view !== "spans" && (
+                      <SelectItem
+                        value="model_name"
+                        className="text-[12px]"
+                        icon={<ModelIcon className="h-3.5 w-3.5 text-muted-foreground" />}
+                      >
+                        Model
+                        <span className="ml-1 text-[10.5px] text-muted-foreground">· Spans</span>
+                      </SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+                {(draft.display?.type === "histogram" || draft.display?.type === "number") && (
+                  <p className="mt-1 text-[10.5px] text-muted-foreground">
+                    Not available for this display type
+                  </p>
+                )}
+                {draft.display?.type &&
+                  BREAKDOWN_REQUIRED_DISPLAYS.has(draft.display.type) &&
+                  !draft.breakdown && (
+                    <p className="mt-1 text-[10.5px] text-amber-600">
+                      A {draft.display.type} chart needs a breakdown dimension
+                    </p>
+                  )}
+              </div>
+            </SectionBox>
+
+            <SectionBox label="Visualization">
+              <div className="p-3">
+                <FieldLabel>Display</FieldLabel>
+                <div className="flex flex-wrap gap-1.5">
+                  {DISPLAY_TYPES.map((t) => (
+                    <Button
+                      key={t}
+                      type="button"
+                      size="sm"
+                      variant={draft.display?.type === t ? "default" : "outline"}
+                      onClick={() => handleDisplayChange(t)}
+                      // Entering the state is blocked when we already know the
+                      // engine will reject it; the hint below covers reaching
+                      // it the other way round (picking the measure last).
+                      disabled={t === "histogram" && measureField?.histogrammable === false}
+                      className="h-7 text-[12px]"
+                    >
+                      {t}
+                    </Button>
+                  ))}
+                </div>
+                {histogramBlocked && (
+                  <p className="mt-1 text-[10.5px] text-amber-600">
+                    {measureField?.label ?? draft.metric?.measure} can&apos;t be histogrammed — pick
+                    another measure or display
+                  </p>
+                )}
+              </div>
+
+              <div className="p-3">
+                <FieldLabel>Name</FieldLabel>
+                <Input
+                  className="h-7 text-[12px]"
+                  placeholder="Widget name"
+                  value={effectiveTitle}
+                  onChange={(e) => {
+                    setTitle(e.target.value);
+                    setTitleLocked(true);
+                  }}
+                />
+              </div>
+            </SectionBox>
+          </div>
+
+          {/* footer */}
+          <div className="flex flex-col gap-2 pt-3">
+            {saveError ? (
+              <p className="text-[11.5px] text-red-600">
+                Failed to save widget
+                {saveError instanceof Error ? `: ${saveError.message}` : ""}
+              </p>
+            ) : null}
+            <div className="flex justify-end gap-2">
+              <Link
+                href={dashboardUrl}
+                className={cn(
+                  buttonVariants({ variant: "outline", size: "sm" }),
+                  "h-7 text-[12px]",
+                )}
+              >
+                Cancel
+              </Link>
+              <Button
+                size="sm"
+                className="h-7 text-[12px]"
+                disabled={!canSave}
+                onClick={handleSave}
+              >
+                Save widget
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {/* right: preview card */}
+        <div className="flex min-w-0 flex-1 flex-col border border-border">
+          <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
+            <span
+              className="truncate text-[12px] font-medium text-muted-foreground"
+              title={effectiveTitle}
+            >
+              {effectiveTitle || "Preview"}
+            </span>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" className="h-7 text-[12px]">
+                  {activePreset.label}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {RANGE_PRESETS.map((preset) => (
+                  <DropdownMenuItem
+                    key={preset.id}
+                    className="text-[12px]"
+                    onClick={() => setRangeId(preset.id)}
+                  >
+                    {preset.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="min-h-0 flex-1 p-4">
+            {!specComplete ? (
+              <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
+                Complete the data selection and display to preview
+              </div>
+            ) : preview.isPending ? (
+              <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
+                Running…
+              </div>
+            ) : preview.error ? (
+              <div className="flex h-full items-start justify-center pt-8 text-[12px] text-red-600">
+                {preview.error instanceof Error ? preview.error.message : "Query failed"}
+              </div>
+            ) : preview.data && debouncedSpec ? (
+              <QueryWidgetRenderer
+                display={debouncedSpec.display.type}
+                result={preview.data}
+                unit={FIELD_UNIT[debouncedSpec.metric.measure]}
+                seriesLabel={debouncedSpec.metric.measure}
+              />
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/lib/date-filter-storage.ts
+++ b/frontend/ui/src/lib/date-filter-storage.ts
@@ -1,0 +1,30 @@
+import { readStored, writeStored } from "@/lib/hooks/use-local-storage";
+
+/**
+ * Per-project, per-browser persistence for the shared date-filter selection.
+ * Every windowed surface (trace list, dashboards, detectors, the widget
+ * builder's preview) reads and writes the same slot, so picking a range on
+ * one page carries to all of them. An explicit `?date_filter=` URL parameter
+ * still wins on the page it targets — shared links show the sender's view —
+ * but only a user action writes the preference.
+ */
+export interface StoredDateFilter {
+  id: string;
+  /** ISO timestamps, present only when id === "custom". */
+  start?: string;
+  end?: string;
+}
+
+export function dateFilterStorageKey(projectId: string): string {
+  return `traceroot:date-filter:v1:${projectId}`;
+}
+
+export function readStoredDateFilter(projectId: string): StoredDateFilter | null {
+  const stored = readStored<StoredDateFilter | null>(dateFilterStorageKey(projectId), null);
+  if (!stored || typeof stored.id !== "string") return null;
+  return stored;
+}
+
+export function writeStoredDateFilter(projectId: string, value: StoredDateFilter): void {
+  writeStored(dateFilterStorageKey(projectId), value);
+}

--- a/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
@@ -10,6 +10,8 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => currentParams,
   useRouter: () => ({ replace }),
   usePathname: () => "/traces",
+  // The date filter persists its selection per project via useParams.
+  useParams: () => ({ projectId: "p1" }),
 }));
 
 import { useListPageState } from "./use-list-page-state";

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import { DATE_FILTER_OPTIONS, findDateFilterOption } from "@/lib/date-filter";
 import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
 import { useUrlDateFilter } from "./use-url-date-filter";
@@ -131,5 +133,39 @@ describe("useUrlDateFilter persistence", () => {
       expect(result.current.dateFilter.id).toBe(DATE_FILTER_OPTIONS.find((o) => o.id === "1d")!.id),
     );
     expect(result.current.customStartDate).toBeNull();
+  });
+
+  it("settles data queries on the restored window, not the default", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
+    const fetchSpy = vi.fn(async (bounds: unknown) => ({ bounds }));
+
+    // Mirror how pages consume the hook: a react-query query keyed on the
+    // effective window. Restoration runs in a layout effect (pre-paint), so
+    // the restored window is what the page settles on; react-query may still
+    // start-and-supersede one default-window fetch during the same commit —
+    // accepted, invisible to the user.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () => {
+        const filter = useUrlDateFilter();
+        const query = useQuery({
+          queryKey: ["window", filter.timestamps.startAfter, filter.timestamps.endBefore],
+          queryFn: () => fetchSpy(filter.timestamps),
+        });
+        return { filter, query };
+      },
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+    expect(result.current.filter.dateFilter.id).toBe("7d");
+    const fetchedWindowMs =
+      new Date(result.current.filter.timestamps.endBefore ?? Date.now()).getTime() -
+      new Date(result.current.filter.timestamps.startAfter!).getTime();
+    expect(Math.round(fetchedWindowMs / 86_400_000)).toBe(7);
+    client.clear();
   });
 });

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DATE_FILTER_OPTIONS, findDateFilterOption } from "@/lib/date-filter";
+import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
+import { useUrlDateFilter } from "./use-url-date-filter";
+
+const replace = vi.fn();
+let search = "";
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(search),
+  useRouter: () => ({ replace }),
+  usePathname: () => "/projects/p1/traces",
+  useParams: () => ({ projectId: "p1" }),
+}));
+
+const KEY = dateFilterStorageKey("p1");
+
+beforeEach(() => {
+  search = "";
+  localStorage.clear();
+});
+afterEach(() => {
+  replace.mockReset();
+});
+
+describe("useUrlDateFilter persistence", () => {
+  it("adopts the stored per-project preset when the URL has no filter", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
+
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("7d"));
+  });
+
+  it("lets an explicit URL filter win over the stored preference", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
+    search = "date_filter=30m";
+
+    const { result, rerender } = renderHook(() => useUrlDateFilter());
+
+    expect(result.current.dateFilter.id).toBe("30m");
+    // Flush effects, then pin that adopting the link never wrote the store.
+    rerender();
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("30m"));
+    expect(readStoredDateFilter("p1")?.id).toBe("7d");
+  });
+
+  it("resets pagination when restoring changes the effective window", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
+    const onFilterChange = vi.fn();
+
+    const { result } = renderHook(() => useUrlDateFilter(onFilterChange));
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("7d"));
+    expect(onFilterChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire the change callback when the stored value matches the default", () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "1d" }));
+    const onFilterChange = vi.fn();
+
+    renderHook(() => useUrlDateFilter(onFilterChange));
+
+    expect(onFilterChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores a stored custom range with inverted bounds", async () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        id: "custom",
+        start: "2026-07-02T00:00:00.000Z",
+        end: "2026-07-01T00:00:00.000Z",
+      }),
+    );
+
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("1d"));
+    expect(result.current.customStartDate).toBeNull();
+  });
+
+  it("persists a picked preset so other pages can adopt it", () => {
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    act(() => result.current.setDateFilter(findDateFilterOption("30d")));
+
+    expect(readStoredDateFilter("p1")).toEqual({ id: "30d" });
+    expect(result.current.dateFilter.id).toBe("30d");
+  });
+
+  it("persists a custom range with its bounds", () => {
+    const { result } = renderHook(() => useUrlDateFilter());
+    const start = new Date("2026-07-01T00:00:00Z");
+    const end = new Date("2026-07-02T00:00:00Z");
+
+    act(() => result.current.setCustomRange(start, end));
+
+    expect(readStoredDateFilter("p1")).toEqual({
+      id: "custom",
+      start: start.toISOString(),
+      end: end.toISOString(),
+    });
+  });
+
+  it("restores a stored custom range, bounds included", async () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        id: "custom",
+        start: "2026-07-01T00:00:00.000Z",
+        end: "2026-07-02T00:00:00.000Z",
+      }),
+    );
+
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    await waitFor(() => expect(result.current.dateFilter.isCustom).toBe(true));
+    expect(result.current.customStartDate?.toISOString()).toBe("2026-07-01T00:00:00.000Z");
+    expect(result.current.customEndDate?.toISOString()).toBe("2026-07-02T00:00:00.000Z");
+  });
+
+  it("ignores a stored custom entry with unparseable bounds", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "custom", start: "garbage" }));
+
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    // Nothing to adopt: stays at the shared default instead of a broken custom.
+    await waitFor(() =>
+      expect(result.current.dateFilter.id).toBe(DATE_FILTER_OPTIONS.find((o) => o.id === "1d")!.id),
+    );
+    expect(result.current.customStartDate).toBeNull();
+  });
+});

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.ts
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.ts
@@ -4,7 +4,7 @@
  * when present; otherwise the stored selection applies, so a range picked on
  * any page (trace list, dashboards, detectors) carries to all of them.
  */
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useState, useCallback, useMemo, useEffect, useLayoutEffect, useRef } from "react";
 import { useSearchParams, useRouter, usePathname, useParams } from "next/navigation";
 import {
   DEFAULT_DATE_FILTER,
@@ -14,6 +14,10 @@ import {
   type DateFilterOption,
 } from "@/lib/date-filter";
 import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-storage";
+
+// useLayoutEffect on the client, useEffect during SSR: layout effects never
+// run on the server, and React warns when a server render encounters one.
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 interface UseUrlDateFilterReturn {
   dateFilter: DateFilterOption;
@@ -60,13 +64,17 @@ export function useUrlDateFilter(
   const onFilterChangeRef = useRef(onFilterChange);
   onFilterChangeRef.current = onFilterChange;
 
-  // Adopt the stored per-project selection once after mount, and only when the
+  // Adopt the stored per-project selection once at mount, and only when the
   // URL carries no explicit filter (a shared link's range must win on the page
-  // it targets). Running post-mount keeps server and first client render
-  // identical, so hydration never mismatches; a stored value differing from
-  // the default flashes once at the default — same tradeoff as useLocalStorage.
+  // it targets). The first render still shows the default — identical to the
+  // server HTML, so hydration never mismatches — but adopting in a LAYOUT
+  // effect re-renders before the browser paints, so the user never sees the
+  // default window. (react-query subscribes during the same commit, so a
+  // default-window fetch can still start and be superseded — invisible, but
+  // one extra backend query per hard load; eliminating it would mean gating
+  // every consumer query on a restoration flag.)
   const restoredRef = useRef(false);
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (restoredRef.current) return;
     restoredRef.current = true;
     if (!projectId || searchParams.get("date_filter")) return;
@@ -90,9 +98,9 @@ export function useUrlDateFilter(
     // The effective window changed under the page: consumers that paginate
     // must reset (a stale ?page_index can point past the restored window).
     onFilterChangeRef.current?.();
-    // dateFilter.id is read only on the once-guarded first run; re-running on
-    // its later changes is prevented by restoredRef.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // dateFilter.id is deliberately not a dependency: it's read only on the
+    // once-guarded first run, and restoredRef prevents any re-run. (The lint
+    // rule doesn't check custom-named hooks, so this documents what it can't.)
   }, [projectId, searchParams]);
 
   // Only explicit user actions persist: adopting a link's URL param must not

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.ts
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.ts
@@ -1,9 +1,11 @@
 /**
- * Hook for managing date filter state synchronized with URL parameters.
- * This allows date filter state to persist across page navigation.
+ * Hook for managing date filter state synchronized with URL parameters and a
+ * per-project localStorage preference. The URL keeps links shareable and wins
+ * when present; otherwise the stored selection applies, so a range picked on
+ * any page (trace list, dashboards, detectors) carries to all of them.
  */
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
-import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useSearchParams, useRouter, usePathname, useParams } from "next/navigation";
 import {
   DEFAULT_DATE_FILTER,
   DATE_FILTER_OPTIONS,
@@ -11,6 +13,7 @@ import {
   findDateFilterOption,
   type DateFilterOption,
 } from "@/lib/date-filter";
+import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-storage";
 
 interface UseUrlDateFilterReturn {
   dateFilter: DateFilterOption;
@@ -31,6 +34,8 @@ export function useUrlDateFilter(
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const routeParams = useParams();
+  const projectId = typeof routeParams?.projectId === "string" ? routeParams.projectId : null;
 
   // Read initial state from URL
   const urlDateFilterId = searchParams.get("date_filter");
@@ -54,6 +59,56 @@ export function useUrlDateFilter(
   // Use ref for callback to avoid dependency issues
   const onFilterChangeRef = useRef(onFilterChange);
   onFilterChangeRef.current = onFilterChange;
+
+  // Adopt the stored per-project selection once after mount, and only when the
+  // URL carries no explicit filter (a shared link's range must win on the page
+  // it targets). Running post-mount keeps server and first client render
+  // identical, so hydration never mismatches; a stored value differing from
+  // the default flashes once at the default — same tradeoff as useLocalStorage.
+  const restoredRef = useRef(false);
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+    if (!projectId || searchParams.get("date_filter")) return;
+    const stored = readStoredDateFilter(projectId);
+    if (!stored) return;
+    const option = findDateFilterOption(stored.id);
+    if (option.isCustom) {
+      const start = stored.start ? new Date(stored.start) : null;
+      const end = stored.end ? new Date(stored.end) : null;
+      // Parseable AND ordered: an inverted range would query start > end and
+      // silently return nothing everywhere.
+      if (!start || !end || isNaN(start.getTime()) || isNaN(end.getTime()) || end < start) return;
+      setCustomStartDateState(start);
+      setCustomEndDateState(end);
+    } else if (option.id === dateFilter.id) {
+      // Stored matches what's already showing — nothing to adopt.
+      return;
+    }
+    setDateFilterState(option);
+    setFilterVersion((v) => v + 1);
+    // The effective window changed under the page: consumers that paginate
+    // must reset (a stale ?page_index can point past the restored window).
+    onFilterChangeRef.current?.();
+    // dateFilter.id is read only on the once-guarded first run; re-running on
+    // its later changes is prevented by restoredRef.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId, searchParams]);
+
+  // Only explicit user actions persist: adopting a link's URL param must not
+  // overwrite the preference the user picked themselves.
+  const persistSelection = useCallback(
+    (id: string, start: Date | null, end: Date | null) => {
+      if (!projectId) return;
+      writeStoredDateFilter(
+        projectId,
+        id === "custom" && start && end
+          ? { id, start: start.toISOString(), end: end.toISOString() }
+          : { id },
+      );
+    },
+    [projectId],
+  );
 
   // Sync state from URL when it changes (e.g., navigating from another page)
   useEffect(() => {
@@ -114,11 +169,12 @@ export function useUrlDateFilter(
 
       if (!option.isCustom) {
         updateUrl(option.id, null, null);
+        persistSelection(option.id, null, null);
       }
 
       onFilterChangeRef.current?.();
     },
-    [updateUrl],
+    [updateUrl, persistSelection],
   );
 
   const setCustomRange = useCallback(
@@ -129,10 +185,11 @@ export function useUrlDateFilter(
       const customOption = DATE_FILTER_OPTIONS.find((o) => o.isCustom)!;
       setDateFilterState(customOption);
       updateUrl("custom", start, end);
+      persistSelection("custom", start, end);
 
       onFilterChangeRef.current?.();
     },
-    [updateUrl],
+    [updateUrl, persistSelection],
   );
 
   // Calculate timestamps

--- a/frontend/ui/src/lib/route-helpers.ts
+++ b/frontend/ui/src/lib/route-helpers.ts
@@ -1,18 +1,24 @@
 import type { NextResponse } from "next/server";
+import { Prisma } from "@prisma/client";
 import {
   errorResponse,
   requireAuth,
   requireProjectAccess,
   type AuthenticatedUser,
+  type Role,
 } from "@/lib/auth-helpers";
 
 /**
  * Require an authenticated user with access to the project named in the
  * route's params. Resolves the params promise so callers can destructure any
  * additional route segments off `params`.
+ *
+ * Pass `minRole` on every mutating handler — without it a VIEWER-role member
+ * passes the membership check and can write.
  */
 export async function requireProjectAuth<P extends { projectId: string }>(
   params: Promise<P>,
+  minRole?: Role,
 ): Promise<
   | { user: AuthenticatedUser; params: P; error?: never }
   | { user?: never; params?: never; error: NextResponse }
@@ -20,7 +26,7 @@ export async function requireProjectAuth<P extends { projectId: string }>(
   const authResult = await requireAuth();
   if (authResult.error) return { error: authResult.error };
   const resolved = await params;
-  const accessResult = await requireProjectAccess(authResult.user.id, resolved.projectId);
+  const accessResult = await requireProjectAccess(authResult.user.id, resolved.projectId, minRole);
   if (accessResult.error) return { error: accessResult.error };
   return { user: authResult.user, params: resolved };
 }
@@ -44,4 +50,13 @@ export async function parseJsonObject(
     return { error: errorResponse("Body must be a JSON object", 400) };
   }
   return { body: body as Record<string, unknown> };
+}
+
+/**
+ * True when a Prisma mutation failed because the row was already gone —
+ * a concurrent delete between a scoped findFirst and the write. Callers map
+ * this to a 404 instead of letting it bubble as a 500.
+ */
+export function isRecordGone(e: unknown): boolean {
+  return e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025";
 }


### PR DESCRIPTION
Eleventh PR in the stacked project-dashboards series (epic #1460), stacked on #1521. The hardening batch for the dashboard/widget CRUD routes, split out from the route-introduction PRs so it reviews as its own diff — this is the PR the "pre-hardening" notes in #1520/#1521 point at.

## What's here
- **Role gates** — all six mutating handlers now require the MEMBER role; a VIEWER-role workspace member could previously create, rewrite, and cascade-delete dashboards and widgets. Reads stay viewer-accessible. Reuses the existing `minRole` plumbing the api-key routes already use.
- **Layout validation** — the layout PATCH validates every entry as an `{i, x, y, w, h}` placement (string id, finite non-negative coordinates) and whitelists exactly those keys, so a single malformed entry can't be persisted into jsonb where it would crash the grid for every member, and properties like `static` can't be smuggled in.
- **Length caps** — widget titles cap at 100 chars and dashboard descriptions at 500, matching the existing 50-char name cap, so one member can't persist unbounded strings that every dashboard read ships to all members. (This is the fix for cubic's two findings on #1521.)
- **P2025 → 404** — a concurrent delete between the scoped `findFirst` and the write now maps to 404 instead of an unhandled 500, via a shared `isRecordGone` helper.
- ~130 lines of tests covering each hardening dimension; the dashboard rename-cap test keeps its exact 50-char boundary probe rather than reverting to the mistitled 101-char version.

closes #1458

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened dashboard and widget mutation routes and shipped dashboards with tabs, a shared per‑project date filter, and a guided widget builder with live preview. Blocks viewer writes, validates layouts and strings, and makes dashboards safe to edit and easier to use; addresses Linear #1458.

- **New Features**
  - Dashboard UI: tabs, shared date filter with presets persisted across pages (URL param still shareable), and a drag/resize grid that saves; index redirects to the default dashboard; seeded Overview is read‑only; create dialog with a 50‑char name cap.
  - Widget builder: create/edit at `/widgets/new` and `/widgets/{id}/edit` with step‑by‑step spec, live preview using real queries/renderers over the shared range, and auto titles until the user edits.

- **Bug Fixes**
  - API hardening: require `Role.MEMBER` for POST/PATCH/DELETE via `requireProjectAuth(minRole)`; validate layout entries `{i,x,y,w,h}`; cap widget `title` (100) and dashboard `description` (500); map Prisma P2025 to 404 via `isRecordGone`.
  - UI fixes: redirect only on true “Dashboard not found”; hide edit controls until detail resolves; duplicate preserves `displayConfig`; create dialog can’t close while pending; builder remounts when widget changes; preview pauses for histogram‑blocked drafts; date filter restores pre‑paint to avoid flashing the default window.

<sup>Written for commit 4d307ed49d0db8e68fa0a95dfd26e3d558067f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

