### PR TITLE
feat(worker): exclude detector-sourced traces from detection enqueue (anti-recursion)

### DIFF
--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -107,6 +107,20 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
 
         root_bearing_trace_ids = {s["trace_id"] for s in spans if s.get("parent_span_id") is None}
 
+        # root_bearing_trace_ids also feeds the trace-insert path below. Detection
+        # uses a narrower set that drops roots of traces the detector worker
+        # itself emitted (source='detector'): those self-traces are still INSERTED
+        # into ClickHouse, but scanning one would trigger detection on a detector's
+        # own emission and recurse forever. Set difference keeps the subset
+        # relationship structural, and a trace that somehow carried both a
+        # detector root and a user root stays excluded — the safe direction.
+        detector_root_trace_ids = {
+            s["trace_id"]
+            for s in spans
+            if s.get("parent_span_id") is None and s.get("source", "user") == "detector"
+        }
+        detection_eligible_root_trace_ids = root_bearing_trace_ids - detector_root_trace_ids
+
         # 3. Insert into ClickHouse
         if traces or spans:
             ch_client = get_clickhouse_client()
@@ -148,11 +162,13 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
         # duplicate root delivery. Batches without the root span are ignored
         # here; the worker waits out the quiescence window before evaluating,
         # so late spans need no enqueue.
-        if root_bearing_trace_ids:
+        # Traces emitted by the detector itself are excluded from the enqueue
+        # (they are still inserted above).
+        if detection_eligible_root_trace_ids:
             try:
                 from worker.detector_tasks import enqueue_detector_runs
 
-                enqueue_detector_runs(project_id, root_bearing_trace_ids)
+                enqueue_detector_runs(project_id, detection_eligible_root_trace_ids)
             except Exception as e:
                 logger.error(f"Failed to call detector tasks: {e}", exc_info=True)
 

--- a/tests/worker/test_ingest_anti_recursion.py
+++ b/tests/worker/test_ingest_anti_recursion.py
@@ -1,0 +1,138 @@
+"""process_s3_traces must never enqueue detection for detector-sourced roots.
+
+The transform is mocked: on this path the transform does not emit a
+detector-sourced record, so the guard's trigger has to be stubbed. That is
+exactly the point — this guard is the backstop for data that should never
+reach this code path.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from worker.ingest_tasks import process_s3_traces
+
+DETECTOR_TRACE = "ab" * 16
+USER_TRACE = "cd" * 16
+
+
+def _root_span(trace_id: str, source: str | None) -> dict:
+    span = {
+        "span_id": "01" * 8,
+        "trace_id": trace_id,
+        "parent_span_id": None,
+        "project_id": "proj-1",
+        "name": "root",
+    }
+    if source is not None:
+        span["source"] = source
+    return span
+
+
+def _trace(trace_id: str) -> dict:
+    return {"trace_id": trace_id, "project_id": "proj-1", "name": "root"}
+
+
+@pytest.fixture()
+def mock_s3(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("rest.services.s3.get_s3_service", lambda: mock)
+    mock.download_json.return_value = {"resourceSpans": []}
+    return mock
+
+
+@pytest.fixture()
+def mock_ch(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("db.clickhouse.client.get_clickhouse_client", lambda: mock)
+    return mock
+
+
+@pytest.fixture()
+def mock_enqueue(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr("worker.detector_tasks.enqueue_detector_runs", mock)
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def quiet_live_publish(monkeypatch):
+    """Live-span publishing is out of scope; stub it for isolation."""
+    monkeypatch.setattr("worker.ingest_tasks._publish_live_spans", MagicMock())
+
+
+@pytest.fixture()
+def transform_returning(monkeypatch):
+    """Make the (mocked) transform return exactly these records."""
+
+    def _set(traces: list[dict], spans: list[dict]) -> None:
+        # The task imports the transform inside its body, so patch the source
+        # module — the deferred import reads this attribute at call time.
+        monkeypatch.setattr(
+            "worker.otel_transform.transform_otel_to_clickhouse",
+            lambda otel_data, project_id: (traces, spans),
+        )
+
+    return _set
+
+
+class TestDetectorSourcedRootsAreNotEnqueued:
+    def test_detector_root_skips_enqueue_but_still_inserts(
+        self, mock_s3, mock_ch, mock_enqueue, transform_returning
+    ):
+        transform_returning([_trace(DETECTOR_TRACE)], [_root_span(DETECTOR_TRACE, "detector")])
+
+        process_s3_traces(s3_key="k.json", project_id="proj-1")
+
+        mock_enqueue.assert_not_called()
+        # INSERT path unaffected: the self-trace row still lands.
+        inserted = mock_ch.insert_traces_batch.call_args[0][0]
+        assert [t["trace_id"] for t in inserted] == [DETECTOR_TRACE]
+
+    def test_user_root_is_enqueued(self, mock_s3, mock_ch, mock_enqueue, transform_returning):
+        transform_returning([_trace(USER_TRACE)], [_root_span(USER_TRACE, "user")])
+
+        process_s3_traces(s3_key="k.json", project_id="proj-1")
+
+        mock_enqueue.assert_called_once_with("proj-1", {USER_TRACE})
+
+    def test_sourceless_root_is_enqueued(self, mock_s3, mock_ch, mock_enqueue, transform_returning):
+        """Records from before the source column default to user traffic."""
+        transform_returning([_trace(USER_TRACE)], [_root_span(USER_TRACE, None)])
+
+        process_s3_traces(s3_key="k.json", project_id="proj-1")
+
+        mock_enqueue.assert_called_once_with("proj-1", {USER_TRACE})
+
+    def test_trace_with_both_detector_and_user_roots_is_excluded(
+        self, mock_s3, mock_ch, mock_enqueue, transform_returning
+    ):
+        """Corrupt/spoofed dual-root data resolves in the safe direction."""
+        transform_returning(
+            [_trace(DETECTOR_TRACE)],
+            [
+                _root_span(DETECTOR_TRACE, "detector"),
+                _root_span(DETECTOR_TRACE, "user"),
+            ],
+        )
+
+        process_s3_traces(s3_key="k.json", project_id="proj-1")
+
+        mock_enqueue.assert_not_called()
+
+    def test_mixed_batch_enqueues_only_the_user_root(
+        self, mock_s3, mock_ch, mock_enqueue, transform_returning
+    ):
+        transform_returning(
+            [_trace(DETECTOR_TRACE), _trace(USER_TRACE)],
+            [
+                _root_span(DETECTOR_TRACE, "detector"),
+                _root_span(USER_TRACE, "user"),
+            ],
+        )
+
+        process_s3_traces(s3_key="k.json", project_id="proj-1")
+
+        mock_enqueue.assert_called_once_with("proj-1", {USER_TRACE})
+        inserted = mock_ch.insert_traces_batch.call_args[0][0]
+        assert {t["trace_id"] for t in inserted} == {DETECTOR_TRACE, USER_TRACE}


### PR DESCRIPTION
## Summary

The R1 anti-recursion backstop: a trace whose root span carries `source='detector'` is never passed to the detection enqueue from `process_s3_traces`, while its rows are still inserted into ClickHouse unchanged.

- `root_bearing_trace_ids` stays untouched — it also drives the trace-INSERT dedup logic, and narrowing it would silently drop detector trace rows from ClickHouse. Detection instead gets `detection_eligible_root_trace_ids`, computed as a set difference (`root_bearing − detector_roots`) so the subset relationship is structural, and so a corrupt/spoofed trace carrying both a detector root and a user root resolves in the safe direction (excluded).
- Defense-in-depth by design: in the production wiring, detector self-traces enter through the secret-gated internal ingest route, which inserts in-process and never runs this task. This guard is the cheap backstop for the day that changes — the failure mode it prevents (detect → self-trace → detect, recursing with an LLM judge in the loop) is catastrophic relative to ~10 lines.
- Spans without a `source` key default to user traffic, so data from before the source column behaves unchanged.

Independent of the open source-column PR stack (#1535/#1537/#1540): this file isn't touched by it, and the tests stub the transform, so nothing here depends on the column code. Known follow-up once that stack merges: an integration test driving the *real* transform over a marker-bearing payload end-to-end into this guard, so the `source`/`detector` key/value contract between the two changes is pinned by execution rather than by mocks.

## Test plan

- `tests/worker/test_ingest_anti_recursion.py` (transform, S3, ClickHouse, enqueue, and live-publish all stubbed): detector root skipped but still inserted; user root enqueued; sourceless root enqueued; mixed batch enqueues only the user root and inserts both trace rows; dual-root (detector + user on one trace id) excluded.
- Full backend suite green (802 passed); diff coverage 100%.

closes #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop detector self-trace recursion by excluding traces with a root span `source='detector'` from detection enqueue in `process_s3_traces`, while still inserting all trace rows into ClickHouse. Satisfies Linear #1311.

- **New Features**
  - Enqueue only detection-eligible roots: `root_bearing` minus detector-sourced roots; dual-root traces are excluded for safety.
  - Keep `root_bearing_trace_ids` for insert dedupe so detector traces are still inserted into ClickHouse.
  - Treat sourceless roots as user traffic; added tests for detector/user/sourceless/mixed batches and dual-root exclusion.

<sup>Written for commit 189cb1355d4ff648d6cbfb13d1b3c650440b668a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

