### PR TITLE
refactor(ui): share the trace-list filter controls with the widget builder

### DIFF
--- a/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
@@ -55,11 +55,10 @@ describe("FilterRow value input", () => {
         filter={{ field: "model_name", op: "=", value: "" }}
       />,
     );
-    // field + op selects; the value control is the trace-list popover dropdown
-    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    // the value control is the trace-list popover dropdown, not a free input
     expect(screen.queryByRole("textbox")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Value" }));
+    fireEvent.click(screen.getByRole("button", { name: "Enter value" }));
     const option = screen.getByRole("option", { name: /gpt-4o/ });
     // the stored value's occurrence count is shown alongside it
     expect(option.textContent).toContain("3");
@@ -72,7 +71,6 @@ describe("FilterRow value input", () => {
     render(
       <FilterRow {...baseProps} filter={{ field: "model_name", op: "contains", value: "gp" }} />,
     );
-    expect(screen.getAllByRole("combobox")).toHaveLength(2);
     expect(screen.getByRole("textbox")).toBeTruthy();
     // the hook is parked while the op is not enumerable
     expect(vi.mocked(useWidgetFieldValues).mock.lastCall?.[4]).toBe(false);
@@ -81,15 +79,55 @@ describe("FilterRow value input", () => {
   it("falls back to free text when no stored values exist", () => {
     vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
     render(<FilterRow {...baseProps} filter={{ field: "model_name", op: "=", value: "" }} />);
-    expect(screen.getAllByRole("combobox")).toHaveLength(2);
     expect(screen.getByRole("textbox")).toBeTruthy();
   });
 
   it("keeps the number input for numeric fields", () => {
     vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
     render(<FilterRow {...baseProps} filter={{ field: "cost", op: ">", value: 5 }} />);
-    expect(screen.getByRole("spinbutton")).toBeTruthy();
+    const input = screen.getByRole("spinbutton");
+    expect(input).toBeTruthy();
+    // the widget builder hosts the shared controls at its compact 12px size
+    expect(input.className).toContain("text-[12px]");
     expect(vi.mocked(useWidgetFieldValues).mock.lastCall?.[4]).toBe(false);
+  });
+
+  it("rejects negative numeric input like the trace-list builder", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    const onChange = vi.fn();
+    render(
+      <FilterRow
+        {...baseProps}
+        onChange={onChange}
+        filter={{ field: "cost", op: ">", value: "" }}
+      />,
+    );
+    const input = screen.getByRole("spinbutton");
+    // typed negative values are dropped instead of propagating into the spec
+    fireEvent.change(input, { target: { value: "-5" } });
+    expect(onChange).not.toHaveBeenCalled();
+    // a non-negative value still propagates as a number
+    fireEvent.change(input, { target: { value: "5" } });
+    expect(onChange).toHaveBeenCalledWith(0, { value: 5 });
+  });
+
+  it("picking a field auto-selects its first operator, like the trace-list builder", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    const onChange = vi.fn();
+    render(
+      <FilterRow {...baseProps} onChange={onChange} filter={{ field: "", op: "", value: "" }} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Field" }));
+    fireEvent.click(screen.getByRole("option", { name: /Cost/ }));
+    expect(onChange).toHaveBeenCalledWith(0, { field: "cost", op: ">", value: "" });
+  });
+
+  it("disables the op and value controls until a field is picked", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    render(<FilterRow {...baseProps} filter={{ field: "", op: "", value: "" }} />);
+    // op trigger shows the placeholder "is" and is disabled; value is a parked input
+    expect(screen.getByRole("button", { name: "is" })).toHaveProperty("disabled", true);
+    expect(screen.getByPlaceholderText("Enter value")).toHaveProperty("disabled", true);
   });
 
   it("shows trace-list wording for string ops and symbols for numeric ops", () => {
@@ -102,6 +140,23 @@ describe("FilterRow value input", () => {
 
     render(<FilterRow {...baseProps} filter={{ field: "cost", op: ">=", value: 5 }} />);
     expect(screen.getByText("≥")).toBeTruthy();
+  });
+
+  it("lists the field's ops in the operator dropdown with shared labels", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    const onChange = vi.fn();
+    render(
+      <FilterRow
+        {...baseProps}
+        onChange={onChange}
+        filter={{ field: "model_name", op: "=", value: "" }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "is" }));
+    expect(screen.getByRole("option", { name: "is not" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "contains" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("option", { name: "is not" }));
+    expect(onChange).toHaveBeenCalledWith(0, { op: "!=" });
   });
 
   it("adorns cost and duration values with their unit like the trace-list builder", () => {

--- a/frontend/ui/src/features/dashboards/components/FilterRow.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.tsx
@@ -2,19 +2,20 @@
 
 import { useMemo } from "react";
 import { X } from "lucide-react";
-import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { ValueDropdown } from "@/features/filters/filter-builder";
+  Dropdown,
+  DropdownItem,
+  FIELD_UNIT,
+  FieldDropdown,
+  FilterControlSizeProvider,
+  NumberField,
+  ParkedValueField,
+  TextField,
+  ValueDropdown,
+} from "@/features/filters/filter-controls";
 import { fieldIcon } from "./field-icons";
 import { useWidgetFieldValues } from "../hooks/use-widget-data";
 import {
-  FIELD_UNIT,
   filterOpLabel,
   isEnumerableFilter,
   type TimeRange,
@@ -46,7 +47,6 @@ export function FilterRow({
   range: TimeRange;
 }) {
   const fieldMeta = fieldsMap[filter.field];
-  const ops = fieldMeta?.filterOps ?? [];
   const isNumeric = fieldMeta?.type === "number";
 
   // Equality on a string dimension offers the field's stored values as a
@@ -71,96 +71,87 @@ export function FilterRow({
   const showValueDropdown = enumerable && (options.length > 0 || isLoading);
 
   return (
-    <div className="flex items-center gap-1.5">
-      {/* field */}
-      <Select
-        value={filter.field}
-        onValueChange={(v) => onChange(index, { field: v, op: "", value: "" })}
-      >
-        <SelectTrigger className="h-7 flex-1 text-[12px]">
-          <SelectValue placeholder="Field" />
-        </SelectTrigger>
-        <SelectContent>
-          {filterableFields.map(([key, meta]) => {
-            const Icon = fieldIcon(key);
-            return (
-              <SelectItem
-                key={key}
-                value={key}
-                className="text-[12px]"
-                icon={<Icon className="h-3.5 w-3.5 text-muted-foreground" />}
-              >
-                {meta.label}
-              </SelectItem>
-            );
-          })}
-        </SelectContent>
-      </Select>
-
-      {/* op — labeled with the trace-list filter vocabulary (is / is not / ≥ / ≤ / ≠) */}
-      <Select
-        value={filter.op}
-        onValueChange={(v) => onChange(index, { op: v })}
-        disabled={!filter.field}
-      >
-        <SelectTrigger className="h-7 w-24 text-[12px]">
-          <SelectValue placeholder="Op">
-            {filter.op ? filterOpLabel(fieldMeta, filter.op) : undefined}
-          </SelectValue>
-        </SelectTrigger>
-        <SelectContent>
-          {ops.map((op) => (
-            <SelectItem key={op} value={op} className="text-[12px]">
-              {filterOpLabel(fieldMeta, op)}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      {/* value — the trace-list stored-values picker, counts included */}
-      {showValueDropdown ? (
-        <ValueDropdown
-          value={String(filter.value)}
-          options={options}
-          onValue={(v) => onChange(index, { value: v })}
-          placeholder={isLoading ? "Loading…" : "Value"}
-          triggerClassName="text-[12px]"
+    // The widget builder's config column runs at 12px, so the shared controls
+    // render at their compact size here.
+    <FilterControlSizeProvider size="sm">
+      <div className="flex items-center gap-1">
+        <FieldDropdown
+          options={filterableFields.map(([key, meta]) => ({
+            key,
+            label: meta.label,
+            icon: fieldIcon(key),
+          }))}
+          valueKey={filter.field || null}
+          // Picking a field selects its first operator, like the trace-list builder.
+          onPick={(key) =>
+            onChange(index, { field: key, op: fieldsMap[key]?.filterOps[0] ?? "", value: "" })
+          }
         />
-      ) : (
-        <div className="flex flex-1 items-center gap-1">
-          {isNumeric && FIELD_UNIT[filter.field]?.prefix && (
-            <span className="shrink-0 text-[11px] text-muted-foreground">
-              {FIELD_UNIT[filter.field].prefix}
-            </span>
-          )}
-          <Input
-            className="h-7 flex-1 text-[12px]"
-            placeholder="Value"
-            type={isNumeric ? "number" : "text"}
-            value={String(filter.value)}
-            onChange={(e) => {
-              const raw = e.target.value;
-              onChange(index, { value: isNumeric && raw !== "" ? Number(raw) : raw });
-            }}
-            disabled={!filter.field}
-          />
-          {isNumeric && FIELD_UNIT[filter.field]?.suffix && (
-            <span className="shrink-0 text-[11px] text-muted-foreground">
-              {FIELD_UNIT[filter.field].suffix}
-            </span>
-          )}
-        </div>
-      )}
 
-      {/* remove */}
-      <button
-        type="button"
-        onClick={() => onRemove(index)}
-        className="rounded p-0.5 text-muted-foreground hover:text-foreground"
-        aria-label="Remove filter"
-      >
-        <X className="h-3.5 w-3.5" />
-      </button>
-    </div>
+        {/* op — labeled with the trace-list filter vocabulary (is / is not / ≥ / ≤ / ≠) */}
+        <Dropdown
+          disabled={!fieldMeta}
+          trigger={
+            <span className="whitespace-nowrap">
+              {fieldMeta && filter.op ? filterOpLabel(fieldMeta, filter.op) : "is"}
+            </span>
+          }
+          triggerClassName="min-w-[3.5rem] shrink-0"
+          contentClassName="w-28"
+        >
+          {(close) =>
+            (fieldMeta?.filterOps ?? []).map((op) => (
+              <DropdownItem
+                key={op}
+                active={op === filter.op}
+                onClick={() => {
+                  onChange(index, { op });
+                  close();
+                }}
+              >
+                {filterOpLabel(fieldMeta, op)}
+              </DropdownItem>
+            ))
+          }
+        </Dropdown>
+
+        {/* value — same controls as the trace-list builder's ValueControl */}
+        {!fieldMeta ? (
+          <ParkedValueField />
+        ) : showValueDropdown ? (
+          <ValueDropdown
+            value={String(filter.value)}
+            options={options}
+            onValue={(v) => onChange(index, { value: v })}
+            placeholder={isLoading ? "Loading…" : undefined}
+          />
+        ) : isNumeric ? (
+          <NumberField
+            ariaLabel="value"
+            placeholder="Enter value"
+            value={String(filter.value)}
+            onChange={(v) => onChange(index, { value: v === "" ? "" : Number(v) })}
+            unit={FIELD_UNIT[filter.field]}
+          />
+        ) : (
+          <TextField
+            ariaLabel="value"
+            placeholder="Enter value"
+            value={String(filter.value)}
+            onChange={(v) => onChange(index, { value: v })}
+          />
+        )}
+
+        {/* remove */}
+        <button
+          type="button"
+          onClick={() => onRemove(index)}
+          className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+          aria-label="Remove filter"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </FilterControlSizeProvider>
   );
 }

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -27,13 +27,13 @@ import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-s
 import {
   BREAKDOWN_REQUIRED_DISPLAYS,
   DISPLAY_TYPES,
-  FIELD_UNIT,
   generateWidgetTitle,
   isSpecComplete,
   parseSpec,
   type DraftSpec,
   type WidgetSchemaField,
 } from "../types";
+import { FIELD_UNIT } from "@/features/filters/filter-controls";
 import { fieldIcon } from "./field-icons";
 import { FilterRow } from "./FilterRow";
 import { QueryWidgetRenderer } from "./renderers";

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -8,7 +8,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useWidgetData } from "../hooks/use-widget-data";
-import { FIELD_UNIT, parseSpec, type TimeRange, type Widget } from "../types";
+import { FIELD_UNIT } from "@/features/filters/filter-controls";
+import { parseSpec, type TimeRange, type Widget } from "../types";
 import { QueryWidgetRenderer } from "./renderers";
 import { TraceFeedWidget } from "./TraceFeedWidget";
 

--- a/frontend/ui/src/features/dashboards/components/field-icons.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.ts
@@ -10,7 +10,7 @@ import {
   Workflow,
   type LucideIcon,
 } from "lucide-react";
-import { FIELD_ICONS } from "@/features/filters/filter-builder";
+import { FIELD_ICONS } from "@/features/filters/filter-controls";
 
 // The trace-list filter icons, extended with the widget registry's field
 // names the trace list spells differently (errors -> error_count), the token

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -17,7 +17,8 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { type DisplayType, type FieldUnit, type WidgetQueryResult, AGGS } from "../types";
+import type { FieldUnit } from "@/features/filters/filter-controls";
+import { type DisplayType, type WidgetQueryResult, AGGS } from "../types";
 
 // Pastel series palette mirroring the span-kind tints
 // (violet=llm, blue=agent, amber=tool, slate=span), then softened extras.

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -143,20 +143,6 @@ export function isEnumerableFilter(field: WidgetSchemaField | undefined, op: str
   return !!field && field.type === "string" && (op === "=" || op === "!=");
 }
 
-export interface FieldUnit {
-  prefix?: string;
-  suffix?: string;
-}
-
-// Units for fields that carry one — shared by the builder's filter inputs and
-// every widget renderer (stat tile, chart tooltips and axes, table cells).
-// Moving these into the backend registry's schema is a tracked follow-up;
-// until then this map is the frontend's single copy.
-export const FIELD_UNIT: Record<string, FieldUnit> = {
-  cost: { prefix: "$" },
-  duration_ms: { suffix: "ms" },
-};
-
 // Numeric comparison symbols shared with the trace-list filter chips.
 const NUMERIC_OP_SYMBOL: Record<string, string> = { ">=": "≥", "<=": "≤", "!=": "≠" };
 

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -8,48 +8,27 @@
  * equals / greater-than-or-equal / less-than-or-equal all emit a `between` predicate with
  * the right (possibly null) bounds, and categorical `is` emits a one-element `in`. "Add
  * filter" emits one predicate (the parent appends it as a chip) and resets the row.
+ *
+ * The field/operator/value controls live in `filter-controls` and are shared
+ * with the dashboard widget builder's filter rows.
  */
 import { useState } from "react";
-import {
-  AlertCircle,
-  Box,
-  ChevronDown,
-  CircleDollarSign,
-  CircleStop,
-  Clock,
-  Globe,
-  Hash,
-  type LucideIcon,
-} from "lucide-react";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
 import type { Predicate } from "@/types/api";
 import { useFilterValues } from "./hooks";
 import type { FilterFieldDef } from "./registry";
 import { buildInPredicate, buildNumericPredicate, buildTextPredicate } from "./predicate-ui";
-
-// Icons mirror the trace detail / list UI for consistency; the model and environment
-// fields, which have no trace-detail icon, use a generic one. Exported so the
-// dashboard widget builder shows the same symbols for the same fields.
-export const FIELD_ICONS: Record<string, LucideIcon> = {
-  trace_id: Hash,
-  cost: CircleDollarSign,
-  total_tokens: CircleStop,
-  duration_ms: Clock,
-  errors: AlertCircle,
-  model_name: Box,
-  environment: Globe,
-};
-
-// Unit shown inside the value input so it's clear what a numeric filter is measured in.
-// Only the short units ($ and ms) are shown; a "tokens" suffix is long enough to crowd
-// out the "Enter value" placeholder, and the Tokens field name already makes it clear.
-const FIELD_UNIT: Record<string, { prefix?: string; suffix?: string }> = {
-  cost: { prefix: "$" },
-  duration_ms: { suffix: "ms" },
-};
+import {
+  Dropdown,
+  DropdownItem,
+  FIELD_ICONS,
+  FIELD_UNIT,
+  FieldDropdown,
+  NumberField,
+  ParkedValueField,
+  TextField,
+  ValueDropdown,
+} from "./filter-controls";
 
 type UiOp = "is" | "eq" | "gt" | "gte" | "lt" | "lte" | "contains";
 const OP_LABEL: Record<UiOp, string> = {
@@ -140,7 +119,14 @@ export function FilterBuilder({
 
   return (
     <div className="flex items-center gap-1 p-1.5">
-      <FieldDropdown fields={fields} value={field} onPick={pickField} />
+      <FieldDropdown
+        options={fields.map((f) => ({ key: f.field, label: f.label, icon: FIELD_ICONS[f.field] }))}
+        valueKey={field?.field ?? null}
+        onPick={(key) => {
+          const f = fields.find((x) => x.field === key);
+          if (f) pickField(f);
+        }}
+      />
       <Dropdown
         disabled={!field}
         trigger={<span className="whitespace-nowrap">{field ? OP_LABEL[op] : "is"}</span>}
@@ -203,15 +189,7 @@ function ValueControl({
   onEnter: () => void;
 }) {
   if (!field) {
-    return (
-      <Input
-        disabled
-        readOnly
-        value=""
-        placeholder="Enter value"
-        className="h-7 min-w-0 flex-1 rounded-md text-[13px]"
-      />
-    );
+    return <ParkedValueField />;
   }
   if (field.type === "categorical") {
     return (
@@ -249,82 +227,6 @@ function ValueControl({
   );
 }
 
-function TextField({
-  ariaLabel,
-  placeholder,
-  value,
-  onChange,
-  onEnter,
-}: {
-  ariaLabel: string;
-  placeholder: string;
-  value: string;
-  onChange: (v: string) => void;
-  onEnter: () => void;
-}) {
-  return (
-    <Input
-      aria-label={ariaLabel}
-      placeholder={placeholder}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") onEnter();
-      }}
-      className="h-7 min-w-0 flex-1 rounded-md text-[13px]"
-    />
-  );
-}
-
-function NumberField({
-  ariaLabel,
-  placeholder,
-  value,
-  onChange,
-  onEnter,
-  unit,
-  integer = false,
-}: {
-  ariaLabel: string;
-  placeholder: string;
-  value: string;
-  onChange: (v: string) => void;
-  onEnter: () => void;
-  unit?: { prefix?: string; suffix?: string };
-  // Integer-typed fields (tokens/latency/errors) can't bind a fractional value in
-  // ClickHouse, so restrict the input to whole numbers.
-  integer?: boolean;
-}) {
-  return (
-    <div className="flex h-7 min-w-0 flex-1 items-center gap-1 rounded-md border border-input bg-transparent px-2 text-[13px] focus-within:ring-1 focus-within:ring-ring">
-      {unit?.prefix && <span className="shrink-0 text-muted-foreground">{unit.prefix}</span>}
-      <input
-        type="number"
-        min={0}
-        step={integer ? 1 : "any"}
-        aria-label={ariaLabel}
-        placeholder={placeholder}
-        value={value}
-        onChange={(e) => {
-          // The filterable metrics are all non-negative — reject negative input; and for
-          // integer fields, reject a fractional value (it can't bind as Int64/UInt64).
-          const v = e.target.value;
-          if (v.startsWith("-") || Number(v) < 0) return;
-          if (integer && v.includes(".")) return;
-          onChange(v);
-        }}
-        onKeyDown={(e) => {
-          // Block a minus sign always, and a decimal point on integer fields.
-          if (e.key === "-" || (integer && e.key === ".")) e.preventDefault();
-          else if (e.key === "Enter") onEnter();
-        }}
-        className="min-w-0 flex-1 bg-transparent text-[13px] outline-none [appearance:textfield] placeholder:text-muted-foreground [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-      />
-      {unit?.suffix && <span className="shrink-0 text-muted-foreground">{unit.suffix}</span>}
-    </div>
-  );
-}
-
 function CategoricalValue({
   projectId,
   field,
@@ -347,165 +249,4 @@ function CategoricalValue({
     : values.map((v) => ({ value: v.value, count: v.count }));
 
   return <ValueDropdown value={value} options={options} onValue={onValue} />;
-}
-
-/**
- * The stored-values picker: a dropdown of a field's values with per-value
- * occurrence counts on the right. Shared by the trace-list filter builder and
- * the dashboard widget filter rows.
- */
-export function ValueDropdown({
-  value,
-  options,
-  onValue,
-  placeholder = "Enter value",
-  triggerClassName,
-}: {
-  value: string;
-  options: { value: string; count?: number }[];
-  onValue: (v: string) => void;
-  placeholder?: string;
-  triggerClassName?: string;
-}) {
-  return (
-    <Dropdown
-      trigger={
-        <span className={cn("truncate", !value && "text-muted-foreground")}>
-          {value || placeholder}
-        </span>
-      }
-      triggerClassName={cn("min-w-0 flex-1", triggerClassName)}
-      contentClassName="w-[12rem]"
-    >
-      {(close) =>
-        options.length === 0 ? (
-          <div className="px-2 py-1.5 text-[13px] text-muted-foreground">No options</div>
-        ) : (
-          options.map((opt) => (
-            <DropdownItem
-              key={opt.value}
-              active={opt.value === value}
-              onClick={() => {
-                onValue(opt.value);
-                close();
-              }}
-            >
-              <span className="flex-1 truncate">{opt.value}</span>
-              {opt.count !== undefined && (
-                <span className="text-[11px] text-muted-foreground">{opt.count}</span>
-              )}
-            </DropdownItem>
-          ))
-        )
-      }
-    </Dropdown>
-  );
-}
-
-function FieldDropdown({
-  fields,
-  value,
-  onPick,
-}: {
-  fields: FilterFieldDef[];
-  value: FilterFieldDef | null;
-  onPick: (f: FilterFieldDef) => void;
-}) {
-  const Icon = value ? (FIELD_ICONS[value.field] ?? Box) : null;
-  return (
-    <Dropdown
-      trigger={
-        <span className="flex min-w-0 items-center gap-1.5">
-          {Icon && <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
-          <span className="truncate">{value ? value.label : "Field"}</span>
-        </span>
-      }
-      triggerClassName="w-[8.5rem] shrink-0"
-      contentClassName="w-[13rem]"
-    >
-      {(close) =>
-        fields.map((f) => {
-          const FIcon = FIELD_ICONS[f.field] ?? Box;
-          return (
-            <DropdownItem
-              key={f.field}
-              active={f.field === value?.field}
-              onClick={() => {
-                onPick(f);
-                close();
-              }}
-            >
-              <FIcon className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="flex-1 truncate">{f.label}</span>
-            </DropdownItem>
-          );
-        })
-      }
-    </Dropdown>
-  );
-}
-
-function Dropdown({
-  trigger,
-  children,
-  triggerClassName,
-  contentClassName,
-  disabled,
-}: {
-  trigger: React.ReactNode;
-  children: (close: () => void) => React.ReactNode;
-  triggerClassName?: string;
-  contentClassName?: string;
-  disabled?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          disabled={disabled}
-          className={cn(
-            "flex h-7 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 text-[13px] font-normal transition-colors",
-            "hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50",
-            triggerClassName,
-          )}
-        >
-          {trigger}
-          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className={cn("max-h-64 overflow-y-auto p-1", contentClassName)}
-      >
-        {children(() => setOpen(false))}
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-function DropdownItem({
-  active,
-  onClick,
-  children,
-}: {
-  active?: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      role="option"
-      aria-selected={active}
-      onClick={onClick}
-      className={cn(
-        "flex w-full items-center gap-2 rounded px-2 py-1 text-left text-[13px] transition-colors hover:bg-muted/50",
-        active && "bg-muted/40",
-      )}
-    >
-      {children}
-    </button>
-  );
 }

--- a/frontend/ui/src/features/filters/filter-controls.test.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Hash } from "lucide-react";
+import {
+  FieldDropdown,
+  FilterControlSizeProvider,
+  NumberField,
+  TextField,
+  ValueDropdown,
+} from "./filter-controls";
+
+afterEach(cleanup);
+
+describe("NumberField", () => {
+  it("drops typed negative values and keeps non-negative ones", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberField ariaLabel="value" placeholder="Enter value" value="" onChange={onChange} />,
+    );
+    const input = screen.getByLabelText("value");
+    fireEvent.change(input, { target: { value: "-5" } });
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.change(input, { target: { value: "5" } });
+    expect(onChange).toHaveBeenCalledWith("5");
+  });
+
+  it("blocks the minus key, and the decimal point on integer fields", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberField
+        ariaLabel="value"
+        placeholder="Enter value"
+        value=""
+        onChange={onChange}
+        integer
+      />,
+    );
+    const input = screen.getByLabelText("value");
+    const minus = fireEvent.keyDown(input, { key: "-" });
+    const dot = fireEvent.keyDown(input, { key: "." });
+    // fireEvent returns false when preventDefault was called
+    expect(minus).toBe(false);
+    expect(dot).toBe(false);
+    fireEvent.change(input, { target: { value: "1.5" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("submits on Enter when a handler is wired, and tolerates its absence", () => {
+    const onEnter = vi.fn();
+    const { unmount } = render(
+      <NumberField
+        ariaLabel="value"
+        placeholder="Enter value"
+        value="5"
+        onChange={vi.fn()}
+        onEnter={onEnter}
+      />,
+    );
+    fireEvent.keyDown(screen.getByLabelText("value"), { key: "Enter" });
+    expect(onEnter).toHaveBeenCalled();
+    unmount();
+
+    // without onEnter (the widget builder's rows) Enter must not throw
+    render(
+      <NumberField ariaLabel="value" placeholder="Enter value" value="5" onChange={vi.fn()} />,
+    );
+    fireEvent.keyDown(screen.getByLabelText("value"), { key: "Enter" });
+  });
+
+  it("renders the unit prefix and suffix around the input", () => {
+    render(
+      <NumberField
+        ariaLabel="value"
+        placeholder="Enter value"
+        value=""
+        onChange={vi.fn()}
+        unit={{ prefix: "$", suffix: "ms" }}
+      />,
+    );
+    expect(screen.getByText("$")).toBeTruthy();
+    expect(screen.getByText("ms")).toBeTruthy();
+  });
+});
+
+describe("TextField", () => {
+  it("propagates edits and tolerates Enter without a handler", () => {
+    const onChange = vi.fn();
+    render(<TextField ariaLabel="value" placeholder="Enter value" value="" onChange={onChange} />);
+    const input = screen.getByLabelText("value");
+    fireEvent.change(input, { target: { value: "abc" } });
+    expect(onChange).toHaveBeenCalledWith("abc");
+    fireEvent.keyDown(input, { key: "Enter" });
+  });
+});
+
+describe("ValueDropdown", () => {
+  it("shows an empty state when there are no options", () => {
+    render(<ValueDropdown value="" options={[]} onValue={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Enter value" }));
+    expect(screen.getByText("No options")).toBeTruthy();
+  });
+});
+
+describe("FieldDropdown", () => {
+  const options = [
+    { key: "trace_id", label: "Trace ID", icon: Hash },
+    { key: "mystery", label: "Mystery" }, // no icon → generic fallback
+  ];
+
+  it("shows the placeholder until a field is picked, then the field's label", () => {
+    const onPick = vi.fn();
+    const { rerender } = render(
+      <FieldDropdown options={options} valueKey={null} onPick={onPick} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Field" }));
+    fireEvent.click(screen.getByRole("option", { name: /Mystery/ }));
+    expect(onPick).toHaveBeenCalledWith("mystery");
+
+    rerender(<FieldDropdown options={options} valueKey="trace_id" onPick={onPick} />);
+    expect(screen.getByRole("button", { name: /Trace ID/ })).toBeTruthy();
+  });
+});
+
+describe("FilterControlSizeProvider", () => {
+  it("renders controls at 13px by default and 12px inside a compact host", () => {
+    const { unmount } = render(
+      <TextField ariaLabel="value" placeholder="Enter value" value="" onChange={vi.fn()} />,
+    );
+    expect(screen.getByLabelText("value").className).toContain("text-[13px]");
+    unmount();
+
+    render(
+      <FilterControlSizeProvider size="sm">
+        <TextField ariaLabel="value" placeholder="Enter value" value="" onChange={vi.fn()} />
+      </FilterControlSizeProvider>,
+    );
+    expect(screen.getByLabelText("value").className).toContain("text-[12px]");
+  });
+});

--- a/frontend/ui/src/features/filters/filter-controls.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+/**
+ * The shared filter controls: the field / operator / value pieces of a filter
+ * row. The trace-list filter builder is the source of truth for how these look
+ * and validate; the dashboard widget builder renders the same controls so the
+ * two filter UIs stay identical.
+ */
+import { createContext, useContext, useState } from "react";
+import {
+  AlertCircle,
+  Box,
+  ChevronDown,
+  CircleDollarSign,
+  CircleStop,
+  Clock,
+  Globe,
+  Hash,
+  type LucideIcon,
+} from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+// Icons mirror the trace detail / list UI for consistency; the model and environment
+// fields, which have no trace-detail icon, use a generic one. The dashboard widget
+// builder extends this map with its registry's extra field names.
+export const FIELD_ICONS: Record<string, LucideIcon> = {
+  trace_id: Hash,
+  cost: CircleDollarSign,
+  total_tokens: CircleStop,
+  duration_ms: Clock,
+  errors: AlertCircle,
+  model_name: Box,
+  environment: Globe,
+};
+
+// Text sizing depends on where the filter lives: the trace-list search bar uses
+// the app's 13px control size, the widget builder's config column runs at 12px.
+// A context (set once by the host via FilterControlsSize) keeps the size out of
+// every control and dropdown-item callsite.
+export type FilterControlSize = "sm" | "md";
+const TEXT_SIZE: Record<FilterControlSize, string> = { sm: "text-[12px]", md: "text-[13px]" };
+const SizeContext = createContext<FilterControlSize>("md");
+const useTextSize = () => TEXT_SIZE[useContext(SizeContext)];
+
+export function FilterControlSizeProvider({
+  size,
+  children,
+}: {
+  size: FilterControlSize;
+  children: React.ReactNode;
+}) {
+  return <SizeContext.Provider value={size}>{children}</SizeContext.Provider>;
+}
+
+/** The disabled value input a filter row parks in until a field is picked. */
+export function ParkedValueField() {
+  return (
+    <Input
+      disabled
+      readOnly
+      value=""
+      placeholder="Enter value"
+      className={cn("h-7 min-w-0 flex-1 rounded-md", useTextSize())}
+    />
+  );
+}
+
+export interface FieldUnit {
+  prefix?: string;
+  suffix?: string;
+}
+
+// Unit shown inside a numeric value input — and by every widget renderer
+// (stat tile, chart tooltips and axes, table cells) — so it's clear what the
+// number is measured in. Only the short units ($ and ms) are
+// shown; a "tokens" suffix is long enough to crowd out the "Enter value"
+// placeholder, and the Tokens field name already makes it clear. Moving these
+// into the backend registry's schema is a tracked follow-up; until then this
+// map is the frontend's single copy.
+export const FIELD_UNIT: Record<string, FieldUnit> = {
+  cost: { prefix: "$" },
+  duration_ms: { suffix: "ms" },
+};
+
+export function TextField({
+  ariaLabel,
+  placeholder,
+  value,
+  onChange,
+  onEnter,
+}: {
+  ariaLabel: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  onEnter?: () => void;
+}) {
+  const textSize = useTextSize();
+  return (
+    <Input
+      aria-label={ariaLabel}
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") onEnter?.();
+      }}
+      className={cn("h-7 min-w-0 flex-1 rounded-md", textSize)}
+    />
+  );
+}
+
+export function NumberField({
+  ariaLabel,
+  placeholder,
+  value,
+  onChange,
+  onEnter,
+  unit,
+  integer = false,
+}: {
+  ariaLabel: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  onEnter?: () => void;
+  unit?: FieldUnit;
+  // Integer-typed fields (tokens/latency/errors) can't bind a fractional value in
+  // ClickHouse, so restrict the input to whole numbers.
+  integer?: boolean;
+}) {
+  const textSize = useTextSize();
+  return (
+    <div
+      className={cn(
+        "flex h-7 min-w-0 flex-1 items-center gap-1 rounded-md border border-input bg-transparent px-2 focus-within:ring-1 focus-within:ring-ring",
+        textSize,
+      )}
+    >
+      {unit?.prefix && <span className="shrink-0 text-muted-foreground">{unit.prefix}</span>}
+      <input
+        type="number"
+        min={0}
+        step={integer ? 1 : "any"}
+        aria-label={ariaLabel}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => {
+          // The filterable metrics are all non-negative — reject negative input; and for
+          // integer fields, reject a fractional value (it can't bind as Int64/UInt64).
+          const v = e.target.value;
+          if (v.startsWith("-") || Number(v) < 0) return;
+          if (integer && v.includes(".")) return;
+          onChange(v);
+        }}
+        onKeyDown={(e) => {
+          // Block a minus sign always, and a decimal point on integer fields.
+          if (e.key === "-" || (integer && e.key === ".")) e.preventDefault();
+          else if (e.key === "Enter") onEnter?.();
+        }}
+        className={cn(
+          "min-w-0 flex-1 bg-transparent outline-none [appearance:textfield] placeholder:text-muted-foreground [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+          textSize,
+        )}
+      />
+      {unit?.suffix && <span className="shrink-0 text-muted-foreground">{unit.suffix}</span>}
+    </div>
+  );
+}
+
+/**
+ * The stored-values picker: a dropdown of a field's values with per-value
+ * occurrence counts on the right.
+ */
+export function ValueDropdown({
+  value,
+  options,
+  onValue,
+  placeholder = "Enter value",
+  triggerClassName,
+}: {
+  value: string;
+  options: { value: string; count?: number }[];
+  onValue: (v: string) => void;
+  placeholder?: string;
+  triggerClassName?: string;
+}) {
+  const textSize = useTextSize();
+  return (
+    <Dropdown
+      trigger={
+        <span className={cn("truncate", !value && "text-muted-foreground")}>
+          {value || placeholder}
+        </span>
+      }
+      triggerClassName={cn("min-w-0 flex-1", triggerClassName)}
+      contentClassName="w-[12rem]"
+    >
+      {(close) =>
+        options.length === 0 ? (
+          <div className={cn("px-2 py-1.5 text-muted-foreground", textSize)}>No options</div>
+        ) : (
+          options.map((opt) => (
+            <DropdownItem
+              key={opt.value}
+              active={opt.value === value}
+              onClick={() => {
+                onValue(opt.value);
+                close();
+              }}
+            >
+              <span className="flex-1 truncate">{opt.value}</span>
+              {opt.count !== undefined && (
+                <span className="text-[11px] text-muted-foreground">{opt.count}</span>
+              )}
+            </DropdownItem>
+          ))
+        )
+      }
+    </Dropdown>
+  );
+}
+
+export interface FieldOption {
+  key: string;
+  label: string;
+  icon?: LucideIcon;
+}
+
+export function FieldDropdown({
+  options,
+  valueKey,
+  onPick,
+}: {
+  options: FieldOption[];
+  valueKey: string | null;
+  onPick: (key: string) => void;
+}) {
+  const selected = valueKey ? (options.find((o) => o.key === valueKey) ?? null) : null;
+  const Icon = selected ? (selected.icon ?? Box) : null;
+  return (
+    <Dropdown
+      trigger={
+        <span className="flex min-w-0 items-center gap-1.5">
+          {Icon && <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+          <span className="truncate">{selected ? selected.label : "Field"}</span>
+        </span>
+      }
+      triggerClassName="w-[8.5rem] shrink-0"
+      contentClassName="w-[13rem]"
+    >
+      {(close) =>
+        options.map((o) => {
+          const OIcon = o.icon ?? Box;
+          return (
+            <DropdownItem
+              key={o.key}
+              active={o.key === valueKey}
+              onClick={() => {
+                onPick(o.key);
+                close();
+              }}
+            >
+              <OIcon className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="flex-1 truncate">{o.label}</span>
+            </DropdownItem>
+          );
+        })
+      }
+    </Dropdown>
+  );
+}
+
+export function Dropdown({
+  trigger,
+  children,
+  triggerClassName,
+  contentClassName,
+  disabled,
+}: {
+  trigger: React.ReactNode;
+  children: (close: () => void) => React.ReactNode;
+  triggerClassName?: string;
+  contentClassName?: string;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const textSize = useTextSize();
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "flex h-7 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 font-normal transition-colors",
+            "hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50",
+            textSize,
+            triggerClassName,
+          )}
+        >
+          {trigger}
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className={cn("max-h-64 overflow-y-auto p-1", contentClassName)}
+      >
+        {children(() => setOpen(false))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function DropdownItem({
+  active,
+  onClick,
+  children,
+}: {
+  active?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  const textSize = useTextSize();
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 rounded px-2 py-1 text-left transition-colors hover:bg-muted/50",
+        textSize,
+        active && "bg-muted/40",
+      )}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## What

The trace-list filter and the dashboard widget-builder filter had drifted UIs: different dropdown components, different operator labels, a duplicated `FIELD_UNIT` map, and a widget-builder number input that accepted negative values the trace filter rejects.

This lifts the trace-list builder's controls into a shared module, `features/filters/filter-controls.tsx` — `Dropdown`, `DropdownItem`, `FieldDropdown`, `NumberField` (non-negative + integer guards), `TextField`, `ValueDropdown`, `ParkedValueField`, `FIELD_ICONS`, `FIELD_UNIT`, and a `FilterControlSizeProvider` context so each host picks its text size — and rebuilds the widget `FilterRow` on those controls, with the trace list as the source of truth.

## Behavior changes (widget builder)

- Numeric filter values are now non-negative: the minus key is blocked and typed negatives are dropped, matching the trace-list builder.
- Picking a field auto-selects its first operator, like the trace list.
- Identical field/operator dropdowns, icons, placeholders, and $/ms unit adornments on both surfaces; the widget builder renders the shared controls at its compact 12px size via the size context (trace list stays at its 13px default).

## Unchanged / kept

- Widget spec wire format and operator vocabulary are untouched — saved widgets are unaffected.
- Widget-only extras kept: the `!=` ("is not") operator (persisted specs use it; it stays data-driven from the schema's `filterOps`), stale-value preservation in the stored-values dropdown, and the loading placeholder.
- `FIELD_UNIT`/`FieldUnit` now live in one place (previously duplicated between the trace filter and `dashboards/types.ts`).

## Known follow-up

The backend widget schema carries no per-field `integer` flag, so the widget builder can't yet enforce whole numbers on token/error-count fields the way the trace registry does — part of the existing follow-up to move field metadata (units, integer-ness) into the backend registry schema.

## Testing

New `filter-controls.test.tsx` unit tests (negative/fraction rejection, minus-key blocking, optional Enter handling, empty-options state, field pick propagation, size context); `FilterRow` tests rewritten for the shared controls plus new cases for negative rejection, operator auto-select, shared op labels, and disabled-until-field. Full frontend suite passes; diff coverage 100% on changed lines.

Part of the project dashboards epic: #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the trace-list and widget-builder filter UIs by sharing controls and behavior. Removes duplicate code, standardizes labels/units, and prevents negative numbers in widget filters.

- **Refactors**
  - Moved shared controls to `features/filters/filter-controls.tsx` (`Dropdown`, `DropdownItem`, `FieldDropdown`, `NumberField`, `TextField`, `ValueDropdown`, `ParkedValueField`, `FIELD_ICONS`, `FIELD_UNIT`, `FilterControlSizeProvider`).
  - Rebuilt widget `FilterRow` on the shared controls; renders at compact 12px via `FilterControlSizeProvider`.
  - Consolidated units and types (`FIELD_UNIT`, `FieldUnit`) in one place; updated imports in widgets and renderers; removed duplicates from `dashboards/types.ts`.
  - Added unit tests for the shared controls; updated `FilterRow` tests.
  - Wire format and operator vocabulary unchanged; saved widgets unaffected.

- **Bug Fixes**
  - Widget numeric inputs now reject negatives (minus key blocked; typed negatives dropped).
  - Picking a field auto-selects its first operator.
  - Operator and value stay disabled until a field is chosen; value dropdown shows counts and a “No options” state with free-text fallback.
  - Operator labels, dropdowns, placeholders, and `$`/`ms` units now match the trace list.

<sup>Written for commit c8784ac421c1ba2651c448defdefc15c36475bcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

