### PR TITLE
fix(ui): dashboard tabs scroll instead of pushing header controls off screen

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -219,6 +219,32 @@ describe("DashboardDetailPage", () => {
     expect(strip.contains(createWidget)).toBe(false);
   });
 
+  it("restores the tab strip scroll position across the remount a tab click causes", () => {
+    mockLists(
+      Array.from({ length: 30 }, (_, i) => ({ ...DASH_A, id: `d${i + 1}`, name: `Dash ${i + 1}` })),
+    );
+    mockDetail({ ...DASH_A, layout: [], widgets: [WIDGET] });
+    const { unmount } = render(
+      <QueryClientProvider client={new QueryClient()}>
+        <DashboardDetailPage />
+      </QueryClientProvider>,
+    );
+
+    // The user scrolls deep into the strip… (the recorded position lives in a
+    // module-scope Map, so it deliberately persists for the rest of this test
+    // file — later mounts restore it, which nothing else asserts on)
+    const strip = screen.getByRole("link", { name: "Dash 30" }).parentElement!;
+    strip.scrollLeft = 480;
+    fireEvent.scroll(strip);
+
+    // …then clicks a tab, which navigates and remounts the whole page.
+    unmount();
+    renderPage();
+
+    const remounted = screen.getByRole("link", { name: "Dash 30" }).parentElement!;
+    expect(remounted.scrollLeft).toBe(480);
+  });
+
   it("opens the create-dashboard dialog and cancelling it does not create", () => {
     renderPage();
 

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -197,6 +197,28 @@ describe("DashboardDetailPage", () => {
     expect(screen.getByRole("button", { name: "＋ new" })).toBeTruthy();
   });
 
+  it("keeps header controls outside the scrollable tab strip when dashboards pile up", () => {
+    mockLists(
+      Array.from({ length: 30 }, (_, i) => ({ ...DASH_A, id: `d${i + 1}`, name: `Dash ${i + 1}` })),
+    );
+    mockDetail({ ...DASH_A, layout: [], widgets: [WIDGET] });
+    renderPage();
+
+    // All tabs render inside one horizontally scrollable strip…
+    const strip = screen.getByRole("link", { name: "Dash 30" }).parentElement!;
+    expect(strip.className).toContain("overflow-x-auto");
+    expect(strip.querySelectorAll("a")).toHaveLength(30);
+
+    // …while ＋ new, the date filter, and the widget controls live outside it,
+    // so an ever-growing dashboard list can never push them off screen.
+    const newButton = screen.getByRole("button", { name: "＋ new" });
+    expect(strip.contains(newButton)).toBe(false);
+    const dateFilterButton = screen.getByRole("button", { name: "Last 24 hours" });
+    expect(strip.contains(dateFilterButton)).toBe(false);
+    const createWidget = screen.getByRole("button", { name: "＋ Create widget" });
+    expect(strip.contains(createWidget)).toBe(false);
+  });
+
   it("opens the create-dashboard dialog and cancelling it does not create", () => {
     renderPage();
 

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -75,6 +75,19 @@ export default function DashboardDetailPage() {
     return () => ro.disconnect();
   }, []);
 
+  // ── keep the active tab visible in the scrollable strip ─────────────────────
+  const tabStripRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    // Without this, a dashboard deep in a long list sits scrolled out of view
+    // after a reload or a switch to a far tab. Optional call: jsdom (and any
+    // environment without layout) doesn't implement scrollIntoView.
+    tabStripRef.current
+      ?.querySelector('[aria-current="page"]')
+      ?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
+    // Length, not the array: re-scroll when the list first arrives or grows,
+    // without snapping the strip on unrelated list refetches mid-browse.
+  }, [dashboardId, dashboards?.length]);
+
   // ── widget builder navigation ────────────────────────────────────────────────
   const openCreate = () =>
     router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/new`);
@@ -200,17 +213,23 @@ export default function DashboardDetailPage() {
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Page header */}
         <div className="flex items-center justify-between border-b border-border px-4 py-2">
-          {/* Left: title + dashboard tabs */}
-          <div className="flex items-center gap-3">
-            <h1 className="text-[13px] font-medium">Dashboard</h1>
-            <div className="flex items-center gap-0.5">
+          {/* Left: title + dashboard tabs. min-w-0 lets the tab strip shrink
+              and scroll instead of growing without bound — however many
+              dashboards exist, the ＋ new button and the right-side controls
+              stay on screen. */}
+          <div className="flex min-w-0 flex-1 items-center gap-3">
+            <h1 className="shrink-0 text-[13px] font-medium">Dashboard</h1>
+            <div
+              ref={tabStripRef}
+              className="flex min-w-0 items-center gap-0.5 overflow-x-auto [scrollbar-width:thin]"
+            >
               {dashboards?.map((d) => (
                 <Link
                   key={d.id}
                   href={`/projects/${projectId}/dashboard/${d.id}`}
                   aria-current={d.id === dashboardId ? "page" : undefined}
                   className={cn(
-                    "flex items-center gap-1 rounded px-2 py-0.5 text-[12px] transition-colors",
+                    "flex shrink-0 items-center gap-1 rounded px-2 py-0.5 text-[12px] transition-colors",
                     d.id === dashboardId
                       ? "border-b-2 border-foreground font-medium text-foreground"
                       : "text-muted-foreground hover:bg-muted hover:text-foreground",
@@ -222,18 +241,18 @@ export default function DashboardDetailPage() {
                   </span>
                 </Link>
               ))}
-              <button
-                type="button"
-                onClick={() => setCreateDashboardOpen(true)}
-                className="rounded px-2 py-0.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                ＋ new
-              </button>
             </div>
+            <button
+              type="button"
+              onClick={() => setCreateDashboardOpen(true)}
+              className="shrink-0 rounded px-2 py-0.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              ＋ new
+            </button>
           </div>
 
           {/* Right: time range, create widget */}
-          <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center gap-2">
             <DateFilterSelect
               dateFilter={dateFilter}
               customStartDate={customStartDate}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -221,7 +221,7 @@ export default function DashboardDetailPage() {
             <h1 className="shrink-0 text-[13px] font-medium">Dashboard</h1>
             <div
               ref={tabStripRef}
-              className="flex min-w-0 items-center gap-0.5 overflow-x-auto [scrollbar-width:thin]"
+              className="flex min-w-0 items-center gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             >
               {dashboards?.map((d) => (
                 <Link

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
@@ -26,6 +26,16 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+
+// useLayoutEffect on the client, useEffect during SSR: layout effects never
+// run on the server, and React warns when a server render encounters one.
+const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+// Tab strip scroll position per project, module-scoped: the page remounts on
+// every dashboard switch, so component state can't carry the position across
+// clicks. In-memory only — a hard reload falls back to scrolling the active
+// tab into view.
+const tabStripScroll = new Map<string, number>();
 
 export default function DashboardDetailPage() {
   const params = useParams();
@@ -75,11 +85,21 @@ export default function DashboardDetailPage() {
     return () => ro.disconnect();
   }, []);
 
-  // ── keep the active tab visible in the scrollable strip ─────────────────────
+  // ── keep the scrollable tab strip where the user left it ────────────────────
   const tabStripRef = useRef<HTMLDivElement>(null);
+  // The route is keyed by the dashboardId segment, so clicking a tab remounts
+  // this page and a fresh strip would snap back to the far left. Restore the
+  // remembered position pre-paint (layout effect) so the switch is seamless;
+  // re-run when the list arrives, since an empty strip can't hold a scroll.
+  useIsomorphicLayoutEffect(() => {
+    const el = tabStripRef.current;
+    const saved = tabStripScroll.get(projectId);
+    if (el && saved !== undefined) el.scrollLeft = saved;
+  }, [projectId, dashboards?.length]);
   useEffect(() => {
-    // Without this, a dashboard deep in a long list sits scrolled out of view
-    // after a reload or a switch to a far tab. Optional call: jsdom (and any
+    // Then make sure the active tab is visible: after a hard reload (nothing
+    // remembered) a deep tab would sit out of view. "nearest" is a no-op when
+    // the restored position already shows it. Optional call: jsdom (and any
     // environment without layout) doesn't implement scrollIntoView.
     tabStripRef.current
       ?.querySelector('[aria-current="page"]')
@@ -221,6 +241,7 @@ export default function DashboardDetailPage() {
             <h1 className="shrink-0 text-[13px] font-medium">Dashboard</h1>
             <div
               ref={tabStripRef}
+              onScroll={(e) => tabStripScroll.set(projectId, e.currentTarget.scrollLeft)}
               className="flex min-w-0 items-center gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             >
               {dashboards?.map((d) => (


### PR DESCRIPTION
Stacked on #1524 (the commit was briefly part of that PR and is now split out for separate review).

Creating dashboards grew the header's tab row without bound: enough tabs pushed the date filter, the ＋ Create widget button, and dashboard deletion past the right edge of the screen where they couldn't be clicked at all.

## The fix
- The tabs move into their own `min-w-0` strip that scrolls horizontally (`overflow-x-auto`, thin scrollbar). With few dashboards nothing changes visually — the strip only scrolls once tabs would otherwise overflow.
- The **＋ new** button sits outside the strip and the right-side controls are `shrink-0`, so every header control stays on screen at any tab count.
- The active tab scrolls itself into view (`inline: "nearest"`, a no-op when already visible), so a dashboard deep in a long list isn't hidden after a reload or a far tab switch. The effect keys on the list *length* rather than the array so background list refetches can't yank the strip mid-browse.
- Test renders 30 dashboards and pins the containment invariant: all tabs inside the scrollable strip, ＋ new / date filter / create-widget outside it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make dashboard tabs scroll horizontally and hide the scrollbar so they don’t push header controls off screen. Keeps ＋ new, the date filter, and ＋ Create widget visible at any tab count, preserves tab strip position across switches, and auto-scrolls the active tab into view.

- **Bug Fixes**
  - Moved tabs into a `min-w-0` horizontally scrollable, chromeless strip (`[scrollbar-width:none]`, `&::-webkit-scrollbar:hidden`); placed ＋ new outside; right-side controls use `shrink-0` so they’re always visible.
  - Persist the tab strip’s scroll position per project across dashboard clicks (module-scope Map, pre-paint restore via isomorphic layout effect); fall back to active-tab `scrollIntoView({ inline: "nearest" })` after hard reloads and re-run on `dashboards.length` only.
  - Added tests with 30 dashboards to ensure controls stay outside the strip and to verify scroll position restoration across a remount.

<sup>Written for commit 86799c2c3b2b266a060885ce1afe187fbb036db6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Part of the project dashboards epic: #1460