### PR TITLE
fix(ui): handle stream_timeout and SSE errors in the live trace stream

### DIFF
--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   traceError: null as unknown,
   traceLoading: false,
   aiPanelOpen: false,
+  streamStatus: "ended" as string,
 }));
 
 // Layout context drives the fullscreen width math (sidebar width).
@@ -27,7 +28,12 @@ vi.mock("@tanstack/react-query", () => ({
   useQuery: () => ({ data: mocks.trace, isLoading: mocks.traceLoading, error: mocks.traceError }),
 }));
 vi.mock("@/lib/api", () => ({ getTrace: vi.fn() }));
-vi.mock("../hooks/use-trace-stream", () => ({ useTraceStream: vi.fn() }));
+vi.mock("../hooks/use-trace-stream", () => ({
+  useTraceStream: () => ({
+    isStreaming: mocks.streamStatus === "live",
+    streamStatus: mocks.streamStatus,
+  }),
+}));
 vi.mock("@/features/detectors/hooks/use-findings", () => ({
   useTraceFindings: () => ({ data: undefined }),
   useRca: () => ({ data: undefined }),
@@ -76,6 +82,7 @@ afterEach(() => {
   mocks.traceError = null;
   mocks.traceLoading = false;
   mocks.aiPanelOpen = false;
+  mocks.streamStatus = "ended";
 });
 
 describe("TraceViewerPanel layout", () => {
@@ -192,5 +199,26 @@ describe("TraceViewerPanel content states", () => {
     mocks.aiPanelOpen = true;
     renderPanel();
     expect(screen.getByTestId("ai-panel")).toBeTruthy();
+  });
+});
+
+describe("live stream status badge", () => {
+  it("shows the Live badge while the stream is live", () => {
+    mocks.streamStatus = "live";
+    renderPanel();
+    expect(screen.getByText("Live")).toBeTruthy();
+  });
+
+  it("shows a disconnected notice when reconnects are exhausted", () => {
+    mocks.streamStatus = "disconnected";
+    renderPanel();
+    expect(screen.getByText("Live view disconnected")).toBeTruthy();
+  });
+
+  it("shows no stream badge for a completed trace", () => {
+    mocks.streamStatus = "ended";
+    renderPanel();
+    expect(screen.queryByText("Live")).toBeNull();
+    expect(screen.queryByText("Live view disconnected")).toBeNull();
   });
 });

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -148,7 +148,7 @@ export function TraceViewerPanel({
     queryFn: () => getTrace(projectId, traceId, ""),
   });
 
-  useTraceStream(projectId, traceId, true);
+  const { streamStatus } = useTraceStream(projectId, traceId, true);
 
   // Reset when navigating to a different trace
   useEffect(() => {
@@ -243,6 +243,24 @@ export function TraceViewerPanel({
             <Workflow className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Trace</span>
             <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
+            {streamStatus === "live" && (
+              <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-600 dark:text-emerald-400">
+                <span className="relative flex h-1.5 w-1.5">
+                  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-500 opacity-75" />
+                  <span className="relative inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                </span>
+                Live
+              </span>
+            )}
+            {streamStatus === "disconnected" && (
+              <span
+                className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-medium text-amber-600 dark:text-amber-500"
+                title="Live updates stopped — reload to catch up"
+              >
+                <span className="inline-flex h-1.5 w-1.5 rounded-full bg-amber-500" />
+                Live view disconnected
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-1">
             {hasRca && (

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useTraceStream } from "./use-trace-stream";
+
+type Listener = (event: MessageEvent) => void;
+
+// Minimal EventSource double: same surface the hook touches, plus test
+// drivers (open/emit/error*) to walk the connection through its lifecycle.
+class MockEventSource {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 2;
+  static instances: MockEventSource[] = [];
+
+  readyState = MockEventSource.CONNECTING;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  private listeners = new Map<string, Listener[]>();
+
+  constructor(public url: string) {
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: Listener) {
+    const arr = this.listeners.get(type) ?? [];
+    arr.push(listener);
+    this.listeners.set(type, arr);
+  }
+
+  close() {
+    this.readyState = MockEventSource.CLOSED;
+  }
+
+  // --- test drivers ---
+  open() {
+    this.readyState = MockEventSource.OPEN;
+    this.onopen?.();
+  }
+
+  emit(type: string, data = "{}") {
+    for (const l of this.listeners.get(type) ?? []) l({ data } as MessageEvent);
+  }
+
+  /** Browser will auto-retry: readyState stays CONNECTING. */
+  errorTransient() {
+    this.readyState = MockEventSource.CONNECTING;
+    this.onerror?.();
+  }
+
+  /** Browser gave up: readyState CLOSED, no auto-retry. */
+  errorFatal() {
+    this.readyState = MockEventSource.CLOSED;
+    this.onerror?.();
+  }
+}
+
+let queryClient: QueryClient;
+let invalidateSpy: MockInstance<QueryClient["invalidateQueries"]>;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const latest = () => MockEventSource.instances[MockEventSource.instances.length - 1];
+
+const renderStream = () => renderHook(() => useTraceStream("p1", "t1", true), { wrapper });
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+  queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("useTraceStream lifecycle", () => {
+  it("reports connecting, then live once the connection opens", () => {
+    const { result } = renderStream();
+    expect(result.current.streamStatus).toBe("connecting");
+    expect(result.current.isStreaming).toBe(false);
+    act(() => latest().open());
+    expect(result.current.streamStatus).toBe("live");
+    expect(result.current.isStreaming).toBe(true);
+  });
+
+  it("merges incoming spans into the trace query cache", () => {
+    queryClient.setQueryData(["trace", "p1", "t1"], { spans: [] });
+    renderStream();
+    act(() => latest().open());
+    act(() => latest().emit("spans", JSON.stringify({ spans: [{ span_id: "a" }] })));
+    const cached = queryClient.getQueryData(["trace", "p1", "t1"]) as {
+      spans: { span_id: string }[];
+    };
+    expect(cached.spans.map((s) => s.span_id)).toEqual(["a"]);
+  });
+
+  it("trace_complete ends the stream, closes it, and refetches the final state", () => {
+    const { result } = renderStream();
+    act(() => latest().open());
+    act(() => latest().emit("trace_complete"));
+    expect(result.current.streamStatus).toBe("ended");
+    expect(result.current.isStreaming).toBe(false);
+    expect(latest().readyState).toBe(MockEventSource.CLOSED);
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(MockEventSource.instances).toHaveLength(1); // never resubscribes
+  });
+});
+
+describe("stream_timeout", () => {
+  it("refetches the gap and resubscribes with a fresh connection", () => {
+    const { result } = renderStream();
+    act(() => latest().open());
+    act(() => latest().emit("stream_timeout"));
+    expect(MockEventSource.instances[0].readyState).toBe(MockEventSource.CLOSED);
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.streamStatus).toBe("connecting");
+    act(() => vi.advanceTimersByTime(0));
+    expect(MockEventSource.instances).toHaveLength(2);
+    act(() => latest().open());
+    expect(result.current.streamStatus).toBe("live");
+  });
+
+  it("closes out via trace_complete on the fresh connection when the trace finished", () => {
+    const { result } = renderStream();
+    act(() => latest().open());
+    act(() => latest().emit("stream_timeout"));
+    act(() => vi.advanceTimersByTime(0));
+    // The server emits trace_complete immediately on subscribe for a finished trace.
+    act(() => latest().emit("trace_complete"));
+    expect(result.current.streamStatus).toBe("ended");
+    expect(invalidateSpy).toHaveBeenCalledTimes(2); // gap refetch + completion refetch
+    act(() => vi.advanceTimersByTime(60_000));
+    expect(MockEventSource.instances).toHaveLength(2);
+  });
+});
+
+describe("connection errors", () => {
+  it("transient errors trigger exactly one gap refetch when the connection reopens", () => {
+    const { result } = renderStream();
+    act(() => latest().open());
+    act(() => {
+      latest().errorTransient();
+      latest().errorTransient();
+    });
+    expect(result.current.streamStatus).toBe("connecting");
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    act(() => latest().open());
+    expect(result.current.streamStatus).toBe("live");
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    expect(MockEventSource.instances).toHaveLength(1); // browser retried, we did not
+  });
+
+  it("fatal errors resubscribe with exponential backoff and eventually give up", () => {
+    const { result } = renderStream();
+    act(() => latest().open());
+
+    act(() => latest().errorFatal());
+    expect(result.current.streamStatus).toBe("connecting");
+    act(() => vi.advanceTimersByTime(999));
+    expect(MockEventSource.instances).toHaveLength(1);
+    act(() => vi.advanceTimersByTime(1));
+    expect(MockEventSource.instances).toHaveLength(2); // retried after 1s
+
+    act(() => latest().errorFatal());
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(MockEventSource.instances).toHaveLength(3); // 2s
+
+    act(() => latest().errorFatal());
+    act(() => vi.advanceTimersByTime(4_000));
+    act(() => latest().errorFatal());
+    act(() => vi.advanceTimersByTime(8_000));
+    act(() => latest().errorFatal());
+    act(() => vi.advanceTimersByTime(16_000));
+    expect(MockEventSource.instances).toHaveLength(6); // 4s, 8s, 16s
+
+    act(() => latest().errorFatal());
+    expect(result.current.streamStatus).toBe("disconnected");
+    expect(result.current.isStreaming).toBe(false);
+    act(() => vi.advanceTimersByTime(300_000));
+    expect(MockEventSource.instances).toHaveLength(6); // retry budget exhausted
+  });
+
+  it("refetches are deduplicated while one is in flight", () => {
+    invalidateSpy.mockReturnValue(new Promise(() => {})); // refetch never settles
+    renderStream();
+    act(() => latest().open());
+    act(() => latest().errorTransient());
+    act(() => latest().open()); // gap refetch — stays in flight
+    act(() => latest().emit("stream_timeout")); // would refetch again
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("unmount", () => {
+  it("closes the stream and cancels any pending retry", () => {
+    const { unmount } = renderStream();
+    act(() => latest().open());
+    act(() => latest().errorFatal());
+    unmount();
+    expect(MockEventSource.instances[0].readyState).toBe(MockEventSource.CLOSED);
+    act(() => vi.advanceTimersByTime(300_000));
+    expect(MockEventSource.instances).toHaveLength(1); // retry timer cancelled
+  });
+});

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
@@ -199,6 +199,18 @@ describe("connection errors", () => {
     act(() => latest().emit("stream_timeout")); // would refetch again
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("covers the gap once when a fatal-error reconnect succeeds", () => {
+    renderStream();
+    act(() => latest().open());
+    act(() => latest().errorFatal());
+    // No refetch while the endpoint is known-down — only after reconnecting.
+    expect(invalidateSpy).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1_000));
+    expect(MockEventSource.instances).toHaveLength(2);
+    act(() => latest().open());
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("unmount", () => {

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
@@ -211,6 +211,26 @@ describe("connection errors", () => {
     act(() => latest().open());
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("queues a gap refetch requested while one is in flight instead of dropping it", async () => {
+    let resolveFirst!: (value?: unknown) => void;
+    invalidateSpy
+      .mockReturnValueOnce(new Promise((r) => (resolveFirst = r)) as Promise<void>)
+      .mockResolvedValue(undefined);
+    renderStream();
+    act(() => latest().open());
+    act(() => latest().errorTransient());
+    act(() => latest().open()); // gap refetch #1 starts and stays in flight
+    act(() => latest().errorTransient());
+    act(() => latest().open()); // gap #2 requested mid-flight — must be queued
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+    // The queued refetch runs after the first one settles, so its snapshot
+    // cannot predate the second gap's spans.
+    await act(async () => {
+      resolveFirst();
+    });
+    expect(invalidateSpy).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("unmount", () => {

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
@@ -212,3 +212,18 @@ describe("unmount", () => {
     expect(MockEventSource.instances).toHaveLength(1); // retry timer cancelled
   });
 });
+
+describe("disabling the stream", () => {
+  it("resets a live status when enabled flips to false", () => {
+    const { result, rerender } = renderHook(({ enabled }) => useTraceStream("p1", "t1", enabled), {
+      wrapper,
+      initialProps: { enabled: true },
+    });
+    act(() => latest().open());
+    expect(result.current.streamStatus).toBe("live");
+    rerender({ enabled: false });
+    expect(result.current.streamStatus).toBe("ended");
+    expect(result.current.isStreaming).toBe(false);
+    expect(MockEventSource.instances[0].readyState).toBe(MockEventSource.CLOSED);
+  });
+});

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -91,12 +91,22 @@ export function useTraceStream(
 
     // At most one gap-covering refetch in flight: a timeout and a reconnect
     // can land close together, and each would otherwise hit the
-    // trace-detail endpoint.
+    // trace-detail endpoint. A request that arrives mid-flight is queued (one
+    // deep) instead of dropped — the in-flight response may predate the spans
+    // the newer request is trying to recover.
+    let refetchQueued = false;
     const refetchGap = () => {
-      if (refetchInFlight) return;
+      if (refetchInFlight) {
+        refetchQueued = true;
+        return;
+      }
       refetchInFlight = true;
       queryClient.invalidateQueries({ queryKey }).finally(() => {
         refetchInFlight = false;
+        if (refetchQueued && !disposed) {
+          refetchQueued = false;
+          refetchGap();
+        }
       });
     };
 

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -65,6 +65,9 @@ export function useTraceStream(
 
   useEffect(() => {
     if (!enabled || !projectId || !traceId) {
+      // A disabled stream is non-live; without this a consumer that toggles
+      // `enabled` off mid-stream would keep reporting the last live status.
+      setStreamStatus("ended");
       return;
     }
 

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -50,10 +50,11 @@ const BACKOFF_MAX_MS = 30_000;
  * Resilience: the server closes every connection at a fixed ceiling and
  * keeps no backlog, so any gap (timeout, network blip, reconnect) can drop
  * spans permanently. Each recovery path therefore refetches the trace detail
- * once to cover the gap: on reopen after a transient error, and on
- * `stream_timeout` before resubscribing. The server re-checks completion on
- * every subscribe and emits `trace_complete` immediately for finished
- * traces, so resubscribing after a timeout self-resolves either way.
+ * once to cover the gap: on the first successful reopen after a connection
+ * error (transient or fatal), and on `stream_timeout` before resubscribing.
+ * The server re-checks completion on every subscribe and emits
+ * `trace_complete` immediately for finished traces, so resubscribing after a
+ * timeout self-resolves either way.
  */
 export function useTraceStream(
   projectId: string,
@@ -79,6 +80,12 @@ export function useTraceStream(
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let attempts = 0;
     let refetchInFlight = false;
+    // Set on any connection error (transient or fatal); the next successful
+    // open then does a single gap-covering refetch. Effect-scoped rather than
+    // per-connection so a fatal error's gap survives into the backoff
+    // reconnect — refetching before that reconnect would just hit an endpoint
+    // we already know is down.
+    let pendingGapRefetch = false;
 
     setStreamStatus("connecting");
 
@@ -117,15 +124,11 @@ export function useTraceStream(
       es = source;
       setStreamStatus("connecting");
 
-      // Set on a transient error; the next open then does a single
-      // gap-covering refetch (one per reopen, not one per error event).
-      let sawTransientError = false;
-
       source.onopen = () => {
         attempts = 0; // a healthy connection restores the full retry budget
         setStreamStatus("live");
-        if (sawTransientError) {
-          sawTransientError = false;
+        if (pendingGapRefetch) {
+          pendingGapRefetch = false;
           refetchGap();
         }
       };
@@ -170,6 +173,10 @@ export function useTraceStream(
       });
 
       source.onerror = () => {
+        // Either way spans published while we are down are gone from the
+        // stream (no backlog); flag the gap so the next successful open
+        // refetches once.
+        pendingGapRefetch = true;
         if (source.readyState === EventSource.CLOSED) {
           // Fatal: the browser will not retry. Back off and resubscribe
           // ourselves, up to the bound.
@@ -183,9 +190,8 @@ export function useTraceStream(
           setStreamStatus("connecting");
           scheduleConnect(delay);
         } else {
-          // Transient: the browser auto-reconnects on its own; remember to
-          // cover the gap once the connection reopens.
-          sawTransientError = true;
+          // Transient: the browser auto-reconnects on its own; the flag above
+          // covers the gap once the connection reopens.
           setStreamStatus("connecting");
         }
       };

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Span, TraceDetail } from "@/types/api";
 import { enrichSpansWithPending } from "../utils";
@@ -18,17 +18,42 @@ export function mergeSpans(existing: Span[], incoming: Span[]): Span[] {
   return [...existing.filter((s) => !incomingIds.has(s.span_id)), ...incoming];
 }
 
+/**
+ * Lifecycle of the live SSE stream as seen by the viewer:
+ * - "connecting": opening the first connection, or reconnecting after an
+ *   error or a server-side connection timeout.
+ * - "live": connection open — span updates stream in as they are ingested.
+ * - "ended": the trace completed and the stream closed normally.
+ * - "disconnected": reconnect attempts are exhausted; the view is no longer
+ *   live and may be missing recent spans until a reload.
+ */
+export type TraceStreamStatus = "connecting" | "live" | "ended" | "disconnected";
+
 interface UseTraceStreamResult {
   isStreaming: boolean;
+  streamStatus: TraceStreamStatus;
 }
+
+// Bounded exponential backoff for fatal connection failures (non-200
+// responses put EventSource in CLOSED and the browser will not retry):
+// 1s, 2s, 4s, 8s, 16s, then give up and mark the stream disconnected.
+const MAX_RECONNECT_ATTEMPTS = 5;
+const BACKOFF_BASE_MS = 1_000;
+const BACKOFF_MAX_MS = 30_000;
 
 /**
  * Hook that connects to the live trace SSE endpoint and merges incoming spans
- * into the React Query cache for the trace detail.
+ * into the React Query cache for the trace detail. When new spans arrive via
+ * SSE, the existing useQuery data for ["trace", projectId, traceId] is updated
+ * in-place, causing SpanTreeView and SpanInfoPanel to re-render automatically.
  *
- * When new spans arrive via SSE, the existing useQuery data for
- * ["trace", projectId, traceId] is updated in-place, causing SpanTreeView
- * and SpanInfoPanel to re-render automatically.
+ * Resilience: the server closes every connection at a fixed ceiling and
+ * keeps no backlog, so any gap (timeout, network blip, reconnect) can drop
+ * spans permanently. Each recovery path therefore refetches the trace detail
+ * once to cover the gap: on reopen after a transient error, and on
+ * `stream_timeout` before resubscribing. The server re-checks completion on
+ * every subscribe and emits `trace_complete` immediately for finished
+ * traces, so resubscribing after a timeout self-resolves either way.
  */
 export function useTraceStream(
   projectId: string,
@@ -36,8 +61,7 @@ export function useTraceStream(
   enabled: boolean,
 ): UseTraceStreamResult {
   const queryClient = useQueryClient();
-  const [isStreaming, setIsStreaming] = useState(false);
-  const eventSourceRef = useRef<EventSource | null>(null);
+  const [streamStatus, setStreamStatus] = useState<TraceStreamStatus>("connecting");
 
   useEffect(() => {
     if (!enabled || !projectId || !traceId) {
@@ -45,50 +69,133 @@ export function useTraceStream(
     }
 
     const url = `/api/projects/${projectId}/traces/${traceId}/live`;
-    const es = new EventSource(url);
-    eventSourceRef.current = es;
+    const queryKey = ["trace", projectId, traceId];
 
-    es.addEventListener("spans", (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        const newSpans: Span[] = data.spans ?? [];
+    let disposed = false;
+    let es: EventSource | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let attempts = 0;
+    let refetchInFlight = false;
 
-        if (newSpans.length === 0) return;
+    setStreamStatus("connecting");
 
-        setIsStreaming(true);
-
-        queryClient.setQueryData<TraceDetail>(["trace", projectId, traceId], (prev) => {
-          if (!prev) return prev;
-          const merged = mergeSpans(prev.spans, newSpans);
-          return {
-            ...prev,
-            spans: enrichSpansWithPending(merged),
-          };
-        });
-      } catch {
-        // Ignore malformed events
-      }
-    });
-
-    es.addEventListener("trace_complete", () => {
-      setIsStreaming(false);
-      es.close();
-      eventSourceRef.current = null;
-
-      // Refetch to get the final consistent state from ClickHouse
-      queryClient.invalidateQueries({ queryKey: ["trace", projectId, traceId] });
-    });
-
-    es.onerror = () => {
-      setIsStreaming(false);
+    // At most one gap-covering refetch in flight: a timeout and a reconnect
+    // can land close together, and each would otherwise hit the
+    // trace-detail endpoint.
+    const refetchGap = () => {
+      if (refetchInFlight) return;
+      refetchInFlight = true;
+      queryClient.invalidateQueries({ queryKey }).finally(() => {
+        refetchInFlight = false;
+      });
     };
 
+    const closeStream = () => {
+      es?.close();
+      es = null;
+    };
+
+    const clearRetryTimer = () => {
+      if (retryTimer) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+    };
+
+    const scheduleConnect = (delayMs: number) => {
+      if (disposed) return;
+      clearRetryTimer();
+      retryTimer = setTimeout(connect, delayMs);
+    };
+
+    function connect() {
+      if (disposed) return;
+      const source = new EventSource(url);
+      es = source;
+      setStreamStatus("connecting");
+
+      // Set on a transient error; the next open then does a single
+      // gap-covering refetch (one per reopen, not one per error event).
+      let sawTransientError = false;
+
+      source.onopen = () => {
+        attempts = 0; // a healthy connection restores the full retry budget
+        setStreamStatus("live");
+        if (sawTransientError) {
+          sawTransientError = false;
+          refetchGap();
+        }
+      };
+
+      source.addEventListener("spans", (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          const newSpans: Span[] = data.spans ?? [];
+
+          if (newSpans.length === 0) return;
+
+          queryClient.setQueryData<TraceDetail>(queryKey, (prev) => {
+            if (!prev) return prev;
+            return {
+              ...prev,
+              spans: enrichSpansWithPending(mergeSpans(prev.spans, newSpans)),
+            };
+          });
+        } catch {
+          // Ignore malformed events
+        }
+      });
+
+      source.addEventListener("trace_complete", () => {
+        setStreamStatus("ended");
+        closeStream();
+        clearRetryTimer();
+
+        // Refetch to get the final consistent state from ClickHouse
+        queryClient.invalidateQueries({ queryKey });
+      });
+
+      source.addEventListener("stream_timeout", () => {
+        // The server closed this connection at its per-connection ceiling;
+        // the trace may still be running. Cover the cutover gap and
+        // resubscribe — a finished trace resolves via the immediate
+        // trace_complete on the fresh connection.
+        closeStream();
+        setStreamStatus("connecting");
+        refetchGap();
+        scheduleConnect(0);
+      });
+
+      source.onerror = () => {
+        if (source.readyState === EventSource.CLOSED) {
+          // Fatal: the browser will not retry. Back off and resubscribe
+          // ourselves, up to the bound.
+          closeStream();
+          if (attempts >= MAX_RECONNECT_ATTEMPTS) {
+            setStreamStatus("disconnected");
+            return;
+          }
+          const delay = Math.min(BACKOFF_BASE_MS * 2 ** attempts, BACKOFF_MAX_MS);
+          attempts += 1;
+          setStreamStatus("connecting");
+          scheduleConnect(delay);
+        } else {
+          // Transient: the browser auto-reconnects on its own; remember to
+          // cover the gap once the connection reopens.
+          sawTransientError = true;
+          setStreamStatus("connecting");
+        }
+      };
+    }
+
+    connect();
+
     return () => {
-      es.close();
-      eventSourceRef.current = null;
-      setIsStreaming(false);
+      disposed = true;
+      clearRetryTimer();
+      closeStream();
     };
   }, [projectId, traceId, enabled, queryClient]);
 
-  return { isStreaming };
+  return { isStreaming: streamStatus === "live", streamStatus };
 }


### PR DESCRIPTION
## Summary

Fixes #1487

A live trace stream that timed out or errored could silently drop spans with no user-visible signal. The stream hook only listened for `spans` and `trace_complete`, so the backend's named `stream_timeout` event (sent at the 600s per-connection ceiling) was silently discarded by the EventSource API. Transient network errors auto-reconnected, but the backend keeps no backlog — spans published during the gap were simply missing until completion or a manual reload. Fatal errors froze the view with no indication it was dead, and `isStreaming` had zero consumers, so the UI couldn't tell the user whether the view was live at all.

This PR rewrites the hook's connection lifecycle as an explicit state machine — timeout resubscription, gap-covering refetches, bounded reconnect backoff — and surfaces the stream state in the trace viewer as a pulsing **Live** badge / amber **Live view disconnected** notice.

## How it works

```
connect()
  → onopen                    → status: live (healthy connection restores the retry budget)
      after a transient error → ONE gap-covering refetch (per reopen, not per error event)
  → "spans"                   → merge into the react-query cache (unchanged behavior)
  → "trace_complete"          → close stream → final-consistency refetch → status: ended
  → "stream_timeout"          → close → gap refetch → resubscribe immediately
                                (the server re-checks completion on every subscribe and
                                 emits trace_complete right away for finished traces,
                                 so a >10-min run stays live and a done one closes out)
  → onerror, CONNECTING       → browser retries on its own; flag a gap refetch for the next open
  → onerror, CLOSED (fatal)   → backoff 1s → 2s → 4s → 8s → 16s (5 attempts)
                                → exhausted → status: disconnected
unmount / trace switch        → close stream, cancel any pending retry
```

Key invariants: at most one trace-detail refetch in flight from the hook (deduped); every recovery path covers the no-backlog gap with a refetch; no dangling EventSource or timer on any exit path.

## What's included

### Stream hook (`frontend/ui/src/features/traces/hooks/use-trace-stream.ts`)
- New exported `TraceStreamStatus` (`connecting | live | ended | disconnected`) alongside the existing `isStreaming` (now derived: `status === "live"`).
- `stream_timeout` listener: closes the connection (pre-empting the browser's blind auto-reconnect), refetches to cover the cutover gap, and resubscribes with a fresh EventSource.
- Transient vs fatal error split on `readyState`: transient defers to the browser's retry with a single gap refetch on reopen; fatal (non-200 → CLOSED, browser won't retry) resubscribes with bounded exponential backoff, then gives up into `disconnected`.
- All connection state is effect-local (no refs to go stale); cleanup closes the stream and cancels pending retries on unmount, trace switch, or disable. Disabling the stream resets a stale `live` status.
- `mergeSpans` and the span-merge updater are untouched.

### Trace viewer (`TraceViewerPanel.tsx`)
- Consumes `streamStatus` (previously the hook's return value was discarded): pulsing green **Live** badge next to the trace id while streaming, amber **Live view disconnected** badge when the retry budget is exhausted. No badge for `connecting` (brief/ambiguous) or `ended` (a normally completed trace is the default look).

### Tests
- New `use-trace-stream.test.tsx` (10 tests, mocked EventSource, fake timers): open→live, span merge into the query cache, trace_complete close-out, timeout-resubscribe, timeout→complete on the fresh connection, transient-error single gap refetch, fatal backoff with exact timing boundaries (999ms no / 1000ms yes) and give-up, refetch dedupe while one is in flight, unmount cleanup, disabled-stream status reset.
- `TraceViewerPanel.test.tsx`: hook mock upgraded to return the full result; 3 badge visibility tests.

### Screenshots

<img width="1321" height="952" alt="image" src="https://github.com/user-attachments/assets/b8f8c7ea-6ac8-44c8-8fb2-9903f72c2895" />

## Test plan
- [x] Hook lifecycle tests with a mocked EventSource (10/10): timeout-resubscribe, timeout-complete, transient-error gap refetch, fatal-error backoff, refetch dedupe, unmount cleanup
- [x] Full traces feature suite green (129 tests); eslint and tsc clean for the feature
- [x] E2E against the real stack: seeded an in-progress trace (open root span) → server held the SSE connection on heartbeats → pulsing **Live** badge rendered
- [x] E2E: killed the REST backend mid-stream → badge flipped to **Live view disconnected** after the ~31s backoff budget; no console errors, no request storm against the trace-detail endpoint
- [ ] Live run outlasting the server's 600s connection ceiling (timeout path is covered by the hook tests; the resubscribe contract was verified against the backend's subscribe-time completion check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the live trace SSE stream resilient to timeouts and errors, preventing silent span loss and showing clear connection status in the trace viewer. Adds gap-covering refetches, bounded reconnects, and a Live/Disconnected badge.

- **Bug Fixes**
  - Handle `stream_timeout`: close, refetch to cover the gap, resubscribe immediately.
  - Distinguish transient vs fatal SSE errors: transient relies on browser auto-retry and refetches once on reopen; fatal uses bounded backoff (1s → 16s, 5 attempts) and refetches once after a successful reconnect, otherwise marks `disconnected`.
  - Deduplicate gap refetches and queue one while another is in flight; clean up EventSource/timers on unmount or trace switch; reset status when streaming is disabled.

- **New Features**
  - Expose `TraceStreamStatus` (`connecting | live | ended | disconnected`); `isStreaming` is derived.
  - Show a pulsing green “Live” badge and an amber “Live view disconnected” badge in TraceViewerPanel.

<sup>Written for commit df6140f6e6ae7cce626d65551615f211eeffd1e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

