### PR TITLE
fix(traces): pending placeholders use true ancestor starts from starts_path

### DIFF
--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -7,6 +7,7 @@ import {
   getTraceDuration,
   summarizeCostDetails,
   getTraceCostBreakdown,
+  buildSpanTree,
 } from "./index";
 import { mergeSpans } from "../hooks/use-trace-stream";
 import type { TraceDetail } from "@/types/api";
@@ -42,11 +43,19 @@ function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
   };
 }
 
-function metadataWith(idsPath: string[], namePath: string[]): string {
+function metadataWith(idsPath: string[], namePath: string[], startsPath?: string[]): string {
   return JSON.stringify({
     "traceroot.span.ids_path": idsPath,
     "traceroot.span.path": namePath,
+    ...(startsPath ? { "traceroot.span.starts_path": startsPath } : {}),
   });
+}
+
+// Converts an ISO timestamp into the epoch-nanosecond decimal string the SDKs
+// emit for traceroot.span.starts_path. Built via BigInt so the 19-digit
+// nanosecond value round-trips exactly (a plain Number would lose precision).
+function ns(iso: string): string {
+  return (BigInt(Date.parse(iso)) * BigInt(1_000_000)).toString();
 }
 
 describe("enrichSpansWithPending", () => {
@@ -192,6 +201,252 @@ describe("enrichSpansWithPending", () => {
 
     expect(s1s).toHaveLength(1);
     expect(s1s[0].pending).toBeFalsy();
+  });
+});
+
+// starts_path carries the ancestor chain's TRUE start times (index-aligned
+// with ids_path), so placeholders no longer have to estimate from whichever
+// descendant happened to arrive first. See issue #1499.
+describe("enrichSpansWithPending — starts_path (issue #1499)", () => {
+  it("uses true ancestor start from starts_path for new placeholders", () => {
+    const rootId = "root-id";
+    const midId = "mid-id";
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: midId,
+      span_start_time: "2026-07-03T10:00:00.788Z",
+      metadata: metadataWith(
+        [rootId, midId],
+        ["root", "mid", "child"],
+        [ns("2026-07-03T10:00:00.700Z"), ns("2026-07-03T10:00:00.784Z")],
+      ),
+    });
+
+    const result = enrichSpansWithPending([child]);
+    const rootPlaceholder = result.find((s) => s.span_id === rootId)!;
+    const midPlaceholder = result.find((s) => s.span_id === midId)!;
+
+    expect(rootPlaceholder.span_start_time).toBe("2026-07-03T10:00:00.700Z");
+    expect(midPlaceholder.span_start_time).toBe("2026-07-03T10:00:00.784Z");
+  });
+
+  it("starts_path wins over a later descendant-derived estimate", () => {
+    const midId = "mid-id";
+
+    // Old-SDK sibling arrives first with no starts_path — placeholder is
+    // estimated from its own start time, exactly like today.
+    const sibling1 = makeSpan({
+      span_id: "sibling1",
+      parent_span_id: midId,
+      span_start_time: "2026-07-03T10:00:00.790Z",
+      metadata: metadataWith([midId], ["mid", "sibling1"]),
+    });
+    const afterFirst = enrichSpansWithPending([sibling1]);
+    expect(afterFirst.find((s) => s.span_id === midId)!.span_start_time).toBe(
+      "2026-07-03T10:00:00.790Z",
+    );
+
+    // A starts_path-bearing descendant arrives next, carrying the true
+    // (earlier) ancestor start — min-refinement adopts it.
+    const sibling2 = makeSpan({
+      span_id: "sibling2",
+      parent_span_id: midId,
+      span_start_time: "2026-07-03T10:00:00.789Z",
+      metadata: metadataWith([midId], ["mid", "sibling2"], [ns("2026-07-03T10:00:00.784Z")]),
+    });
+    const afterSecond = enrichSpansWithPending([...afterFirst, sibling2]);
+    expect(afterSecond.find((s) => s.span_id === midId)!.span_start_time).toBe(
+      "2026-07-03T10:00:00.784Z",
+    );
+  });
+
+  it("misaligned starts_path is ignored (falls back to estimate)", () => {
+    const rootId = "root-id";
+    const midId = "mid-id";
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: midId,
+      span_start_time: "2026-07-03T10:00:00.788Z",
+      metadata: metadataWith(
+        [rootId, midId],
+        ["root", "mid", "child"],
+        // Only one entry for two ancestors — length mismatch.
+        [ns("2026-07-03T10:00:00.700Z")],
+      ),
+    });
+
+    const result = enrichSpansWithPending([child]);
+    const rootPlaceholder = result.find((s) => s.span_id === rootId)!;
+    const midPlaceholder = result.find((s) => s.span_id === midId)!;
+
+    expect(rootPlaceholder.span_start_time).toBe("2026-07-03T10:00:00.788Z");
+    expect(midPlaceholder.span_start_time).toBe("2026-07-03T10:00:00.788Z");
+  });
+
+  it("malformed starts_path entries are ignored (per-entry fallback)", () => {
+    const rootId = "root-id";
+    const midId = "mid-id";
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: midId,
+      span_start_time: "2026-07-03T10:00:00.788Z",
+      metadata: metadataWith(
+        [rootId, midId],
+        ["root", "mid", "child"],
+        ["not-a-number", ns("2026-07-03T10:00:00.784Z")],
+      ),
+    });
+
+    const result = enrichSpansWithPending([child]);
+    const rootPlaceholder = result.find((s) => s.span_id === rootId)!;
+    const midPlaceholder = result.find((s) => s.span_id === midId)!;
+
+    // Malformed entry at index 0 falls back to the descendant's own start.
+    expect(rootPlaceholder.span_start_time).toBe("2026-07-03T10:00:00.788Z");
+    // Valid entry at index 1 is still used.
+    expect(midPlaceholder.span_start_time).toBe("2026-07-03T10:00:00.784Z");
+  });
+
+  it("ms-aligned starts_path value converts to the exact millisecond (no truncation)", () => {
+    const rootId = "root-id";
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: rootId,
+      span_start_time: "2026-07-03T10:00:05.000Z",
+      metadata: metadataWith([rootId], ["root", "child"], ["1782123600002000000"]),
+    });
+
+    const result = enrichSpansWithPending([child]);
+    const rootPlaceholder = result.find((s) => s.span_id === rootId)!;
+
+    expect(Date.parse(rootPlaceholder.span_start_time)).toBe(1782123600002);
+    expect(rootPlaceholder.span_start_time.endsWith(":00.002Z")).toBe(true);
+  });
+
+  it("overlong starts_path digit string is treated as malformed (falls back, does not throw)", () => {
+    const rootId = "root-id";
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: rootId,
+      span_start_time: "2026-07-03T10:00:00.788Z",
+      metadata: metadataWith([rootId], ["root", "child"], ["9".repeat(26)]),
+    });
+
+    expect(() => enrichSpansWithPending([child])).not.toThrow();
+    const result = enrichSpansWithPending([child]);
+    const rootPlaceholder = result.find((s) => s.span_id === rootId)!;
+
+    expect(rootPlaceholder.span_start_time).toBe("2026-07-03T10:00:00.788Z");
+  });
+
+  it("starts_path longer than ids_path is ignored (falls back to estimate)", () => {
+    const rootId = "root-id";
+    const child = makeSpan({
+      span_id: "child",
+      parent_span_id: rootId,
+      span_start_time: "2026-07-03T10:00:00.788Z",
+      metadata: metadataWith(
+        [rootId],
+        ["root", "child"],
+        [ns("2026-07-03T10:00:00.700Z"), ns("2026-07-03T10:00:00.750Z")],
+      ),
+    });
+
+    const result = enrichSpansWithPending([child]);
+    const rootPlaceholder = result.find((s) => s.span_id === rootId)!;
+
+    expect(rootPlaceholder.span_start_time).toBe("2026-07-03T10:00:00.788Z");
+  });
+
+  // Replay regression (issue #1499 acceptance criterion): two concurrent
+  // sibling sections under root R — branch A's ancestor a1 truly starts at
+  // .784 but its real span arrives last (slow); branch B's ancestor b1 truly
+  // starts at .785 but its real span arrives early (fast). Without true
+  // ancestor starts, a1's placeholder is estimated from whatever descendant
+  // created it and can sort AFTER b1 even though a1 started first.
+  describe("concurrent sibling sections never flip order during batch-by-batch replay", () => {
+    const rootId = "r";
+    const aId = "a1";
+    const bId = "b1";
+
+    function buildFixtures(includeStartsPath: boolean) {
+      const sp = (path: string[]) => (includeStartsPath ? path : undefined);
+
+      const aTools = makeSpan({
+        span_id: "a-tools",
+        parent_span_id: aId,
+        span_start_time: "2026-07-03T10:00:00.788Z",
+        metadata: metadataWith(
+          [rootId, aId],
+          ["r", "a1", "a-tools"],
+          sp([ns("2026-07-03T10:00:00.700Z"), ns("2026-07-03T10:00:00.784Z")]),
+        ),
+      });
+      const b1 = makeSpan({
+        span_id: bId,
+        parent_span_id: rootId,
+        span_start_time: "2026-07-03T10:00:00.785Z",
+        metadata: metadataWith([rootId], ["r", "b1"], sp([ns("2026-07-03T10:00:00.700Z")])),
+      });
+      const bTools = makeSpan({
+        span_id: "b-tools",
+        parent_span_id: bId,
+        span_start_time: "2026-07-03T10:00:00.790Z",
+        metadata: metadataWith(
+          [rootId, bId],
+          ["r", "b1", "b-tools"],
+          sp([ns("2026-07-03T10:00:00.700Z"), ns("2026-07-03T10:00:00.785Z")]),
+        ),
+      });
+      const a1 = makeSpan({
+        span_id: aId,
+        parent_span_id: rootId,
+        span_start_time: "2026-07-03T10:00:00.784Z",
+        metadata: metadataWith([rootId], ["r", "a1"], sp([ns("2026-07-03T10:00:00.700Z")])),
+      });
+
+      return { aTools, b1, bTools, a1 };
+    }
+
+    function rootChildOrder(spans: Span[]): string[] {
+      return buildSpanTree(spans)
+        .filter((row) => row.span.parent_span_id === rootId)
+        .map((row) => row.span.span_id);
+    }
+
+    it("with starts_path: order stays [a1, b1] at every batch", () => {
+      const { aTools, b1, bTools, a1 } = buildFixtures(true);
+
+      let real: Span[] = [aTools];
+      let enriched = enrichSpansWithPending(real);
+      expect(rootChildOrder(enriched)).toEqual([aId]);
+
+      real = [...real, b1, bTools];
+      enriched = enrichSpansWithPending(real);
+      expect(rootChildOrder(enriched)).toEqual([aId, bId]);
+
+      real = [...real, a1];
+      enriched = enrichSpansWithPending(real);
+      expect(rootChildOrder(enriched)).toEqual([aId, bId]);
+    });
+
+    it("pre-fix failure mode: without starts_path, order flips at batch 2", () => {
+      const { aTools, b1, bTools, a1 } = buildFixtures(false);
+
+      let real: Span[] = [aTools];
+      let enriched = enrichSpansWithPending(real);
+      expect(rootChildOrder(enriched)).toEqual([aId]);
+
+      real = [...real, b1, bTools];
+      enriched = enrichSpansWithPending(real);
+      // a1's placeholder is estimated from a-tools' own start (.788), later
+      // than b1's real start (.785) — sections swap order mid-run.
+      expect(rootChildOrder(enriched)).toEqual([bId, aId]);
+
+      real = [...real, a1];
+      enriched = enrichSpansWithPending(real);
+      expect(rootChildOrder(enriched)).toEqual([aId, bId]);
+    });
   });
 });
 

--- a/frontend/ui/src/features/traces/utils/index.ts
+++ b/frontend/ui/src/features/traces/utils/index.ts
@@ -19,6 +19,20 @@ function parseMetadata(metadata: string | null): Record<string, unknown> {
   }
 }
 
+// Converts an epoch-nanosecond decimal string (traceroot.span.starts_path) to
+// an ISO timestamp. Uses exact BigInt integer division (not Number()/1e6 +
+// Math.floor) so ms-aligned inputs never truncate to ms-1 from double
+// rounding. The /^\d+$/ regex above guarantees BigInt(ns) won't throw.
+function nsStringToIso(ns: string): string | null {
+  if (!/^\d+$/.test(ns)) return null;
+  const ms = Number(BigInt(ns) / BigInt(1_000_000));
+  // 8.64e15 is the largest ms value Date can represent (±100,000,000 days
+  // from epoch); anything past that (e.g. a garbage/overlong digit string)
+  // would make toISOString() throw and crash the render path.
+  if (!Number.isFinite(ms) || ms <= 0 || ms > 8.64e15) return null;
+  return new Date(ms).toISOString();
+}
+
 /**
  * For every span that carries traceroot.span.ids_path (ancestor IDs, root→parent)
  * and traceroot.span.path (root→current names) in its metadata, create lightweight
@@ -43,23 +57,31 @@ export function enrichSpansWithPending(spans: Span[]): Span[] {
     const meta = parseMetadata(span.metadata ?? null);
     const idsPath = meta["traceroot.span.ids_path"] as string[] | undefined;
     const namePath = meta["traceroot.span.path"] as string[] | undefined;
+    const startsPath = meta["traceroot.span.starts_path"] as string[] | undefined;
 
     if (!idsPath || !namePath || idsPath.length === 0) continue;
     const ancestorNames = namePath.slice(0, -1);
     if (idsPath.length !== ancestorNames.length) continue;
 
+    // starts_path carries the ancestor chain's TRUE start times (epoch-ns,
+    // index-aligned with idsPath). Only trust it when the lengths match;
+    // otherwise every ancestor falls back to today's estimate (the
+    // descendant's own start), byte-identical to pre-starts_path behavior.
+    const hasStarts = !!startsPath && startsPath.length === idsPath.length;
+
     for (let i = 0; i < idsPath.length; i++) {
       const spanId = idsPath[i];
       const spanName = ancestorNames[i];
+      const candidateStart = (hasStarts && nsStringToIso(startsPath[i])) || span.span_start_time;
 
       if (existingSpanIds.has(spanId) && !pendingSpans.has(spanId)) continue;
 
       if (pendingSpans.has(spanId)) {
         const existing = pendingSpans.get(spanId)!;
         const existStart = parseTimestamp(existing.span_start_time);
-        const curStart = parseTimestamp(span.span_start_time);
+        const curStart = parseTimestamp(candidateStart);
         if (curStart < existStart) {
-          pendingSpans.set(spanId, { ...existing, span_start_time: span.span_start_time });
+          pendingSpans.set(spanId, { ...existing, span_start_time: candidateStart });
         }
         continue;
       }
@@ -71,7 +93,7 @@ export function enrichSpansWithPending(spans: Span[]): Span[] {
         parent_span_id: parentId,
         name: spanName,
         span_kind: SpanKind.SPAN,
-        span_start_time: span.span_start_time,
+        span_start_time: candidateStart,
         span_end_time: null,
         status: SpanStatus.OK,
         status_message: null,


### PR DESCRIPTION
## Summary

Fixes #1530.

Fixes the live-view section swap on concurrent traces: `enrichSpansWithPending` synthesized missing-ancestor placeholders with a start time estimated from the earliest-seen descendant — always later than the real start — so a fast sibling branch's real spans out-sorted a slow branch's still-pending placeholder, and whole sections swapped order mid-run before snapping back at completion.

The SDKs now emit `traceroot.span.starts_path` (the ancestor chain's true start times, epoch-ns decimal strings, index-aligned with `ids_path`) inside span metadata. This PR makes the frontend use those exact starts for placeholders, and pins the zero-backend-code-change contract that gets the attribute there. With no `starts_path` (old SDKs, misaligned or malformed data), behavior is byte-identical to today — the change is a safe no-op until an SDK release emits the attribute.

## How it works

```
SSE `spans` event → span.metadata carries traceroot.span.starts_path
  → enrichSpansWithPending trusts it only when startsPath.length === idsPath.length
    → per ancestor i:  candidateStart = nsStringToIso(startsPath[i]) ?? descendant start
      → placeholder creation AND the existing min-refinement both use candidateStart
        → a true parent start is always ≤ any descendant start, so min-refinement
          adopts and keeps the exact value — no new Span field, flag, or
          comparator change; tree + timeline order stays stable and correct
```

`nsStringToIso` converts with exact `BigInt` integer division (a float divide + floor truncates ~12.5% of ms-aligned inputs — e.g. every Mastra-emitted value — to the previous millisecond) and guards the Date range (`ms > 8.64e15 → null`) so a garbage digit string can never throw in the render path; malformed entries fall back to the estimate per-entry.

Backend: no code change. `starts_path` intentionally stays out of `_KNOWN_ATTRIBUTE_PREFIXES` so it survives into stored/published span metadata via the leftover-attributes bucket — a worker test pins that contract so a future whitelist edit can't silently strip it.

## What's included

- `frontend/ui/src/features/traces/utils/index.ts` — `nsStringToIso` helper (regex-validated, exact BigInt division, Date-range guard) and `candidateStart` integration in both the placeholder-creation and min-refinement paths of `enrichSpansWithPending`.
- `frontend/ui/src/features/traces/utils/index.test.ts` — new tests: placeholders get true ancestor starts; a `starts_path`-bearing descendant supersedes an earlier estimate; misaligned (shorter and longer) and malformed entries fall back per-entry; out-of-range digit strings don't throw; ms-aligned boundary value converts exactly (`…002000000` → `.002`, not `.001`); and the **batch-by-batch replay regression** — the captured concurrent-agent scenario (branches started 1 ms apart, faster branch's real spans arriving first) replayed through `enrichSpansWithPending` → `buildSpanTree`, asserting sibling order holds at every batch, plus the same fixtures with `starts_path` stripped asserting the pre-fix order flip (the test cannot pass vacuously).
- `backend/worker/tests/test_otel_transform_trace_naming.py` — pins that `traceroot.span.starts_path` survives into the stored span `metadata` JSON alongside known attributes.

Existing backdating tests are untouched (old-SDK behavior pinned); no sort comparators or `buildSpanTree` changes.

## Test plan

- [x] `pnpm vitest run src/features/traces/utils/index.test.ts` — 37/37 passing (replay regression flips without the fix, holds with it)
- [x] `pnpm vitest run` — full frontend suite passing (only pre-existing, unrelated GitHubStarWidget failures remain)
- [x] `uv run pytest backend/worker/tests/test_otel_transform_trace_naming.py` — 8/8 passing
- [x] `npx tsc --noEmit` — clean for touched files
- [ ] With an SDK build that emits `starts_path`: watch a live concurrent multi-agent run and confirm sibling sections never swap mid-run and match the post-completion order
- [ ] With the current released SDK (no `starts_path`): confirm the live view behaves exactly as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pending placeholders now use true ancestor start times from `traceroot.span.starts_path` to keep sibling sections in a stable order during live runs and after reloads. Adds precise ns-to-ISO conversion and safe parsing to prevent truncation and render errors.

- **Bug Fixes**
  - Read `traceroot.span.starts_path` (index-aligned with `ids_path`) and use it for placeholder creation and min-refinement; fall back cleanly when lengths misalign or entries are malformed; added exact BigInt ns-to-ISO conversion with a Date-range guard.
  - Placeholders no longer fake durations: `getSpanDuration` returns null for pending spans, `getTraceDuration` ignores them when computing max end, and the timeline stops marking them as in-progress.
  - Tests cover starts-path precedence over estimates, misaligned/malformed entries, exact millisecond conversion, overlong digit strings falling back safely, and a batch-by-batch replay that proves sibling order never flips (with a pre-fix case that asserts the flip).

<sup>Written for commit ed751f7aa651e68f6b2b0f24efea5cb46720a579. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

