### PR TITLE
fix(ai-assistant): link empty-state and clear phantom model selection

### DIFF
--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  projectData: undefined as { workspace_id: string } | undefined,
+  llmModels: undefined as
+    | {
+        systemModels: Array<{
+          provider: string;
+          adapter: string;
+          source: "system";
+          models: Array<{ id: string; label: string; supported?: boolean }>;
+        }>;
+        byokProviders: Array<{
+          provider: string;
+          adapter: string;
+          source: "byok";
+          models: Array<{ id: string; label: string; supported?: boolean }>;
+        }>;
+      }
+    | undefined,
+  onClose: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQuery: ({ queryKey }: { queryKey: string[] }) => {
+    if (queryKey[0] === "project") return { data: mocks.projectData };
+    if (queryKey[0] === "llm-models") return { data: mocks.llmModels };
+    return { data: undefined };
+  },
+}));
+
+vi.mock("@/lib/api", () => ({
+  getProject: vi.fn(),
+  getAvailableLLMModels: vi.fn(),
+}));
+
+vi.mock("./ai-chat-context", () => ({
+  useAiChatContext: () => ({
+    messages: [],
+    isStreaming: false,
+    sessions: [],
+    historyOpen: false,
+    currentSessionId: null,
+    setHistoryOpen: vi.fn(),
+    handleSend: vi.fn(),
+    handleAbort: vi.fn(),
+    handleNewSession: vi.fn(),
+    handleClose: vi.fn(),
+    handleOpenHistory: vi.fn(),
+    handleSelectSession: vi.fn(),
+    handleDeleteSession: vi.fn(),
+  }),
+}));
+
+vi.mock("./message-list", () => ({ MessageList: () => null }));
+vi.mock("./message-input", () => ({ MessageInput: () => null }));
+vi.mock("./session-history", () => ({ SessionHistory: () => null }));
+
+import { AiAssistantPanel } from "./ai-assistant-panel";
+
+afterEach(() => {
+  cleanup();
+  mocks.projectData = undefined;
+  mocks.llmModels = undefined;
+  mocks.onClose.mockReset();
+});
+
+describe("AiAssistantPanel", () => {
+  it("renders a clickable link to model providers in the no-models empty state", () => {
+    mocks.projectData = { workspace_id: "ws-abc" };
+    mocks.llmModels = { systemModels: [], byokProviders: [] };
+
+    render(<AiAssistantPanel projectId="proj-1" onClose={mocks.onClose} />);
+
+    const link = screen.getByRole("link", { name: /Workspace Settings.*Model Providers/i });
+    expect(link.getAttribute("href")).toBe("/workspaces/ws-abc/settings/model-providers");
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -169,9 +169,12 @@ export function AiAssistantPanel({ projectId, onClose, compact = false }: AiAssi
             <p className="text-[12px] text-muted-foreground">
               To use the AI assistant, configure a system API key (e.g. Anthropic, OpenAI) in your
               environment, or add a BYOK provider in{" "}
-              <span className="font-medium text-foreground">
+              <a
+                href={`/workspaces/${workspaceId}/settings/model-providers`}
+                className="font-medium underline"
+              >
                 Workspace Settings &rarr; Model Providers
-              </span>
+              </a>
               .
             </p>
           </div>

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -64,6 +64,47 @@ describe("ModelSelector", () => {
     expect(mocks.onChange).not.toHaveBeenCalled();
   });
 
+  it("clears a phantom selection when models resolve to empty", () => {
+    // Simulates: query was loading (FALLBACK_MODELS picked claude-opus-4-8),
+    // then resolved with no models. The selector must clear the phantom value.
+    mocks.models = { byokProviders: [], systemModels: [] };
+
+    render(
+      <ModelSelector
+        value={{
+          model: "claude-opus-4-8",
+          provider: "anthropic",
+          source: "system",
+          adapter: "anthropic",
+        }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: "",
+      provider: "",
+      source: "system",
+      adapter: "",
+    });
+  });
+
+  it("shows 'Select model' placeholder when no model is selected and no models exist", () => {
+    mocks.models = { byokProviders: [], systemModels: [] };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    expect(screen.getByRole("button").textContent).toContain("Select model");
+    expect(mocks.onChange).not.toHaveBeenCalled();
+  });
+
   it("auto-picks a default only when the model is empty", () => {
     mocks.models = {
       byokProviders: [],

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen } from "@testing-library/react";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   models: undefined as
@@ -19,11 +19,12 @@ const mocks = vi.hoisted(() => ({
         }>;
       }
     | undefined,
+  isPending: false,
   onChange: vi.fn(),
 }));
 
 vi.mock("@tanstack/react-query", () => ({
-  useQuery: () => ({ data: mocks.models }),
+  useQuery: () => ({ data: mocks.models, isPending: mocks.isPending }),
 }));
 
 vi.mock("@/lib/api", () => ({
@@ -35,6 +36,7 @@ import { ModelSelector } from "./model-selector";
 afterEach(() => {
   cleanup();
   mocks.models = undefined;
+  mocks.isPending = false;
   mocks.onChange.mockReset();
 });
 
@@ -64,10 +66,27 @@ describe("ModelSelector", () => {
     expect(mocks.onChange).not.toHaveBeenCalled();
   });
 
-  it("clears a phantom selection when models resolve to empty", () => {
-    // Simulates: query was loading (FALLBACK_MODELS picked claude-opus-4-8),
-    // then resolved with no models. The selector must clear the phantom value.
+  it("does not auto-pick a default while the query is still pending", () => {
+    // While pending, models resolves to the compiled-in fallback list (non-empty),
+    // but the selector must not auto-pick from it — only once settled.
+    mocks.models = undefined;
+    mocks.isPending = true;
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    expect(screen.getByRole("button").textContent).toContain("Select model");
+    expect(mocks.onChange).not.toHaveBeenCalled();
+  });
+
+  it("does not clobber an existing selection once the query settles with zero models", () => {
     mocks.models = { byokProviders: [], systemModels: [] };
+    mocks.isPending = false;
 
     render(
       <ModelSelector
@@ -82,12 +101,24 @@ describe("ModelSelector", () => {
       />,
     );
 
-    expect(mocks.onChange).toHaveBeenCalledWith({
-      model: "",
-      provider: "",
-      source: "system",
-      adapter: "",
-    });
+    expect(mocks.onChange).not.toHaveBeenCalled();
+  });
+
+  it("links to workspace model-provider settings from the empty dropdown state", () => {
+    mocks.models = { byokProviders: [], systemModels: [] };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    const link = screen.getByRole("link", { name: "configure one" });
+    expect(link.getAttribute("href")).toBe("/workspaces/workspace-1/settings/model-providers");
   });
 
   it("shows 'Select model' placeholder when no model is selected and no models exist", () => {

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -104,6 +104,26 @@ describe("ModelSelector", () => {
     expect(mocks.onChange).not.toHaveBeenCalled();
   });
 
+  it("does not backfill a provider onto a partially-hydrated selection while pending", () => {
+    // A legacy row (e.g. project.rca_model set, rca_provider NULL) arrives as a
+    // model-id-only selection. While the query is pending, `models` is the
+    // compiled-in fallback list, which DOES contain this id — so the reconcile
+    // effect must not run yet, or it would backfill provider="Anthropic" the
+    // user never chose and self-enable Save. It reconciles once settled.
+    mocks.models = undefined;
+    mocks.isPending = true;
+
+    render(
+      <ModelSelector
+        value={{ model: "claude-opus-4-8", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    expect(mocks.onChange).not.toHaveBeenCalled();
+  });
+
   it("links to workspace model-provider settings from the empty dropdown state", () => {
     mocks.models = { byokProviders: [], systemModels: [] };
 

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -47,7 +47,14 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
   // Without case 2 the selector would silently auto-pick a default when a
   // partially-hydrated saved selection arrives, clobbering the user's choice.
   useEffect(() => {
-    if (models.length === 0) return;
+    if (models.length === 0) {
+      // Query resolved with zero models — clear any phantom selection that was
+      // set from FALLBACK_MODELS while the query was still loading.
+      if (value.model) {
+        onChange({ model: "", provider: "", source: "system", adapter: "" });
+      }
+      return;
+    }
 
     const exact = models.find(
       (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -29,33 +29,29 @@ function modelKey(m: { id?: string; model?: string; source: string; provider: st
 export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
 
-  const { data } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: ["llm-models", workspaceId],
     queryFn: () => getAvailableLLMModels(workspaceId!),
     enabled: !!workspaceId,
   });
 
-  // BYOK models first, then system models. No deduplication.
-  const models = flattenAvailableModels(data);
+  // BYOK models first, then system models. No deduplication. Only shows the
+  // compiled-in fallback list while the query is still pending — once settled,
+  // an empty response means the workspace genuinely has no models.
+  const models = flattenAvailableModels(data, isPending);
 
   // Reconcile the incoming selection against the catalog:
   //   1. exact match on (model, provider, source) → check adapter; backfill if empty/wrong
   //   2. model-id-only match (legacy/hydrated state where the parent only has
   //      `model` saved, e.g. `project.rca_model: string`) → backfill the rest
   //   3. no match → preserve the current selection if the user already picked
-  //      one, and only auto-pick a default when the model is still empty.
+  //      one, and only auto-pick a default once the query has settled and the
+  //      model is still empty. Gating on settled state (rather than picking from
+  //      the pending fallback list and clearing it later) avoids ever showing a
+  //      phantom default the user didn't choose.
   // Without case 2 the selector would silently auto-pick a default when a
   // partially-hydrated saved selection arrives, clobbering the user's choice.
   useEffect(() => {
-    if (models.length === 0) {
-      // Query resolved with zero models — clear any phantom selection that was
-      // set from FALLBACK_MODELS while the query was still loading.
-      if (value.model) {
-        onChange({ model: "", provider: "", source: "system", adapter: "" });
-      }
-      return;
-    }
-
     const exact = models.find(
       (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,
     );
@@ -64,7 +60,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
     const match = exact ?? modelOnly;
 
     if (!match) {
-      if (!value.model) {
+      if (!value.model && !isPending) {
         const pick = pickDefaultModel(models);
         if (pick) {
           onChange({
@@ -94,7 +90,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
         adapter: match.adapter,
       });
     }
-  }, [models, value, onChange]);
+  }, [models, value, onChange, isPending]);
 
   const selectedKey = modelKey({ id: value.model, source: value.source, provider: value.provider });
   const selectedModel = models.find((m) => modelKey(m) === selectedKey);
@@ -156,6 +152,17 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
           {models.length === 0 && (
             <div className="px-2.5 py-3 text-center text-[11px] text-muted-foreground">
               No models available
+              {workspaceId && (
+                <>
+                  {" — "}
+                  <a
+                    href={`/workspaces/${workspaceId}/settings/model-providers`}
+                    className="font-medium underline"
+                  >
+                    configure one
+                  </a>
+                </>
+              )}
             </div>
           )}
         </PopoverContent>

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -45,13 +45,16 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
   //   2. model-id-only match (legacy/hydrated state where the parent only has
   //      `model` saved, e.g. `project.rca_model: string`) → backfill the rest
   //   3. no match → preserve the current selection if the user already picked
-  //      one, and only auto-pick a default once the query has settled and the
-  //      model is still empty. Gating on settled state (rather than picking from
-  //      the pending fallback list and clearing it later) avoids ever showing a
-  //      phantom default the user didn't choose.
-  // Without case 2 the selector would silently auto-pick a default when a
-  // partially-hydrated saved selection arrives, clobbering the user's choice.
+  //      one, and only auto-pick a default once the model is still empty.
+  // The whole reconcile is skipped while the query is pending: `models` is still
+  // the compiled-in fallback list then, so reconciling against it would backfill
+  // a phantom provider onto a partially-hydrated selection (e.g. a legacy
+  // `project.rca_model` with no provider), self-enabling a Save the user never
+  // touched. Waiting for settled state means case 2 only ever matches real
+  // models, and case 3 only auto-picks from real models.
   useEffect(() => {
+    if (isPending) return;
+
     const exact = models.find(
       (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,
     );
@@ -60,7 +63,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
     const match = exact ?? modelOnly;
 
     if (!match) {
-      if (!value.model && !isPending) {
+      if (!value.model) {
         const pick = pickDefaultModel(models);
         if (pick) {
           onChange({

--- a/frontend/ui/src/features/ai-assistant/lib/resolve-model.ts
+++ b/frontend/ui/src/features/ai-assistant/lib/resolve-model.ts
@@ -3,8 +3,13 @@
  * Shared by ModelSelector (interactive picker) and AgentModelLink (read-only label).
  *
  * Behavior:
- * - When the API response is undefined (loading / no workspace), fall back to the
- *   compiled-in SYSTEM_MODELS so the UI still renders something usable.
+ * - While the query is still pending (no data and no error yet — covers both the
+ *   initial load and a disabled/no-workspace query), fall back to the compiled-in
+ *   SYSTEM_MODELS so the UI still renders something usable.
+ * - Once the query has settled (success or error) with no usable data, the result
+ *   is genuinely empty — callers must not keep showing the fallback list, since
+ *   that's what caused a fallback-only model to get auto-picked as a phantom
+ *   default even though the workspace has no real models configured.
  * - When the API response is defined, BYOK models come first, then system models.
  *   No deduplication — both consumers depend on this ordering.
  * - Default-pick walks PROVIDER_PRIORITY by adapter, then falls back to models[0].
@@ -33,8 +38,11 @@ const FALLBACK_MODELS: ResolvedModel[] = SYSTEM_MODELS.flatMap((s) =>
   })),
 );
 
-export function flattenAvailableModels(data: LLMModelsResponse | undefined): ResolvedModel[] {
-  if (!data) return FALLBACK_MODELS;
+export function flattenAvailableModels(
+  data: LLMModelsResponse | undefined,
+  isPending: boolean,
+): ResolvedModel[] {
+  if (!data) return isPending ? FALLBACK_MODELS : [];
   const systemList: ResolvedModel[] = data.systemModels.flatMap((g) =>
     g.models.map((m) => ({
       id: m.id,

--- a/frontend/ui/src/features/detectors/components/agent-model-link.tsx
+++ b/frontend/ui/src/features/detectors/components/agent-model-link.tsx
@@ -16,13 +16,13 @@ interface AgentModelLinkProps {
 }
 
 export function AgentModelLink({ projectId, rcaModel, workspaceId }: AgentModelLinkProps) {
-  const { data } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: ["llm-models", workspaceId],
     queryFn: () => getAvailableLLMModels(workspaceId!),
     enabled: !!workspaceId,
   });
 
-  const models = flattenAvailableModels(data);
+  const models = flattenAvailableModels(data, isPending);
 
   const resolvedLabel = (() => {
     if (rcaModel) {


### PR DESCRIPTION
## Summary

Fixes both issues reported in #1500.

**Part 1 — dead-end empty state**

`ai-assistant-panel.tsx:172` had `"Workspace Settings → Model Providers"` wrapped in a plain `<span>`. Changed it to an `<a>` tag pointing to `/workspaces/${workspaceId}/settings/model-providers`, using the identical pattern already used a few lines above for the unsupported-model warning (line 151–156). `workspaceId` is already in scope since the empty state only renders when `llmModels` has resolved (which requires `workspaceId`).

**Part 2 — phantom `claude-opus-4-8`**

Root cause: while the `llm-models` query was loading, `flattenAvailableModels(undefined)` returned `FALLBACK_MODELS` (containing claude-opus-4-8). The reconcile effect picked it as the default. When the query resolved to empty `[]`, the effect hit `if (models.length === 0) return` and never cleared the selection.

Fix: when `models.length === 0` and `value.model` is non-empty, call `onChange({ model: "", ... })` to clear the phantom. The button already has `"Select model"` as its final fallback (`selectedModel?.label || value.model || "Select model"`), so it shows the neutral placeholder once cleared.

No change to the disabled state — the input remains disabled via `disabled={!projectId || !hasModels}`.

## Test plan

- [x] Two new tests in `model-selector.test.tsx`: phantom cleared when models resolve empty; placeholder shown when both selection and models are empty
- [ ] Manually verify: workspace with no system keys and no BYOK provider → empty state link is clickable → lands on `/workspaces/.../settings/model-providers`
- [ ] Verify: model selector shows "Select model", not "claude-opus-4-8", in the no-models state
- [ ] Verify: workspace with models configured is unaffected

Closes #1500


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the AI assistant’s no-models state actionable and stop phantom selections by showing fallback models only while the models query is pending and skipping reconcile during that window. Users can jump to model setup from the panel and the empty dropdown; the selector won’t auto-pick or backfill from fallbacks.

- **Bug Fixes**
  - Link “Workspace Settings → Model Providers” to `/workspaces/${workspaceId}/settings/model-providers` in the panel empty state and the selector’s “No models available” dropdown.
  - Gate fallbacks and default-pick on `isPending`; once settled, an empty response means no models. Skip reconcile while pending to avoid backfilling a provider onto partially-hydrated selections.
  - Update `resolve-model` to accept `isPending`, and wire through `ModelSelector` and `AgentModelLink`. Add tests for the panel link, pending behavior, placeholder label, and the dropdown link.

<sup>Written for commit ee1bae1eb6b8e3430d3c4593179124a0d35a4960. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<img width="902" height="852" alt="image" src="https://github.com/user-attachments/assets/ccf07449-f692-454c-be72-4029e8947d4c" />
<img width="677" height="822" alt="image" src="https://github.com/user-attachments/assets/ebd5bc3c-4fbf-4c4e-a30d-7f081f7c7711" />
