### PR TITLE
feat(ui): replace dashboard tabs with auto-open and a dashboards list page

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.test.ts
@@ -7,12 +7,16 @@ vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
 
 const dashboardFindManyMock = vi.fn();
 const dashboardCreateMock = vi.fn();
+const userFindManyMock = vi.fn();
 vi.mock("@traceroot/core", () => ({
   Role: { VIEWER: "VIEWER", MEMBER: "MEMBER", ADMIN: "ADMIN" },
   prisma: {
     dashboard: {
       findMany: (...args: unknown[]) => dashboardFindManyMock(...args),
       create: (...args: unknown[]) => dashboardCreateMock(...args),
+    },
+    user: {
+      findMany: (...args: unknown[]) => userFindManyMock(...args),
     },
   },
 }));
@@ -51,6 +55,8 @@ function makeParams(projectId = "proj-1") {
 beforeEach(() => {
   dashboardFindManyMock.mockReset();
   dashboardCreateMock.mockReset();
+  userFindManyMock.mockReset();
+  userFindManyMock.mockResolvedValue([]);
   requireAuthMock.mockReset();
   requireProjectAccessMock.mockReset();
   // Default: authenticated with project access.
@@ -66,19 +72,55 @@ describe("GET /dashboards — existing dashboards", () => {
         name: "Overview",
         description: null,
         isDefault: true,
+        createdBy: "user-1",
+        updateTime: new Date(),
+      },
+      {
+        id: "dash-2",
+        name: "Costs",
+        description: null,
+        isDefault: false,
+        createdBy: "user-gone",
         updateTime: new Date(),
       },
     ];
     dashboardFindManyMock.mockResolvedValue(existing);
+    userFindManyMock.mockResolvedValue([{ id: "user-1", name: "Ada", email: "ada@example.com" }]);
 
     const res = await GET(makeGetRequest(), makeParams());
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { data: unknown[] };
-    expect(body.data).toHaveLength(1);
+    const body = (await res.json()) as {
+      data: { creator: string | null; createdBy?: string }[];
+    };
+    expect(body.data).toHaveLength(2);
+    // creator ids resolve to display names in one batch; a deleted account
+    // resolves to null, and the raw id never leaves the API
+    expect(userFindManyMock).toHaveBeenCalledTimes(1);
+    expect(body.data[0].creator).toBe("Ada");
+    expect(body.data[1].creator).toBeNull();
+    expect(body.data[0].createdBy).toBeUndefined();
     // create must never have been called
     expect(dashboardCreateMock).not.toHaveBeenCalled();
     // findMany called exactly once (no re-read needed)
     expect(dashboardFindManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the creator's email when the account has no name", async () => {
+    dashboardFindManyMock.mockResolvedValue([
+      {
+        id: "dash-1",
+        name: "Overview",
+        description: null,
+        isDefault: true,
+        createdBy: "user-1",
+        updateTime: new Date(),
+      },
+    ]);
+    userFindManyMock.mockResolvedValue([{ id: "user-1", name: null, email: "ada@example.com" }]);
+
+    const res = await GET(makeGetRequest(), makeParams());
+    const body = (await res.json()) as { data: { creator: string | null }[] };
+    expect(body.data[0].creator).toBe("ada@example.com");
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -109,6 +151,7 @@ describe("GET /dashboards — lazy seeding (no existing dashboards)", () => {
         name: "Overview",
         description: null,
         isDefault: true,
+        createdBy: "user-1",
         updateTime: new Date(),
       },
     ]);
@@ -129,7 +172,16 @@ describe("GET /dashboards — lazy seeding (no existing dashboards)", () => {
 
     expect(data.id).toBe("default_proj-1");
     expect(data.isDefault).toBe(true);
+    expect((data as { name?: string }).name).toBe("Default");
+    // The seeded Overview ships with a purpose note like any user dashboard.
+    expect((data as { description?: string }).description).toMatch(/overview/i);
     expect(data.widgets.create.length).toBeGreaterThanOrEqual(7);
+
+    // The failures feed filters on the trace-list errors predicate.
+    const failures = (
+      data.widgets.create as unknown as Array<{ title: string; spec: { filters?: unknown[] } }>
+    ).find((w) => w.title === "Recent failures");
+    expect(failures?.spec.filters).toEqual([{ field: "errors", op: "gt", value: 0 }]);
 
     // Every layout[i].i must equal widgets.create[i].id
     data.layout.forEach((layoutItem, idx) => {
@@ -149,6 +201,7 @@ describe("GET /dashboards — lazy seeding (no existing dashboards)", () => {
         name: "Overview",
         description: null,
         isDefault: true,
+        createdBy: "user-1",
         updateTime: new Date(),
       },
     ]);

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.ts
@@ -11,11 +11,37 @@ type RouteParams = { params: Promise<{ projectId: string }> };
 const listArgs = (projectId: string) => ({
   where: { projectId },
   orderBy: [{ isDefault: "desc" as const }, { createTime: "asc" as const }],
-  select: { id: true, name: true, description: true, isDefault: true, updateTime: true },
+  select: {
+    id: true,
+    name: true,
+    description: true,
+    isDefault: true,
+    createdBy: true,
+    createTime: true,
+    updateTime: true,
+  },
 });
 
+// Dashboards are shared across a project's members, so the list shows who
+// created each one. createdBy holds a bare user id (no relation on the
+// model); resolve the display names in one batch and swap them in — a
+// deleted account resolves to null and renders as "—".
+async function withCreators<T extends { createdBy: string }>(dashboards: T[]) {
+  const ids = [...new Set(dashboards.map((d) => d.createdBy))];
+  const users = await prisma.user.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, name: true, email: true },
+  });
+  // || not ??: an empty-string name must fall through to the email too.
+  const byId = new Map(users.map((u) => [u.id, u.name || u.email]));
+  return dashboards.map(({ createdBy, ...d }) => ({
+    ...d,
+    creator: byId.get(createdBy) ?? null,
+  }));
+}
+
 // GET /api/projects/[projectId]/dashboards — list; lazily seeds the default
-// "Overview" dashboard the first time a project's dashboards are fetched.
+// "Default" dashboard the first time a project's dashboards are fetched.
 export async function GET(_req: NextRequest, { params }: RouteParams) {
   const auth = await requireProjectAuth(params);
   if (auth.error) return auth.error;
@@ -32,7 +58,8 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
         data: {
           id: defaultDashboardId(projectId),
           projectId,
-          name: "Overview",
+          name: "Default",
+          description: "Auto-created overview of traces, cost, tokens, and latency.",
           isDefault: true,
           createdBy: user.id,
           // layout keys MUST equal widget ids (react-grid-layout matches on `i`)
@@ -49,7 +76,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     dashboards = await prisma.dashboard.findMany(listArgs(projectId));
   }
 
-  return successResponse({ data: dashboards });
+  return successResponse({ data: await withCreators(dashboards) });
 }
 
 // POST /api/projects/[projectId]/dashboards — create a named dashboard

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -39,12 +39,6 @@ vi.mock("next/link", () => ({
 }));
 vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
 
-const createDashboard: {
-  mutate: ReturnType<typeof vi.fn>;
-  reset: ReturnType<typeof vi.fn>;
-  isPending: boolean;
-  error: Error | null;
-} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, error: null };
 const updateLayout: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
   {
     mutate: vi.fn(),
@@ -63,22 +57,13 @@ const removeWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; erro
     isPending: false,
     error: null,
   };
-const removeDashboard: {
-  mutate: ReturnType<typeof vi.fn>;
-  isPending: boolean;
-  isError: boolean;
-  error: Error | null;
-} = { mutate: vi.fn(), isPending: false, isError: false, error: null };
 
 vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
-  useDashboards: vi.fn(),
   useDashboard: vi.fn(),
   useDashboardMutations: () => ({
-    createDashboard,
     updateLayout,
     createWidget,
     removeWidget,
-    removeDashboard,
   }),
 }));
 
@@ -117,15 +102,16 @@ vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
   },
 }));
 
-import { useDashboard, useDashboards } from "@/features/dashboards/hooks/use-dashboards";
+import { useDashboard } from "@/features/dashboards/hooks/use-dashboards";
 
 // d1 is a user dashboard; d2 is the seeded default (Overview) — both are
-// fully editable, the default is just auto-created and tab-marked.
+// fully editable, the default is just auto-created and home-marked.
 const DASH_A: DashboardSummary = {
   id: "d1",
   name: "Custom",
   description: null,
   isDefault: false,
+  createTime: "",
   updateTime: "",
 };
 const DASH_B: DashboardSummary = {
@@ -133,6 +119,7 @@ const DASH_B: DashboardSummary = {
   name: "Overview",
   description: null,
   isDefault: true,
+  createTime: "",
   updateTime: "",
 };
 
@@ -144,12 +131,6 @@ const WIDGET: Widget = {
   spec: { view: "spans" },
   displayConfig: {},
 };
-
-function mockLists(dashboards: DashboardSummary[] | undefined) {
-  vi.mocked(useDashboards).mockReturnValue({
-    data: dashboards,
-  } as ReturnType<typeof useDashboards>);
-}
 
 function mockDetail(data: DashboardDetail | undefined, error: unknown = null) {
   vi.mocked(useDashboard).mockReturnValue({ data, error } as ReturnType<typeof useDashboard>);
@@ -171,106 +152,30 @@ describe("DashboardDetailPage", () => {
   beforeEach(() => {
     push.mockReset();
     replace.mockReset();
-    createDashboard.mutate.mockReset();
     updateLayout.mutate.mockReset();
     createWidget.mutate.mockReset();
     removeWidget.mutate.mockReset();
-    removeDashboard.mutate.mockReset();
-    removeDashboard.isError = false;
-    removeDashboard.error = null;
     lastGridProps = null;
-    mockLists([DASH_A, DASH_B]);
     mockDetail({ ...DASH_A, layout: [], widgets: [] });
   });
 
-  it("renders dashboard tabs with the default marked and the current one highlighted", () => {
+  it("shows the dashboard's name in the header with a back link to the list", () => {
     renderPage();
 
-    const customTab = screen.getByRole("link", { name: "Custom" });
-    expect(customTab.textContent).not.toContain("⌂");
-    expect(customTab.getAttribute("aria-current")).toBe("page");
-
-    const overviewTab = screen.getByRole("link", { name: /Overview/ });
-    expect(overviewTab.textContent).toContain("⌂");
-    expect(overviewTab.getAttribute("aria-current")).toBeNull();
-
-    expect(screen.getByRole("button", { name: "＋ new" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Custom" })).toBeTruthy();
+    // the breadcrumb reads exactly like the list page's heading (no arrow)
+    const back = screen.getByRole("link", { name: "Dashboards" });
+    expect(back.getAttribute("href")).toBe("/projects/p1/dashboard?list=1");
+    // No tab strip: the other dashboard is not rendered here anymore.
+    expect(screen.queryByText("Overview")).toBeNull();
   });
 
-  it("keeps header controls outside the scrollable tab strip when dashboards pile up", () => {
-    mockLists(
-      Array.from({ length: 30 }, (_, i) => ({ ...DASH_A, id: `d${i + 1}`, name: `Dash ${i + 1}` })),
-    );
-    mockDetail({ ...DASH_A, layout: [], widgets: [WIDGET] });
+  it("shows the default dashboard's plain name in the header, no marker glyph", () => {
+    mockDetail({ ...DASH_B, layout: [], widgets: [] });
     renderPage();
 
-    // All tabs render inside one horizontally scrollable strip…
-    const strip = screen.getByRole("link", { name: "Dash 30" }).parentElement!;
-    expect(strip.className).toContain("overflow-x-auto");
-    expect(strip.querySelectorAll("a")).toHaveLength(30);
-
-    // …while ＋ new, the date filter, and the widget controls live outside it,
-    // so an ever-growing dashboard list can never push them off screen.
-    const newButton = screen.getByRole("button", { name: "＋ new" });
-    expect(strip.contains(newButton)).toBe(false);
-    const dateFilterButton = screen.getByRole("button", { name: "Last 24 hours" });
-    expect(strip.contains(dateFilterButton)).toBe(false);
-    const createWidget = screen.getByRole("button", { name: "＋ Create widget" });
-    expect(strip.contains(createWidget)).toBe(false);
-  });
-
-  it("restores the tab strip scroll position across the remount a tab click causes", () => {
-    mockLists(
-      Array.from({ length: 30 }, (_, i) => ({ ...DASH_A, id: `d${i + 1}`, name: `Dash ${i + 1}` })),
-    );
-    mockDetail({ ...DASH_A, layout: [], widgets: [WIDGET] });
-    const { unmount } = render(
-      <QueryClientProvider client={new QueryClient()}>
-        <DashboardDetailPage />
-      </QueryClientProvider>,
-    );
-
-    // The user scrolls deep into the strip… (the recorded position lives in a
-    // module-scope Map, so it deliberately persists for the rest of this test
-    // file — later mounts restore it, which nothing else asserts on)
-    const strip = screen.getByRole("link", { name: "Dash 30" }).parentElement!;
-    strip.scrollLeft = 480;
-    fireEvent.scroll(strip);
-
-    // …then clicks a tab, which navigates and remounts the whole page.
-    unmount();
-    renderPage();
-
-    const remounted = screen.getByRole("link", { name: "Dash 30" }).parentElement!;
-    expect(remounted.scrollLeft).toBe(480);
-  });
-
-  it("opens the create-dashboard dialog and cancelling it does not create", () => {
-    renderPage();
-
-    expect(screen.queryByText("Create Dashboard")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "＋ new" }));
-    expect(screen.getByText("Create Dashboard")).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(createDashboard.mutate).not.toHaveBeenCalled();
-  });
-
-  it("creates a dashboard from the dialog and navigates to it on success", () => {
-    renderPage();
-
-    fireEvent.click(screen.getByRole("button", { name: "＋ new" }));
-    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
-      target: { value: "New dash" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Create" }));
-
-    expect(createDashboard.mutate).toHaveBeenCalledTimes(1);
-    const [payload, options] = createDashboard.mutate.mock.calls[0];
-    expect(payload).toEqual({ name: "New dash" });
-
-    options.onSuccess({ dashboard: { id: "d9" } });
-    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d9");
+    expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+    expect(screen.queryByText("⌂")).toBeNull();
   });
 
   it("shows the active range preset label", () => {
@@ -307,51 +212,24 @@ describe("DashboardDetailPage", () => {
     expect(lastGridProps?.readOnly).toBeUndefined();
   });
 
-  it("holds the header edit controls until the dashboard detail loads", () => {
+  it("holds the create-widget button until the dashboard detail loads", () => {
     mockDetail(undefined);
     renderPage();
 
     expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
+  });
+
+  it("offers no delete affordance — deleting lives in the list page's row actions", () => {
+    renderPage();
     expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
+    expect(screen.queryByText("Delete Dashboard")).toBeNull();
   });
 
-  it("deletes the dashboard through the confirm dialog and navigates to the index", () => {
+  it("renders the create-widget button before the time-range control", () => {
     renderPage();
-
-    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
-    expect(screen.getByText("Delete Dashboard")).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
-    expect(removeDashboard.mutate).toHaveBeenCalledTimes(1);
-    const [id, options] = removeDashboard.mutate.mock.calls[0];
-    expect(id).toBe("d1");
-
-    options.onSuccess();
-    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
-  });
-
-  it("shows the delete error inside the dialog when the mutation fails", () => {
-    removeDashboard.isError = true;
-    removeDashboard.error = new Error("boom");
-    renderPage();
-
-    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
-    expect(screen.getByText("boom")).toBeTruthy();
-  });
-
-  it("cancelling the delete dialog does not delete", () => {
-    renderPage();
-
-    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-
-    expect(removeDashboard.mutate).not.toHaveBeenCalled();
-  });
-
-  it("shows the delete button on the default dashboard", () => {
-    mockDetail({ ...DASH_B, layout: [], widgets: [] });
-    renderPage();
-    expect(screen.getByRole("button", { name: "Delete dashboard" })).toBeTruthy();
+    const create = screen.getAllByRole("button", { name: "＋ Create widget" })[0];
+    const range = screen.getByRole("button", { name: "Last 24 hours" });
+    expect(create.compareDocumentPosition(range) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("redirects to the dashboard index and invalidates the list cache when the dashboard is gone", () => {
@@ -389,7 +267,6 @@ describe("DashboardDetailPage", () => {
 
     expect(screen.getByText("Loading…")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
   });
 
   it("passes widgets, layout and range to the grid and wires edit/duplicate/delete", () => {

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -1,41 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import {
-  useDashboards,
-  useDashboard,
-  useDashboardMutations,
-} from "@/features/dashboards/hooks/use-dashboards";
+import { useDashboard, useDashboardMutations } from "@/features/dashboards/hooks/use-dashboards";
 import { DashboardGrid } from "@/features/dashboards/components/DashboardGrid";
-import { CreateDashboardDialog } from "@/features/dashboards/components/CreateDashboardDialog";
 import type { TimeRange, Widget } from "@/features/dashboards/types";
 import { DateFilterSelect } from "@/components/date-filter-select";
 import { useUrlDateFilter } from "@/lib/hooks/use-url-date-filter";
 import { Button } from "@/components/ui/button";
-import { DeleteIconButton } from "@/components/ui/delete-button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { cn } from "@/lib/utils";
-
-// useLayoutEffect on the client, useEffect during SSR: layout effects never
-// run on the server, and React warns when a server render encounters one.
-const useIsomorphicLayoutEffect = typeof window !== "undefined" ? useLayoutEffect : useEffect;
-
-// Tab strip scroll position per project, module-scoped: the page remounts on
-// every dashboard switch, so component state can't carry the position across
-// clicks. In-memory only — a hard reload falls back to scrolling the active
-// tab into view.
-const tabStripScroll = new Map<string, number>();
 
 export default function DashboardDetailPage() {
   const params = useParams();
@@ -45,10 +20,9 @@ export default function DashboardDetailPage() {
   const dashboardId = params.dashboardId as string;
 
   // ── remote data ──────────────────────────────────────────────────────────────
-  const { data: dashboards } = useDashboards(projectId);
   const { data: dashboard, error: dashboardError } = useDashboard(projectId, dashboardId);
 
-  const { updateLayout, createWidget, removeWidget, removeDashboard } = useDashboardMutations(
+  const { updateLayout, createWidget, removeWidget } = useDashboardMutations(
     projectId,
     dashboardId,
   );
@@ -85,29 +59,6 @@ export default function DashboardDetailPage() {
     return () => ro.disconnect();
   }, []);
 
-  // ── keep the scrollable tab strip where the user left it ────────────────────
-  const tabStripRef = useRef<HTMLDivElement>(null);
-  // The route is keyed by the dashboardId segment, so clicking a tab remounts
-  // this page and a fresh strip would snap back to the far left. Restore the
-  // remembered position pre-paint (layout effect) so the switch is seamless;
-  // re-run when the list arrives, since an empty strip can't hold a scroll.
-  useIsomorphicLayoutEffect(() => {
-    const el = tabStripRef.current;
-    const saved = tabStripScroll.get(projectId);
-    if (el && saved !== undefined) el.scrollLeft = saved;
-  }, [projectId, dashboards?.length]);
-  useEffect(() => {
-    // Then make sure the active tab is visible: after a hard reload (nothing
-    // remembered) a deep tab would sit out of view. "nearest" is a no-op when
-    // the restored position already shows it. Optional call: jsdom (and any
-    // environment without layout) doesn't implement scrollIntoView.
-    tabStripRef.current
-      ?.querySelector('[aria-current="page"]')
-      ?.scrollIntoView?.({ block: "nearest", inline: "nearest" });
-    // Length, not the array: re-scroll when the list first arrives or grows,
-    // without snapping the strip on unrelated list refetches mid-browse.
-  }, [dashboardId, dashboards?.length]);
-
   // ── widget builder navigation ────────────────────────────────────────────────
   const openCreate = () =>
     router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/new`);
@@ -136,21 +87,6 @@ export default function DashboardDetailPage() {
   // useDashboard resolves to undefined while loading and surfaces failures via
   // its error field; the redirect above handles gone dashboards, so the render
   // below only needs the loading and failure branches.
-
-  // ── new dashboard ────────────────────────────────────────────────────────────
-  const [createDashboardOpen, setCreateDashboardOpen] = useState(false);
-
-  // ── delete dashboard ─────────────────────────────────────────────────────────
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const handleDeleteDashboard = () => {
-    removeDashboard.mutate(dashboardId, {
-      onSuccess: () => {
-        setDeleteOpen(false);
-        // The index route resolves to the default dashboard.
-        router.replace(`/projects/${projectId}/dashboard`);
-      },
-    });
-  };
 
   // ── layout change ────────────────────────────────────────────────────────────
   const handleLayoutChange = useCallback(
@@ -189,86 +125,39 @@ export default function DashboardDetailPage() {
     <div className="relative flex h-full text-[13px]">
       <ProjectBreadcrumb projectId={projectId} />
 
-      <CreateDashboardDialog
-        projectId={projectId}
-        open={createDashboardOpen}
-        onOpenChange={setCreateDashboardOpen}
-      />
-
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Dashboard</DialogTitle>
-            <DialogDescription>
-              Permanently delete “{dashboard?.name}” and all of its widgets? This cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          {removeDashboard.isError && (
-            <p className="text-sm text-destructive">{removeDashboard.error.message}</p>
-          )}
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setDeleteOpen(false)}
-              disabled={removeDashboard.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteDashboard}
-              disabled={removeDashboard.isPending}
-            >
-              {removeDashboard.isPending ? "Deleting..." : "Delete"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Page header */}
-        <div className="flex items-center justify-between border-b border-border px-4 py-2">
-          {/* Left: title + dashboard tabs. min-w-0 lets the tab strip shrink
-              and scroll instead of growing without bound — however many
-              dashboards exist, the ＋ new button and the right-side controls
-              stay on screen. */}
-          <div className="flex min-w-0 flex-1 items-center gap-3">
-            <h1 className="shrink-0 text-[13px] font-medium">Dashboard</h1>
-            <div
-              ref={tabStripRef}
-              onScroll={(e) => tabStripScroll.set(projectId, e.currentTarget.scrollLeft)}
-              className="flex min-w-0 items-center gap-0.5 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        <div className="flex h-[45px] shrink-0 items-center justify-between border-b border-border px-4">
+          {/* Left: breadcrumb back to the list + the dashboard's identity
+              (the tabs are gone; the list page is the way to switch).
+              "Dashboards" renders exactly like the list page's heading. */}
+          <div className="flex min-w-0 items-center gap-2">
+            <Link
+              // ?list=1 pins the index on the list: without it a project with
+              // a single dashboard would auto-open right back here.
+              href={`/projects/${projectId}/dashboard?list=1`}
+              className="shrink-0 text-[13px] font-medium hover:underline"
             >
-              {dashboards?.map((d) => (
-                <Link
-                  key={d.id}
-                  href={`/projects/${projectId}/dashboard/${d.id}`}
-                  aria-current={d.id === dashboardId ? "page" : undefined}
-                  className={cn(
-                    "flex shrink-0 items-center gap-1 rounded px-2 py-0.5 text-[12px] transition-colors",
-                    d.id === dashboardId
-                      ? "border-b-2 border-foreground font-medium text-foreground"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                  )}
-                >
-                  {d.isDefault && <span className="text-[10px]">⌂</span>}
-                  <span className="max-w-[10rem] truncate" title={d.name}>
-                    {d.name}
-                  </span>
-                </Link>
-              ))}
-            </div>
-            <button
-              type="button"
-              onClick={() => setCreateDashboardOpen(true)}
-              className="shrink-0 rounded px-2 py-0.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
-            >
-              ＋ new
-            </button>
+              Dashboards
+            </Link>
+            <span className="shrink-0 text-muted-foreground">/</span>
+            <h1 className="min-w-0 text-[13px] font-medium">
+              <span className="block max-w-[16rem] truncate" title={dashboard?.name}>
+                {dashboard?.name ?? "Dashboard"}
+              </span>
+            </h1>
           </div>
 
-          {/* Right: time range, create widget */}
-          <div className="flex shrink-0 items-center gap-2">
+          {/* Right: create widget, then the time range. Deleting a dashboard
+              lives only in the list page's row actions. */}
+          <div className="flex items-center gap-2">
+            {/* Held back until the detail loads so it can't act on a
+                dashboard the app doesn't know yet. */}
+            {dashboard && (
+              <Button size="sm" className="h-7 text-[12px]" onClick={openCreate}>
+                ＋ Create widget
+              </Button>
+            )}
             <DateFilterSelect
               dateFilter={dateFilter}
               customStartDate={customStartDate}
@@ -276,20 +165,6 @@ export default function DashboardDetailPage() {
               onDateFilterChange={setDateFilter}
               onCustomRangeChange={setCustomRange}
             />
-
-            {/* Held back until the detail loads so edit controls don't act
-                on a dashboard the app doesn't know yet. */}
-            {dashboard && (
-              <>
-                <Button size="sm" className="h-7 text-[12px]" onClick={openCreate}>
-                  ＋ Create widget
-                </Button>
-                <DeleteIconButton
-                  aria-label="Delete dashboard"
-                  onClick={() => setDeleteOpen(true)}
-                />
-              </>
-            )}
           </div>
         </div>
 

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
@@ -1,13 +1,40 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { DashboardSummary } from "@/features/dashboards/types";
+import type { DashboardListItem } from "@/features/dashboards/types";
 import DashboardIndexPage from "./page";
 
 const replace = vi.fn();
+const push = vi.fn();
+let searchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "p1" }),
-  useRouter: () => ({ replace }),
+  useRouter: () => ({ replace, push }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+// The dialogs carry their own tests; here they only need to mount.
+vi.mock("@/features/dashboards/components/CreateDashboardDialog", () => ({
+  CreateDashboardDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="create-dialog" /> : null,
+}));
+vi.mock("@/features/dashboards/components/EditDashboardDialog", () => ({
+  EditDashboardDialog: ({
+    target,
+  }: {
+    target: { name: string; description: string | null } | null;
+  }) =>
+    target ? (
+      <div data-testid="edit-dialog">
+        {target.name}:{target.description ?? "∅"}
+      </div>
+    ) : null,
+}));
+vi.mock("@/features/dashboards/components/DeleteDashboardDialog", () => ({
+  DeleteDashboardDialog: ({ target }: { target: { name: string } | null }) =>
+    target ? <div data-testid="delete-dialog">{target.name}</div> : null,
 }));
 
 const refetch = vi.fn();
@@ -17,7 +44,7 @@ vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
 
 import { useDashboards } from "@/features/dashboards/hooks/use-dashboards";
 
-function mockDashboards(data: DashboardSummary[] | undefined, error: unknown = null) {
+function mockDashboards(data: DashboardListItem[] | undefined, error: unknown = null) {
   vi.mocked(useDashboards).mockReturnValue({
     data,
     error,
@@ -25,26 +52,32 @@ function mockDashboards(data: DashboardSummary[] | undefined, error: unknown = n
   } as unknown as ReturnType<typeof useDashboards>);
 }
 
-const DASH_A: DashboardSummary = {
+const OVERVIEW: DashboardListItem = {
   id: "d1",
   name: "Overview",
   description: null,
-  isDefault: false,
-  updateTime: "",
+  isDefault: true,
+  creator: "Ada",
+  createTime: "2026-06-01T10:00:00Z",
+  updateTime: "2026-07-01T10:00:00Z",
 };
-const DASH_B: DashboardSummary = {
+const COSTS: DashboardListItem = {
   id: "d2",
   name: "Costs",
-  description: null,
-  isDefault: true,
-  updateTime: "",
+  description: "Cost breakdowns",
+  isDefault: false,
+  creator: null,
+  createTime: "2026-06-02T10:00:00Z",
+  updateTime: "2026-07-02T10:00:00Z",
 };
 
 describe("DashboardIndexPage", () => {
   afterEach(cleanup);
   beforeEach(() => {
     replace.mockReset();
+    push.mockReset();
     refetch.mockReset();
+    searchParams = new URLSearchParams();
   });
 
   it("shows a loading state while the dashboard list is in flight", () => {
@@ -54,19 +87,90 @@ describe("DashboardIndexPage", () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
-  it("redirects to the default dashboard once the list resolves", () => {
-    mockDashboards([DASH_A, DASH_B]);
+  it("auto-opens the only dashboard instead of listing it", () => {
+    mockDashboards([OVERVIEW]);
+    render(<DashboardIndexPage />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+    // No list flashes while the redirect is in flight.
+    expect(screen.queryByText("Dashboards")).toBeNull();
+    expect(screen.getByText("Loading dashboards…")).toBeTruthy();
+  });
+
+  it("auto-opens a sole non-default dashboard too (the rule is count-based)", () => {
+    mockDashboards([{ ...COSTS, isDefault: false }]);
     render(<DashboardIndexPage />);
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d2");
   });
 
-  it("redirects to the first dashboard when none is marked default", () => {
-    mockDashboards([
-      { ...DASH_A, isDefault: false },
-      { ...DASH_B, isDefault: false },
-    ]);
+  it("lists dashboards when there is more than one, without redirecting", () => {
+    mockDashboards([OVERVIEW, COSTS]);
     render(<DashboardIndexPage />);
-    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText("Dashboards")).toBeTruthy();
+    expect(screen.getByText("Overview")).toBeTruthy();
+    expect(screen.getByText("Costs")).toBeTruthy();
+    // description column: value for Costs, em-dash for the description-less
+    expect(screen.getByText("Cost breakdowns")).toBeTruthy();
+    // owner and created sit between Description and Updated (Updated stays last)
+    const headers = screen.getAllByRole("columnheader").map((h) => h.textContent);
+    expect(headers.slice(1)).toEqual(["Description", "Owner", "Created", "Updated", ""]);
+    expect(screen.getByText("Ada")).toBeTruthy();
+    // em-dashes: Overview's missing description, Costs' deleted creator
+    expect(screen.getAllByText("—")).toHaveLength(2);
+    // no marker glyph on the default dashboard — its row reads like any other
+    expect(screen.queryByText("⌂")).toBeNull();
+  });
+
+  it("keeps showing the list when a delete brings it down to one row", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    const { rerender } = render(<DashboardIndexPage />);
+    expect(screen.getByText("Costs")).toBeTruthy();
+
+    mockDashboards([OVERVIEW]);
+    rerender(<DashboardIndexPage />);
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText("Overview")).toBeTruthy();
+  });
+
+  it("navigates into a dashboard on row click", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getByText("Costs"));
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d2");
+  });
+
+  it("opens the create dialog from the header button", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getByRole("button", { name: "＋ New dashboard" }));
+    expect(screen.getByTestId("create-dialog")).toBeTruthy();
+  });
+
+  it("opens the edit dialog from a row's actions with the row's fields, without navigating", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getAllByRole("button", { name: "Dashboard actions" })[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    expect(screen.getByTestId("edit-dialog").textContent).toBe("Costs:Cost breakdowns");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("opens the delete confirm from a row's actions without navigating", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getAllByRole("button", { name: "Dashboard actions" })[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(screen.getByTestId("delete-dialog").textContent).toBe("Costs");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("?list=1 pins the list even for a sole dashboard, keeping create reachable", () => {
+    searchParams = new URLSearchParams("list=1");
+    mockDashboards([OVERVIEW]);
+    render(<DashboardIndexPage />);
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText("Overview")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "＋ New dashboard" })).toBeTruthy();
   });
 
   it("shows a retry button on error and refetches on click", () => {

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
@@ -1,23 +1,53 @@
 "use client";
 
-import { useEffect } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { ProjectBreadcrumb } from "@/features/projects/components";
 import { useDashboards } from "@/features/dashboards/hooks/use-dashboards";
+import { CreateDashboardDialog } from "@/features/dashboards/components/CreateDashboardDialog";
+import { DeleteDashboardDialog } from "@/features/dashboards/components/DeleteDashboardDialog";
+import { EditDashboardDialog } from "@/features/dashboards/components/EditDashboardDialog";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { formatDate } from "@/lib/utils";
 
+/**
+ * The dashboards entry point. A project with a single dashboard (the common
+ * case — the list endpoint lazily seeds the default Overview, so there is
+ * always at least one) opens straight into it; with several, this renders a
+ * list page in the house table style, one row per dashboard.
+ */
 export default function DashboardIndexPage() {
   const params = useParams();
   const router = useRouter();
   const projectId = params.projectId as string;
+  // The detail page's back link arrives with ?list=1: without it a project
+  // with a single dashboard would auto-open right back, making the list (and
+  // its "New dashboard" button) unreachable from a sole dashboard.
+  const wantList = useSearchParams().has("list");
   const { data: dashboards, error, refetch } = useDashboards(projectId);
 
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<{
+    id: string;
+    name: string;
+    description: string | null;
+  } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
+  const [actionsOpen, setActionsOpen] = useState<string | null>(null);
+
+  // Auto-open applies on ENTRY only: once the list has been shown, deleting
+  // down to one row must not yank the user into the survivor mid-interaction.
+  const [listPinned, setListPinned] = useState(false);
+  // One derivation drives both the redirect effect and the loading branch
+  // below, so they can't drift apart.
+  const autoOpening = !!dashboards && dashboards.length === 1 && !wantList && !listPinned;
   useEffect(() => {
-    // The list endpoint lazily seeds the default Overview, so there is always
-    // at least one dashboard once the query resolves.
-    if (dashboards && dashboards.length > 0) {
-      const target = dashboards.find((d) => d.isDefault) ?? dashboards[0];
-      router.replace(`/projects/${projectId}/dashboard/${target.id}`);
-    }
-  }, [dashboards, projectId, router]);
+    if (!dashboards || dashboards.length === 0) return;
+    if (autoOpening) router.replace(`/projects/${projectId}/dashboard/${dashboards[0].id}`);
+    else setListPinned(true);
+  }, [autoOpening, dashboards, projectId, router]);
 
   if (error) {
     return (
@@ -34,9 +64,144 @@ export default function DashboardIndexPage() {
     );
   }
 
+  // Loading, or a single dashboard about to be auto-opened by the effect.
+  if (!dashboards || dashboards.length === 0 || autoOpening) {
+    return (
+      <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+        Loading dashboards…
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
-      Loading dashboards…
+    <div className="relative flex h-full text-[13px]">
+      <ProjectBreadcrumb projectId={projectId} />
+
+      <CreateDashboardDialog projectId={projectId} open={createOpen} onOpenChange={setCreateOpen} />
+
+      {/* The dialog seeds its drafts on mount, so callers must key it by the
+          target's id to reset them per row. */}
+      <EditDashboardDialog
+        key={editTarget?.id ?? "closed"}
+        projectId={projectId}
+        target={editTarget}
+        onClose={() => setEditTarget(null)}
+      />
+
+      <DeleteDashboardDialog
+        projectId={projectId}
+        target={deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+      />
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Page header */}
+        <div className="flex h-[45px] shrink-0 items-center justify-between border-b border-border px-4">
+          <h1 className="text-[13px] font-medium">Dashboards</h1>
+          <Button size="sm" className="h-7 text-[12px]" onClick={() => setCreateOpen(true)}>
+            ＋ New dashboard
+          </Button>
+        </div>
+
+        {/* List */}
+        <div className="flex-1 overflow-auto bg-background">
+          <table className="w-full">
+            <thead className="sticky top-0 bg-background">
+              <tr className="border-b border-border bg-muted/50">
+                <th className="w-[16rem] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Name
+                </th>
+                <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Description
+                </th>
+                <th className="w-[12rem] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Owner
+                </th>
+                <th className="w-[10rem] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Created
+                </th>
+                <th className="w-[10rem] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Updated
+                </th>
+                <th className="w-10 px-2 py-1.5" />
+              </tr>
+            </thead>
+            <tbody>
+              {dashboards.map((d) => (
+                <tr
+                  key={d.id}
+                  onClick={() => router.push(`/projects/${projectId}/dashboard/${d.id}`)}
+                  className="cursor-pointer border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
+                >
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
+                    <span className="block truncate" title={d.name}>
+                      {d.name}
+                    </span>
+                  </td>
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                    <span className="block truncate" title={d.description ?? undefined}>
+                      {d.description || "—"}
+                    </span>
+                  </td>
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                    <span className="block truncate" title={d.creator ?? undefined}>
+                      {d.creator ?? "—"}
+                    </span>
+                  </td>
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                    {formatDate(d.createTime)}
+                  </td>
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                    {formatDate(d.updateTime)}
+                  </td>
+                  <td className="px-2 text-right">
+                    <Popover
+                      open={actionsOpen === d.id}
+                      onOpenChange={(open) => setActionsOpen(open ? d.id : null)}
+                    >
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label="Dashboard actions"
+                          className="h-5 w-6 p-0 text-muted-foreground hover:text-foreground"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <MoreHorizontal className="h-3.5 w-3.5" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent align="end" className="w-36 p-1">
+                        <button
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] hover:bg-muted/60"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setEditTarget({ id: d.id, name: d.name, description: d.description });
+                            setActionsOpen(null);
+                          }}
+                        >
+                          <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+                          Edit
+                        </button>
+                        <button
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteTarget({ id: d.id, name: d.name });
+                            setActionsOpen(null);
+                          }}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                          Delete
+                        </button>
+                      </PopoverContent>
+                    </Popover>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/ui/src/features/dashboards/api.ts
+++ b/frontend/ui/src/features/dashboards/api.ts
@@ -1,6 +1,7 @@
 import { fetchNextApi, fetchTraceApi, type TraceApiUser } from "@/lib/api/client";
 import type {
   DashboardDetail,
+  DashboardListItem,
   DashboardSummary,
   LayoutItem,
   TimeRange,
@@ -12,7 +13,7 @@ import type {
 } from "./types";
 
 export function listDashboards(projectId: string) {
-  return fetchNextApi<{ data: DashboardSummary[] }>(`/projects/${projectId}/dashboards`);
+  return fetchNextApi<{ data: DashboardListItem[] }>(`/projects/${projectId}/dashboards`);
 }
 
 export function getDashboard(projectId: string, dashboardId: string) {

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
@@ -64,6 +64,24 @@ describe("CreateDashboardDialog", () => {
     expect(create.hasAttribute("disabled")).toBe(false);
   });
 
+  it("omits an empty description and sends a filled one trimmed", () => {
+    renderDialog();
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "Spend" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(createDashboard.mutate.mock.calls[0][0]).toEqual({ name: "Spend" });
+
+    fireEvent.change(screen.getByLabelText("Dashboard description"), {
+      target: { value: "  Monthly spend  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(createDashboard.mutate.mock.calls[1][0]).toEqual({
+      name: "Spend",
+      description: "Monthly spend",
+    });
+  });
+
   it("submits the trimmed name, then closes and navigates on success", () => {
     const { onOpenChange } = renderDialog();
 

--- a/frontend/ui/src/features/dashboards/components/DeleteDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/DeleteDashboardDialog.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeleteDashboardDialog } from "./DeleteDashboardDialog";
+
+const removeDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false, error: null };
+
+vi.mock("../hooks/use-dashboards", () => ({
+  useDashboardMutations: () => ({ removeDashboard }),
+}));
+
+const TARGET = { id: "d2", name: "Costs" };
+
+describe("DeleteDashboardDialog", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    removeDashboard.mutate.mockReset();
+    removeDashboard.reset.mockReset();
+    removeDashboard.isPending = false;
+    removeDashboard.isError = false;
+    removeDashboard.error = null;
+  });
+
+  it("deletes the target and closes on success", () => {
+    const onClose = vi.fn();
+    render(<DeleteDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    expect(screen.getByText(/Permanently delete “Costs”/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(removeDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [id, options] = removeDashboard.mutate.mock.calls[0];
+    expect(id).toBe("d2");
+    options.onSuccess();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel closes and resets the mutation so a stale error can't leak to the next target", () => {
+    const onClose = vi.fn();
+    render(<DeleteDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(removeDashboard.mutate).not.toHaveBeenCalled();
+    expect(removeDashboard.reset).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the mutation error and locks the dialog while deleting is in flight", () => {
+    removeDashboard.isError = true;
+    removeDashboard.error = new Error("boom");
+    removeDashboard.isPending = true;
+    const onClose = vi.fn();
+    render(<DeleteDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    expect(screen.getByText("boom")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveProperty("disabled", true);
+    // Radix close paths (Escape) are ignored while the delete is pending.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when there is no target", () => {
+    render(<DeleteDashboardDialog projectId="p1" target={null} onClose={vi.fn()} />);
+    expect(screen.queryByText("Delete Dashboard")).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/DeleteDashboardDialog.tsx
+++ b/frontend/ui/src/features/dashboards/components/DeleteDashboardDialog.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useDashboardMutations } from "../hooks/use-dashboards";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * Confirm-delete for a dashboard, opened from the list page's row actions.
+ * `target` doubles as the open state.
+ */
+export function DeleteDashboardDialog({
+  projectId,
+  target,
+  onClose,
+}: {
+  projectId: string;
+  target: { id: string; name: string } | null;
+  onClose: () => void;
+}) {
+  const { removeDashboard } = useDashboardMutations(projectId);
+
+  const handleOpenChange = (next: boolean) => {
+    // Radix close paths (Escape, overlay click) bypass the disabled Cancel
+    // button — ignore them while the delete is in flight.
+    if (!next && removeDashboard.isPending) return;
+    if (!next) {
+      // Reset so a failed delete of one dashboard doesn't show its error the
+      // next time the dialog opens for another.
+      removeDashboard.reset();
+      onClose();
+    }
+  };
+
+  const handleDelete = () => {
+    if (!target) return;
+    removeDashboard.mutate(target.id, {
+      onSuccess: () => {
+        removeDashboard.reset();
+        onClose();
+      },
+    });
+  };
+
+  return (
+    <Dialog open={target !== null} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Dashboard</DialogTitle>
+          <DialogDescription>
+            Permanently delete “{target?.name}” and all of its widgets? This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        {removeDashboard.isError && (
+          <p className="text-sm text-destructive">{removeDashboard.error.message}</p>
+        )}
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={removeDashboard.isPending}
+          >
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={removeDashboard.isPending}>
+            {removeDashboard.isPending ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/EditDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/EditDashboardDialog.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EditDashboardDialog } from "./EditDashboardDialog";
+
+const renameDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false, error: null };
+
+vi.mock("../hooks/use-dashboards", () => ({
+  useDashboardMutations: vi.fn(() => ({ renameDashboard })),
+}));
+import { useDashboardMutations } from "../hooks/use-dashboards";
+
+const TARGET = { id: "d2", name: "Costs", description: "Cost breakdowns" };
+
+describe("EditDashboardDialog", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    renameDashboard.mutate.mockReset();
+    renameDashboard.reset.mockReset();
+    renameDashboard.isPending = false;
+    renameDashboard.isError = false;
+    renameDashboard.error = null;
+  });
+
+  it("prefills both fields and saves trimmed values, closing on success", () => {
+    const onClose = vi.fn();
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    // the mutation hook is bound to the row being edited
+    expect(vi.mocked(useDashboardMutations)).toHaveBeenCalledWith("p1", "d2");
+
+    const name = screen.getByLabelText("Dashboard name") as HTMLInputElement;
+    const description = screen.getByLabelText("Dashboard description") as HTMLTextAreaElement;
+    expect(name.value).toBe("Costs");
+    expect(description.value).toBe("Cost breakdowns");
+
+    fireEvent.change(name, { target: { value: "  Spend  " } });
+    fireEvent.change(description, { target: { value: "  Monthly spend  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(renameDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = renameDashboard.mutate.mock.calls[0];
+    expect(payload).toEqual({ name: "Spend", description: "Monthly spend" });
+    options.onSuccess();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearing the description saves null so the stored one is removed", () => {
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Dashboard description"), { target: { value: "  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(renameDashboard.mutate.mock.calls[0][0]).toEqual({ name: "Costs", description: null });
+  });
+
+  it("prefills an empty draft for a description-less dashboard", () => {
+    render(
+      <EditDashboardDialog
+        projectId="p1"
+        target={{ ...TARGET, description: null }}
+        onClose={vi.fn()}
+      />,
+    );
+    expect((screen.getByLabelText("Dashboard description") as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("cancel closes and resets without saving", () => {
+    const onClose = vi.fn();
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(renameDashboard.mutate).not.toHaveBeenCalled();
+    expect(renameDashboard.reset).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables save for a blank name", () => {
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Dashboard name"), { target: { value: "   " } });
+    expect(screen.getByRole("button", { name: "Save" })).toHaveProperty("disabled", true);
+  });
+
+  it("surfaces the mutation error and locks the dialog while saving is in flight", () => {
+    renameDashboard.isError = true;
+    renameDashboard.error = new Error("boom");
+    renameDashboard.isPending = true;
+    const onClose = vi.fn();
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    expect(screen.getByText("boom")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveProperty("disabled", true);
+    // Radix close paths (Escape) are ignored while the save is pending.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when there is no target", () => {
+    render(<EditDashboardDialog projectId="p1" target={null} onClose={vi.fn()} />);
+    expect(screen.queryByText("Edit Dashboard")).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/EditDashboardDialog.tsx
+++ b/frontend/ui/src/features/dashboards/components/EditDashboardDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { useDashboardMutations } from "../hooks/use-dashboards";
 import { DASHBOARD_DESCRIPTION_MAX, DASHBOARD_NAME_MAX } from "../types";
 import { Button } from "@/components/ui/button";
@@ -15,65 +14,64 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
-export function CreateDashboardDialog({
+/**
+ * Edit a dashboard's name and description from the list page. `target`
+ * doubles as the open state: a row's Edit action sets it, closing clears it.
+ * The drafts seed on mount, so callers must key this component by the
+ * target's id to reset them per row.
+ */
+export function EditDashboardDialog({
   projectId,
-  open,
-  onOpenChange,
+  target,
+  onClose,
 }: {
   projectId: string;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  target: { id: string; name: string; description: string | null } | null;
+  onClose: () => void;
 }) {
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const router = useRouter();
-  const { createDashboard } = useDashboardMutations(projectId);
+  const { renameDashboard } = useDashboardMutations(projectId, target?.id);
+  const [name, setName] = useState(target?.name ?? "");
+  const [description, setDescription] = useState(target?.description ?? "");
 
-  // Closing discards the draft: a cancelled name or stale error must not
-  // reappear the next time the dialog opens.
   const handleOpenChange = (next: boolean) => {
-    // Radix close paths (Escape, overlay click, the X) bypass the disabled
-    // Cancel button — ignore them while a create is in flight, so the pending
-    // mutation can't be reset mid-request and resubmitted.
-    if (!next && createDashboard.isPending) return;
+    // Radix close paths (Escape, overlay click) bypass the disabled Cancel
+    // button — ignore them while the save is in flight.
+    if (!next && renameDashboard.isPending) return;
     if (!next) {
-      setName("");
-      setDescription("");
-      createDashboard.reset();
+      renameDashboard.reset();
+      onClose();
     }
-    onOpenChange(next);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
-    createDashboard.mutate(
-      { name: name.trim(), ...(description.trim() ? { description: description.trim() } : {}) },
-      {
-        onSuccess: (res) => {
-          handleOpenChange(false);
-          router.push(`/projects/${projectId}/dashboard/${res.dashboard.id}`);
-        },
-      },
+    renameDashboard.mutate(
+      // An emptied description clears the stored one, not just the draft.
+      { name: name.trim(), description: description.trim() || null },
+      { onSuccess: () => onClose() },
     );
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={target !== null} onOpenChange={handleOpenChange}>
       <DialogContent>
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>Create Dashboard</DialogTitle>
-            <DialogDescription>Create a new dashboard to organize your widgets.</DialogDescription>
+            <DialogTitle>Edit Dashboard</DialogTitle>
+            <DialogDescription>
+              Update the name and description of “{target?.name}”.
+            </DialogDescription>
           </DialogHeader>
           <div className="flex flex-col gap-3 py-4">
             <Input
               autoFocus
+              aria-label="Dashboard name"
               maxLength={DASHBOARD_NAME_MAX}
               placeholder="Dashboard name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              disabled={createDashboard.isPending}
+              disabled={renameDashboard.isPending}
             />
             <textarea
               aria-label="Dashboard description"
@@ -82,11 +80,11 @@ export function CreateDashboardDialog({
               placeholder="Describe the purpose of this dashboard (optional)"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              disabled={createDashboard.isPending}
+              disabled={renameDashboard.isPending}
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
             />
-            {createDashboard.isError && (
-              <p className="text-sm text-destructive">{createDashboard.error.message}</p>
+            {renameDashboard.isError && (
+              <p className="text-sm text-destructive">{renameDashboard.error.message}</p>
             )}
           </div>
           <DialogFooter>
@@ -94,12 +92,12 @@ export function CreateDashboardDialog({
               type="button"
               variant="outline"
               onClick={() => handleOpenChange(false)}
-              disabled={createDashboard.isPending}
+              disabled={renameDashboard.isPending}
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={!name.trim() || createDashboard.isPending}>
-              {createDashboard.isPending ? "Creating..." : "Create"}
+            <Button type="submit" disabled={!name.trim() || renameDashboard.isPending}>
+              {renameDashboard.isPending ? "Saving..." : "Save"}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
@@ -46,7 +46,7 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
-function renderWidget(spec: { limit?: number } = {}) {
+function renderWidget(spec: React.ComponentProps<typeof TraceFeedWidget>["spec"] = {}) {
   return render(<TraceFeedWidget projectId="p1" spec={spec} range={RANGE} />, { wrapper });
 }
 
@@ -154,11 +154,30 @@ describe("TraceFeedWidget", () => {
       {
         page: 0,
         limit: 25,
+        filters: [],
         start_after: RANGE.start.toISOString(),
         end_before: RANGE.end.toISOString(),
       },
       { id: "u1", email: "u@example.com" },
     );
+  });
+
+  it("passes spec.filters through as trace-list predicates, dropping invalid entries", async () => {
+    vi.mocked(getTraces).mockResolvedValue({
+      data: [makeTrace()],
+      meta: { page: 0, limit: 10, total: 1 },
+    });
+    renderWidget({
+      filters: [
+        { field: "errors", op: "gt", value: 0 },
+        // Stored specs are arbitrary JSON — a malformed entry must not reach the API.
+        { field: "errors", op: "gt", value: Number.NaN },
+      ],
+    });
+
+    await waitFor(() => expect(getTraces).toHaveBeenCalled());
+    const options = vi.mocked(getTraces).mock.calls[0][2];
+    expect(options?.filters).toEqual([{ field: "errors", op: "gt", value: 0 }]);
   });
 
   it("defaults the limit to 10 when spec.limit is not provided", async () => {

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
@@ -4,13 +4,16 @@ import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { useTraceApiUser } from "@/lib/hooks/use-trace-api-user";
 import { getTraces } from "@/lib/api/traces";
-import type { TraceListItem } from "@/types/api";
+import type { Predicate, TraceListItem } from "@/types/api";
+import { canonicalizeFilters, isValidPredicate } from "@/features/filters/predicate";
 import { formatCost, formatDuration } from "@/lib/utils";
 import type { TimeRange } from "../types";
 
 interface TraceFeedWidgetProps {
   projectId: string;
-  spec: { limit?: number };
+  // Filters use the trace-list predicate wire format; the spec is stored
+  // JSON, so entries are validated before they reach the query.
+  spec: { limit?: number; filters?: Predicate[] };
   range: TimeRange;
 }
 
@@ -39,10 +42,18 @@ function fmtTime(iso: string): string {
 
 export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps) {
   const limit = spec.limit ?? 10;
+  const filters = (spec.filters ?? []).filter(isValidPredicate);
   const { user, sessionReady } = useTraceApiUser();
 
   const { data, isPending, isError } = useQuery({
-    queryKey: ["trace-feed", projectId, limit, range.start.getTime(), range.end.getTime()],
+    queryKey: [
+      "trace-feed",
+      projectId,
+      limit,
+      canonicalizeFilters(filters),
+      range.start.getTime(),
+      range.end.getTime(),
+    ],
     queryFn: () =>
       getTraces(
         projectId,
@@ -50,6 +61,7 @@ export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps
         {
           page: 0,
           limit,
+          filters,
           start_after: range.start.toISOString(),
           end_before: range.end.toISOString(),
         },

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -98,13 +98,12 @@ const WIDGET: Widget = {
   displayConfig: {},
 };
 
-// Non-default: the builder is only reachable for editable dashboards — the
-// default one redirects away, which its dedicated test covers.
 const DASHBOARD = {
   id: "d1",
   name: "Custom",
   description: null,
   isDefault: false,
+  createTime: "",
   updateTime: "",
   layout: [],
   widgets: [WIDGET],

--- a/frontend/ui/src/features/dashboards/hooks/use-dashboards.test.tsx
+++ b/frontend/ui/src/features/dashboards/hooks/use-dashboards.test.tsx
@@ -31,6 +31,7 @@ const fakeSummary: DashboardSummary = {
   name: "Overview",
   description: null,
   isDefault: true,
+  createTime: "2026-05-01T00:00:00Z",
   updateTime: "2026-06-01T00:00:00Z",
 };
 
@@ -66,11 +67,12 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 describe("useDashboards", () => {
   it("unwraps the data array from the list response", async () => {
-    vi.mocked(api.listDashboards).mockResolvedValue({ data: [fakeSummary] });
+    const listItem = { ...fakeSummary, creator: "Ada" };
+    vi.mocked(api.listDashboards).mockResolvedValue({ data: [listItem] });
     const { wrapper } = makeWrapper();
 
     const { result } = renderHook(() => useDashboards("proj-1"), { wrapper });
-    await waitFor(() => expect(result.current.data).toEqual([fakeSummary]));
+    await waitFor(() => expect(result.current.data).toEqual([listItem]));
     expect(api.listDashboards).toHaveBeenCalledWith("proj-1");
   });
 

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -76,7 +76,16 @@ export interface DashboardSummary {
   name: string;
   description: string | null;
   isDefault: boolean;
+  createTime: string;
   updateTime: string;
+}
+
+// A dashboards-list row: the summary plus the creator's display name (or
+// email), which only the list route resolves — dashboards are shared across
+// a project's members, so the list shows who made each one. Null when the
+// creating account is gone.
+export interface DashboardListItem extends DashboardSummary {
+  creator: string | null;
 }
 
 export interface LayoutItem {

--- a/frontend/ui/src/lib/dashboard-seed.ts
+++ b/frontend/ui/src/lib/dashboard-seed.ts
@@ -1,4 +1,4 @@
-// Widget definitions for the lazily-created default "Overview" dashboard.
+// Widget definitions for the lazily-created "Default" dashboard.
 // Created once per project on first dashboards fetch, then fully user-owned —
 // never re-seeded or force-updated.
 
@@ -96,7 +96,14 @@ export function seedWidgets(): SeedWidget[] {
       title: "Recent traces",
       type: "trace_feed",
       spec: { filters: [], limit: 10 },
-      layout: { x: 0, y: 8, w: 12, h: 4 },
+      layout: { x: 0, y: 8, w: 6, h: 4 },
+    },
+    {
+      title: "Recent failures",
+      type: "trace_feed",
+      // Trace-list predicate wire format: only traces that recorded errors.
+      spec: { filters: [{ field: "errors", op: "gt", value: 0 }], limit: 10 },
+      layout: { x: 6, y: 8, w: 6, h: 4 },
     },
   ];
 


### PR DESCRIPTION
## What

Removes the dashboard tab strip. The dashboard section now works like the rest of the app's list pages:

- **Auto-open**: entering `/dashboard` with exactly one dashboard (first visit / just the seeded Default) opens straight into it. The rule is count-based, so a sole custom dashboard auto-opens too.
- **List page** when a project has several dashboards, in the house table style (same shell as the detectors list): Name, Description, Owner, Created, Updated, and a per-row `⋯` menu with Edit and Delete. Row click opens the dashboard; the header hosts "＋ New dashboard". On the detail page the create-widget button sits before the time-range control.
- **Owner column**: dashboards are shared across a project's members, so the list route resolves each row's `createdBy` to a display name (name, falling back to email) in one batched user lookup — the raw user id never leaves the API; deleted accounts render as "—".
- **Descriptions become writable end-to-end**: the create dialog gains an optional description textarea, the row's Edit dialog updates name + description together (clearing the field removes the stored description), and the seeded dashboard ships with a canned purpose note so the default row isn't blank.
- **The seeded dashboard is named "Default"** (was "Overview") and renders without any marker glyph — it reads like any other dashboard, matching its now fully editable behavior.
- **The seeded feed row splits in two**: half-width "Recent traces" beside a new "Recent failures" feed (an errors > 0 predicate). Under the hood the trace-feed widget now honors its spec's `filters` array — entries are validated (specs are stored JSON) and forwarded to the trace list query as trace-list predicates — so any feed widget can be filtered this way.
- **Detail page**: the header is now a breadcrumb — "Dashboards / <name>" — where "Dashboards" is styled identically to the list page's heading and links back to the list; both headers share a fixed height so the text doesn't shift between pages. The page no longer fetches the full dashboard list.

## Edge behavior

- Auto-open applies on entry only: deleting down to one row while on the list keeps the list up instead of yanking into the survivor.
- The breadcrumb link carries `?list=1`, which pins the index on the list — without it, a sole-dashboard project could never reach the list or its "New dashboard" button.
- Deleting the last dashboard bounces to the index, which re-seeds the Default dashboard and auto-opens it.

## New/changed components

- `EditDashboardDialog` (renamed from the rename-only dialog; first UI consumer of the existing `renameDashboard` mutation).
- `DeleteDashboardDialog` opened from the list rows — deleting a dashboard lives only in the list's row actions (the detail header has no delete button); both dialogs reset their mutation on close so a failed attempt can't leak its error into the next open.
- `DashboardListItem` type (summary + `creator`) keeps the list-only field off `DashboardSummary`; `createTime` joins the summary since every dashboard response returns it.

## Notes

- This supersedes the tab-overflow scrolling fix in the open tabs PR — the strip it patches no longer exists.
- Stacked on the shared-filter-controls PR; merge order follows the stack.

## Testing

Index page tests cover auto-open (count-based), list rendering and column order, entry-only pinning via rerender, `?list=1` pinning, row navigation, and both row actions. Route tests cover the batched creator lookup, email fallback, deleted-account null, id stripping, and the seeded name/description. Dialog tests cover prefill, trim/clear-to-null semantics, blank-name disable, and the pending-Escape lockout. Full frontend suite passes; diff coverage 100% on changed lines.

Part of the project dashboards epic: #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)