### PR TITLE
feat(ui): widget builder page with live preview

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import EditWidgetPage from "./page";
+
+const mounted = vi.fn();
+vi.mock("@/features/dashboards/components/WidgetBuilderPage", () => ({
+  WidgetBuilderPage: (props: { projectId: string; dashboardId: string; widgetId?: string }) => {
+    // Fires once per mount (not per update) — how the tests below tell a
+    // remounted builder from a prop-updated one.
+    useEffect(() => {
+      mounted(props.widgetId);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <div>{`builder-${props.projectId}-${props.dashboardId}-${props.widgetId}`}</div>;
+  },
+}));
+
+let widgetId = "w1";
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1", dashboardId: "d1", widgetId }),
+}));
+
+describe("EditWidgetPage", () => {
+  it("passes the route params through and remounts the builder per widget", () => {
+    const { rerender } = render(<EditWidgetPage />);
+    expect(screen.getByText("builder-p1-d1-w1")).toBeTruthy();
+
+    // A widgetId change without a segment remount (App Router keeps the
+    // subtree on same-route param changes) must reset the builder: it
+    // hydrates its draft once behind a flag, so a reused instance would show
+    // the previous widget's draft. The key makes it a fresh mount.
+    widgetId = "w2";
+    rerender(<EditWidgetPage />);
+    expect(screen.getByText("builder-p1-d1-w2")).toBeTruthy();
+    expect(mounted).toHaveBeenCalledTimes(2);
+    expect(mounted).toHaveBeenNthCalledWith(1, "w1");
+    expect(mounted).toHaveBeenNthCalledWith(2, "w2");
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { WidgetBuilderPage } from "@/features/dashboards/components/WidgetBuilderPage";
+
+export default function EditWidgetPage() {
+  const params = useParams();
+  return (
+    <WidgetBuilderPage
+      projectId={params.projectId as string}
+      dashboardId={params.dashboardId as string}
+      widgetId={params.widgetId as string}
+    />
+  );
+}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/[widgetId]/edit/page.tsx
@@ -6,7 +6,13 @@ import { WidgetBuilderPage } from "@/features/dashboards/components/WidgetBuilde
 export default function EditWidgetPage() {
   const params = useParams();
   return (
+    // Keyed by widget: the builder hydrates its draft once behind a flag (so
+    // the dashboard poll can't clobber in-progress edits), which means a
+    // widgetId change without a remount would keep the previous widget's
+    // draft. The key makes a different widget a fresh form; the same widget
+    // across polls keeps its instance.
     <WidgetBuilderPage
+      key={params.widgetId as string}
       projectId={params.projectId as string}
       dashboardId={params.dashboardId as string}
       widgetId={params.widgetId as string}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/widgets/new/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { WidgetBuilderPage } from "@/features/dashboards/components/WidgetBuilderPage";
+
+export default function NewWidgetPage() {
+  const params = useParams();
+  return (
+    <WidgetBuilderPage
+      projectId={params.projectId as string}
+      dashboardId={params.dashboardId as string}
+    />
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, Widget } from "../types";
 import { WidgetBuilderPage } from "./WidgetBuilderPage";
@@ -252,6 +252,15 @@ describe("WidgetBuilderPage", () => {
 
     expect(screen.getByText(/can't be histogrammed/)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+
+    // The preview is starved rather than firing a query the compiler is
+    // guaranteed to reject: the pane shows guidance immediately, and once
+    // the debounce settles the hook receives a null draft (the gate judges
+    // the same debounced value the hook consumes).
+    expect(
+      screen.getByText("Preview unavailable for this measure/display combination"),
+    ).toBeTruthy();
+    await waitFor(() => expect(vi.mocked(useWidgetPreview).mock.lastCall?.[1]).toBeNull());
   });
 
   it("warns and blocks save when pie/bar is picked without a breakdown", async () => {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -1,0 +1,437 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardDetail, Widget } from "../types";
+import { WidgetBuilderPage } from "./WidgetBuilderPage";
+
+// Radix Select opens on pointerdown and relies on pointer-capture APIs jsdom
+// doesn't implement.
+window.HTMLElement.prototype.hasPointerCapture = vi.fn();
+window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
+
+const push = vi.fn();
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push, replace }) }));
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const createWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  { mutate: vi.fn(), isPending: false, error: null };
+const updateWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  { mutate: vi.fn(), isPending: false, error: null };
+vi.mock("../hooks/use-dashboards", () => ({
+  useDashboard: vi.fn(),
+  useDashboardMutations: () => ({ createWidget, updateWidget }),
+}));
+vi.mock("../hooks/use-widget-data", () => ({
+  useWidgetSchema: () => ({ data: SCHEMA }),
+  useWidgetPreview: vi.fn(),
+  useWidgetFieldValues: () => ({ values: [], isLoading: false }),
+}));
+import { useDashboard } from "../hooks/use-dashboards";
+import { useWidgetPreview } from "../hooks/use-widget-data";
+
+const SCHEMA = {
+  spans: {
+    fields: {
+      model_name: {
+        type: "string",
+        label: "Model",
+        filterOps: ["=", "!=", "contains"],
+        groupable: true,
+        aggs: [],
+      },
+      cost: {
+        type: "number",
+        label: "Cost",
+        filterOps: [">", ">="],
+        groupable: false,
+        aggs: ["sum", "avg"],
+      },
+      count: {
+        type: "number",
+        label: "Count",
+        filterOps: [],
+        groupable: false,
+        aggs: ["count"],
+        histogrammable: false,
+      },
+    },
+  },
+  traces: {
+    fields: {
+      cost: {
+        type: "number",
+        label: "Cost",
+        filterOps: [">", ">="],
+        groupable: false,
+        aggs: ["sum", "avg"],
+      },
+      error_count: {
+        type: "number",
+        label: "Errors",
+        filterOps: [">"],
+        groupable: false,
+        aggs: ["sum"],
+      },
+    },
+  },
+};
+
+const WIDGET: Widget = {
+  id: "w1",
+  dashboardId: "d1",
+  title: "My cost widget",
+  type: "query",
+  spec: {
+    view: "spans",
+    filters: [],
+    metric: { measure: "cost", agg: "sum" },
+    breakdown: null,
+    display: { type: "number" },
+  },
+  displayConfig: {},
+};
+
+// Non-default: the builder is only reachable for editable dashboards — the
+// default one redirects away, which its dedicated test covers.
+const DASHBOARD = {
+  id: "d1",
+  name: "Custom",
+  description: null,
+  isDefault: false,
+  updateTime: "",
+  layout: [],
+  widgets: [WIDGET],
+} as DashboardDetail;
+
+function mockDashboard(data: DashboardDetail | undefined, error: unknown = null) {
+  vi.mocked(useDashboard).mockReturnValue({ data, error } as ReturnType<typeof useDashboard>);
+}
+
+function mockPreview(state: { isPending?: boolean; error?: unknown; data?: unknown }) {
+  vi.mocked(useWidgetPreview).mockReturnValue({
+    isPending: false,
+    error: null,
+    data: undefined,
+    ...state,
+  } as ReturnType<typeof useWidgetPreview>);
+}
+
+describe("WidgetBuilderPage", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    push.mockReset();
+    replace.mockReset();
+    createWidget.mutate.mockReset();
+    createWidget.isPending = false;
+    createWidget.error = null;
+    updateWidget.mutate.mockReset();
+    updateWidget.isPending = false;
+    updateWidget.error = null;
+    mockDashboard(DASHBOARD);
+    mockPreview({});
+  });
+
+  it("renders the two config sections with save disabled on a fresh draft", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(screen.getByText("Data selection")).toBeTruthy();
+    expect(screen.getByText("Visualization")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+  });
+
+  it("links back to the dashboard by name", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    const back = screen.getByRole("link", { name: /Custom/ });
+    expect(back.getAttribute("href")).toBe("/projects/p1/dashboard/d1");
+  });
+
+  it("hydrates the form from the widget in edit mode and saves via update", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    const name = screen.getByPlaceholderText("Widget name") as HTMLInputElement;
+    expect(name.value).toBe("My cost widget");
+
+    const save = screen.getByRole("button", { name: "Save widget" });
+    expect(save).toHaveProperty("disabled", false);
+    fireEvent.click(save);
+
+    expect(updateWidget.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = updateWidget.mutate.mock.calls[0];
+    expect(payload).toMatchObject({ widgetId: "w1", title: "My cost widget" });
+    options.onSuccess();
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  it("keeps a manually edited name (lock) in edit mode", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    const name = screen.getByPlaceholderText("Widget name") as HTMLInputElement;
+    fireEvent.change(name, { target: { value: "Renamed" } });
+    expect(name.value).toBe("Renamed");
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    expect(updateWidget.mutate.mock.calls[0][0]).toMatchObject({ title: "Renamed" });
+  });
+
+  it("redirects to the dashboard when the widget is missing or not a query widget", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="nope" />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  it("redirects to the dashboard index when the dashboard failed to load", () => {
+    mockDashboard(undefined, new Error("404"));
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+  });
+
+  it("redirects back to the read-only default dashboard instead of opening the builder", () => {
+    mockDashboard({ ...DASHBOARD, isDefault: true });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  function openSelect(currentText: string) {
+    const trigger = screen.getByText(currentText).closest("button") as HTMLElement;
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: "mouse" });
+    return trigger;
+  }
+
+  it("offers Model from the traces view and switches to spans keeping a compatible measure", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Traces" }));
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Cost" }));
+
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: /Model/ }));
+
+    // The view flipped to Spans and the measure survived (cost exists there).
+    expect(screen.getByText("Spans")).toBeTruthy();
+    expect(screen.getByText("Cost")).toBeTruthy();
+    expect(screen.getByText("Model")).toBeTruthy();
+  });
+
+  it("clears a traces-only measure when Model switches the view to spans", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Traces" }));
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Errors" }));
+
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: /Model/ }));
+
+    expect(screen.getByText("Spans")).toBeTruthy();
+    // error_count doesn't exist on spans — the measure select resets.
+    expect(screen.queryByText("Errors")).toBeNull();
+    expect(screen.getByText("Measure")).toBeTruthy();
+  });
+
+  it("blocks the histogram display for a non-histogrammable measure", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Spans" }));
+
+    // Measure picked first: the histogram button itself is disabled.
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Count" }));
+    expect(screen.getByRole("button", { name: "histogram" })).toHaveProperty("disabled", true);
+
+    // Reached the other way (display first, then the measure): warn + block save.
+    openSelect("Count");
+    fireEvent.click(await screen.findByRole("option", { name: "Cost" }));
+    fireEvent.click(screen.getByRole("button", { name: "histogram" }));
+    openSelect("Cost");
+    fireEvent.click(await screen.findByRole("option", { name: "Count" }));
+
+    expect(screen.getByText(/can't be histogrammed/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+  });
+
+  it("warns and blocks save when pie/bar is picked without a breakdown", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Spans" }));
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Cost" }));
+    fireEvent.click(screen.getByRole("button", { name: "pie" }));
+
+    expect(screen.getByText("A pie chart needs a breakdown dimension")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+
+    // Picking a breakdown clears the warning and unblocks save.
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: "Model" }));
+    expect(screen.queryByText("A pie chart needs a breakdown dimension")).toBeNull();
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", false);
+  });
+
+  it("drives the form through view, measure, agg and display in create mode, then saves via create", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+
+    openSelect("Select view");
+    fireEvent.click(await screen.findByRole("option", { name: "Spans" }));
+
+    openSelect("Measure");
+    fireEvent.click(await screen.findByRole("option", { name: "Cost" }));
+
+    // Measure auto-picks the field's first aggregation (sum); pick a different
+    // one explicitly to exercise the Agg select.
+    openSelect("sum");
+    fireEvent.click(await screen.findByRole("option", { name: "avg" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "number" }));
+
+    const save = screen.getByRole("button", { name: "Save widget" });
+    expect(save).toHaveProperty("disabled", false);
+    fireEvent.click(save);
+
+    expect(createWidget.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = createWidget.mutate.mock.calls[0];
+    expect(payload).toEqual({
+      title: "Avg Cost",
+      type: "query",
+      spec: {
+        view: "spans",
+        filters: [],
+        metric: { measure: "cost", agg: "avg" },
+        breakdown: null,
+        display: { type: "number" },
+      },
+    });
+
+    options.onSuccess();
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  it("switches the selected display type and gates breakdown for number and histogram", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    const numberBtn = screen.getByRole("button", { name: "number" });
+    const histogramBtn = screen.getByRole("button", { name: "histogram" });
+    const barBtn = screen.getByRole("button", { name: "bar" });
+    // the fixture widget is a number tile, so the gate notice shows immediately
+    expect(numberBtn.className).toContain("bg-primary");
+    expect(screen.getByText("Not available for this display type")).toBeTruthy();
+
+    fireEvent.click(barBtn);
+    expect(barBtn.className).toContain("bg-primary");
+    expect(screen.queryByText("Not available for this display type")).toBeNull();
+
+    fireEvent.click(histogramBtn);
+    expect(histogramBtn.className).toContain("bg-primary");
+    expect(numberBtn.className).not.toContain("bg-primary");
+    expect(screen.getByText("Not available for this display type")).toBeTruthy();
+  });
+
+  it("clears an existing breakdown when number is selected", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    fireEvent.click(screen.getByRole("button", { name: "bar" }));
+    openSelect("None");
+    fireEvent.click(screen.getByRole("option", { name: "Model" }));
+    fireEvent.click(screen.getByRole("button", { name: "number" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    const [payload] = updateWidget.mutate.mock.calls.at(-1)!;
+    expect(payload.spec.breakdown).toBeNull();
+  });
+
+  it("adds a filter row with '+ Add filter' and removes it via the row's remove button", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.queryByText("Field")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "＋ Add filter" }));
+    expect(screen.getByText("Field")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove filter" }));
+    expect(screen.queryByText("Field")).toBeNull();
+  });
+
+  it("changes the breakdown field and can reset it back to none", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+
+    // line allows a breakdown but doesn't require one, so both saves are valid.
+    fireEvent.click(screen.getByRole("button", { name: "line" }));
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: "Model" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    expect(updateWidget.mutate).toHaveBeenCalledTimes(1);
+    expect(updateWidget.mutate.mock.calls[0][0]).toMatchObject({
+      spec: expect.objectContaining({ breakdown: "model_name" }),
+    });
+
+    openSelect("Model");
+    fireEvent.click(await screen.findByRole("option", { name: "None" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    expect(updateWidget.mutate).toHaveBeenCalledTimes(2);
+    expect(updateWidget.mutate.mock.calls[1][0]).toMatchObject({
+      spec: expect.objectContaining({ breakdown: null }),
+    });
+  });
+
+  it("does not fall through to create when editing and the widget disappears from the dashboard", () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="nope" />);
+    const save = screen.getByRole("button", { name: "Save widget" });
+    fireEvent.click(save);
+    expect(createWidget.mutate).not.toHaveBeenCalled();
+    expect(updateWidget.mutate).not.toHaveBeenCalled();
+  });
+
+  it("clears an existing breakdown when switching to histogram display before saving", async () => {
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+
+    fireEvent.click(screen.getByRole("button", { name: "bar" }));
+    openSelect("None");
+    fireEvent.click(await screen.findByRole("option", { name: "Model" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "histogram" }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Save widget" }));
+    expect(updateWidget.mutate).toHaveBeenCalledTimes(1);
+    expect(updateWidget.mutate.mock.calls[0][0]).toMatchObject({
+      spec: expect.objectContaining({ breakdown: null }),
+    });
+  });
+
+  it("shows an inline error when the save mutation fails", () => {
+    updateWidget.error = new Error("boom");
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.getByText("Failed to save widget: boom")).toBeTruthy();
+  });
+
+  it("shows a pending state while the preview query is in flight", () => {
+    mockPreview({ isPending: true });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.getByText("Running…")).toBeTruthy();
+  });
+
+  it("surfaces the preview query error message", () => {
+    mockPreview({ error: new Error("bad query") });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.getByText("bad query")).toBeTruthy();
+  });
+
+  it("renders the query result once preview data resolves", () => {
+    vi.useFakeTimers();
+    try {
+      mockPreview({ data: { columns: ["value"], rows: [[42]], meta: {} } });
+      render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+      // The preview draft is debounced 400ms before the renderer picks it up.
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+      // cost measure carries its $ unit through the preview renderer
+      expect(screen.getByText("$42")).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -54,6 +54,20 @@ type View = "spans" | "traces";
 
 const EMPTY_DRAFT: DraftSpec = { filters: [], breakdown: null };
 
+// A histogram-blocked draft (histogram display on a measure the registry says
+// can't be histogrammed) still parses complete — histogrammable is registry
+// data, not schema shape — so completeness checks alone won't catch it. Used
+// against both the live draft (warning/save UI) and the debounced draft (the
+// preview gate must judge the same value the query hook consumes, or leaving
+// the blocked state would fire the stale blocked spec once).
+function isHistogramBlocked(
+  draft: DraftSpec,
+  viewFields: Record<string, WidgetSchemaField>,
+): boolean {
+  const field = draft.metric?.measure ? viewFields[draft.metric.measure] : undefined;
+  return draft.display?.type === "histogram" && field?.histogrammable === false;
+}
+
 // Section boxes match the detector creation form: square-cornered border with
 // a muted header strip, sub-fields divided inside.
 function SectionBox({ label, children }: { label: string; children: React.ReactNode }) {
@@ -232,20 +246,28 @@ export function WidgetBuilderPage({
   // ── name (auto until edited) ──────────────────────────────────────────────
   const effectiveTitle = titleLocked ? title : generateWidgetTitle(draft, viewFields);
 
-  // ── preview ───────────────────────────────────────────────────────────────
-  const debouncedDraft = useDebounced(draft, 400);
-  const preview = useWidgetPreview(projectId, debouncedDraft, range);
-  const debouncedSpec = useMemo(() => parseSpec(debouncedDraft), [debouncedDraft]);
-
-  // ── save ──────────────────────────────────────────────────────────────────
-  const specComplete = isSpecComplete(draft);
   // The schema tells us which measures the query engine can histogram
   // (count's expr is the count(*) sentinel, which it permanently rejects) —
   // without this gate the widget saves and then renders "Query failed"
   // forever on the dashboard.
   const measureField = draft.metric?.measure ? viewFields[draft.metric.measure] : undefined;
-  const histogramBlocked =
-    draft.display?.type === "histogram" && measureField?.histogrammable === false;
+  const histogramBlocked = isHistogramBlocked(draft, viewFields);
+
+  // ── preview ───────────────────────────────────────────────────────────────
+  const debouncedDraft = useDebounced(draft, 400);
+  // The compiler is guaranteed to reject a histogram-blocked spec — starve
+  // the preview query instead of rendering its error under the inline
+  // warning that already explains the problem. Judged on the debounced
+  // draft the hook consumes, not the fresher `histogramBlocked`.
+  const preview = useWidgetPreview(
+    projectId,
+    isHistogramBlocked(debouncedDraft, viewFields) ? null : debouncedDraft,
+    range,
+  );
+  const debouncedSpec = useMemo(() => parseSpec(debouncedDraft), [debouncedDraft]);
+
+  // ── save ──────────────────────────────────────────────────────────────────
+  const specComplete = isSpecComplete(draft);
   const saving = createWidget.isPending || updateWidget.isPending;
   const canSave = specComplete && !histogramBlocked && effectiveTitle.trim().length > 0 && !saving;
   const saveError = createWidget.error ?? updateWidget.error;
@@ -531,9 +553,11 @@ export function WidgetBuilderPage({
             </DropdownMenu>
           </div>
           <div className="min-h-0 flex-1 p-4">
-            {!specComplete ? (
+            {!specComplete || histogramBlocked ? (
               <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
-                Complete the data selection and display to preview
+                {histogramBlocked
+                  ? "Preview unavailable for this measure/display combination"
+                  : "Complete the data selection and display to preview"}
               </div>
             ) : preview.isPending ? (
               <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -1,0 +1,559 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useDashboard, useDashboardMutations } from "../hooks/use-dashboards";
+import { useWidgetPreview, useWidgetSchema } from "../hooks/use-widget-data";
+import { DEFAULT_RANGE_ID, RANGE_PRESETS, makeRange } from "../range-presets";
+import {
+  BREAKDOWN_REQUIRED_DISPLAYS,
+  DISPLAY_TYPES,
+  FIELD_UNIT,
+  generateWidgetTitle,
+  isSpecComplete,
+  parseSpec,
+  type DraftSpec,
+  type WidgetSchemaField,
+} from "../types";
+import { fieldIcon } from "./field-icons";
+import { FilterRow } from "./FilterRow";
+import { QueryWidgetRenderer } from "./renderers";
+
+const ModelIcon = fieldIcon("model_name");
+
+function useDebounced<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(id);
+  }, [value, ms]);
+  return debounced;
+}
+
+const NONE_SENTINEL = "__none__";
+
+type View = "spans" | "traces";
+
+const EMPTY_DRAFT: DraftSpec = { filters: [], breakdown: null };
+
+// Section boxes match the detector creation form: square-cornered border with
+// a muted header strip, sub-fields divided inside.
+function SectionBox({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="border border-border">
+      <div className="border-b border-border bg-muted/50 px-3 py-1.5">
+        <span className="text-[12px] font-medium text-muted-foreground">{label}</span>
+      </div>
+      <div className="divide-y divide-border">{children}</div>
+    </div>
+  );
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return <p className="mb-1.5 text-[11px] font-medium text-muted-foreground">{children}</p>;
+}
+
+export function WidgetBuilderPage({
+  projectId,
+  dashboardId,
+  widgetId,
+}: {
+  projectId: string;
+  dashboardId: string;
+  widgetId?: string;
+}) {
+  const router = useRouter();
+  const isEdit = widgetId !== undefined;
+  const dashboardUrl = `/projects/${projectId}/dashboard/${dashboardId}`;
+
+  const { data: dashboard, error: dashboardError } = useDashboard(projectId, dashboardId);
+  const { createWidget, updateWidget } = useDashboardMutations(projectId, dashboardId);
+
+  const [draft, setDraft] = useState<DraftSpec>(EMPTY_DRAFT);
+  // Auto-name: `title` holds user text once locked; until then the generated
+  // title is displayed. Edit mode starts locked — existing titles are user-owned.
+  const [title, setTitle] = useState("");
+  const [titleLocked, setTitleLocked] = useState(isEdit);
+
+  // The page doesn't inherit the dashboard's picked range; the preview gets
+  // its own preset dropdown. Presets and default come from the shared
+  // date-filter module (via range-presets.ts) so the preview window always
+  // matches the trace list's and dashboard page's vocabulary and 24h default.
+  // Preview-only, not persisted.
+  const [rangeId, setRangeId] = useState<string>(DEFAULT_RANGE_ID);
+  const range = useMemo(() => makeRange(rangeId), [rangeId]);
+
+  // ── edit mode: hydrate once the widget arrives, guard bad targets ─────────
+  const widget = isEdit ? dashboard?.widgets.find((w) => w.id === widgetId) : undefined;
+  const [hydrated, setHydrated] = useState(false);
+  useEffect(() => {
+    if (!isEdit || hydrated || !widget) return;
+    setDraft(widget.spec as DraftSpec);
+    setTitle(widget.title);
+    setHydrated(true);
+  }, [isEdit, hydrated, widget]);
+
+  useEffect(() => {
+    if (dashboardError) router.replace(`/projects/${projectId}/dashboard`);
+  }, [dashboardError, projectId, router]);
+
+  useEffect(() => {
+    if (isEdit && dashboard && (!widget || widget.type !== "query")) {
+      router.replace(dashboardUrl);
+    }
+  }, [isEdit, dashboard, widget, dashboardUrl, router]);
+
+  // The default dashboard is read-only — widgets can be neither added nor
+  // edited, so bounce straight back. The API enforces the same rule.
+  useEffect(() => {
+    if (dashboard?.isDefault) router.replace(dashboardUrl);
+  }, [dashboard, dashboardUrl, router]);
+
+  // ── schema-driven field lists (same derivation as the old modal) ──────────
+  const { data: schema } = useWidgetSchema(projectId);
+  const view = draft.view as View | undefined;
+  const viewFields: Record<string, WidgetSchemaField> = view ? (schema?.[view]?.fields ?? {}) : {};
+  const pickFields = (pred: (f: WidgetSchemaField) => boolean) =>
+    Object.entries(viewFields).filter(([, f]) => pred(f)) as [string, WidgetSchemaField][];
+  const filterableFields = pickFields((f) => f.filterOps.length > 0);
+  const measurableFields = pickFields((f) => f.aggs.length > 0);
+  const groupableFields = pickFields((f) => f.groupable);
+
+  function handleViewChange(v: View) {
+    setDraft({ view: v, filters: [], breakdown: null });
+  }
+
+  // ── filters ────────────────────────────────────────────────────────────────
+  const filters = draft.filters ?? [];
+
+  // Filter rows use `op: string` while DraftSpec expects the strict op union.
+  // Rows are partial/in-progress; parseSpec/isSpecComplete validates the final
+  // shape — so we cast through unknown here to satisfy the type checker.
+  function handleFilterChange(
+    idx: number,
+    patch: Partial<{ field: string; op: string; value: string | number }>,
+  ) {
+    setDraft(
+      (d) =>
+        ({
+          ...d,
+          filters: (d.filters ?? []).map((f, i) => (i === idx ? { ...f, ...patch } : f)),
+        }) as unknown as DraftSpec,
+    );
+  }
+
+  function handleFilterRemove(idx: number) {
+    setDraft(
+      (d) =>
+        ({ ...d, filters: (d.filters ?? []).filter((_, i) => i !== idx) }) as unknown as DraftSpec,
+    );
+  }
+
+  function handleAddFilter() {
+    setDraft(
+      (d) =>
+        ({
+          ...d,
+          filters: [...(d.filters ?? []), { field: "", op: "", value: "" }],
+        }) as unknown as DraftSpec,
+    );
+  }
+
+  // ── metric / breakdown / display ──────────────────────────────────────────
+  const measure = draft.metric?.measure ?? "";
+  const agg = draft.metric?.agg ?? "";
+  const measureMeta = viewFields[measure];
+  const allowedAggs = measureMeta?.aggs ?? [];
+
+  function handleMeasureChange(m: string) {
+    const firstAgg = viewFields[m]?.aggs[0] ?? "";
+    setDraft((d) => ({ ...d, metric: { measure: m, agg: firstAgg } }) as unknown as DraftSpec);
+  }
+
+  function handleAggChange(a: string) {
+    setDraft(
+      (d) =>
+        ({ ...d, metric: { measure: d.metric?.measure ?? "", agg: a } }) as unknown as DraftSpec,
+    );
+  }
+
+  function handleBreakdownChange(v: string) {
+    const breakdown = v === NONE_SENTINEL ? null : v;
+    // Model is span-level data but the most-wanted breakdown, so it's offered
+    // from every view: picking it switches to Spans like a manual view change
+    // (filters reset), keeping the metric when the measure exists there too.
+    if (breakdown === "model_name" && view !== "spans") {
+      const spansFields = schema?.spans?.fields ?? {};
+      setDraft((d) => {
+        const spansField = d.metric?.measure ? spansFields[d.metric.measure] : undefined;
+        const metricSurvives =
+          spansField && d.metric?.agg ? spansField.aggs.includes(d.metric.agg) : false;
+        return {
+          view: "spans",
+          filters: [],
+          breakdown,
+          metric: metricSurvives ? d.metric : undefined,
+          display: d.display,
+        };
+      });
+      return;
+    }
+    setDraft((d) => ({ ...d, breakdown }));
+  }
+
+  function handleDisplayChange(t: (typeof DISPLAY_TYPES)[number]) {
+    setDraft((d) => ({
+      ...d,
+      display: { type: t },
+      // histogram has its own shape and a number tile shows a single value —
+      // neither can express a breakdown, so clear it automatically
+      ...(t === "histogram" || t === "number" ? { breakdown: null } : {}),
+    }));
+  }
+
+  // ── name (auto until edited) ──────────────────────────────────────────────
+  const effectiveTitle = titleLocked ? title : generateWidgetTitle(draft, viewFields);
+
+  // ── preview ───────────────────────────────────────────────────────────────
+  const debouncedDraft = useDebounced(draft, 400);
+  const preview = useWidgetPreview(projectId, debouncedDraft, range);
+  const debouncedSpec = useMemo(() => parseSpec(debouncedDraft), [debouncedDraft]);
+
+  // ── save ──────────────────────────────────────────────────────────────────
+  const specComplete = isSpecComplete(draft);
+  // The schema tells us which measures the query engine can histogram
+  // (count's expr is the count(*) sentinel, which it permanently rejects) —
+  // without this gate the widget saves and then renders "Query failed"
+  // forever on the dashboard.
+  const measureField = draft.metric?.measure ? viewFields[draft.metric.measure] : undefined;
+  const histogramBlocked =
+    draft.display?.type === "histogram" && measureField?.histogrammable === false;
+  const saving = createWidget.isPending || updateWidget.isPending;
+  const canSave = specComplete && !histogramBlocked && effectiveTitle.trim().length > 0 && !saving;
+  const saveError = createWidget.error ?? updateWidget.error;
+
+  function handleSave() {
+    const spec = parseSpec(draft);
+    if (!spec) return;
+    const payload = { title: effectiveTitle.trim(), spec };
+    const onSuccess = () => router.push(dashboardUrl);
+    if (isEdit) {
+      if (!widget) return; // deleted from under us — the redirect guard takes over
+      updateWidget.mutate({ widgetId: widget.id, ...payload }, { onSuccess });
+    } else {
+      createWidget.mutate({ ...payload, type: "query" }, { onSuccess });
+    }
+  }
+
+  // Fall back to the default option so an unmatched id shows the same label
+  // as the window makeRange actually builds for it.
+  const activePreset =
+    RANGE_PRESETS.find((p) => p.id === rangeId) ??
+    RANGE_PRESETS.find((p) => p.id === DEFAULT_RANGE_ID)!;
+
+  return (
+    <div className="flex h-full flex-col text-[13px]">
+      {/* header */}
+      <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+        <Link
+          href={dashboardUrl}
+          className="inline-flex items-center gap-1 text-[12px] text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          {dashboard?.name ?? "Dashboard"}
+        </Link>
+        <h1 className="text-[13px] font-medium">{isEdit ? "Edit widget" : "New widget"}</h1>
+      </div>
+
+      {/* body: config card left, preview right */}
+      <div className="flex min-h-0 flex-1 gap-4 overflow-hidden p-4">
+        {/* left: configuration column, sectioned like the detector form */}
+        <div className="flex w-1/3 min-w-[340px] max-w-[420px] flex-col">
+          <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
+            <SectionBox label="Data selection">
+              <div className="p-3">
+                <FieldLabel>View</FieldLabel>
+                <Select value={view ?? ""} onValueChange={handleViewChange}>
+                  <SelectTrigger className="h-7 text-[12px]">
+                    <SelectValue placeholder="Select view" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="traces" className="text-[12px]">
+                      Traces
+                    </SelectItem>
+                    <SelectItem value="spans" className="text-[12px]">
+                      Spans
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="p-3">
+                <FieldLabel>Filters</FieldLabel>
+                <div className="flex flex-col gap-1.5">
+                  {filters.map((f, i) => (
+                    <FilterRow
+                      key={i}
+                      index={i}
+                      filter={f as { field: string; op: string; value: string | number }}
+                      filterableFields={filterableFields}
+                      fieldsMap={viewFields}
+                      onChange={handleFilterChange}
+                      onRemove={handleFilterRemove}
+                      projectId={projectId}
+                      view={view}
+                      range={range}
+                    />
+                  ))}
+                  <button
+                    type="button"
+                    disabled={!view}
+                    onClick={handleAddFilter}
+                    className="mt-0.5 self-start text-[11.5px] text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    ＋ Add filter
+                  </button>
+                </div>
+              </div>
+
+              <div className="p-3">
+                <FieldLabel>Metric</FieldLabel>
+                <div className="flex flex-col gap-1.5">
+                  <Select value={measure} onValueChange={handleMeasureChange} disabled={!view}>
+                    <SelectTrigger className="h-7 text-[12px]">
+                      <SelectValue placeholder="Measure" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {measurableFields.map(([key, meta]) => {
+                        const Icon = fieldIcon(key);
+                        return (
+                          <SelectItem
+                            key={key}
+                            value={key}
+                            className="text-[12px]"
+                            icon={<Icon className="h-3.5 w-3.5 text-muted-foreground" />}
+                          >
+                            {meta.label}
+                          </SelectItem>
+                        );
+                      })}
+                    </SelectContent>
+                  </Select>
+                  <Select value={agg} onValueChange={handleAggChange} disabled={!measure}>
+                    <SelectTrigger className="h-7 text-[12px]">
+                      <SelectValue placeholder="Aggregation" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {allowedAggs.map((a) => (
+                        <SelectItem key={a} value={a} className="text-[12px]">
+                          {a}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="p-3">
+                <FieldLabel>Breakdown</FieldLabel>
+                <Select
+                  value={draft.breakdown ?? NONE_SENTINEL}
+                  onValueChange={handleBreakdownChange}
+                  disabled={
+                    !view || draft.display?.type === "histogram" || draft.display?.type === "number"
+                  }
+                >
+                  <SelectTrigger className="h-7 text-[12px]">
+                    <SelectValue placeholder="None" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NONE_SENTINEL} className="text-[12px]">
+                      None
+                    </SelectItem>
+                    {groupableFields.map(([key, meta]) => {
+                      const Icon = fieldIcon(key);
+                      return (
+                        <SelectItem
+                          key={key}
+                          value={key}
+                          className="text-[12px]"
+                          icon={<Icon className="h-3.5 w-3.5 text-muted-foreground" />}
+                        >
+                          {meta.label}
+                        </SelectItem>
+                      );
+                    })}
+                    {view !== "spans" && (
+                      <SelectItem
+                        value="model_name"
+                        className="text-[12px]"
+                        icon={<ModelIcon className="h-3.5 w-3.5 text-muted-foreground" />}
+                      >
+                        Model
+                        <span className="ml-1 text-[10.5px] text-muted-foreground">· Spans</span>
+                      </SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+                {(draft.display?.type === "histogram" || draft.display?.type === "number") && (
+                  <p className="mt-1 text-[10.5px] text-muted-foreground">
+                    Not available for this display type
+                  </p>
+                )}
+                {draft.display?.type &&
+                  BREAKDOWN_REQUIRED_DISPLAYS.has(draft.display.type) &&
+                  !draft.breakdown && (
+                    <p className="mt-1 text-[10.5px] text-amber-600">
+                      A {draft.display.type} chart needs a breakdown dimension
+                    </p>
+                  )}
+              </div>
+            </SectionBox>
+
+            <SectionBox label="Visualization">
+              <div className="p-3">
+                <FieldLabel>Display</FieldLabel>
+                <div className="flex flex-wrap gap-1.5">
+                  {DISPLAY_TYPES.map((t) => (
+                    <Button
+                      key={t}
+                      type="button"
+                      size="sm"
+                      variant={draft.display?.type === t ? "default" : "outline"}
+                      onClick={() => handleDisplayChange(t)}
+                      // Entering the state is blocked when we already know the
+                      // engine will reject it; the hint below covers reaching
+                      // it the other way round (picking the measure last).
+                      disabled={t === "histogram" && measureField?.histogrammable === false}
+                      className="h-7 text-[12px]"
+                    >
+                      {t}
+                    </Button>
+                  ))}
+                </div>
+                {histogramBlocked && (
+                  <p className="mt-1 text-[10.5px] text-amber-600">
+                    {measureField?.label ?? draft.metric?.measure} can&apos;t be histogrammed — pick
+                    another measure or display
+                  </p>
+                )}
+              </div>
+
+              <div className="p-3">
+                <FieldLabel>Name</FieldLabel>
+                <Input
+                  className="h-7 text-[12px]"
+                  placeholder="Widget name"
+                  value={effectiveTitle}
+                  onChange={(e) => {
+                    setTitle(e.target.value);
+                    setTitleLocked(true);
+                  }}
+                />
+              </div>
+            </SectionBox>
+          </div>
+
+          {/* footer */}
+          <div className="flex flex-col gap-2 pt-3">
+            {saveError ? (
+              <p className="text-[11.5px] text-red-600">
+                Failed to save widget
+                {saveError instanceof Error ? `: ${saveError.message}` : ""}
+              </p>
+            ) : null}
+            <div className="flex justify-end gap-2">
+              <Link
+                href={dashboardUrl}
+                className={cn(
+                  buttonVariants({ variant: "outline", size: "sm" }),
+                  "h-7 text-[12px]",
+                )}
+              >
+                Cancel
+              </Link>
+              <Button
+                size="sm"
+                className="h-7 text-[12px]"
+                disabled={!canSave}
+                onClick={handleSave}
+              >
+                Save widget
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        {/* right: preview card */}
+        <div className="flex min-w-0 flex-1 flex-col border border-border">
+          <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
+            <span
+              className="truncate text-[12px] font-medium text-muted-foreground"
+              title={effectiveTitle}
+            >
+              {effectiveTitle || "Preview"}
+            </span>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" size="sm" className="h-7 text-[12px]">
+                  {activePreset.label}
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {RANGE_PRESETS.map((preset) => (
+                  <DropdownMenuItem
+                    key={preset.id}
+                    className="text-[12px]"
+                    onClick={() => setRangeId(preset.id)}
+                  >
+                    {preset.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+          <div className="min-h-0 flex-1 p-4">
+            {!specComplete ? (
+              <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
+                Complete the data selection and display to preview
+              </div>
+            ) : preview.isPending ? (
+              <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
+                Running…
+              </div>
+            ) : preview.error ? (
+              <div className="flex h-full items-start justify-center pt-8 text-[12px] text-red-600">
+                {preview.error instanceof Error ? preview.error.message : "Query failed"}
+              </div>
+            ) : preview.data && debouncedSpec ? (
+              <QueryWidgetRenderer
+                display={debouncedSpec.display.type}
+                result={preview.data}
+                unit={FIELD_UNIT[debouncedSpec.metric.measure]}
+                seriesLabel={debouncedSpec.metric.measure}
+              />
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Twelfth PR in the stacked project-dashboards series (epic #1460), stacked on #1522. The full-page builder for creating and editing query widgets.

## What's here
- **WidgetBuilderPage** — step-by-step spec assembly driven by the registry schema: view (spans/traces), metric (measure + aggregation), optional breakdown, display type, and filter rows reusing the stored-value dropdowns from #1515. Combinations the schema and compiler reject (pie/bar without a breakdown, histogram on a non-histogrammable measure, number with a breakdown) disable save with an inline reason — the same rules enforced server-side, so the preview gates too.
- **Live preview** — once the draft parses complete it runs through the real query hook against the real endpoint and renders with the real widget renderers (#1514), over a preview window driven by the shared date-filter presets.
- **Auto-generated titles** — "p95 Latency by Model"-style names templated from the registry labels until the user edits the name; after that their text is never overwritten.
- **Thin route wrappers** — `/widgets/new` and `/widgets/{id}/edit` mount the same component for create and edit; edit mode hydrates the widget from the dashboard detail cache, guards deleted widgets, and redirects away from the read-only default.

closes #1454

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds a full-page Widget Builder with live preview for creating and editing query widgets, replacing JSON with a guided, schema-driven flow. Enforces valid combos, pauses invalid histogram previews, and remounts on widget changes to prevent stale drafts. Addresses Linear #1454.

- **New Features**
  - Step-by-step builder: view (spans/traces), measure + aggregation, optional breakdown, display type, and filters with stored-value dropdowns.
  - Live preview runs real queries and uses shared date range presets.
  - Auto-generated titles until the user edits the name.
  - Save guards: block pie/bar without breakdown, histogram on non-histogrammable measures, and number with breakdown; auto-clear breakdown for number/histogram.
  - Unified component for `/widgets/new` and `/widgets/{id}/edit`; edit hydrates from cache, redirects if widget is missing/non-query; default dashboards redirect (read-only).
  - Tests for form flow, redirects, save mutations, preview pending/error/data states, and edit-page remounting.

- **Bug Fixes**
  - Paused preview for histogram-blocked drafts; gating uses the debounced draft to avoid stale requests.
  - Remounted the builder when `widgetId` changes in edit mode to prevent reusing the previous widget’s draft.

<sup>Written for commit 99d41b19104483c5eb10ada3f46b576690d2c677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

