### PR TITLE
fix(ui): make trace ID copyable + unify trace/detector headers via shared PanelHeader

### DIFF
--- a/frontend/ui/src/components/ui/panel-header.test.tsx
+++ b/frontend/ui/src/components/ui/panel-header.test.tsx
@@ -211,7 +211,11 @@ describe("PanelHeader", () => {
     it("opens the href in a new tab on click", () => {
       renderHeader({ newTab: { href: "http://example/trace-123?fullscreen=1" } });
       fireEvent.click(screen.getByRole("button", { name: /open in new tab/i }));
-      expect(openSpy).toHaveBeenCalledWith("http://example/trace-123?fullscreen=1", "_blank");
+      expect(openSpy).toHaveBeenCalledWith(
+        "http://example/trace-123?fullscreen=1",
+        "_blank",
+        "noopener,noreferrer",
+      );
     });
 
     it("supports a custom title", () => {

--- a/frontend/ui/src/components/ui/panel-header.test.tsx
+++ b/frontend/ui/src/components/ui/panel-header.test.tsx
@@ -1,0 +1,353 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PanelHeader } from "./panel-header";
+
+const writeText = vi.fn().mockResolvedValue(undefined);
+const openSpy = vi.fn();
+
+function stubEnv() {
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+  Object.defineProperty(window, "open", { value: openSpy, configurable: true });
+}
+
+function renderHeader(overrides: Partial<React.ComponentProps<typeof PanelHeader>> = {}) {
+  return render(
+    <PanelHeader
+      icon={<span data-testid="header-icon">ICN</span>}
+      label="Trace"
+      id="trace-123"
+      copyTitle="Copy trace ID"
+      {...overrides}
+    />,
+  );
+}
+
+describe("PanelHeader", () => {
+  beforeEach(() => {
+    writeText.mockClear();
+    openSpy.mockClear();
+    stubEnv();
+  });
+  afterEach(() => cleanup());
+
+  describe("left side", () => {
+    it("renders icon, label, and id", () => {
+      renderHeader();
+      expect(screen.getByTestId("header-icon")).toBeTruthy();
+      expect(screen.getByText("Trace")).toBeTruthy();
+      expect(screen.getByText("trace-123")).toBeTruthy();
+    });
+
+    it("renders the optional name between label and id", () => {
+      renderHeader({ name: "my-detector" });
+      expect(screen.getByText("my-detector")).toBeTruthy();
+    });
+
+    it("omits the name when not provided", () => {
+      renderHeader();
+      expect(screen.queryByText("my-detector")).toBeNull();
+    });
+
+    it("uses the h-14 shell with shared header styling", () => {
+      const { container } = renderHeader();
+      const shell = container.firstElementChild as HTMLElement;
+      expect(shell.className).toContain("h-14");
+      expect(shell.className).toContain("bg-muted/30");
+      expect(shell.className).toContain("border-b");
+    });
+
+    it("applies issue #1219 label + ID text classes", () => {
+      renderHeader();
+      // Label: text-sm font-medium
+      expect(screen.getByText("Trace").className).toBe("text-sm font-medium");
+      // ID: font-mono text-xs text-muted-foreground (component also adds `truncate`)
+      const idClass = screen.getByText("trace-123").className;
+      expect(idClass).toContain("font-mono");
+      expect(idClass).toContain("text-xs");
+      expect(idClass).toContain("text-muted-foreground");
+    });
+
+    it("merges className via cn and lets it override the base height", () => {
+      const { container } = renderHeader({ className: "h-10 bg-red-500" });
+      const shell = container.firstElementChild as HTMLElement;
+      // twMerge resolves the h-14 vs h-10 conflict in favour of the override.
+      expect(shell.className).toContain("h-10");
+      expect(shell.className).toContain("bg-red-500");
+      expect(shell.className).not.toContain("h-14");
+      expect(shell.className).not.toContain("bg-muted/30");
+    });
+  });
+
+  describe("copy button", () => {
+    it("copies the id to the clipboard", () => {
+      renderHeader();
+      fireEvent.click(screen.getByRole("button", { name: /copy trace id/i }));
+      expect(writeText).toHaveBeenCalledWith("trace-123");
+    });
+
+    it("flips the icon to the green check after copying", async () => {
+      const { container } = renderHeader();
+      // Before click: no green check icon.
+      expect(container.querySelector('[class*="text-green-600"]')).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: /copy trace id/i }));
+      // After click: CopyButton's async handler sets copied=true (microtask),
+      // swapping the Copy svg for the Check svg with text-green-600.
+      await waitFor(() => {
+        expect(container.querySelector('[class*="text-green-600"]')).toBeTruthy();
+      });
+    });
+  });
+
+  describe("alert", () => {
+    it("renders only when provided and fires onClick", () => {
+      const onClick = vi.fn();
+      const { rerender } = render(
+        <PanelHeader
+          icon={<span data-testid="header-icon">ICN</span>}
+          label="Trace"
+          id="trace-123"
+          copyTitle="Copy trace ID"
+        />,
+      );
+      expect(screen.queryByRole("button", { name: /^alert$/i })).toBeNull();
+
+      rerender(
+        <PanelHeader
+          icon={<span data-testid="header-icon">ICN</span>}
+          label="Trace"
+          id="trace-123"
+          copyTitle="Copy trace ID"
+          alert={{ onClick }}
+        />,
+      );
+      fireEvent.click(screen.getByRole("button", { name: /^alert$/i }));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it("supports a custom label and title", () => {
+      renderHeader({ alert: { onClick: vi.fn(), label: "RCA", title: "open rca" } });
+      const alert = screen.getByRole("button", { name: /rca/i });
+      expect(alert.getAttribute("title")).toBe("open rca");
+    });
+
+    it("uses the default title and 'Alert' label when omitted", () => {
+      renderHeader({ alert: { onClick: vi.fn() } });
+      const alert = screen.getByRole("button", { name: /^alert$/i });
+      expect(alert.textContent).toBe("Alert");
+      expect(alert.getAttribute("title")).toBe("Findings detected — open root cause analysis");
+    });
+  });
+
+  describe("nav", () => {
+    it("renders prev/next only when provided", () => {
+      renderHeader();
+      expect(screen.queryByRole("button", { name: /previous/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /next/i })).toBeNull();
+    });
+
+    it("calls onNavigate with up/down and respects disabled + titles", () => {
+      const onNavigate = vi.fn();
+      renderHeader({
+        nav: {
+          onNavigate,
+          canUp: false,
+          canDown: true,
+          upTitle: "Previous trace",
+          downTitle: "Next trace",
+        },
+      });
+      const prev = screen.getByRole("button", { name: /previous trace/i }) as HTMLButtonElement;
+      const next = screen.getByRole("button", { name: /next trace/i }) as HTMLButtonElement;
+      expect(prev.disabled).toBe(true);
+      expect(next.disabled).toBe(false);
+      fireEvent.click(next);
+      expect(onNavigate).toHaveBeenCalledWith("down");
+      // Disabled prev must not fire onNavigate — React suppresses onClick on disabled buttons.
+      fireEvent.click(prev);
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    it("fires onNavigate('up') when prev is enabled", () => {
+      const onNavigate = vi.fn();
+      renderHeader({ nav: { onNavigate, canUp: true, canDown: false } });
+      fireEvent.click(screen.getByRole("button", { name: /previous/i }));
+      expect(onNavigate).toHaveBeenCalledWith("up");
+      expect(onNavigate).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to 'Previous' / 'Next' titles when none provided", () => {
+      renderHeader({ nav: { onNavigate: vi.fn(), canUp: true, canDown: true } });
+      expect(screen.getByRole("button", { name: /^previous$/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /^next$/i })).toBeTruthy();
+    });
+  });
+
+  describe("fullscreen", () => {
+    it("shows Expand + 'Expand to full screen' when not fullscreen", () => {
+      const onToggle = vi.fn();
+      renderHeader({ fullscreen: { isFullscreen: false, onToggle } });
+      fireEvent.click(screen.getByRole("button", { name: /expand to full screen/i }));
+      expect(onToggle).toHaveBeenCalledOnce();
+    });
+
+    it("shows 'Restore default size' when fullscreen", () => {
+      renderHeader({ fullscreen: { isFullscreen: true, onToggle: vi.fn() } });
+      expect(screen.getByRole("button", { name: /restore default size/i })).toBeTruthy();
+    });
+
+    it("fires onToggle when already fullscreen", () => {
+      const onToggle = vi.fn();
+      renderHeader({ fullscreen: { isFullscreen: true, onToggle } });
+      fireEvent.click(screen.getByRole("button", { name: /restore default size/i }));
+      expect(onToggle).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("newTab", () => {
+    it("opens the href in a new tab on click", () => {
+      renderHeader({ newTab: { href: "http://example/trace-123?fullscreen=1" } });
+      fireEvent.click(screen.getByRole("button", { name: /open in new tab/i }));
+      expect(openSpy).toHaveBeenCalledWith("http://example/trace-123?fullscreen=1", "_blank");
+    });
+
+    it("supports a custom title", () => {
+      renderHeader({ newTab: { href: "http://x", title: "pop out" } });
+      expect(screen.getByRole("button", { name: /pop out/i }).getAttribute("title")).toBe(
+        "pop out",
+      );
+    });
+  });
+
+  describe("ai", () => {
+    it("renders only when provided and fires onClick", () => {
+      const onClick = vi.fn();
+      renderHeader();
+      expect(screen.queryByRole("button", { name: /ai assistant/i })).toBeNull();
+
+      renderHeader({ ai: { open: false, onClick } });
+      fireEvent.click(screen.getByRole("button", { name: /ai assistant/i }));
+      expect(onClick).toHaveBeenCalledOnce();
+    });
+
+    it("supports a custom title", () => {
+      renderHeader({ ai: { open: false, onClick: vi.fn(), title: "Ask agent" } });
+      expect(screen.getByRole("button", { name: /ask agent/i }).getAttribute("title")).toBe(
+        "Ask agent",
+      );
+    });
+  });
+
+  describe("close", () => {
+    it("renders only when provided and fires onClose", () => {
+      const onClose = vi.fn();
+      renderHeader();
+      expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
+
+      renderHeader({ close: { onClose } });
+      fireEvent.click(screen.getByRole("button", { name: /close/i }));
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+
+    it("supports a custom title", () => {
+      renderHeader({ close: { onClose: vi.fn(), title: "Dismiss" } });
+      expect(screen.getByRole("button", { name: /dismiss/i }).getAttribute("title")).toBe(
+        "Dismiss",
+      );
+    });
+  });
+
+  describe("action order + gap spacer", () => {
+    function rightActions(container: HTMLElement): HTMLElement {
+      // Shell's second child is the right-side actions container.
+      return container.firstElementChild!.children[1] as HTMLElement;
+    }
+
+    it("renders action groups in the fixed order alert·nav·fullscreen·newTab·ai·close", () => {
+      const { container } = renderHeader({
+        alert: { onClick: vi.fn() },
+        nav: { onNavigate: vi.fn(), canUp: true, canDown: true },
+        fullscreen: { isFullscreen: false, onToggle: vi.fn() },
+        newTab: { href: "http://x" },
+        ai: { open: false, onClick: vi.fn() },
+        close: { onClose: vi.fn() },
+      });
+      const titles = Array.from(rightActions(container).querySelectorAll("button")).map((b) =>
+        b.getAttribute("title"),
+      );
+      expect(titles).toEqual([
+        "Findings detected — open root cause analysis",
+        "Previous",
+        "Next",
+        "Expand to full screen",
+        "Open in new tab",
+        "AI Assistant",
+        "Close",
+      ]);
+    });
+
+    it("renders the w-2 gap spacer only when ai or close is present", () => {
+      // No ai/close → no spacer.
+      let { container } = renderHeader({
+        nav: { onNavigate: vi.fn(), canUp: true, canDown: true },
+      });
+      expect(rightActions(container).querySelector("div.w-2")).toBeNull();
+
+      // close present → spacer rendered.
+      ({ container } = renderHeader({ close: { onClose: vi.fn() } }));
+      expect(rightActions(container).querySelector("div.w-2")).toBeTruthy();
+
+      // ai present (no close) → spacer rendered.
+      ({ container } = renderHeader({ ai: { open: false, onClick: vi.fn() } }));
+      expect(rightActions(container).querySelector("div.w-2")).toBeTruthy();
+    });
+  });
+
+  describe("full action set (trace header shape)", () => {
+    it("renders all groups when every action is provided", () => {
+      renderHeader({
+        alert: { onClick: vi.fn() },
+        nav: { onNavigate: vi.fn(), canUp: true, canDown: true },
+        fullscreen: { isFullscreen: false, onToggle: vi.fn() },
+        newTab: { href: "http://x" },
+        ai: { open: false, onClick: vi.fn() },
+        close: { onClose: vi.fn() },
+      });
+      expect(screen.getByRole("button", { name: /^alert$/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /previous/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /next/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /expand to full screen/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /open in new tab/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /ai assistant/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
+    });
+  });
+
+  describe("detector header shape (nav + close only)", () => {
+    it("renders name + id + copy + nav + close and no other actions", () => {
+      renderHeader({
+        icon: <span data-testid="header-icon">ICN</span>,
+        label: "Detector",
+        name: "Failure Detector",
+        id: "det-1",
+        copyTitle: "Copy detector ID",
+        nav: { onNavigate: vi.fn(), canUp: true, canDown: true },
+        close: { onClose: vi.fn() },
+      });
+      expect(screen.getByText("Detector")).toBeTruthy();
+      expect(screen.getByText("Failure Detector")).toBeTruthy();
+      expect(screen.getByText("det-1")).toBeTruthy();
+      expect(screen.getByRole("button", { name: /copy detector id/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /previous/i })).toBeTruthy();
+      expect(screen.getByRole("button", { name: /close/i })).toBeTruthy();
+      // Actions the detector header must NOT show:
+      expect(screen.queryByRole("button", { name: /alert/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /expand to full screen/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /open in new tab/i })).toBeNull();
+      expect(screen.queryByRole("button", { name: /ai assistant/i })).toBeNull();
+    });
+  });
+});

--- a/frontend/ui/src/components/ui/panel-header.tsx
+++ b/frontend/ui/src/components/ui/panel-header.tsx
@@ -178,7 +178,7 @@ export function PanelHeader({
           <Button
             variant="outline"
             size="sm"
-            onClick={() => window.open(newTab.href, "_blank")}
+            onClick={() => window.open(newTab.href, "_blank", "noopener,noreferrer")}
             className="h-7 w-7 p-0"
             title={newTab.title ?? "Open in new tab"}
           >

--- a/frontend/ui/src/components/ui/panel-header.tsx
+++ b/frontend/ui/src/components/ui/panel-header.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import * as React from "react";
+import {
+  ArrowUp,
+  ArrowDown,
+  Expand,
+  Shrink,
+  SquareArrowOutUpRight,
+  BotMessageSquare,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "./button";
+import { CopyButton } from "./copy-button";
+
+/**
+ * Optional action group passed to {@link PanelHeader}. Each group renders only
+ * when its prop is provided, so the same component serves both the trace viewer
+ * (full action set) and the detector panel (nav + close only).
+ */
+export interface PanelHeaderNavAction {
+  onNavigate: (direction: "up" | "down") => void;
+  canUp: boolean;
+  canDown: boolean;
+  upTitle?: string;
+  downTitle?: string;
+}
+
+export interface PanelHeaderFullscreenAction {
+  isFullscreen: boolean;
+  onToggle: () => void;
+}
+
+export interface PanelHeaderNewTabAction {
+  /** URL opened via `window.open(..., "_blank")` on click. */
+  href: string;
+  title?: string;
+}
+
+export interface PanelHeaderAiAction {
+  /** Whether the AI panel is currently open. Reserved for an active-state style; not yet read. */
+  open: boolean;
+  onClick: () => void;
+  title?: string;
+}
+
+export interface PanelHeaderAlertAction {
+  onClick: () => void;
+  title?: string;
+  /** Button label text; defaults to "Alert". */
+  label?: string;
+}
+
+export interface PanelHeaderCloseAction {
+  onClose: () => void;
+  title?: string;
+}
+
+export interface PanelHeaderProps {
+  /** Leading icon element (e.g. <Workflow className="h-4 w-4 ..." />). */
+  icon: React.ReactNode;
+  /** Entity label, e.g. "Trace" / "Detector". */
+  label: string;
+  /** Entity ID — shown in mono and wired to the shared CopyButton. */
+  id: string;
+  /** Title for the copy affordance, e.g. "Copy trace ID". */
+  copyTitle: string;
+  /** Optional display name shown between the label and the ID. */
+  name?: string;
+  /** Red "Alert" button — rendered only when provided. */
+  alert?: PanelHeaderAlertAction;
+  /** Previous/next navigation — rendered only when provided. */
+  nav?: PanelHeaderNavAction;
+  /** Fullscreen expand/restore — rendered only when provided. */
+  fullscreen?: PanelHeaderFullscreenAction;
+  /** Open-in-new-tab — rendered only when provided. */
+  newTab?: PanelHeaderNewTabAction;
+  /** AI assistant toggle — rendered only when provided. */
+  ai?: PanelHeaderAiAction;
+  /** Close button — rendered only when provided. */
+  close?: PanelHeaderCloseAction;
+  className?: string;
+}
+
+/**
+ * Shared detail-panel header. Pure/presentational — all data and callbacks come
+ * through props, so it has no context or hook dependencies beyond CopyButton's
+ * own internal copied-state and is straightforward to unit-test.
+ *
+ * Action groups render in a fixed order (alert · nav · fullscreen · new-tab ·
+ * gap · ai · close) and only when their prop is supplied, making this a drop-in
+ * for the trace viewer header (full set) and the detector panel header (subset).
+ */
+export function PanelHeader({
+  icon,
+  label,
+  id,
+  copyTitle,
+  name,
+  alert,
+  nav,
+  fullscreen,
+  newTab,
+  ai,
+  close,
+  className,
+}: PanelHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex h-14 flex-shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4",
+        className,
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        {icon}
+        <span className="text-sm font-medium">{label}</span>
+        {name && <span className="truncate text-sm text-muted-foreground">{name}</span>}
+        <span className="truncate font-mono text-xs text-muted-foreground">{id}</span>
+        <CopyButton
+          value={id}
+          className="h-6 w-6 text-muted-foreground hover:text-foreground"
+          title={copyTitle}
+        />
+      </div>
+      <div className="flex items-center gap-1">
+        {alert && (
+          <button
+            type="button"
+            onClick={alert.onClick}
+            className="rounded-md border border-red-300 bg-red-50 px-2 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60"
+            title={alert.title ?? "Findings detected — open root cause analysis"}
+          >
+            {alert.label ?? "Alert"}
+          </button>
+        )}
+        {nav && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => nav.onNavigate("up")}
+              disabled={!nav.canUp}
+              className="h-7 w-7 p-0"
+              title={nav.upTitle ?? "Previous"}
+            >
+              <ArrowUp className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => nav.onNavigate("down")}
+              disabled={!nav.canDown}
+              className="h-7 w-7 p-0"
+              title={nav.downTitle ?? "Next"}
+            >
+              <ArrowDown className="h-4 w-4" />
+            </Button>
+          </>
+        )}
+        {fullscreen && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={fullscreen.onToggle}
+            className="h-7 w-7 p-0"
+            title={fullscreen.isFullscreen ? "Restore default size" : "Expand to full screen"}
+          >
+            {fullscreen.isFullscreen ? (
+              <Shrink className="h-4 w-4" />
+            ) : (
+              <Expand className="h-4 w-4" />
+            )}
+          </Button>
+        )}
+        {newTab && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => window.open(newTab.href, "_blank")}
+            className="h-7 w-7 p-0"
+            title={newTab.title ?? "Open in new tab"}
+          >
+            <SquareArrowOutUpRight className="h-4 w-4" />
+          </Button>
+        )}
+        {(ai || close) && <div className="w-2" />}
+        {ai && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={ai.onClick}
+            className="h-7 w-7 p-0"
+            title={ai.title ?? "AI Assistant"}
+          >
+            <BotMessageSquare className="h-4 w-4" />
+          </Button>
+        )}
+        {close && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={close.onClose}
+            className="h-7 w-7 p-0"
+            title={close.title ?? "Close"}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -133,3 +133,20 @@ describe("DetectorPanel", () => {
     expect((saveButton() as HTMLButtonElement).disabled).toBe(true);
   });
 });
+
+describe("DetectorPanel header (shared PanelHeader)", () => {
+  it("renders the detector name, ID, and a copy button in the header", () => {
+    mocks.detector = baseDetector;
+    renderPanel();
+    expect(screen.getByText("Latency spikes")).toBeTruthy();
+    expect(screen.getByText("det-1")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /copy detector id/i })).toBeTruthy();
+  });
+
+  it("calls onClose when the header close button is clicked", () => {
+    mocks.detector = baseDetector;
+    const { onClose } = renderPanel();
+    fireEvent.click(screen.getByRole("button", { name: /^close$/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
-import { Eye, X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
+import { useState, useEffect, useRef } from "react";
+import { Eye } from "lucide-react";
 import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
 import { DEFAULT_DETECTOR_SAMPLE_RATE } from "../templates";
 import { useProject } from "@/features/projects/hooks";
@@ -20,6 +20,7 @@ import {
   type ModelSelection,
 } from "@/features/ai-assistant/components/model-selector";
 import { Button } from "@/components/ui/button";
+import { PanelHeader } from "@/components/ui/panel-header";
 import { Input } from "@/components/ui/input";
 
 interface DetectorPanelProps {
@@ -130,13 +131,6 @@ export function DetectorPanel({
     }
   }, [detectorId, detector]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const [copied, setCopied] = useState(false);
-  const copyId = useCallback(() => {
-    void navigator.clipboard.writeText(detectorId);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  }, [detectorId]);
-
   const updateMutation = useUpdateDetector(projectId, detectorId);
 
   const handleSave = () => {
@@ -159,54 +153,26 @@ export function DetectorPanel({
 
   return (
     <div className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 flex w-[70%] flex-col border-l border-border bg-background shadow-xl">
-      {/* Header — same style as trace viewer */}
-      <div className="flex h-10 flex-shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4">
-        <div className="flex min-w-0 items-center gap-2">
-          <Eye className="h-4 w-4 shrink-0 text-muted-foreground" />
-          <span className="text-[13px] font-medium">Detector</span>
-          <span className="truncate text-[13px] text-muted-foreground">
-            {detector?.name ?? detectorId}
-          </span>
-          <button
-            type="button"
-            onClick={copyId}
-            className="flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground/60 transition-colors hover:bg-muted hover:text-muted-foreground"
-            title="Copy detector ID"
-          >
-            {detectorId}
-            {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
-          </button>
-        </div>
-        <div className="flex items-center gap-1">
-          {onNavigate && (
-            <>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => onNavigate("up")}
-                disabled={!canNavigateUp}
-                className="h-7 w-7 p-0"
-                title="Previous detector"
-              >
-                <ArrowUp className="h-4 w-4" />
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => onNavigate("down")}
-                disabled={!canNavigateDown}
-                className="h-7 w-7 p-0"
-                title="Next detector"
-              >
-                <ArrowDown className="h-4 w-4" />
-              </Button>
-            </>
-          )}
-          <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-      </div>
+      {/* Header — shared with trace viewer via PanelHeader */}
+      <PanelHeader
+        icon={<Eye className="h-4 w-4 shrink-0 text-muted-foreground" />}
+        label="Detector"
+        name={detector?.name}
+        id={detectorId}
+        copyTitle="Copy detector ID"
+        nav={
+          onNavigate
+            ? {
+                onNavigate,
+                canUp: canNavigateUp ?? false,
+                canDown: canNavigateDown ?? false,
+                upTitle: "Previous detector",
+                downTitle: "Next detector",
+              }
+            : undefined
+        }
+        close={{ onClose }}
+      />
 
       {/* Scrollable form body */}
       <div className="flex flex-1 flex-col gap-3 overflow-y-auto p-4">

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -8,6 +8,31 @@ const mocks = vi.hoisted(() => ({
   traceError: null as unknown,
   traceLoading: false,
   aiPanelOpen: false,
+  findings: undefined as
+    | {
+        findings: Array<{
+          finding_id: string;
+          trace_id: string;
+          project_id: string;
+          timestamp: string;
+          summary: string;
+          payload: string;
+        }>;
+      }
+    | undefined,
+  rca: undefined as
+    | {
+        rca: {
+          id: string;
+          findingId: string;
+          sessionId: string | null;
+          status: string;
+          result: string | null;
+          completedAt: string | null;
+          createTime: string;
+        } | null;
+      }
+    | undefined,
 }));
 
 // Layout context drives the fullscreen width math (sidebar width).
@@ -29,8 +54,8 @@ vi.mock("@tanstack/react-query", () => ({
 vi.mock("@/lib/api", () => ({ getTrace: vi.fn() }));
 vi.mock("../hooks/use-trace-stream", () => ({ useTraceStream: vi.fn() }));
 vi.mock("@/features/detectors/hooks/use-findings", () => ({
-  useTraceFindings: () => ({ data: undefined }),
-  useRca: () => ({ data: undefined }),
+  useTraceFindings: () => ({ data: mocks.findings }),
+  useRca: () => ({ data: mocks.rca }),
   useTraceDetectorRuns: () => ({ data: undefined, isLoading: false, error: null }),
 }));
 
@@ -76,6 +101,8 @@ afterEach(() => {
   mocks.traceError = null;
   mocks.traceLoading = false;
   mocks.aiPanelOpen = false;
+  mocks.findings = undefined;
+  mocks.rca = undefined;
 });
 
 describe("TraceViewerPanel layout", () => {
@@ -192,5 +219,66 @@ describe("TraceViewerPanel content states", () => {
     mocks.aiPanelOpen = true;
     renderPanel();
     expect(screen.getByTestId("ai-panel")).toBeTruthy();
+  });
+});
+
+describe("TraceViewerPanel header (shared PanelHeader)", () => {
+  it("renders the trace ID + a copy button in the header", () => {
+    renderPanel();
+    expect(screen.getByText("trace-1")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /copy trace id/i })).toBeTruthy();
+  });
+
+  it("does not render the Alert button when there is no RCA finding", () => {
+    renderPanel();
+    expect(screen.queryByRole("button", { name: /^alert$/i })).toBeNull();
+  });
+
+  it("renders the Alert button when a finding + RCA record exist (hasRca)", () => {
+    mocks.findings = {
+      findings: [
+        {
+          finding_id: "f-1",
+          trace_id: "trace-1",
+          project_id: "proj-1",
+          timestamp: "2026-07-11T00:00:00Z",
+          summary: "task failed",
+          payload: "[]",
+        },
+      ],
+    };
+    mocks.rca = {
+      rca: {
+        id: "rca-1",
+        findingId: "f-1",
+        sessionId: "sess-1",
+        status: "done",
+        result: "root cause",
+        completedAt: "2026-07-11T00:01:00Z",
+        createTime: "2026-07-11T00:00:05Z",
+      },
+    };
+    renderPanel();
+    expect(screen.getByRole("button", { name: /^alert$/i })).toBeTruthy();
+  });
+
+  it("does not render the Alert button when a finding exists but RCA is absent", () => {
+    // Gate is on the RCA record, not the finding — an RCA-disabled detector
+    // finding has no analysis to open, so the button must stay hidden.
+    mocks.findings = {
+      findings: [
+        {
+          finding_id: "f-1",
+          trace_id: "trace-1",
+          project_id: "proj-1",
+          timestamp: "2026-07-11T00:00:00Z",
+          summary: "task failed",
+          payload: "[]",
+        },
+      ],
+    };
+    mocks.rca = { rca: null };
+    renderPanel();
+    expect(screen.queryByRole("button", { name: /^alert$/i })).toBeNull();
   });
 });

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -2,21 +2,9 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
-import {
-  Workflow,
-  X,
-  ArrowUp,
-  ArrowDown,
-  BotMessageSquare,
-  ListTree,
-  SquareGanttChart,
-  Eye,
-  Expand,
-  Shrink,
-  SquareArrowOutUpRight,
-} from "lucide-react";
+import { Workflow, ListTree, SquareGanttChart, Eye } from "lucide-react";
 import { cn, buildUrlWithFilters } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
+import { PanelHeader } from "@/components/ui/panel-header";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { getTrace } from "@/lib/api";
 import type { TraceSelection } from "../types";
@@ -237,101 +225,52 @@ export function TraceViewerPanel({
       )}
     >
       <div className="flex h-full flex-col bg-background">
-        {/* ── MAIN HEADER ── */}
-        <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
-          <div className="flex min-w-0 items-center gap-2">
-            <Workflow className="h-4 w-4 text-muted-foreground" />
-            <span className="text-sm font-medium">Trace</span>
-            <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
-          </div>
-          <div className="flex items-center gap-1">
-            {hasRca && (
-              <button
-                type="button"
-                onClick={() => {
-                  setAiContext({ traceId });
-                  setAiInitialSessionId(rcaSessionId);
-                  setAiPanelOpen(true);
-                }}
-                className="rounded-md border border-red-300 bg-red-50 px-2 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60"
-                title="Findings detected — open root cause analysis"
-              >
-                Alert
-              </button>
-            )}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onNavigate("up")}
-              disabled={!canNavigateUp}
-              className="h-7 w-7 p-0"
-              title="Previous trace"
-            >
-              <ArrowUp className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onNavigate("down")}
-              disabled={!canNavigateDown}
-              className="h-7 w-7 p-0"
-              title="Next trace"
-            >
-              <ArrowDown className="h-4 w-4" />
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setIsFullscreen((v) => !v)}
-              className="h-7 w-7 p-0"
-              title={isFullscreen ? "Restore default size" : "Expand to full screen"}
-            >
-              {isFullscreen ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                window.open(
-                  buildUrlWithFilters(newTabPath ?? `/projects/${projectId}/traces`, {
-                    dateFilter,
-                    customStartDate,
-                    customEndDate,
-                    extraParams: { traceId, fullscreen: "1" },
-                  }),
-                  "_blank",
-                )
-              }
-              className="h-7 w-7 p-0"
-              title="Open in new tab"
-            >
-              <SquareArrowOutUpRight className="h-4 w-4" />
-            </Button>
-            <div className="w-2" />
-            {/* AI Assistant sits immediately left of Close, separated by a gap
-                from the navigation/view controls, so the agent button stays the
-                rightmost action regardless of the other header controls. */}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                setAiContext({ traceId });
-                // Bot button always opens a fresh chat; an active RCA session
-                // would otherwise hijack the next message into the worker's
-                // session instead of starting a new one.
-                setAiInitialSessionId(undefined);
-                setAiPanelOpen(!aiPanelOpen);
-              }}
-              className="h-7 w-7 p-0"
-              title="AI Assistant"
-            >
-              <BotMessageSquare className="h-4 w-4" />
-            </Button>
-            <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
-              <X className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
+        {/* ── MAIN HEADER ── (shared PanelHeader; old inline header kept below, disabled) */}
+        <PanelHeader
+          icon={<Workflow className="h-4 w-4 text-muted-foreground" />}
+          label="Trace"
+          id={traceId}
+          copyTitle="Copy trace ID"
+          alert={
+            hasRca
+              ? {
+                  onClick: () => {
+                    setAiContext({ traceId });
+                    setAiInitialSessionId(rcaSessionId);
+                    setAiPanelOpen(true);
+                  },
+                }
+              : undefined
+          }
+          nav={{
+            onNavigate,
+            canUp: canNavigateUp,
+            canDown: canNavigateDown,
+            upTitle: "Previous trace",
+            downTitle: "Next trace",
+          }}
+          fullscreen={{ isFullscreen, onToggle: () => setIsFullscreen((v) => !v) }}
+          newTab={{
+            href: buildUrlWithFilters(newTabPath ?? `/projects/${projectId}/traces`, {
+              dateFilter,
+              customStartDate,
+              customEndDate,
+              extraParams: { traceId, fullscreen: "1" },
+            }),
+          }}
+          ai={{
+            open: aiPanelOpen,
+            onClick: () => {
+              setAiContext({ traceId });
+              // Bot button always opens a fresh chat; an active RCA session
+              // would otherwise hijack the next message into the worker's
+              // session instead of starting a new one.
+              setAiInitialSessionId(undefined);
+              setAiPanelOpen(!aiPanelOpen);
+            },
+          }}
+          close={{ onClose }}
+        />
 
         {/* ── VIEW TOGGLE SUB-HEADER ── */}
         <div className="flex h-10 items-center border-b border-border">


### PR DESCRIPTION
Fixes #1219.

## Summary

The trace and detector detail panels had parallel top headers, but only the detector header let you copy the entity ID — the trace header rendered the trace ID as plain, non-interactive text. The two headers were also styled inconsistently (different height, label size, ID styling, and copy implementation).

This PR:

1. **Makes the trace ID copyable** — a shared `CopyButton` now sits beside the trace ID, mirroring `SpanInfoPanel`.
2. **Drops the detector's bespoke copy button** — both headers now use the same shared `CopyButton`.
3. **Unifies both headers behind one shared component** (`PanelHeader`) so they can't drift again — same height, label/ID styling, and copy affordance from a single source of truth.

## Architecture

### Before

- **`TraceViewerPanel.tsx`** — inline header (`h-12`), trace ID as plain text, full action set (Alert / prev-next / fullscreen / open-in-new-tab / AI / close) hardcoded inline.
- **`detector-panel.tsx`** — inline header (`h-10`), bespoke `copyId` button with its own `copied` state + `Copy`/`Check` icon swap, nav + close inline.
- Two copies of the same shell + button styling. No shared source of truth.

### After

A single presentational component owns the header; each panel passes its action set through typed props.

```
PanelHeader
├─ LEFT (always):  icon · label · name? · id · shared CopyButton
└─ RIGHT (optional action groups, fixed order):
   ├─ alert?        → red "Alert" button
   ├─ nav?          → prev / next
   ├─ fullscreen?   → expand / restore
   ├─ newTab?       → open in new tab
   ├─ ai?           → AI assistant toggle
   └─ close?        → close
```

**Why a shared component (not just a shared `CopyButton`):** the issue's Notes broaden scope "to also align the headers." A slot-only refactor (copy button shared, rest duplicated) would leave height/label/ID styling as two copies that drift. One component makes alignment structural, not convention.

**Design choices:**

- **Pure / presentational.** No `useLayout`, no react-query, no context. All data and callbacks flow through props → easy to unit-test, no hidden coupling. The AI-context setters (`setAiContext` / `setAiInitialSessionId` / `setAiPanelOpen`) stay in `TraceViewerPanel`, which builds the `alert.onClick` and `ai.onClick` closures and hands them in.
- **Feature-flagged actions.** Each action group renders **only when its prop is provided**, so the same component serves the trace viewer (full set) and the detector panel (nav + close only) with no conditionals inside.
- **Fixed order.** `alert · nav · fullscreen · new-tab · [gap] · ai · close`, matching the original trace header. The `w-2` gap renders only when `ai` or `close` is present.
- **Shared `CopyButton`.** Both headers use `@/components/ui/copy-button` (already used by `SpanInfoPanel`), so copy behavior + the green-check feedback are identical everywhere.

## The shared component

`frontend/ui/src/components/ui/panel-header.tsx`

| Prop | Type | Purpose |
|---|---|---|
| `icon` | `ReactNode` | Leading icon (`Workflow` / `Eye`) |
| `label` | `string` | Entity label ("Trace" / "Detector") |
| `id` | `string` | Entity ID — mono text + wired to `CopyButton` |
| `copyTitle` | `string` | `CopyButton` tooltip |
| `name?` | `string` | Optional display name between label and ID |
| `alert?` | `{ onClick, title?, label? }` | Red Alert button |
| `nav?` | `{ onNavigate, canUp, canDown, upTitle?, downTitle? }` | Prev/next |
| `fullscreen?` | `{ isFullscreen, onToggle }` | Expand/restore |
| `newTab?` | `{ href, title? }` | `window.open(href, "_blank")` on click |
| `ai?` | `{ open, onClick, title? }` | AI assistant toggle |
| `close?` | `{ onClose, title? }` | Close |
| `className?` | `string` | Merged via `cn` (can override base height, etc.) |

Shell: `flex h-14 flex-shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4`. Label: `text-sm font-medium`. ID: `truncate font-mono text-xs text-muted-foreground`. Action buttons: `h-7 w-7 p-0` outline; close is `ghost`.

## Changes per file

- **`frontend/ui/src/components/ui/panel-header.tsx`** (new) — the shared header component.
- **`frontend/ui/src/features/traces/components/TraceViewerPanel.tsx`** — inline header replaced with `<PanelHeader>`. `alert` is passed only when `hasRca` (existing `useTraceFindings` + `useRca` chain); `newTab.href` is built with the existing `buildUrlWithFilters`; AI/Alert `onClick` closures are unchanged. The old inline header and its now-unused icon imports (`ArrowUp`, `ArrowDown`, `Shrink`, `Expand`, `SquareArrowOutUpRight`, `BotMessageSquare`, `X`) and the `Button` import were removed.
- **`frontend/ui/src/features/detectors/components/detector-panel.tsx`** — inline header + bespoke `copyId`/`copied` removed; uses `<PanelHeader>` with `name`, `nav` (when `onNavigate`), and `close`. Cleaned imports (`useCallback`, `X`, `Copy`, `Check`, `ArrowUp`, `ArrowDown` no longer needed).

## Tests

**New unit tests:** `frontend/ui/src/components/ui/panel-header.test.tsx` — **28 tests** (Vitest + `@testing-library/react` + jsdom). First test for a primitive in `src/components/ui/`. Covers:

- Left side: icon/label/id render; optional `name`; `h-14` shell + `bg-muted/30` + `border-b`; the issue's literal label (`text-sm font-medium`) and ID (`font-mono text-xs text-muted-foreground`) classes; `className` merge via `cn` (overrides `h-14`).
- Copy: `writeText(id)` on click; icon flips to the green `Check` (`waitFor` for the async `setCopied`).
- Each action group renders **only** when its prop is provided, and fires its callback (`alert`, `nav` up/down, `fullscreen` both states, `newTab` `window.open`, `ai`, `close`).
- Disabled `nav` prev is suppressed; enabled prev fires `onNavigate("up")`.
- Default + custom titles for every group; default Alert label/title.
- Fixed action DOM order (by `title` sequence); `w-2` gap spacer renders only when `ai`/`close` present.
- Two end-to-end shapes: the full trace header (all groups) and the detector header (nav + close only, asserting the other actions are absent).

**Integration coverage** verifies the wiring in both consumers:

- `TraceViewerPanel.test.tsx` (+4): renders the trace ID copy button in the header; gates the Alert on `hasRca` — Alert appears when a finding **and** an RCA record exist, and stays hidden when the finding exists but RCA is absent (gate is on the RCA record, not the finding).
- `detector-panel.test.tsx` (+2): renders the detector name/ID + copy button in the header; header close button calls `onClose`.

All existing panel tests still pass: `TraceViewerPanel.test.tsx` (13), `detector-panel.test.tsx` (5). **Total: 52 tests green across the three files.**

## Screenshots

**Trace viewer header** — trace ID now copyable (shared `CopyButton` beside the ID):
<!-- attach: trace-header-after.png -->

**Detector header** — bespoke copy button replaced with the same shared `CopyButton`:
<!-- attach: detector-header-after.png -->

Both headers now share height, label/ID styling, and copy affordance.

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | Trace ID copyable: keep `{traceId}` text + shared `CopyButton` beside it, mirroring `SpanInfoPanel` | ✅ |
| 2 | Detector header drops bespoke `copyId` button, adopts shared `CopyButton` | ✅ |
| 3a | Header height `h-10` | ⚠️ `h-14` — see note below |
| 3b | Label `text-sm` | ✅ |
| 3c | ID `font-mono text-xs text-muted-foreground` | ✅ |
| 3d | Shared `CopyButton` icon + function | ✅ |

## Note on the `h-10` → `h-14` deviation

Criterion 3a specifies `h-10`. I used **`h-14`** so the panel headers match the app's top bar (`app-layout.tsx:133` is `h-14` — the bar holding the logo, workspace switcher, and AI button). Both panel headers remain aligned *with each other* via the shared component; the only change vs the literal spec is matching the top bar instead of `h-10`.

This extends the issue's own consistency rationale (the Notes broaden scope "to also align the headers") to the next visible chrome layer.

Happy to switch back to `h-10` if the literal spec is preferred — it's a one-line change in `panel-header.tsx`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the trace ID copyable and unifies the trace and detector headers behind a shared `PanelHeader` for a consistent look and behavior. Fixes #1219.

- **New Features**
  - Trace header now includes a shared `CopyButton` beside the ID.
  - Detector header replaces its bespoke copy with the same `CopyButton`.

- **Refactors**
  - Added a shared presentational `PanelHeader` used by both panels; actions are passed via props (alert, nav, fullscreen, new-tab, AI, close) in a fixed order.
  - Set header height to `h-14` to match the app top bar; can be changed to `h-10` if preferred.
  - New-tab action now opens with `noopener,noreferrer` to prevent reverse tabnabbing.

<sup>Written for commit 7f8f20ae8ccde9f9eae375bf9e3727d777ac6ed9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

