### PR TITLE
fix: wrap long git_repo/git_source_file badges in Error box (#1413)

### DIFF
--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -93,6 +93,10 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     expect(repoParentDiv?.className).toContain("inline-flex");
     expect(repoParentDiv?.className).toContain("min-w-0");
 
+    const repoIcon = repoParentDiv?.querySelector("svg");
+    expect(repoIcon).toBeTruthy();
+    expect(repoIcon?.getAttribute("class")).toContain("shrink-0");
+
     // 2. Verify git_source_file badge wrapping styles
     const expectedFilePath =
       "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/events.py:123";
@@ -105,6 +109,10 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     expect(fileParentDiv).toBeTruthy();
     expect(fileParentDiv?.className).toContain("inline-flex");
     expect(fileParentDiv?.className).toContain("min-w-0");
+
+    const fileIcon = fileParentDiv?.querySelector("svg");
+    expect(fileIcon).toBeTruthy();
+    expect(fileIcon?.getAttribute("class")).toContain("shrink-0");
 
     // 3. Verify git_ref badge is NOT affected (no min-w-0, no break-all on span or parent)
     const refSpan = screen.getByText("a1b2c3d");
@@ -142,6 +150,14 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     expect(repoParentLink?.tagName.toLowerCase()).toBe("a");
     expect(repoParentLink?.className).toContain("inline-flex");
     expect(repoParentLink?.className).toContain("min-w-0");
+
+    const headerRepoIcon = repoParentLink?.querySelector("svg");
+    expect(headerRepoIcon).toBeTruthy();
+    expect(headerRepoIcon?.getAttribute("class")).toContain("shrink-0");
+
+    const headerRepoLabel = screen.getByText("Repo:");
+    expect(headerRepoLabel).toBeTruthy();
+    expect(headerRepoLabel.className).toContain("shrink-0");
 
     // Verify header git_ref badge is NOT affected (no min-w-0, no break-all on span or parent)
     const refSpan = screen.getByText("a1b2c3d");

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import React from "react";
+import { SpanStatus } from "@traceroot/core";
+import { SpanInfoPanel } from "./SpanInfoPanel";
+import type { TraceDetail } from "@/types/api";
+import type { TraceSelection } from "../types";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("../hooks", () => ({
+  useSpanIO: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock("@/components/ui/copy-button", () => ({
+  CopyButton: () => <button data-testid="copy-button" />,
+}));
+
+vi.mock("@/components/ui/expandable-section", () => ({
+  ExpandableSection: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div data-testid={`expandable-${title.toLowerCase()}`}>{children}</div>
+  ),
+}));
+
+vi.mock("./ContentRenderer", () => ({
+  ContentRenderer: () => <div data-testid="content-renderer" />,
+}));
+
+vi.mock("./SpanKindIcon", () => ({
+  SpanKindIcon: () => <div data-testid="span-kind-icon" />,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SpanInfoPanel - Error box source location badges", () => {
+  const mockTrace: TraceDetail = {
+    trace_id: "trace-123",
+    project_id: "proj-123",
+    name: "test-trace",
+    trace_start_time: "2026-07-12T12:00:00Z",
+    user_id: null,
+    session_id: null,
+    git_ref: "a1b2c3d4e5f6g7h8i9j0",
+    git_repo: "github.com/org-name/a-very-long-monorepo-name-example",
+    environment: "production",
+    release: null,
+    input: null,
+    output: null,
+    metadata: null,
+    spans: [],
+  };
+
+  const mockSelection: TraceSelection = {
+    type: "span",
+    span: {
+      span_id: "span-456",
+      trace_id: "trace-123",
+      parent_span_id: null,
+      name: "test-span",
+      span_kind: "LLM",
+      span_start_time: "2026-07-12T12:00:00Z",
+      span_end_time: "2026-07-12T12:00:01Z",
+      status: SpanStatus.ERROR,
+      status_message: "Traceback (most recent call last): ...",
+      model_name: "gpt-4o",
+      cost: 0.005,
+      input_tokens: 150,
+      output_tokens: 250,
+      total_tokens: 400,
+      git_source_file:
+        "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/events.py",
+      git_source_line: 123,
+      git_source_function: "run",
+    },
+  };
+
+  it("renders Error box with git_repo, git_source_file, and git_ref badges", () => {
+    render(<SpanInfoPanel projectId="proj-123" trace={mockTrace} selection={mockSelection} />);
+
+    // 1. Verify git_repo badge wrapping styles
+    const repoSpan = screen.getByText("github.com/org-name/a-very-long-monorepo-name-example");
+    expect(repoSpan).toBeTruthy();
+    expect(repoSpan.className).toContain("min-w-0");
+    expect(repoSpan.className).toContain("break-all");
+
+    const repoParentDiv = repoSpan.parentElement;
+    expect(repoParentDiv).toBeTruthy();
+    expect(repoParentDiv?.className).toContain("inline-flex");
+    expect(repoParentDiv?.className).toContain("min-w-0");
+
+    // 2. Verify git_source_file badge wrapping styles
+    const expectedFilePath =
+      "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/events.py:123";
+    const fileSpan = screen.getByText(expectedFilePath);
+    expect(fileSpan).toBeTruthy();
+    expect(fileSpan.className).toContain("min-w-0");
+    expect(fileSpan.className).toContain("break-all");
+
+    const fileParentDiv = fileSpan.parentElement;
+    expect(fileParentDiv).toBeTruthy();
+    expect(fileParentDiv?.className).toContain("inline-flex");
+    expect(fileParentDiv?.className).toContain("min-w-0");
+
+    // 3. Verify git_ref badge is NOT affected (no min-w-0, no break-all on span or parent)
+    const refSpan = screen.getByText("a1b2c3d");
+    expect(refSpan).toBeTruthy();
+    expect(refSpan.className).not.toContain("min-w-0");
+    expect(refSpan.className).not.toContain("break-all");
+
+    const refParentDiv = refSpan.parentElement;
+    expect(refParentDiv).toBeTruthy();
+    expect(refParentDiv?.className).toContain("inline-flex");
+    expect(refParentDiv?.className).not.toContain("min-w-0");
+
+    // 4. Verify the sibling error message text is rendered
+    const errorMessage = screen.getByText("Traceback (most recent call last): ...");
+    expect(errorMessage).toBeTruthy();
+    expect(errorMessage.className).toContain("whitespace-pre-wrap");
+    expect(errorMessage.className).toContain("break-all");
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -123,4 +123,36 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     expect(errorMessage.className).toContain("whitespace-pre-wrap");
     expect(errorMessage.className).toContain("break-all");
   });
+
+  it("renders Trace header with git_repo and git_ref badges with correct wrapping styles", () => {
+    const mockTraceSelection: TraceSelection = {
+      type: "trace",
+    };
+
+    render(<SpanInfoPanel projectId="proj-123" trace={mockTrace} selection={mockTraceSelection} />);
+
+    // Verify header git_repo badge wrapping styles
+    const repoSpan = screen.getByText("github.com/org-name/a-very-long-monorepo-name-example");
+    expect(repoSpan).toBeTruthy();
+    expect(repoSpan.className).toContain("min-w-0");
+    expect(repoSpan.className).toContain("break-all");
+
+    const repoParentLink = repoSpan.parentElement;
+    expect(repoParentLink).toBeTruthy();
+    expect(repoParentLink?.tagName.toLowerCase()).toBe("a");
+    expect(repoParentLink?.className).toContain("inline-flex");
+    expect(repoParentLink?.className).toContain("min-w-0");
+
+    // Verify header git_ref badge is NOT affected (no min-w-0, no break-all on span or parent)
+    const refSpan = screen.getByText("a1b2c3d");
+    expect(refSpan).toBeTruthy();
+    expect(refSpan.className).not.toContain("min-w-0");
+    expect(refSpan.className).not.toContain("break-all");
+
+    const refParentLink = refSpan.parentElement;
+    expect(refParentLink).toBeTruthy();
+    expect(refParentLink?.tagName.toLowerCase()).toBe("a");
+    expect(refParentLink?.className).toContain("inline-flex");
+    expect(refParentLink?.className).not.toContain("min-w-0");
+  });
 });

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -100,7 +100,13 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     // 2. Verify git_source_file badge wrapping styles
     const expectedFilePath =
       "/opt/homebrew/Cellar/python@3.14/3.14.6/Frameworks/Python.framework/Versions/3.14/lib/python3.14/asyncio/events.py:123";
-    const fileSpan = screen.getByText(expectedFilePath);
+    const fileSpan = screen.getByText((content, element) => {
+      const text = element?.textContent || "";
+      return (
+        text.replace(/\s+/g, "") === expectedFilePath.replace(/\s+/g, "") &&
+        element?.tagName.toLowerCase() === "span"
+      );
+    });
     expect(fileSpan).toBeTruthy();
     expect(fileSpan.className).toContain("min-w-0");
     expect(fileSpan.className).toContain("break-all");
@@ -124,6 +130,10 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     expect(refParentDiv).toBeTruthy();
     expect(refParentDiv?.className).toContain("inline-flex");
     expect(refParentDiv?.className).not.toContain("min-w-0");
+
+    const refIcon = refParentDiv?.querySelector("svg");
+    expect(refIcon).toBeTruthy();
+    expect(refIcon?.getAttribute("class")).toContain("shrink-0");
 
     // 4. Verify the sibling error message text is rendered
     const errorMessage = screen.getByText("Traceback (most recent call last): ...");
@@ -170,5 +180,13 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     expect(refParentLink?.tagName.toLowerCase()).toBe("a");
     expect(refParentLink?.className).toContain("inline-flex");
     expect(refParentLink?.className).not.toContain("min-w-0");
+
+    const headerRefIcon = refParentLink?.querySelector("svg");
+    expect(headerRefIcon).toBeTruthy();
+    expect(headerRefIcon?.getAttribute("class")).toContain("shrink-0");
+
+    const headerRefLabel = screen.getByText("Ref:");
+    expect(headerRefLabel).toBeTruthy();
+    expect(headerRefLabel.className).toContain("shrink-0");
   });
 });

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -301,7 +301,8 @@ export function SpanInfoPanel({
                   <div className="inline-flex min-w-0 items-center gap-1.5 rounded bg-red-100 px-2 py-0.5 text-xs dark:bg-red-900/50">
                     <FileCode className="h-3 w-3 shrink-0 text-red-600 dark:text-red-400" />
                     <span className="min-w-0 break-all font-mono text-red-700 dark:text-red-300">
-                      {selection.span.git_source_file}{selection.span.git_source_line && (
+                      {selection.span.git_source_file}
+                      {selection.span.git_source_line && (
                         <span className="whitespace-nowrap">:{selection.span.git_source_line}</span>
                       )}
                     </span>

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -195,11 +195,11 @@ export function SpanInfoPanel({
                 href={`https://github.com/${trace.git_repo}`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors hover:bg-muted"
+                className="inline-flex min-w-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors hover:bg-muted"
               >
                 <GitBranch className="h-3 w-3 text-muted-foreground" />
                 <span className="text-muted-foreground">Repo:</span>
-                <span className="font-mono font-medium">{trace.git_repo}</span>
+                <span className="min-w-0 break-all font-mono font-medium">{trace.git_repo}</span>
               </a>
             )}
             {trace.git_ref && (

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -282,9 +282,9 @@ export function SpanInfoPanel({
             {!isTrace && (trace.git_repo || trace.git_ref || selection.span.git_source_file) && (
               <div className="mb-2 flex flex-wrap items-center gap-2">
                 {trace.git_repo && (
-                  <div className="inline-flex items-center gap-1.5 rounded bg-red-100 px-2 py-0.5 text-xs dark:bg-red-900/50">
+                  <div className="inline-flex min-w-0 items-center gap-1.5 rounded bg-red-100 px-2 py-0.5 text-xs dark:bg-red-900/50">
                     <GitBranch className="h-3 w-3 text-red-600 dark:text-red-400" />
-                    <span className="font-mono text-red-700 dark:text-red-300">
+                    <span className="min-w-0 break-all font-mono text-red-700 dark:text-red-300">
                       {trace.git_repo}
                     </span>
                   </div>
@@ -298,9 +298,9 @@ export function SpanInfoPanel({
                   </div>
                 )}
                 {selection.span.git_source_file && (
-                  <div className="inline-flex items-center gap-1.5 rounded bg-red-100 px-2 py-0.5 text-xs dark:bg-red-900/50">
+                  <div className="inline-flex min-w-0 items-center gap-1.5 rounded bg-red-100 px-2 py-0.5 text-xs dark:bg-red-900/50">
                     <FileCode className="h-3 w-3 text-red-600 dark:text-red-400" />
-                    <span className="font-mono text-red-700 dark:text-red-300">
+                    <span className="min-w-0 break-all font-mono text-red-700 dark:text-red-300">
                       {selection.span.git_source_file}
                       {selection.span.git_source_line && `:${selection.span.git_source_line}`}
                     </span>

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -197,8 +197,8 @@ export function SpanInfoPanel({
                 rel="noopener noreferrer"
                 className="inline-flex min-w-0 items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors hover:bg-muted"
               >
-                <GitBranch className="h-3 w-3 text-muted-foreground" />
-                <span className="text-muted-foreground">Repo:</span>
+                <GitBranch className="h-3 w-3 shrink-0 text-muted-foreground" />
+                <span className="shrink-0 text-muted-foreground">Repo:</span>
                 <span className="min-w-0 break-all font-mono font-medium">{trace.git_repo}</span>
               </a>
             )}
@@ -283,7 +283,7 @@ export function SpanInfoPanel({
               <div className="mb-2 flex flex-wrap items-center gap-2">
                 {trace.git_repo && (
                   <div className="inline-flex min-w-0 items-center gap-1.5 rounded bg-red-100 px-2 py-0.5 text-xs dark:bg-red-900/50">
-                    <GitBranch className="h-3 w-3 text-red-600 dark:text-red-400" />
+                    <GitBranch className="h-3 w-3 shrink-0 text-red-600 dark:text-red-400" />
                     <span className="min-w-0 break-all font-mono text-red-700 dark:text-red-300">
                       {trace.git_repo}
                     </span>
@@ -299,7 +299,7 @@ export function SpanInfoPanel({
                 )}
                 {selection.span.git_source_file && (
                   <div className="inline-flex min-w-0 items-center gap-1.5 rounded bg-red-100 px-2 py-0.5 text-xs dark:bg-red-900/50">
-                    <FileCode className="h-3 w-3 text-red-600 dark:text-red-400" />
+                    <FileCode className="h-3 w-3 shrink-0 text-red-600 dark:text-red-400" />
                     <span className="min-w-0 break-all font-mono text-red-700 dark:text-red-300">
                       {selection.span.git_source_file}
                       {selection.span.git_source_line && `:${selection.span.git_source_line}`}

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -216,8 +216,8 @@ export function SpanInfoPanel({
                 }`}
                 title={trace.git_ref}
               >
-                <GitCommitHorizontal className="h-3 w-3 text-muted-foreground" />
-                <span className="text-muted-foreground">Ref:</span>
+                <GitCommitHorizontal className="h-3 w-3 shrink-0 text-muted-foreground" />
+                <span className="shrink-0 text-muted-foreground">Ref:</span>
                 <span className="font-mono font-medium">{trace.git_ref.substring(0, 7)}</span>
               </a>
             )}
@@ -291,7 +291,7 @@ export function SpanInfoPanel({
                 )}
                 {trace.git_ref && (
                   <div className="inline-flex items-center gap-1.5 rounded bg-red-100 px-2 py-0.5 text-xs dark:bg-red-900/50">
-                    <GitCommitHorizontal className="h-3 w-3 text-red-600 dark:text-red-400" />
+                    <GitCommitHorizontal className="h-3 w-3 shrink-0 text-red-600 dark:text-red-400" />
                     <span className="font-mono text-red-700 dark:text-red-300">
                       {trace.git_ref.substring(0, 7)}
                     </span>
@@ -301,8 +301,9 @@ export function SpanInfoPanel({
                   <div className="inline-flex min-w-0 items-center gap-1.5 rounded bg-red-100 px-2 py-0.5 text-xs dark:bg-red-900/50">
                     <FileCode className="h-3 w-3 shrink-0 text-red-600 dark:text-red-400" />
                     <span className="min-w-0 break-all font-mono text-red-700 dark:text-red-300">
-                      {selection.span.git_source_file}
-                      {selection.span.git_source_line && `:${selection.span.git_source_line}`}
+                      {selection.span.git_source_file}{selection.span.git_source_line && (
+                        <span className="whitespace-nowrap">:{selection.span.git_source_line}</span>
+                      )}
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
This PR resolves #1413 by fixing horizontal layout overflow in the Error box inside the span detail info panel (`SpanInfoPanel.tsx`).

#### The Problem
Unbreakable long strings (e.g., extremely long repository URLs or deep source-file paths) rendered within `git_repo` and `git_source_file` badges did not wrap. Because flex items default to `min-width: auto`, the badges refused to shrink, causing them to push out past the right boundary of the details panel.

#### The Fix
- Added `min-w-0` to the parent `inline-flex` container `div`s, allowing them to shrink below their content size.
- Added `min-w-0 break-all` classes to the `<span>` tags for both `git_repo` and `git_source_file` to force wrapping on overflow.
- Kept the `git_ref` badge untouched (which is already truncated to 7 characters).
- Preserved existing styling for the sibling error message below it.

---

### Validation & Testing

1. **Unit Tests**:
   - Added a new unit test suite: `frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx`
   - Verified that long repo URLs and long source file paths correctly render and receive the appropriate tailwind utility classes (`break-all`, `min-w-0`).
   - Verified that the `git_ref` badge remains untouched (does not have these classes).
   - Ran `corepack pnpm test SpanInfoPanel.test.tsx` to verify successful execution (100% test pass rate).

2. **Formatting & Linting**:
   - Ran `corepack pnpm format` and `corepack pnpm format:check` to ensure the codebase remains correctly formatted.
   - Ran `corepack pnpm lint` to verify that no new linter rules were violated.
