### PR TITLE
fix(pricing): strip gateway/router prefixes before model price lookup

### DIFF
--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -77,17 +77,66 @@ def _load_cache() -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
+# Gateway/router prefix normalisation
+# ---------------------------------------------------------------------------
+
+# Prefixes injected by LiteLLM, OpenRouter, and cloud provider SDKs before
+# the bare model name.  Strip them so `get_model_price` can match models like
+# `vertex_ai/gemini-2.5-pro` or `openrouter/anthropic/claude-opus-4-8` against
+# the same patterns used for plain `gemini-2.5-pro` / `claude-opus-4-8`.
+_GATEWAY_PREFIXES = frozenset(
+    {
+        "openai",
+        "azure",
+        "google",
+        "googleai",
+        "vertex_ai",
+        "anthropic",
+        "bedrock",
+        "openrouter",
+        "litellm",
+        "models",
+        "deepseek",
+        "xai",
+        "moonshot",
+        "zai",
+    }
+)
+
+
+def _strip_gateway_prefix(model: str) -> str:
+    """Strip one or more leading gateway/router prefixes separated by ``/``.
+
+    Iterates so chained prefixes like ``openrouter/anthropic/claude-opus-4-8``
+    or ``litellm/openai/gpt-5`` are fully reduced.  Stops as soon as the first
+    path segment is not a recognised gateway name, leaving Bedrock dot-format
+    (``us.anthropic.claude-...``) and Vertex ``@date`` variants unchanged.
+    """
+    while True:
+        slash = model.find("/")
+        if slash == -1:
+            break
+        prefix = model[:slash].lower()
+        if prefix not in _GATEWAY_PREFIXES:
+            break
+        model = model[slash + 1 :]
+    return model
+
+
+# ---------------------------------------------------------------------------
 # Public API (unchanged signatures)
 # ---------------------------------------------------------------------------
 
 
 def get_model_price(model: str) -> dict[str, float] | None:
-    """Lookup price for model. Tries exact match, then regex fallback.
+    """Lookup price for model. Normalises gateway prefixes, then tries exact
+    match and regex fallback.
 
     Returns dict with keys like ``input``, ``output``, ``cacheRead``, ``cacheWrite``
     (values in USD per token), or None if not found.
     """
     cache = _load_cache()
+    model = _strip_gateway_prefix(model)
 
     # Exact match on model_name
     for entry in cache:

--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -94,7 +94,6 @@ _GATEWAY_PREFIXES = frozenset(
         "anthropic",
         "bedrock",
         "openrouter",
-        "litellm",
         "models",
         "deepseek",
         "xai",
@@ -107,9 +106,9 @@ _GATEWAY_PREFIXES = frozenset(
 def _strip_gateway_prefix(model: str) -> str:
     """Strip one or more leading gateway/router prefixes separated by ``/``.
 
-    Iterates so chained prefixes like ``openrouter/anthropic/claude-opus-4-8``
-    or ``litellm/openai/gpt-5`` are fully reduced.  Stops as soon as the first
-    path segment is not a recognised gateway name, leaving Bedrock dot-format
+    Iterates so a chained prefix like ``openrouter/anthropic/claude-opus-4-8``
+    is fully reduced.  Stops as soon as the first path segment is not a
+    recognised gateway name, leaving Bedrock dot-format
     (``us.anthropic.claude-...``) and Vertex ``@date`` variants unchanged.
     """
     while True:

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
-from worker.tokens.pricing import calculate_cost, get_model_price
+from worker.tokens.pricing import _strip_gateway_prefix, calculate_cost, get_model_price
 
 MATCHED_MODEL_NAME = "__matched_model_name"
 
@@ -172,6 +172,83 @@ DEEPSEEK_MODEL_CASES = [
     ("deepseek/deepseek-v4-pro", "deepseek-v4-pro"),
     ("deepseek-v4-pro-20260424", "deepseek-v4-pro"),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Gateway/router prefix normalisation — unit tests for _strip_gateway_prefix
+# and integration tests against the real price table.
+# ---------------------------------------------------------------------------
+
+# Cases where a gateway/router prefix must be stripped before the bare model
+# name can be matched.  These previously returned None (issue #1556).
+GATEWAY_PREFIX_CASES = [
+    # vertex_ai/ — not included in any Gemini pattern
+    ("vertex_ai/gemini-2.5-pro", "gemini-2.5-pro"),
+    ("vertex_ai/gemini-2.5-flash", "gemini-2.5-flash"),
+    # azure/ on models whose patterns only cover openai/ (gpt-5.4 and below)
+    ("azure/gpt-5.4", "gpt-5.4"),
+    ("azure/gpt-5.4-mini", "gpt-5.4-mini"),
+    ("azure/gpt-5", "gpt-5"),
+    # openrouter/ — single prefix
+    ("openrouter/gpt-5", "gpt-5"),
+    ("openrouter/gemini-2.5-pro", "gemini-2.5-pro"),
+    ("openrouter/claude-opus-4-8", "claude-opus-4-8"),
+    # openrouter/ — double prefix (openrouter/provider/model)
+    ("openrouter/anthropic/claude-opus-4-8", "claude-opus-4-8"),
+    ("openrouter/openai/gpt-5", "gpt-5"),
+    ("openrouter/google/gemini-2.5-pro", "gemini-2.5-pro"),
+    # litellm/ — single prefix
+    ("litellm/gpt-5", "gpt-5"),
+    ("litellm/gemini-2.5-pro", "gemini-2.5-pro"),
+    # litellm/ — double prefix (litellm/provider/model)
+    ("litellm/openai/gpt-5", "gpt-5"),
+    ("litellm/anthropic/claude-opus-4-8", "claude-opus-4-8"),
+    # googleai/ — not included in any Gemini pattern
+    ("googleai/gemini-2.5-pro", "gemini-2.5-pro"),
+]
+
+
+class TestStripGatewayPrefix:
+    def test_no_prefix_unchanged(self):
+        assert _strip_gateway_prefix("gpt-5") == "gpt-5"
+
+    def test_single_known_prefix_stripped(self):
+        assert _strip_gateway_prefix("openai/gpt-5") == "gpt-5"
+        assert _strip_gateway_prefix("vertex_ai/gemini-2.5-pro") == "gemini-2.5-pro"
+        assert _strip_gateway_prefix("litellm/gpt-5") == "gpt-5"
+
+    def test_double_prefix_fully_stripped(self):
+        assert _strip_gateway_prefix("openrouter/anthropic/claude-opus-4-8") == "claude-opus-4-8"
+        assert _strip_gateway_prefix("litellm/openai/gpt-5") == "gpt-5"
+
+    def test_unknown_prefix_unchanged(self):
+        assert _strip_gateway_prefix("my-gateway/gpt-5") == "my-gateway/gpt-5"
+
+    def test_bedrock_dot_format_unchanged(self):
+        # Bedrock uses dots, not slashes — must not be altered.
+        assert (
+            _strip_gateway_prefix("us.anthropic.claude-opus-4-8-20260601-v1:0")
+            == "us.anthropic.claude-opus-4-8-20260601-v1:0"
+        )
+
+    def test_vertex_at_date_format_unchanged(self):
+        # Vertex AI bare format uses @date separator, no slash prefix.
+        assert _strip_gateway_prefix("claude-4-8-opus@20260601") == "claude-4-8-opus@20260601"
+
+
+class TestGatewayPrefixedModelIds:
+    @pytest.mark.parametrize("model_id,expected_name", GATEWAY_PREFIX_CASES)
+    def test_gateway_prefixed_model_resolves(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+
+        assert price is not None, (
+            f"{model_id!r} should resolve to {expected_name!r} but returned None"
+        )
+        assert "input" in price and "output" in price
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id!r} matched {price[MATCHED_MODEL_NAME]!r}, expected {expected_name!r}"
+        )
 
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -1,6 +1,7 @@
 """Unit tests for model pricing and cost calculation."""
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -248,6 +249,27 @@ class TestGatewayPrefixedModelIds:
         assert "input" in price and "output" in price
         assert price[MATCHED_MODEL_NAME] == expected_name, (
             f"{model_id!r} matched {price[MATCHED_MODEL_NAME]!r}, expected {expected_name!r}"
+        )
+
+    @pytest.mark.parametrize("model_id,expected_name", GATEWAY_PREFIX_CASES)
+    def test_stripped_id_matches_exactly_one_entry(self, real_cache, model_id, expected_name):
+        """get_model_price returns the first entry that matches and stops there,
+        so if prefix-stripping ever made a string ambiguous between two catalog
+        entries, a silent collision would hide behind whichever happens to sit
+        first in the cache. Re-run the same exact/regex matching independently
+        here, but count every entry that matches instead of short-circuiting,
+        to lock in that each stripped id is unambiguous.
+        """
+        stripped = _strip_gateway_prefix(model_id)
+        matches = [
+            entry["model_name"]
+            for entry in real_cache
+            if entry["model_name"] == stripped
+            or re.search(entry["match_pattern"], stripped, re.IGNORECASE)
+        ]
+        assert matches == [expected_name], (
+            f"{model_id!r} (stripped to {stripped!r}) matched {matches!r}, "
+            f"expected exactly one match: {expected_name!r}"
         )
 
 

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -198,12 +198,6 @@ GATEWAY_PREFIX_CASES = [
     ("openrouter/anthropic/claude-opus-4-8", "claude-opus-4-8"),
     ("openrouter/openai/gpt-5", "gpt-5"),
     ("openrouter/google/gemini-2.5-pro", "gemini-2.5-pro"),
-    # litellm/ — single prefix
-    ("litellm/gpt-5", "gpt-5"),
-    ("litellm/gemini-2.5-pro", "gemini-2.5-pro"),
-    # litellm/ — double prefix (litellm/provider/model)
-    ("litellm/openai/gpt-5", "gpt-5"),
-    ("litellm/anthropic/claude-opus-4-8", "claude-opus-4-8"),
     # googleai/ — not included in any Gemini pattern
     ("googleai/gemini-2.5-pro", "gemini-2.5-pro"),
 ]
@@ -216,14 +210,18 @@ class TestStripGatewayPrefix:
     def test_single_known_prefix_stripped(self):
         assert _strip_gateway_prefix("openai/gpt-5") == "gpt-5"
         assert _strip_gateway_prefix("vertex_ai/gemini-2.5-pro") == "gemini-2.5-pro"
-        assert _strip_gateway_prefix("litellm/gpt-5") == "gpt-5"
 
     def test_double_prefix_fully_stripped(self):
         assert _strip_gateway_prefix("openrouter/anthropic/claude-opus-4-8") == "claude-opus-4-8"
-        assert _strip_gateway_prefix("litellm/openai/gpt-5") == "gpt-5"
 
     def test_unknown_prefix_unchanged(self):
         assert _strip_gateway_prefix("my-gateway/gpt-5") == "my-gateway/gpt-5"
+
+    def test_litellm_prefix_unchanged(self):
+        # LiteLLM never emits a literal "litellm/" segment — when it routes
+        # through OpenRouter the id is openrouter/<provider>/<model>, not
+        # litellm/openrouter/... — so "litellm" is not a recognised prefix.
+        assert _strip_gateway_prefix("litellm/gpt-5") == "litellm/gpt-5"
 
     def test_bedrock_dot_format_unchanged(self):
         # Bedrock uses dots, not slashes — must not be altered.


### PR DESCRIPTION
## Problem

When a model name is sent with a gateway/router prefix — e.g. `vertex_ai/gemini-2.5-pro`, or `openrouter/anthropic/claude-opus-4-8` (OpenRouter-via-LiteLLM, where LiteLLM prepends its `openrouter/` provider tag onto OpenRouter's own `anthropic/<model>` id) — `get_model_price` returns `None` and the span is recorded with `$0` cost. This happens because the exact-match pass compares the full string (including prefix) against `model_name`, and the regex patterns in `standard-model-prices.json` only cover a subset of prefixes (e.g. `(openai\/)?`, `(azure\/)?`) — never `vertex_ai/`, `openrouter/`, `googleai/`, or chained double-prefixes.

Fixes #1556.

## Solution

Added `_strip_gateway_prefix(model)` in `backend/worker/tokens/pricing.py`. It iterates over the leading `/`-separated segments and removes each one while it is a known gateway name. This normalises the model string before it enters the exact-match / regex lookup:

```
vertex_ai/gemini-2.5-pro            → gemini-2.5-pro
openrouter/anthropic/claude-opus-4-8 → claude-opus-4-8  (two iterations)
azure/gpt-5.4                       → gpt-5.4
```

Note: `litellm` is deliberately **not** in the recognised prefix set. LiteLLM never emits a literal `litellm/` segment on the wire — when it routes through OpenRouter the id is `openrouter/<provider>/<model>`, not `litellm/openrouter/...` — so `litellm/gpt-5` correctly passes through unchanged (verified by a new unit test).

Bedrock dot-format (`us.anthropic.claude-…`) and Vertex `@date` variants (`claude-4-8-opus@20260601`) use `.` / `@` rather than `/`, so `model.find("/")` returns -1 immediately and they pass through unchanged — all existing Bedrock/Vertex test cases still pass.

The existing per-provider regex alternations (`(openai\/)?`, `(azure\/)?`, etc.) remain in `standard-model-prices.json` and continue to work; the normalisation step just makes every pattern work for every gateway prefix, not just the ones whose maintainers anticipated.

## Tests

- **`TestStripGatewayPrefix`** — 7 unit tests for the normaliser: no-prefix, single prefix, double prefix, unknown prefix (unchanged), `litellm/` specifically unchanged (not a recognised prefix), Bedrock/Vertex formats (unchanged).
- **`TestGatewayPrefixedModelIds`** — 12 parametrised integration tests against the real `standard-model-prices.json`, covering the previously-broken cases: `vertex_ai/`, `azure/gpt-5.4`, `openrouter/`, `openrouter/<provider>/`, `googleai/`.
- All existing tests continue to pass; **213 total** in `test_pricing.py`.

## Checklist

- [x] `backend/worker/tokens/pricing.py` — added `_GATEWAY_PREFIXES`, `_strip_gateway_prefix`, called from `get_model_price`
- [x] `tests/worker/tokens/test_pricing.py` — added `TestStripGatewayPrefix` + `TestGatewayPrefixedModelIds`
- [x] All 213 tests pass (`python -m pytest tests/worker/tokens/test_pricing.py`)
- [x] No changes to public API signatures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize model IDs by stripping gateway/router prefixes before price lookup so prefixed models resolve and costs are calculated correctly. Fixes #1556.

- **Bug Fixes**
  - Add `_strip_gateway_prefix` to remove known prefixes (e.g., `openai/`, `azure/`, `google/`, `googleai/`, `vertex_ai/`, `anthropic/`, `bedrock/`, `openrouter/`), including chained prefixes.
  - Call it in `get_model_price` before exact and regex matching.
  - Leave Bedrock dot-format and Vertex `@date` variants unchanged; do not strip `litellm/` (it isn’t emitted). Add a unit test to lock this in.
  - Add tests: unit tests for the normalizer, integration tests for prefixed IDs, and a guard that each stripped ID matches exactly one price entry.

<sup>Written for commit e2508b91464b1daf639e9704f0fccc9487ea76ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

