### PR TITLE
fix(auth): enforce seat limit on direct workspace member add

### DIFF
--- a/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
+++ b/frontend/packages/core/src/ee/billing/__tests__/plans.test.ts
@@ -10,7 +10,26 @@ import {
   isDetectorRunBlocked,
   isIngestionBlocked,
   hasEntitlement,
+  countCurrentSeats,
 } from "../plans.ts";
+
+describe("countCurrentSeats", () => {
+  it("sums members and pending invites", () => {
+    expect(countCurrentSeats({ members: 2, invites: 3 })).toBe(5);
+  });
+
+  it("subtracts one when the operation supersedes an invite", () => {
+    expect(countCurrentSeats({ members: 2, invites: 3 }, { supersedesInvite: true })).toBe(4);
+  });
+
+  it("does not go negative when invites is already zero and supersedesInvite is true", () => {
+    // Callers only pass supersedesInvite: true when they already found a
+    // matching invite, so invites >= 1 in practice, but the math itself
+    // shouldn't silently clamp — this documents the (unreachable in
+    // practice) edge rather than hiding it.
+    expect(countCurrentSeats({ members: 2, invites: 0 }, { supersedesInvite: true })).toBe(1);
+  });
+});
 
 describe("slack-integration entitlement", () => {
   it("is available on every plan (free tier included)", () => {

--- a/frontend/packages/core/src/ee/billing/index.ts
+++ b/frontend/packages/core/src/ee/billing/index.ts
@@ -28,6 +28,7 @@ export {
   getEntitlements,
   requireEntitlement,
   // Seat enforcement
+  countCurrentSeats,
   getSeatLimit,
   canAddSeat,
   requireSeatAvailable,

--- a/frontend/packages/core/src/ee/billing/plans.ts
+++ b/frontend/packages/core/src/ee/billing/plans.ts
@@ -323,6 +323,20 @@ export function requireEntitlement(
 // =============================================================================
 // SEAT ENFORCEMENT
 // =============================================================================
+/**
+ * Members plus pending invites — the seat-count math both invite creation
+ * and direct member-add check against the plan limit. Pass
+ * `supersedesInvite: true` when the invite for this exact email is about to
+ * be deleted by the same operation (direct-add deletes and replaces it with
+ * a membership), so that invite isn't double-counted against itself.
+ */
+export function countCurrentSeats(
+  counts: { members: number; invites: number },
+  options?: { supersedesInvite?: boolean },
+): number {
+  return counts.members + counts.invites - (options?.supersedesInvite ? 1 : 0);
+}
+
 export function getSeatLimit(plan: PlanType): number {
   return SEAT_LIMITS[plan];
 }

--- a/frontend/ui/src/app/api/invites/[inviteId]/accept/route.ts
+++ b/frontend/ui/src/app/api/invites/[inviteId]/accept/route.ts
@@ -58,6 +58,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
   // Check seat limit before accepting invite
   // (Plan may have been downgraded since invite was sent)
+  // Counts existing members only, not `+ invites` like invite-create does:
+  // the invite being accepted is deleted in the same transaction below, so
+  // counting it here would double-count it against itself.
   const plan = (invite.workspace.billingPlan || PlanType.FREE) as PlanType;
   const currentMembers = invite.workspace._count.members;
   const seatLimit = getSeatLimit(plan);

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/invites/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/invites/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  workspaceFindUnique,
+  userFindUnique,
+  memberFindUnique,
+  inviteFindUnique,
+  inviteCreate,
+  requireWorkspaceMembershipMock,
+  sendInviteEmailMock,
+} = vi.hoisted(() => ({
+  workspaceFindUnique: vi.fn(),
+  userFindUnique: vi.fn(),
+  memberFindUnique: vi.fn(),
+  inviteFindUnique: vi.fn(),
+  inviteCreate: vi.fn(),
+  requireWorkspaceMembershipMock: vi.fn(),
+  sendInviteEmailMock: vi.fn(),
+}));
+
+vi.mock("@traceroot/core", async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>);
+  return {
+    ...actual,
+    prisma: {
+      workspace: { findUnique: workspaceFindUnique },
+      user: { findUnique: userFindUnique },
+      workspaceMember: { findUnique: memberFindUnique },
+      invite: { findUnique: inviteFindUnique, create: inviteCreate },
+    },
+  };
+});
+
+// Auth/access helpers. The real module pulls in env-validated auth config, so
+// stub the whole module: open the gates and reimplement the pure response
+// helpers with NextResponse (their only behavior the handler relies on).
+vi.mock("@/lib/auth-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    requireAuth: async () => ({ user: { id: "u1", email: "admin@x.com", name: "Admin" } }),
+    requireWorkspaceMembership: requireWorkspaceMembershipMock,
+    errorResponse: (message: string, status: number) =>
+      NextResponse.json({ error: message }, { status }),
+    successResponse: <T>(data: T, status = 200) => NextResponse.json(data, { status }),
+  };
+});
+
+vi.mock("@/lib/email", () => ({
+  sendInviteEmail: sendInviteEmailMock,
+}));
+
+import { POST } from "./route";
+
+function post(body: unknown) {
+  return POST(
+    new Request("http://t/api", { method: "POST", body: JSON.stringify(body) }) as never,
+    { params: Promise.resolve({ workspaceId: "w1" }) } as never,
+  );
+}
+
+describe("workspace invites POST seat limit", () => {
+  beforeEach(() => {
+    requireWorkspaceMembershipMock.mockReset().mockResolvedValue({
+      membership: { workspaceId: "w1", userId: "u1", role: "ADMIN" },
+    });
+    userFindUnique.mockReset().mockResolvedValue(null);
+    memberFindUnique.mockReset().mockResolvedValue(null);
+    inviteFindUnique.mockReset().mockResolvedValue(null);
+    inviteCreate.mockReset().mockResolvedValue({
+      id: "inv1",
+      email: "new@x.com",
+      role: "MEMBER",
+      createTime: new Date(),
+      invitedBy: null,
+      workspace: { name: "Acme" },
+    });
+    sendInviteEmailMock.mockReset().mockResolvedValue(undefined);
+    workspaceFindUnique.mockReset().mockResolvedValue({
+      id: "w1",
+      billingPlan: "free",
+      _count: { members: 1, invites: 0 },
+    });
+  });
+
+  it("rejects at the seat limit and does not create an invite", async () => {
+    workspaceFindUnique.mockResolvedValue({
+      id: "w1",
+      billingPlan: "free",
+      _count: { members: 2, invites: 0 },
+    });
+    const res = await post({ email: "new@x.com", role: "MEMBER" });
+    expect(res.status).toBe(403);
+    expect(inviteCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects when members + pending invites hit the cap", async () => {
+    workspaceFindUnique.mockResolvedValue({
+      id: "w1",
+      billingPlan: "free",
+      _count: { members: 1, invites: 1 },
+    });
+    const res = await post({ email: "new@x.com", role: "MEMBER" });
+    expect(res.status).toBe(403);
+    expect(inviteCreate).not.toHaveBeenCalled();
+  });
+
+  it("succeeds under the seat limit", async () => {
+    const res = await post({ email: "new@x.com", role: "MEMBER" });
+    expect(res.status).toBe(201);
+    expect(inviteCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects when the target email already belongs to a member", async () => {
+    userFindUnique.mockResolvedValue({ id: "u2", email: "new@x.com" });
+    memberFindUnique.mockResolvedValue({ id: "existing" });
+    const res = await post({ email: "new@x.com", role: "MEMBER" });
+    expect(res.status).toBe(409);
+    expect(workspaceFindUnique).not.toHaveBeenCalled();
+    expect(inviteCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a duplicate invite for the same email before checking the seat limit", async () => {
+    inviteFindUnique.mockResolvedValue({ id: "inv-existing" });
+    const res = await post({ email: "new@x.com", role: "MEMBER" });
+    expect(res.status).toBe(409);
+    expect(workspaceFindUnique).not.toHaveBeenCalled();
+    expect(inviteCreate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/invites/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/invites/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma, Role, RoleSchema, getSeatLimit, canAddSeat, PlanType } from "@traceroot/core";
+import {
+  prisma,
+  Role,
+  RoleSchema,
+  countCurrentSeats,
+  getSeatLimit,
+  canAddSeat,
+  PlanType,
+} from "@traceroot/core";
 import {
   requireAuth,
   requireWorkspaceMembership,
@@ -132,7 +140,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   }
 
   const plan = (workspace.billingPlan || PlanType.FREE) as PlanType;
-  const currentSeats = workspace._count.members + workspace._count.invites;
+  const currentSeats = countCurrentSeats(workspace._count);
   const seatLimit = getSeatLimit(plan);
 
   if (!canAddSeat(plan, currentSeats)) {

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
@@ -6,7 +6,6 @@ const {
   memberFindUnique,
   memberCreate,
   inviteFindUnique,
-  inviteDelete,
   inviteDeleteMany,
   requireWorkspaceMembershipMock,
 } = vi.hoisted(() => ({
@@ -15,7 +14,6 @@ const {
   memberFindUnique: vi.fn(),
   memberCreate: vi.fn(),
   inviteFindUnique: vi.fn(),
-  inviteDelete: vi.fn(),
   inviteDeleteMany: vi.fn(),
   requireWorkspaceMembershipMock: vi.fn(),
 }));
@@ -28,7 +26,7 @@ vi.mock("@traceroot/core", async (orig) => {
       workspace: { findUnique: workspaceFindUnique },
       user: { findUnique: userFindUnique },
       workspaceMember: { findUnique: memberFindUnique, create: memberCreate },
-      invite: { findUnique: inviteFindUnique, delete: inviteDelete, deleteMany: inviteDeleteMany },
+      invite: { findUnique: inviteFindUnique, deleteMany: inviteDeleteMany },
       $transaction: vi.fn((ops: unknown[]) => Promise.all(ops)),
     },
   };
@@ -68,7 +66,6 @@ describe("workspace members POST seat limit", () => {
       .mockReset()
       .mockResolvedValue({ id: "m1", role: "MEMBER", createTime: new Date() });
     inviteFindUnique.mockReset().mockResolvedValue(null);
-    inviteDelete.mockReset().mockResolvedValue({ id: "inv1" });
     inviteDeleteMany.mockReset().mockResolvedValue({ count: 0 });
     workspaceFindUnique.mockReset().mockResolvedValue({
       id: "w1",
@@ -113,7 +110,7 @@ describe("workspace members POST seat limit", () => {
     const res = await post({ userId: "u2", role: "MEMBER" });
     expect(res.status).toBe(201);
     expect(memberCreate).toHaveBeenCalledTimes(1);
-    expect(inviteDelete).toHaveBeenCalledWith({ where: { id: "inv1" } });
+    expect(inviteDeleteMany).toHaveBeenCalledWith({ where: { id: "inv1" } });
   });
 
   it("succeeds under the seat limit", async () => {

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  workspaceFindUnique,
+  userFindUnique,
+  memberFindUnique,
+  memberCreate,
+  requireWorkspaceMembershipMock,
+} = vi.hoisted(() => ({
+  workspaceFindUnique: vi.fn(),
+  userFindUnique: vi.fn(),
+  memberFindUnique: vi.fn(),
+  memberCreate: vi.fn(),
+  requireWorkspaceMembershipMock: vi.fn(),
+}));
+
+vi.mock("@traceroot/core", async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>);
+  return {
+    ...actual,
+    prisma: {
+      workspace: { findUnique: workspaceFindUnique },
+      user: { findUnique: userFindUnique },
+      workspaceMember: { findUnique: memberFindUnique, create: memberCreate },
+    },
+  };
+});
+
+// Auth/access helpers. The real module pulls in env-validated auth config, so
+// stub the whole module: open the gates and reimplement the pure response
+// helpers with NextResponse (their only behavior the handler relies on).
+vi.mock("@/lib/auth-helpers", async () => {
+  const { NextResponse } = await import("next/server");
+  return {
+    requireAuth: async () => ({ user: { id: "u1", email: null, name: null } }),
+    requireWorkspaceMembership: requireWorkspaceMembershipMock,
+    errorResponse: (message: string, status: number) =>
+      NextResponse.json({ error: message }, { status }),
+    successResponse: <T>(data: T, status = 200) => NextResponse.json(data, { status }),
+  };
+});
+
+import { POST } from "./route";
+
+function post(body: unknown) {
+  return POST(
+    new Request("http://t/api", { method: "POST", body: JSON.stringify(body) }) as never,
+    { params: Promise.resolve({ workspaceId: "w1" }) } as never,
+  );
+}
+
+describe("workspace members POST seat limit", () => {
+  beforeEach(() => {
+    requireWorkspaceMembershipMock.mockReset().mockResolvedValue({
+      membership: { workspaceId: "w1", userId: "u1", role: "ADMIN" },
+    });
+    userFindUnique.mockReset().mockResolvedValue({ id: "u2", email: "u2@x.com", name: "U2" });
+    memberFindUnique.mockReset().mockResolvedValue(null);
+    memberCreate
+      .mockReset()
+      .mockResolvedValue({ id: "m1", role: "MEMBER", createTime: new Date() });
+    workspaceFindUnique.mockReset().mockResolvedValue({
+      id: "w1",
+      billingPlan: "free",
+      _count: { members: 1, invites: 0 },
+    });
+  });
+
+  it("rejects at the seat limit and does not create a member", async () => {
+    workspaceFindUnique.mockResolvedValue({
+      id: "w1",
+      billingPlan: "free",
+      _count: { members: 2, invites: 0 },
+    });
+    const res = await post({ userId: "u2", role: "MEMBER" });
+    expect(res.status).toBe(403);
+    expect(memberCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects when members + pending invites hit the cap", async () => {
+    workspaceFindUnique.mockResolvedValue({
+      id: "w1",
+      billingPlan: "free",
+      _count: { members: 1, invites: 1 },
+    });
+    const res = await post({ userId: "u2", role: "MEMBER" });
+    expect(res.status).toBe(403);
+    expect(memberCreate).not.toHaveBeenCalled();
+  });
+
+  it("succeeds under the seat limit", async () => {
+    const res = await post({ userId: "u2", role: "MEMBER" });
+    expect(res.status).toBe(201);
+    expect(memberCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("succeeds on an unlimited plan even past the free cap", async () => {
+    workspaceFindUnique.mockResolvedValue({
+      id: "w1",
+      billingPlan: "pro",
+      _count: { members: 10, invites: 0 },
+    });
+    const res = await post({ userId: "u2", role: "MEMBER" });
+    expect(res.status).toBe(201);
+  });
+
+  it("succeeds when billing is disabled even past the free cap", async () => {
+    const original = process.env.ENABLE_BILLING;
+    process.env.ENABLE_BILLING = "false";
+    try {
+      workspaceFindUnique.mockResolvedValue({
+        id: "w1",
+        billingPlan: "free",
+        _count: { members: 5, invites: 0 },
+      });
+      const res = await post({ userId: "u2", role: "MEMBER" });
+      expect(res.status).toBe(201);
+    } finally {
+      process.env.ENABLE_BILLING = original;
+    }
+  });
+
+  it("rejects non-ADMIN before ever checking the seat limit", async () => {
+    const { NextResponse } = await import("next/server");
+    requireWorkspaceMembershipMock.mockResolvedValue({
+      error: NextResponse.json({ error: "Requires ADMIN role or higher" }, { status: 403 }),
+    });
+    const res = await post({ userId: "u2", role: "MEMBER" });
+    expect(res.status).toBe(403);
+    expect(workspaceFindUnique).not.toHaveBeenCalled();
+  });
+
+  it("rejects a duplicate membership before ever checking the seat limit", async () => {
+    memberFindUnique.mockResolvedValue({ id: "existing" });
+    const res = await post({ userId: "u2", role: "MEMBER" });
+    expect(res.status).toBe(409);
+    expect(workspaceFindUnique).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
@@ -1,16 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const {
   workspaceFindUnique,
   userFindUnique,
   memberFindUnique,
   memberCreate,
+  inviteFindUnique,
+  inviteDelete,
   requireWorkspaceMembershipMock,
 } = vi.hoisted(() => ({
   workspaceFindUnique: vi.fn(),
   userFindUnique: vi.fn(),
   memberFindUnique: vi.fn(),
   memberCreate: vi.fn(),
+  inviteFindUnique: vi.fn(),
+  inviteDelete: vi.fn(),
   requireWorkspaceMembershipMock: vi.fn(),
 }));
 
@@ -22,6 +26,8 @@ vi.mock("@traceroot/core", async (orig) => {
       workspace: { findUnique: workspaceFindUnique },
       user: { findUnique: userFindUnique },
       workspaceMember: { findUnique: memberFindUnique, create: memberCreate },
+      invite: { findUnique: inviteFindUnique, delete: inviteDelete },
+      $transaction: vi.fn((ops: unknown[]) => Promise.all(ops)),
     },
   };
 });
@@ -59,11 +65,17 @@ describe("workspace members POST seat limit", () => {
     memberCreate
       .mockReset()
       .mockResolvedValue({ id: "m1", role: "MEMBER", createTime: new Date() });
+    inviteFindUnique.mockReset().mockResolvedValue(null);
+    inviteDelete.mockReset().mockResolvedValue({ id: "inv1" });
     workspaceFindUnique.mockReset().mockResolvedValue({
       id: "w1",
       billingPlan: "free",
       _count: { members: 1, invites: 0 },
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it("rejects at the seat limit and does not create a member", async () => {
@@ -88,6 +100,19 @@ describe("workspace members POST seat limit", () => {
     expect(memberCreate).not.toHaveBeenCalled();
   });
 
+  it("excludes the target's own pending invite from the seat count and deletes it", async () => {
+    workspaceFindUnique.mockResolvedValue({
+      id: "w1",
+      billingPlan: "free",
+      _count: { members: 1, invites: 1 },
+    });
+    inviteFindUnique.mockResolvedValue({ id: "inv1", email: "u2@x.com", workspaceId: "w1" });
+    const res = await post({ userId: "u2", role: "MEMBER" });
+    expect(res.status).toBe(201);
+    expect(memberCreate).toHaveBeenCalledTimes(1);
+    expect(inviteDelete).toHaveBeenCalledWith({ where: { id: "inv1" } });
+  });
+
   it("succeeds under the seat limit", async () => {
     const res = await post({ userId: "u2", role: "MEMBER" });
     expect(res.status).toBe(201);
@@ -105,19 +130,14 @@ describe("workspace members POST seat limit", () => {
   });
 
   it("succeeds when billing is disabled even past the free cap", async () => {
-    const original = process.env.ENABLE_BILLING;
-    process.env.ENABLE_BILLING = "false";
-    try {
-      workspaceFindUnique.mockResolvedValue({
-        id: "w1",
-        billingPlan: "free",
-        _count: { members: 5, invites: 0 },
-      });
-      const res = await post({ userId: "u2", role: "MEMBER" });
-      expect(res.status).toBe(201);
-    } finally {
-      process.env.ENABLE_BILLING = original;
-    }
+    vi.stubEnv("ENABLE_BILLING", "false");
+    workspaceFindUnique.mockResolvedValue({
+      id: "w1",
+      billingPlan: "free",
+      _count: { members: 5, invites: 0 },
+    });
+    const res = await post({ userId: "u2", role: "MEMBER" });
+    expect(res.status).toBe(201);
   });
 
   it("rejects non-ADMIN before ever checking the seat limit", async () => {

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
@@ -156,4 +156,13 @@ describe("workspace members POST seat limit", () => {
     expect(res.status).toBe(409);
     expect(workspaceFindUnique).not.toHaveBeenCalled();
   });
+
+  it("cleans up a stale invite when the target is already a member (legacy data)", async () => {
+    memberFindUnique.mockResolvedValue({ id: "existing" });
+    inviteFindUnique.mockResolvedValue({ id: "inv1", email: "u2@x.com", workspaceId: "w1" });
+    const res = await post({ userId: "u2", role: "MEMBER" });
+    expect(res.status).toBe(409);
+    expect(inviteDelete).toHaveBeenCalledWith({ where: { id: "inv1" } });
+    expect(workspaceFindUnique).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.test.ts
@@ -7,6 +7,7 @@ const {
   memberCreate,
   inviteFindUnique,
   inviteDelete,
+  inviteDeleteMany,
   requireWorkspaceMembershipMock,
 } = vi.hoisted(() => ({
   workspaceFindUnique: vi.fn(),
@@ -15,6 +16,7 @@ const {
   memberCreate: vi.fn(),
   inviteFindUnique: vi.fn(),
   inviteDelete: vi.fn(),
+  inviteDeleteMany: vi.fn(),
   requireWorkspaceMembershipMock: vi.fn(),
 }));
 
@@ -26,7 +28,7 @@ vi.mock("@traceroot/core", async (orig) => {
       workspace: { findUnique: workspaceFindUnique },
       user: { findUnique: userFindUnique },
       workspaceMember: { findUnique: memberFindUnique, create: memberCreate },
-      invite: { findUnique: inviteFindUnique, delete: inviteDelete },
+      invite: { findUnique: inviteFindUnique, delete: inviteDelete, deleteMany: inviteDeleteMany },
       $transaction: vi.fn((ops: unknown[]) => Promise.all(ops)),
     },
   };
@@ -67,6 +69,7 @@ describe("workspace members POST seat limit", () => {
       .mockResolvedValue({ id: "m1", role: "MEMBER", createTime: new Date() });
     inviteFindUnique.mockReset().mockResolvedValue(null);
     inviteDelete.mockReset().mockResolvedValue({ id: "inv1" });
+    inviteDeleteMany.mockReset().mockResolvedValue({ count: 0 });
     workspaceFindUnique.mockReset().mockResolvedValue({
       id: "w1",
       billingPlan: "free",
@@ -159,10 +162,12 @@ describe("workspace members POST seat limit", () => {
 
   it("cleans up a stale invite when the target is already a member (legacy data)", async () => {
     memberFindUnique.mockResolvedValue({ id: "existing" });
-    inviteFindUnique.mockResolvedValue({ id: "inv1", email: "u2@x.com", workspaceId: "w1" });
+    inviteDeleteMany.mockResolvedValue({ count: 1 });
     const res = await post({ userId: "u2", role: "MEMBER" });
     expect(res.status).toBe(409);
-    expect(inviteDelete).toHaveBeenCalledWith({ where: { id: "inv1" } });
+    expect(inviteDeleteMany).toHaveBeenCalledWith({
+      where: { email: "u2@x.com", workspaceId: "w1" },
+    });
     expect(workspaceFindUnique).not.toHaveBeenCalled();
   });
 });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma, Role, RoleSchema } from "@traceroot/core";
+import { prisma, Role, RoleSchema, getSeatLimit, canAddSeat, PlanType } from "@traceroot/core";
 import {
   requireAuth,
   requireWorkspaceMembership,
@@ -99,6 +99,37 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
   if (existingMembership) {
     return errorResponse("User is already a member of this workspace", 409);
+  }
+
+  // Check seat limit before adding member. Counts members + pending invites
+  // (mirrors invite-create) since an outstanding invite can still be
+  // accepted later; see the accept route for why it counts members only.
+  const workspace = await prisma.workspace.findUnique({
+    where: { id: workspaceId },
+    include: {
+      _count: {
+        select: {
+          members: true,
+          invites: true,
+        },
+      },
+    },
+  });
+
+  if (!workspace) {
+    return errorResponse("Workspace not found", 404);
+  }
+
+  const plan = (workspace.billingPlan || PlanType.FREE) as PlanType;
+  const currentSeats = workspace._count.members + workspace._count.invites;
+  const seatLimit = getSeatLimit(plan);
+
+  if (!canAddSeat(plan, currentSeats)) {
+    return errorResponse(
+      `Your ${plan} plan is limited to ${seatLimit} seat${seatLimit === 1 ? "" : "s"}. ` +
+        `Upgrade your plan to add more members.`,
+      403,
+    );
   }
 
   const membershipId = crypto.randomUUID();

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
@@ -1,6 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma, Role, RoleSchema, getSeatLimit, canAddSeat, PlanType } from "@traceroot/core";
+import {
+  prisma,
+  Role,
+  RoleSchema,
+  countCurrentSeats,
+  getSeatLimit,
+  canAddSeat,
+  PlanType,
+} from "@traceroot/core";
 import {
   requireAuth,
   requireWorkspaceMembership,
@@ -143,8 +151,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   });
 
   const plan = (workspace.billingPlan || PlanType.FREE) as PlanType;
-  const currentSeats =
-    workspace._count.members + workspace._count.invites - (pendingInvite ? 1 : 0);
+  const currentSeats = countCurrentSeats(workspace._count, { supersedesInvite: !!pendingInvite });
   const seatLimit = getSeatLimit(plan);
 
   if (!canAddSeat(plan, currentSeats)) {
@@ -166,10 +173,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     },
   });
 
+  // deleteMany (not delete): a concurrent request that already removed this
+  // same invite must not fail the whole transaction and roll back a
+  // legitimate membership create — mirrors the 409 branch's race-safety fix.
   const [membership] = pendingInvite
     ? await prisma.$transaction([
         createMembership,
-        prisma.invite.delete({ where: { id: pendingInvite.id } }),
+        prisma.invite.deleteMany({ where: { id: pendingInvite.id } }),
       ])
     : await prisma.$transaction([createMembership]);
 

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
@@ -100,19 +100,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   if (existingMembership) {
     // Self-healing for legacy data: routes prior to this fix could create a
     // membership without deleting the matching invite (mirrors accept-route's
-    // cleanup on its own already-a-member branch).
-    const staleInvite = await prisma.invite.findUnique({
-      where: {
-        email_workspaceId: {
-          email: targetUser.email.toLowerCase(),
-          workspaceId,
-        },
-      },
+    // cleanup on its own already-a-member branch). deleteMany is a no-op
+    // (not a throw) when no row matches, so a concurrent request that
+    // already cleaned up the same stale invite can't turn this best-effort
+    // cleanup into an unhandled 500.
+    await prisma.invite.deleteMany({
+      where: { email: targetUser.email.toLowerCase(), workspaceId },
     });
-
-    if (staleInvite) {
-      await prisma.invite.delete({ where: { id: staleInvite.id } });
-    }
 
     return errorResponse("User is already a member of this workspace", 409);
   }

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
@@ -120,8 +120,21 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return errorResponse("Workspace not found", 404);
   }
 
+  // A pending invite for this user's email is about to be superseded by the
+  // direct membership created below, so it must not be double-counted
+  // against the seat limit (mirrors invite-accept's own transaction).
+  const pendingInvite = await prisma.invite.findUnique({
+    where: {
+      email_workspaceId: {
+        email: targetUser.email.toLowerCase(),
+        workspaceId,
+      },
+    },
+  });
+
   const plan = (workspace.billingPlan || PlanType.FREE) as PlanType;
-  const currentSeats = workspace._count.members + workspace._count.invites;
+  const currentSeats =
+    workspace._count.members + workspace._count.invites - (pendingInvite ? 1 : 0);
   const seatLimit = getSeatLimit(plan);
 
   if (!canAddSeat(plan, currentSeats)) {
@@ -134,7 +147,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
   const membershipId = crypto.randomUUID();
 
-  const membership = await prisma.workspaceMember.create({
+  const createMembership = prisma.workspaceMember.create({
     data: {
       id: membershipId,
       workspaceId,
@@ -142,6 +155,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       role,
     },
   });
+
+  const [membership] = pendingInvite
+    ? await prisma.$transaction([
+        createMembership,
+        prisma.invite.delete({ where: { id: pendingInvite.id } }),
+      ])
+    : await prisma.$transaction([createMembership]);
 
   return NextResponse.json(
     {

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/members/route.ts
@@ -98,6 +98,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   });
 
   if (existingMembership) {
+    // Self-healing for legacy data: routes prior to this fix could create a
+    // membership without deleting the matching invite (mirrors accept-route's
+    // cleanup on its own already-a-member branch).
+    const staleInvite = await prisma.invite.findUnique({
+      where: {
+        email_workspaceId: {
+          email: targetUser.email.toLowerCase(),
+          workspaceId,
+        },
+      },
+    });
+
+    if (staleInvite) {
+      await prisma.invite.delete({ where: { id: staleInvite.id } });
+    }
+
     return errorResponse("User is already a member of this workspace", 409);
   }
 


### PR DESCRIPTION
Fixes #1505

## Summary

`POST /api/workspaces/[workspaceId]/members` skipped the seat-limit check that both invite paths already enforce. A workspace ADMIN could bypass the plan's seat cap by adding members directly instead of inviting them.

## Type of Change

- [x] fix - A bug fix

## Details

- Added the same `canAddSeat` check the invite-create path already uses (count members + pending invites) to the direct-add route, before creating the membership.
- Added a comment on invite-accept explaining why it intentionally counts members only, not `+ invites`. The invite being accepted is deleted in the same transaction, so counting it there would double-count it against itself.
- The seat check runs after the existing auth/role/user-exists/duplicate-membership checks, so their error precedence is unchanged.
- TOCTOU (the check-then-create isn't atomic) is a pre-existing gap shared with the invite paths and is out of scope here, per the issue.

## Screenshots / Recordings (if applicable)

N/A, backend-only change with no UI.

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (N/A, no UI change)
- [x] I have updated documentation where necessary (N/A, no doc-facing behavior change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces seat limits on direct workspace member adds, fixes double‑counting when a pending invite exists, and self‑heals stale invites with race‑safe deletes. Adds a shared `countCurrentSeats` helper in `@traceroot/core` and uses it across member and invite routes.

- **Bug Fixes**
  - Members POST: run seat check with `getSeatLimit`, `canAddSeat`, and `countCurrentSeats`; if a matching invite exists, subtract it from the count and remove it in the same transaction with `invite.deleteMany`.
  - Already-a-member: clean up any stale invite with `deleteMany` to avoid race errors; success-path transaction also uses `deleteMany` for the same reason.
  - Invites POST: switched to `countCurrentSeats` instead of inline math; invite-accept documents why it counts members only. Added tests for both routes, cap enforcement, invite exclusion/cleanup, unlimited plans or billing disabled (`vi.stubEnv`), and error precedence.

<sup>Written for commit 87101e3321397b0bc3de56cb015a96384fa05c94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

