### PR TITLE
fix(billing): don't show a bare 0 before the usage snapshot exists

### DIFF
--- a/frontend/ui/src/ee/features/billing/BillingTab.test.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.test.tsx
@@ -120,4 +120,21 @@ describe("BillingTab", () => {
     expect(screen.getByText("Spans")).toBeTruthy();
     expect(screen.getByText(/Last updated:/)).toBeTruthy();
   });
+
+  it("omits the quota suffix on total events for an unlimited plan", () => {
+    const usage: UsageStats = {
+      traces: 5,
+      spans: 3,
+      tokens: 0,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    };
+
+    render(
+      <BillingTab workspaceId="ws_1" currentPlan={PlanType.ENTERPRISE} currentUsage={usage} />,
+    );
+
+    const totalEventsRow = screen.getByText("Total events").closest("div");
+    expect(totalEventsRow?.textContent).toContain("8");
+    expect(totalEventsRow?.textContent).not.toContain("/");
+  });
 });

--- a/frontend/ui/src/ee/features/billing/BillingTab.test.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.test.tsx
@@ -95,4 +95,29 @@ describe("BillingTab", () => {
     expect(screen.queryByText("unknown")).toBeNull();
     expect(screen.getByText("claude-opus-4-8")).toBeTruthy();
   });
+
+  it("shows a not-yet-computed state instead of zero counts when no usage snapshot exists", () => {
+    render(<BillingTab workspaceId="ws_1" currentPlan={PlanType.FREE} currentUsage={null} />);
+
+    expect(screen.getByText(/Usage has not been computed yet/)).toBeTruthy();
+    expect(screen.queryByText("Traces")).toBeNull();
+    expect(screen.queryByText("Spans")).toBeNull();
+    expect(screen.queryByText("Total events")).toBeNull();
+  });
+
+  it("renders genuine zero counts when a computed snapshot reports zero usage", () => {
+    const usage: UsageStats = {
+      traces: 0,
+      spans: 0,
+      tokens: 0,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    };
+
+    render(<BillingTab workspaceId="ws_1" currentPlan={PlanType.FREE} currentUsage={usage} />);
+
+    expect(screen.queryByText(/Usage has not been computed yet/)).toBeNull();
+    expect(screen.getByText("Traces")).toBeTruthy();
+    expect(screen.getByText("Spans")).toBeTruthy();
+    expect(screen.getByText(/Last updated:/)).toBeTruthy();
+  });
 });

--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -263,28 +263,38 @@ export function BillingTab({
                 ? "Events used this billing period. Unlimited events included."
                 : `Events used this billing period. ${eventQuota.included.toLocaleString()} included, then ${eventQuota.overageLabel}.`}
           </p>
-          <div className="mt-3 space-y-2 text-sm">
-            <div className="flex justify-between">
-              <span className="text-muted-foreground">Traces</span>
-              <span>{(currentUsage?.traces ?? 0).toLocaleString()}</span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-muted-foreground">Spans</span>
-              <span>{(currentUsage?.spans ?? 0).toLocaleString()}</span>
-            </div>
-            <div className="-mx-4 flex justify-between border-t px-4 pt-2">
-              <span className="font-medium">Total events</span>
-              <span className="font-medium">
-                {((currentUsage?.traces ?? 0) + (currentUsage?.spans ?? 0)).toLocaleString()}
-                {eventQuota.included === Infinity
-                  ? ""
-                  : ` / ${eventQuota.included.toLocaleString()}`}
-              </span>
-            </div>
-          </div>
-          {currentUsage?.updatedAt && (
-            <p className="mt-2 text-xs text-muted-foreground">
-              Last updated: {new Date(currentUsage.updatedAt).toLocaleString()}
+          {currentUsage ? (
+            <>
+              <div className="mt-3 space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Traces</span>
+                  <span>{currentUsage.traces.toLocaleString()}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Spans</span>
+                  <span>{currentUsage.spans.toLocaleString()}</span>
+                </div>
+                <div className="-mx-4 flex justify-between border-t px-4 pt-2">
+                  <span className="font-medium">Total events</span>
+                  <span className="font-medium">
+                    {(currentUsage.traces + currentUsage.spans).toLocaleString()}
+                    {eventQuota.included === Infinity
+                      ? ""
+                      : ` / ${eventQuota.included.toLocaleString()}`}
+                  </span>
+                </div>
+              </div>
+              {currentUsage.updatedAt && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  Last updated: {new Date(currentUsage.updatedAt).toLocaleString()}
+                </p>
+              )}
+            </>
+          ) : (
+            // The snapshot is written by the hourly metering job; until its
+            // first run, usage is unknown — not zero.
+            <p className="mt-3 text-sm text-muted-foreground">
+              Usage has not been computed yet. Counts appear after the first metering run.
             </p>
           )}
         </div>

--- a/frontend/worker/src/ee/billing/__tests__/clickhouse.test.ts
+++ b/frontend/worker/src/ee/billing/__tests__/clickhouse.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getWorkspaceUsageDetails } from "../clickhouse.js";
+
+describe("getWorkspaceUsageDetails", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ traces: 3, spans: 7, detector_runs: 1 }),
+      }),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("bounds the internal API request with an AbortSignal timeout", async () => {
+    const result = await getWorkspaceUsageDetails({
+      projectIds: ["p1"],
+      start: new Date("2026-01-01T00:00:00Z"),
+      end: new Date("2026-02-01T00:00:00Z"),
+    });
+
+    expect(result).toEqual({ traces: 3, spans: 7, detectorRuns: 1 });
+    const [, options] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("short-circuits with zero counts and no fetch when there are no project ids", async () => {
+    const result = await getWorkspaceUsageDetails({
+      projectIds: [],
+      start: new Date(),
+      end: new Date(),
+    });
+
+    expect(result).toEqual({ traces: 0, spans: 0, detectorRuns: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/worker/src/ee/billing/__tests__/usageMetering.test.ts
+++ b/frontend/worker/src/ee/billing/__tests__/usageMetering.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import type Stripe from "stripe";
-import { reportRcaRunOverageToStripe } from "../usageMetering.js";
+import { reportRcaRunOverageToStripe, runStartupBillingPass } from "../usageMetering.js";
 
 function makeStripeStub(): {
   client: Stripe;
@@ -142,5 +142,18 @@ describe("RCA unit math", () => {
     expect(rcaUnitsForOverage(0, 2.0)).toBe(0); // no overage runs => no markup either (gated by caller)
     // Combined: 5 overage runs ($10 fee = 1000 units) + $2 token markup (210 units) = 1210
     expect(rcaUnitsForOverage(5, 2.0)).toBe(1210);
+  });
+});
+
+describe("runStartupBillingPass", () => {
+  it("runs the injected job", async () => {
+    const job = vi.fn().mockResolvedValue(undefined);
+    await runStartupBillingPass(job);
+    expect(job).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows a rejected job instead of throwing", async () => {
+    const job = vi.fn().mockRejectedValue(new Error("clickhouse down"));
+    await expect(runStartupBillingPass(job)).resolves.toBeUndefined();
   });
 });

--- a/frontend/worker/src/ee/billing/clickhouse.ts
+++ b/frontend/worker/src/ee/billing/clickhouse.ts
@@ -6,6 +6,9 @@
 const BACKEND_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
 const INTERNAL_API_SECRET = process.env.INTERNAL_API_SECRET || "";
 
+// A not-yet-ready backend (e.g. at worker startup) must not hang this call forever.
+const REQUEST_TIMEOUT_MS = 10_000;
+
 /**
  * Make an authenticated request to the internal backend API.
  */
@@ -23,6 +26,7 @@ async function internalApiRequest<T>(path: string, params?: Record<string, strin
       "Content-Type": "application/json",
       "X-Internal-Secret": INTERNAL_API_SECRET,
     },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
 
   if (!response.ok) {

--- a/frontend/worker/src/ee/billing/index.ts
+++ b/frontend/worker/src/ee/billing/index.ts
@@ -2,6 +2,6 @@
  * Billing module exports.
  */
 
-export { runBillingJob } from "./usageMetering.js";
+export { runBillingJob, runStartupBillingPass } from "./usageMetering.js";
 
 export { getWorkspaceUsageDetails, closeClickHouseClient } from "./clickhouse.js";

--- a/frontend/worker/src/ee/billing/usageMetering.ts
+++ b/frontend/worker/src/ee/billing/usageMetering.ts
@@ -93,6 +93,23 @@ export async function runBillingJob(): Promise<void> {
   }
 }
 
+/**
+ * Runs the billing job once, logging and swallowing any error instead of
+ * rethrowing — used for the worker's startup pass so a fresh boot writes
+ * the first usage snapshot within seconds instead of waiting for the next
+ * hourly cron tick. `job` is injectable for tests; defaults to runBillingJob.
+ */
+export async function runStartupBillingPass(
+  job: () => Promise<void> = runBillingJob,
+): Promise<void> {
+  console.log("[Billing] Running startup billing pass...");
+  try {
+    await job();
+  } catch (error) {
+    console.error("[Billing] Startup billing pass failed:", error);
+  }
+}
+
 async function processWorkspace(
   workspace: {
     id: string;

--- a/frontend/worker/src/index.test.ts
+++ b/frontend/worker/src/index.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const {
+  projectCount,
+  disconnect,
+  syncStandardPrices,
+  runBillingJob,
+  runStartupBillingPass,
+  closeClickHouseClient,
+  cronSchedule,
+} = vi.hoisted(() => ({
+  projectCount: vi.fn(),
+  disconnect: vi.fn(),
+  syncStandardPrices: vi.fn(),
+  runBillingJob: vi.fn(),
+  runStartupBillingPass: vi.fn(),
+  closeClickHouseClient: vi.fn(),
+  cronSchedule: vi.fn(),
+}));
+
+vi.mock("@traceroot/core", async (orig) => {
+  const actual = await (orig() as Promise<Record<string, unknown>>);
+  return {
+    ...actual,
+    prisma: {
+      project: { count: projectCount },
+      $disconnect: disconnect,
+    },
+    syncStandardPrices,
+  };
+});
+
+vi.mock("./ee/billing/index.js", () => ({
+  runBillingJob,
+  runStartupBillingPass,
+  closeClickHouseClient,
+}));
+
+vi.mock("node-cron", () => ({
+  default: { schedule: cronSchedule },
+}));
+
+describe("billing worker entrypoint", () => {
+  let sigtermHandler: (() => void | Promise<void>) | undefined;
+
+  beforeEach(() => {
+    vi.resetModules();
+    projectCount.mockReset().mockResolvedValue(3);
+    disconnect.mockReset().mockResolvedValue(undefined);
+    syncStandardPrices.mockReset().mockResolvedValue(undefined);
+    runBillingJob.mockReset().mockResolvedValue(undefined);
+    runStartupBillingPass.mockReset().mockResolvedValue(undefined);
+    closeClickHouseClient.mockReset().mockResolvedValue(undefined);
+    cronSchedule.mockReset();
+    sigtermHandler = undefined;
+
+    vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    vi.spyOn(process, "on").mockImplementation(((event: string, handler: () => void) => {
+      if (event === "SIGTERM") sigtermHandler = handler;
+      return process;
+    }) as typeof process.on);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("connects, syncs prices, schedules the hourly cron, and fires the startup pass", async () => {
+    await import("./index.js");
+
+    await vi.waitFor(() => expect(cronSchedule).toHaveBeenCalled());
+
+    expect(projectCount).toHaveBeenCalled();
+    expect(syncStandardPrices).toHaveBeenCalled();
+    expect(cronSchedule).toHaveBeenCalledWith("5 * * * *", expect.any(Function));
+    await vi.waitFor(() => expect(runStartupBillingPass).toHaveBeenCalled());
+  });
+
+  it("runs the scheduled billing job when the cron callback fires", async () => {
+    await import("./index.js");
+    await vi.waitFor(() => expect(cronSchedule).toHaveBeenCalled());
+    await vi.waitFor(() => expect(runStartupBillingPass).toHaveBeenCalled());
+
+    const [, cronCallback] = cronSchedule.mock.calls[0];
+    await cronCallback();
+
+    expect(runBillingJob).toHaveBeenCalled();
+  });
+
+  it("logs and swallows a rejected scheduled billing job instead of throwing", async () => {
+    runBillingJob.mockRejectedValue(new Error("clickhouse down"));
+
+    await import("./index.js");
+    await vi.waitFor(() => expect(cronSchedule).toHaveBeenCalled());
+    await vi.waitFor(() => expect(runStartupBillingPass).toHaveBeenCalled());
+
+    const [, cronCallback] = cronSchedule.mock.calls[0];
+    await expect(cronCallback()).resolves.toBeUndefined();
+  });
+
+  it("skips a concurrent cron tick while the startup pass is still in flight", async () => {
+    let resolveStartup: () => void = () => {};
+    runStartupBillingPass.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveStartup = resolve;
+        }),
+    );
+
+    await import("./index.js");
+    await vi.waitFor(() => expect(cronSchedule).toHaveBeenCalled());
+    await vi.waitFor(() => expect(runStartupBillingPass).toHaveBeenCalled());
+
+    const [, cronCallback] = cronSchedule.mock.calls[0];
+    await cronCallback();
+
+    expect(runBillingJob).not.toHaveBeenCalled();
+
+    resolveStartup();
+  });
+
+  it("shuts down cleanly on SIGTERM", async () => {
+    await import("./index.js");
+    await vi.waitFor(() => expect(cronSchedule).toHaveBeenCalled());
+
+    expect(sigtermHandler).toBeDefined();
+    await sigtermHandler?.();
+
+    expect(closeClickHouseClient).toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(0);
+  });
+});

--- a/frontend/worker/src/index.ts
+++ b/frontend/worker/src/index.ts
@@ -7,7 +7,7 @@
 
 import cron from "node-cron";
 import { prisma, syncStandardPrices } from "@traceroot/core";
-import { runBillingJob, closeClickHouseClient } from "./ee/billing/index.js";
+import { runBillingJob, runStartupBillingPass, closeClickHouseClient } from "./ee/billing/index.js";
 
 // Graceful shutdown handling
 let isShuttingDown = false;
@@ -46,6 +46,10 @@ async function main(): Promise<void> {
 
   // Sync standard model pricing from JSON → DB
   await syncStandardPrices();
+
+  // Run once immediately so the first usage snapshot lands within seconds
+  // of startup instead of waiting for the next cron tick (up to ~1h away).
+  await runStartupBillingPass();
 
   // Schedule billing job (default: every hour at minute 5)
   const billingCron = process.env.USAGE_METERING_CRON || "5 * * * *";

--- a/frontend/worker/src/index.ts
+++ b/frontend/worker/src/index.ts
@@ -12,6 +12,24 @@ import { runBillingJob, runStartupBillingPass, closeClickHouseClient } from "./e
 // Graceful shutdown handling
 let isShuttingDown = false;
 
+// Guards against a cron tick and the startup pass (or two overlapping cron
+// ticks) running runBillingJob() concurrently against the same stale
+// currentUsage, which would double-report overage deltas to Stripe.
+let billingPassInFlight = false;
+
+async function runExclusiveBillingPass(job: () => Promise<void>): Promise<void> {
+  if (billingPassInFlight) {
+    console.log("[Billing Worker] Skipping billing pass: previous pass still running");
+    return;
+  }
+  billingPassInFlight = true;
+  try {
+    await job();
+  } finally {
+    billingPassInFlight = false;
+  }
+}
+
 async function shutdown(signal: string): Promise<void> {
   if (isShuttingDown) return;
   isShuttingDown = true;
@@ -53,17 +71,21 @@ async function main(): Promise<void> {
     if (isShuttingDown) return;
 
     console.log("[Billing Worker] Running scheduled billing job...");
-    try {
-      await runBillingJob();
-    } catch (error) {
-      console.error("[Billing Worker] Billing job failed:", error);
-    }
+    await runExclusiveBillingPass(async () => {
+      try {
+        await runBillingJob();
+      } catch (error) {
+        console.error("[Billing Worker] Billing job failed:", error);
+      }
+    });
   });
 
   // Fire once immediately so the first usage snapshot lands within seconds
   // of startup instead of waiting for the next cron tick (up to ~1h away).
   // Not awaited: a slow/not-yet-ready backend must not delay cron registration.
-  void runStartupBillingPass();
+  // Goes through the same exclusive-pass guard as the cron callback so an
+  // early tick can't run concurrently with it.
+  void runExclusiveBillingPass(runStartupBillingPass);
 
   console.log("[Billing Worker] Scheduled jobs:");
   console.log(`  - Billing: ${billingCron}`);

--- a/frontend/worker/src/index.ts
+++ b/frontend/worker/src/index.ts
@@ -47,10 +47,6 @@ async function main(): Promise<void> {
   // Sync standard model pricing from JSON → DB
   await syncStandardPrices();
 
-  // Run once immediately so the first usage snapshot lands within seconds
-  // of startup instead of waiting for the next cron tick (up to ~1h away).
-  await runStartupBillingPass();
-
   // Schedule billing job (default: every hour at minute 5)
   const billingCron = process.env.USAGE_METERING_CRON || "5 * * * *";
   cron.schedule(billingCron, async () => {
@@ -63,6 +59,11 @@ async function main(): Promise<void> {
       console.error("[Billing Worker] Billing job failed:", error);
     }
   });
+
+  // Fire once immediately so the first usage snapshot lands within seconds
+  // of startup instead of waiting for the next cron tick (up to ~1h away).
+  // Not awaited: a slow/not-yet-ready backend must not delay cron registration.
+  void runStartupBillingPass();
 
   console.log("[Billing Worker] Scheduled jobs:");
   console.log(`  - Billing: ${billingCron}`);


### PR DESCRIPTION
Fixes #1501

## Summary

On self-host, Event Usage showed 0 traces / 0 spans even with real ingested traffic, because the billing page renders the cached `currentUsage` snapshot directly (`?? 0`), and that snapshot is null until the hourly metering job writes it. A freshly booted worker doesn't run the job until the next `:05` tick, so every workspace shows 0/0 for up to an hour after startup, indistinguishable from genuinely having no events.

## Type of Change

- [x] fix - A bug fix

## Details

- `BillingTab.tsx`: when `currentUsage` is null, render "Usage has not been computed yet" instead of falling back to `?? 0`. Once a snapshot exists, rendering is unchanged, including a real all-zero snapshot.
- `usageMetering.ts`: added `runStartupBillingPass`, an injectable wrapper around `runBillingJob` with the same log-and-swallow error handling as the scheduled cron callback. Called once during worker boot (`frontend/worker/src/index.ts`), before the cron is scheduled, so the first snapshot lands within seconds instead of waiting up to an hour.
- The issue's root-cause section says the metering job is missing from the self-host deployment entirely. From what I can tell, both documented self-host paths (`make dev`'s tmux pane running `pnpm dev:billing`, and `make prod`'s `billing` compose service) already run it, and it's already independent of Stripe configuration (`getStripe()` throwing is caught and logged, not fatal). The reported 0/0 looks like it came from running the base `docker-compose.yml` directly, which is infra-only by design and isn't one of the two documented ways to self-host. Happy to be corrected if I'm missing a deployment path. Either way, the startup-run change here fixes the boot window regardless of which deployment path is used.
- Live-computing usage on page load (the other fork the issue mentions for `currentUsage`) isn't done here: the UI's API routes have no outbound path to the backend/ClickHouse (no `BACKEND_INTERNAL_URL` equivalent on that side), so it would need new cross-service plumbing. Flagging it as a possible follow-up rather than folding it into this fix.

## Screenshots / Recordings (if applicable)

None. This is a genuine UI change, but reproducing it visually needs the full self-host stack (Postgres, ClickHouse, Redis, an authenticated workspace) running locally, which I didn't have available. Verified instead with component tests asserting the exact rendered output for both states (see below).

## Checklist

- [x] I have read the CONTRIBUTING.md
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (not done, see above)
- [x] I have updated documentation where necessary (N/A, no doc-facing behavior change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the misleading “0 traces / 0 spans” state on the billing page before a usage snapshot exists, and makes the worker write the first snapshot within seconds of boot instead of waiting for the next hourly cron tick. Addresses #1501.

- **Bug Fixes**
  - UI: In `BillingTab`, show “Usage has not been computed yet” when `currentUsage` is null; render counts normally once a snapshot exists, including genuine zeros.
  - Worker: Run a startup billing pass fire-and-forget after cron registration, with a 10s timeout on the internal usage fetch so a slow backend can’t hang startup or delay cron scheduling.
  - Concurrency: A shared in-flight guard serializes the startup pass and the scheduled cron to prevent overlapping runs and double-reporting overage to Stripe.
  - Tests: Add coverage for the worker entrypoint (startup sequence, cron ordering, guard branches, SIGTERM shutdown), the usage-fetch timeout, and the unlimited-plan quota display.

<sup>Written for commit 72c781003d184a807aed612e5c13e8c31e049e3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

