### PR TITLE
fix: price GA Gemini 3 Flash

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -797,7 +797,7 @@
   {
     "id": "tr-gemini-3-flash-preview",
     "modelName": "gemini-3-flash-preview",
-    "matchPattern": "(?i)^(google\\/|models\\/)?gemini-3-flash-preview(-[\\d-]+)?$",
+    "matchPattern": "(?i)^(google\\/|models\\/)?gemini-3-flash(-preview)?(-[\\d-]+)?$",
     "provider": "google",
     "prices": {
       "input": 0.0000005,

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -148,6 +148,7 @@ GEMINI_MODEL_CASES = [
     ("gemini-3.1-pro-preview-customtools", "gemini-3.1-pro-preview"),
     ("gemini-3.1-flash-lite", "gemini-3.1-flash-lite"),
     ("gemini-3.1-flash-lite-preview", "gemini-3.1-flash-lite-preview"),
+    ("google/gemini-3-flash", "gemini-3-flash-preview"),
     ("gemini-3-flash-preview", "gemini-3-flash-preview"),
     ("gemini-2.5-pro", "gemini-2.5-pro"),
     ("gemini-2.5-flash", "gemini-2.5-flash"),


### PR DESCRIPTION
## Summary
- make the Gemini 3 Flash pricing match pattern cover GA `google/gemini-3-flash`
- keep the existing preview model mapping intact
- add a regression case for the GA Google-prefixed model id

Closes #1558

## Validation
- `python -m pytest tests/worker/tokens/test_pricing.py -q`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pricing pattern for Gemini 3 Flash to match GA `google/gemini-3-flash` while keeping the existing `gemini-3-flash-preview` mapping. Adds a regression test for the Google-prefixed GA model id.

<sup>Written for commit 9fd4dc0f37b68c034c45f8d36f416b850fd62c7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

