### PR TITLE
fix: percentile and average series render empty buckets as gaps, not zeros

### DIFF
--- a/backend/rest/services/widget_query.py
+++ b/backend/rest/services/widget_query.py
@@ -31,6 +31,12 @@ _AGG_SQL = {
     "p99": "quantile(0.99)({expr})",
 }
 
+# Aggregations where an empty time bucket has no meaningful value: count/sum
+# of nothing is honestly 0, but the average or a percentile of nothing is a
+# gap, not a zero. Drives Nullable metrics on time series so WITH FILL rows
+# come back NULL and charts render gaps instead of false drops to zero.
+_NON_ADDITIVE_AGGS = frozenset({"avg", "min", "max", "p50", "p95", "p99"})
+
 _OP_SQL = {
     "=": "{expr} = {{{p}:{t}}}",
     "!=": "{expr} != {{{p}:{t}}}",
@@ -161,6 +167,12 @@ def compile_widget_query(
     order_by = ""
 
     is_timeseries = spec.display.type in ("line", "area")
+    if is_timeseries and spec.metric.agg in _NON_ADDITIVE_AGGS:
+        # For count/sum an empty bucket genuinely is zero, but for averages
+        # and percentiles it has NO value — a filled 0 would render as a false
+        # collapse (a p95 latency line dipping to nothing). Nullable makes the
+        # WITH FILL rows below carry NULL, which the chart draws as a gap.
+        metric_sql = f"toNullable({metric_sql})"
     # Bound unconditionally: both the bucketing branch and the row-cap branch
     # below key off is_timeseries, and an implicit binding would let them drift.
     gran = _pick_granularity(start_time, end_time)

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -462,18 +462,30 @@ describe("WidgetBuilderPage", () => {
   });
 
   it("renders the query result once preview data resolves", () => {
-    vi.useFakeTimers();
-    try {
-      mockPreview({ data: { columns: ["value"], rows: [[42]], meta: {} } });
-      render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
-      // The preview draft is debounced 400ms before the renderer picks it up.
-      act(() => {
-        vi.advanceTimersByTime(400);
-      });
-      // cost measure carries its $ unit through the preview renderer
-      expect(screen.getByText("$42")).toBeTruthy();
-    } finally {
-      vi.useRealTimers();
-    }
+    // The renderer draws straight from the preview data (spec + rows), so no
+    // debounce needs to elapse first.
+    mockPreview({
+      data: { spec: WIDGET.spec, result: { columns: ["value"], rows: [[42]], meta: {} } },
+    });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    // cost measure carries its $ unit through the preview renderer
+    expect(screen.getByText("$42")).toBeTruthy();
+  });
+
+  it("renders the preview from the spec that produced the data, not the live draft", () => {
+    // keepPreviousData can leave the previous query's rows on screen while a
+    // new draft is fetching; the renderer must label them with the spec that
+    // produced them. Here the stored widget measures duration, but the data
+    // came from a cost spec — the $ unit must follow the data.
+    const durationWidget = {
+      ...WIDGET,
+      spec: { ...WIDGET.spec, metric: { measure: "duration_ms", agg: "avg" } },
+    };
+    mockDashboard({ ...DASHBOARD, widgets: [durationWidget] });
+    mockPreview({
+      data: { spec: WIDGET.spec, result: { columns: ["value"], rows: [[42]], meta: {} } },
+    });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.getByText("$42")).toBeTruthy();
   });
 });

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -274,7 +274,6 @@ export function WidgetBuilderPage({
     isHistogramBlocked(debouncedDraft, viewFields) ? null : debouncedDraft,
     range,
   );
-  const debouncedSpec = useMemo(() => parseSpec(debouncedDraft), [debouncedDraft]);
 
   // ── save ──────────────────────────────────────────────────────────────────
   const specComplete = isSpecComplete(draft);
@@ -577,12 +576,18 @@ export function WidgetBuilderPage({
               <div className="flex h-full items-start justify-center pt-8 text-[12px] text-red-600">
                 {preview.error instanceof Error ? preview.error.message : "Query failed"}
               </div>
-            ) : preview.data && debouncedSpec ? (
+            ) : preview.data ? (
+              // Everything spec-derived comes from the spec that produced the
+              // rows (preview.data.spec, not the live draft): keepPreviousData
+              // can show the previous result while a new query is in flight,
+              // and mixing old rows with the new draft's display/unit/agg
+              // would briefly mislabel them.
               <QueryWidgetRenderer
-                display={debouncedSpec.display.type}
-                result={preview.data}
-                unit={FIELD_UNIT[debouncedSpec.metric.measure]}
-                seriesLabel={debouncedSpec.metric.measure}
+                display={preview.data.spec.display.type}
+                result={preview.data.result}
+                unit={FIELD_UNIT[preview.data.spec.metric.measure]}
+                seriesLabel={preview.data.spec.metric.measure}
+                agg={preview.data.spec.metric.agg}
               />
             ) : null}
           </div>

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -62,6 +62,7 @@ function QueryWidgetBody({
       result={data}
       unit={FIELD_UNIT[spec.metric.measure]}
       seriesLabel={spec.metric.measure}
+      agg={spec.metric.agg}
     />
   );
 }

--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -152,6 +152,56 @@ describe("QueryWidgetRenderer", () => {
       expect(screen.getByText("No data in range")).toBeTruthy();
       expect(container.querySelectorAll(".recharts-line-curve").length).toBe(0);
     });
+
+    it("draws a non-additive series through NULL gap buckets instead of dropping to 0", () => {
+      // p95 over a window with an empty middle bucket: the backend's Nullable
+      // WITH FILL row carries null, and the line must bridge it (connectNulls)
+      // rather than chart a false collapse. Both flanking points survive.
+      const result = makeResult(
+        ["bucket", "value"],
+        [
+          ["2026-06-01T00:00:00", 120],
+          ["2026-06-02T00:00:00", null],
+          ["2026-06-03T00:00:00", 90],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(
+        <QueryWidgetRenderer display="line" result={result} agg="p95" />,
+      );
+      const [curve] = Array.from(container.querySelectorAll(".recharts-line-curve"));
+      expect(curve).toBeTruthy();
+      // One unbroken path: a broken (per-segment) render or a dip to the
+      // 0-baseline would betray the gap handling. The path must span from the
+      // first bucket to the last.
+      const d = curve.getAttribute("d") ?? "";
+      expect(d.length).toBeGreaterThan(0);
+      expect((d.match(/M/g) ?? []).length).toBe(1);
+    });
+
+    it("keeps a non-additive AREA off the zero baseline over gap buckets", () => {
+      // Stacked areas are the trap: recharts' stack accessor coerces null to
+      // 0 BEFORE connectNulls is consulted, redrawing the false collapse. A
+      // non-additive area therefore renders unstacked — its bridged curve has
+      // exactly two points (M + one L); a baseline dip would add a third.
+      const result = makeResult(
+        ["bucket", "value"],
+        [
+          ["2026-06-01T00:00:00", 120],
+          ["2026-06-02T00:00:00", null],
+          ["2026-06-03T00:00:00", 90],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(
+        <QueryWidgetRenderer display="area" result={result} agg="p95" />,
+      );
+      const [curve] = Array.from(container.querySelectorAll(".recharts-area-curve"));
+      expect(curve).toBeTruthy();
+      const d = curve.getAttribute("d") ?? "";
+      expect((d.match(/M/g) ?? []).length).toBe(1);
+      expect((d.match(/L/g) ?? []).length).toBe(1);
+    });
   });
 
   describe("line/area empty-breakdown fallback", () => {

--- a/frontend/ui/src/features/dashboards/components/renderers.test.ts
+++ b/frontend/ui/src/features/dashboards/components/renderers.test.ts
@@ -67,6 +67,26 @@ describe("pivotRows", () => {
     ]);
   });
 
+  it("fills bucket×series holes with null for non-additive aggs", () => {
+    // A percentile has no value for an empty bucket: the hole must be a gap
+    // (null), not a zero that would chart as a false collapse.
+    const out = pivotRows(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt-4o", 120],
+        ["2026-06-02T00:00:00", null, null], // WITH FILL gap row (Nullable metric)
+        ["2026-06-03T00:00:00", "gpt-4o", 90],
+      ],
+      null,
+    );
+    expect(out.seriesKeys).toEqual(["gpt-4o"]);
+    expect(out.data).toEqual([
+      { bucket: "2026-06-01T00:00:00", "gpt-4o": 120 },
+      { bucket: "2026-06-02T00:00:00", "gpt-4o": null },
+      { bucket: "2026-06-03T00:00:00", "gpt-4o": 90 },
+    ]);
+  });
+
   it("keeps a genuine empty-string dim with a nonzero value as a real series", () => {
     const out = pivotRows(["bucket", "model_name", "value"], [["2026-06-01T00:00:00", "", 2]]);
     expect(out.seriesKeys).toEqual([""]);

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -17,7 +17,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { DisplayType, FieldUnit, WidgetQueryResult } from "../types";
+import { type DisplayType, type FieldUnit, type WidgetQueryResult, AGGS } from "../types";
 
 // Pastel series palette mirroring the span-kind tints
 // (violet=llm, blue=agent, amber=tool, slate=span), then softened extras.
@@ -46,7 +46,14 @@ const CHART_FOCUS_RESET =
 const coerceNumeric = (v: unknown): unknown =>
   typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v)) ? Number(v) : v;
 
-export function pivotRows(columns: string[], rows: WidgetQueryResult["rows"]) {
+export function pivotRows(
+  columns: string[],
+  rows: WidgetQueryResult["rows"],
+  // What a bucket×series hole means: 0 for additive aggs (a count/sum of
+  // nothing IS zero), null for non-additive ones (an empty bucket has no
+  // average or percentile — charts draw the null as a gap, not a collapse).
+  gapValue: 0 | null = 0,
+) {
   // Shapes: [value] | [bucket, value] | [dim, value] | [bucket, dim, value]
   const valueIdx = columns.length - 1;
   const hasBucket = columns[0] === "bucket";
@@ -84,8 +91,9 @@ export function pivotRows(columns: string[], rows: WidgetQueryResult["rows"]) {
     const rawDim = r[dimIdx];
     // The query's WITH FILL synthesizes rows for empty buckets, carrying the
     // breakdown column's default ('' — or NULL if a Nullable expr ever slips
-    // past the compiler's type pin) and a zero value. They extend the x-axis
-    // domain but are not a series: register the bucket and move on.
+    // past the compiler's type pin) and a zero or NULL value (NULL for the
+    // Nullable non-additive metrics). They extend the x-axis domain but are
+    // not a series: register the bucket and move on.
     if ((rawDim === "" || rawDim == null) && !Number(r[valueIdx])) {
       if (!byBucket.has(bucket)) byBucket.set(bucket, { bucket });
       continue;
@@ -103,13 +111,12 @@ export function pivotRows(columns: string[], rows: WidgetQueryResult["rows"]) {
     byBucket.get(bucket)![dim] = coerceNumeric(r[valueIdx]);
   }
 
-  // Uniform zero-fill: missing series keys per bucket are set to 0 so
-  // line/area charts tell the same story. Honest for count/sum (the dominant
-  // dashboard aggregations), slightly lossy for percentile gaps — accepted tradeoff.
+  // Uniform fill: missing series keys per bucket get the agg-appropriate gap
+  // value so line/area charts tell the same story across series.
   const data = [...byBucket.values()].map((row) => {
     const filled = { ...row };
     for (const k of seriesKeys) {
-      if (!Object.hasOwn(filled, k)) filled[k] = 0;
+      if (!Object.hasOwn(filled, k)) filled[k] = gapValue;
     }
     return filled;
   });
@@ -210,12 +217,18 @@ function TimeSeries({
   result,
   area,
   seriesLabel,
+  additive = true,
 }: {
   result: WidgetQueryResult;
   area: boolean;
   seriesLabel?: string;
+  /** False for avg/percentile series: empty buckets render as gaps, not 0. */
+  additive?: boolean;
 }) {
-  const { seriesKeys, data } = useMemo(() => pivotRows(result.columns, result.rows), [result]);
+  const { seriesKeys, data } = useMemo(
+    () => pivotRows(result.columns, result.rows, additive ? 0 : null),
+    [result, additive],
+  );
   const Chart = area ? AreaChart : LineChart;
   const granularity = result.meta.granularity;
 
@@ -243,8 +256,12 @@ function TimeSeries({
         <CartesianGrid strokeOpacity={0.15} vertical={false} />
         <XAxis dataKey="bucket" tick={{ fontSize: 10 }} tickFormatter={tickFormatter} />
         <YAxis tick={{ fontSize: 10 }} width={42} />
+        {/* filterNull: recharts strips null payload items by default, which
+            would drop a non-additive series' row from the tooltip on its empty
+            (gap) buckets — keep them so ChartTip shows an em-dash instead. */}
         <Tooltip
           isAnimationActive={false}
+          filterNull={false}
           content={
             <ChartTip
               nameFormatter={seriesNameFormatter(seriesLabel)}
@@ -255,16 +272,24 @@ function TimeSeries({
         {/* isAnimationActive={false} on every mark (here and in the other
             charts): the default ~1.4s geometry morph makes charts visibly lag
             behind their tile during grid resizes and data refreshes. */}
+        {/* A non-additive series carries NULL for empty buckets (backend
+            WITH FILL + the pivot's gap fill): connectNulls bridges them so one
+            readable line survives without inventing zeros. Areas additionally
+            drop stacking for non-additive aggs — recharts' stack accessor
+            coerces null to 0 BEFORE connectNulls is consulted, which would
+            redraw the false collapse (and stacking percentiles is
+            meaningless anyway). */}
         {seriesKeys.map((k, i) =>
           area ? (
             <Area
               key={k}
               dataKey={k}
-              stackId="1"
+              stackId={additive ? "1" : undefined}
               stroke={seriesColor(i)}
               fill={seriesColor(i)}
               fillOpacity={0.35}
               isAnimationActive={false}
+              connectNulls={!additive}
             />
           ) : (
             <Line
@@ -274,6 +299,7 @@ function TimeSeries({
               dot={false}
               strokeWidth={1.5}
               isAnimationActive={false}
+              connectNulls={!additive}
             />
           ),
         )}
@@ -421,18 +447,29 @@ function HistogramView({
   );
 }
 
+// Aggs whose empty buckets have no value (no average or percentile of
+// nothing): their series shows a gap instead of a false drop to 0. Mirrors
+// the backend's _NON_ADDITIVE_AGGS — same polarity, so an agg added to one
+// list but not the other degrades to the additive (zero-filled) treatment on
+// both sides rather than diverging. Absent agg = additive (legacy callers).
+const NON_ADDITIVE_AGGS = new Set<string>(["avg", "min", "max", "p50", "p95", "p99"]);
+
 export function QueryWidgetRenderer({
   display,
   result,
   unit,
   seriesLabel,
+  agg,
 }: {
   display: DisplayType;
   result: WidgetQueryResult;
   unit?: FieldUnit;
   /** Measure name from the widget spec, shown as the single-series tooltip row name. */
   seriesLabel?: string;
+  /** Aggregation from the widget spec; decides how empty buckets render. */
+  agg?: (typeof AGGS)[number];
 }) {
+  const additive = agg === undefined || !NON_ADDITIVE_AGGS.has(agg);
   if (result.rows.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
@@ -442,9 +479,11 @@ export function QueryWidgetRenderer({
   }
   switch (display) {
     case "line":
-      return <TimeSeries result={result} area={false} seriesLabel={seriesLabel} />;
+      return (
+        <TimeSeries result={result} area={false} seriesLabel={seriesLabel} additive={additive} />
+      );
     case "area":
-      return <TimeSeries result={result} area seriesLabel={seriesLabel} />;
+      return <TimeSeries result={result} area seriesLabel={seriesLabel} additive={additive} />;
     case "bar":
       return <Bars result={result} seriesLabel={seriesLabel} />;
     case "pie":

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
@@ -142,19 +142,20 @@ describe("useWidgetPreview", () => {
     };
     const queryResult = { columns: ["count"], rows: [[1]], meta: {} };
     vi.mocked(api.runWidgetQuery).mockResolvedValue(queryResult);
+    const parsed = {
+      view: "spans",
+      filters: [],
+      metric: { measure: "count", agg: "count" },
+      breakdown: null,
+      display: { type: "number" },
+    };
     const { result } = renderHook(() => useWidgetPreview("p1", draft, RANGE), { wrapper });
-    await waitFor(() => expect(result.current.data).toEqual(queryResult));
-    expect(api.runWidgetQuery).toHaveBeenCalledWith(
-      "p1",
-      {
-        view: "spans",
-        filters: [],
-        metric: { measure: "count", agg: "count" },
-        breakdown: null,
-        display: { type: "number" },
-      },
-      RANGE,
-      { id: "u1", email: "u@example.com" },
-    );
+    // The result carries the spec that produced it so the preview can render
+    // kept-previous data with matching display/unit/agg semantics.
+    await waitFor(() => expect(result.current.data).toEqual({ spec: parsed, result: queryResult }));
+    expect(api.runWidgetQuery).toHaveBeenCalledWith("p1", parsed, RANGE, {
+      id: "u1",
+      email: "u@example.com",
+    });
   });
 });

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
@@ -6,6 +6,7 @@ import {
   parseSpec,
   type TimeRange,
   type WidgetFieldValue,
+  type WidgetQueryResult,
   type WidgetSpec,
 } from "../types";
 
@@ -78,6 +79,16 @@ export function useWidgetFieldValues(
   return active ? { values: data?.values ?? [], isLoading } : { values: [], isLoading: false };
 }
 
+// The preview pairs each result with the spec that produced it: keepPreviousData
+// shows the previous rows while a new query is in flight, and rendering those
+// rows with the NEW draft's display/unit/aggregation would briefly mislabel
+// them (e.g. an old additive sum series drawn with avg's gap semantics).
+// Rendering from data.spec keeps every frame internally consistent.
+export interface WidgetPreviewData {
+  spec: WidgetSpec;
+  result: WidgetQueryResult;
+}
+
 export function useWidgetPreview(projectId: string, draft: unknown, range: TimeRange) {
   const { user, sessionReady } = useTraceApiUser();
 
@@ -89,7 +100,10 @@ export function useWidgetPreview(projectId: string, draft: unknown, range: TimeR
       range.start.getTime(),
       range.end.getTime(),
     ],
-    queryFn: () => api.runWidgetQuery(projectId, parseSpec(draft)!, range, user),
+    queryFn: async (): Promise<WidgetPreviewData> => {
+      const spec = parseSpec(draft)!;
+      return { spec, result: await api.runWidgetQuery(projectId, spec, range, user) };
+    },
     enabled: sessionReady && !!projectId && isSpecComplete(draft),
     staleTime: 10_000,
     retry: false,

--- a/tests/rest/test_widget_query.py
+++ b/tests/rest/test_widget_query.py
@@ -305,6 +305,41 @@ def test_non_timeseries_has_no_fill():
         assert "WITH FILL" not in sql
 
 
+def test_non_additive_timeseries_metric_is_nullable():
+    """Percentile/average time series wrap the metric in toNullable.
+
+    WITH FILL rows carry the column default — 0 for a plain Float64 — which
+    would draw a false collapse for aggs where an empty bucket has no value.
+    Nullable makes the filled rows NULL, and the chart renders them as gaps.
+    """
+    for agg in ("avg", "min", "max", "p50", "p95", "p99"):
+        sql, _ = compile_(
+            make_spec(metric={"measure": "duration_ms", "agg": agg}, display={"type": "line"})
+        )
+        assert "toNullable(" in sql, agg
+
+
+def test_additive_timeseries_metric_stays_plain():
+    """count/sum of an empty bucket genuinely is zero — no Nullable wrapper."""
+    for metric in ({"measure": "count", "agg": "count"}, {"measure": "cost", "agg": "sum"}):
+        sql, _ = compile_(make_spec(metric=metric, display={"type": "line"}))
+        assert "toNullable(" not in sql, metric
+
+
+def test_non_additive_without_fill_stays_plain():
+    """The wrapper exists only for WITH FILL; number/table shapes skip it."""
+    for display in ({"type": "number"}, {"type": "table"}):
+        sql, _ = compile_(
+            make_spec(
+                metric={"measure": "duration_ms", "agg": "p95"},
+                display=display,
+                # Number rejects a breakdown outright; keep the shapes minimal.
+                breakdown=None,
+            )
+        )
+        assert "toNullable(" not in sql, display
+
+
 def test_other_fold_shape():
     """The 'other' fold uses a subquery with LIMIT 50 (MAX_GROUPS)."""
     sql, _ = compile_(make_spec(display={"type": "bar"}))


### PR DESCRIPTION
Stacked on #1531. From external review of the dashboard stack: a count or sum of an empty time bucket genuinely is zero, but an average or percentile of nothing has no value — the WITH FILL zero rows and the pivot's uniform zero-fill drew a p95 latency line collapsing to 0 whenever a bucket was empty, which reads as a real latency drop on exactly the surface meant to catch such drops.

## The fix
- **Backend** — the compiler wraps non-additive aggregations (`avg`, `min`, `max`, `p50`, `p95`, `p99`) in `toNullable` for time series, so WITH FILL rows carry NULL instead of the column default. Gated to time series only (the wrapper exists for the fill); count/sum stay plain — zero is their honest value.
- **Frontend** — the pivot fills bucket×series holes with the agg-appropriate gap value (0 additive, null otherwise); lines bridge nulls with `connectNulls`; **non-additive areas additionally render unstacked** — verified empirically during review that recharts' stack accessor coerces null to 0 *before* `connectNulls` is consulted, which would redraw the false collapse (and stacking percentiles is semantically meaningless anyway). Tooltips show a gap bucket as "—".
- The renderer learns the spec's agg from the widget card and builder preview; the frontend's non-additive set mirrors the backend's polarity so a future agg added to one side degrades safely to zero-fill rather than diverging.

Tests: all six non-additive aggs pinned on the SQL wrapper (plus both negative cases), pivot null-fill, and jsdom path-shape assertions for line and area gap rendering (the area test's oracle is the exact stacked-vs-unstacked path geometry observed in review).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render averages and percentiles as gaps (not zeros) for empty time buckets to prevent false “drops to 0” in time-series (e.g., p95 latency). Applies to line/area charts; counts and sums keep zero-fill.

- **Bug Fixes**
  - Backend: wrap non-additive aggs (`avg`, `min`, `max`, `p50`, `p95`, `p99`) in `toNullable` for time series so WITH FILL rows are NULL; counts/sums and non-time-series unchanged.
  - Frontend: pivot fills bucket×series holes with 0 for additive and null for non-additive; lines/areas bridge nulls with connectNulls; non-additive areas render unstacked; tooltips include gap buckets and show "—".
  - Renderer/Preview: `agg` is passed from the widget card and builder preview; preview results include the producing spec so display/unit/agg semantics stay consistent while drafts load; older callers default to additive.
  - Tests cover SQL wrapping, pivot null-fill, line/area gap rendering, and preview-spec wiring.

<sup>Written for commit b041c2f6d56c57dd449c6a3e6e446c77c1bb3a93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Part of the project dashboards epic: #1460