### PR TITLE
example(groq): exercise all four tools with richer demo queries

### DIFF
--- a/examples/python/groq-tool-agent/main.py
+++ b/examples/python/groq-tool-agent/main.py
@@ -1,5 +1,5 @@
 """
-Groq Tool Agent — TraceRoot Observability
+Groq Tool Agent - TraceRoot Observability
 
 A ReAct-style agent built with the Groq SDK, instrumented
 with TraceRoot via traceroot.initialize(integrations=[Integration.GROQ]).
@@ -249,7 +249,12 @@ class ReActAgent:
 # ---------------------------------------------------------------------------
 
 DEMO_QUERIES = [
+    # get_weather (x2) + comparison reasoning
     "What's the weather in San Francisco and Tokyo? Compare them.",
+    # get_stock_price + calculate (percentage math)
+    "What's the NVDA stock price? If it goes up 10%, what would the new price be?",
+    # get_current_time (x2) + get_weather (x2) - multi-tool, multi-city
+    "What time is it in Tokyo and New York right now, and what's the weather in each?",
 ]
 
 


### PR DESCRIPTION
## What

The `groq-tool-agent` example ran a single weather query, so it only exercised **one** of the agent's four tools. This expands `DEMO_QUERIES` to **three multi-step queries** that cover the full tool surface:

1. **Weather comparison** — `get_weather` (two cities)
2. **Stock price + percentage math** — `get_stock_price` + `calculate`
3. **Time + weather across two cities** — `get_current_time` + `get_weather`


## Screenshots
<img width="1722" height="921" alt="Screenshot 2026-07-11 at 2 50 12 PM" src="https://github.com/user-attachments/assets/1e62c55a-f8e9-4d2b-8fdd-cf09eabc746f" />

## Why

The single-query demo produced a thin trace. Three multi-tool queries give a much richer, more representative trace: `demo_session -> agent_turn (x3) -> nested tool spans` across all four tools — better for showcasing the instrumentation.

## Notes

- Only `examples/python/groq-tool-agent/main.py` changes — `DEMO_QUERIES` is the sole edit.
- No new dependencies, no changes to the agent loop or tools.
- Verified end-to-end: all three queries run clean and export a trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the `groq-tool-agent` example to run three multi-step demo queries that exercise all four tools and produce richer traces. Updates `DEMO_QUERIES` in `examples/python/groq-tool-agent/main.py`; no logic or dependency changes.

- **New Features**
  - Weather comparison for San Francisco and Tokyo using `get_weather` (twice).
  - NVDA price + 10% calculation using `get_stock_price` and `calculate`.
  - Current time and weather in Tokyo and New York using `get_current_time` and `get_weather`.

<sup>Written for commit 2a641559e9ba29af51c19c3f396fa99f635bfccb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

