### PR TITLE
docs(pi-agent-sdk): add TypeScript example for Pi Coding Agent SDK

### DIFF
--- a/examples/typescript/.gitignore
+++ b/examples/typescript/.gitignore
@@ -1,1 +1,2 @@
 examples/typescript/*/pnpm-lock.yaml
+examples/typescript/pi-agent-sdk/workspace/

--- a/examples/typescript/.gitignore
+++ b/examples/typescript/.gitignore
@@ -1,2 +1,2 @@
-examples/typescript/*/pnpm-lock.yaml
-examples/typescript/pi-agent-sdk/workspace/
+*/pnpm-lock.yaml
+pi-agent-sdk/workspace/

--- a/examples/typescript/pi-agent-sdk/.env.example
+++ b/examples/typescript/pi-agent-sdk/.env.example
@@ -1,0 +1,7 @@
+# TraceRoot
+TRACEROOT_API_KEY=your_traceroot_api_key_here
+# Override to send traces to a local dev server instead of app.traceroot.ai
+# TRACEROOT_HOST_URL=http://localhost:8000
+
+# OpenAI (used by the demo's model)
+OPENAI_API_KEY=your_openai_api_key_here

--- a/examples/typescript/pi-agent-sdk/README.md
+++ b/examples/typescript/pi-agent-sdk/README.md
@@ -1,0 +1,31 @@
+# Pi Coding Agent SDK
+
+Programmatically-embedded [Pi coding agent](https://pi.dev) session (`@earendil-works/pi-coding-agent`), instrumented with [TraceRoot](https://traceroot.ai).
+
+## Setup
+
+Requires Node >=22.19 — `@earendil-works/pi-coding-agent` is ESM-only and won't run on older LTS versions.
+
+```bash
+cp .env.example .env  # fill in your API keys
+pnpm install
+pnpm demo
+```
+
+## What it does
+
+Runs three short-lived `AgentSession`s against a scratch workspace to exercise the distinct span shapes TraceRoot captures for a coding agent:
+
+1. **No tools** — a question the model can answer directly. Produces an `AGENT → LLM` span only.
+2. **Write + run** — write `add.js` and a test for it, then run the test with `node` via the `bash` tool. Produces `AGENT → TOOL (write)` ×2 and `AGENT → TOOL (bash)`.
+3. **Tool error** — read a file that doesn't exist. Produces `AGENT → TOOL (read)` with `ERROR` status.
+
+## Why three sessions instead of one?
+
+Tool availability (`tools` / `noTools`) is set when an `AgentSession` is created — there's no per-prompt override. Each turn above needs a different tool configuration, so the demo creates a fresh session per turn rather than reusing one across all three.
+
+## How the tracing works
+
+`instrumentPiCodingAgent()` patches `AgentSession.prototype` before any session is created, so every session — however it's built — is traced automatically with full agent/LLM/tool span semantics. There's no `observe()` call to add and no manual span code: the package instruments the SDK directly, independent of the generic `@traceroot-ai/traceroot` SDK used in the other examples in this directory.
+
+See the [`@traceroot-ai/pi` README](https://github.com/traceroot-ai/traceroot-ts/tree/main/packages/pi) for the full configuration surface.

--- a/examples/typescript/pi-agent-sdk/README.md
+++ b/examples/typescript/pi-agent-sdk/README.md
@@ -12,20 +12,60 @@ pnpm install
 pnpm demo
 ```
 
-## What it does
+## The scenario
 
-Runs three short-lived `AgentSession`s against a scratch workspace to exercise the distinct span shapes TraceRoot captures for a coding agent:
+Incident INV-2041: a storefront checkout is overcharging customers who apply coupons. The demo seeds a tiny, deliberately-broken Node project into a scratch `workspace/` directory — `src/pricing.js` has a planted bug where the flat-coupon branch *adds* the discount instead of subtracting it — then drives a **single persistent `AgentSession`** through the incident end to end, the way an on-call engineer would actually use a coding agent: look before you touch, then fix, then write it up.
 
-1. **No tools** — a question the model can answer directly. Produces an `AGENT → LLM` span only.
-2. **Write + run** — write `add.js` and a test for it, then run the test with `node` via the `bash` tool. Produces `AGENT → TOOL (write)` ×2 and `AGENT → TOOL (bash)`.
-3. **Tool error** — read a file that doesn't exist. Produces `AGENT → TOOL (read)` with `ERROR` status.
+1. **Recon** (read-only tools: `ls`, `find`, `grep`, `read`)
+   - Prompt 1: map the repo with `ls` and `find`.
+   - Prompt 2: investigate the overcharge — `grep` for coupon logic, `read` `src/pricing.js`, and `read` `config/pricing.json` for a per-store override. That file doesn't exist, so this `read` call genuinely errors; the agent is told to report the error rather than treat it as fatal.
+2. **Remediate** (full tool set: `read`, `bash`, `edit`, `write`, `grep`, `find`, `ls`)
+   - Prompt 3: run `node test/pricing.test.js` first — it genuinely fails (nonzero exit) against the planted bug — fix `src/pricing.js` with `edit`, then re-run the test to confirm it now passes.
+3. **Report** (same full tool set)
+   - Prompt 4: write `POSTMORTEM.md` with the root cause, the fix, and how it was verified, using `write`.
 
-## Why three sessions instead of one?
+## Span tree
 
-Tool availability (`tools` / `noTools`) is set when an `AgentSession` is created — there's no per-prompt override. Each turn above needs a different tool configuration, so the demo creates a fresh session per turn rather than reusing one across all three.
+```
+incident_inv_2041                        (observe: agent)
+├─ recon                                 (observe: span)
+│   ├─ AGENT  prompt 1: map the repo
+│   │   └─ TOOL  ls, find
+│   └─ AGENT  prompt 2: investigate the overcharge
+│       └─ TOOL  grep, read, read (ERROR — config/pricing.json is missing)
+├─ remediate                             (observe: span)
+│   └─ AGENT  prompt 3: reproduce, fix, verify
+│       └─ TOOL  bash (ERROR — test fails pre-fix), edit, bash
+└─ report                                (observe: span)
+    └─ AGENT  prompt 4: write POSTMORTEM.md
+        └─ TOOL  write
+```
+
+Both `ERROR` spans are real failures, not staged ones: the `read config/pricing.json` call errors because that file was never created (a plausible dangling reference to a per-store override), and the first `bash` test run errors because the planted bug makes the assertion fail and the process exits nonzero.
+
+**Span count:**
+
+| Spans | Count | Source |
+|---|---|---|
+| Custom (`observe()`) | 4 | root `incident_inv_2041` + `recon` + `remediate` + `report` |
+| AGENT | 4 | one per `session.prompt()` call |
+| TOOL | 9 | `ls`, `find` \| `grep`, `read`, `read`(ERROR) \| `bash`(ERROR), `edit`, `bash` \| `write` — all 7 builtin tools, 2 genuine ERROR spans |
+| LLM | ~7-13 | one per model turn; fewer if the model batches several tool calls into a single turn |
+| **Total** | **≈24-30** | |
+
+## One session, changing tool sets
+
+Tool availability has two layers in `@earendil-works/pi-coding-agent`, and the distinction matters:
+
+- **`tools` / `noTools` at `createAgentSession()` time** filter the tool **registry** itself, permanently, for the life of the session. If you pass `tools: ['read', 'grep']` at creation, no later call can ever enable `bash`, `edit`, or `write` on that session — the registry simply doesn't contain them.
+- **`session.setActiveToolsByName(names)`** swaps the **active** set drawn from whatever registry the session has. It takes effect on the next turn, unknown names are silently ignored, and it never widens beyond the registry `tools`/`noTools` established at creation.
+
+So narrow-then-widen only works if the session is created with the full registry (no `tools` option) and narrowed immediately with `setActiveToolsByName()` before the first prompt. That's what this demo does: `createAgentSession()` is called without `tools`, then `session.setActiveToolsByName(['ls', 'find', 'grep', 'read'])` runs before recon's first prompt to get genuine least-privilege read-only access, and `session.setActiveToolsByName([...all seven])` widens it before remediate's prompt once the fix actually needs to write files and run shell commands. One session, one incident, tool sets that change shape as the investigation progresses — instead of three sessions standing in for three tool configurations.
 
 ## How the tracing works
 
-`instrumentPiCodingAgent()` patches `AgentSession.prototype` before any session is created, so every session — however it's built — is traced automatically with full agent/LLM/tool span semantics. There's no `observe()` call to add and no manual span code: the package instruments the SDK directly, independent of the generic `@traceroot-ai/traceroot` SDK used in the other examples in this directory.
+`instrumentPiCodingAgent()` patches `AgentSession.prototype` before any session is created, so every `session.prompt()` call is traced automatically with full agent/LLM/tool span semantics — no manual span code for those three layers.
+
+This example also uses the core `@traceroot-ai/traceroot` SDK's `observe()` and `usingAttributes()` directly, for the workflow-framing spans (`incident_inv_2041`, `recon`, `remediate`, `report`) that group the four prompts into the incident narrative. Both instrumentation paths must agree on where spans get exported, which is why initialization order matters: `TraceRoot.initialize()` runs first and registers the global OpenTelemetry pipeline; `instrumentPiCodingAgent()` then detects that pipeline and attaches to it instead of building its own. Get the order backwards and `instrumentPiCodingAgent()` commits to a private pipeline that a later `TraceRoot.initialize()` can never join. With the order right, a single `TraceRoot.shutdown()` at the end flushes everything — the pi spans and the `observe()`/`usingAttributes()` spans alike.
 
 See the [`@traceroot-ai/pi` README](https://github.com/traceroot-ai/traceroot-ts/tree/main/packages/pi) for the full configuration surface.

--- a/examples/typescript/pi-agent-sdk/README.md
+++ b/examples/typescript/pi-agent-sdk/README.md
@@ -64,8 +64,8 @@ So narrow-then-widen only works if the session is created with the full registry
 
 ## How the tracing works
 
-`instrumentPiCodingAgent()` patches `AgentSession.prototype` before any session is created, so every `session.prompt()` call is traced automatically with full agent/LLM/tool span semantics — no manual span code for those three layers.
+`TraceRoot.initialize({ instrumentModules: { piCodingAgent: pi } })` instruments `AgentSession` before any session is created, so every `session.prompt()` call is traced automatically with full agent/LLM/tool span semantics — no manual span code for those three layers.
 
-This example also uses the core `@traceroot-ai/traceroot` SDK's `observe()` and `usingAttributes()` directly, for the workflow-framing spans (`incident_inv_2041`, `recon`, `remediate`, `report`) that group the four prompts into the incident narrative. Both instrumentation paths must agree on where spans get exported, which is why initialization order matters: `TraceRoot.initialize()` runs first and registers the global OpenTelemetry pipeline; `instrumentPiCodingAgent()` then detects that pipeline and attaches to it instead of building its own. Get the order backwards and `instrumentPiCodingAgent()` commits to a private pipeline that a later `TraceRoot.initialize()` can never join. With the order right, a single `TraceRoot.shutdown()` at the end flushes everything — the pi spans and the `observe()`/`usingAttributes()` spans alike.
+This example also uses the core `@traceroot-ai/traceroot` SDK's `observe()` and `usingAttributes()` directly, for the workflow-framing spans (`incident_inv_2041`, `recon`, `remediate`, `report`) that group the four prompts into the incident narrative. Both the pi spans and these direct spans flow through the one OpenTelemetry pipeline `TraceRoot.initialize()` registers, so a single `TraceRoot.shutdown()` at the end flushes everything. `initialize()` must run before `createAgentSession()`, since wiring pi patches `AgentSession`'s prototype.
 
-See the [`@traceroot-ai/pi` README](https://github.com/traceroot-ai/traceroot-ts/tree/main/packages/pi) for the full configuration surface.
+See the [pi integration docs](https://traceroot.ai/docs/integrations/pi) for the full configuration surface.

--- a/examples/typescript/pi-agent-sdk/agent.ts
+++ b/examples/typescript/pi-agent-sdk/agent.ts
@@ -8,14 +8,30 @@
  * so every session — however it was constructed — is traced with full
  * agent/LLM/tool span semantics, no manual span code required.
  *
- * Tool availability is fixed when a session is created (there's no per-prompt
- * override), so this demo uses three short-lived sessions to show the
- * distinct span shapes TraceRoot captures:
+ * This demo plays out a small on-call incident end-to-end on ONE persistent
+ * `AgentSession`, narrowing and widening its tool set between phases instead
+ * of recreating the session (see "One session, changing tool sets" in the
+ * README for why that's possible, and why the session must be created
+ * without a `tools` allowlist for it to work):
  *
- *   1. no tools available                      → AGENT → LLM only
- *   2. write a function + a test, run it        → AGENT → TOOL (write) ×2,
- *      via bash                                    AGENT → TOOL (bash)
- *   3. read a file that does not exist          → AGENT → TOOL (read), ERROR status
+ *   incident_inv_2041                        (observe: agent)
+ *   ├─ recon                                 (observe: span) — read-only tools
+ *   │   ├─ AGENT  prompt 1: map the repo
+ *   │   │   └─ TOOL  ls, find
+ *   │   └─ AGENT  prompt 2: investigate the overcharge
+ *   │       └─ TOOL  grep, read, read (ERROR — config/pricing.json is missing)
+ *   ├─ remediate                             (observe: span) — full tool set
+ *   │   └─ AGENT  prompt 3: reproduce, fix, verify
+ *   │       └─ TOOL  bash (ERROR — failing test), edit, bash
+ *   └─ report                                (observe: span)
+ *       └─ AGENT  prompt 4: write POSTMORTEM.md
+ *           └─ TOOL  write
+ *
+ * Span count: 4 custom (root + 3 phases) + 4 AGENT (one per session.prompt()
+ * call) + 9 TOOL (ls, find, grep, read, read-ERROR, bash-ERROR, edit, bash,
+ * write — all 7 builtin tool types, 2 genuine ERROR spans) + roughly 7-13 LLM
+ * spans (one per model turn; fewer if the model batches several tool calls
+ * into a single turn) ≈ 24-30 spans total.
  *
  * Env vars required: OPENAI_API_KEY, TRACEROOT_API_KEY
  *
@@ -33,15 +49,25 @@ import {
   createAgentSession,
   ModelRegistry,
   type AgentSession,
-  type CreateAgentSessionOptions,
 } from '@earendil-works/pi-coding-agent';
 import { instrumentPiCodingAgent } from '@traceroot-ai/pi';
+import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
+
+// TraceRoot.initialize() must run FIRST. instrumentPiCodingAgent() checks for
+// an already-registered global OpenTelemetry provider: if one exists, it
+// attaches to that SHARED pipeline (so the TraceRoot.shutdown() call at the
+// bottom of this file flushes both the pi spans and the observe()/
+// usingAttributes() spans this file creates directly). If instrumentation
+// ran first, it would find no provider yet, build its own PRIVATE export
+// pipeline, and commit to it for the life of the process — a
+// TraceRoot.initialize() call afterwards would never be seen by it.
+TraceRoot.initialize();
 
 // Instrument BEFORE creating any session — instrumentPiCodingAgent() patches
 // AgentSession.prototype, so this must run before createAgentSession() below.
-instrumentPiCodingAgent(pi, {
-  apiKey: process.env.TRACEROOT_API_KEY,
-});
+// No apiKey argument needed: in shared mode it rides on the pipeline
+// TraceRoot.initialize() just registered, which already read TRACEROOT_API_KEY.
+instrumentPiCodingAgent(pi);
 
 console.log('[Observability: TraceRoot]');
 
@@ -50,12 +76,86 @@ console.log('[Observability: TraceRoot]');
 // self-contained and don't touch wherever `pnpm demo` happens to run from.
 const workspace = join(fileURLToPath(new URL('.', import.meta.url)), 'workspace');
 rmSync(workspace, { recursive: true, force: true });
-mkdirSync(workspace, { recursive: true });
-// Mark the workspace CommonJS so the agent's generated require()-based files
-// (turn 2, below) run under `node` without hitting a module-type error.
+mkdirSync(join(workspace, 'src'), { recursive: true });
+mkdirSync(join(workspace, 'test'), { recursive: true });
+
+// Mark the workspace CommonJS so the seeded require()-based source and test
+// files run under `node` without hitting a module-type error.
 writeFileSync(
   join(workspace, 'package.json'),
-  JSON.stringify({ name: 'traceroot-pi-demo-workspace', private: true, type: 'commonjs' }, null, 2),
+  JSON.stringify({ name: 'checkout-pricing', private: true, type: 'commonjs' }, null, 2),
+);
+
+writeFileSync(
+  join(workspace, 'README.md'),
+  '# checkout-pricing\n\n' +
+    'Order-total calculation for a storefront checkout: sum item prices into a\n' +
+    'subtotal, then apply an optional coupon (flat-amount or percent-off) on top.\n',
+);
+
+// PLANTED BUG: the flat branch adds the coupon amount instead of subtracting
+// it, so a flat coupon *increases* the total — this is incident INV-2041. The
+// percent branch is correct. The config/pricing.json reference below is a
+// realistic dangling pointer (per-store overrides would live there if a store
+// had customized its coupon rules; none exists in this workspace), giving
+// recon a genuine tool error to hit rather than a staged one.
+writeFileSync(
+  join(workspace, 'src', 'pricing.js'),
+  `'use strict';
+
+// Per-store discount overrides, when a store has customized coupon rules,
+// live in config/pricing.json. Most stores don't have one and use these
+// defaults.
+function applyCoupon(subtotal, coupon) {
+  if (coupon.type === 'flat') {
+    return subtotal + coupon.amount;
+  }
+  if (coupon.type === 'percent') {
+    return subtotal * (1 - coupon.amount / 100);
+  }
+  throw new Error(\`Unknown coupon type: \${coupon.type}\`);
+}
+
+module.exports = { applyCoupon };
+`,
+);
+
+writeFileSync(
+  join(workspace, 'src', 'cart.js'),
+  `'use strict';
+
+const { applyCoupon } = require('./pricing');
+
+// Sums item prices and applies an optional coupon to get the cart total.
+function cartTotal(items, coupon) {
+  const subtotal = items.reduce((sum, item) => sum + item.price, 0);
+  return coupon ? applyCoupon(subtotal, coupon) : subtotal;
+}
+
+module.exports = { cartTotal };
+`,
+);
+
+// Plain assert — no test runner needed for a two-assertion smoke test, and an
+// uncaught throw from assert.strictEqual exits the process with a nonzero
+// code, which is all the demo needs for a genuine ERROR-status bash span.
+writeFileSync(
+  join(workspace, 'test', 'pricing.test.js'),
+  `'use strict';
+
+const assert = require('node:assert');
+const { applyCoupon } = require('../src/pricing');
+
+// $20 flat off a $100 subtotal should total $80. Fails today: the bug adds
+// the coupon amount instead of subtracting it.
+assert.strictEqual(applyCoupon(100, { type: 'flat', amount: 20 }), 80);
+
+// 10% off a $100 subtotal should total $90 — already correct, kept here so a
+// green run proves the fix didn't just special-case the flat branch.
+assert.strictEqual(applyCoupon(100, { type: 'percent', amount: 10 }), 90);
+
+console.log('pricing tests passed');
+`,
 );
 
 const authStorage = AuthStorage.create();
@@ -99,46 +199,115 @@ function logEvents(session: AgentSession): void {
   });
 }
 
-/** Runs one prompt on a freshly created, freshly disposed session. */
-async function runTurn(prompt: string, sessionOptions: Partial<CreateAgentSessionOptions>) {
+const INCIDENT_SUMMARY =
+  'Incident INV-2041: storefront checkout is overcharging customers who apply coupons.';
+
+const RECON_PROMPTS: readonly [string, string] = [
+  'Map the repo: use ls on the project root, then find to locate every .js file. ' +
+    'Briefly describe the project layout — no need to read file contents yet.',
+  `${INCIDENT_SUMMARY} Flat-amount coupons appear to increase the total instead of ` +
+    'reducing it. grep for coupon-related code, then read src/pricing.js. Also check ' +
+    'whether this store has a per-store override by reading config/pricing.json — if ' +
+    "that read fails, report the exact error rather than treating it as fatal. Give me " +
+    'your working theory of the bug.',
+];
+
+const REMEDIATE_PROMPT =
+  'Reproduce, fix, and verify. First run `node test/pricing.test.js` and tell me exactly ' +
+  'how it fails. Then make the minimal fix to src/pricing.js using the edit tool. Then ' +
+  're-run the same test and confirm it now passes.';
+
+const REPORT_PROMPT =
+  'Write POSTMORTEM.md in this directory documenting INV-2041: root cause, the fix ' +
+  'applied, and how it was verified. Keep it short — a few short sections, not an essay.';
+
+/**
+ * Read-only investigation. The agent physically cannot write, edit, or run
+ * shell commands here — enforced by tool availability rather than prompt
+ * engineering. Two prompts, one span: mapping the repo and diagnosing the
+ * bug are both "look, don't touch" work.
+ */
+async function recon(session: AgentSession, prompts: readonly [string, string]): Promise<void> {
+  return observe(
+    { name: 'recon', type: 'span' },
+    async ([mapPrompt, investigatePrompt]: readonly [string, string]) => {
+      await session.prompt(mapPrompt);
+      await session.prompt(investigatePrompt);
+    },
+    prompts,
+  );
+}
+
+/**
+ * Widen to the full tool set and let the agent reproduce, fix, and verify.
+ * setActiveToolsByName() takes effect on the NEXT turn — the session.prompt()
+ * call below — not retroactively; recon's already-completed turns keep
+ * whatever tool set was active when they ran.
+ */
+async function remediate(session: AgentSession, prompt: string): Promise<void> {
+  session.setActiveToolsByName(['read', 'bash', 'edit', 'write', 'grep', 'find', 'ls']);
+  return observe({ name: 'remediate', type: 'span' }, (p: string) => session.prompt(p), prompt);
+}
+
+/** Document the incident. The write tool is already active from remediate(). */
+async function report(session: AgentSession, prompt: string): Promise<void> {
+  return observe({ name: 'report', type: 'span' }, (p: string) => session.prompt(p), prompt);
+}
+
+async function main(): Promise<void> {
   const { session } = await createAgentSession({
     cwd: workspace,
     model,
     authStorage,
     modelRegistry,
-    ...sessionOptions,
+    // Deliberately NO `tools` option here. Passing one would permanently cap
+    // the tool REGISTRY (not just the active set) to that allowlist, and
+    // setActiveToolsByName() could then never widen past it later. Creating
+    // with the full registry and narrowing immediately below is the only way
+    // to get least-privilege recon that can still widen for the fix. See
+    // "One session, changing tool sets" in the README.
   });
   logEvents(session);
+
+  // Narrow to a read-only set before the FIRST prompt. The default active set
+  // on a `tools`-less session would be read/bash/edit/write — already wider
+  // than recon should have — so this line, not the omission above, is what
+  // actually enforces least privilege for the recon phase.
+  session.setActiveToolsByName(['ls', 'find', 'grep', 'read']);
+
   try {
-    await session.prompt(prompt);
+    await usingAttributes(
+      { userId: 'example-user', sessionId: 'pi-agent-sdk-incident-session' },
+      () =>
+        observe(
+          { name: 'incident_inv_2041', type: 'agent' },
+          async (summary: string) => {
+            console.log(`\n--- ${summary} ---`);
+            await recon(session, RECON_PROMPTS);
+            await remediate(session, REMEDIATE_PROMPT);
+            await report(session, REPORT_PROMPT);
+          },
+          INCIDENT_SUMMARY,
+        ),
+    );
   } finally {
     session.dispose();
+    // Flush inside main()'s own finally, not a separate .finally() bolted
+    // onto the call below: shutdown() can itself reject (network failure,
+    // bad TRACEROOT_API_KEY, unreachable backend), and a rejection from a
+    // .finally() callback on an already-caught chain becomes an unhandled
+    // rejection nothing downstream consumes. Keeping it here means any
+    // shutdown failure flows through the single catch() below like every
+    // other error in this file. instrumentPiCodingAgent() attached to the
+    // shared pipeline TraceRoot.initialize() registered, so this one call
+    // flushes both the pi spans and the observe()/usingAttributes() spans
+    // created directly in this file.
+    await TraceRoot.shutdown();
+    console.log('\n[Traces exported]');
   }
 }
 
-async function main() {
-  console.log('\n--- Turn 1: no tools (pure AGENT → LLM) ---');
-  await runTurn('What is the capital of France? Answer in one word.', { noTools: 'all' });
-
-  console.log('\n--- Turn 2: write a function, then write + run a test for it ---');
-  await runTurn(
-    'Create add.js exporting a function add(a, b) that returns a + b (CommonJS, ' +
-      'module.exports). Then write test-add.js that requires add.js and asserts ' +
-      'add(2, 3) === 5, run it with node, and tell me whether it passed.',
-    { tools: ['write', 'bash'] },
-  );
-
-  console.log('\n--- Turn 3: tool error (read a file that does not exist) ---');
-  await runTurn(
-    'Use the read tool to read /tmp/definitely-does-not-exist-traceroot-demo.txt ' +
-      'and tell me exactly what error occurred.',
-    { tools: ['read'] },
-  );
-}
-
-main()
-  .then(() => console.log('\n[Traces exported]'))
-  .catch((error) => {
-    console.error(error);
-    process.exitCode = 1;
-  });
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/examples/typescript/pi-agent-sdk/agent.ts
+++ b/examples/typescript/pi-agent-sdk/agent.ts
@@ -4,7 +4,7 @@
  * `@earendil-works/pi-coding-agent` is the library form of the `pi` coding
  * agent: instead of an interactive CLI, you drive an `AgentSession` from your
  * own Node process and it reads/writes files and runs shell commands in a
- * real working directory. `@traceroot-ai/pi` patches `AgentSession.prototype`
+ * real working directory. `TraceRoot.initialize()` instruments `AgentSession`
  * so every session — however it was constructed — is traced with full
  * agent/LLM/tool span semantics, no manual span code required.
  *
@@ -50,24 +50,18 @@ import {
   ModelRegistry,
   type AgentSession,
 } from '@earendil-works/pi-coding-agent';
-import { instrumentPiCodingAgent } from '@traceroot-ai/pi';
 import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
 
-// TraceRoot.initialize() must run FIRST. instrumentPiCodingAgent() checks for
-// an already-registered global OpenTelemetry provider: if one exists, it
-// attaches to that SHARED pipeline (so the TraceRoot.shutdown() call at the
-// bottom of this file flushes both the pi spans and the observe()/
-// usingAttributes() spans this file creates directly). If instrumentation
-// ran first, it would find no provider yet, build its own PRIVATE export
-// pipeline, and commit to it for the life of the process — a
-// TraceRoot.initialize() call afterwards would never be seen by it.
-TraceRoot.initialize();
-
-// Instrument BEFORE creating any session — instrumentPiCodingAgent() patches
-// AgentSession.prototype, so this must run before createAgentSession() below.
-// No apiKey argument needed: in shared mode it rides on the pipeline
-// TraceRoot.initialize() just registered, which already read TRACEROOT_API_KEY.
-instrumentPiCodingAgent(pi);
+// One call wires the pi instrumentation (via instrumentModules.piCodingAgent)
+// and registers the OpenTelemetry pipeline. It must run BEFORE
+// createAgentSession() below, because wiring pi patches AgentSession's
+// prototype. The pi spans and the observe()/usingAttributes() spans this file
+// creates directly all flow through that one pipeline, flushed by the
+// TraceRoot.shutdown() call at the bottom. apiKey falls back to
+// TRACEROOT_API_KEY when omitted.
+TraceRoot.initialize({
+  instrumentModules: { piCodingAgent: pi },
+});
 
 console.log('[Observability: TraceRoot]');
 
@@ -298,10 +292,10 @@ async function main(): Promise<void> {
     // .finally() callback on an already-caught chain becomes an unhandled
     // rejection nothing downstream consumes. Keeping it here means any
     // shutdown failure flows through the single catch() below like every
-    // other error in this file. instrumentPiCodingAgent() attached to the
-    // shared pipeline TraceRoot.initialize() registered, so this one call
-    // flushes both the pi spans and the observe()/usingAttributes() spans
-    // created directly in this file.
+    // other error in this file. The pi instrumentation rides the pipeline
+    // TraceRoot.initialize() registered, so this one call flushes both the pi
+    // spans and the observe()/usingAttributes() spans created directly in this
+    // file.
     await TraceRoot.shutdown();
     console.log('\n[Traces exported]');
   }

--- a/examples/typescript/pi-agent-sdk/agent.ts
+++ b/examples/typescript/pi-agent-sdk/agent.ts
@@ -1,0 +1,144 @@
+/**
+ * Pi Coding Agent SDK — TraceRoot Observability
+ *
+ * `@earendil-works/pi-coding-agent` is the library form of the `pi` coding
+ * agent: instead of an interactive CLI, you drive an `AgentSession` from your
+ * own Node process and it reads/writes files and runs shell commands in a
+ * real working directory. `@traceroot-ai/pi` patches `AgentSession.prototype`
+ * so every session — however it was constructed — is traced with full
+ * agent/LLM/tool span semantics, no manual span code required.
+ *
+ * Tool availability is fixed when a session is created (there's no per-prompt
+ * override), so this demo uses three short-lived sessions to show the
+ * distinct span shapes TraceRoot captures:
+ *
+ *   1. no tools available                      → AGENT → LLM only
+ *   2. write a function + a test, run it        → AGENT → TOOL (write) ×2,
+ *      via bash                                    AGENT → TOOL (bash)
+ *   3. read a file that does not exist          → AGENT → TOOL (read), ERROR status
+ *
+ * Env vars required: OPENAI_API_KEY, TRACEROOT_API_KEY
+ *
+ * Run:
+ *   pnpm demo
+ */
+
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import 'dotenv/config';
+import * as pi from '@earendil-works/pi-coding-agent';
+import {
+  AuthStorage,
+  createAgentSession,
+  ModelRegistry,
+  type AgentSession,
+  type CreateAgentSessionOptions,
+} from '@earendil-works/pi-coding-agent';
+import { instrumentPiCodingAgent } from '@traceroot-ai/pi';
+
+// Instrument BEFORE creating any session — instrumentPiCodingAgent() patches
+// AgentSession.prototype, so this must run before createAgentSession() below.
+instrumentPiCodingAgent(pi, {
+  apiKey: process.env.TRACEROOT_API_KEY,
+});
+
+console.log('[Observability: TraceRoot]');
+
+// The agent operates on a real directory. Use a scratch workspace next to
+// this script rather than process.cwd() so the demo's file writes stay
+// self-contained and don't touch wherever `pnpm demo` happens to run from.
+const workspace = join(fileURLToPath(new URL('.', import.meta.url)), 'workspace');
+rmSync(workspace, { recursive: true, force: true });
+mkdirSync(workspace, { recursive: true });
+// Mark the workspace CommonJS so the agent's generated require()-based files
+// (turn 2, below) run under `node` without hitting a module-type error.
+writeFileSync(
+  join(workspace, 'package.json'),
+  JSON.stringify({ name: 'traceroot-pi-demo-workspace', private: true, type: 'commonjs' }, null, 2),
+);
+
+const authStorage = AuthStorage.create();
+const modelRegistry = ModelRegistry.create(authStorage);
+const model = modelRegistry.find('openai', 'gpt-4o-mini');
+if (!model) {
+  // find() only checks pi's static built-in model list, not auth — gpt-4o-mini is
+  // always in that list, so this would only fire if pi renames/drops the model id.
+  throw new Error('gpt-4o-mini is not a known model id in this version of pi-coding-agent.');
+}
+if (!modelRegistry.hasConfiguredAuth(model)) {
+  throw new Error(
+    'No OpenAI credentials found. Set OPENAI_API_KEY in your environment (pi falls back to it ' +
+      "when there's no `pi auth login` credential on disk).",
+  );
+}
+
+/** subscribe() surfaces tool calls and assistant messages as they happen — useful
+ *  for demo output, and independent of what gets traced. TraceRoot observes the
+ *  same session through the prototype patch, not this listener. */
+function logEvents(session: AgentSession): void {
+  session.subscribe((event) => {
+    switch (event.type) {
+      case 'tool_execution_start':
+        console.log(`   tool → ${event.toolName} ${JSON.stringify(event.args)}`);
+        break;
+      case 'tool_execution_end':
+        console.log(`   tool ← ${event.toolName}${event.isError ? ' (error)' : ''}`);
+        break;
+      case 'message_end': {
+        const { message } = event;
+        if (message.role === 'assistant') {
+          const text = message.content.find((c) => c.type === 'text')?.text;
+          if (text) console.log(`   assistant: ${text.slice(0, 300)}`);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  });
+}
+
+/** Runs one prompt on a freshly created, freshly disposed session. */
+async function runTurn(prompt: string, sessionOptions: Partial<CreateAgentSessionOptions>) {
+  const { session } = await createAgentSession({
+    cwd: workspace,
+    model,
+    authStorage,
+    modelRegistry,
+    ...sessionOptions,
+  });
+  logEvents(session);
+  try {
+    await session.prompt(prompt);
+  } finally {
+    session.dispose();
+  }
+}
+
+async function main() {
+  console.log('\n--- Turn 1: no tools (pure AGENT → LLM) ---');
+  await runTurn('What is the capital of France? Answer in one word.', { noTools: 'all' });
+
+  console.log('\n--- Turn 2: write a function, then write + run a test for it ---');
+  await runTurn(
+    'Create add.js exporting a function add(a, b) that returns a + b (CommonJS, ' +
+      'module.exports). Then write test-add.js that requires add.js and asserts ' +
+      'add(2, 3) === 5, run it with node, and tell me whether it passed.',
+    { tools: ['write', 'bash'] },
+  );
+
+  console.log('\n--- Turn 3: tool error (read a file that does not exist) ---');
+  await runTurn(
+    'Use the read tool to read /tmp/definitely-does-not-exist-traceroot-demo.txt ' +
+      'and tell me exactly what error occurred.',
+    { tools: ['read'] },
+  );
+}
+
+main()
+  .then(() => console.log('\n[Traces exported]'))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });

--- a/examples/typescript/pi-agent-sdk/package.json
+++ b/examples/typescript/pi-agent-sdk/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.0",
-    "@traceroot-ai/pi": "0.1.0",
     "@traceroot-ai/traceroot": "^0.1.7",
     "dotenv": "^16.4.5"
   },

--- a/examples/typescript/pi-agent-sdk/package.json
+++ b/examples/typescript/pi-agent-sdk/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.0",
     "@traceroot-ai/pi": "0.1.0",
+    "@traceroot-ai/traceroot": "^0.1.7",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {

--- a/examples/typescript/pi-agent-sdk/package.json
+++ b/examples/typescript/pi-agent-sdk/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.80.0",
-    "@traceroot-ai/traceroot": "^0.1.7",
+    "@traceroot-ai/traceroot": "^0.1.8",
     "dotenv": "^16.4.5"
   },
   "devDependencies": {

--- a/examples/typescript/pi-agent-sdk/package.json
+++ b/examples/typescript/pi-agent-sdk/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@traceroot/example-pi-agent-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "demo": "tsx agent.ts"
+  },
+  "dependencies": {
+    "@earendil-works/pi-coding-agent": "^0.80.0",
+    "@traceroot-ai/pi": "0.1.0",
+    "dotenv": "^16.4.5"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/typescript/pi-agent-sdk/tsconfig.json
+++ b/examples/typescript/pi-agent-sdk/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["*.ts"]
+}


### PR DESCRIPTION
Sister PR to [114 in traceroot-ts](https://github.com/traceroot-ai/traceroot-ts/pull/114)

## Summary
Once PR114 merges in traceroot/traceroot-ts, adding a TypeScript example for `@traceroot-ai/pi`, TraceRoot’s instrumentation package for the Pi Coding Agent SDK (`@earendil-works/pi-coding-agent`), following the same structure as the existing mastra, vercel-ai, and claude-agent-sdk examples.

The demo lives under `examples/typescript/pi-agent-sdk`, adds 6 files with 214 insertions, and is packaged as `@traceroot/example-pi-agent-sdk` with a `pnpm demo` script that runs `tsx agent.ts`.

## Type of Change
- [x] docs - Documentation only changes

## Details

It runs three short-lived `AgentSession`s against a scratch workspace to demonstrate the distinct span shapes TraceRoot captures:

1. **No tools** — a direct question that produces `AGENT → LLM`.
2. **Write + run** — writes `add.js`, writes `test-add.js`, and runs it with `node`, producing `AGENT → TOOL (write)` and `AGENT → TOOL (bash)`.
3. **Tool error** — attempts to read a missing file, producing `AGENT → TOOL (read)` with `ERROR` status.

The README explains why this uses three separate sessions: tool availability is fixed when an `AgentSession` is created, so there is no per-prompt override for `tools` or `noTools`.

Tracing is enabled by calling `instrumentPiCodingAgent(pi, { apiKey: process.env.TRACEROOT_API_KEY })` before any session is created. The example documents that this patches `AgentSession.prototype`, so sessions are traced automatically without manual span code.

The script creates an isolated local `workspace`, resets it on each run, and writes a local `package.json` with `"type": "commonjs"` so generated `require()`-based files run cleanly under `node`. It also subscribes to session events to log tool executions and assistant output during the demo.

Setup is documented as:

```bash
cp .env.example .env
pnpm install
pnpm demo
```

The environment requires `TRACEROOT_API_KEY` and `OPENAI_API_KEY`, and the README notes Node `>=22.19` because `@earendil-works/pi-coding-agent` is ESM-only.

Important caveat: this example depends on `@traceroot-ai/pi@0.1.0`, which is referenced in `package.json` but not yet published to npm, so `pnpm install` will not succeed until the corresponding traceroot-ts PR ships and the package is published.

## Screenshots / Recordings (if applicable)

N/A

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [x] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TypeScript example that traces `@earendil-works/pi-coding-agent` using `@traceroot-ai/traceroot`’s built-in Pi integration, showing AGENT/LLM/TOOL spans in a single-session incident walkthrough with changing tool sets. Lives at `examples/typescript/pi-agent-sdk`; run with `pnpm demo`.

- **New Features**
  - One persistent `AgentSession` across recon (read-only), remediate (full tools), and report; narrows/widens with `session.setActiveToolsByName()`.
  - Two real ERROR spans: missing `config/pricing.json` read and a failing test before the fix.
  - Workflow spans via `observe()` and `usingAttributes`; call `TraceRoot.initialize({ instrumentModules: { piCodingAgent: pi } })` before `createAgentSession()` so the prototype patch applies.
  - Auto-instruments `AgentSession.prototype`; no manual span code for agent/LLM/tool spans.
  - Seeds and resets an isolated `workspace/`; logs tool calls and assistant output; `.gitignore` updated to ignore the workspace.
  - Requires Node >=22.19 and `TRACEROOT_API_KEY` + `OPENAI_API_KEY`.

- **Dependencies**
  - Drops `@traceroot-ai/pi`; uses `@traceroot-ai/traceroot` with the in-tree Pi integration, pinned to `^0.1.8` (first release with Pi support).
  - Keeps `@earendil-works/pi-coding-agent`; install works without unpublished packages.

<sup>Written for commit a35be351325c5c6d2f3cd9e2640189d0b1bb4f2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

