### PR TITLE
fix(worker): preserve span-path columns when explicit metadata is set

### DIFF
--- a/backend/db/clickhouse/client.py
+++ b/backend/db/clickhouse/client.py
@@ -114,6 +114,8 @@ class ClickHouseClient:
                     s.get("git_source_file"),
                     s.get("git_source_line"),
                     s.get("git_source_function"),
+                    s.get("ids_path") or [],
+                    s.get("path") or [],
                     now,  # ch_create_time
                     now,  # ch_update_time
                 ]
@@ -145,6 +147,8 @@ class ClickHouseClient:
                 "git_source_file",
                 "git_source_line",
                 "git_source_function",
+                "ids_path",
+                "path",
                 "ch_create_time",
                 "ch_update_time",
             ],

--- a/backend/db/clickhouse/migrations/006_add_span_path_columns.sql
+++ b/backend/db/clickhouse/migrations/006_add_span_path_columns.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- Internal tree-repair bookkeeping: root→current ancestor IDs (span_ids) and ancestor
+-- names for pending-span reconstruction. These are extracted from the SDK's
+-- `traceroot.span.ids_path` and `traceroot.span.path` OTel attributes. Previously
+-- stored only in the metadata blob, they were lost when explicit metadata was set,
+-- breaking frontend enrichSpansWithPending.
+--
+-- Dedicated columns fix both the live-SSE delivery path AND the base-fetch skeleton
+-- read (which skips metadata to save payload size, issue #1040), following the
+-- existing pattern used for git_source_* fields.
+--
+-- These are internal bookkeeping keys, not user-facing metadata — distinct from the
+-- metadata column which stores leftover attributes and user annotations.
+ALTER TABLE spans
+    ADD COLUMN IF NOT EXISTS ids_path Array(String) DEFAULT [],
+    ADD COLUMN IF NOT EXISTS path     Array(String) DEFAULT [];
+
+-- +goose Down
+ALTER TABLE spans
+    DROP COLUMN IF EXISTS ids_path;
+ALTER TABLE spans
+    DROP COLUMN IF EXISTS path;

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -812,6 +812,14 @@
             ],
             "title": "Git Source Line"
           },
+          "ids_path": {
+            "description": "Ancestor span IDs from root to parent (excludes this span). Internal tree-repair bookkeeping consumed by the dashboard to reconstruct partial live traces; empty for root spans and spans predating this field. Capped at 128 entries by dropping the root-most prefix, preserving the immediate-parent side of very deep chains.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Ids Path",
+            "type": "array"
+          },
           "input": {
             "anyOf": [
               {
@@ -892,6 +900,14 @@
               }
             ],
             "title": "Parent Span Id"
+          },
+          "path": {
+            "description": "Ancestor span names from root to parent (excludes this span), aligned index-for-index with ids_path. Internal tree-repair bookkeeping; empty for root spans and spans predating this field. Capped at 128 entries by dropping the root-most prefix, matching ids_path truncation so the arrays remain aligned.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Path",
+            "type": "array"
           },
           "span_end_time": {
             "anyOf": [

--- a/backend/rest/schemas/traces.py
+++ b/backend/rest/schemas/traces.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from rest.schemas.common import PaginationMeta
 
@@ -38,6 +38,26 @@ class SpanSkeletonResponse(BaseModel):
     git_source_file: str | None = None
     git_source_line: int | None = None
     git_source_function: str | None = None
+    ids_path: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Ancestor span IDs from root to parent (excludes this span). Internal "
+            "tree-repair bookkeeping consumed by the dashboard to reconstruct partial "
+            "live traces; empty for root spans and spans predating this field. Capped "
+            "at 128 entries by dropping the root-most prefix, preserving the "
+            "immediate-parent side of very deep chains."
+        ),
+    )
+    path: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Ancestor span names from root to parent (excludes this span), aligned "
+            "index-for-index with ids_path. Internal tree-repair bookkeeping; empty "
+            "for root spans and spans predating this field. Capped at 128 entries by "
+            "dropping the root-most prefix, matching ids_path truncation so the arrays "
+            "remain aligned."
+        ),
+    )
 
 
 class SpanResponse(SpanSkeletonResponse):

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -439,14 +439,16 @@ class TraceReaderService:
                 span_start_time, span_end_time, status, status_message,
                 model_name, cost, input_tokens, output_tokens, total_tokens,
                 usage_details,
-                git_source_file, git_source_line, git_source_function
+                git_source_file, git_source_line, git_source_function,
+                ids_path, path
             FROM (
                 SELECT
                     span_id, trace_id, parent_span_id, name, span_kind,
                     span_start_time, span_end_time, status, status_message,
                     model_name, cost, input_tokens, output_tokens, total_tokens,
                     usage_details,
-                    git_source_file, git_source_line, git_source_function
+                    git_source_file, git_source_line, git_source_function,
+                    ids_path, path
                 FROM spans
                 WHERE {spans_where_clause}
                 ORDER BY ch_update_time DESC
@@ -487,6 +489,8 @@ class TraceReaderService:
                     "git_source_file": row[15],
                     "git_source_line": int(row[16]) if row[16] is not None else None,
                     "git_source_function": row[17],
+                    "ids_path": list(row[18]) if row[18] else [],
+                    "path": list(row[19]) if row[19] else [],
                 }
             )
 

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -52,6 +52,38 @@ def _scope_skips_text_token_estimation(scope_name: str | None) -> bool:
     return scope_name in _SKIP_TEXT_TOKEN_ESTIMATION_SCOPES
 
 
+# Trace depth realistically stays far below this. The cap exists for malformed or
+# adversarial ``traceroot.span.ids_path`` / ``traceroot.span.path`` attributes: keep
+# the parent-near tail used for live tree repair, and drop only the root-most prefix
+# once the arrays are too deep.
+MAX_SPAN_PATH_DEPTH = 128
+
+
+def _extract_span_path_columns(
+    ids_path_value: object,
+    path_value: object,
+) -> tuple[list[str], list[str]]:
+    """Return bounded, index-aligned ancestor IDs and names for live tree repair.
+
+    SDKs historically emit ``traceroot.span.path`` as root→current names while
+    ``traceroot.span.ids_path`` is root→parent IDs. The stored/public columns are
+    a stricter ancestor-chain contract: both arrays exclude this span, align
+    index-for-index, and are capped by dropping the root-most prefix so the
+    immediate parent side of the chain remains repairable.
+    """
+
+    ids_path = list(ids_path_value) if isinstance(ids_path_value, (list, tuple)) else []
+    path = list(path_value) if isinstance(path_value, (list, tuple)) else []
+
+    # Normalize legacy root→current path values to root→parent ancestor names.
+    ancestor_path = path[:-1] if len(path) == len(ids_path) + 1 else path
+    bounded_depth = min(len(ids_path), len(ancestor_path), MAX_SPAN_PATH_DEPTH)
+    if bounded_depth == 0:
+        return [], []
+
+    return ids_path[-bounded_depth:], ancestor_path[-bounded_depth:]
+
+
 # Attributes that are already extracted into dedicated fields
 _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.input",
@@ -59,6 +91,8 @@ _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.type",
     "traceroot.span.metadata",
     "traceroot.span.tags",
+    "traceroot.span.ids_path",  # Internal tree-repair bookkeeping: now in dedicated column
+    "traceroot.span.path",  # Internal tree-repair bookkeeping: now in dedicated column
     "traceroot.llm.",
     "traceroot.trace.",
     "traceroot.environment",
@@ -396,6 +430,21 @@ def transform_otel_to_clickhouse(
                     span_record["git_source_line"] = git_source_line
                 if git_source_function is not None:
                     span_record["git_source_function"] = git_source_function
+
+                # Extract tree-repair bookkeeping: ancestor IDs and names.
+                # These are internal; they drive frontend enrichSpansWithPending to
+                # synthesize placeholders for children whose real parent hasn't streamed
+                # yet. Stored as dedicated columns (not in metadata blob) so they survive
+                # the base-fetch skeleton read, which skips metadata for payload size.
+                # Capped at depth so a malformed/adversarial OTel payload (an SDK bug or a
+                # misbehaving client) can't force an unbounded array into ClickHouse or
+                # balloon worker memory during the transform.
+                ids_path = span_attrs.get("traceroot.span.ids_path")
+                path_value = span_attrs.get("traceroot.span.path")
+                span_record["ids_path"], span_record["path"] = _extract_span_path_columns(
+                    ids_path,
+                    path_value,
+                )
 
                 # Extraction priority (first key present/not-None wins):
                 # 1. TraceRoot SDK: user-provided explicit values — highest authority.

--- a/backend/worker/tests/test_otel_transform_trace_naming.py
+++ b/backend/worker/tests/test_otel_transform_trace_naming.py
@@ -3,7 +3,7 @@
 Covers the corner cases introduced during live-trace-streaming work:
   - Eager trace name should use traceroot.span.path[0], not the span's own name
   - When a batch has spans at multiple depths, the shallowest span's path[0] wins
-  - traceroot.span.path / traceroot.span.ids_path must be preserved in span metadata
+  - traceroot.span.path / traceroot.span.ids_path must be extracted to dedicated columns
     (enrichSpansWithPending on the frontend reads them to create phantom ancestor spans)
 """
 
@@ -208,8 +208,12 @@ def test_batch_with_root_span_uses_root_name():
 # ── path / ids_path preserved in metadata ──────────────────────────────────────
 
 
-def test_span_path_preserved_in_metadata():
-    """traceroot.span.path must NOT be stripped — enrichSpansWithPending reads it."""
+def test_span_path_extracted_to_dedicated_columns():
+    """After fix: traceroot.span.path/ids_path go to dedicated fields, not metadata.
+
+    enrichSpansWithPending reads from dedicated fields with metadata fallback for
+    backward compatibility, so the fields must be accessible via span_record columns.
+    """
     tid = _tid(0x04)
     path = ["research_session", "model", "ChatAnthropic"]
     ids_path = ["aabbccdd11223344", "aabbccdd11223345"]
@@ -228,14 +232,22 @@ def test_span_path_preserved_in_metadata():
     _, spans = transform_otel_to_clickhouse(_payload(child), project_id="proj-1")
 
     assert len(spans) == 1
-    assert "metadata" in spans[0], "span should have metadata when path attrs are present"
-    meta = json.loads(spans[0]["metadata"])
-    assert meta.get("traceroot.span.path") == path, (
-        "traceroot.span.path must be preserved in metadata for enrichSpansWithPending"
+    # Core assertion: path attrs must be in dedicated fields
+    assert spans[0]["path"] == path[:-1], (
+        f"traceroot.span.path must be in dedicated 'path' field, got {spans[0].get('path')}"
     )
-    assert meta.get("traceroot.span.ids_path") == ids_path, (
-        "traceroot.span.ids_path must be preserved in metadata for enrichSpansWithPending"
+    assert spans[0]["ids_path"] == ids_path, (
+        f"traceroot.span.ids_path must be in dedicated 'ids_path' field, got {spans[0].get('ids_path')}"
     )
+    # Verify they don't leak into metadata
+    if "metadata" in spans[0]:
+        meta = json.loads(spans[0]["metadata"])
+        assert "traceroot.span.path" not in meta, (
+            "path must not be in metadata (now in dedicated field)"
+        )
+        assert "traceroot.span.ids_path" not in meta, (
+            "ids_path must not be in metadata (now in dedicated field)"
+        )
 
 
 def test_sdk_name_version_preserved_in_metadata():
@@ -260,3 +272,147 @@ def test_sdk_name_version_preserved_in_metadata():
     assert meta.get("traceroot.sdk.name") == "traceroot-py"
     assert meta.get("traceroot.sdk.version") == "1.2.3"
     assert meta.get("my.custom.attr") == "keep-me"
+
+
+# ── Issue #1498: Dedicated path/ids_path columns (not dropped when metadata present) ──
+
+
+def test_ids_path_extracted_to_dedicated_field_with_explicit_metadata():
+    """Regression: ids_path/path MUST be extracted even when explicit metadata is set.
+
+    Before fix: explicit traceroot.span.metadata caused path attrs to be skipped (only
+    in fallback branch). After fix: path attrs go to dedicated fields unconditionally,
+    so they're never lost. Core regression test for issue #1498.
+    """
+    tid = _tid(0x06)
+    path = ["research", "model_call", "ChatAnthropic"]
+    ids_path = ["aabbccdd11223344", "aabbccdd11223345"]
+    user_metadata = {"session_id": "user-session-123", "retry_count": 2}
+
+    child = _span(
+        "ChatAnthropic",
+        trace_id=tid,
+        span_id=_sid(0x02),
+        parent_span_id=_sid(0x10),
+        attributes=[
+            _arr_attr("traceroot.span.path", path),
+            _arr_attr("traceroot.span.ids_path", ids_path),
+            # Explicit user metadata: this used to suppress path attr extraction.
+            # Serialized from `user_metadata` so the fixture and the assertions
+            # below can never drift apart.
+            {
+                "key": "traceroot.span.metadata",
+                "value": {"stringValue": json.dumps(user_metadata)},
+            },
+        ],
+    )
+
+    _, spans = transform_otel_to_clickhouse(_payload(child), project_id="proj-1")
+
+    assert len(spans) == 1
+    span_record = spans[0]
+
+    # Core assertion: ids_path/path MUST be in dedicated fields
+    assert span_record["ids_path"] == ids_path, (
+        f"ids_path must be extracted to dedicated field, got {span_record.get('ids_path')}"
+    )
+    assert span_record["path"] == path[:-1], (
+        f"path must be extracted to dedicated field, got {span_record.get('path')}"
+    )
+
+    # Verify user metadata is intact and path attrs are NOT leaked into it
+    assert "metadata" in span_record, "span should have metadata field"
+    meta = json.loads(span_record["metadata"])
+    assert meta.get("session_id") == user_metadata["session_id"], (
+        "user-provided session_id should be in metadata"
+    )
+    assert meta.get("retry_count") == user_metadata["retry_count"], (
+        "user-provided retry_count should be in metadata"
+    )
+    assert "traceroot.span.path" not in meta, (
+        "traceroot.span.path must NOT leak into metadata (now in dedicated column)"
+    )
+    assert "traceroot.span.ids_path" not in meta, (
+        "traceroot.span.ids_path must NOT leak into metadata (now in dedicated column)"
+    )
+
+
+def test_ids_path_extracted_without_explicit_metadata():
+    """Regression guard: path attrs extraction must work when NO explicit metadata.
+
+    Before fix, this case already worked (via the fallback branch after metadata).
+    After fix, the unconditional extraction code path must not break this case.
+    """
+    tid = _tid(0x07)
+    path = ["agent_session", "tool_call", "search"]
+    ids_path = ["deadbeef00000001", "deadbeef00000002"]
+    other_attr = "some_custom_value"
+
+    child = _span(
+        "search",
+        trace_id=tid,
+        span_id=_sid(0x03),
+        parent_span_id=_sid(0x10),
+        attributes=[
+            _arr_attr("traceroot.span.path", path),
+            _arr_attr("traceroot.span.ids_path", ids_path),
+            # No explicit traceroot.span.metadata; only custom attrs
+            _str_attr("my.custom.attr", other_attr),
+        ],
+    )
+
+    _, spans = transform_otel_to_clickhouse(_payload(child), project_id="proj-1")
+
+    assert len(spans) == 1
+    span_record = spans[0]
+
+    # Path attrs must still reach dedicated fields
+    assert span_record["ids_path"] == ids_path, (
+        f"ids_path must be extracted to dedicated field, got {span_record.get('ids_path')}"
+    )
+    assert span_record["path"] == path[:-1], (
+        f"path must be extracted to dedicated field, got {span_record.get('path')}"
+    )
+
+    # Custom attrs should be in metadata (they're not known attributes)
+    if "metadata" in span_record:
+        meta = json.loads(span_record["metadata"])
+        assert meta.get("my.custom.attr") == other_attr, (
+            "custom attributes should be preserved in metadata"
+        )
+
+
+def test_ids_path_and_path_capped_at_max_depth():
+    """Regression: an oversized ids_path/path must be truncated, not stored whole.
+
+    Security hardening for #1498: a malformed or adversarial OTel payload
+    shouldn't be able to force an unbounded array into ClickHouse or balloon
+    worker memory during the transform. See MAX_SPAN_PATH_DEPTH.
+    """
+    from worker.otel_transform import MAX_SPAN_PATH_DEPTH
+
+    tid = _tid(0x08)
+    oversized_path = [f"frame-{i}" for i in range(MAX_SPAN_PATH_DEPTH + 51)]
+    oversized_ids_path = [f"id-{i}" for i in range(MAX_SPAN_PATH_DEPTH + 50)]
+
+    child = _span(
+        "deep_leaf",
+        trace_id=tid,
+        span_id=_sid(0x04),
+        parent_span_id=_sid(0x11),
+        attributes=[
+            _arr_attr("traceroot.span.path", oversized_path),
+            _arr_attr("traceroot.span.ids_path", oversized_ids_path),
+        ],
+    )
+
+    _, spans = transform_otel_to_clickhouse(_payload(child), project_id="proj-1")
+
+    assert len(spans) == 1
+    span_record = spans[0]
+    assert len(span_record["path"]) == MAX_SPAN_PATH_DEPTH
+    assert len(span_record["ids_path"]) == MAX_SPAN_PATH_DEPTH
+    # Truncation drops the root-most prefix from both arrays, preserving the
+    # immediate-parent side that live tree repair needs while keeping indexes aligned.
+    assert span_record["path"] == oversized_path[-(MAX_SPAN_PATH_DEPTH + 1) : -1]
+    assert span_record["ids_path"] == oversized_ids_path[-MAX_SPAN_PATH_DEPTH:]

--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -458,6 +458,51 @@ describe("two-phase loading compatibility", () => {
     expect(placeholder!.name).toBe("demo_session");
   });
 
+  it("enrichSpansWithPending synthesizes ancestors from dedicated ids_path/path fields (issue #1498)", () => {
+    // After the fix, spans carry ids_path/path as dedicated top-level fields instead
+    // of (or in addition to) metadata. This test verifies ancestors are synthesized
+    // correctly from the new dedicated fields, ensuring backward compatibility with
+    // the metadata fallback was not broken.
+    const rootId = "root-agent-id";
+    const midId = "turbo-id";
+    const childId = "llm-completion-id";
+
+    // Child span with dedicated ids_path/path fields (not in metadata)
+    const child = makeSpan({
+      span_id: childId,
+      parent_span_id: midId,
+      ids_path: [rootId, midId],
+      path: ["agent_session", "turbo_mode"],
+      // Metadata does NOT contain ids_path/path; it's now in dedicated fields
+      metadata: JSON.stringify({ "custom.field": "user_data" }),
+    });
+
+    const result = enrichSpansWithPending([child]);
+
+    // Verify both missing ancestors are synthesized
+    const placeholders = result.filter((s) => s.pending);
+    const placeholderIds = placeholders.map((s) => s.span_id);
+    expect(placeholderIds).toContain(rootId);
+    expect(placeholderIds).toContain(midId);
+
+    // Verify root placeholder
+    const rootPlaceholder = result.find((s) => s.span_id === rootId)!;
+    expect(rootPlaceholder.name).toBe("agent_session");
+    expect(rootPlaceholder.parent_span_id).toBeNull();
+    expect(rootPlaceholder.pending).toBe(true);
+
+    // Verify mid placeholder
+    const midPlaceholder = result.find((s) => s.span_id === midId)!;
+    expect(midPlaceholder.name).toBe("turbo_mode");
+    expect(midPlaceholder.parent_span_id).toBe(rootId);
+    expect(midPlaceholder.pending).toBe(true);
+
+    // Verify real child span is intact
+    const realChild = result.find((s) => s.span_id === childId)!;
+    expect(realChild.pending).toBeFalsy();
+    expect(realChild.parent_span_id).toBe(midId);
+  });
+
   it("getTraceDuration works over a mix of skeleton and full live spans", () => {
     const trace = {
       spans: [

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -21,11 +21,12 @@ function parseMetadata(metadata: string | null): Record<string, unknown> {
 
 /**
  * For every span that carries traceroot.span.ids_path (ancestor IDs, root→parent)
- * and traceroot.span.path (root→current names) in its metadata, create lightweight
+ * and traceroot.span.path (ancestor names, root→parent), create lightweight
  * placeholder spans for any missing ancestors.
  *
- * Works for both live SSE streaming AND completed traces loaded from ClickHouse,
- * because both carry the same metadata JSON.
+ * Path data now comes from dedicated span columns (preferred) with fallback to
+ * metadata for backward compatibility with historical/cached spans. Works for both
+ * live SSE streaming AND completed traces loaded from ClickHouse.
  */
 export function enrichSpansWithPending(spans: Span[]): Span[] {
   const existingSpanIds = new Set(spans.map((s) => s.span_id));
@@ -38,14 +39,18 @@ export function enrichSpansWithPending(spans: Span[]): Span[] {
   for (const span of spans) {
     if (!span.parent_span_id) continue;
 
-    // Skeleton spans omit metadata (parseMetadata(null|undefined) → {}); live
-    // SSE spans still carry it, so enrichment keeps working from live events.
+    // Prefer dedicated columns (newly populated); fall back to metadata for
+    // backward compatibility with historical/cached spans that may still carry
+    // the paths embedded in metadata.
     const meta = parseMetadata(span.metadata ?? null);
-    const idsPath = meta["traceroot.span.ids_path"] as string[] | undefined;
-    const namePath = meta["traceroot.span.path"] as string[] | undefined;
+    const idsPath = span.ids_path?.length
+      ? span.ids_path
+      : (meta["traceroot.span.ids_path"] as string[] | undefined);
+    const ancestorNames = span.path?.length
+      ? span.path
+      : (meta["traceroot.span.path"] as string[] | undefined)?.slice(0, -1);
 
-    if (!idsPath || !namePath || idsPath.length === 0) continue;
-    const ancestorNames = namePath.slice(0, -1);
+    if (!idsPath || !ancestorNames || idsPath.length === 0) continue;
     if (idsPath.length !== ancestorNames.length) continue;
 
     for (let i = 0; i < idsPath.length; i++) {

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -142,6 +142,15 @@ export interface Span {
   git_source_file: string | null;
   git_source_line: number | null;
   git_source_function: string | null;
+  // Internal tree-repair bookkeeping: ancestor span IDs / names (root->parent),
+  // used by enrichSpansWithPending to reconstruct partial live traces. These
+  // arrays are capped at 128 entries by dropping the root-most prefix, preserving
+  // the immediate-parent side of very deep chains. Present in both the internal
+  // dashboard and the public API response (SpanResponse is shared between them
+  // on the backend). Optional for backward compatibility with historical/cached
+  // spans that predate this field.
+  ids_path?: string[];
+  path?: string[];
   pending?: boolean;
 }
 

--- a/tests/db/test_client.py
+++ b/tests/db/test_client.py
@@ -112,9 +112,12 @@ class TestInsertSpansBatch:
         assert row[12] == 100  # input_tokens
         assert row[13] == 50  # output_tokens
         assert row[14] == 150  # total_tokens
-        # 3 fixed breakdown columns collapsed into one usage_details map (net -2).
-        assert len(columns) == 24
+        # 3 fixed breakdown columns collapsed into one usage_details map (net -2);
+        # +2 for ids_path/path (internal tree-repair bookkeeping columns, #1498).
+        assert len(columns) == 26
         assert "usage_details" in columns
+        assert "ids_path" in columns
+        assert "path" in columns
 
     def test_optional_fields_none(self):
         """None values for optional fields (cost, tokens)."""

--- a/tests/rest/test_public_traces_export.py
+++ b/tests/rest/test_public_traces_export.py
@@ -53,6 +53,8 @@ TRACE_DETAIL = {
             "git_source_file": "app/main.py",
             "git_source_line": 42,
             "git_source_function": "handler",
+            "ids_path": ["root-span"],
+            "path": ["test-trace"],
         }
     ],
 }

--- a/tests/rest/test_public_traces_read.py
+++ b/tests/rest/test_public_traces_read.py
@@ -62,6 +62,8 @@ TRACE_DETAIL = {
             "input": None,
             "output": None,
             "metadata": None,
+            "ids_path": [],
+            "path": [],
         }
     ],
 }
@@ -225,6 +227,10 @@ class TestPublicGetTrace:
         assert data["metadata"] == "{}"
         assert len(data["spans"]) == 1
         assert data["spans"][0]["span_id"] == "span-1"
+        # ids_path/path (#1498): always present on the public span payload,
+        # defaulting to [] for a root span with no ancestors.
+        assert data["spans"][0]["ids_path"] == []
+        assert data["spans"][0]["path"] == []
         assert data["trace_url"] == "http://localhost:3000/projects/proj-A/traces?traceId=abc123"
 
     def test_trace_url_uses_public_ui_url_not_internal(self, client, mock_reader, monkeypatch):

--- a/tests/rest/test_trace_reader.py
+++ b/tests/rest/test_trace_reader.py
@@ -183,6 +183,8 @@ class TestGetTraceSkeleton:
                         "file.py",  # git_source_file
                         12,  # git_source_line
                         "fn",  # git_source_function
+                        ["root-id"],  # ids_path
+                        ["root"],  # path
                     )
                 ]
             )


### PR DESCRIPTION
Closes #1498

## Root cause

`backend/worker/otel_transform.py` stored `traceroot.span.ids_path`/`traceroot.span.path` only via the leftover-attributes fallback. Explicit `traceroot.span.metadata` short-circuited that branch, so annotated spans lost the two keys `enrichSpansWithPending` needs for pending-ancestor repair — silently degrading to root-pinned orphans on both the live SSE
path and the base-fetch skeleton path.

## Fix

- Extract `ids_path`/`path` unconditionally at transform time into two new dedicated ClickHouse columns (migration `006_add_span_path_columns.sql`), independent of whether explicit metadata is present.
- Surface both fields on `SpanSkeletonResponse` (inherited by `SpanResponse`, shared with the public API) — no public/internal split, since this is already-public denormalized data (same category as `parent_span_id`), cheap and semantically stable.
- Cap both arrays at 128 entries, dropping the root-most prefix so the immediate-parent side of the chain — what repair actually consumes — survives. Truncation is index-aligned between `ids_path`/`path` and documented on both public schema fields.
- Frontend (`enrichSpansWithPending`) prefers the dedicated fields, falling back to parsing metadata for historical/cached spans that predate this change.

## Testing

- `backend/worker/tests/test_otel_transform_trace_naming.py`: regression test asserting a span with explicit metadata still carries `ids_path`/`path` through to the stored record, plus a companion test confirming the no-explicit-metadata path still work and the keys no longer leak into the `metadata` blob.
- `frontend/ui/src/features/traces/utils/index.test.ts`: asserts `enrichSpansWithPending` synthesizes ancestor placeholders from the dedicated fields for an annotated span whose parent hasn't arrived.
- Updated `tests/db/test_client.py`, `tests/rest/test_public_traces_export.py`, `tests/rest/test_public_traces_read.py`, `tests/rest/test_trace_reader.py` for the new columns/response fields.

## Proof
##Before
<img width="1280" height="720" alt="frame01-pending-repaired" src="https://github.com/user-attachments/assets/d0ce02ff-3fdd-44a4-81e9-3a510aa20f82" />
##After
<img width="1280" height="720" alt="frame02-after-parents-arrive" src="https://github.com/user-attachments/assets/5ec46893-21f9-410f-b897-c1c4dc39f0bf" />
##Video

https://github.com/user-attachments/assets/417266d0-04a4-4fe7-9990-1ab212b9c1e3


## Checklist

- [x] One logical change, scoped to #1498
- [x] Tests ship with the fix
- [x] `diff-cover` on changed lines (backend + frontend suites both green locally)
- [x] Matches existing comment-heavy style


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing ancestor path data on annotated spans by extracting `ids_path` and `path` into dedicated columns and API fields, so the UI can rebuild pending parents correctly in live SSE and base-fetch flows. Addresses #1498.

- **Bug Fixes**
  - Extracted `traceroot.span.ids_path` and `traceroot.span.path` unconditionally into new ClickHouse columns and surfaced them on `SpanSkeletonResponse` and `SpanResponse` (public API).
  - Kept arrays index-aligned, exclude the current span, and cap at 128 by dropping the root-most prefix.
  - Updated `enrichSpansWithPending` to prefer the new fields, with metadata parsing as a fallback for historical/cached spans.
  - Adjusted backend query, OpenAPI schema, and tests to include the new fields.

- **Migration**
  - Run ClickHouse migration `006_add_span_path_columns.sql`.
  - Deploy backend and frontend together; responses include `ids_path` and `path` (default `[]`). Backward compatible with older data.

<sup>Written for commit f84acc8381fef2dae1be619378c97b77758e15ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

