### PR TITLE
chore(ui): drop the widget Duplicate action

### DIFF
--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -45,12 +45,6 @@ const updateLayout: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; erro
     isPending: false,
     error: null,
   };
-const createWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
-  {
-    mutate: vi.fn(),
-    isPending: false,
-    error: null,
-  };
 const removeWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
   {
     mutate: vi.fn(),
@@ -62,7 +56,6 @@ vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
   useDashboard: vi.fn(),
   useDashboardMutations: () => ({
     updateLayout,
-    createWidget,
     removeWidget,
   }),
 }));
@@ -73,7 +66,6 @@ let lastGridProps: {
   range: unknown;
   readOnly?: boolean;
   onEdit: (w: Widget) => void;
-  onDuplicate: (w: Widget) => void;
   onDelete: (w: Widget) => void;
 } | null = null;
 
@@ -84,7 +76,6 @@ vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
     range: unknown;
     readOnly?: boolean;
     onEdit: (w: Widget) => void;
-    onDuplicate: (w: Widget) => void;
     onDelete: (w: Widget) => void;
   }) => {
     lastGridProps = props;
@@ -93,7 +84,6 @@ vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
         {props.widgets.map((w) => (
           <div key={w.id}>
             <button onClick={() => props.onEdit(w)}>{`edit-${w.id}`}</button>
-            <button onClick={() => props.onDuplicate(w)}>{`duplicate-${w.id}`}</button>
             <button onClick={() => props.onDelete(w)}>{`delete-${w.id}`}</button>
           </div>
         ))}
@@ -153,7 +143,6 @@ describe("DashboardDetailPage", () => {
     push.mockReset();
     replace.mockReset();
     updateLayout.mutate.mockReset();
-    createWidget.mutate.mockReset();
     removeWidget.mutate.mockReset();
     lastGridProps = null;
     mockDetail({ ...DASH_A, layout: [], widgets: [] });
@@ -269,7 +258,7 @@ describe("DashboardDetailPage", () => {
     expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
   });
 
-  it("passes widgets, layout and range to the grid and wires edit/duplicate/delete", () => {
+  it("passes widgets, layout and range to the grid and wires edit/delete", () => {
     mockDetail({
       ...DASH_A,
       layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }],
@@ -282,15 +271,6 @@ describe("DashboardDetailPage", () => {
     expect(lastGridProps?.layout).toEqual([{ i: "w1", x: 0, y: 0, w: 4, h: 4 }]);
     expect(lastGridProps?.range).toHaveProperty("start");
     expect(lastGridProps?.range).toHaveProperty("end");
-
-    fireEvent.click(screen.getByRole("button", { name: "duplicate-w1" }));
-    expect(createWidget.mutate).toHaveBeenCalledWith({
-      title: "Cost (copy)",
-      type: "query",
-      spec: WIDGET.spec,
-      // A duplicate carries the display settings too, not just the query.
-      displayConfig: WIDGET.displayConfig,
-    });
 
     fireEvent.click(screen.getByRole("button", { name: "delete-w1" }));
     expect(removeWidget.mutate).toHaveBeenCalledWith("w1");

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -22,10 +22,7 @@ export default function DashboardDetailPage() {
   // ── remote data ──────────────────────────────────────────────────────────────
   const { data: dashboard, error: dashboardError } = useDashboard(projectId, dashboardId);
 
-  const { updateLayout, createWidget, removeWidget } = useDashboardMutations(
-    projectId,
-    dashboardId,
-  );
+  const { updateLayout, removeWidget } = useDashboardMutations(projectId, dashboardId);
 
   // ── time range — the same URL-synced filter AND default the trace list uses ──
   const { dateFilter, customStartDate, customEndDate, setDateFilter, setCustomRange, timestamps } =
@@ -94,19 +91,6 @@ export default function DashboardDetailPage() {
       updateLayout.mutate(layout);
     },
     [updateLayout],
-  );
-
-  // ── duplicate widget ─────────────────────────────────────────────────────────
-  const handleDuplicate = useCallback(
-    (w: Widget) => {
-      createWidget.mutate({
-        title: `${w.title} (copy)`,
-        type: w.type,
-        spec: w.spec,
-        displayConfig: w.displayConfig,
-      });
-    },
-    [createWidget],
   );
 
   // ── delete widget ────────────────────────────────────────────────────────────
@@ -196,7 +180,6 @@ export default function DashboardDetailPage() {
               width={width}
               onLayoutChange={handleLayoutChange}
               onEdit={openEdit}
-              onDuplicate={handleDuplicate}
               onDelete={handleDelete}
             />
           )}

--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
@@ -73,7 +73,6 @@ describe("DashboardGrid", () => {
           width={1000}
           onLayoutChange={vi.fn()}
           onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
           onDelete={vi.fn()}
         />,
       );
@@ -99,7 +98,6 @@ describe("DashboardGrid", () => {
           width={1000}
           onLayoutChange={vi.fn()}
           onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
           onDelete={vi.fn()}
         />,
       );
@@ -118,7 +116,6 @@ describe("DashboardGrid", () => {
           width={1000}
           onLayoutChange={vi.fn()}
           onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
           onDelete={vi.fn()}
         />,
       );
@@ -146,7 +143,6 @@ describe("DashboardGrid", () => {
           width={1000}
           onLayoutChange={onLayoutChange}
           onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
           onDelete={vi.fn()}
         />,
       );

--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
@@ -22,7 +22,6 @@ export function DashboardGrid({
   width,
   onLayoutChange,
   onEdit,
-  onDuplicate,
   onDelete,
 }: {
   projectId: string;
@@ -32,7 +31,6 @@ export function DashboardGrid({
   width: number;
   onLayoutChange: (layout: LayoutItem[]) => void;
   onEdit: (w: Widget) => void;
-  onDuplicate: (w: Widget) => void;
   onDelete: (w: Widget) => void;
 }) {
   // Widgets missing from layout (e.g. just created) get appended at the bottom.
@@ -121,7 +119,6 @@ export function DashboardGrid({
             widget={w}
             range={range}
             onEdit={() => onEdit(w)}
-            onDuplicate={() => onDuplicate(w)}
             onDelete={() => onDelete(w)}
           />
         </div>

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
@@ -50,22 +50,14 @@ function makeWidget(overrides: Partial<Widget> = {}): Widget {
 
 function renderCard(
   widget: Widget,
-  callbacks: Partial<{ onEdit: () => void; onDuplicate: () => void; onDelete: () => void }> = {},
+  callbacks: Partial<{ onEdit: () => void; onDelete: () => void }> = {},
 ) {
   const onEdit = callbacks.onEdit ?? vi.fn();
-  const onDuplicate = callbacks.onDuplicate ?? vi.fn();
   const onDelete = callbacks.onDelete ?? vi.fn();
   render(
-    <WidgetCard
-      projectId="p1"
-      widget={widget}
-      range={RANGE}
-      onEdit={onEdit}
-      onDuplicate={onDuplicate}
-      onDelete={onDelete}
-    />,
+    <WidgetCard projectId="p1" widget={widget} range={RANGE} onEdit={onEdit} onDelete={onDelete} />,
   );
-  return { onEdit, onDuplicate, onDelete };
+  return { onEdit, onDelete };
 }
 
 async function openMenu() {
@@ -97,29 +89,21 @@ describe("WidgetCard menu gating", () => {
     expect(screen.queryByRole("menuitem", { name: "Edit" })).toBeNull();
   });
 
-  it("always shows Duplicate and Delete, wired to their callbacks", async () => {
+  it("always shows Delete wired to its callback, and no Duplicate item", async () => {
     useWidgetData.mockReturnValue({ data: undefined, isPending: false, error: null });
-    const { onDuplicate, onDelete } = renderCard(makeWidget());
+    const { onDelete } = renderCard(makeWidget());
 
     await openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
-    expect(onDuplicate).toHaveBeenCalledTimes(1);
-
-    await openMenu();
+    expect(screen.queryByRole("menuitem", { name: "Duplicate" })).toBeNull();
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
 
-  it("still shows Duplicate and Delete for a non-query widget", async () => {
-    const { onDuplicate, onDelete } = renderCard(
-      makeWidget({ type: "trace_feed", spec: { limit: 5 } }),
-    );
+  it("still shows Delete for a non-query widget", async () => {
+    const { onDelete } = renderCard(makeWidget({ type: "trace_feed", spec: { limit: 5 } }));
 
     await openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
-    expect(onDuplicate).toHaveBeenCalledTimes(1);
-
-    await openMenu();
+    expect(screen.queryByRole("menuitem", { name: "Duplicate" })).toBeNull();
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
     expect(onDelete).toHaveBeenCalledTimes(1);
   });

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -73,14 +73,12 @@ export function WidgetCard({
   widget,
   range,
   onEdit,
-  onDuplicate,
   onDelete,
 }: {
   projectId: string;
   widget: Widget;
   range: TimeRange;
   onEdit: () => void;
-  onDuplicate: () => void;
   onDelete: () => void;
 }) {
   return (
@@ -102,7 +100,6 @@ export function WidgetCard({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             {widget.type === "query" && <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>}
-            <DropdownMenuItem onSelect={onDuplicate}>Duplicate</DropdownMenuItem>
             <DropdownMenuItem onSelect={onDelete} className="text-red-600 focus:text-red-600">
               Delete
             </DropdownMenuItem>


### PR DESCRIPTION
## What

Removes Duplicate from the widget card's options menu, along with its plumbing: the `onDuplicate` prop through `DashboardGrid`, and the detail page's `handleDuplicate` callback plus its now-unused `createWidget` mutation destructure. The menu keeps Edit (query widgets) and Delete.

## Why

The action added little over creating a widget fresh — the builder opens prefilled in a couple of clicks — while carrying real rough edges: the blind `"(copy)"` title suffix could silently exceed the widget title cap with no error surface, and repeated copies stacked indistinguishable `"(copy) (copy)"` tiles. Retiring the action retires that known follow-up with it.

`createWidget` in the data hooks stays: the widget builder is its remaining consumer, so nothing upstream goes dead.

## Testing

Tests updated in place: the grid-wiring test asserts edit/delete only, both widget-card menu tests assert the Duplicate item is gone (query and trace-feed variants) while still clicking Delete through the real menu, and the page test's orphaned `createWidget` mock fixture is dropped. Full frontend suite passes; diff coverage 100% on changed lines.

Stacked on the chart-legend PR; merge order follows the stack.

Part of the project dashboards epic: #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the widget Duplicate action and all related wiring across dashboards. The menu now only shows Edit (query widgets) and Delete, avoiding "(copy)" title issues and simplifying the flow.

- **Refactors**
  - Removed onDuplicate from DashboardGrid and WidgetCard; deleted the Duplicate menu item.
  - Dropped handleDuplicate and removed createWidget usage/destructure in the dashboard detail page; the builder still uses createWidget.
  - Updated tests to assert no Duplicate item (query and non-query), keep Delete behavior, and remove the unused createWidget mock.

<sup>Written for commit 89a3e297c3c9aa43a9b2315070094c63d7d44ec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

