### PR TITLE
feat(ui): show measure units on charts, tooltips, and tables

### DIFF
--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -337,6 +337,22 @@ describe("ChartTip", () => {
     expect(empty.firstChild).toBeNull();
   });
 
+  it("applies the measure unit to every value row", () => {
+    render(
+      <ChartTip
+        active
+        payload={[
+          { name: "gpt-4o", value: "0.0034", color: "#a78bfa" },
+          { name: "haiku", value: null, color: "#60a5fa" },
+        ]}
+        unit={{ prefix: "$" }}
+      />,
+    );
+    expect(screen.getByText("$0.0034")).toBeTruthy();
+    // A gap bucket stays a bare dash — no unit on nothing.
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
   it("renders the label header and one swatch+name+value row per series", () => {
     const { container } = render(
       <ChartTip
@@ -395,5 +411,33 @@ describe("fmtStatNumber", () => {
     expect(fmtStatNumber("12.5")).toBe("12.5");
     expect(fmtStatNumber(99999)).toBe("99,999");
     expect(fmtStatNumber(0.0004)).toBe("0.0004");
+  });
+});
+
+describe("unit formatting on charts and tables", () => {
+  afterEach(cleanup);
+
+  it("applies the measure unit to the table's metric column", () => {
+    const result = makeResult(["model_name", "value"], [["gpt-4o", "0.0034"]]);
+    render(<QueryWidgetRenderer display="table" result={result} unit={{ prefix: "$" }} />);
+    expect(screen.getByText("$0.0034")).toBeTruthy();
+    // Dimension cells stay verbatim — no unit, no numeric reformatting.
+    expect(screen.getByText("gpt-4o")).toBeTruthy();
+  });
+
+  it("applies the measure unit to time-series axis ticks", () => {
+    const result = makeResult(
+      ["bucket", "value"],
+      [
+        ["2026-06-01T00:00:00", 100],
+        ["2026-06-02T00:00:00", 200],
+      ],
+      { granularity: "day" },
+    );
+    const { container } = render(
+      <QueryWidgetRenderer display="line" result={result} unit={{ suffix: "ms" }} />,
+    );
+    const ticks = Array.from(container.querySelectorAll(".recharts-cartesian-axis-tick-value"));
+    expect(ticks.some((t) => t.textContent?.includes("ms"))).toBe(true);
   });
 });

--- a/frontend/ui/src/features/dashboards/components/renderers.test.ts
+++ b/frontend/ui/src/features/dashboards/components/renderers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fmtNumber, pivotRows } from "./renderers";
+import { fmtNumber, fmtValueWithUnit, pivotRows } from "./renderers";
 
 describe("fmtNumber", () => {
   it("formats a numeric string (Decimal from ClickHouse) as a formatted number", () => {
@@ -172,5 +172,20 @@ describe("pivotRows", () => {
     expect(d[0]["rare-model"]).toBe(0); // first bucket: zero-filled
     expect(d[2]["rare-model"]).toBe(0); // last bucket: zero-filled
     expect(d[1]["rare-model"]).toBe(5); // middle bucket: real value
+  });
+});
+
+describe("fmtValueWithUnit", () => {
+  it("applies prefix and suffix units around the formatted number", () => {
+    expect(fmtValueWithUnit(0.0034, { prefix: "$" })).toBe("$0.0034");
+    expect(fmtValueWithUnit(1500, { suffix: "ms" })).toBe("1,500 ms");
+  });
+
+  it("passes through unadorned without a unit", () => {
+    expect(fmtValueWithUnit(1500)).toBe("1,500");
+  });
+
+  it("keeps gap values a bare dash — no unit on nothing", () => {
+    expect(fmtValueWithUnit(null, { prefix: "$" })).toBe("—");
   });
 });

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -143,6 +143,27 @@ export const fmtNumber = (v: unknown) => {
 export const seriesNameFormatter = (seriesLabel?: string) => (name: string) =>
   name === "value" && seriesLabel ? seriesLabel : name;
 
+// Unit-aware metric formatting for tooltips, axis ticks, and table cells:
+// "$0.0034", "1,500 ms". Gap values stay a bare "—" — a unit on nothing
+// ("$—") reads wrong.
+export const fmtValueWithUnit = (v: unknown, unit?: FieldUnit) => {
+  const text = fmtNumber(v);
+  if (!unit || text === "—") return text;
+  return `${unit.prefix ?? ""}${text}${unit.suffix ? ` ${unit.suffix}` : ""}`;
+};
+
+// Y-axis ticks live in a fixed gutter, and recharts right-anchors them: an
+// overflowing label clips its LEADING digits and reads as a wrong number.
+// Compact notation bounds the glyph count at any magnitude ("100000" →
+// "100K", "$1.2M"), so the gutter widths below hold for every tick.
+const Y_AXIS_WIDTH = 42;
+const Y_AXIS_WIDTH_WITH_UNIT = 58;
+export const fmtAxisTick = (v: unknown, unit?: FieldUnit) => {
+  const text = fmtStatNumber(v);
+  if (!unit || text === "—") return text;
+  return `${unit.prefix ?? ""}${text}${unit.suffix ? ` ${unit.suffix}` : ""}`;
+};
+
 // Bucket keys come back ISO-ish ("2026-06-01T00:00:00"); a space reads better
 // in the tooltip header than the "T" separator.
 export const bucketLabel = (label: unknown) => String(label).replace("T", " ");
@@ -157,6 +178,7 @@ export function ChartTip({
   label,
   nameFormatter,
   labelFormatter,
+  unit,
 }: {
   active?: boolean;
   payload?: {
@@ -168,6 +190,8 @@ export function ChartTip({
   label?: unknown;
   nameFormatter?: (name: string) => string;
   labelFormatter?: (label: unknown) => string;
+  /** Measure unit ($, ms) applied to every value row. */
+  unit?: FieldUnit;
 }) {
   if (!active || !payload?.length) return null;
   return (
@@ -189,7 +213,7 @@ export function ChartTip({
                   {nameFormatter ? nameFormatter(rawName) : rawName}
                 </span>
                 <span className="shrink-0 whitespace-nowrap font-mono font-medium tabular-nums text-foreground">
-                  {fmtNumber(item.value)}
+                  {fmtValueWithUnit(item.value, unit)}
                 </span>
               </div>
             </div>
@@ -218,12 +242,14 @@ function TimeSeries({
   area,
   seriesLabel,
   additive = true,
+  unit,
 }: {
   result: WidgetQueryResult;
   area: boolean;
   seriesLabel?: string;
   /** False for avg/percentile series: empty buckets render as gaps, not 0. */
   additive?: boolean;
+  unit?: FieldUnit;
 }) {
   const { seriesKeys, data } = useMemo(
     () => pivotRows(result.columns, result.rows, additive ? 0 : null),
@@ -255,7 +281,11 @@ function TimeSeries({
       <Chart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
         <CartesianGrid strokeOpacity={0.15} vertical={false} />
         <XAxis dataKey="bucket" tick={{ fontSize: 10 }} tickFormatter={tickFormatter} />
-        <YAxis tick={{ fontSize: 10 }} width={42} />
+        <YAxis
+          tick={{ fontSize: 10 }}
+          width={unit ? Y_AXIS_WIDTH_WITH_UNIT : Y_AXIS_WIDTH}
+          tickFormatter={(v: unknown) => fmtAxisTick(v, unit)}
+        />
         {/* filterNull: recharts strips null payload items by default, which
             would drop a non-additive series' row from the tooltip on its empty
             (gap) buckets — keep them so ChartTip shows an em-dash instead. */}
@@ -266,6 +296,7 @@ function TimeSeries({
             <ChartTip
               nameFormatter={seriesNameFormatter(seriesLabel)}
               labelFormatter={bucketLabel}
+              unit={unit}
             />
           }
         />
@@ -308,17 +339,29 @@ function TimeSeries({
   );
 }
 
-function Bars({ result, seriesLabel }: { result: WidgetQueryResult; seriesLabel?: string }) {
+function Bars({
+  result,
+  seriesLabel,
+  unit,
+}: {
+  result: WidgetQueryResult;
+  seriesLabel?: string;
+  unit?: FieldUnit;
+}) {
   const data = useColoredRows(result);
   return (
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
       <BarChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
         <CartesianGrid strokeOpacity={0.15} vertical={false} />
         <XAxis dataKey="name" tick={{ fontSize: 10 }} />
-        <YAxis tick={{ fontSize: 10 }} width={42} />
+        <YAxis
+          tick={{ fontSize: 10 }}
+          width={unit ? Y_AXIS_WIDTH_WITH_UNIT : Y_AXIS_WIDTH}
+          tickFormatter={(v: unknown) => fmtAxisTick(v, unit)}
+        />
         <Tooltip
           isAnimationActive={false}
-          content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} />}
+          content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} unit={unit} />}
         />
         <Bar dataKey="value" isAnimationActive={false}>
           {data.map((_, i) => (
@@ -330,12 +373,12 @@ function Bars({ result, seriesLabel }: { result: WidgetQueryResult; seriesLabel?
   );
 }
 
-function PieView({ result }: { result: WidgetQueryResult }) {
+function PieView({ result, unit }: { result: WidgetQueryResult; unit?: FieldUnit }) {
   const data = useColoredRows(result);
   return (
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
       <PieChart>
-        <Tooltip isAnimationActive={false} content={<ChartTip />} />
+        <Tooltip isAnimationActive={false} content={<ChartTip unit={unit} />} />
         {/* Pie reads each sector's fill from its data row — no Cells needed. */}
         <Pie
           data={data}
@@ -379,7 +422,7 @@ function NumberView({ result, unit }: { result: WidgetQueryResult; unit?: FieldU
   );
 }
 
-function TableView({ result }: { result: WidgetQueryResult }) {
+function TableView({ result, unit }: { result: WidgetQueryResult; unit?: FieldUnit }) {
   // Only the metric column (always last, aliased "value" by the compiler) is
   // numeric — formatting every cell reformats string dimensions too, and a
   // numeric-looking identifier (user_id, session_id) silently loses digits
@@ -402,7 +445,7 @@ function TableView({ result }: { result: WidgetQueryResult }) {
             <tr key={i} className="border-t border-border/60">
               {r.map((v, j) => (
                 <td key={j} className="py-1 pr-3">
-                  {j === valueIdx ? fmtNumber(v) : v == null ? "—" : String(v)}
+                  {j === valueIdx ? fmtValueWithUnit(v, unit) : v == null ? "—" : String(v)}
                 </td>
               ))}
             </tr>
@@ -430,7 +473,13 @@ function HistogramView({
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
       <BarChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
         <XAxis dataKey="name" tick={{ fontSize: 9 }} interval="preserveStartEnd" />
-        <YAxis tick={{ fontSize: 10 }} width={42} />
+        {/* The y-axis counts rows per bin (no unit), but large counts clip in
+            the fixed gutter just like the other charts — compact them too. */}
+        <YAxis
+          tick={{ fontSize: 10 }}
+          width={Y_AXIS_WIDTH}
+          tickFormatter={(v: unknown) => fmtAxisTick(v)}
+        />
         <Tooltip
           isAnimationActive={false}
           content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} />}
@@ -480,18 +529,32 @@ export function QueryWidgetRenderer({
   switch (display) {
     case "line":
       return (
-        <TimeSeries result={result} area={false} seriesLabel={seriesLabel} additive={additive} />
+        <TimeSeries
+          result={result}
+          area={false}
+          seriesLabel={seriesLabel}
+          additive={additive}
+          unit={unit}
+        />
       );
     case "area":
-      return <TimeSeries result={result} area seriesLabel={seriesLabel} additive={additive} />;
+      return (
+        <TimeSeries
+          result={result}
+          area
+          seriesLabel={seriesLabel}
+          additive={additive}
+          unit={unit}
+        />
+      );
     case "bar":
-      return <Bars result={result} seriesLabel={seriesLabel} />;
+      return <Bars result={result} seriesLabel={seriesLabel} unit={unit} />;
     case "pie":
-      return <PieView result={result} />;
+      return <PieView result={result} unit={unit} />;
     case "number":
       return <NumberView result={result} unit={unit} />;
     case "table":
-      return <TableView result={result} />;
+      return <TableView result={result} unit={unit} />;
     case "histogram":
       return <HistogramView result={result} seriesLabel={seriesLabel} />;
   }

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -149,8 +149,9 @@ export interface FieldUnit {
 }
 
 // Units for fields that carry one — shared by the builder's filter inputs and
-// the stat renderer. Moving these into the backend registry's schema is a
-// tracked follow-up; until then this map is the frontend's single copy.
+// every widget renderer (stat tile, chart tooltips and axes, table cells).
+// Moving these into the backend registry's schema is a tracked follow-up;
+// until then this map is the frontend's single copy.
 export const FIELD_UNIT: Record<string, FieldUnit> = {
   cost: { prefix: "$" },
   duration_ms: { suffix: "ms" },


### PR DESCRIPTION
Stacked on #1550. From external review of the dashboard stack: `FIELD_UNIT` ($ for cost, ms for durations) previously reached only the number tile, so a cost line chart's tooltip said `0.0034` while the stat tile next to it said `$0.0034`.

## The fix
- One unit-aware formatter (`fmtValueWithUnit`) feeds chart tooltips, the pie tooltip, and the table's metric column. Dimension cells stay verbatim (no numeric reformatting of ids), and gap values stay a bare "—" — a unit on nothing reads wrong.
- **Y-axis ticks get compact notation** (`fmtAxisTick`: `$1.2M`, `100K ms`) rather than plain unit-prefixed numbers: recharts right-anchors ticks in a fixed gutter, so an overflowing label clips its *leading* digits and reads as a wrong number. Compact bounds the glyph count at any magnitude; the gutter widens slightly when a unit is present.
- The stat tile keeps its own layout deliberately (separate prefix/suffix spans + its compact stat formatting).

Known follow-up (logged): histogram bin-edge labels are measure values and still render unitless.

advances #1453

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply field units ($, ms) across charts, tooltips, and the table’s metric column to match the stat tile. Y-axes now use compact, unit-aware ticks with a wider gutter in `recharts`; the histogram y-axis shows compact counts. Advances #1453.

- New Features
  - Added `fmtValueWithUnit` for chart tooltips (line/bar/pie) and the table’s metric column; `QueryWidgetRenderer` now passes `unit` to `TimeSeries`, `Bars`, `PieView`, and `TableView`. Gap values render as "—"; dimensions stay verbatim.
  - Y-axis ticks use `fmtAxisTick` with compact notation (e.g., `$1.2M`, `100K ms`) and wider gutters when units are present on time-series and bar charts; histogram counts compacted (no unit).

<sup>Written for commit b76a3c9b490ac9aceaeec4264296d63331b0f593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Part of the project dashboards epic: #1460