### PR TITLE
fix: make gemini-3-flash pricing match both GA and preview model IDs

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -797,7 +797,7 @@
   {
     "id": "tr-gemini-3-flash-preview",
     "modelName": "gemini-3-flash-preview",
-    "matchPattern": "(?i)^(google\\/|models\\/)?gemini-3-flash-preview(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(google\\/|models\\/)?gemini-3-flash(-preview)?(-[\\d-]+)?$",
     "provider": "google",
     "prices": {
       "input": 0.0000005,

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -149,6 +149,8 @@ GEMINI_MODEL_CASES = [
     ("gemini-3.1-flash-lite", "gemini-3.1-flash-lite"),
     ("gemini-3.1-flash-lite-preview", "gemini-3.1-flash-lite-preview"),
     ("gemini-3-flash-preview", "gemini-3-flash-preview"),
+    ("gemini-3-flash", "gemini-3-flash-preview"),
+    ("google/gemini-3-flash", "gemini-3-flash-preview"),
     ("gemini-2.5-pro", "gemini-2.5-pro"),
     ("gemini-2.5-flash", "gemini-2.5-flash"),
     ("gemini-2.5-flash-lite", "gemini-2.5-flash-lite"),


### PR DESCRIPTION
## Summary

The `gemini-3-flash-preview` matchPattern in `standard-model-prices.json` required the literal `-preview` suffix, causing GA model IDs like `google/gemini-3-flash` to return no pricing (cost reads $0 despite real token usage).

## What Changed

- **`frontend/packages/core/src/standard-model-prices.json`**: Made `-preview` optional in the `matchPattern` so both GA and preview spellings resolve to the same entry: `(?i)^(google\\/|models\\/)?gemini-3-flash(-preview)?(-[\d-]+)?$`
- **`tests/worker/tokens/test_pricing.py`**: Added test cases for `gemini-3-flash` and `google/gemini-3-flash`

## Verification

All four model string spellings now match:

| model string | before | after |
|---|---|---|
| `google/gemini-3-flash` | MISS | HIT |
| `gemini-3-flash` | MISS | HIT |
| `gemini-3-flash-preview` | HIT | HIT |
| `google/gemini-3-flash-preview` | HIT | HIT |

Closes #1558

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pricing lookup for Gemini 3 Flash by matching both GA and preview model IDs. GA IDs like `google/gemini-3-flash` now return correct costs instead of $0.

- **Bug Fixes**
  - Updated `frontend/packages/core/src/standard-model-prices.json` to make `-preview` optional in the pattern: `(?i)^(google\/|models\/)?gemini-3-flash(-preview)?(-[\d-]+)?$`.
  - Added tests in `tests/worker/tokens/test_pricing.py` to ensure `gemini-3-flash` and `google/gemini-3-flash` resolve to the `gemini-3-flash-preview` pricing entry.

<sup>Written for commit 22edfb2537187daa549e710e49b1c31fdb2eb0e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

