### PR TITLE
perf: stop refiring every widget query on each dashboard visit

### DIFF
--- a/backend/rest/services/widget_query.py
+++ b/backend/rest/services/widget_query.py
@@ -19,6 +19,7 @@ MAX_TABLE_ROWS = 1000
 HISTOGRAM_BINS = 20
 QUERY_TIMEOUT_S = 10
 HOUR_BUCKET_MAX = timedelta(days=2)
+GROUP_BY_SPILL_BYTES = 1 * 1024**3  # aggregation memory ceiling before disk spill
 
 _AGG_SQL = {
     "count": "count({expr})",
@@ -274,7 +275,16 @@ def run_widget_query(
     result = client.query(
         sql,
         parameters=params,
-        settings={"readonly": 1, "max_execution_time": QUERY_TIMEOUT_S},
+        settings={
+            "readonly": 1,
+            "max_execution_time": QUERY_TIMEOUT_S,
+            # Large breakdown GROUP BYs spill to disk past this threshold
+            # instead of ballooning server memory: slower beats OOM for a
+            # dashboard tile. (use_query_condition_cache would help the
+            # repeated same-window scans too, but it needs ClickHouse >= 25.4
+            # — the current server rejects it as an unknown setting.)
+            "max_bytes_before_external_group_by": GROUP_BY_SPILL_BYTES,
+        },
     )
     meta: dict[str, Any] = {}
     if spec.display.type in ("line", "area"):

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "../api";
 import type { DraftSpec, TimeRange, WidgetSpec } from "../types";
 import {
+  quantizeRange,
   useWidgetData,
   useWidgetFieldValues,
   useWidgetPreview,
@@ -120,6 +121,69 @@ describe("useWidgetData", () => {
   it("stays disabled without a widgetId", () => {
     renderHook(() => useWidgetData("p1", "", SPEC, RANGE), { wrapper });
     expect(api.runWidgetQuery).not.toHaveBeenCalled();
+  });
+
+  it("floors the window to the minute for the request", async () => {
+    vi.mocked(api.runWidgetQuery).mockResolvedValue({ columns: [], rows: [], meta: {} });
+    const ragged: TimeRange = {
+      start: new Date("2026-06-01T00:00:10.500Z"),
+      end: new Date("2026-06-02T00:00:42.900Z"),
+    };
+    renderHook(() => useWidgetData("p1", "w1", SPEC, ragged), { wrapper });
+
+    await waitFor(() => expect(api.runWidgetQuery).toHaveBeenCalled());
+    const [, , window] = vi.mocked(api.runWidgetQuery).mock.calls[0];
+    expect(window.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    expect(window.end.toISOString()).toBe("2026-06-02T00:00:00.000Z");
+  });
+
+  it("serves a same-minute remount from cache without refetching", async () => {
+    // Relative presets recompute end="now" per mount: raw millisecond keys
+    // would refire every widget on every dashboard round-trip. Same client
+    // across two mounts = the navigation case.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const sharedWrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    vi.mocked(api.runWidgetQuery).mockResolvedValue({ columns: [], rows: [], meta: {} });
+
+    const first = renderHook(
+      () =>
+        useWidgetData("p1", "w1", SPEC, {
+          start: new Date("2026-06-01T00:00:05Z"),
+          end: new Date("2026-06-02T00:00:05Z"),
+        }),
+      { wrapper: sharedWrapper },
+    );
+    await waitFor(() => expect(api.runWidgetQuery).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    // Seconds later the remounted page computes a slightly different raw
+    // window — same floored minute, so the cache answers with zero requests.
+    const second = renderHook(
+      () =>
+        useWidgetData("p1", "w1", SPEC, {
+          start: new Date("2026-06-01T00:00:25Z"),
+          end: new Date("2026-06-02T00:00:25Z"),
+        }),
+      { wrapper: sharedWrapper },
+    );
+    await waitFor(() => expect(second.result.current.data).toBeTruthy());
+    expect(api.runWidgetQuery).toHaveBeenCalledTimes(1);
+    client.clear();
+  });
+});
+
+describe("quantizeRange", () => {
+  it("widens a sub-minute window to one minute instead of an empty range", () => {
+    const q = quantizeRange({
+      start: new Date("2026-06-01T00:00:10Z"),
+      end: new Date("2026-06-01T00:00:40Z"),
+    });
+    expect(q.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    // Both bounds floor to the same minute; the end must stay one step ahead
+    // or the backend would reject end <= start.
+    expect(q.end.toISOString()).toBe("2026-06-01T00:01:00.000Z");
   });
 });
 

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
@@ -21,6 +21,22 @@ export function useWidgetSchema(projectId: string) {
   });
 }
 
+const MINUTE = 60_000;
+
+// Relative presets recompute end="now" on every page mount, so raw
+// millisecond bounds would mint a fresh cache key per visit and refire every
+// widget query. Flooring the window to the minute (the same keying the
+// server's distinct-values cache uses) keeps keys stable within a minute, and
+// the matching staleTime serves those remounts from cache with zero requests.
+// Cost: charts lag "now" by up to 60s — the right trade for a dashboard.
+// A sub-minute custom window floors to an empty range; keep it one minute
+// wide rather than compiling an end<=start query the backend rejects.
+export function quantizeRange(range: TimeRange): TimeRange {
+  const start = Math.floor(range.start.getTime() / MINUTE) * MINUTE;
+  const end = Math.floor(range.end.getTime() / MINUTE) * MINUTE;
+  return { start: new Date(start), end: new Date(Math.max(end, start + MINUTE)) };
+}
+
 export function useWidgetData(
   projectId: string,
   widgetId: string,
@@ -29,6 +45,7 @@ export function useWidgetData(
   enabled = true,
 ) {
   const { user, sessionReady } = useTraceApiUser();
+  const floored = quantizeRange(range);
 
   return useQuery({
     queryKey: [
@@ -36,12 +53,13 @@ export function useWidgetData(
       projectId,
       widgetId,
       JSON.stringify(spec),
-      range.start.getTime(),
-      range.end.getTime(),
+      floored.start.getTime(),
+      floored.end.getTime(),
     ],
-    queryFn: () => api.runWidgetQuery(projectId, spec, range, user),
+    queryFn: () => api.runWidgetQuery(projectId, spec, floored, user),
     enabled: enabled && sessionReady && !!projectId && !!widgetId,
     retry: 1,
+    staleTime: MINUTE,
     placeholderData: keepPreviousData,
   });
 }
@@ -59,6 +77,7 @@ export function useWidgetFieldValues(
   enabled: boolean,
 ): { values: WidgetFieldValue[]; isLoading: boolean } {
   const { user, sessionReady } = useTraceApiUser();
+  const floored = quantizeRange(range);
 
   const active = enabled && sessionReady && !!projectId && !!view && !!field;
   const { data, isLoading } = useQuery({
@@ -67,10 +86,10 @@ export function useWidgetFieldValues(
       projectId,
       view ?? null,
       field,
-      range.start.getTime(),
-      range.end.getTime(),
+      floored.start.getTime(),
+      floored.end.getTime(),
     ],
-    queryFn: () => api.fetchWidgetFieldValues(projectId, view!, field, range, user),
+    queryFn: () => api.fetchWidgetFieldValues(projectId, view!, field, floored, user),
     enabled: active,
     staleTime: 30_000,
   });
@@ -91,18 +110,19 @@ export interface WidgetPreviewData {
 
 export function useWidgetPreview(projectId: string, draft: unknown, range: TimeRange) {
   const { user, sessionReady } = useTraceApiUser();
+  const floored = quantizeRange(range);
 
   return useQuery({
     queryKey: [
       "widget-preview",
       projectId,
       JSON.stringify(draft),
-      range.start.getTime(),
-      range.end.getTime(),
+      floored.start.getTime(),
+      floored.end.getTime(),
     ],
     queryFn: async (): Promise<WidgetPreviewData> => {
       const spec = parseSpec(draft)!;
-      return { spec, result: await api.runWidgetQuery(projectId, spec, range, user) };
+      return { spec, result: await api.runWidgetQuery(projectId, spec, floored, user) };
     },
     enabled: sessionReady && !!projectId && isSpecComplete(draft),
     staleTime: 10_000,

--- a/tests/rest/test_widget_query.py
+++ b/tests/rest/test_widget_query.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from typing import get_args
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.encoders import jsonable_encoder
@@ -14,6 +15,7 @@ from rest.schemas.dashboards import (
     WidgetQueryResponse,
     WidgetSpec,
 )
+from rest.services import widget_query as wq
 from rest.services.widget_query import WidgetSpecError, compile_widget_query
 from rest.services.widget_registry import (
     AGGS_NUMBER,
@@ -429,3 +431,24 @@ def test_number_display_rejects_breakdown():
     with pytest.raises(WidgetSpecError) as exc:
         compile_widget_query(spec, "p1", START, END)
     assert exc.value.step == "breakdown"
+
+
+def test_run_widget_query_sets_execution_guards(monkeypatch):
+    """Every widget query runs read-only, time-capped, and with a GROUP BY
+    memory ceiling that spills to disk instead of OOMing the server."""
+    fake_result = MagicMock(column_names=["value"], result_rows=[(1,)])
+    fake_client = MagicMock()
+    fake_client.query.return_value = fake_result
+    monkeypatch.setattr(wq, "get_clickhouse_client", lambda: fake_client)
+
+    wq.run_widget_query(
+        spec=WidgetSpec.model_validate(make_spec()),
+        project_id="p1",
+        start_time=START,
+        end_time=END,
+    )
+
+    settings = fake_client.query.call_args.kwargs["settings"]
+    assert settings["readonly"] == 1
+    assert settings["max_execution_time"] == wq.QUERY_TIMEOUT_S
+    assert settings["max_bytes_before_external_group_by"] == wq.GROUP_BY_SPILL_BYTES


### PR DESCRIPTION
Stacked on #1551. First of the quick wins from the dashboard-query performance research (competitor survey + a profiled cost model of our widget query path).

## The problem
Relative presets recompute `end="now"` on every page mount, so widget-data query keys carried fresh millisecond bounds per visit and the client cache never hit: a dashboard round-trip (open builder, come back; switch tabs; navigate away and return) re-ran all six seeded Overview ClickHouse scans seconds apart, every time.

## The fix
- **Minute-floored query windows** — the widget data, builder preview, and field-values hooks floor their window to the minute for both the cache key and the request body (the same keying the server's distinct-values cache already uses — floored requests now match that cache's keys exactly), with a matching one-minute `staleTime` on widget data. Same-minute remounts serve from cache with **zero requests**; charts lag "now" by at most 60 seconds — the right trade for a dashboard. A sub-minute custom window widens to one minute rather than compiling an empty range.
- **GROUP BY spill ceiling** — widget queries run with `max_bytes_before_external_group_by = 1 GiB`, so a huge breakdown aggregation degrades to disk instead of pressuring server memory. (`use_query_condition_cache` is deliberately excluded: verified rejected as unknown by our ClickHouse 25.2 — noted in code for the ≥ 25.4 upgrade.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops refiring widget queries on dashboard revisit by flooring time windows to the minute and caching for 60s. Adds a ClickHouse GROUP BY spill ceiling to protect memory.

- **Performance**
  - Floors widget, preview, and field-values windows to the minute for both cache keys and request bodies; widens sub-minute windows to 1 minute; sets a 60s staleTime so same-minute remounts serve from cache.
  - Runs widget queries with `max_bytes_before_external_group_by = 1 GiB`, keeping queries read-only and time-capped.

- **Bug Fixes**
  - Pauses preview when histogram isn’t available for the chosen measure and shows “Preview paused” instead of “Running…”.

<sup>Written for commit c33f31f4b2bdd1f7d48ff83d327e16d80c77a499. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Part of the project dashboards epic: #1460