### PR TITLE
feat(ui): make the seeded Overview editable like any other dashboard

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
@@ -459,50 +459,35 @@ describe("DELETE /dashboards/[dashboardId]/widgets/[widgetId]", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Default dashboard is read-only
+// Default dashboard is editable like any other dashboard
 // ---------------------------------------------------------------------------
-describe("default dashboard is read-only", () => {
+describe("default dashboard is editable", () => {
   const defaultDashboard = { ...fakeDashboard, isDefault: true };
 
-  it("PATCH /dashboards/[dashboardId] returns 403", async () => {
+  it("PATCH /dashboards/[dashboardId] renames it", async () => {
     dashboardFindFirstMock.mockResolvedValue(defaultDashboard);
+    dashboardUpdateMock.mockResolvedValue({ ...defaultDashboard, name: "renamed" });
     const res = (await PATCH(makeRequest({ name: "renamed" }), makeParams())) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(dashboardUpdateMock).toHaveBeenCalledTimes(1);
   });
 
-  it("DELETE /dashboards/[dashboardId] returns 403", async () => {
+  it("DELETE /dashboards/[dashboardId] deletes it", async () => {
     dashboardFindFirstMock.mockResolvedValue(defaultDashboard);
     const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(dashboardDeleteMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(dashboardDeleteMock).toHaveBeenCalledTimes(1);
   });
 
-  it("POST .../widgets returns 403", async () => {
+  it("POST .../widgets adds a widget", async () => {
     dashboardFindFirstMock.mockResolvedValue(defaultDashboard);
+    widgetCreateMock.mockResolvedValue(fakeWidget);
     const res = (await widgetPOST(
-      makeRequest({ title: "t", type: "query", spec: {} }),
+      makeRequest({ title: "My Widget", type: "query", spec: { sql: "SELECT 1" } }),
       makeParams(),
     )) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(widgetCreateMock).not.toHaveBeenCalled();
-  });
-
-  it("PATCH .../widgets/[widgetId] returns 403", async () => {
-    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: true } });
-    const res = (await widgetPATCH(
-      makeRequest({ title: "renamed" }),
-      makeWidgetParams(),
-    )) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(widgetUpdateMock).not.toHaveBeenCalled();
-  });
-
-  it("DELETE .../widgets/[widgetId] returns 403", async () => {
-    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: true } });
-    const res = (await widgetDELETE(makeRequest(), makeWidgetParams())) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(widgetDeleteMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(201);
+    expect(widgetCreateMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -610,7 +595,7 @@ describe("mutation hardening", () => {
     )) as MockResponse;
     expect(post.status).toBe(400);
 
-    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: false } });
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
     const patch = (await widgetPATCH(
       makeRequest({ title: "x".repeat(101) }),
       makeWidgetParams(),
@@ -635,7 +620,7 @@ describe("mutation hardening", () => {
     const del = (await DELETE(makeRequest(), makeParams())) as MockResponse;
     expect(del.status).toBe(404);
 
-    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: false } });
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
     widgetUpdateMock.mockRejectedValue(gone);
     const wpatch = (await widgetPATCH(
       makeRequest({ title: "renamed" }),

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
@@ -87,7 +87,6 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     where: { id: dashboardId, projectId },
   });
   if (!existing) return errorResponse("Dashboard not found", 404);
-  if (existing.isDefault) return errorResponse("The default dashboard is read-only", 403);
 
   try {
     const dashboard = await prisma.dashboard.update({
@@ -111,7 +110,6 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
     where: { id: dashboardId, projectId },
   });
   if (!existing) return errorResponse("Dashboard not found", 404);
-  if (existing.isDefault) return errorResponse("The default dashboard is read-only", 403);
 
   try {
     await prisma.dashboard.delete({ where: { id: dashboardId } });

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.ts
@@ -11,7 +11,6 @@ type RouteParams = {
 async function findWidget(dashboardId: string, widgetId: string, projectId: string) {
   return prisma.widget.findFirst({
     where: { id: widgetId, dashboardId, dashboard: { projectId } },
-    include: { dashboard: { select: { isDefault: true } } },
   });
 }
 
@@ -22,9 +21,6 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
 
   const existing = await findWidget(dashboardId, widgetId, projectId);
   if (!existing) return errorResponse("Widget not found", 404);
-  if (existing.dashboard?.isDefault) {
-    return errorResponse("The default dashboard is read-only", 403);
-  }
 
   const parsed = await parseJsonObject(req);
   if (parsed.error) return parsed.error;
@@ -78,9 +74,6 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
 
   const existing = await findWidget(dashboardId, widgetId, projectId);
   if (!existing) return errorResponse("Widget not found", 404);
-  if (existing.dashboard?.isDefault) {
-    return errorResponse("The default dashboard is read-only", 403);
-  }
 
   try {
     await prisma.widget.delete({ where: { id: widgetId } });

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.ts
@@ -18,7 +18,6 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     where: { id: dashboardId, projectId },
   });
   if (!dashboard) return errorResponse("Dashboard not found", 404);
-  if (dashboard.isDefault) return errorResponse("The default dashboard is read-only", 403);
 
   const parsed = await parseJsonObject(req);
   if (parsed.error) return parsed.error;

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -119,8 +119,8 @@ vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
 
 import { useDashboard, useDashboards } from "@/features/dashboards/hooks/use-dashboards";
 
-// The rendered dashboard (d1) is deliberately non-default: the default one is
-// read-only, which the dedicated tests below cover.
+// d1 is a user dashboard; d2 is the seeded default (Overview) — both are
+// fully editable, the default is just auto-created and tab-marked.
 const DASH_A: DashboardSummary = {
   id: "d1",
   name: "Custom",
@@ -299,20 +299,20 @@ describe("DashboardDetailPage", () => {
     expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1/widgets/new");
   });
 
-  it("marks the grid read-only and hides both create-widget buttons on the default dashboard", () => {
+  it("shows the create-widget button and passes no readOnly prop for the default dashboard", () => {
     mockDetail({ ...DASH_B, layout: [], widgets: [WIDGET] });
     renderPage();
 
-    expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
-    expect(lastGridProps?.readOnly).toBe(true);
+    expect(screen.getAllByRole("button", { name: "＋ Create widget" }).length).toBe(1);
+    expect(lastGridProps?.readOnly).toBeUndefined();
   });
 
-  it("keeps the grid editable on a non-default dashboard", () => {
-    mockDetail({ ...DASH_A, layout: [], widgets: [WIDGET] });
+  it("holds the header edit controls until the dashboard detail loads", () => {
+    mockDetail(undefined);
     renderPage();
 
-    expect(screen.getAllByRole("button", { name: "＋ Create widget" }).length).toBe(1);
-    expect(lastGridProps?.readOnly).toBe(false);
+    expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
   });
 
   it("deletes the dashboard through the confirm dialog and navigates to the index", () => {
@@ -348,10 +348,10 @@ describe("DashboardDetailPage", () => {
     expect(removeDashboard.mutate).not.toHaveBeenCalled();
   });
 
-  it("hides the delete button on the read-only default dashboard", () => {
+  it("shows the delete button on the default dashboard", () => {
     mockDetail({ ...DASH_B, layout: [], widgets: [] });
     renderPage();
-    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Delete dashboard" })).toBeTruthy();
   });
 
   it("redirects to the dashboard index and invalidates the list cache when the dashboard is gone", () => {

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -184,11 +184,6 @@ export default function DashboardDetailPage() {
   // ── render ───────────────────────────────────────────────────────────────────
   const widgets = dashboard?.widgets ?? [];
   const layout = dashboard?.layout ?? [];
-  // The seeded default dashboard is read-only: custom dashboards start from
-  // "＋ new" instead. The API enforces the same rule. Treated as read-only
-  // while the detail is still loading so edit controls never flash on the
-  // Overview before the app knows which dashboard this is.
-  const readOnly = dashboard ? dashboard.isDefault : true;
 
   return (
     <div className="relative flex h-full text-[13px]">
@@ -282,7 +277,9 @@ export default function DashboardDetailPage() {
               onCustomRangeChange={setCustomRange}
             />
 
-            {!readOnly && (
+            {/* Held back until the detail loads so edit controls don't act
+                on a dashboard the app doesn't know yet. */}
+            {dashboard && (
               <>
                 <Button size="sm" className="h-7 text-[12px]" onClick={openCreate}>
                   ＋ Create widget
@@ -311,11 +308,9 @@ export default function DashboardDetailPage() {
           ) : widgets.length === 0 ? (
             <div className="flex h-64 flex-col items-center justify-center gap-3">
               <p className="text-[13px] text-muted-foreground">No widgets yet.</p>
-              {!readOnly && (
-                <Button size="sm" className="text-[12px]" onClick={openCreate}>
-                  ＋ Create widget
-                </Button>
-              )}
+              <Button size="sm" className="text-[12px]" onClick={openCreate}>
+                ＋ Create widget
+              </Button>
             </div>
           ) : (
             <DashboardGrid
@@ -324,7 +319,6 @@ export default function DashboardDetailPage() {
               layout={layout}
               range={range}
               width={width}
-              readOnly={readOnly}
               onLayoutChange={handleLayoutChange}
               onEdit={openEdit}
               onDuplicate={handleDuplicate}

--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
@@ -107,36 +107,6 @@ describe("DashboardGrid", () => {
       expect(latestProps().layout).toEqual([{ i: "w1", x: 0, y: 0, w: 4, h: 4, minW: 2, minH: 2 }]);
     });
 
-    it("marks every item static and never persists layout changes when read-only", () => {
-      vi.useFakeTimers();
-      const onLayoutChange = vi.fn();
-      render(
-        <DashboardGrid
-          projectId="p1"
-          widgets={[widget("w1")]}
-          layout={[{ i: "w1", x: 0, y: 0, w: 4, h: 4 }]}
-          range={RANGE}
-          width={1000}
-          readOnly
-          onLayoutChange={onLayoutChange}
-          onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
-          onDelete={vi.fn()}
-        />,
-      );
-
-      const { layout: fullLayout, onLayoutChange: onChange } = latestProps();
-      expect(fullLayout).toEqual([
-        { i: "w1", x: 0, y: 0, w: 4, h: 4, minW: 2, minH: 2, static: true },
-      ]);
-
-      // Even if the grid fires (e.g. mount-fire compaction), nothing goes upstream.
-      onChange([{ i: "w1", x: 2, y: 0, w: 4, h: 4 }]);
-      vi.advanceTimersByTime(600);
-      expect(onLayoutChange).not.toHaveBeenCalled();
-      vi.useRealTimers();
-    });
-
     it("stamps the minimum size on every item so widgets can't be shrunk into clipping", () => {
       const widgets = [widget("w1"), widget("w2")];
       render(

--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
@@ -20,7 +20,6 @@ export function DashboardGrid({
   layout,
   range,
   width,
-  readOnly = false,
   onLayoutChange,
   onEdit,
   onDuplicate,
@@ -31,8 +30,6 @@ export function DashboardGrid({
   layout: LayoutItem[];
   range: TimeRange;
   width: number;
-  /** Read-only dashboards (the seeded default) can't be rearranged or resized. */
-  readOnly?: boolean;
   onLayoutChange: (layout: LayoutItem[]) => void;
   onEdit: (w: Widget) => void;
   onDuplicate: (w: Widget) => void;
@@ -44,10 +41,7 @@ export function DashboardGrid({
   const fullLayout: RGLLayoutItem[] = useMemo(() => {
     const known = new Map(layout.map((l) => [l.i, l]));
     let maxY = Math.max(0, ...layout.map((l) => l.y + l.h));
-    // `static` items can't be dragged or resized.
-    const constraints = readOnly
-      ? { minW: MIN_W, minH: MIN_H, static: true }
-      : { minW: MIN_W, minH: MIN_H };
+    const constraints = { minW: MIN_W, minH: MIN_H };
     return widgets.map((w) => {
       const item = known.get(w.id);
       if (item) return { ...item, ...constraints };
@@ -55,7 +49,7 @@ export function DashboardGrid({
       maxY += 4;
       return fresh;
     });
-  }, [widgets, layout, readOnly]);
+  }, [widgets, layout]);
 
   // Snapshot of the last layout sent upstream, used to skip no-op PATCH calls.
   // react-grid-layout fires onLayoutChange on mount with the initial layout, so
@@ -89,9 +83,6 @@ export function DashboardGrid({
   );
 
   const handleChange = (next: Layout) => {
-    // Static items can still be re-compacted on mount; never persist from a
-    // read-only grid.
-    if (readOnly) return;
     const mapped: LayoutItem[] = next.map(({ i, x, y, w, h }) => ({ i, x, y, w, h }));
 
     // Lazy-init: on the first call (mount-fire from react-grid-layout) treat the
@@ -129,7 +120,6 @@ export function DashboardGrid({
             projectId={projectId}
             widget={w}
             range={range}
-            readOnly={readOnly}
             onEdit={() => onEdit(w)}
             onDuplicate={() => onDuplicate(w)}
             onDelete={() => onDelete(w)}

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -219,10 +219,11 @@ describe("WidgetBuilderPage", () => {
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
   });
 
-  it("redirects back to the read-only default dashboard instead of opening the builder", () => {
+  it("opens the builder for the default dashboard like any other", () => {
     mockDashboard({ ...DASHBOARD, isDefault: true });
     render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
-    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText("New widget")).toBeTruthy();
   });
 
   function openSelect(currentText: string) {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -145,12 +145,6 @@ export function WidgetBuilderPage({
     }
   }, [isEdit, dashboard, widget, dashboardUrl, router]);
 
-  // The default dashboard is read-only — widgets can be neither added nor
-  // edited, so bounce straight back. The API enforces the same rule.
-  useEffect(() => {
-    if (dashboard?.isDefault) router.replace(dashboardUrl);
-  }, [dashboard, dashboardUrl, router]);
-
   // ── schema-driven field lists (same derivation as the old modal) ──────────
   const { data: schema } = useWidgetSchema(projectId);
   const view = draft.view as View | undefined;

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
@@ -51,7 +51,6 @@ function makeWidget(overrides: Partial<Widget> = {}): Widget {
 function renderCard(
   widget: Widget,
   callbacks: Partial<{ onEdit: () => void; onDuplicate: () => void; onDelete: () => void }> = {},
-  readOnly = false,
 ) {
   const onEdit = callbacks.onEdit ?? vi.fn();
   const onDuplicate = callbacks.onDuplicate ?? vi.fn();
@@ -61,7 +60,6 @@ function renderCard(
       projectId="p1"
       widget={widget}
       range={RANGE}
-      readOnly={readOnly}
       onEdit={onEdit}
       onDuplicate={onDuplicate}
       onDelete={onDelete}
@@ -90,16 +88,6 @@ describe("WidgetCard menu gating", () => {
     fireEvent.click(edit);
 
     expect(onEdit).toHaveBeenCalledTimes(1);
-  });
-
-  it("hides the options menu and drag handle entirely when read-only", () => {
-    useWidgetData.mockReturnValue({ data: undefined, isPending: false, error: null });
-    renderCard(makeWidget(), {}, true);
-
-    expect(screen.queryByRole("button", { name: "Widget options" })).toBeNull();
-    expect(screen.queryByText("⠿")).toBeNull();
-    // The widget body still renders.
-    expect(screen.getByText("My widget")).toBeTruthy();
   });
 
   it("hides Edit for a non-query widget", async () => {

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -71,7 +71,6 @@ export function WidgetCard({
   projectId,
   widget,
   range,
-  readOnly = false,
   onEdit,
   onDuplicate,
   onDelete,
@@ -79,8 +78,6 @@ export function WidgetCard({
   projectId: string;
   widget: Widget;
   range: TimeRange;
-  /** Read-only dashboards (the seeded default) hide the drag handle and menu. */
-  readOnly?: boolean;
   onEdit: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
@@ -89,33 +86,27 @@ export function WidgetCard({
     <div className="flex h-full flex-col rounded-md border bg-background p-3">
       {/* Header: drag handle + title + menu */}
       <div className="mb-2 flex items-center gap-1.5">
-        {!readOnly && (
-          <span className="drag-handle cursor-move select-none text-muted-foreground/50">⠿</span>
-        )}
+        <span className="drag-handle cursor-move select-none text-muted-foreground/50">⠿</span>
         <span className="flex-1 truncate text-[12px] font-medium" title={widget.title}>
           {widget.title}
         </span>
-        {!readOnly && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted focus:opacity-100 group-hover:opacity-100"
-                aria-label="Widget options"
-              >
-                <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {widget.type === "query" && (
-                <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>
-              )}
-              <DropdownMenuItem onSelect={onDuplicate}>Duplicate</DropdownMenuItem>
-              <DropdownMenuItem onSelect={onDelete} className="text-red-600 focus:text-red-600">
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted focus:opacity-100 group-hover:opacity-100"
+              aria-label="Widget options"
+            >
+              <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {widget.type === "query" && <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>}
+            <DropdownMenuItem onSelect={onDuplicate}>Duplicate</DropdownMenuItem>
+            <DropdownMenuItem onSelect={onDelete} className="text-red-600 focus:text-red-600">
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       {/* Body */}


### PR DESCRIPTION
## What

Reverts the read-only special-casing of the seeded default ("Overview") dashboard. It is now a normal dashboard that just happens to be pre-populated when a project's dashboard list is first fetched.

- Removed the five API 403 guards ("The default dashboard is read-only") on dashboard PATCH/DELETE and widget POST/PATCH/DELETE, plus the now-unneeded `dashboard.isDefault` include in the widget lookup.
- Removed the widget builder's bounce-back redirect for the default dashboard.
- Removed the page's `readOnly` derivation and the `readOnly` prop plumbing through `DashboardGrid` (no more `static` grid items; layout drags persist) and `WidgetCard` (drag handle and Edit/Duplicate/Delete menu always render).
- Header edit controls are now gated on the dashboard detail having loaded, preserving the old no-flash-while-loading behavior.

## What isDefault still does

Lazy seeding with a deterministic id (concurrent first visits can't double-create), default-first tab ordering, the ⌂ tab marker, the index-route landing target, and the guard that `isDefault` can't be set through the API body.

## Behavior note

Deleting the Overview behaves like deleting any dashboard. If it was the project's only dashboard, the next list fetch re-seeds it (the lazy seed runs whenever a project has zero dashboards); if other dashboards exist, it stays deleted.

## Testing

- Read-only tests replaced with editable-path equivalents: mutation routes return 200 on the default dashboard, the builder opens instead of redirecting, the grid gets no readOnly prop, the delete button shows.
- New test that header edit controls stay hidden until the detail loads.
- Full frontend suite passes; diff coverage 100% on changed lines.

Part of the project dashboards epic: #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the seeded “Overview” dashboard editable like any other. You can now add, edit, rearrange, and delete widgets on Overview, and delete the dashboard itself.

- **New Features**
  - API: Removed read-only 403s; Overview supports dashboard PATCH/DELETE and widget POST/PATCH/DELETE.
  - UI: Builder opens for Overview; header edit controls render after detail loads; grid is always draggable/resizable and persists layout; widget cards always show drag handle and options.
  - `isDefault`: Only used for lazy seeding with a deterministic id, default-first tab ordering, the ⌂ tab marker, and the index-route landing target; not settable via the API.
  - Deleting Overview behaves like any dashboard. If it was the only one, the next list fetch re-seeds it.

<sup>Written for commit a73d63bf0ca2b23d0548305a220a1004f7e04423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

