### PR TITLE
feat(ui): per-series chart legend with window totals and hover highlight

### DIFF
--- a/frontend/ui/src/features/dashboards/components/ChartLegend.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/ChartLegend.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChartLegend, type LegendEntry } from "./ChartLegend";
+
+afterEach(cleanup);
+
+const fmt = (v: number | null) => (v === null ? "—" : `#${v}`);
+
+function makeEntries(n: number): LegendEntry[] {
+  // ascending values so sorting is observable
+  return Array.from({ length: n }, (_, i) => ({
+    key: `s${i}`,
+    label: `series-${i}`,
+    color: `rgb(${i}, 0, 0)`,
+    value: i * 10,
+  }));
+}
+
+describe("ChartLegend", () => {
+  it("sorts rows by value descending and keeps each entry's own color", () => {
+    render(
+      <ChartLegend
+        entries={makeEntries(3)}
+        total={30}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    const rows = screen.getAllByRole("listitem");
+    expect(rows.map((r) => r.textContent)).toEqual([
+      "Total#30",
+      "series-2#20",
+      "series-1#10",
+      "series-0#0",
+    ]);
+    // color follows the entry (its chart pivot index), not the sorted position
+    const swatch = rows[1].querySelector("div[style]") as HTMLElement;
+    expect(swatch.style.backgroundColor).toBe("rgb(2, 0, 0)");
+  });
+
+  it("shows a Total row only when a total is given", () => {
+    const { unmount } = render(
+      <ChartLegend
+        entries={makeEntries(2)}
+        total={99}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Total")).toBeTruthy();
+    expect(screen.getByText("#99")).toBeTruthy();
+    unmount();
+
+    render(
+      <ChartLegend
+        entries={makeEntries(2)}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Total")).toBeNull();
+  });
+
+  it("caps visible rows and expands the full list in a popover", () => {
+    render(
+      <ChartLegend
+        entries={makeEntries(8)}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    const more = screen.getByRole("button", { name: "5 more" });
+
+    fireEvent.click(more);
+    const panel = screen.getByRole("dialog");
+    expect(panel.textContent).toContain("series-0");
+    expect(panel.textContent).toContain("series-7");
+    // The tile rows stay in the DOM behind the popover but leave the
+    // accessibility tree (aria-hidden), so only the popover's 8 rows count.
+    expect(screen.getAllByRole("listitem")).toHaveLength(8);
+
+    fireEvent.click(screen.getByRole("button", { name: "show less" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("clears the hover whenever the popover closes (Escape or the toggle)", () => {
+    // Outside-click and Escape dismissal are Radix Popover's own behavior; what
+    // we own is that a close — however triggered — clears the hover, or a row
+    // that unmounted mid-hover would leave the chart dimmed.
+    const onHoverKey = vi.fn();
+    render(
+      <ChartLegend
+        entries={makeEntries(5)}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={onHoverKey}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "2 more" }));
+    const panel = screen.getByRole("dialog");
+    fireEvent.mouseEnter(panel.querySelectorAll('[role="listitem"]')[4]!);
+    expect(onHoverKey).toHaveBeenLastCalledWith("s0");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(onHoverKey).toHaveBeenLastCalledWith(null);
+
+    // reopen, hover, then collapse via the toggle — hover clears again
+    fireEvent.click(screen.getByRole("button", { name: "2 more" }));
+    fireEvent.mouseEnter(screen.getByRole("dialog").querySelectorAll('[role="listitem"]')[0]!);
+    fireEvent.click(screen.getByRole("button", { name: "show less" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(onHoverKey).toHaveBeenLastCalledWith(null);
+  });
+
+  it("reports hover enter/leave so the chart can dim other series", () => {
+    const onHoverKey = vi.fn();
+    render(
+      <ChartLegend
+        entries={makeEntries(2)}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={onHoverKey}
+      />,
+    );
+    const [first] = screen.getAllByRole("listitem");
+    fireEvent.mouseEnter(first);
+    expect(onHoverKey).toHaveBeenLastCalledWith("s1"); // sorted first (value 10)
+    fireEvent.mouseLeave(first);
+    expect(onHoverKey).toHaveBeenLastCalledWith(null);
+  });
+
+  it("formats null values through the caller's formatter", () => {
+    render(
+      <ChartLegend
+        entries={[{ key: "a", label: "a", color: "red", value: null }]}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/ChartLegend.tsx
+++ b/frontend/ui/src/features/dashboards/components/ChartLegend.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+export interface LegendEntry {
+  /** Series key, as the chart knows it (dataKey / category name). */
+  key: string;
+  label: string;
+  /** The chart's color for this series — bound to its pivot index, not the
+   * legend's sorted position. */
+  color: string;
+  value: number | null;
+}
+
+// The tile shows this many rows; the rest live behind "N more".
+const VISIBLE_ROWS = 3;
+
+/**
+ * Per-series legend under a chart: swatch · label · right-aligned value,
+ * sorted by value, with a Total row for additive measures. The tile shows the
+ * top rows; "N more" opens the full list in a popover anchored to that button
+ * (portaled out of the widget card, so it neither covers the chart nor shrinks
+ * the tile, and flips above near the viewport edge). Hovering a row highlights
+ * its series via onHoverKey.
+ */
+export function ChartLegend({
+  entries,
+  total,
+  format,
+  hoveredKey,
+  onHoverKey,
+}: {
+  entries: LegendEntry[];
+  /** Window total across series; null for non-additive measures (no honest total). */
+  total: number | null;
+  format: (v: number | null) => string;
+  hoveredKey: string | null;
+  onHoverKey: (key: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  // Closing can unmount a hovered row without its mouseleave firing — clear
+  // the hover with it, or the chart stays dimmed.
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) onHoverKey(null);
+  };
+
+  const sorted = [...entries].sort((a, b) => (b.value ?? -Infinity) - (a.value ?? -Infinity));
+  const shown = sorted.slice(0, VISIBLE_ROWS);
+  const hiddenCount = sorted.length - shown.length;
+
+  const totalRow =
+    total === null ? null : (
+      <div role="listitem" className="flex w-full items-center gap-2 rounded px-1 py-0.5">
+        <div className="h-2.5 w-2.5 shrink-0" />
+        <div className="flex min-w-0 flex-1 items-center justify-between gap-x-3 leading-tight">
+          <span className="truncate text-muted-foreground">Total</span>
+          <span className="shrink-0 whitespace-nowrap font-mono font-medium tabular-nums text-foreground">
+            {format(total)}
+          </span>
+        </div>
+      </div>
+    );
+
+  const row = (e: LegendEntry) => (
+    <div
+      key={e.key}
+      role="listitem"
+      onMouseEnter={() => onHoverKey(e.key)}
+      onMouseLeave={() => onHoverKey(null)}
+      className={cn(
+        "flex w-full items-center gap-2 rounded px-1 py-0.5",
+        hoveredKey === e.key && "bg-muted/50",
+      )}
+    >
+      <div className="h-2.5 w-2.5 shrink-0 rounded-[2px]" style={{ backgroundColor: e.color }} />
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-x-3 leading-tight">
+        <span className="truncate text-muted-foreground" title={e.label}>
+          {e.label}
+        </span>
+        <span className="shrink-0 whitespace-nowrap font-mono tabular-nums text-foreground">
+          {format(e.value)}
+        </span>
+      </div>
+    </div>
+  );
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <div className="shrink-0 pt-1 text-[11px]">
+        {/* Tile rows hide from assistive tech while the popover mirrors them. */}
+        <div role="list" aria-label="Chart legend" aria-hidden={open || undefined}>
+          {totalRow}
+          {shown.map(row)}
+        </div>
+        {/* Keep the trigger mounted while open: a background refresh can
+            shrink the list below the cap, and unmounting the trigger would
+            strand the portaled popover with no anchor or toggle. */}
+        {(hiddenCount > 0 || open) && (
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="rounded px-1 py-0.5 text-[10.5px] text-muted-foreground hover:text-foreground"
+            >
+              {open ? "show less" : `${hiddenCount} more`}
+            </button>
+          </PopoverTrigger>
+        )}
+      </div>
+      <PopoverContent
+        align="start"
+        className="max-h-64 w-56 overflow-auto p-1 text-[11px] shadow-xl"
+      >
+        <div role="list" aria-label="Chart legend (all series)">
+          {totalRow}
+          {sorted.map(row)}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { cloneElement, isValidElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WidgetQueryResult } from "../types";
@@ -247,9 +247,10 @@ describe("QueryWidgetRenderer", () => {
       const { container } = render(<QueryWidgetRenderer display="bar" result={result} />);
       const cells = container.querySelectorAll(".recharts-bar-rectangle");
       expect(cells.length).toBe(3);
-      expect(screen.getByText("api")).toBeTruthy();
-      expect(screen.getByText("worker")).toBeTruthy();
-      expect(screen.getByText("frontend")).toBeTruthy();
+      // each category shows exactly twice: on the axis AND in the legend row
+      for (const name of ["api", "worker", "frontend"]) {
+        expect(screen.getAllByText(name)).toHaveLength(2);
+      }
     });
   });
 
@@ -439,5 +440,72 @@ describe("unit formatting on charts and tables", () => {
     );
     const ticks = Array.from(container.querySelectorAll(".recharts-cartesian-axis-tick-value"));
     expect(ticks.some((t) => t.textContent?.includes("ms"))).toBe(true);
+  });
+});
+
+describe("chart legend", () => {
+  // RTL auto-cleanup needs vitest globals, which this config doesn't enable.
+  afterEach(cleanup);
+
+  it("multi-series line: legend lists series sorted with a window Total, single series gets none", () => {
+    const multi = makeResult(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt", 10],
+        ["2026-06-01T00:00:00", "claude", 30],
+        ["2026-06-01T01:00:00", "gpt", 5],
+      ],
+    );
+    const { unmount } = render(<QueryWidgetRenderer display="line" result={multi} agg="sum" />);
+    const legend = screen.getByRole("list", { name: "Chart legend" });
+    expect(legend).toBeTruthy();
+    const rows = screen.getAllByRole("listitem").map((r) => r.textContent);
+    // Total 45 leads, then series sorted descending: claude 30, gpt 15
+    expect(rows[0]).toContain("Total");
+    expect(rows[0]).toContain("45");
+    expect(rows[1]).toContain("claude");
+    expect(rows[1]).toContain("30");
+    expect(rows[2]).toContain("gpt");
+    expect(rows[2]).toContain("15");
+    unmount();
+
+    const single = makeResult(["bucket", "value"], [["2026-06-01T00:00:00", 10]]);
+    render(<QueryWidgetRenderer display="line" result={single} agg="sum" />);
+    expect(screen.queryByRole("list", { name: "Chart legend" })).toBeNull();
+  });
+
+  it("non-additive series legend shows per-series bucket averages and no Total", () => {
+    const multi = makeResult(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt", 100],
+        ["2026-06-01T01:00:00", "gpt", 200],
+        ["2026-06-01T00:00:00", "claude", 50],
+      ],
+    );
+    render(<QueryWidgetRenderer display="line" result={multi} agg="p95" />);
+    const legend = screen.getByRole("list", { name: "Chart legend" });
+    // gpt averages its two buckets (150); claude's gap bucket stays out of its average
+    expect(legend.textContent).toContain("150");
+    expect(legend.textContent).not.toContain("Total");
+  });
+  it("bar legend hover dims the other categories", () => {
+    const result = makeResult(
+      ["service", "value"],
+      [
+        ["api", 10],
+        ["worker", 20],
+      ],
+    );
+    const { container } = render(<QueryWidgetRenderer display="bar" result={result} />);
+    const rows = screen.getAllByRole("listitem");
+    // rows[0] is the Total row; rows[1] is "worker" (sorted first at 20)
+    fireEvent.mouseEnter(rows[1]);
+    const dimmed = container.querySelectorAll('.recharts-bar-rectangle path[fill-opacity="0.14"]');
+    expect(dimmed.length).toBe(1); // "api" dimmed (0.7 * 0.2)
+    fireEvent.mouseLeave(rows[1]);
+    expect(
+      container.querySelectorAll('.recharts-bar-rectangle path[fill-opacity="0.14"]').length,
+    ).toBe(0);
   });
 });

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -18,29 +18,39 @@ import {
   YAxis,
 } from "recharts";
 import type { FieldUnit } from "@/features/filters/filter-controls";
+import { ChartLegend, type LegendEntry } from "./ChartLegend";
 import { type DisplayType, type WidgetQueryResult, AGGS } from "../types";
 
-// Pastel series palette mirroring the span-kind tints
-// (violet=llm, blue=agent, amber=tool, slate=span), then softened extras.
+// Categorical series palette: 12 hues spread evenly round the wheel and
+// ORDERED so consecutive series sit on opposite sides of it — a 2-3 series
+// chart (the common case) gets maximally separated colors, and breakdowns up
+// to a dozen categories stay distinct. No gray in the rotation: a gray series
+// reads as muted/"other", not as real data. Amber and cyan are the -500 shades
+// so thin line strokes keep contrast on a light background.
 export const SERIES_COLORS = [
-  "#a78bfa",
-  "#60a5fa",
-  "#fbbf24",
-  "#94a3b8",
-  "#34d399",
-  "#f472b6",
-  "#22d3ee",
-  "#fb923c",
+  "#fb7185", // rose
+  "#06b6d4", // cyan
+  "#4ade80", // green
+  "#a78bfa", // violet
+  "#fb923c", // orange
+  "#60a5fa", // blue
+  "#10b981", // emerald
+  "#e879f9", // fuchsia
+  "#f59e0b", // amber
+  "#818cf8", // indigo
+  "#2dd4bf", // teal
+  "#f472b6", // pink
 ];
 
 const seriesColor = (i: number) => SERIES_COLORS[i % SERIES_COLORS.length];
 
-// Recharts marks its wrapper and SVG internals keyboard-focusable, so clicking
-// anywhere in a chart paints the browser's focus outline around the clicked
-// wrapper/layer/sector — suppress it on every chart surface.
-const CHART_FOCUS_RESET =
-  "[&_.recharts-wrapper]:outline-none [&_.recharts-surface]:outline-none " +
-  "[&_.recharts-layer]:outline-none [&_.recharts-sector]:outline-none";
+// Recharts makes its wrapper, SVG, and individual marks (bar rects, line/area
+// paths, pie sectors) keyboard-focusable, so a click paints the browser's focus
+// outline around whatever was clicked. Suppress the outline on every focused
+// descendant — charts here have no keyboard-interaction model, so there's no
+// focus affordance to preserve. (The legend rows and buttons live outside this
+// wrapper and keep their focus rings.)
+const CHART_FOCUS_RESET = "[&_*:focus]:outline-none [&_*:focus-visible]:outline-none";
 
 // ClickHouse returns Decimal columns as strings; coerce them before charting
 // or formatting — recharts (the pie especially) can't plot string values.
@@ -225,6 +235,55 @@ export function ChartTip({
   );
 }
 
+// Legend hover dims every OTHER series so the hovered one stands out.
+const seriesOpacity = (hovered: string | null, key: string, base = 1) =>
+  hovered !== null && hovered !== key ? Number((base * 0.2).toFixed(3)) : base;
+
+/**
+ * Per-series aggregates for the legend, from the same pivot the charts draw.
+ * Additive measures sum across buckets (a true window total); non-additive
+ * ones average their non-null buckets — an approximation (bucketed
+ * percentiles can't be re-aggregated), so those get no Total row.
+ * Single-series charts (no breakdown) return null: nothing to disambiguate.
+ */
+function legendFor(
+  result: WidgetQueryResult,
+  additive: boolean,
+): { entries: LegendEntry[]; total: number | null } | null {
+  const { seriesKeys, data } = pivotRows(result.columns, result.rows, additive ? 0 : null);
+  if (seriesKeys.length <= 1) return null;
+  const entries = seriesKeys.map((k, i) => {
+    const nums = data
+      .map((r) => (r as Record<string, unknown>)[k])
+      .filter((v): v is number => typeof v === "number");
+    const sum = nums.reduce((a, b) => a + b, 0);
+    const value = nums.length === 0 ? null : additive ? sum : sum / nums.length;
+    return { key: k, label: k, color: seriesColor(i), value };
+  });
+  const total = additive ? entries.reduce((a, e) => a + (e.value ?? 0), 0) : null;
+  return { entries, total };
+}
+
+/** Categorical charts (bar/pie): one legend entry per category row. */
+function categoricalLegend(
+  result: WidgetQueryResult,
+  additive: boolean,
+): { entries: LegendEntry[]; total: number | null } | null {
+  const { data } = pivotRows(result.columns, result.rows);
+  if (data.length <= 1) return null;
+  const entries = data.map((r, i) => {
+    const v = r.value;
+    return {
+      key: String(r.name),
+      label: String(r.name),
+      color: seriesColor(i),
+      value: typeof v === "number" ? v : null,
+    };
+  });
+  const total = additive ? entries.reduce((a, e) => a + (e.value ?? 0), 0) : null;
+  return { entries, total };
+}
+
 // Categorical rows tinted per-index; the `fill` on each row is also what the
 // tooltip payload reads for its swatch.
 function useColoredRows(result: WidgetQueryResult) {
@@ -244,6 +303,7 @@ function TimeSeries({
   seriesLabel,
   additive = true,
   unit,
+  hovered = null,
 }: {
   result: WidgetQueryResult;
   area: boolean;
@@ -251,6 +311,8 @@ function TimeSeries({
   /** False for avg/percentile series: empty buckets render as gaps, not 0. */
   additive?: boolean;
   unit?: FieldUnit;
+  /** Legend-hovered series key; the others render dimmed. */
+  hovered?: string | null;
 }) {
   const { seriesKeys, data } = useMemo(
     () => pivotRows(result.columns, result.rows, additive ? 0 : null),
@@ -318,8 +380,9 @@ function TimeSeries({
               dataKey={k}
               stackId={additive ? "1" : undefined}
               stroke={seriesColor(i)}
+              strokeOpacity={seriesOpacity(hovered, k)}
               fill={seriesColor(i)}
-              fillOpacity={0.35}
+              fillOpacity={seriesOpacity(hovered, k, 0.35)}
               isAnimationActive={false}
               connectNulls={!additive}
             />
@@ -328,6 +391,7 @@ function TimeSeries({
               key={k}
               dataKey={k}
               stroke={seriesColor(i)}
+              strokeOpacity={seriesOpacity(hovered, k)}
               dot={false}
               strokeWidth={1.5}
               isAnimationActive={false}
@@ -344,10 +408,12 @@ function Bars({
   result,
   seriesLabel,
   unit,
+  hovered = null,
 }: {
   result: WidgetQueryResult;
   seriesLabel?: string;
   unit?: FieldUnit;
+  hovered?: string | null;
 }) {
   const data = useColoredRows(result);
   return (
@@ -365,8 +431,14 @@ function Bars({
           content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} unit={unit} />}
         />
         <Bar dataKey="value" isAnimationActive={false}>
-          {data.map((_, i) => (
-            <Cell key={i} fill={seriesColor(i)} fillOpacity={0.7} stroke={seriesColor(i)} />
+          {data.map((d, i) => (
+            <Cell
+              key={i}
+              fill={seriesColor(i)}
+              fillOpacity={seriesOpacity(hovered, String((d as { name?: unknown }).name), 0.7)}
+              stroke={seriesColor(i)}
+              strokeOpacity={seriesOpacity(hovered, String((d as { name?: unknown }).name))}
+            />
           ))}
         </Bar>
       </BarChart>
@@ -374,13 +446,20 @@ function Bars({
   );
 }
 
-function PieView({ result, unit }: { result: WidgetQueryResult; unit?: FieldUnit }) {
+function PieView({
+  result,
+  unit,
+  hovered = null,
+}: {
+  result: WidgetQueryResult;
+  unit?: FieldUnit;
+  hovered?: string | null;
+}) {
   const data = useColoredRows(result);
   return (
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
       <PieChart>
         <Tooltip isAnimationActive={false} content={<ChartTip unit={unit} />} />
-        {/* Pie reads each sector's fill from its data row — no Cells needed. */}
         <Pie
           data={data}
           dataKey="value"
@@ -388,7 +467,16 @@ function PieView({ result, unit }: { result: WidgetQueryResult; unit?: FieldUnit
           innerRadius="45%"
           outerRadius="80%"
           isAnimationActive={false}
-        />
+        >
+          {/* Explicit Cells so legend hover can dim the other sectors. */}
+          {data.map((d, i) => (
+            <Cell
+              key={i}
+              fill={seriesColor(i)}
+              fillOpacity={seriesOpacity(hovered, String((d as { name?: unknown }).name))}
+            />
+          ))}
+        </Pie>
       </PieChart>
     </ResponsiveContainer>
   );
@@ -520,6 +608,26 @@ export function QueryWidgetRenderer({
   agg?: (typeof AGGS)[number];
 }) {
   const additive = agg === undefined || !NON_ADDITIVE_AGGS.has(agg);
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  // Multi-series charts get a legend under the plot; everything else
+  // (single series, stat tiles, tables, histograms) stays legend-free.
+  const legend = useMemo(() => {
+    if (result.rows.length === 0) return null;
+    if (display === "line" || display === "area") return legendFor(result, additive);
+    if (display === "bar" || display === "pie") return categoricalLegend(result, additive);
+    return null;
+  }, [display, result, additive]);
+  // A background refresh can drop the hovered series between renders; a stale
+  // key matches nothing and would dim EVERY series — treat it as no hover.
+  const hoveredInLegend =
+    hoveredKey !== null && (legend?.entries.some((e) => e.key === hoveredKey) ?? false);
+  // Mask a stale key this render, and clear it from state so a series that
+  // RETURNS in a later refresh doesn't resurrect the dim with no row hovered.
+  useEffect(() => {
+    if (hoveredKey !== null && !hoveredInLegend) setHoveredKey(null);
+  }, [hoveredKey, hoveredInLegend]);
+  const hovered = hoveredInLegend ? hoveredKey : null;
+
   if (result.rows.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
@@ -527,36 +635,55 @@ export function QueryWidgetRenderer({
       </div>
     );
   }
-  switch (display) {
-    case "line":
-      return (
-        <TimeSeries
-          result={result}
-          area={false}
-          seriesLabel={seriesLabel}
-          additive={additive}
-          unit={unit}
-        />
-      );
-    case "area":
-      return (
-        <TimeSeries
-          result={result}
-          area
-          seriesLabel={seriesLabel}
-          additive={additive}
-          unit={unit}
-        />
-      );
-    case "bar":
-      return <Bars result={result} seriesLabel={seriesLabel} unit={unit} />;
-    case "pie":
-      return <PieView result={result} unit={unit} />;
-    case "number":
-      return <NumberView result={result} unit={unit} />;
-    case "table":
-      return <TableView result={result} unit={unit} />;
-    case "histogram":
-      return <HistogramView result={result} seriesLabel={seriesLabel} />;
-  }
+
+  const chart = (() => {
+    switch (display) {
+      case "line":
+        return (
+          <TimeSeries
+            result={result}
+            area={false}
+            seriesLabel={seriesLabel}
+            additive={additive}
+            unit={unit}
+            hovered={hovered}
+          />
+        );
+      case "area":
+        return (
+          <TimeSeries
+            result={result}
+            area
+            seriesLabel={seriesLabel}
+            additive={additive}
+            unit={unit}
+            hovered={hovered}
+          />
+        );
+      case "bar":
+        return <Bars result={result} seriesLabel={seriesLabel} unit={unit} hovered={hovered} />;
+      case "pie":
+        return <PieView result={result} unit={unit} hovered={hovered} />;
+      case "number":
+        return <NumberView result={result} unit={unit} />;
+      case "table":
+        return <TableView result={result} unit={unit} />;
+      case "histogram":
+        return <HistogramView result={result} seriesLabel={seriesLabel} />;
+    }
+  })();
+
+  if (!legend) return chart;
+  return (
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1">{chart}</div>
+      <ChartLegend
+        entries={legend.entries}
+        total={legend.total}
+        format={(v) => fmtValueWithUnit(v, unit)}
+        hoveredKey={hovered}
+        onHoverKey={setHoveredKey}
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## What

Multi-series widgets (breakdown lines/areas, bar and pie categories) had no legend — colors were only decipherable by hovering the marks. This adds a compact legend under the plot: swatch · label · right-aligned value, sorted by value.

- **Window totals**: additive measures (count/sum) show each series' window total plus a Total row. Non-additive measures (avg/percentiles) show the mean of their non-null buckets and no Total — bucketed percentiles can't be re-aggregated honestly.
- **"N more" popover**: the tile shows the top three rows; the rest open in a popover anchored to the button, portaled out of the widget card so it neither covers the chart nor resizes the grid tile, collision-flipping near viewport edges. Escape, an outside click, or the toggle closes it.
- **Hover highlight**: hovering a legend row dims every other series in the chart (lines, areas, bar and pie cells). Colors stay bound to each series' pivot index, not its sorted legend position, so legend swatches always match the marks. A background refresh that drops the hovered series clears the dim, and closing the popover clears any hover held by an unmounted row.
- **Palette rework**: the categorical series palette grows from 8 to 12 hues, ordered so consecutive series land on opposite sides of the hue wheel (a 2–4 series chart always gets maximally separated colors), with the gray dropped — a gray series read as muted rather than real data. Five of the original hues are retained so existing dashboards don't reskin jarringly.
- **Focus-outline fix**: clicking a bar/line/sector focused the SVG mark itself and painted the browser's focus outline around it; the chart focus reset now suppresses the outline on every focused descendant (charts have no keyboard-interaction model; the legend's rows and buttons sit outside the reset and keep their focus rings).

Values format through the existing unit-aware formatter ($, ms, compact); labels truncate with a title tooltip. Single-series charts, stat tiles, tables, histograms, and trace feeds stay legend-free.

## Implementation notes

- The legend derives from the same `pivotRows` call (including the additive-vs-null gap polarity) the charts draw from, so keys, colors, and gap semantics can't drift.
- Tile rows go `aria-hidden` while the popover mirrors them, so assistive tech sees one list, not two.
- The popover trigger stays mounted while open even if a refresh shrinks the list below the cap — unmounting it would strand the portaled content with no anchor.

## Follow-ups (noted, not built)

- Very high-cardinality breakdowns ultimately want a backend top-N + "Other" rollup; past ~12 hues the palette wraps and legend labels do the disambiguating.
- The legend row markup mirrors the tooltip's — worth extracting a shared row primitive if a third value-row surface appears.

## Testing

`ChartLegend` unit tests cover sorting, Total behavior, the popover expansion via `role="dialog"`, hover-clear on close, and null-value formatting. Renderer integration tests cover legend presence per display type, per-series window totals vs bucket means, and hover dimming with exact opacity values. Full frontend suite passes; diff coverage 100% on changed lines.

Part of the project dashboards epic: #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact per‑series legend to multi‑series charts (line/area breakdowns, bar, pie) with window totals and a hover highlight to make categories and values clear at a glance.

- **New Features**
  - Swatch · label · right‑aligned value, sorted by value.
  - Additive aggs (`sum`, `count`) show per‑series window totals plus a Total; non‑additive (`avg`, percentiles) show per‑series means with no Total.
  - Top 3 rows show in‑tile; an “N more” button opens a popover that doesn’t cover the chart or resize the tile. Closing the popover clears hover.
  - Hovering a legend row dims the other series across lines, areas, bars, and pie sectors; colors stay bound to each series’ pivot index. Background refreshes that drop the hovered series clear the dim.
  - Expanded categorical palette from 8 to 12 high‑contrast hues; gray removed.
  - Values use the existing unit formatter (e.g., $, ms); labels truncate with a title tooltip.
  - Single‑series charts, stat tiles, tables, and histograms remain legend‑free.

- **Bug Fixes**
  - Suppressed browser focus outlines on all chart marks so clicks no longer paint stray outlines (legend controls keep their focus rings).

<sup>Written for commit 537f08d7c668cc7e102f575f95e6cf7610dd2b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

