### PR TITLE
feat(examples): add Vercel AI SDK ToolLoopAgent tracing example

### DIFF
--- a/examples/typescript/vercel-ai/README.md
+++ b/examples/typescript/vercel-ai/README.md
@@ -12,16 +12,25 @@ pnpm install
 ## Usage
 
 ```bash
-pnpm demo
+pnpm demo            # agent.ts — multi-step tool-use agent (generateText)
+pnpm demo:streaming  # agent-streaming.ts — streamed handler with deferred work
+pnpm demo:agent      # tool-loop-agent.ts — ToolLoopAgent + generateObject + embeddings
 ```
 
-## What it does
+## What the demos show
 
-Runs two demo queries that exercise multi-step tool use:
+**`pnpm demo`** — two queries that exercise multi-step tool use:
 1. Weather comparison (San Francisco vs Tokyo)
 2. Stock price lookup + calculation (NVDA +10%)
 
 Tools: `getWeather`, `getStockPrice`, `calculate`
+
+**`pnpm demo:agent`** — a support-triage assistant that proves TraceRoot traces
+far more than `generateText`. In one run it exercises four AI SDK surfaces, all
+captured automatically:
+- `embedMany` + `embed` + `cosineSimilarity` (semantic routing over a small KB)
+- the **`ToolLoopAgent`** class — `.generate()` (tool loop) and `.stream()`
+- `generateObject` (schema-validated triage record)
 
 ## Why no `instrumentModules` config?
 

--- a/examples/typescript/vercel-ai/package.json
+++ b/examples/typescript/vercel-ai/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "scripts": {
     "demo": "tsx agent.ts",
-    "demo:streaming": "tsx agent-streaming.ts"
+    "demo:streaming": "tsx agent-streaming.ts",
+    "demo:agent": "tsx tool-loop-agent.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^3.0.0",
-    "@traceroot-ai/traceroot": "^0.1.6",
+    "@traceroot-ai/traceroot": "^0.1.7",
     "ai": "^6.0.0",
     "dotenv": "^16.0.0",
     "openai": "^6.0.0",

--- a/examples/typescript/vercel-ai/tool-loop-agent.ts
+++ b/examples/typescript/vercel-ai/tool-loop-agent.ts
@@ -1,0 +1,314 @@
+/**
+ * Vercel AI SDK — ToolLoopAgent + friends, all traced by TraceRoot
+ *
+ * TraceRoot's Vercel AI SDK integration works at the OpenTelemetry layer: it
+ * enriches the spans the AI SDK emits when `experimental_telemetry: { isEnabled:
+ * true }` is set, rather than wrapping any single function. Every core function
+ * is traced on equal footing — including the `ToolLoopAgent` class, which is
+ * itself a thin wrapper over generateText/streamText and therefore emits the
+ * exact same spans.
+ *
+ * This example demonstrates that by exercising FOUR distinct AI SDK surfaces in
+ * one run, framed as a small customer-support triage assistant:
+ *
+ *   support_ticket                       (observe: agent)
+ *   ├─ route_query                       (observe: span)
+ *   │   ├─ ai.embedMany.doEmbed          (embed the knowledge base)
+ *   │   └─ ai.embed.doEmbed              (embed the incoming question)
+ *   ├─ ai.generateText / .doGenerate     (ToolLoopAgent.generate — the tool loop)
+ *   │   └─ ai.toolCall  ×N               (getOrderStatus / getRefundPolicy / calculate)
+ *   └─ ai.generateObject.doGenerate      (schema-validated triage record)
+ *
+ * Plus a separate streaming demo using the SAME agent's `.stream()` method.
+ *
+ * ── On observe() and span input/output ──────────────────────────────────────
+ * observe(options, fn, ...args) auto-captures the ARGS you pass as the span's
+ * input and the return value as its output. If you wrap a zero-arg closure —
+ * observe({...}, async () => {...}) — there are no args, so the span records NO
+ * input (only output). We therefore pass the real arguments through, e.g.
+ * observe({ name: 'support_ticket', type: 'agent' }, handler, question).
+ *
+ * Note: the AI SDK already emits an `ai.toolCall` span per tool with args+result
+ * captured, so tool `execute` bodies do NOT need their own observe() wrapper —
+ * doing so just creates an empty-input duplicate span. We let the AI SDK trace
+ * the tools natively.
+ *
+ * Env vars required: OPENAI_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm demo:agent
+ *   # or: npx tsx tool-loop-agent.ts
+ */
+
+import 'dotenv/config';
+
+import {
+  ToolLoopAgent,
+  generateObject,
+  embed,
+  embedMany,
+  cosineSimilarity,
+  tool,
+  stepCountIs,
+} from 'ai';
+import { openai } from '@ai-sdk/openai';
+import { z } from 'zod';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
+
+// ── TraceRoot setup ───────────────────────────────────────────────────────────
+// No instrumentModules needed — Vercel AI SDK telemetry is handled automatically
+// via the OpenInference span processor registered inside TraceRoot.initialize().
+// Every AI SDK call below just sets experimental_telemetry: { isEnabled: true }.
+TraceRoot.initialize();
+console.log('[Observability: TraceRoot]');
+
+const LLM = openai('gpt-4o-mini');
+const EMBEDDINGS = openai.embedding('text-embedding-3-small');
+
+// ── Mock data (stands in for a real orders / policy backend) ────────────────────
+
+const orderDb: Record<string, { status: string; total: number; eta: string }> = {
+  'A-1001': { status: 'shipped', total: 129.99, eta: '2 days' },
+  'A-1002': { status: 'processing', total: 58.5, eta: '5 days' },
+  'A-1003': { status: 'delivered', total: 412.0, eta: 'delivered' },
+};
+
+// A tiny "knowledge base" we route against with embeddings (semantic routing).
+const KNOWLEDGE_BASE = [
+  {
+    topic: 'orders',
+    text: 'Track an order, check shipping status, delivery estimates, and where a package currently is.',
+  },
+  {
+    topic: 'refunds',
+    text: 'Refund eligibility, return windows, how to start a return, and how long refunds take to process.',
+  },
+  {
+    topic: 'billing',
+    text: 'Charges, invoices, payment methods, taxes, discounts, and disputing an incorrect amount.',
+  },
+];
+
+// ── ToolLoopAgent ───────────────────────────────────────────────────────────────
+// The centerpiece. `ToolLoopAgent` (v6; formerly `Experimental_Agent` / `Agent`)
+// runs the model → tool → model loop for you. Under the hood it calls
+// generateText/streamText, so it emits the identical OpenTelemetry spans and is
+// traced by TraceRoot with zero extra setup.
+//
+// The tool `execute` bodies are NOT wrapped in observe(): the AI SDK already emits
+// an `ai.toolCall` span for each with the args as input and the return value as
+// output. Wrapping them again would just add an empty-input duplicate span.
+
+const SUPPORT_INSTRUCTIONS = `You are "Ferry", a concise, reliable customer-support agent.
+You have exactly three tools: getOrderStatus, getRefundPolicy, and calculate.
+Always obtain order facts and policy text from the tools — never invent them.
+Route arithmetic (e.g. applying a restocking fee) through calculate so it is auditable.
+When you have enough information, answer in 2-4 short sentences of clean prose. No emoji.`;
+
+const supportAgent = new ToolLoopAgent({
+  model: LLM,
+  instructions: SUPPORT_INSTRUCTIONS,
+  // Stop after at most 5 model steps (loop iterations). Default would be 20.
+  stopWhen: stepCountIs(5),
+  // ↓ This single line makes the agent's underlying generateText/streamText calls
+  // emit Vercel AI SDK OpenTelemetry spans. TraceRoot enriches them automatically.
+  experimental_telemetry: { isEnabled: true, functionId: 'support_agent' },
+  tools: {
+    getOrderStatus: tool({
+      description: 'Look up the status, total, and ETA for an order id (e.g. A-1001)',
+      inputSchema: z.object({ orderId: z.string().describe('Order id like A-1001') }),
+      execute: async ({ orderId }) => {
+        const data = orderDb[orderId.toUpperCase()];
+        return data ? { orderId, ...data } : { orderId, error: 'not found' };
+      },
+    }),
+    getRefundPolicy: tool({
+      description: 'Get the refund/return policy for a product category',
+      inputSchema: z.object({
+        category: z.enum(['electronics', 'apparel', 'default']).describe('Product category'),
+      }),
+      execute: async ({ category }) => {
+        const policies: Record<string, string> = {
+          electronics: '30-day returns; 15% restocking fee on opened items.',
+          apparel: '45-day returns; free, no restocking fee.',
+          default: '30-day returns; no restocking fee.',
+        };
+        return { category, policy: policies[category] ?? policies.default };
+      },
+    }),
+    calculate: tool({
+      description: 'Evaluate a simple arithmetic expression (digits and + - * / . () only)',
+      inputSchema: z.object({ expression: z.string().describe("e.g. '129.99 * 0.15'") }),
+      execute: async ({ expression }) => {
+        if (!/^[\d\s+\-*/().]+$/.test(expression)) {
+          return { error: `Unsupported expression: ${expression}` };
+        }
+        try {
+          // eslint-disable-next-line no-new-func
+          const result = Function(`"use strict"; return (${expression})`)() as number;
+          return { expression, result };
+        } catch {
+          return { error: `Invalid expression: ${expression}` };
+        }
+      },
+    }),
+  },
+});
+
+// ── Structured-output schema (generateObject) ───────────────────────────────────
+// After the agent answers, we extract a schema-validated triage record. This
+// exercises generateObject, which TraceRoot also traces natively.
+
+const triageSchema = z.object({
+  category: z.enum(['orders', 'refunds', 'billing', 'other']),
+  priority: z.enum(['low', 'medium', 'high']),
+  sentiment: z.enum(['positive', 'neutral', 'negative']),
+  needsHuman: z.boolean(),
+  summary: z.string().describe('One-sentence summary of the resolution'),
+});
+
+// ── Steps ───────────────────────────────────────────────────────────────────────
+
+/**
+ * Semantic routing with embeddings: embed the KB topics once, embed the incoming
+ * question, and pick the closest topic by cosine similarity. Exercises embedMany,
+ * embed, and cosineSimilarity — all traced.
+ *
+ * `question` is passed as an observe() arg so the route_query span records it as input.
+ */
+async function routeQuery(question: string): Promise<{ topic: string; score: number }> {
+  return observe(
+    { name: 'route_query', type: 'span' },
+    async (q: string) => {
+      const { embeddings } = await embedMany({
+        model: EMBEDDINGS,
+        values: KNOWLEDGE_BASE.map((k) => k.text),
+        experimental_telemetry: { isEnabled: true, functionId: 'kb_embed' },
+      });
+      const { embedding: queryVec } = await embed({
+        model: EMBEDDINGS,
+        value: q,
+        experimental_telemetry: { isEnabled: true, functionId: 'query_embed' },
+      });
+
+      let best = { topic: KNOWLEDGE_BASE[0].topic, score: -Infinity };
+      embeddings.forEach((vec, i) => {
+        const score = cosineSimilarity(queryVec, vec);
+        if (score > best.score) best = { topic: KNOWLEDGE_BASE[i].topic, score };
+      });
+      console.log(`   routed to "${best.topic}" (score ${best.score.toFixed(3)})`);
+      return best;
+    },
+    question,
+  );
+}
+
+/** Extract a schema-validated triage record from the agent's answer. */
+async function extractTriage(question: string, answer: string, topic: string) {
+  const { object } = await generateObject({
+    model: LLM,
+    schema: triageSchema,
+    experimental_telemetry: { isEnabled: true, functionId: 'triage_extract' },
+    prompt:
+      `Produce a triage record for this support interaction.\n` +
+      `Routed topic: ${topic}\n\nCustomer: ${question}\n\nAgent answer: ${answer}`,
+  });
+  return object;
+}
+
+/**
+ * Full non-streaming ticket: route → agent.generate (tool loop) → structured triage.
+ * `question` is passed as an observe() arg so the support_ticket span records it as input.
+ */
+async function handleTicket(question: string) {
+  return observe(
+    { name: 'support_ticket', type: 'agent' },
+    async (q: string) => {
+      const route = await routeQuery(q);
+
+      const result = await supportAgent.generate({
+        prompt: `Relevant area: ${route.topic}\n\nCustomer question: ${q}`,
+      });
+
+      const triage = await extractTriage(q, result.text, route.topic);
+
+      const u = result.usage;
+      console.log(
+        `   usage → input=${u.inputTokens} output=${u.outputTokens} total=${u.totalTokens} ` +
+          `| steps=${result.steps.length}`,
+      );
+      return { answer: result.text, triage };
+    },
+    question,
+  );
+}
+
+/** Streaming variant using the SAME agent's .stream() method. */
+async function handleTicketStreaming(question: string): Promise<string> {
+  return observe(
+    { name: 'support_ticket_streaming', type: 'agent' },
+    async (q: string) => {
+      const stream = await supportAgent.stream({
+        prompt: `Customer question: ${q}`,
+      });
+
+      let answer = '';
+      process.stdout.write('   streaming: ');
+      for await (const chunk of stream.textStream) {
+        answer += chunk;
+        process.stdout.write(chunk);
+      }
+      process.stdout.write('\n');
+      return answer;
+    },
+    question,
+  );
+}
+
+// ── Demo ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const tickets = [
+    "Where's my order A-1001, and when will it arrive?",
+    "I opened my A-1003 electronics order — if I return it, what's the restocking fee on the $412 total?",
+  ];
+  const streamingTicket = 'Can I return apparel I bought 3 weeks ago?';
+
+  try {
+    await usingAttributes(
+      { userId: 'example-user', sessionId: 'vercel-ai-tool-loop-agent-session' },
+      () =>
+        // Pass the ticket list as an observe() arg so demo_session records it as input.
+        observe(
+          { name: 'demo_session', type: 'agent' },
+          async (allTickets: string[]) => {
+            console.log('='.repeat(60));
+            console.log('Vercel AI SDK — ToolLoopAgent + generateObject + embeddings');
+            console.log('='.repeat(60));
+
+            for (let i = 0; i < allTickets.length; i++) {
+              const question = allTickets[i];
+              console.log(`\n${'='.repeat(60)}`);
+              console.log(`Ticket ${i + 1}: ${question}`);
+              console.log('='.repeat(60));
+              const { answer, triage } = await handleTicket(question);
+              console.log('\nAgent: ' + answer);
+              console.log('Triage: ' + JSON.stringify(triage));
+            }
+
+            // Streaming demo on one more ticket, reusing the same agent.
+            console.log(`\n${'='.repeat(60)}`);
+            console.log('Streaming demo (agent.stream)');
+            console.log('='.repeat(60));
+            await handleTicketStreaming(streamingTicket);
+          },
+          tickets,
+        ),
+    );
+  } finally {
+    await TraceRoot.shutdown();
+    console.log('\n[Traces exported]');
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## What

Adds a Vercel AI SDK example that demonstrates TraceRoot tracing the full breadth of the AI SDK — not just `generateText`.

`examples/typescript/vercel-ai/tool-loop-agent.ts` is a small support-triage assistant that exercises four AI SDK surfaces in a single run, all captured automatically by TraceRoot's OpenTelemetry span-processor integration:

- **`embedMany` + `embed` + `cosineSimilarity`** — semantic routing over a small knowledge base
- **`ToolLoopAgent.generate()` and `.stream()`** — the multi-step tool loop (the v6 agent class), plus streaming
- **`generateObject`** — a schema-validated triage record

Because `ToolLoopAgent` is a thin wrapper over `generateText`/`streamText`, it emits the same OpenTelemetry spans and is traced with no extra setup beyond `experimental_telemetry: { isEnabled: true }`.

## Also

- `docs/integrations/vercel-ai.mdx`: adds a "More than `generateText`" section (covers `ToolLoopAgent` and the image/speech/transcription caveat) and fixes a stale snippet that used the pre-v6 API (`maxSteps` → `stopWhen`, `parameters` → `inputSchema`) so it runs against the pinned `ai@^6`.
- Adds a `demo:agent` script and documents all three demos in the example README.

## Verification

- `tsc --noEmit` passes (strict mode).
- Ran end-to-end against a live workspace: the multi-step tool loops, streaming, and `generateObject` all produce correct output and export cleanly, with span input/output populated as expected.

<img width="1716" height="916" alt="Screenshot 2026-07-11 at 2 45 13 PM" src="https://github.com/user-attachments/assets/86902258-1054-471a-b480-05dc7483004e" />
<img width="1720" height="919" alt="Screenshot 2026-07-11 at 2 44 40 PM" src="https://github.com/user-attachments/assets/0fb6b31e-6d2c-4f17-b7ac-0f91f8153266" />





🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Vercel `ai` SDK example that proves TraceRoot traces more than `generateText`, covering `ToolLoopAgent`, embeddings, streaming, and `generateObject`. Also adds a `demo:agent` script and updates the example README.

- **New Features**
  - Example `tool-loop-agent.ts`: a support triage assistant using `embedMany` + `embed` + `cosineSimilarity` (routing), `ToolLoopAgent.generate()` and `.stream()` (tool loop), and `generateObject` (structured output). Tracing works via `experimental_telemetry: { isEnabled: true }` with no extra setup.
  - README: documents all three demos and what they show; adds `pnpm demo:agent`.
  - Scripts: adds `demo:agent` in the example `package.json`.

- **Dependencies**
  - Updates `@traceroot-ai/traceroot` to `^0.1.7`.

<sup>Written for commit 4065339c04af599af6fe2fc524d957d6bdba68f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

