### PR TITLE
perf(ui): cache span metadata parsing and enrich spans once per live update

### DIFF
--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { Span, TraceDetail } from "@/types/api";
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+vi.mock("../hooks", () => ({
+  useSpanIO: () => ({
+    data: { input: "span-in", output: "span-out", metadata: "{}" },
+    isLoading: false,
+  }),
+}));
+// Heavy renderers stubbed — this suite covers the panel's own derivation
+// (duration + trace aggregates), not the content viewers.
+vi.mock("./ContentRenderer", () => ({
+  ContentRenderer: ({ content }: { content: string | null }) => (
+    <div data-testid="content">{content ?? "-"}</div>
+  ),
+}));
+vi.mock("./TokenChip", () => ({ TokenChip: () => <div data-testid="token-chip" /> }));
+vi.mock("./CostChip", () => ({ CostChip: () => <div data-testid="cost-chip" /> }));
+
+import { SpanInfoPanel } from "./SpanInfoPanel";
+
+// Minimal span factory — only fields the info panel reads.
+function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
+  return {
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: overrides.span_id,
+    span_kind: SpanKind.SPAN,
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:01.000Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    input: null,
+    output: null,
+    metadata: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...overrides,
+  };
+}
+
+const llmSpan = makeSpan({
+  span_id: "llm",
+  name: "llm_call",
+  parent_span_id: "root",
+  span_kind: SpanKind.LLM,
+  span_start_time: "2024-01-01T00:00:01.000Z",
+  span_end_time: "2024-01-01T00:00:05.000Z",
+  input_tokens: 1000,
+  output_tokens: 500,
+  total_tokens: 1500,
+  cost: 0.0123,
+});
+
+const trace = {
+  trace_id: "t1",
+  project_id: "p1",
+  name: "demo-trace",
+  trace_start_time: "2024-01-01T00:00:00.000Z",
+  input: '{"q":"hi"}',
+  output: '{"a":"ok"}',
+  metadata: "{}",
+  user_id: null,
+  session_id: null,
+  git_ref: null,
+  git_repo: null,
+  spans: [
+    makeSpan({
+      span_id: "root",
+      name: "root_span",
+      span_start_time: "2024-01-01T00:00:00.000Z",
+      span_end_time: "2024-01-01T00:00:10.000Z",
+    }),
+    llmSpan,
+  ],
+} as unknown as TraceDetail;
+
+afterEach(() => cleanup());
+
+describe("SpanInfoPanel", () => {
+  it("shows trace-level duration and aggregate chips for a trace selection", () => {
+    render(<SpanInfoPanel projectId="p1" trace={trace} selection={{ type: "trace" }} />);
+    expect(screen.getByText("demo-trace")).toBeTruthy();
+    // getTraceDuration over the fixture: 10s extent
+    expect(screen.getByText("10.0s")).toBeTruthy();
+    // Aggregates render through the (stubbed) chips
+    expect(screen.getByTestId("token-chip")).toBeTruthy();
+    expect(screen.getByTestId("cost-chip")).toBeTruthy();
+  });
+
+  it("shows the span's own duration and lazy-fetched I/O for a span selection", () => {
+    render(
+      <SpanInfoPanel projectId="p1" trace={trace} selection={{ type: "span", span: llmSpan }} />,
+    );
+    expect(screen.getByText("llm_call")).toBeTruthy();
+    // getSpanDuration(llmSpan): 4s
+    expect(screen.getByText("4.0s")).toBeTruthy();
+    // Lazy span I/O flows through the content renderer
+    expect(screen.getAllByTestId("content").some((n) => n.textContent === "span-in")).toBe(true);
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useRouter } from "next/navigation";
 import {
   Clock,
@@ -65,7 +66,10 @@ export function SpanInfoPanel({
   const selectionId = isTrace ? trace.trace_id : selection.span.span_id;
   const name = isTrace ? trace.name : selection.span.name;
   const kind = isTrace ? "trace" : selection.span.span_kind;
-  const duration = isTrace ? getTraceDuration(trace) : getSpanDuration(selection.span);
+  const duration = useMemo(
+    () => (isTrace ? getTraceDuration(trace) : getSpanDuration(selection.span)),
+    [isTrace, trace, selection],
+  );
   const timestamp = isTrace ? trace.trace_start_time : selection.span.span_start_time;
   // Per-span I/O is fetched lazily (the trace skeleton no longer ships it).
   // Trace-level I/O still lives on the trace object and needs no fetch.
@@ -92,10 +96,16 @@ export function SpanInfoPanel({
     }
   })();
 
-  // Trace-level aggregates
-  const traceTotalCost = isTrace ? getTraceTotalCost(trace) : null;
-  const traceCostDetails = isTrace ? getTraceCostBreakdown(trace) : null;
-  const traceTokenUsage = isTrace ? getTraceTokenUsage(trace) : null;
+  // Trace-level aggregates, memoized on trace identity so hover/scroll
+  // re-renders of the parent panel don't recompute them.
+  const { traceTotalCost, traceCostDetails, traceTokenUsage } = useMemo(
+    () => ({
+      traceTotalCost: isTrace ? getTraceTotalCost(trace) : null,
+      traceCostDetails: isTrace ? getTraceCostBreakdown(trace) : null,
+      traceTokenUsage: isTrace ? getTraceTokenUsage(trace) : null,
+    }),
+    [isTrace, trace],
+  );
 
   // Error status
   const hasError = isTrace ? false : selection.span.status === SpanStatus.ERROR;

--- a/frontend/ui/src/features/traces/components/SpanTimelineView.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTimelineView.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { Span, TraceDetail } from "@/types/api";
+
+// Render every row: the real virtualizer measures a zero-height scroll
+// element under jsdom and would mount nothing.
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 28,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, start: index * 28, size: 28 })),
+    scrollToIndex: vi.fn(),
+  }),
+}));
+
+import { SpanTimelineView } from "./SpanTimelineView";
+
+// Minimal span factory — only fields the timeline reads.
+function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
+  return {
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: overrides.span_id,
+    span_kind: SpanKind.SPAN,
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:01.000Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    input: null,
+    output: null,
+    metadata: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...overrides,
+  };
+}
+
+function makeTrace(spans: Span[]): TraceDetail {
+  return { trace_id: "t1", project_id: "p1", name: "demo", spans } as unknown as TraceDetail;
+}
+
+const baseSpans = [
+  makeSpan({
+    span_id: "root",
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:10.000Z",
+  }),
+  makeSpan({
+    span_id: "llm",
+    parent_span_id: "root",
+    span_kind: SpanKind.LLM,
+    span_start_time: "2024-01-01T00:00:01.000Z",
+    span_end_time: "2024-01-01T00:00:05.000Z",
+    input_tokens: 1000,
+    output_tokens: 500,
+    total_tokens: 1500,
+    cost: 0.0123,
+  }),
+  makeSpan({
+    span_id: "tool",
+    parent_span_id: "root",
+    span_kind: SpanKind.TOOL,
+    span_start_time: "2024-01-01T00:00:05.000Z",
+    span_end_time: "2024-01-01T00:00:05.001Z",
+  }),
+  makeSpan({
+    span_id: "bad",
+    parent_span_id: "root",
+    status: SpanStatus.ERROR,
+    span_start_time: "2024-01-01T00:00:06.000Z",
+    span_end_time: "2024-01-01T00:00:07.000Z",
+  }),
+];
+
+function renderTimeline(overrides: Partial<Parameters<typeof SpanTimelineView>[0]> = {}) {
+  const onSelect = vi.fn();
+  const onHoverChange = vi.fn();
+  const utils = render(
+    <SpanTimelineView
+      trace={makeTrace(baseSpans)}
+      selection={{ type: "trace" }}
+      onSelect={onSelect}
+      collapsedIds={new Set()}
+      scrollRef={createRef<HTMLDivElement>()}
+      hoveredSpanId={null}
+      onHoverChange={onHoverChange}
+      {...overrides}
+    />,
+  );
+  return { onSelect, onHoverChange, ...utils };
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("SpanTimelineView rendering", () => {
+  it("renders the ruler, the trace-root bar, and one bar row per span", () => {
+    renderTimeline();
+    // Ruler ticks (10s window → 0..10s in 1s or 2s steps; "0" always present)
+    expect(screen.getByText("0")).toBeTruthy();
+    // Trace-root row duration + root span row duration
+    expect(screen.getAllByText("10.0s").length).toBeGreaterThanOrEqual(2);
+    // LLM row metrics
+    expect(screen.getByText("4.0s")).toBeTruthy();
+    expect(screen.getAllByText(/1\.5K/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("0.0123").length).toBeGreaterThanOrEqual(1);
+    // Tool row duration
+    expect(screen.getByText("1ms")).toBeTruthy();
+  });
+
+  it("styles error spans with the error bar treatment", () => {
+    const { container } = renderTimeline();
+    expect(container.querySelector(".border-red-300")).toBeTruthy();
+  });
+
+  it("marks in-progress spans with the pulsing bar treatment", () => {
+    const spans = [
+      baseSpans[0],
+      makeSpan({
+        span_id: "open",
+        parent_span_id: "root",
+        span_start_time: "2024-01-01T00:00:02.000Z",
+        span_end_time: null,
+      }),
+    ];
+    const { container } = renderTimeline({ trace: makeTrace(spans) });
+    expect(container.querySelector(".animate-pulse")).toBeTruthy();
+  });
+
+  it("selects a span on row click and reports hover changes", () => {
+    const { onSelect, onHoverChange } = renderTimeline();
+    const llmRow = screen.getByText("4.0s").closest("div.group")!;
+    fireEvent.mouseEnter(llmRow);
+    expect(onHoverChange).toHaveBeenCalledWith("llm");
+    fireEvent.mouseLeave(llmRow);
+    expect(onHoverChange).toHaveBeenCalledWith(null);
+    fireEvent.click(llmRow);
+    expect(onSelect).toHaveBeenCalledWith({ type: "span", span: baseSpans[1] });
+  });
+
+  it("selects the trace from the trace-root row", () => {
+    const { onSelect, onHoverChange, container } = renderTimeline();
+    const rootRow = container.querySelector("div.hover\\:bg-muted\\/50")!;
+    fireEvent.mouseEnter(rootRow);
+    expect(onHoverChange).toHaveBeenCalledWith("trace");
+    fireEvent.click(rootRow);
+    expect(onSelect).toHaveBeenCalledWith({ type: "trace" });
+  });
+
+  it("renders only the trace-root row when the trace is collapsed", () => {
+    renderTimeline({ collapsedIds: new Set(["trace"]) });
+    expect(screen.queryByText("4.0s")).toBeNull();
+    expect(screen.getAllByText("10.0s").length).toBe(1); // trace-root bar only
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState, useMemo, useRef, useEffect, type RefObject } from "react";
+import { memo, useState, useMemo, useRef, useEffect, type RefObject } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { CircleStop, CircleDollarSign } from "lucide-react";
 import { cn, formatDuration, formatTokenFlow } from "@/lib/utils";
 import { SpanStatus, SpanKind } from "@traceroot/core";
-import { flattenTreeWithMetrics } from "../utils/timeline";
+import { flattenTreeWithMetrics, type FlatTimelineItem } from "../utils/timeline";
 import {
   TREE_LAYOUT,
   TREE_OVERSCAN_ROWS,
@@ -52,6 +52,110 @@ function formatTickLabel(sec: number): string {
 type TimelineRow =
   | { type: "trace-root" }
   | { type: "span"; data: ReturnType<typeof flattenTreeWithMetrics>[number] };
+
+/**
+ * One Gantt bar row, memoized: a row's item, position, and size are stable
+ * for a given data update (virtualized rows are absolutely positioned inside
+ * the scrolled content, so scrolling moves nothing per-row). Memoizing means
+ * a scroll frame re-renders only the rows entering the virtual window, and a
+ * hover change repaints exactly the rows whose highlight flipped — instead of
+ * every mounted row in the panel.
+ */
+const TimelineSpanRow = memo(function TimelineSpanRow({
+  item,
+  top,
+  height,
+  isSelected,
+  isHovered,
+  onSelect,
+  onHoverChange,
+}: {
+  item: FlatTimelineItem;
+  top: number;
+  height: number;
+  isSelected: boolean;
+  isHovered: boolean;
+  onSelect: (s: TraceSelection) => void;
+  onHoverChange: (id: string | null) => void;
+}) {
+  const span = item.span;
+  const isError = span.status === SpanStatus.ERROR;
+  const durationText = formatDuration(item.metrics.durationMs);
+
+  const isRootSpan = span.parent_span_id === null;
+  const showDuration =
+    span.span_kind === SpanKind.LLM || span.span_kind === SpanKind.TOOL || isRootSpan;
+
+  const showRightMetrics = span.span_kind === SpanKind.LLM || isRootSpan;
+  const showTokens = showRightMetrics && span.total_tokens != null && span.total_tokens > 0;
+  const showCost =
+    showRightMetrics && span.cost != null && Number.isFinite(span.cost) && span.cost > 0;
+
+  return (
+    <div
+      className={cn(
+        "group absolute left-0 top-0 z-10 flex w-full cursor-pointer items-center border-b border-border/5 transition-colors",
+        isHovered ? "bg-muted/60" : "bg-transparent",
+        isSelected && "bg-muted/80",
+      )}
+      style={{ height, transform: `translateY(${top}px)` }}
+      onMouseEnter={(e) => {
+        e.stopPropagation();
+        onHoverChange(span.span_id);
+      }}
+      onMouseLeave={(e) => {
+        e.stopPropagation();
+        onHoverChange(null);
+      }}
+      onClick={() => onSelect({ type: "span", span })}
+    >
+      {showDuration && (
+        <span className="absolute left-2 z-20 whitespace-nowrap text-[10px] text-muted-foreground">
+          {durationText}
+        </span>
+      )}
+      {(showTokens || showCost) && (
+        <span className="absolute right-2 z-20 inline-flex items-center gap-2 whitespace-nowrap text-[10px] text-muted-foreground">
+          {showTokens && (
+            <span className="inline-flex items-center gap-0.5 font-sans font-medium">
+              <CircleStop className="h-2.5 w-2.5" />
+              {formatTokenFlow(span.input_tokens, span.output_tokens, span.total_tokens)}
+            </span>
+          )}
+          {showCost && (
+            <span className="inline-flex items-center gap-0.5">
+              <CircleDollarSign className="h-2.5 w-2.5" />
+              {span.cost!.toFixed(4)}
+            </span>
+          )}
+        </span>
+      )}
+      {item.metrics.isInstant && !item.metrics.isInProgress ? (
+        <div
+          className="absolute z-10 h-3 w-[2px] bg-muted-foreground/50 transition-colors"
+          style={{ left: `${item.metrics.startOffsetPx}px` }}
+        />
+      ) : (
+        <div
+          className={cn(
+            "absolute z-10 overflow-hidden rounded-[2px] border border-solid transition-colors",
+            isError
+              ? "border-red-300 bg-red-100 dark:border-red-800 dark:bg-red-950/60"
+              : getSpanKindColor(span.span_kind).surface,
+            item.metrics.isInProgress && "animate-pulse border-dashed opacity-70",
+            // Tinted bars wash out a neutral ring; foreground/50 stays legible on every kind
+            isSelected && "ring-1 ring-foreground/50",
+          )}
+          style={{
+            left: `${item.metrics.startOffsetPx}px`,
+            width: `${Math.max(4, item.metrics.widthPx)}px`,
+            height: "20px",
+          }}
+        />
+      )}
+    </div>
+  );
+});
 
 interface SpanTimelineViewProps {
   trace: TraceDetail;
@@ -267,86 +371,19 @@ export function SpanTimelineView({
             }
 
             const item = row.data;
-            const span = item.span;
-            const isSelected = selection.type === "span" && selection.span.span_id === span.span_id;
-            const isError = span.status === SpanStatus.ERROR;
-            const isInProgress = item.metrics.isInProgress;
-            const durationText = formatDuration(item.metrics.durationMs);
-
-            const isRootSpan = span.parent_span_id === null;
-            const showDuration =
-              span.span_kind === SpanKind.LLM || span.span_kind === SpanKind.TOOL || isRootSpan;
-
-            const showRightMetrics = span.span_kind === SpanKind.LLM || isRootSpan;
-            const showTokens =
-              showRightMetrics && span.total_tokens != null && span.total_tokens > 0;
-            const showCost =
-              showRightMetrics && span.cost != null && Number.isFinite(span.cost) && span.cost > 0;
-
             return (
-              <div
-                key={span.span_id}
-                className={cn(
-                  "group absolute left-0 top-0 z-10 flex w-full cursor-pointer items-center border-b border-border/5 transition-colors",
-                  hoveredSpanId === span.span_id ? "bg-muted/60" : "bg-transparent",
-                  isSelected && "bg-muted/80",
-                )}
-                style={rowStyle}
-                onMouseEnter={(e) => {
-                  e.stopPropagation();
-                  onHoverChange(span.span_id);
-                }}
-                onMouseLeave={(e) => {
-                  e.stopPropagation();
-                  onHoverChange(null);
-                }}
-                onClick={() => onSelect({ type: "span", span })}
-              >
-                {showDuration && (
-                  <span className="absolute left-2 z-20 whitespace-nowrap text-[10px] text-muted-foreground">
-                    {durationText}
-                  </span>
-                )}
-                {(showTokens || showCost) && (
-                  <span className="absolute right-2 z-20 inline-flex items-center gap-2 whitespace-nowrap text-[10px] text-muted-foreground">
-                    {showTokens && (
-                      <span className="inline-flex items-center gap-0.5 font-sans font-medium">
-                        <CircleStop className="h-2.5 w-2.5" />
-                        {formatTokenFlow(span.input_tokens, span.output_tokens, span.total_tokens)}
-                      </span>
-                    )}
-                    {showCost && (
-                      <span className="inline-flex items-center gap-0.5">
-                        <CircleDollarSign className="h-2.5 w-2.5" />
-                        {span.cost!.toFixed(4)}
-                      </span>
-                    )}
-                  </span>
-                )}
-                {item.metrics.isInstant && !item.metrics.isInProgress ? (
-                  <div
-                    className="absolute z-10 h-3 w-[2px] bg-muted-foreground/50 transition-colors"
-                    style={{ left: `${item.metrics.startOffsetPx}px` }}
-                  />
-                ) : (
-                  <div
-                    className={cn(
-                      "absolute z-10 overflow-hidden rounded-[2px] border border-solid transition-colors",
-                      isError
-                        ? "border-red-300 bg-red-100 dark:border-red-800 dark:bg-red-950/60"
-                        : getSpanKindColor(span.span_kind).surface,
-                      item.metrics.isInProgress && "animate-pulse border-dashed opacity-70",
-                      // Tinted bars wash out a neutral ring; foreground/50 stays legible on every kind
-                      isSelected && "ring-1 ring-foreground/50",
-                    )}
-                    style={{
-                      left: `${item.metrics.startOffsetPx}px`,
-                      width: `${Math.max(4, item.metrics.widthPx)}px`,
-                      height: "20px",
-                    }}
-                  />
-                )}
-              </div>
+              <TimelineSpanRow
+                key={item.span.span_id}
+                item={item}
+                top={virtualRow.start}
+                height={virtualRow.size}
+                isSelected={
+                  selection.type === "span" && selection.span.span_id === item.span.span_id
+                }
+                isHovered={hoveredSpanId === item.span.span_id}
+                onSelect={onSelect}
+                onHoverChange={onHoverChange}
+              />
             );
           })}
         </div>

--- a/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
@@ -129,7 +129,8 @@ export function SpanTimelineView({
   const traceIsCollapsed = collapsedIds.has("trace");
   const flattenedItems = useMemo(() => {
     if (traceIsCollapsed) return [];
-    // Must enrich here too so row count matches SpanTreeView (pending placeholders add rows)
+    // Same per-array-cached enrichment the tree view consumes, so both panels
+    // render the identical span array and row counts always match.
     const enrichedSpans = enrichSpansWithPending(trace.spans);
     return flattenTreeWithMetrics(enrichedSpans, collapsedIds, traceDurationMs, timelineWidth);
   }, [trace.spans, collapsedIds, traceIsCollapsed, traceDurationMs, timelineWidth]);

--- a/frontend/ui/src/features/traces/components/SpanTreeView.render.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.render.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { createRef } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { Span, TraceDetail } from "@/types/api";
+
+// Render every row: the real virtualizer measures a zero-height scroll
+// element under jsdom and would mount nothing. The scrollToIndex spy is
+// exposed for the imperative scroll-to-span test.
+vi.mock("@tanstack/react-virtual", () => {
+  const scrollToIndex = vi.fn();
+  (globalThis as Record<string, unknown>).__treeScrollToIndex = scrollToIndex;
+  return {
+    useVirtualizer: ({ count }: { count: number }) => ({
+      getTotalSize: () => count * 28,
+      getVirtualItems: () =>
+        Array.from({ length: count }, (_, index) => ({ index, start: index * 28, size: 28 })),
+      scrollToIndex,
+    }),
+  };
+});
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "u1", email: "u@x.dev" } } }),
+}));
+const getSpanIO = vi.fn().mockResolvedValue({ input: null, output: null, metadata: null });
+vi.mock("@/lib/api", () => ({
+  getSpanIO: (...a: unknown[]) => getSpanIO(...a),
+}));
+vi.mock("../hooks", () => ({
+  spanIOQueryKey: (p: string, t: string, s: string) => ["span-io", p, t, s],
+  SPAN_IO_STALE_TIME_MS: 300_000,
+}));
+
+import { SpanTreeView, type SpanTreeViewHandle } from "./SpanTreeView";
+
+// Minimal span factory — only fields the tree reads.
+function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
+  return {
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: overrides.span_id,
+    span_kind: SpanKind.SPAN,
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:01.000Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    input: null,
+    output: null,
+    metadata: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...overrides,
+  };
+}
+
+const spans = [
+  makeSpan({
+    span_id: "root",
+    name: "root_span",
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:10.000Z",
+  }),
+  makeSpan({
+    span_id: "agent",
+    name: "agent_turn",
+    parent_span_id: "root",
+    span_start_time: "2024-01-01T00:00:00.500Z",
+    span_end_time: "2024-01-01T00:00:09.000Z",
+  }),
+  makeSpan({
+    span_id: "llm",
+    name: "llm_call",
+    parent_span_id: "agent",
+    span_kind: SpanKind.LLM,
+    span_start_time: "2024-01-01T00:00:01.000Z",
+    span_end_time: "2024-01-01T00:00:05.000Z",
+    input_tokens: 1000,
+    output_tokens: 500,
+    total_tokens: 1500,
+    cost: 0.0123,
+  }),
+  makeSpan({
+    span_id: "bad",
+    name: "broken_tool",
+    parent_span_id: "agent",
+    status: SpanStatus.ERROR,
+    span_start_time: "2024-01-01T00:00:06.000Z",
+    span_end_time: "2024-01-01T00:00:07.000Z",
+  }),
+  // Orphan whose metadata names its missing ancestor — enrichment must
+  // synthesize a pending "ghost_stage" placeholder row.
+  makeSpan({
+    span_id: "deep",
+    name: "deep_step",
+    parent_span_id: "ghost01",
+    span_start_time: "2024-01-01T00:00:08.000Z",
+    span_end_time: "2024-01-01T00:00:08.500Z",
+    metadata: JSON.stringify({
+      "traceroot.span.ids_path": ["root", "ghost01"],
+      "traceroot.span.path": ["root_span", "ghost_stage", "deep_step"],
+    }),
+  }),
+];
+
+const trace = {
+  trace_id: "t1",
+  project_id: "p1",
+  name: "demo-trace",
+  spans,
+} as unknown as TraceDetail;
+
+function renderTree(overrides: Partial<Parameters<typeof SpanTreeView>[0]> = {}) {
+  const onSelect = vi.fn();
+  const onHoverChange = vi.fn();
+  const onToggleCollapse = vi.fn();
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const ref = createRef<SpanTreeViewHandle>();
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <SpanTreeView
+        ref={ref}
+        trace={trace}
+        selection={{ type: "trace" }}
+        onSelect={onSelect}
+        collapsedIds={new Set()}
+        onToggleCollapse={onToggleCollapse}
+        hoveredSpanId={null}
+        onHoverChange={onHoverChange}
+        scrollRef={createRef<HTMLDivElement>()}
+        {...overrides}
+      />
+    </QueryClientProvider>,
+  );
+  return { onSelect, onHoverChange, onToggleCollapse, ref, ...utils };
+}
+
+afterEach(() => {
+  cleanup();
+  getSpanIO.mockClear();
+});
+
+describe("SpanTreeView rendering", () => {
+  it("renders the trace root with aggregates and every span row", () => {
+    renderTree();
+    expect(screen.getByText("demo-trace")).toBeTruthy();
+    expect(screen.getByText("agent_turn")).toBeTruthy();
+    expect(screen.getByText("llm_call")).toBeTruthy();
+    expect(screen.getByText("ERROR")).toBeTruthy();
+    // Pending placeholder synthesized from the orphan's metadata
+    expect(screen.getByText("ghost_stage")).toBeTruthy();
+    expect(screen.getByText("deep_step")).toBeTruthy();
+    // LLM metrics and trace aggregates
+    expect(screen.getAllByText(/1\.5K/).length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("0.0123").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText("4.0s")).toBeTruthy();
+  });
+
+  it("hides per-row metrics in compact mode", () => {
+    renderTree({ compact: true });
+    expect(screen.getByText("llm_call")).toBeTruthy();
+    expect(screen.queryByText("4.0s")).toBeNull();
+    expect(screen.queryByText(/1\.5K/)).toBeNull();
+  });
+
+  it("selects a span on click and reports hover changes", () => {
+    const { onSelect, onHoverChange } = renderTree();
+    const row = screen.getByText("llm_call").closest("div.group")!;
+    fireEvent.mouseEnter(row);
+    expect(onHoverChange).toHaveBeenCalledWith("llm");
+    fireEvent.mouseLeave(row);
+    expect(onHoverChange).toHaveBeenCalledWith(null);
+    fireEvent.click(row);
+    expect(onSelect).toHaveBeenCalledWith({ type: "span", span: spans[2] });
+  });
+
+  it("prefetches span I/O after an intentional hover, not a pass-over", async () => {
+    renderTree();
+    const row = screen.getByText("llm_call").closest("div.group")!;
+    // Quick pass-over: leave before the debounce elapses → no request.
+    fireEvent.mouseEnter(row);
+    fireEvent.mouseLeave(row);
+    await new Promise((r) => setTimeout(r, 250));
+    expect(getSpanIO).not.toHaveBeenCalled();
+    // Intentional hover: the debounced prefetch fires with the auth user.
+    fireEvent.mouseEnter(row);
+    await waitFor(() => expect(getSpanIO).toHaveBeenCalled(), { timeout: 2000 });
+    expect(getSpanIO).toHaveBeenCalledWith("p1", "t1", "llm", { id: "u1", email: "u@x.dev" });
+  });
+
+  it("toggles collapse from the row chevron and the trace root chevron", () => {
+    const { onToggleCollapse } = renderTree();
+    const agentRow = screen.getByText("agent_turn").closest("div.group")!;
+    fireEvent.click(within(agentRow as HTMLElement).getByRole("button"));
+    expect(onToggleCollapse).toHaveBeenCalledWith("agent");
+
+    const traceRow = screen.getByText("demo-trace").closest('div[class*="cursor-pointer"]')!;
+    fireEvent.click(within(traceRow as HTMLElement).getByRole("button"));
+    expect(onToggleCollapse).toHaveBeenCalledWith("trace");
+  });
+
+  it("scrolls to a visible span via the imperative handle", () => {
+    const { ref } = renderTree();
+    const scrollToIndex = (globalThis as Record<string, unknown>).__treeScrollToIndex as ReturnType<
+      typeof vi.fn
+    >;
+    scrollToIndex.mockClear();
+    act(() => ref.current!.scrollToSpan("llm"));
+    expect(scrollToIndex).toHaveBeenCalledWith(expect.any(Number), { align: "center" });
+    scrollToIndex.mockClear();
+    act(() => ref.current!.scrollToSpan("not-a-span"));
+    expect(scrollToIndex).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
@@ -160,3 +160,20 @@ describe("buildSpanTree caching", () => {
     expect(buildSpanTree(spans)).toBe(buildSpanTree(spans));
   });
 });
+
+describe("buildSpanTree depth", () => {
+  it("builds a very deeply nested trace without overflowing the call stack", () => {
+    // One 20 000-level parent chain — a recursive traversal overflows well
+    // before this depth; the iterative builder must not.
+    const spans: Span[] = [];
+    let parent: string | null = null;
+    for (let i = 0; i < 20_000; i++) {
+      spans.push(makeSpan({ span_id: `s${i}`, parent_span_id: parent }));
+      parent = `s${i}`;
+    }
+    const rows = buildSpanTree(spans);
+    expect(rows).toHaveLength(20_000);
+    expect(rows[0].span.span_id).toBe("s0");
+    expect(rows[19_999].level).toBe(19_999);
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
@@ -153,3 +153,10 @@ describe("buildTreeRows ↔ flattenTreeWithMetrics ordering parity", () => {
     expect(treeIds).toEqual(["root", "a", "b"]);
   });
 });
+
+describe("buildSpanTree caching", () => {
+  it("returns the identical rows array for the same spans array", () => {
+    const { spans } = makeTree();
+    expect(buildSpanTree(spans)).toBe(buildSpanTree(spans));
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { forwardRef, useImperativeHandle, useMemo, useCallback, useRef, useEffect } from "react";
+import {
+  forwardRef,
+  memo,
+  useImperativeHandle,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+} from "react";
 import type { RefObject } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { useQueryClient } from "@tanstack/react-query";
@@ -69,6 +77,146 @@ export function buildTreeRows(
   ];
 }
 
+/**
+ * One span row, memoized: a row's model object, position, and size are stable
+ * for a given data update (virtualized rows are absolutely positioned inside
+ * the scrolled content, so scrolling moves nothing per-row). Memoizing means
+ * a scroll frame re-renders only the rows entering the virtual window, and a
+ * hover change repaints exactly the rows whose highlight flipped — instead of
+ * every mounted row in the panel.
+ */
+const SpanTreeRowItem = memo(function SpanTreeRowItem({
+  row,
+  top,
+  height,
+  compact,
+  isSelected,
+  isHovered,
+  hasChildren,
+  isCollapsed,
+  onSelect,
+  onHoverChange,
+  onToggleCollapse,
+  onPrefetchSchedule,
+  onPrefetchCancel,
+}: {
+  row: SpanTreeRow;
+  top: number;
+  height: number;
+  compact: boolean;
+  isSelected: boolean;
+  isHovered: boolean;
+  hasChildren: boolean;
+  isCollapsed: boolean;
+  onSelect: (selection: TraceSelection) => void;
+  onHoverChange: (id: string | null) => void;
+  onToggleCollapse: (id: string) => void;
+  onPrefetchSchedule: (span: Span) => void;
+  onPrefetchCancel: () => void;
+}) {
+  const { span, level, isTerminal, parentLevels } = row;
+  const adjustedLevel = level + 1;
+  const adjustedParentLevels = parentLevels.map((l) => l + 1);
+
+  return (
+    <div
+      className={cn(
+        "group flex cursor-pointer items-center border-b border-border/5 transition-colors",
+        isHovered ? "bg-muted/60" : "bg-transparent",
+        isSelected && "bg-muted/80",
+      )}
+      style={{
+        position: "absolute",
+        top: 0,
+        left: 0,
+        width: "100%",
+        height,
+        transform: `translateY(${top}px)`,
+      }}
+      onMouseEnter={(e) => {
+        e.stopPropagation();
+        onHoverChange(span.span_id);
+        onPrefetchSchedule(span);
+      }}
+      onMouseLeave={(e) => {
+        e.stopPropagation();
+        onHoverChange(null);
+        onPrefetchCancel();
+      }}
+      onClick={() => onSelect({ type: "span", span })}
+    >
+      <SpanTreeConnector
+        level={adjustedLevel}
+        isTerminal={isTerminal}
+        parentLevels={adjustedParentLevels}
+      />
+
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 pr-2">
+        <SpanKindIcon kind={span.span_kind} inTree />
+        <span
+          className={cn(
+            "min-w-0 shrink truncate text-xs",
+            span.pending && "text-muted-foreground/60",
+          )}
+        >
+          {span.name}
+        </span>
+        {/* Error badge stays outside the @container to guarantee it is always visible */}
+        {span.status === SpanStatus.ERROR && (
+          <span className="shrink-0 whitespace-nowrap rounded bg-red-100 px-1 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
+            ERROR
+          </span>
+        )}
+
+        {/* Always render the flex-1 container to lock the gap math */}
+        <div className="flex min-w-0 flex-1 items-center justify-start gap-1.5 @container">
+          {!compact && (
+            <>
+              {!span.pending && (
+                <span className="hidden shrink-0 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[45px]:inline-flex">
+                  {formatDuration(getSpanDuration(span))}
+                </span>
+              )}
+
+              {span.span_kind === SpanKind.LLM && span.total_tokens != null && (
+                <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap text-[10px] font-medium text-muted-foreground @[130px]:inline-flex">
+                  <CircleStop className="h-2.5 w-2.5" />
+                  {formatTokenFlow(span.input_tokens, span.output_tokens, span.total_tokens)}
+                </span>
+              )}
+
+              {span.span_kind === SpanKind.LLM &&
+                span.cost != null &&
+                Number.isFinite(span.cost) && (
+                  <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[190px]:inline-flex">
+                    <CircleDollarSign className="h-2.5 w-2.5" />
+                    {span.cost.toFixed(4)}
+                  </span>
+                )}
+            </>
+          )}
+        </div>
+
+        {hasChildren && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggleCollapse(span.span_id);
+            }}
+            className="shrink-0 rounded p-0.5 transition-colors hover:bg-muted"
+          >
+            {isCollapsed ? (
+              <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+            ) : (
+              <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+});
+
 interface SpanTreeViewProps {
   trace: TraceDetail;
   selection: TraceSelection;
@@ -121,32 +269,32 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
   const spanById = useMemo(() => new Map(spans.map((s) => [s.span_id, s])), [spans]);
   const spanRows = useMemo(() => buildSpanTree(spans), [spans]);
 
-  const hasChildren = (spanId: string | null) => {
-    const children = childrenByParent.get(spanId) || [];
-    return children.length > 0;
-  };
-
   // Prefetch a span's I/O on hover so the click → SpanInfoPanel render is
   // instant. Skips placeholder (pending) spans, which have no row in ClickHouse.
   const queryClient = useQueryClient();
   const { data: authSession } = useAuthSession();
   const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Depend on the primitive auth fields, not the session object: its identity
+  // can change per render, and an unstable callback here would defeat the
+  // row-level memoization below.
+  const authUserId = authSession?.user?.id;
+  const authUserEmail = authSession?.user?.email;
   const runSpanIOPrefetch = useCallback(
     (span: Span) => {
       if (span.pending) return;
       // Skip prefetch until the auth session is ready: prefetching with no user
       // would trigger a fallback session fetch per hover and could cache an
       // unauthenticated result under the shared span-io query key.
-      if (!authSession?.user) return;
-      const user = { id: authSession.user.id, email: authSession.user.email };
+      if (!authUserId) return;
+      const user = { id: authUserId, email: authUserEmail };
       queryClient.prefetchQuery({
         queryKey: spanIOQueryKey(trace.project_id, trace.trace_id, span.span_id),
         queryFn: () => getSpanIO(trace.project_id, trace.trace_id, span.span_id, user),
         staleTime: SPAN_IO_STALE_TIME_MS,
       });
     },
-    [queryClient, authSession, trace.project_id, trace.trace_id],
+    [queryClient, authUserId, authUserEmail, trace.project_id, trace.trace_id],
   );
 
   // Schedule the prefetch after a short hover delay; cancel on leave / unmount so a
@@ -172,11 +320,6 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
 
   useEffect(() => () => cancelSpanIOPrefetch(), [cancelSpanIOPrefetch]);
 
-  const toggleCollapse = (spanId: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    onToggleCollapse(spanId);
-  };
-
   const isTraceSelected = selection.type === "trace";
   // Memoized on trace identity: recompute only when new data arrives, not on
   // hover/scroll/collapse re-renders. In-progress traces measure open spans
@@ -190,7 +333,7 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
     }),
     [trace],
   );
-  const traceHasChildren = hasChildren(null);
+  const traceHasChildren = (childrenByParent.get(null) ?? []).length > 0;
   const traceIsCollapsed = collapsedIds.has("trace");
 
   // Full virtualized row model: trace root at index 0, then collapse-filtered
@@ -291,7 +434,10 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
 
                   {traceHasChildren && (
                     <button
-                      onClick={(e) => toggleCollapse("trace", e)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onToggleCollapse("trace");
+                      }}
                       className="shrink-0 rounded p-0.5 transition-colors hover:bg-muted"
                     >
                       {traceIsCollapsed ? (
@@ -306,104 +452,24 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
             );
           }
 
-          const { span, level, isTerminal, parentLevels } = rowData.row;
-          const isSelected = selection.type === "span" && selection.span.span_id === span.span_id;
-          const adjustedLevel = level + 1;
-          const adjustedParentLevels = parentLevels.map((l) => l + 1);
-          const spanHasChildren = hasChildren(span.span_id);
-          const isCollapsed = collapsedIds.has(span.span_id);
-
+          const { span } = rowData.row;
           return (
-            <div
+            <SpanTreeRowItem
               key={span.span_id}
-              className={cn(
-                "group flex cursor-pointer items-center border-b border-border/5 transition-colors",
-                hoveredSpanId === span.span_id ? "bg-muted/60" : "bg-transparent",
-                isSelected && "bg-muted/80",
-              )}
-              style={rowStyle}
-              onMouseEnter={(e) => {
-                e.stopPropagation();
-                onHoverChange(span.span_id);
-                scheduleSpanIOPrefetch(span);
-              }}
-              onMouseLeave={(e) => {
-                e.stopPropagation();
-                onHoverChange(null);
-                cancelSpanIOPrefetch();
-              }}
-              onClick={() => onSelect({ type: "span", span })}
-            >
-              <SpanTreeConnector
-                level={adjustedLevel}
-                isTerminal={isTerminal}
-                parentLevels={adjustedParentLevels}
-              />
-
-              <div className="flex min-w-0 flex-1 items-center gap-1.5 pr-2">
-                <SpanKindIcon kind={span.span_kind} inTree />
-                <span
-                  className={cn(
-                    "min-w-0 shrink truncate text-xs",
-                    span.pending && "text-muted-foreground/60",
-                  )}
-                >
-                  {span.name}
-                </span>
-                {/* Error badge stays outside the @container to guarantee it is always visible */}
-                {span.status === SpanStatus.ERROR && (
-                  <span className="shrink-0 whitespace-nowrap rounded bg-red-100 px-1 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
-                    ERROR
-                  </span>
-                )}
-
-                {/* Always render the flex-1 container to lock the gap math */}
-                <div className="flex min-w-0 flex-1 items-center justify-start gap-1.5 @container">
-                  {!compact && (
-                    <>
-                      {!span.pending && (
-                        <span className="hidden shrink-0 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[45px]:inline-flex">
-                          {formatDuration(getSpanDuration(span))}
-                        </span>
-                      )}
-
-                      {span.span_kind === SpanKind.LLM && span.total_tokens != null && (
-                        <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap text-[10px] font-medium text-muted-foreground @[130px]:inline-flex">
-                          <CircleStop className="h-2.5 w-2.5" />
-                          {formatTokenFlow(
-                            span.input_tokens,
-                            span.output_tokens,
-                            span.total_tokens,
-                          )}
-                        </span>
-                      )}
-
-                      {span.span_kind === SpanKind.LLM &&
-                        span.cost != null &&
-                        Number.isFinite(span.cost) && (
-                          <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[190px]:inline-flex">
-                            <CircleDollarSign className="h-2.5 w-2.5" />
-                            {span.cost.toFixed(4)}
-                          </span>
-                        )}
-                    </>
-                  )}
-                </div>
-
-                {spanHasChildren && (
-                  <button
-                    onClick={(e) => toggleCollapse(span.span_id, e)}
-                    className="shrink-0 rounded p-0.5 transition-colors hover:bg-muted"
-                  >
-                    {isCollapsed ? (
-                      <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
-                    ) : (
-                      <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                    )}
-                  </button>
-                )}
-              </div>
-            </div>
+              row={rowData.row}
+              top={virtualRow.start}
+              height={virtualRow.size}
+              compact={compact}
+              isSelected={selection.type === "span" && selection.span.span_id === span.span_id}
+              isHovered={hoveredSpanId === span.span_id}
+              hasChildren={(childrenByParent.get(span.span_id) ?? []).length > 0}
+              isCollapsed={collapsedIds.has(span.span_id)}
+              onSelect={onSelect}
+              onHoverChange={onHoverChange}
+              onToggleCollapse={onToggleCollapse}
+              onPrefetchSchedule={scheduleSpanIOPrefetch}
+              onPrefetchCancel={cancelSpanIOPrefetch}
+            />
           );
         })}
       </div>

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -19,6 +19,7 @@ import {
   getTraceDuration,
   getTraceTotalCost,
   getTraceTokenUsage,
+  getVisibleSpanRows,
   TREE_LAYOUT,
   TREE_OVERSCAN_ROWS,
 } from "../utils";
@@ -39,26 +40,9 @@ const SPAN_IO_PREFETCH_DEBOUNCE_MS = 150;
 // row-height math lives in the parent anymore.
 export type TreeRow = { type: "trace" } | { type: "span"; row: SpanTreeRow };
 
-/**
- * Returns the flattened span rows that are currently visible, i.e. none of
- * their ancestors are collapsed. Kept pure (no React) so the row model can be
- * unit-tested and so the virtualizer count matches exactly what is rendered.
- */
-export function getVisibleSpanRows(
-  spanRows: SpanTreeRow[],
-  spanById: Map<string, Span>,
-  collapsedIds: Set<string>,
-): SpanTreeRow[] {
-  if (collapsedIds.size === 0) return spanRows;
-  return spanRows.filter(({ span }) => {
-    let currentId = span.parent_span_id;
-    while (currentId) {
-      if (collapsedIds.has(currentId)) return false;
-      currentId = spanById.get(currentId)?.parent_span_id || null;
-    }
-    return true;
-  });
-}
+// getVisibleSpanRows moved to ../utils so the timeline flattener can share the
+// exact same collapse filter; re-exported here for existing importers.
+export { getVisibleSpanRows } from "../utils";
 
 /**
  * Builds the full virtualized row model: the trace root at index 0 followed by

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -178,9 +178,18 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
   };
 
   const isTraceSelected = selection.type === "trace";
-  const traceDuration = getTraceDuration(trace);
-  const traceTotalCost = getTraceTotalCost(trace);
-  const traceTokenUsage = getTraceTokenUsage(trace);
+  // Memoized on trace identity: recompute only when new data arrives, not on
+  // hover/scroll/collapse re-renders. In-progress traces measure open spans
+  // against Date.now(), so the displayed duration intentionally advances when
+  // the next update lands rather than drifting on every render.
+  const { traceDuration, traceTotalCost, traceTokenUsage } = useMemo(
+    () => ({
+      traceDuration: getTraceDuration(trace),
+      traceTotalCost: getTraceTotalCost(trace),
+      traceTokenUsage: getTraceTokenUsage(trace),
+    }),
+    [trace],
+  );
   const traceHasChildren = hasChildren(null);
   const traceIsCollapsed = collapsedIds.has("trace");
 

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -222,3 +222,14 @@ describe("live stream status badge", () => {
     expect(screen.queryByText("Live view disconnected")).toBeNull();
   });
 });
+
+describe("scroll sync", () => {
+  it("the tree scroll handler no-ops while the timeline panel is unmounted", () => {
+    const root = renderPanel();
+    const scroller = root.querySelector(".overflow-y-auto");
+    expect(scroller).toBeTruthy();
+    // Tree mode: the timeline scroll ref is null, so the mirror must bail
+    // without touching anything (and without throwing).
+    fireEvent.scroll(scroller!);
+  });
+});

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -110,7 +110,6 @@ export function TraceViewerPanel({
   // Scroll sync refs
   const treeScrollRef = useRef<HTMLDivElement>(null);
   const timelineScrollRef = useRef<HTMLDivElement>(null);
-  const isSyncing = useRef(false);
   // Imperative handle so a timeline click can scroll the tree to the span;
   // the tree owns the virtualizer and resolves the row index itself.
   const treeViewRef = useRef<SpanTreeViewHandle>(null);
@@ -201,24 +200,29 @@ export function TraceViewerPanel({
     }
   }, []);
 
+  // Scroll sync mirrors positions by VALUE, not with a timing flag: writing
+  // scrollTop raises a scroll event on the other panel, whose handler then
+  // finds the positions already equal and stops. Unlike the previous
+  // requestAnimationFrame-reset guard, this drops no mirror updates during
+  // momentum scrolling and a late echo event can never mirror stale state
+  // backwards — both showed up as the timeline visibly trailing the tree.
+
   // Sync tree scroll → timeline
   const handleTreeScroll = useCallback(() => {
-    if (isSyncing.current || !treeScrollRef.current || !timelineScrollRef.current) return;
-    isSyncing.current = true;
-    timelineScrollRef.current.scrollTop = treeScrollRef.current.scrollTop;
-    requestAnimationFrame(() => {
-      isSyncing.current = false;
-    });
+    const tree = treeScrollRef.current;
+    const timeline = timelineScrollRef.current;
+    if (!tree || !timeline) return;
+    if (Math.abs(timeline.scrollTop - tree.scrollTop) < 1) return;
+    timeline.scrollTop = tree.scrollTop;
   }, []);
 
   // Sync timeline scroll → tree
   const handleTimelineScroll = useCallback(() => {
-    if (isSyncing.current || !treeScrollRef.current || !timelineScrollRef.current) return;
-    isSyncing.current = true;
-    treeScrollRef.current.scrollTop = timelineScrollRef.current.scrollTop;
-    requestAnimationFrame(() => {
-      isSyncing.current = false;
-    });
+    const tree = treeScrollRef.current;
+    const timeline = timelineScrollRef.current;
+    if (!tree || !timeline) return;
+    if (Math.abs(tree.scrollTop - timeline.scrollTop) < 1) return;
+    tree.scrollTop = timeline.scrollTop;
   }, []);
 
   return (

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.ts
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { Span, TraceDetail } from "@/types/api";
-import { enrichSpansWithPending } from "../utils";
 
 /**
  * Merge incoming spans into existing spans array.
@@ -42,10 +41,10 @@ const BACKOFF_BASE_MS = 1_000;
 const BACKOFF_MAX_MS = 30_000;
 
 /**
- * Hook that connects to the live trace SSE endpoint and merges incoming spans
- * into the React Query cache for the trace detail. When new spans arrive via
- * SSE, the existing useQuery data for ["trace", projectId, traceId] is updated
- * in-place, causing SpanTreeView and SpanInfoPanel to re-render automatically.
+ * Hook that connects to the live trace SSE endpoint and merges incoming raw
+ * spans into the React Query cache for the trace detail. Enrichment
+ * (pending-child placeholders) is left to consumers via
+ * `enrichSpansWithPending`, which caches its result per input array.
  *
  * Resilience: the server closes every connection at a fixed ceiling and
  * keeps no backlog, so any gap (timeout, network blip, reconnect) can drop
@@ -141,7 +140,7 @@ export function useTraceStream(
             if (!prev) return prev;
             return {
               ...prev,
-              spans: enrichSpansWithPending(mergeSpans(prev.spans, newSpans)),
+              spans: mergeSpans(prev.spans, newSpans),
             };
           });
         } catch {

--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { SpanKind, SpanStatus } from "@traceroot/core";
 import type { Span } from "@/types/api";
 import {
   enrichSpansWithPending,
   getSpanDuration,
+  getSpanMetadata,
   getTraceDuration,
   summarizeCostDetails,
   getTraceCostBreakdown,
@@ -477,6 +478,42 @@ describe("two-phase loading compatibility", () => {
     } as unknown as TraceDetail;
     // 3s extent (max end − min start).
     expect(getTraceDuration(trace)).toBe(3000);
+  });
+});
+
+describe("getSpanMetadata", () => {
+  it("returns the identical parsed object for the same span object", () => {
+    const span = makeSpan({
+      span_id: "child",
+      parent_span_id: "parent-id",
+      metadata: metadataWith(["parent-id"], ["parent-name", "child"]),
+    });
+    const first = getSpanMetadata(span);
+    expect(first["traceroot.span.ids_path"]).toEqual(["parent-id"]);
+    expect(getSpanMetadata(span)).toBe(first);
+  });
+
+  it("caches the empty result for metadata-less spans", () => {
+    const span = makeSpan({ span_id: "bare", metadata: null });
+    expect(getSpanMetadata(span)).toEqual({});
+    expect(getSpanMetadata(span)).toBe(getSpanMetadata(span));
+  });
+
+  it("does not re-parse metadata for span objects that survive a merge", () => {
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: "parent-id",
+      metadata: metadataWith(["parent-id"], ["parent-name", "child"]),
+    });
+    // First pass parses and caches the child's metadata.
+    enrichSpansWithPending([child]);
+
+    const parseSpy = vi.spyOn(JSON, "parse");
+    // A later update delivers a NEW array (fresh identity) still containing the
+    // same child object — exactly what mergeSpans produces for untouched spans.
+    enrichSpansWithPending([child, makeSpan({ span_id: "root-2" })]);
+    expect(parseSpy).not.toHaveBeenCalled();
+    parseSpy.mockRestore();
   });
 });
 

--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -8,6 +8,9 @@ import {
   getTraceDuration,
   summarizeCostDetails,
   getTraceCostBreakdown,
+  getSpanStartMs,
+  getSpanEndMs,
+  parseTimestamp,
 } from "./index";
 import { mergeSpans } from "../hooks/use-trace-stream";
 import type { TraceDetail } from "@/types/api";
@@ -560,5 +563,31 @@ describe("mergeSpans (live-SSE compat)", () => {
     expect(enriched.find((s) => s.span_id === "mid")?.pending).toBe(true);
     expect(enriched.find((s) => s.span_id === "root")).toBeDefined();
     expect(enriched.find((s) => s.span_id === "child")).toBeDefined();
+  });
+});
+
+describe("getSpanStartMs / getSpanEndMs", () => {
+  it("agree with parseTimestamp for closed spans", () => {
+    const span = makeSpan({
+      span_id: "s",
+      span_start_time: "2024-01-01T00:00:00.000Z",
+      span_end_time: "2024-01-01T00:00:01.500Z",
+    });
+    expect(getSpanStartMs(span)).toBe(parseTimestamp("2024-01-01T00:00:00.000Z"));
+    expect(getSpanEndMs(span)).toBe(parseTimestamp("2024-01-01T00:00:01.500Z"));
+  });
+
+  it("returns null end for in-progress spans (never caches a live end)", () => {
+    const open = makeSpan({ span_id: "open", span_end_time: null });
+    expect(getSpanEndMs(open)).toBeNull();
+  });
+
+  it("handles timezone-naive whole-second timestamps like parseTimestamp", () => {
+    const span = makeSpan({
+      span_id: "naive",
+      span_start_time: "2026-06-04T06:37:22.527000",
+      span_end_time: "2026-06-04T06:37:30",
+    });
+    expect(getSpanEndMs(span)! - getSpanStartMs(span)).toBe(7_473);
   });
 });

--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -591,3 +591,32 @@ describe("getSpanStartMs / getSpanEndMs", () => {
     expect(getSpanEndMs(span)! - getSpanStartMs(span)).toBe(7_473);
   });
 });
+
+describe("enrichSpansWithPending caching", () => {
+  it("returns the identical array for the same input array", () => {
+    const spans = [makeSpan({ span_id: "root" })];
+    expect(enrichSpansWithPending(spans)).toBe(enrichSpansWithPending(spans));
+  });
+
+  it("re-enriching an enriched array is the identity operation", () => {
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: "parent-id",
+      metadata: metadataWith(["parent-id"], ["parent-name", "child"]),
+    });
+    const enriched = enrichSpansWithPending([child]);
+    // Sanity: enrichment actually did something (placeholder synthesized).
+    expect(enriched.some((s) => s.pending)).toBe(true);
+    expect(enrichSpansWithPending(enriched)).toBe(enriched);
+  });
+
+  it("recomputes for a new array after a merge, keeping untouched span objects", () => {
+    const root = makeSpan({ span_id: "root" });
+    const first = enrichSpansWithPending([root]);
+    const merged = mergeSpans([root], [makeSpan({ span_id: "child", parent_span_id: "root" })]);
+    const second = enrichSpansWithPending(merged);
+    expect(second).not.toBe(first);
+    // The untouched root span keeps its identity through merge + enrichment.
+    expect(second.find((s) => s.span_id === "root")).toBe(root);
+  });
+});

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -215,10 +215,44 @@ export function getTraceDuration(trace: TraceDetail): number | null {
   return Math.max(rootDuration, extent);
 }
 
+// One row-model per spans-array identity, so the tree and timeline panels —
+// which both derive rows from the same enriched array — share a single
+// computation per data update.
+const spanTreeCache = new WeakMap<Span[], SpanTreeRow[]>();
+
 /**
  * Build a linearized tree structure from spans for rendering
  */
 export function buildSpanTree(spans: Span[]): SpanTreeRow[] {
+  const cached = spanTreeCache.get(spans);
+  if (cached) return cached;
+  const rows = computeSpanTree(spans);
+  spanTreeCache.set(spans, rows);
+  return rows;
+}
+
+/**
+ * Returns the flattened span rows that are currently visible, i.e. none of
+ * their ancestors are collapsed. Kept pure (no React) so the row model can be
+ * unit-tested and so the virtualizer count matches exactly what is rendered.
+ */
+export function getVisibleSpanRows(
+  spanRows: SpanTreeRow[],
+  spanById: Map<string, Span>,
+  collapsedIds: Set<string>,
+): SpanTreeRow[] {
+  if (collapsedIds.size === 0) return spanRows;
+  return spanRows.filter(({ span }) => {
+    let currentId = span.parent_span_id;
+    while (currentId) {
+      if (collapsedIds.has(currentId)) return false;
+      currentId = spanById.get(currentId)?.parent_span_id || null;
+    }
+    return true;
+  });
+}
+
+function computeSpanTree(spans: Span[]): SpanTreeRow[] {
   const childrenByParent = new Map<string | null, Span[]>();
   const spanIds = new Set(spans.map((s) => s.span_id));
 

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -40,6 +40,32 @@ export function getSpanMetadata(span: Span): Record<string, unknown> {
   return parsed;
 }
 
+const spanStartMsCache = new WeakMap<Span, number>();
+const spanEndMsCache = new WeakMap<Span, number>();
+
+/** Parsed `span_start_time` in epoch ms, computed at most once per span object. */
+export function getSpanStartMs(span: Span): number {
+  const cached = spanStartMsCache.get(span);
+  if (cached !== undefined) return cached;
+  const ms = parseTimestamp(span.span_start_time);
+  spanStartMsCache.set(span, ms);
+  return ms;
+}
+
+/**
+ * Parsed `span_end_time` in epoch ms, or null while the span is still open.
+ * Callers decide what "now" means for open spans (`?? Date.now()`), so a live
+ * end time is never cached.
+ */
+export function getSpanEndMs(span: Span): number | null {
+  if (!span.span_end_time) return null;
+  const cached = spanEndMsCache.get(span);
+  if (cached !== undefined) return cached;
+  const ms = parseTimestamp(span.span_end_time);
+  spanEndMsCache.set(span, ms);
+  return ms;
+}
+
 /**
  * For every span that carries traceroot.span.ids_path (ancestor IDs, root→parent)
  * and traceroot.span.path (root→current names) in its metadata, create lightweight
@@ -78,8 +104,8 @@ export function enrichSpansWithPending(spans: Span[]): Span[] {
 
       if (pendingSpans.has(spanId)) {
         const existing = pendingSpans.get(spanId)!;
-        const existStart = parseTimestamp(existing.span_start_time);
-        const curStart = parseTimestamp(span.span_start_time);
+        const existStart = getSpanStartMs(existing);
+        const curStart = getSpanStartMs(span);
         if (curStart < existStart) {
           pendingSpans.set(spanId, { ...existing, span_start_time: span.span_start_time });
         }
@@ -142,9 +168,8 @@ export const TREE_OVERSCAN_ROWS = 26;
  */
 export function getSpanDuration(span: Span): number | null {
   if (!span.span_start_time) return null;
-  const start = parseTimestamp(span.span_start_time);
-  const end = span.span_end_time ? parseTimestamp(span.span_end_time) : Date.now();
-  return Math.max(0, end - start);
+  const end = getSpanEndMs(span) ?? Date.now();
+  return Math.max(0, end - getSpanStartMs(span));
 }
 
 /**
@@ -163,10 +188,8 @@ export function getTraceDuration(trace: TraceDetail): number | null {
   if (!allSpans.length) return null;
 
   const now = Date.now();
-  const minStart = Math.min(...allSpans.map((s) => parseTimestamp(s.span_start_time)));
-  const maxEnd = Math.max(
-    ...allSpans.map((s) => (s.span_end_time ? parseTimestamp(s.span_end_time) : now)),
-  );
+  const minStart = Math.min(...allSpans.map((s) => getSpanStartMs(s)));
+  const maxEnd = Math.max(...allSpans.map((s) => getSpanEndMs(s) ?? now));
   const extent = Math.max(0, maxEnd - minStart);
 
   const root = allSpans.find((s) => !s.parent_span_id);

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -270,16 +270,6 @@ function computeSpanTree(spans: Span[]): SpanTreeRow[] {
 
   const rows: SpanTreeRow[] = [];
 
-  function traverse(span: Span, level: number, isTerminal: boolean, parentLevels: number[]) {
-    rows.push({ span, level, isTerminal, parentLevels });
-    const children = childrenByParent.get(span.span_id) || [];
-    children.forEach((child, idx) => {
-      const childIsTerminal = idx === children.length - 1;
-      const nextParentLevels = childIsTerminal ? parentLevels : [...parentLevels, level];
-      traverse(child, level + 1, childIsTerminal, nextParentLevels);
-    });
-  }
-
   // Combine true roots with orphan spans (parent not yet arrived) into a single
   // top-level list sorted by start_time. This ensures:
   // 1. Connector lines are correct across all top-level items.
@@ -288,9 +278,37 @@ function computeSpanTree(spans: Span[]): SpanTreeRow[] {
   const topLevel = [...(childrenByParent.get(null) ?? []), ...orphans].sort(
     (a, b) => parseTimestamp(a.span_start_time) - parseTimestamp(b.span_start_time),
   );
-  topLevel.forEach((span, idx) => {
-    traverse(span, 0, idx === topLevel.length - 1, []);
-  });
+
+  // Iterative preorder DFS — an explicit stack instead of recursion so very
+  // deeply nested traces (recursive agents, deep ReAct loops) can't overflow
+  // the call stack. Children are pushed in reverse so the first child is
+  // popped first, preserving chronological DFS order. Both panels derive
+  // their rows from this builder, so the guard covers the tree and the
+  // timeline alike.
+  const stack: SpanTreeRow[] = [];
+  for (let i = topLevel.length - 1; i >= 0; i--) {
+    stack.push({
+      span: topLevel[i],
+      level: 0,
+      isTerminal: i === topLevel.length - 1,
+      parentLevels: [],
+    });
+  }
+
+  while (stack.length > 0) {
+    const row = stack.pop()!;
+    rows.push(row);
+    const children = childrenByParent.get(row.span.span_id) || [];
+    for (let i = children.length - 1; i >= 0; i--) {
+      const childIsTerminal = i === children.length - 1;
+      stack.push({
+        span: children[i],
+        level: row.level + 1,
+        isTerminal: childIsTerminal,
+        parentLevels: childIsTerminal ? row.parentLevels : [...row.parentLevels, row.level],
+      });
+    }
+  }
 
   return rows;
 }

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -66,6 +66,14 @@ export function getSpanEndMs(span: Span): number | null {
   return ms;
 }
 
+// One enrichment result per spans-array identity. The live-stream hook
+// enriches at merge time, and every view/helper then calls
+// enrichSpansWithPending on whatever array it holds; this cache collapses all
+// of those calls into a single computation per data update. Mapping
+// result → result makes re-enriching an already-enriched array the identity
+// operation, so downstream useMemo chains keyed on the array stay stable.
+const enrichedSpansCache = new WeakMap<Span[], Span[]>();
+
 /**
  * For every span that carries traceroot.span.ids_path (ancestor IDs, root→parent)
  * and traceroot.span.path (root→current names) in its metadata, create lightweight
@@ -75,6 +83,15 @@ export function getSpanEndMs(span: Span): number | null {
  * because both carry the same metadata JSON.
  */
 export function enrichSpansWithPending(spans: Span[]): Span[] {
+  const cached = enrichedSpansCache.get(spans);
+  if (cached) return cached;
+  const result = computeEnrichedSpans(spans);
+  enrichedSpansCache.set(spans, result);
+  enrichedSpansCache.set(result, result);
+  return result;
+}
+
+function computeEnrichedSpans(spans: Span[]): Span[] {
   const existingSpanIds = new Set(spans.map((s) => s.span_id));
   const pendingSpans = new Map<string, Span>();
 

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -19,6 +19,27 @@ function parseMetadata(metadata: string | null): Record<string, unknown> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Span-keyed caches.
+//
+// Live updates flow through mergeSpans, which preserves object identity for
+// every span the incoming SSE batch didn't replace. Keying by span object
+// therefore makes per-update parse work proportional to newly arrived spans
+// only, and entries are GC'd together with the spans they belong to. Spans are
+// treated as immutable after creation (react-query updates replace objects,
+// never mutate them) — these caches rely on that.
+// ---------------------------------------------------------------------------
+const spanMetadataCache = new WeakMap<Span, Record<string, unknown>>();
+
+/** Parsed `span.metadata` JSON, computed at most once per span object. */
+export function getSpanMetadata(span: Span): Record<string, unknown> {
+  const cached = spanMetadataCache.get(span);
+  if (cached) return cached;
+  const parsed = parseMetadata(span.metadata ?? null);
+  spanMetadataCache.set(span, parsed);
+  return parsed;
+}
+
 /**
  * For every span that carries traceroot.span.ids_path (ancestor IDs, root→parent)
  * and traceroot.span.path (root→current names) in its metadata, create lightweight
@@ -38,9 +59,10 @@ export function enrichSpansWithPending(spans: Span[]): Span[] {
   for (const span of spans) {
     if (!span.parent_span_id) continue;
 
-    // Skeleton spans omit metadata (parseMetadata(null|undefined) → {}); live
-    // SSE spans still carry it, so enrichment keeps working from live events.
-    const meta = parseMetadata(span.metadata ?? null);
+    // Skeleton spans omit metadata (the parse yields {}); live SSE spans still
+    // carry it, so enrichment keeps working from live events. Parsed once per
+    // span object via the span-keyed cache.
+    const meta = getSpanMetadata(span);
     const idsPath = meta["traceroot.span.ids_path"] as string[] | undefined;
     const namePath = meta["traceroot.span.path"] as string[] | undefined;
 

--- a/frontend/ui/src/features/traces/utils/timeline.test.ts
+++ b/frontend/ui/src/features/traces/utils/timeline.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { Span } from "@/types/api";
+import { flattenTreeWithMetrics } from "./timeline";
+
+// Minimal span factory — only fields relevant to timeline metrics.
+function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
+  return {
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: overrides.span_id,
+    span_kind: SpanKind.SPAN,
+    span_start_time: "2024-01-01T00:00:00.000Z",
+    span_end_time: "2024-01-01T00:00:01.000Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    input: null,
+    output: null,
+    metadata: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...overrides,
+  };
+}
+
+describe("flattenTreeWithMetrics pixel metrics", () => {
+  it("computes offsets and widths from span times against the trace window", () => {
+    const spans = [
+      makeSpan({
+        span_id: "root",
+        span_start_time: "2024-01-01T00:00:00.000Z",
+        span_end_time: "2024-01-01T00:00:01.000Z",
+      }),
+      makeSpan({
+        span_id: "child",
+        parent_span_id: "root",
+        span_start_time: "2024-01-01T00:00:00.100Z",
+        span_end_time: "2024-01-01T00:00:00.400Z",
+      }),
+    ];
+    const items = flattenTreeWithMetrics(spans, new Set(), 1000, 800);
+    expect(items.map((i) => i.span.span_id)).toEqual(["root", "child"]);
+
+    const [rootMetrics, childMetrics] = items.map((i) => i.metrics);
+    expect(rootMetrics.startOffsetPx).toBe(0);
+    expect(rootMetrics.widthPx).toBe(800);
+    expect(rootMetrics.durationMs).toBe(1000);
+    expect(rootMetrics.isInProgress).toBe(false);
+    expect(rootMetrics.isInstant).toBe(false);
+    expect(childMetrics.startOffsetPx).toBeCloseTo(80, 5);
+    expect(childMetrics.widthPx).toBeCloseTo(240, 5);
+    expect(childMetrics.durationMs).toBe(300);
+  });
+
+  it("marks sub-2px closed spans instant and open spans in-progress", () => {
+    const spans = [
+      makeSpan({
+        span_id: "tiny",
+        span_start_time: "2024-01-01T00:00:00.000Z",
+        span_end_time: "2024-01-01T00:00:00.001Z",
+      }),
+      makeSpan({
+        span_id: "open",
+        span_start_time: "2024-01-01T00:00:00.000Z",
+        span_end_time: null,
+      }),
+    ];
+    const items = flattenTreeWithMetrics(spans, new Set(), 100_000, 800);
+    const tiny = items.find((i) => i.span.span_id === "tiny")!.metrics;
+    const open = items.find((i) => i.span.span_id === "open")!.metrics;
+    expect(tiny.isInstant).toBe(true);
+    expect(open.isInProgress).toBe(true);
+    expect(open.isInstant).toBe(false);
+  });
+
+  it("keeps a collapsed span visible but drops its descendants", () => {
+    const spans = [
+      makeSpan({ span_id: "root" }),
+      makeSpan({
+        span_id: "a",
+        parent_span_id: "root",
+        span_start_time: "2024-01-01T00:00:00.100Z",
+      }),
+      makeSpan({
+        span_id: "a1",
+        parent_span_id: "a",
+        span_start_time: "2024-01-01T00:00:00.200Z",
+      }),
+    ];
+    const items = flattenTreeWithMetrics(spans, new Set(["a"]), 1000, 800);
+    expect(items.map((i) => i.span.span_id)).toEqual(["root", "a"]);
+  });
+});

--- a/frontend/ui/src/features/traces/utils/timeline.ts
+++ b/frontend/ui/src/features/traces/utils/timeline.ts
@@ -1,5 +1,5 @@
 import type { Span } from "@/types/api";
-import { buildChildrenMap, getSpanDuration, parseTimestamp } from "../utils";
+import { buildSpanTree, getSpanDuration, getSpanStartMs, getVisibleSpanRows } from "../utils";
 
 export interface TimelineMetrics {
   startOffsetPx: number;
@@ -15,21 +15,14 @@ export interface FlatTimelineItem {
 }
 
 /**
- * Flattens a flat array of spans into a DFS-ordered list for virtualized rendering,
- * pre-computing pixel offsets and widths for the Gantt bars.
+ * Flattens spans into the DFS-ordered visible-row list for virtualized
+ * rendering, pre-computing pixel offsets and widths for the Gantt bars.
  *
- * The visible-span ORDER produced here must stay identical to SpanTreeView's
- * `buildTreeRows`/`getVisibleSpanRows` — the timeline and tree panels are
- * scroll-synced row-for-row, so any divergence in which spans are emitted (or
- * their order) silently misaligns them. The collapse skip below mirrors the
- * tree's ancestor-collapse filter, and a parity test guards it in
- * SpanTreeView.test.ts.
- *
- * TODO: unify this visible-span derivation with SpanTreeView's
- * getVisibleSpanRows/buildTreeRows so the collapse logic lives in one place.
- * Deferred because this flattener also computes pixel metrics and works on raw
- * Span[] (not SpanTreeRow[]), so the merge is non-trivial. The parity test
- * protects the invariant until then.
+ * Row derivation is shared with SpanTreeView: both panels consume the same
+ * cached buildSpanTree rows and the same getVisibleSpanRows collapse filter,
+ * so the scroll-synced, row-aligned panels cannot diverge in visible-span
+ * order. This flattener only layers per-span pixel metrics on top. The parity
+ * test in SpanTreeView.test.ts still guards the row-order invariant.
  */
 export function flattenTreeWithMetrics(
   spans: Span[],
@@ -39,46 +32,15 @@ export function flattenTreeWithMetrics(
 ): FlatTimelineItem[] {
   if (!spans || spans.length === 0) return [];
 
-  // Cache parsed timestamps to avoid re-parsing during traversal
-  const startTimes = new Map<string, number>();
-  for (const span of spans) {
-    startTimes.set(span.span_id, parseTimestamp(span.span_start_time));
-  }
+  const rows = buildSpanTree(spans);
+  const spanById = new Map(spans.map((s) => [s.span_id, s]));
+  const visibleRows = getVisibleSpanRows(rows, spanById, collapsedIds);
 
-  const traceStartMs = spans.reduce(
-    (min, s) => Math.min(min, startTimes.get(s.span_id)!),
-    Infinity,
-  );
-
-  const childrenMap = buildChildrenMap(spans);
-  const spanIds = new Set(spans.map((s) => s.span_id));
-
-  for (const children of childrenMap.values()) {
-    children.sort((a, b) => startTimes.get(a.span_id)! - startTimes.get(b.span_id)!);
-  }
-
-  // True roots + orphan spans (parent not yet arrived), sorted by time
-  const trueRoots = childrenMap.get(null) ?? [];
-  const orphans = spans.filter((s) => s.parent_span_id !== null && !spanIds.has(s.parent_span_id));
-  const topLevel = [...trueRoots, ...orphans].sort(
-    (a, b) => startTimes.get(a.span_id)! - startTimes.get(b.span_id)!,
-  );
-
-  const flatList: FlatTimelineItem[] = [];
+  const traceStartMs = spans.reduce((min, s) => Math.min(min, getSpanStartMs(s)), Infinity);
   const safeTraceDuration = Math.max(1, traceDurationMs);
 
-  // Iterative DFS — avoids stack overflow on deeply-nested traces (recursive
-  // agents, deep ReAct loops). Children are pushed in reverse so the first
-  // child is popped first, preserving chronological DFS order.
-  const stack: Span[] = [];
-  for (let i = topLevel.length - 1; i >= 0; i--) {
-    stack.push(topLevel[i]);
-  }
-
-  while (stack.length > 0) {
-    const span = stack.pop()!;
-
-    const offsetMs = startTimes.get(span.span_id)! - traceStartMs;
+  return visibleRows.map(({ span }) => {
+    const offsetMs = getSpanStartMs(span) - traceStartMs;
     const durationMs = getSpanDuration(span) ?? 0;
     const isInProgress = span.span_end_time === null;
 
@@ -86,7 +48,7 @@ export function flattenTreeWithMetrics(
     const widthPx = (durationMs / safeTraceDuration) * scaleWidth;
     const isInstant = !isInProgress && (widthPx < 2 || durationMs / safeTraceDuration < 0.002);
 
-    flatList.push({
+    return {
       span,
       metrics: {
         startOffsetPx: Math.max(0, startOffsetPx),
@@ -95,15 +57,6 @@ export function flattenTreeWithMetrics(
         isInProgress,
         isInstant,
       },
-    });
-
-    if (!collapsedIds.has(span.span_id)) {
-      const children = childrenMap.get(span.span_id) ?? [];
-      for (let i = children.length - 1; i >= 0; i--) {
-        stack.push(children[i]);
-      }
-    }
-  }
-
-  return flatList;
+    };
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #1488

The dominant client-side cost in the live trace view was redundant recomputation: `enrichSpansWithPending` ran 3–6 times per SSE event across the stream hook, tree view, timeline view, and duration helpers, and every pass re-parsed every span's metadata JSON with no caching. Worse, the trace-level duration/cost/token aggregates were computed un-memoized on every render, so every hover and scroll repeated the full pass even with no new data.

This PR makes each of those computations happen exactly once per data update, keyed on object identity, with no behavior change: rendered tree, timeline, and durations are identical at each update (in-progress durations now intentionally advance when data arrives rather than drifting per render).

Profiling a real trace also surfaced a second bottleneck: scrolling in timeline mode re-rendered every mounted row in both panels on every frame, and a racy scroll-sync guard made the timeline visibly trail the tree. Three follow-up commits memoize the row components and sync scroll positions by value, taking timeline scrolling from **66fps** with frequent main-thread stalls to a capped **116fps** with none.

## How it works

```
SSE event → mergeSpans (preserves object identity for untouched spans)
  → stored RAW in the react-query cache (single source, same as the base fetch)
    → enrichSpansWithPending(spans)    WeakMap keyed per spans-array: the first
      caller computes, every other consumer gets the SAME array back
      (result → result too, so re-enriching is the identity operation)
      → buildSpanTree(spans)           WeakMap per-array cache, now shared by the
        tree panel AND the timeline flattener — one derivation, aligned rows
        → getSpanMetadata(span)        WeakMap per-span: metadata parsed at most
          getSpanStartMs/EndMs(span)   once per span object; per-update parse work
                                       is proportional to newly arrived spans only
```

Why identity-keyed WeakMaps are safe here: `mergeSpans` preserves span-object identity for anything the incoming batch didn't replace, and react-query replaces objects rather than mutating them — so cache entries stay valid exactly as long as their objects live, and are garbage-collected with them.

## What's included

### Utils (`frontend/ui/src/features/traces/utils/`)
- `getSpanMetadata(span)` — span-keyed metadata parse cache (the `traceroot.span.ids_path`/`path` reads).
- `getSpanStartMs(span)` / `getSpanEndMs(span)` — span-keyed timestamp caches; `getSpanEndMs` returns null for open spans and never caches a live end. Also the shared groundwork the span-tree builder efficiency work will consume.
- `enrichSpansWithPending` — per-array result cache; identity-stable output so downstream `useMemo` chains keyed on the array stay stable across consumers.
- `buildSpanTree` — same per-array cache pattern; `getVisibleSpanRows` moved here from the tree component so the collapse filter has one home.
- `flattenTreeWithMetrics` (timeline) — rewritten to consume the shared `buildSpanTree` + `getVisibleSpanRows` derivation instead of its own duplicate DFS; pixel-metric math unchanged. Resolves the long-standing TODO about unifying the two derivations; the tree↔timeline row-parity test passes unchanged.

### Components
- `SpanTreeView` / `SpanInfoPanel` — trace duration/cost/token aggregates memoized on trace identity; hover/scroll/collapse re-renders no longer recompute anything.
- Stream hook — stores raw merged spans; consumers enrich once via the cached util (react-query's structural sharing would discard the identity of a hook-side enriched array anyway, which previously made that eager enrichment wasted work).

### Scroll render path (follow-up commits, from e2e profiling)
- `SpanTimelineView` / `SpanTreeView` — row JSX extracted into `React.memo` components with stable props (row model objects and virtual positions are identity-stable per data update). Scrolling re-renders only rows entering the virtual window instead of every mounted row in both panels; hover repaints exactly the rows whose highlight flipped. The tree view's span-I/O prefetch callback now depends on primitive auth fields so an unstable session object can't defeat the row memoization.
- `TraceViewerPanel` — scroll sync mirrors positions by value with echo suppression (mirror only when the panels actually differ) instead of a `requestAnimationFrame`-reset flag. The old guard could drop mirror updates during momentum scrolling and let a late echo mirror stale state backwards — both visible as the timeline trailing the tree.

### Tests
- ~200 new test lines: cache identity semantics (`.toBe` on repeated calls, enriched-array self-identity, recompute-on-new-array with object reuse), a `JSON.parse` spy proving no re-parse for spans that survive a merge, timestamp-cache equivalence including the timezone-naive regression shapes, and timeline pixel-metric characterization tests locked in **before** the flattener rewrite.

## Test plan
- [x] Full traces feature suite green (116 tests at this branch's tip), including the pre-existing enrichment, duration, two-phase-loading, and tree↔timeline parity suites — no existing assertion modified
- [x] Characterization tests for `flattenTreeWithMetrics` written against the old implementation first, then verified unchanged after the rewrite
- [x] eslint and tsc clean for the feature
- [x] E2E in the browser against seeded data: trace list aggregates, tree render (durations, ERROR badge, orphan spans), span info panel with lazy I/O, timeline bars vs the ruler, and collapse staying row-aligned across both panels in timeline mode
- [ ] Profile a long live agent run to quantify the per-event CPU reduction


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches per-span metadata/timestamp parsing and enriches spans once per live update, then shares one tree derivation between the tree and timeline to remove redundant work. Adds memoized row components and value-based scroll sync; the span tree now builds iteratively to handle very deep traces.

- **Refactors**
  - Span-keyed WeakMap caches for `getSpanMetadata`, `getSpanStartMs`, `getSpanEndMs`; per-array cache for `enrichSpansWithPending` (result → result identity).
  - One shared derivation via `buildSpanTree` + `getVisibleSpanRows` used by both panels; timeline only adds pixel metrics. The tree builder is iterative to survive deeply nested traces.
  - Memoized row components in timeline and tree; memoized trace aggregates/durations in `SpanTreeView` and `SpanInfoPanel`.
  - Stream hook now stores raw merged spans via `mergeSpans` in `@tanstack/react-query`; consumers enrich once per input array.
  - Tests add cache identity/timestamp parity, deep-tree stack safety, virtualized render coverage, timeline pixel metrics, and tree↔timeline row-order parity.

- **Bug Fixes**
  - Scroll sync mirrors `scrollTop` by value between panels, preventing missed updates during momentum scrolling.

<sup>Written for commit d8957fc5a8287361d19e0cba5f266cf1695660d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



