### PR TITLE
feat(ui): persist the date-filter selection per project across pages

### DIFF
--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -2,6 +2,7 @@
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, Widget } from "../types";
+import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
 import { WidgetBuilderPage } from "./WidgetBuilderPage";
 
 // Radix Select opens on pointerdown and relies on pointer-capture APIs jsdom
@@ -133,8 +134,40 @@ describe("WidgetBuilderPage", () => {
     updateWidget.mutate.mockReset();
     updateWidget.isPending = false;
     updateWidget.error = null;
+    localStorage.clear();
     mockDashboard(DASHBOARD);
     mockPreview({});
+  });
+
+  it("adopts the project's persisted range and persists a picked preset", async () => {
+    localStorage.setItem(dateFilterStorageKey("p1"), JSON.stringify({ id: "7d" }));
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    // The preview dropdown adopts the stored selection after mount…
+    expect(await screen.findByText("Last 7 days")).toBeTruthy();
+
+    // …and picking a preset writes the shared store for the other pages.
+    fireEvent.pointerDown(screen.getByText("Last 7 days").closest("button") as HTMLElement, {
+      button: 0,
+      pointerType: "mouse",
+    });
+    fireEvent.click(await screen.findByText("Last 30 days"));
+    expect(readStoredDateFilter("p1")).toEqual({ id: "30d" });
+  });
+
+  it("leaves a stored custom range untouched and previews the shared default", () => {
+    const custom = {
+      id: "custom",
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-07-02T00:00:00.000Z",
+    };
+    localStorage.setItem(dateFilterStorageKey("p1"), JSON.stringify(custom));
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+
+    // The preset-only dropdown can't express custom: default preview window,
+    // stored preference preserved for the pages that can render it.
+    expect(screen.getByText("Last 24 hours")).toBeTruthy();
+    expect(readStoredDateFilter("p1")).toEqual(custom);
   });
 
   it("renders the two config sections with save disabled on a fresh draft", () => {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -23,6 +23,7 @@ import {
 import { useDashboard, useDashboardMutations } from "../hooks/use-dashboards";
 import { useWidgetPreview, useWidgetSchema } from "../hooks/use-widget-data";
 import { DEFAULT_RANGE_ID, RANGE_PRESETS, makeRange } from "../range-presets";
+import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-storage";
 import {
   BREAKDOWN_REQUIRED_DISPLAYS,
   DISPLAY_TYPES,
@@ -93,12 +94,21 @@ export function WidgetBuilderPage({
   const [title, setTitle] = useState("");
   const [titleLocked, setTitleLocked] = useState(isEdit);
 
-  // The page doesn't inherit the dashboard's picked range; the preview gets
-  // its own preset dropdown. Presets and default come from the shared
-  // date-filter module (via range-presets.ts) so the preview window always
-  // matches the trace list's and dashboard page's vocabulary and 24h default.
-  // Preview-only, not persisted.
+  // The preview shares the project's persisted date-filter selection: it
+  // adopts the stored preset after mount (post-mount so hydration never
+  // mismatches) and picking a preset here writes it back, carrying to the
+  // dashboard and trace list too. The store may hold "custom", which the
+  // preview's preset-only dropdown can't express — that stays at the shared
+  // 24h default and is left untouched in the store.
   const [rangeId, setRangeId] = useState<string>(DEFAULT_RANGE_ID);
+  useEffect(() => {
+    const stored = readStoredDateFilter(projectId);
+    if (stored && RANGE_PRESETS.some((p) => p.id === stored.id)) setRangeId(stored.id);
+  }, [projectId]);
+  const handleRangePick = (id: string) => {
+    setRangeId(id);
+    writeStoredDateFilter(projectId, { id });
+  };
   const range = useMemo(() => makeRange(rangeId), [rangeId]);
 
   // ── edit mode: hydrate once the widget arrives, guard bad targets ─────────
@@ -522,7 +532,7 @@ export function WidgetBuilderPage({
                   <DropdownMenuItem
                     key={preset.id}
                     className="text-[12px]"
-                    onClick={() => setRangeId(preset.id)}
+                    onClick={() => handleRangePick(preset.id)}
                   >
                     {preset.label}
                   </DropdownMenuItem>

--- a/frontend/ui/src/lib/date-filter-storage.ts
+++ b/frontend/ui/src/lib/date-filter-storage.ts
@@ -1,0 +1,30 @@
+import { readStored, writeStored } from "@/lib/hooks/use-local-storage";
+
+/**
+ * Per-project, per-browser persistence for the shared date-filter selection.
+ * Every windowed surface (trace list, dashboards, detectors, the widget
+ * builder's preview) reads and writes the same slot, so picking a range on
+ * one page carries to all of them. An explicit `?date_filter=` URL parameter
+ * still wins on the page it targets — shared links show the sender's view —
+ * but only a user action writes the preference.
+ */
+export interface StoredDateFilter {
+  id: string;
+  /** ISO timestamps, present only when id === "custom". */
+  start?: string;
+  end?: string;
+}
+
+export function dateFilterStorageKey(projectId: string): string {
+  return `traceroot:date-filter:v1:${projectId}`;
+}
+
+export function readStoredDateFilter(projectId: string): StoredDateFilter | null {
+  const stored = readStored<StoredDateFilter | null>(dateFilterStorageKey(projectId), null);
+  if (!stored || typeof stored.id !== "string") return null;
+  return stored;
+}
+
+export function writeStoredDateFilter(projectId: string, value: StoredDateFilter): void {
+  writeStored(dateFilterStorageKey(projectId), value);
+}

--- a/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-list-page-state.test.tsx
@@ -10,6 +10,8 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => currentParams,
   useRouter: () => ({ replace }),
   usePathname: () => "/traces",
+  // The date filter persists its selection per project via useParams.
+  useParams: () => ({ projectId: "p1" }),
 }));
 
 import { useListPageState } from "./use-list-page-state";

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
@@ -1,6 +1,8 @@
 // @vitest-environment jsdom
 import { renderHook, act, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactNode } from "react";
 import { DATE_FILTER_OPTIONS, findDateFilterOption } from "@/lib/date-filter";
 import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
 import { useUrlDateFilter } from "./use-url-date-filter";
@@ -131,5 +133,39 @@ describe("useUrlDateFilter persistence", () => {
       expect(result.current.dateFilter.id).toBe(DATE_FILTER_OPTIONS.find((o) => o.id === "1d")!.id),
     );
     expect(result.current.customStartDate).toBeNull();
+  });
+
+  it("settles data queries on the restored window, not the default", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
+    const fetchSpy = vi.fn(async (bounds: unknown) => ({ bounds }));
+
+    // Mirror how pages consume the hook: a react-query query keyed on the
+    // effective window. Restoration runs in a layout effect (pre-paint), so
+    // the restored window is what the page settles on; react-query may still
+    // start-and-supersede one default-window fetch during the same commit —
+    // accepted, invisible to the user.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const { result } = renderHook(
+      () => {
+        const filter = useUrlDateFilter();
+        const query = useQuery({
+          queryKey: ["window", filter.timestamps.startAfter, filter.timestamps.endBefore],
+          queryFn: () => fetchSpy(filter.timestamps),
+        });
+        return { filter, query };
+      },
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+    expect(result.current.filter.dateFilter.id).toBe("7d");
+    const fetchedWindowMs =
+      new Date(result.current.filter.timestamps.endBefore ?? Date.now()).getTime() -
+      new Date(result.current.filter.timestamps.startAfter!).getTime();
+    expect(Math.round(fetchedWindowMs / 86_400_000)).toBe(7);
+    client.clear();
   });
 });

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DATE_FILTER_OPTIONS, findDateFilterOption } from "@/lib/date-filter";
+import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
+import { useUrlDateFilter } from "./use-url-date-filter";
+
+const replace = vi.fn();
+let search = "";
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(search),
+  useRouter: () => ({ replace }),
+  usePathname: () => "/projects/p1/traces",
+  useParams: () => ({ projectId: "p1" }),
+}));
+
+const KEY = dateFilterStorageKey("p1");
+
+beforeEach(() => {
+  search = "";
+  localStorage.clear();
+});
+afterEach(() => {
+  replace.mockReset();
+});
+
+describe("useUrlDateFilter persistence", () => {
+  it("adopts the stored per-project preset when the URL has no filter", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
+
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("7d"));
+  });
+
+  it("lets an explicit URL filter win over the stored preference", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
+    search = "date_filter=30m";
+
+    const { result, rerender } = renderHook(() => useUrlDateFilter());
+
+    expect(result.current.dateFilter.id).toBe("30m");
+    // Flush effects, then pin that adopting the link never wrote the store.
+    rerender();
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("30m"));
+    expect(readStoredDateFilter("p1")?.id).toBe("7d");
+  });
+
+  it("resets pagination when restoring changes the effective window", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "7d" }));
+    const onFilterChange = vi.fn();
+
+    const { result } = renderHook(() => useUrlDateFilter(onFilterChange));
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("7d"));
+    expect(onFilterChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire the change callback when the stored value matches the default", () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "1d" }));
+    const onFilterChange = vi.fn();
+
+    renderHook(() => useUrlDateFilter(onFilterChange));
+
+    expect(onFilterChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores a stored custom range with inverted bounds", async () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        id: "custom",
+        start: "2026-07-02T00:00:00.000Z",
+        end: "2026-07-01T00:00:00.000Z",
+      }),
+    );
+
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    await waitFor(() => expect(result.current.dateFilter.id).toBe("1d"));
+    expect(result.current.customStartDate).toBeNull();
+  });
+
+  it("persists a picked preset so other pages can adopt it", () => {
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    act(() => result.current.setDateFilter(findDateFilterOption("30d")));
+
+    expect(readStoredDateFilter("p1")).toEqual({ id: "30d" });
+    expect(result.current.dateFilter.id).toBe("30d");
+  });
+
+  it("persists a custom range with its bounds", () => {
+    const { result } = renderHook(() => useUrlDateFilter());
+    const start = new Date("2026-07-01T00:00:00Z");
+    const end = new Date("2026-07-02T00:00:00Z");
+
+    act(() => result.current.setCustomRange(start, end));
+
+    expect(readStoredDateFilter("p1")).toEqual({
+      id: "custom",
+      start: start.toISOString(),
+      end: end.toISOString(),
+    });
+  });
+
+  it("restores a stored custom range, bounds included", async () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        id: "custom",
+        start: "2026-07-01T00:00:00.000Z",
+        end: "2026-07-02T00:00:00.000Z",
+      }),
+    );
+
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    await waitFor(() => expect(result.current.dateFilter.isCustom).toBe(true));
+    expect(result.current.customStartDate?.toISOString()).toBe("2026-07-01T00:00:00.000Z");
+    expect(result.current.customEndDate?.toISOString()).toBe("2026-07-02T00:00:00.000Z");
+  });
+
+  it("ignores a stored custom entry with unparseable bounds", async () => {
+    localStorage.setItem(KEY, JSON.stringify({ id: "custom", start: "garbage" }));
+
+    const { result } = renderHook(() => useUrlDateFilter());
+
+    // Nothing to adopt: stays at the shared default instead of a broken custom.
+    await waitFor(() =>
+      expect(result.current.dateFilter.id).toBe(DATE_FILTER_OPTIONS.find((o) => o.id === "1d")!.id),
+    );
+    expect(result.current.customStartDate).toBeNull();
+  });
+});

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.ts
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.ts
@@ -4,7 +4,7 @@
  * when present; otherwise the stored selection applies, so a range picked on
  * any page (trace list, dashboards, detectors) carries to all of them.
  */
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useState, useCallback, useMemo, useEffect, useLayoutEffect, useRef } from "react";
 import { useSearchParams, useRouter, usePathname, useParams } from "next/navigation";
 import {
   DEFAULT_DATE_FILTER,
@@ -14,6 +14,10 @@ import {
   type DateFilterOption,
 } from "@/lib/date-filter";
 import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-storage";
+
+// useLayoutEffect on the client, useEffect during SSR: layout effects never
+// run on the server, and React warns when a server render encounters one.
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
 interface UseUrlDateFilterReturn {
   dateFilter: DateFilterOption;
@@ -60,13 +64,17 @@ export function useUrlDateFilter(
   const onFilterChangeRef = useRef(onFilterChange);
   onFilterChangeRef.current = onFilterChange;
 
-  // Adopt the stored per-project selection once after mount, and only when the
+  // Adopt the stored per-project selection once at mount, and only when the
   // URL carries no explicit filter (a shared link's range must win on the page
-  // it targets). Running post-mount keeps server and first client render
-  // identical, so hydration never mismatches; a stored value differing from
-  // the default flashes once at the default — same tradeoff as useLocalStorage.
+  // it targets). The first render still shows the default — identical to the
+  // server HTML, so hydration never mismatches — but adopting in a LAYOUT
+  // effect re-renders before the browser paints, so the user never sees the
+  // default window. (react-query subscribes during the same commit, so a
+  // default-window fetch can still start and be superseded — invisible, but
+  // one extra backend query per hard load; eliminating it would mean gating
+  // every consumer query on a restoration flag.)
   const restoredRef = useRef(false);
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (restoredRef.current) return;
     restoredRef.current = true;
     if (!projectId || searchParams.get("date_filter")) return;
@@ -90,9 +98,9 @@ export function useUrlDateFilter(
     // The effective window changed under the page: consumers that paginate
     // must reset (a stale ?page_index can point past the restored window).
     onFilterChangeRef.current?.();
-    // dateFilter.id is read only on the once-guarded first run; re-running on
-    // its later changes is prevented by restoredRef.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // dateFilter.id is deliberately not a dependency: it's read only on the
+    // once-guarded first run, and restoredRef prevents any re-run. (The lint
+    // rule doesn't check custom-named hooks, so this documents what it can't.)
   }, [projectId, searchParams]);
 
   // Only explicit user actions persist: adopting a link's URL param must not

--- a/frontend/ui/src/lib/hooks/use-url-date-filter.ts
+++ b/frontend/ui/src/lib/hooks/use-url-date-filter.ts
@@ -1,9 +1,11 @@
 /**
- * Hook for managing date filter state synchronized with URL parameters.
- * This allows date filter state to persist across page navigation.
+ * Hook for managing date filter state synchronized with URL parameters and a
+ * per-project localStorage preference. The URL keeps links shareable and wins
+ * when present; otherwise the stored selection applies, so a range picked on
+ * any page (trace list, dashboards, detectors) carries to all of them.
  */
 import { useState, useCallback, useMemo, useEffect, useRef } from "react";
-import { useSearchParams, useRouter, usePathname } from "next/navigation";
+import { useSearchParams, useRouter, usePathname, useParams } from "next/navigation";
 import {
   DEFAULT_DATE_FILTER,
   DATE_FILTER_OPTIONS,
@@ -11,6 +13,7 @@ import {
   findDateFilterOption,
   type DateFilterOption,
 } from "@/lib/date-filter";
+import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-storage";
 
 interface UseUrlDateFilterReturn {
   dateFilter: DateFilterOption;
@@ -31,6 +34,8 @@ export function useUrlDateFilter(
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const routeParams = useParams();
+  const projectId = typeof routeParams?.projectId === "string" ? routeParams.projectId : null;
 
   // Read initial state from URL
   const urlDateFilterId = searchParams.get("date_filter");
@@ -54,6 +59,56 @@ export function useUrlDateFilter(
   // Use ref for callback to avoid dependency issues
   const onFilterChangeRef = useRef(onFilterChange);
   onFilterChangeRef.current = onFilterChange;
+
+  // Adopt the stored per-project selection once after mount, and only when the
+  // URL carries no explicit filter (a shared link's range must win on the page
+  // it targets). Running post-mount keeps server and first client render
+  // identical, so hydration never mismatches; a stored value differing from
+  // the default flashes once at the default — same tradeoff as useLocalStorage.
+  const restoredRef = useRef(false);
+  useEffect(() => {
+    if (restoredRef.current) return;
+    restoredRef.current = true;
+    if (!projectId || searchParams.get("date_filter")) return;
+    const stored = readStoredDateFilter(projectId);
+    if (!stored) return;
+    const option = findDateFilterOption(stored.id);
+    if (option.isCustom) {
+      const start = stored.start ? new Date(stored.start) : null;
+      const end = stored.end ? new Date(stored.end) : null;
+      // Parseable AND ordered: an inverted range would query start > end and
+      // silently return nothing everywhere.
+      if (!start || !end || isNaN(start.getTime()) || isNaN(end.getTime()) || end < start) return;
+      setCustomStartDateState(start);
+      setCustomEndDateState(end);
+    } else if (option.id === dateFilter.id) {
+      // Stored matches what's already showing — nothing to adopt.
+      return;
+    }
+    setDateFilterState(option);
+    setFilterVersion((v) => v + 1);
+    // The effective window changed under the page: consumers that paginate
+    // must reset (a stale ?page_index can point past the restored window).
+    onFilterChangeRef.current?.();
+    // dateFilter.id is read only on the once-guarded first run; re-running on
+    // its later changes is prevented by restoredRef.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId, searchParams]);
+
+  // Only explicit user actions persist: adopting a link's URL param must not
+  // overwrite the preference the user picked themselves.
+  const persistSelection = useCallback(
+    (id: string, start: Date | null, end: Date | null) => {
+      if (!projectId) return;
+      writeStoredDateFilter(
+        projectId,
+        id === "custom" && start && end
+          ? { id, start: start.toISOString(), end: end.toISOString() }
+          : { id },
+      );
+    },
+    [projectId],
+  );
 
   // Sync state from URL when it changes (e.g., navigating from another page)
   useEffect(() => {
@@ -114,11 +169,12 @@ export function useUrlDateFilter(
 
       if (!option.isCustom) {
         updateUrl(option.id, null, null);
+        persistSelection(option.id, null, null);
       }
 
       onFilterChangeRef.current?.();
     },
-    [updateUrl],
+    [updateUrl, persistSelection],
   );
 
   const setCustomRange = useCallback(
@@ -129,10 +185,11 @@ export function useUrlDateFilter(
       const customOption = DATE_FILTER_OPTIONS.find((o) => o.isCustom)!;
       setDateFilterState(customOption);
       updateUrl("custom", start, end);
+      persistSelection("custom", start, end);
 
       onFilterChangeRef.current?.();
     },
-    [updateUrl],
+    [updateUrl, persistSelection],
   );
 
   // Calculate timestamps


### PR DESCRIPTION
Stacked on #1524. Picking a time range anywhere now carries everywhere: the trace list, every dashboard, the detectors list, and the widget builder's preview share one per-project preference, surviving navigation, tab switches, builder round-trips, and reloads. (This also resolves the "range lost on builder round-trip / tab switch" notes from #1524's review.)

## How it works
- **One per-project localStorage slot** (`traceroot:date-filter:v1:{projectId}`, new `lib/date-filter-storage.ts` on the existing SSR-safe storage helpers). `useUrlDateFilter` adopts it when the URL carries no explicit filter and writes it on every user pick, so all its consumers get the behavior with no signature change.
- **URL still wins when present** — a shared link with `?date_filter=` shows the sender's view on that page, and following a link never overwrites the viewer's stored preference; only a user's own pick persists.
- **Custom ranges** persist their exact bounds and restore them (unparseable or inverted bounds are ignored). Restoring a different window fires the filter-change callback so paginated consumers reset instead of pointing a stale page index past the restored window.
- **The widget builder's preview** joins the same store: it adopts a stored preset and picking one writes it back. A stored custom range stays untouched there (the preset-only dropdown can't express it) and the preview falls back to the shared default.
- **No default-window flash**: restoration runs in a pre-paint layout effect, so the first visible frame is always the stored window while server HTML and first client render stay identical (no hydration mismatch). Known accepted residual, documented in-code: react-query subscribes during the same commit, so one superseded default-window fetch can still start on hard loads — eliminating it would mean gating every consumer query on a restoration flag.

Same shape as the equivalent feature in a reference product's table views (URL-wins-else-stored, per-project key, write-on-pick), extended to dashboards and made durable via localStorage rather than session-scoped.

advances #1459

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the date-filter selection per project across traces, dashboards, detectors, and the widget builder preview. URL `?date_filter=` still wins; stored selection restores pre‑paint to avoid flicker. Advances Linear #1459.

- **New Features**
  - One per‑project `localStorage` slot: `traceroot:date-filter:v1:{projectId}` via `lib/date-filter-storage.ts`.
  - `useUrlDateFilter` adopts the stored selection when the URL has no filter; only user picks persist; pagination resets when the effective window changes.
  - Custom ranges persist with bounds and restore if parseable and ordered; otherwise ignored.
  - Widget builder preview adopts a stored preset and writes back; if a custom range is stored, it shows the shared default without changing the store.

- **Bug Fixes**
  - Fixes losing the selected range on widget builder round‑trip and tab switch.
  - Removes the default-window flash by restoring in a layout effect; one superseded react-query fetch may still start on hard loads.

<sup>Written for commit 6b695dcf89ce58350382ba4fe556abf5a66c46cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Part of the project dashboards epic: #1460