### PR TITLE
feat(ui): dashboard pages with tabs, range presets, and a persisted grid

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -306,12 +306,42 @@ describe("DashboardDetailPage", () => {
     expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
   });
 
-  it("redirects to the dashboard index and invalidates the list cache when the dashboard fails to load", () => {
-    mockDetail(undefined, new Error("404"));
+  it("redirects to the dashboard index and invalidates the list cache when the dashboard is gone", () => {
+    mockDetail(undefined, new Error("Dashboard not found"));
     const { invalidateSpy } = renderPage();
 
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "p1"] });
+  });
+
+  it("stays put and shows a failure notice on a transient load error", () => {
+    mockDetail(undefined, new Error("API error: 503"));
+    const { invalidateSpy } = renderPage();
+
+    expect(replace).not.toHaveBeenCalled();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    expect(screen.getByText(/Failed to load the dashboard/)).toBeTruthy();
+  });
+
+  it("keeps rendering the cached dashboard when a background poll fails", () => {
+    mockDetail(
+      { ...DASH_A, widgets: [WIDGET], layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }] },
+      new Error("API error: 503"),
+    );
+    renderPage();
+
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Failed to load the dashboard/)).toBeNull();
+    expect(lastGridProps?.widgets).toEqual([WIDGET]);
+  });
+
+  it("hides edit controls while the dashboard is still loading", () => {
+    mockDetail(undefined);
+    renderPage();
+
+    expect(screen.getByText("Loading…")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
   });
 
   it("passes widgets, layout and range to the grid and wires edit/duplicate/delete", () => {
@@ -333,6 +363,8 @@ describe("DashboardDetailPage", () => {
       title: "Cost (copy)",
       type: "query",
       spec: WIDGET.spec,
+      // A duplicate carries the display settings too, not just the query.
+      displayConfig: WIDGET.displayConfig,
     });
 
     fireEvent.click(screen.getByRole("button", { name: "delete-w1" }));

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -1,0 +1,344 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardDetail, DashboardSummary, Widget } from "@/features/dashboards/types";
+import DashboardDetailPage from "./page";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// jsdom doesn't implement ResizeObserver, which DashboardDetailPage uses to
+// track the grid body's width.
+(global as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+  ResizeObserverStub;
+
+const push = vi.fn();
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1", dashboardId: "d1" }),
+  useRouter: () => ({ push, replace }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/dashboard/d1",
+}));
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+const createDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, error: null };
+const updateLayout: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  {
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  };
+const createWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  {
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  };
+const removeWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
+  {
+    mutate: vi.fn(),
+    isPending: false,
+    error: null,
+  };
+const removeDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), isPending: false, isError: false, error: null };
+
+vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
+  useDashboards: vi.fn(),
+  useDashboard: vi.fn(),
+  useDashboardMutations: () => ({
+    createDashboard,
+    updateLayout,
+    createWidget,
+    removeWidget,
+    removeDashboard,
+  }),
+}));
+
+let lastGridProps: {
+  widgets: Widget[];
+  layout: unknown;
+  range: unknown;
+  readOnly?: boolean;
+  onEdit: (w: Widget) => void;
+  onDuplicate: (w: Widget) => void;
+  onDelete: (w: Widget) => void;
+} | null = null;
+
+vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
+  DashboardGrid: (props: {
+    widgets: Widget[];
+    layout: unknown;
+    range: unknown;
+    readOnly?: boolean;
+    onEdit: (w: Widget) => void;
+    onDuplicate: (w: Widget) => void;
+    onDelete: (w: Widget) => void;
+  }) => {
+    lastGridProps = props;
+    return (
+      <div data-testid="dashboard-grid">
+        {props.widgets.map((w) => (
+          <div key={w.id}>
+            <button onClick={() => props.onEdit(w)}>{`edit-${w.id}`}</button>
+            <button onClick={() => props.onDuplicate(w)}>{`duplicate-${w.id}`}</button>
+            <button onClick={() => props.onDelete(w)}>{`delete-${w.id}`}</button>
+          </div>
+        ))}
+      </div>
+    );
+  },
+}));
+
+import { useDashboard, useDashboards } from "@/features/dashboards/hooks/use-dashboards";
+
+// The rendered dashboard (d1) is deliberately non-default: the default one is
+// read-only, which the dedicated tests below cover.
+const DASH_A: DashboardSummary = {
+  id: "d1",
+  name: "Custom",
+  description: null,
+  isDefault: false,
+  updateTime: "",
+};
+const DASH_B: DashboardSummary = {
+  id: "d2",
+  name: "Overview",
+  description: null,
+  isDefault: true,
+  updateTime: "",
+};
+
+const WIDGET: Widget = {
+  id: "w1",
+  dashboardId: "d1",
+  title: "Cost",
+  type: "query",
+  spec: { view: "spans" },
+  displayConfig: {},
+};
+
+function mockLists(dashboards: DashboardSummary[] | undefined) {
+  vi.mocked(useDashboards).mockReturnValue({
+    data: dashboards,
+  } as ReturnType<typeof useDashboards>);
+}
+
+function mockDetail(data: DashboardDetail | undefined, error: unknown = null) {
+  vi.mocked(useDashboard).mockReturnValue({ data, error } as ReturnType<typeof useDashboard>);
+}
+
+function renderPage() {
+  const queryClient = new QueryClient();
+  const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+  render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardDetailPage />
+    </QueryClientProvider>,
+  );
+  return { invalidateSpy };
+}
+
+describe("DashboardDetailPage", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    push.mockReset();
+    replace.mockReset();
+    createDashboard.mutate.mockReset();
+    updateLayout.mutate.mockReset();
+    createWidget.mutate.mockReset();
+    removeWidget.mutate.mockReset();
+    removeDashboard.mutate.mockReset();
+    removeDashboard.isError = false;
+    removeDashboard.error = null;
+    lastGridProps = null;
+    mockLists([DASH_A, DASH_B]);
+    mockDetail({ ...DASH_A, layout: [], widgets: [] });
+  });
+
+  it("renders dashboard tabs with the default marked and the current one highlighted", () => {
+    renderPage();
+
+    const customTab = screen.getByRole("link", { name: "Custom" });
+    expect(customTab.textContent).not.toContain("⌂");
+    expect(customTab.getAttribute("aria-current")).toBe("page");
+
+    const overviewTab = screen.getByRole("link", { name: /Overview/ });
+    expect(overviewTab.textContent).toContain("⌂");
+    expect(overviewTab.getAttribute("aria-current")).toBeNull();
+
+    expect(screen.getByRole("button", { name: "＋ new" })).toBeTruthy();
+  });
+
+  it("opens the create-dashboard dialog and cancelling it does not create", () => {
+    renderPage();
+
+    expect(screen.queryByText("Create Dashboard")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "＋ new" }));
+    expect(screen.getByText("Create Dashboard")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(createDashboard.mutate).not.toHaveBeenCalled();
+  });
+
+  it("creates a dashboard from the dialog and navigates to it on success", () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "＋ new" }));
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "New dash" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(createDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = createDashboard.mutate.mock.calls[0];
+    expect(payload).toEqual({ name: "New dash" });
+
+    options.onSuccess({ dashboard: { id: "d9" } });
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d9");
+  });
+
+  it("shows the active range preset label", () => {
+    renderPage();
+    // Same default as the trace list (DEFAULT_DATE_FILTER = 24 hours).
+    expect(screen.getByRole("button", { name: "Last 24 hours" })).toBeTruthy();
+  });
+
+  it("pushes to the widgets/new route from the header create-widget button", () => {
+    renderPage();
+    // The empty-state CTA renders the same label, so target the header button
+    // (the first one in document order) specifically.
+    const [headerButton] = screen.getAllByRole("button", { name: "＋ Create widget" });
+    fireEvent.click(headerButton);
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1/widgets/new");
+  });
+
+  it("pushes to the widgets/new route from the empty-state CTA when there are no widgets", () => {
+    renderPage();
+    expect(screen.getByText("No widgets yet.")).toBeTruthy();
+
+    const buttons = screen.getAllByRole("button", { name: "＋ Create widget" });
+    expect(buttons.length).toBe(2);
+
+    fireEvent.click(buttons[1]);
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1/widgets/new");
+  });
+
+  it("marks the grid read-only and hides both create-widget buttons on the default dashboard", () => {
+    mockDetail({ ...DASH_B, layout: [], widgets: [WIDGET] });
+    renderPage();
+
+    expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
+    expect(lastGridProps?.readOnly).toBe(true);
+  });
+
+  it("keeps the grid editable on a non-default dashboard", () => {
+    mockDetail({ ...DASH_A, layout: [], widgets: [WIDGET] });
+    renderPage();
+
+    expect(screen.getAllByRole("button", { name: "＋ Create widget" }).length).toBe(1);
+    expect(lastGridProps?.readOnly).toBe(false);
+  });
+
+  it("deletes the dashboard through the confirm dialog and navigates to the index", () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
+    expect(screen.getByText("Delete Dashboard")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(removeDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [id, options] = removeDashboard.mutate.mock.calls[0];
+    expect(id).toBe("d1");
+
+    options.onSuccess();
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+  });
+
+  it("shows the delete error inside the dialog when the mutation fails", () => {
+    removeDashboard.isError = true;
+    removeDashboard.error = new Error("boom");
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
+    expect(screen.getByText("boom")).toBeTruthy();
+  });
+
+  it("cancelling the delete dialog does not delete", () => {
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(removeDashboard.mutate).not.toHaveBeenCalled();
+  });
+
+  it("hides the delete button on the read-only default dashboard", () => {
+    mockDetail({ ...DASH_B, layout: [], widgets: [] });
+    renderPage();
+    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
+  });
+
+  it("redirects to the dashboard index and invalidates the list cache when the dashboard fails to load", () => {
+    mockDetail(undefined, new Error("404"));
+    const { invalidateSpy } = renderPage();
+
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "p1"] });
+  });
+
+  it("passes widgets, layout and range to the grid and wires edit/duplicate/delete", () => {
+    mockDetail({
+      ...DASH_A,
+      layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }],
+      widgets: [WIDGET],
+    });
+    renderPage();
+
+    expect(screen.queryByText("No widgets yet.")).toBeNull();
+    expect(lastGridProps?.widgets).toEqual([WIDGET]);
+    expect(lastGridProps?.layout).toEqual([{ i: "w1", x: 0, y: 0, w: 4, h: 4 }]);
+    expect(lastGridProps?.range).toHaveProperty("start");
+    expect(lastGridProps?.range).toHaveProperty("end");
+
+    fireEvent.click(screen.getByRole("button", { name: "duplicate-w1" }));
+    expect(createWidget.mutate).toHaveBeenCalledWith({
+      title: "Cost (copy)",
+      type: "query",
+      spec: WIDGET.spec,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "delete-w1" }));
+    expect(removeWidget.mutate).toHaveBeenCalledWith("w1");
+
+    fireEvent.click(screen.getByRole("button", { name: "edit-w1" }));
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1/widgets/w1/edit");
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
+import { ProjectBreadcrumb } from "@/features/projects/components";
+import {
+  useDashboards,
+  useDashboard,
+  useDashboardMutations,
+} from "@/features/dashboards/hooks/use-dashboards";
+import { DashboardGrid } from "@/features/dashboards/components/DashboardGrid";
+import { CreateDashboardDialog } from "@/features/dashboards/components/CreateDashboardDialog";
+import type { TimeRange, Widget } from "@/features/dashboards/types";
+import { DateFilterSelect } from "@/components/date-filter-select";
+import { useUrlDateFilter } from "@/lib/hooks/use-url-date-filter";
+import { Button } from "@/components/ui/button";
+import { DeleteIconButton } from "@/components/ui/delete-button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
+
+export default function DashboardDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const projectId = params.projectId as string;
+  const dashboardId = params.dashboardId as string;
+
+  // ── remote data ──────────────────────────────────────────────────────────────
+  const { data: dashboards } = useDashboards(projectId);
+  const { data: dashboard, error: dashboardError } = useDashboard(projectId, dashboardId);
+
+  const { updateLayout, createWidget, removeWidget, removeDashboard } = useDashboardMutations(
+    projectId,
+    dashboardId,
+  );
+
+  // ── time range — the same URL-synced filter AND default the trace list uses ──
+  const { dateFilter, customStartDate, customEndDate, setDateFilter, setCustomRange, timestamps } =
+    useUrlDateFilter();
+  const range: TimeRange = useMemo(
+    () => ({
+      // Widgets need concrete bounds. startAfter is only absent for a custom
+      // filter arriving via URL without its dates — fall back to the shared
+      // 24h default; endBefore is absent for now-anchored presets, whose end
+      // is "now" frozen at selection.
+      start: timestamps.startAfter
+        ? new Date(timestamps.startAfter)
+        : new Date(Date.now() - 86_400_000),
+      end: timestamps.endBefore ? new Date(timestamps.endBefore) : new Date(),
+    }),
+    [timestamps.startAfter, timestamps.endBefore],
+  );
+
+  // ── grid width via ResizeObserver ────────────────────────────────────────────
+  const [width, setWidth] = useState(1200);
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = bodyRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setWidth(entry.contentRect.width);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // ── widget builder navigation ────────────────────────────────────────────────
+  const openCreate = () =>
+    router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/new`);
+
+  const openEdit = (w: Widget) =>
+    router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/${w.id}/edit`);
+
+  // ── deleted / missing dashboard redirect ─────────────────────────────────────
+  useEffect(() => {
+    if (dashboardError) {
+      // Invalidate the list so a stale cache can't bounce the user back here.
+      void queryClient.invalidateQueries({ queryKey: ["dashboards", projectId] });
+      router.replace(`/projects/${projectId}/dashboard`);
+    }
+  }, [dashboardError, projectId, queryClient, router]);
+
+  // useDashboard resolves to undefined while loading and throws on 404/error,
+  // so dashboardError above handles the redirect. No additional null check needed.
+
+  // ── new dashboard ────────────────────────────────────────────────────────────
+  const [createDashboardOpen, setCreateDashboardOpen] = useState(false);
+
+  // ── delete dashboard ─────────────────────────────────────────────────────────
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const handleDeleteDashboard = () => {
+    removeDashboard.mutate(dashboardId, {
+      onSuccess: () => {
+        setDeleteOpen(false);
+        // The index route resolves to the default dashboard.
+        router.replace(`/projects/${projectId}/dashboard`);
+      },
+    });
+  };
+
+  // ── layout change ────────────────────────────────────────────────────────────
+  const handleLayoutChange = useCallback(
+    (layout: Parameters<typeof updateLayout.mutate>[0]) => {
+      updateLayout.mutate(layout);
+    },
+    [updateLayout],
+  );
+
+  // ── duplicate widget ─────────────────────────────────────────────────────────
+  const handleDuplicate = useCallback(
+    (w: Widget) => {
+      createWidget.mutate({
+        title: `${w.title} (copy)`,
+        type: w.type,
+        spec: w.spec,
+      });
+    },
+    [createWidget],
+  );
+
+  // ── delete widget ────────────────────────────────────────────────────────────
+  const handleDelete = useCallback(
+    (w: Widget) => {
+      removeWidget.mutate(w.id);
+    },
+    [removeWidget],
+  );
+
+  // ── render ───────────────────────────────────────────────────────────────────
+  const widgets = dashboard?.widgets ?? [];
+  const layout = dashboard?.layout ?? [];
+  // The seeded default dashboard is read-only: custom dashboards start from
+  // "＋ new" instead. The API enforces the same rule.
+  const readOnly = dashboard?.isDefault ?? false;
+
+  return (
+    <div className="relative flex h-full text-[13px]">
+      <ProjectBreadcrumb projectId={projectId} />
+
+      <CreateDashboardDialog
+        projectId={projectId}
+        open={createDashboardOpen}
+        onOpenChange={setCreateDashboardOpen}
+      />
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Dashboard</DialogTitle>
+            <DialogDescription>
+              Permanently delete “{dashboard?.name}” and all of its widgets? This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {removeDashboard.isError && (
+            <p className="text-sm text-destructive">{removeDashboard.error.message}</p>
+          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteOpen(false)}
+              disabled={removeDashboard.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteDashboard}
+              disabled={removeDashboard.isPending}
+            >
+              {removeDashboard.isPending ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Page header */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-2">
+          {/* Left: title + dashboard tabs */}
+          <div className="flex items-center gap-3">
+            <h1 className="text-[13px] font-medium">Dashboard</h1>
+            <div className="flex items-center gap-0.5">
+              {dashboards?.map((d) => (
+                <Link
+                  key={d.id}
+                  href={`/projects/${projectId}/dashboard/${d.id}`}
+                  aria-current={d.id === dashboardId ? "page" : undefined}
+                  className={cn(
+                    "flex items-center gap-1 rounded px-2 py-0.5 text-[12px] transition-colors",
+                    d.id === dashboardId
+                      ? "border-b-2 border-foreground font-medium text-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                  )}
+                >
+                  {d.isDefault && <span className="text-[10px]">⌂</span>}
+                  <span className="max-w-[10rem] truncate" title={d.name}>
+                    {d.name}
+                  </span>
+                </Link>
+              ))}
+              <button
+                type="button"
+                onClick={() => setCreateDashboardOpen(true)}
+                className="rounded px-2 py-0.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                ＋ new
+              </button>
+            </div>
+          </div>
+
+          {/* Right: time range, create widget */}
+          <div className="flex items-center gap-2">
+            <DateFilterSelect
+              dateFilter={dateFilter}
+              customStartDate={customStartDate}
+              customEndDate={customEndDate}
+              onDateFilterChange={setDateFilter}
+              onCustomRangeChange={setCustomRange}
+            />
+
+            {!readOnly && (
+              <>
+                <Button size="sm" className="h-7 text-[12px]" onClick={openCreate}>
+                  ＋ Create widget
+                </Button>
+                <DeleteIconButton
+                  aria-label="Delete dashboard"
+                  onClick={() => setDeleteOpen(true)}
+                />
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Body */}
+        <div ref={bodyRef} className="flex-1 overflow-auto bg-background">
+          {!dashboard ? (
+            <div className="flex h-64 items-center justify-center text-[13px] text-muted-foreground">
+              Loading…
+            </div>
+          ) : widgets.length === 0 ? (
+            <div className="flex h-64 flex-col items-center justify-center gap-3">
+              <p className="text-[13px] text-muted-foreground">No widgets yet.</p>
+              {!readOnly && (
+                <Button size="sm" className="text-[12px]" onClick={openCreate}>
+                  ＋ Create widget
+                </Button>
+              )}
+            </div>
+          ) : (
+            <DashboardGrid
+              projectId={projectId}
+              widgets={widgets}
+              layout={layout}
+              range={range}
+              width={width}
+              readOnly={readOnly}
+              onLayoutChange={handleLayoutChange}
+              onEdit={openEdit}
+              onDuplicate={handleDuplicate}
+              onDelete={handleDelete}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -83,16 +83,26 @@ export default function DashboardDetailPage() {
     router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/${w.id}/edit`);
 
   // ── deleted / missing dashboard redirect ─────────────────────────────────────
+  // fetchNextApi doesn't carry the HTTP status, so gone-ness is detected from
+  // the API's error message. The exact match keeps "Project not found" (a
+  // deleted project) and auth failures from redirecting; only a genuinely
+  // missing dashboard leaves the page. Everything else keeps the user here —
+  // the detail query's 30s poll retries, with a failure notice while empty.
+  const dashboardGone =
+    dashboardError instanceof Error &&
+    (dashboardError.message === "Dashboard not found" ||
+      /API error: 404/i.test(dashboardError.message));
   useEffect(() => {
-    if (dashboardError) {
+    if (dashboardGone) {
       // Invalidate the list so a stale cache can't bounce the user back here.
       void queryClient.invalidateQueries({ queryKey: ["dashboards", projectId] });
       router.replace(`/projects/${projectId}/dashboard`);
     }
-  }, [dashboardError, projectId, queryClient, router]);
+  }, [dashboardGone, projectId, queryClient, router]);
 
-  // useDashboard resolves to undefined while loading and throws on 404/error,
-  // so dashboardError above handles the redirect. No additional null check needed.
+  // useDashboard resolves to undefined while loading and surfaces failures via
+  // its error field; the redirect above handles gone dashboards, so the render
+  // below only needs the loading and failure branches.
 
   // ── new dashboard ────────────────────────────────────────────────────────────
   const [createDashboardOpen, setCreateDashboardOpen] = useState(false);
@@ -124,6 +134,7 @@ export default function DashboardDetailPage() {
         title: `${w.title} (copy)`,
         type: w.type,
         spec: w.spec,
+        displayConfig: w.displayConfig,
       });
     },
     [createWidget],
@@ -141,8 +152,10 @@ export default function DashboardDetailPage() {
   const widgets = dashboard?.widgets ?? [];
   const layout = dashboard?.layout ?? [];
   // The seeded default dashboard is read-only: custom dashboards start from
-  // "＋ new" instead. The API enforces the same rule.
-  const readOnly = dashboard?.isDefault ?? false;
+  // "＋ new" instead. The API enforces the same rule. Treated as read-only
+  // while the detail is still loading so edit controls never flash on the
+  // Overview before the app knows which dashboard this is.
+  const readOnly = dashboard ? dashboard.isDefault : true;
 
   return (
     <div className="relative flex h-full text-[13px]">
@@ -245,7 +258,13 @@ export default function DashboardDetailPage() {
 
         {/* Body */}
         <div ref={bodyRef} className="flex-1 overflow-auto bg-background">
-          {!dashboard ? (
+          {dashboardError && !dashboardGone && !dashboard ? (
+            // Only when there's nothing to render: a failed background poll
+            // keeps the cached dashboard, and the stale grid beats a notice.
+            <div className="flex h-64 items-center justify-center text-[13px] text-red-600">
+              Failed to load the dashboard — retrying automatically
+            </div>
+          ) : !dashboard ? (
             <div className="flex h-64 items-center justify-center text-[13px] text-muted-foreground">
               Loading…
             </div>

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DashboardSummary } from "@/features/dashboards/types";
+import DashboardIndexPage from "./page";
+
+const replace = vi.fn();
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1" }),
+  useRouter: () => ({ replace }),
+}));
+
+const refetch = vi.fn();
+vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
+  useDashboards: vi.fn(),
+}));
+
+import { useDashboards } from "@/features/dashboards/hooks/use-dashboards";
+
+function mockDashboards(data: DashboardSummary[] | undefined, error: unknown = null) {
+  vi.mocked(useDashboards).mockReturnValue({
+    data,
+    error,
+    refetch,
+  } as unknown as ReturnType<typeof useDashboards>);
+}
+
+const DASH_A: DashboardSummary = {
+  id: "d1",
+  name: "Overview",
+  description: null,
+  isDefault: false,
+  updateTime: "",
+};
+const DASH_B: DashboardSummary = {
+  id: "d2",
+  name: "Costs",
+  description: null,
+  isDefault: true,
+  updateTime: "",
+};
+
+describe("DashboardIndexPage", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    replace.mockReset();
+    refetch.mockReset();
+  });
+
+  it("shows a loading state while the dashboard list is in flight", () => {
+    mockDashboards(undefined);
+    render(<DashboardIndexPage />);
+    expect(screen.getByText("Loading dashboards…")).toBeTruthy();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("redirects to the default dashboard once the list resolves", () => {
+    mockDashboards([DASH_A, DASH_B]);
+    render(<DashboardIndexPage />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d2");
+  });
+
+  it("redirects to the first dashboard when none is marked default", () => {
+    mockDashboards([
+      { ...DASH_A, isDefault: false },
+      { ...DASH_B, isDefault: false },
+    ]);
+    render(<DashboardIndexPage />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+  });
+
+  it("shows a retry button on error and refetches on click", () => {
+    mockDashboards(undefined, new Error("boom"));
+    render(<DashboardIndexPage />);
+    expect(screen.getByText("Failed to load dashboards — retry")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
@@ -1,32 +1,42 @@
 "use client";
 
-import { useParams } from "next/navigation";
-import { LayoutDashboard } from "lucide-react";
-import { ProjectBreadcrumb } from "@/features/projects/components";
+import { useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useDashboards } from "@/features/dashboards/hooks/use-dashboards";
 
-export default function DashboardPage() {
+export default function DashboardIndexPage() {
   const params = useParams();
+  const router = useRouter();
   const projectId = params.projectId as string;
+  const { data: dashboards, error, refetch } = useDashboards(projectId);
+
+  useEffect(() => {
+    // The list endpoint lazily seeds the default Overview, so there is always
+    // at least one dashboard once the query resolves.
+    if (dashboards && dashboards.length > 0) {
+      const target = dashboards.find((d) => d.isDefault) ?? dashboards[0];
+      router.replace(`/projects/${projectId}/dashboard/${target.id}`);
+    }
+  }, [dashboards, projectId, router]);
+
+  if (error) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-[13px]">
+        <span className="text-destructive">Failed to load dashboards — retry</span>
+        <button
+          type="button"
+          onClick={() => void refetch()}
+          className="rounded border border-border px-3 py-1 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
 
   return (
-    <div className="relative flex h-full text-[13px]">
-      <ProjectBreadcrumb projectId={projectId} />
-
-      <div className="flex flex-1 flex-col overflow-hidden">
-        {/* Page header */}
-        <div className="flex items-center justify-between border-b border-border px-4 py-2">
-          <h1 className="text-[13px] font-medium">Dashboard</h1>
-        </div>
-
-        {/* Coming soon placeholder */}
-        <div className="flex flex-1 flex-col items-center justify-center gap-3 bg-background">
-          <LayoutDashboard className="h-8 w-8 text-muted-foreground/40" />
-          <p className="text-[13px] text-muted-foreground">Coming soon</p>
-          <p className="text-[12px] text-muted-foreground">
-            The dashboard is under construction. Check back later.
-          </p>
-        </div>
-      </div>
+    <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+      Loading dashboards…
     </div>
   );
 }

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
@@ -103,6 +103,18 @@ describe("CreateDashboardDialog", () => {
     expect(createDashboard.mutate).not.toHaveBeenCalled();
   });
 
+  it("ignores Escape and other Radix close paths while a create is in flight", () => {
+    createDashboard.isPending = true;
+    const { onOpenChange } = renderDialog();
+
+    // Escape bypasses the disabled Cancel button; the dialog must stay open
+    // so the pending mutation can't be reset and resubmitted mid-request.
+    fireEvent.keyDown(screen.getByPlaceholderText("Dashboard name"), { key: "Escape" });
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(createDashboard.reset).not.toHaveBeenCalled();
+  });
+
   it("shows the mutation error message and a pending Create label", () => {
     createDashboard.isPending = true;
     createDashboard.isError = true;

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+const createDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false, error: null };
+
+vi.mock("../hooks/use-dashboards", () => ({
+  useDashboardMutations: () => ({ createDashboard }),
+}));
+
+import { CreateDashboardDialog } from "./CreateDashboardDialog";
+
+describe("CreateDashboardDialog", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    push.mockReset();
+    createDashboard.mutate.mockReset();
+    createDashboard.reset.mockReset();
+    createDashboard.isPending = false;
+    createDashboard.isError = false;
+    createDashboard.error = null;
+  });
+
+  function renderDialog() {
+    const onOpenChange = vi.fn();
+    render(<CreateDashboardDialog projectId="p1" open={true} onOpenChange={onOpenChange} />);
+    return { onOpenChange };
+  }
+
+  it("autofocuses the name input when opened", () => {
+    renderDialog();
+    expect(document.activeElement).toBe(screen.getByPlaceholderText("Dashboard name"));
+  });
+
+  it("caps the name input at 50 characters", () => {
+    renderDialog();
+    expect(screen.getByPlaceholderText("Dashboard name").getAttribute("maxLength")).toBe("50");
+  });
+
+  it("disables Create until a non-blank name is entered", () => {
+    renderDialog();
+    const create = screen.getByRole("button", { name: "Create" });
+    expect(create.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "   " },
+    });
+    expect(create.hasAttribute("disabled")).toBe(true);
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "Costs" },
+    });
+    expect(create.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("submits the trimmed name, then closes and navigates on success", () => {
+    const { onOpenChange } = renderDialog();
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "  New dash  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(createDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = createDashboard.mutate.mock.calls[0];
+    expect(payload).toEqual({ name: "New dash" });
+
+    options.onSuccess({ dashboard: { id: "d9" } });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d9");
+  });
+
+  it("clears the draft name and mutation state when closed via Cancel", () => {
+    const { onOpenChange } = renderDialog();
+
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "Draft" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(createDashboard.reset).toHaveBeenCalled();
+    expect((screen.getByPlaceholderText("Dashboard name") as HTMLInputElement).value).toBe("");
+  });
+
+  it("closes via Cancel without creating", () => {
+    const { onOpenChange } = renderDialog();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(createDashboard.mutate).not.toHaveBeenCalled();
+  });
+
+  it("shows the mutation error message and a pending Create label", () => {
+    createDashboard.isPending = true;
+    createDashboard.isError = true;
+    createDashboard.error = new Error("boom");
+    renderDialog();
+
+    expect(screen.getByText("boom")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Creating..." }).hasAttribute("disabled")).toBe(true);
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useDashboardMutations } from "../hooks/use-dashboards";
+import { DASHBOARD_NAME_MAX } from "../types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export function CreateDashboardDialog({
+  projectId,
+  open,
+  onOpenChange,
+}: {
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [name, setName] = useState("");
+  const router = useRouter();
+  const { createDashboard } = useDashboardMutations(projectId);
+
+  // Closing discards the draft: a cancelled name or stale error must not
+  // reappear the next time the dialog opens.
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setName("");
+      createDashboard.reset();
+    }
+    onOpenChange(next);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+    createDashboard.mutate(
+      { name: name.trim() },
+      {
+        onSuccess: (res) => {
+          handleOpenChange(false);
+          router.push(`/projects/${projectId}/dashboard/${res.dashboard.id}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create Dashboard</DialogTitle>
+            <DialogDescription>Create a new dashboard to organize your widgets.</DialogDescription>
+          </DialogHeader>
+          <div className="py-4">
+            <Input
+              autoFocus
+              maxLength={DASHBOARD_NAME_MAX}
+              placeholder="Dashboard name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={createDashboard.isPending}
+            />
+            {createDashboard.isError && (
+              <p className="mt-2 text-sm text-destructive">{createDashboard.error.message}</p>
+            )}
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={createDashboard.isPending}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!name.trim() || createDashboard.isPending}>
+              {createDashboard.isPending ? "Creating..." : "Create"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.tsx
@@ -31,6 +31,10 @@ export function CreateDashboardDialog({
   // Closing discards the draft: a cancelled name or stale error must not
   // reappear the next time the dialog opens.
   const handleOpenChange = (next: boolean) => {
+    // Radix close paths (Escape, overlay click, the X) bypass the disabled
+    // Cancel button — ignore them while a create is in flight, so the pending
+    // mutation can't be reset mid-request and resubmitted.
+    if (!next && createDashboard.isPending) return;
     if (!next) {
       setName("");
       createDashboard.reset();


### PR DESCRIPTION
Thirteenth and final PR in the stacked project-dashboards series (epic #1460), stacked on #1523. The user-facing dashboard surface, wiring together everything below it in the stack.

## What's here
- **`/projects/{id}/dashboard`** — redirects to the project's default dashboard, seeding the read-only Overview on first visit.
- **`/projects/{id}/dashboard/{dashboardId}`** — a tab per dashboard, a create button, and the shared date-filter control with the same URL-persisted selection the trace list uses, so links share the view. The widget grid renders over the selected window: drag/resize persists through the layout PATCH (debounced, deduped, flushed on unmount), widget new/edit/duplicate/delete flow through the widget routes and the builder, and the seeded Overview renders read-only (static grid, no edit controls). Dashboard deletion lives in the header behind a confirm step and navigates back to the default.
- **CreateDashboardDialog** — names a dashboard (50-char cap) and lands on the new empty dashboard ready for widgets.

closes #1452
closes #1456

Completes the scope of epic #1460.

## Video

https://github.com/user-attachments/assets/058662a7-abff-463f-b217-e6c150b3c8ae




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Built the user-facing dashboard pages with tabs, URL-synced date presets, and a persisted widget grid with create/edit/duplicate/delete. Closes #1452 and #1456; completes epic #1460.

- **New Features**
  - `/projects/{id}/dashboard` redirects to the project's default dashboard (seeds read‑only Overview on first visit) and shows a retry on load error.
  - `/projects/{id}/dashboard/{dashboardId}` adds tabs (default marked), a URL‑synced date filter, and a grid with persisted drag/resize; create/edit/duplicate/delete; delete via confirm; default dashboard hides edit/delete.
  - CreateDashboardDialog caps names at 50 chars and navigates to the new dashboard on success.

- **Bug Fixes**
  - Only “Dashboard not found”/404 redirects and invalidates the list; other errors stay put with a notice, and cached grids keep rendering during background poll failures.
  - Edit controls stay hidden while loading to prevent flashing.
  - Duplicating a widget now copies `displayConfig`.
  - Create dialog ignores Escape/overlay/X while creating to avoid resetting the pending request.

<sup>Written for commit 3b1aa6a22bdf75a4ec9c6188e33c864376219066. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



