### PR TITLE
fix(worker): fail and retry RCA runs when the agent stream errors or produces no output

### DIFF
--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -451,6 +451,32 @@ describe("runRcaSession", () => {
       }),
     ).rejects.toThrow(/Invalid API key for provider/);
   });
+
+  it("surfaces the raw message when the error frame's data isn't JSON", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    // hono's own generic streamSSE `run()` wrapper (triggered when the route
+    // callback throws outside runAgent's own onError handling) writes
+    // `event: error` with a RAW string data payload — not our JSON shape.
+    const rawFrame = "event: error\ndata: Unexpected token in provider response\n\n";
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce(chunkedSseBody([rawFrame]));
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+    await expect(
+      runRcaSession({
+        findingId: "f1",
+        projectId: "p1",
+        workspaceId: "ws1",
+        traceId: "t1",
+        findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+        hasGitHub: false,
+      }),
+    ).rejects.toThrow(/Unexpected token in provider response/);
+  });
 });
 
 describe("processRcaJob", () => {

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -410,7 +410,58 @@ describe("processRcaJob", () => {
     expect(detectorRcaUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { findingId: "f1" },
-        data: { status: "failed" },
+        data: expect.objectContaining({
+          status: "failed",
+          result: expect.stringContaining("Prisma error"),
+          completedAt: expect.any(Date),
+        }),
+      }),
+    );
+  });
+
+  it("records the RCA agent's error message into result when the agent stream fails", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.workspace, "findUnique").mockResolvedValue({
+      billingPlan: "pro",
+      rcaBlocked: false,
+    } as any);
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+    const detectorRcaUpdate = vi.spyOn(p.detectorRca, "update").mockResolvedValue({} as any);
+    vi.spyOn(p.gitHubInstallation, "count").mockResolvedValue(0);
+    vi.spyOn(p.project, "findUnique").mockResolvedValue({
+      rcaModel: null,
+      rcaProvider: null,
+      rcaSource: null,
+      alertConfig: { alertWindow: "30m" },
+    } as any);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce(
+        sseBody([{ event: "error", data: { message: "Invalid API key for provider" } }]),
+      );
+
+    const { processRcaJob } = await import("../detector-rca-processor.js");
+    await expect(
+      processRcaJob({
+        data: {
+          findingId: "f1",
+          projectId: "p1",
+          traceId: "t1",
+          workspaceId: "ws1",
+          findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+        },
+      } as any),
+    ).rejects.toThrow(/Invalid API key for provider/);
+
+    expect(detectorRcaUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { findingId: "f1" },
+        data: expect.objectContaining({
+          status: "failed",
+          result: expect.stringContaining("Invalid API key for provider"),
+          completedAt: expect.any(Date),
+        }),
       }),
     );
   });

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -127,29 +127,40 @@ describe("resolveProjectModel", () => {
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
-// Encodes SSE frames the way hono's streamSSE/writeSSE does (event: <name>\n
-// data: <json>\n\n) into a single chunk, then a terminal `done` read — enough
-// to exercise the line-buffering consumer in runRcaSession without a real stream.
-function sseBody(frames: Array<{ event?: string; data: unknown }>) {
-  const text = frames
+// Encodes SSE frames the way hono's streamSSE/writeSSE does: event: <name>\n
+// data: <json>\n\n.
+function sseText(frames: Array<{ event?: string; data: unknown }>): string {
+  return frames
     .map((f) => `${f.event ? `event: ${f.event}\n` : ""}data: ${JSON.stringify(f.data)}\n\n`)
     .join("");
-  const bytes = new TextEncoder().encode(text);
-  let delivered = false;
+}
+
+// Delivers pre-split string chunks one per reader.read() call, then a
+// terminal `done` read — lets tests simulate SSE bytes arriving split at
+// arbitrary (including hostile) boundaries across the underlying TCP stream.
+function chunkedSseBody(chunks: string[]) {
+  const encoded = chunks.map((c) => new TextEncoder().encode(c));
+  let i = 0;
   return {
     ok: true,
     body: {
       getReader: () => ({
         read: () => {
-          if (!delivered) {
-            delivered = true;
-            return Promise.resolve({ done: false, value: bytes });
+          if (i < encoded.length) {
+            const value = encoded[i];
+            i += 1;
+            return Promise.resolve({ done: false, value });
           }
           return Promise.resolve({ done: true, value: undefined });
         },
       }),
     },
   };
+}
+
+// Single-chunk delivery — the common case exercised by most tests below.
+function sseBody(frames: Array<{ event?: string; data: unknown }>) {
+  return chunkedSseBody([sseText(frames)]);
 }
 
 const textDeltaFrame = {
@@ -296,6 +307,9 @@ describe("runRcaSession", () => {
             event: "message_end",
             data: { type: "message_end", message: { stopReason: "end_turn" } },
           },
+          // The real producer's onDone handler writes this terminal frame
+          // (frontend/packages/agent/src/index.ts) after a successful run.
+          { event: "done", data: {} },
         ]),
       );
 
@@ -311,6 +325,131 @@ describe("runRcaSession", () => {
 
     expect(result.result).toBe("Root cause: found it. Code location: foo.ts:12.");
     expect(result.sessionId).toBe("s1");
+  });
+
+  it("accumulates identical text when the same frames arrive split across multiple chunks at hostile boundaries", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    const frame1 = textDeltaFrame;
+    const frame2 = {
+      event: "message_update",
+      data: {
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: " Code location: foo.ts:12." },
+      },
+    };
+    const frame3 = {
+      event: "message_end",
+      data: { type: "message_end", message: { stopReason: "end_turn" } },
+    };
+    const frame4 = { event: "done", data: {} };
+    const frames = [frame1, frame2, frame3, frame4];
+
+    // Split hostilely: (1) frame1's `event:` line from its `data:` line, and
+    // (2) frame2's `data:` line mid-JSON, inside the delta string itself.
+    const f1Text = sseText([frame1]);
+    const f1SplitAt = f1Text.indexOf("data: ");
+    const f2Json = JSON.stringify(frame2.data);
+    const f2SplitInJson = f2Json.indexOf("Code location") + 5;
+
+    const chunks = [
+      f1Text.slice(0, f1SplitAt), // "event: message_update\n" only
+      f1Text.slice(f1SplitAt) + // rest of frame1
+        "event: message_update\ndata: " +
+        f2Json.slice(0, f2SplitInJson), // frame2's event + data prefix + half its JSON
+      f2Json.slice(f2SplitInJson) + "\n\n" + sseText([frame3, frame4]), // rest of frame2 + frame3 + frame4
+    ];
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce(chunkedSseBody(chunks))
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s2" }) })
+      .mockResolvedValueOnce(sseBody(frames));
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+    const chunkedResult = await runRcaSession({
+      findingId: "f1",
+      projectId: "p1",
+      workspaceId: "ws1",
+      traceId: "t1",
+      findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+      hasGitHub: false,
+    });
+    const singleChunkResult = await runRcaSession({
+      findingId: "f1",
+      projectId: "p1",
+      workspaceId: "ws1",
+      traceId: "t1",
+      findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+      hasGitHub: false,
+    });
+
+    expect(chunkedResult.result).toBe("Root cause: found it. Code location: foo.ts:12.");
+    expect(chunkedResult.result).toBe(singleChunkResult.result);
+  });
+
+  it("throws with the agent's message when an `event: error` frame is split across chunks", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    const errorText = sseText([
+      { event: "error", data: { message: "Invalid API key for provider" } },
+    ]);
+    const splitAt = errorText.indexOf("data: ");
+    const chunks = [errorText.slice(0, splitAt), errorText.slice(splitAt)];
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce(chunkedSseBody(chunks));
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+    await expect(
+      runRcaSession({
+        findingId: "f1",
+        projectId: "p1",
+        workspaceId: "ws1",
+        traceId: "t1",
+        findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+        hasGitHub: false,
+      }),
+    ).rejects.toThrow(/Invalid API key for provider/);
+  });
+
+  it("resets the current event name at the blank line so an event-less frame after an error isn't misread as another error", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce(
+        sseBody([
+          { event: "error", data: { message: "Invalid API key for provider" } },
+          // No `event:` line — if the blank line terminating the previous
+          // frame failed to reset currentEventName, this would be
+          // misclassified as another "error" data payload and its lack of a
+          // `message` field would overwrite the real error with
+          // "unknown agent error".
+          {
+            data: {
+              type: "message_update",
+              assistantMessageEvent: { type: "text_delta", delta: "some text" },
+            },
+          },
+        ]),
+      );
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+    await expect(
+      runRcaSession({
+        findingId: "f1",
+        projectId: "p1",
+        workspaceId: "ws1",
+        traceId: "t1",
+        findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+        hasGitHub: false,
+      }),
+    ).rejects.toThrow(/Invalid API key for provider/);
   });
 });
 
@@ -417,6 +556,9 @@ describe("processRcaJob", () => {
         }),
       }),
     );
+    // A failed RCA must still alert: scheduleDigestFlush runs from the catch
+    // block so the finding isn't silently dropped from the digest.
+    expect(digestAddMock).toHaveBeenCalledTimes(1);
   });
 
   it("records the RCA agent's error message into result when the agent stream fails", async () => {
@@ -464,6 +606,9 @@ describe("processRcaJob", () => {
         }),
       }),
     );
+    // A failed RCA must still alert: scheduleDigestFlush runs from the catch
+    // block so the finding isn't silently dropped from the digest.
+    expect(digestAddMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-rca-processor.test.ts
@@ -127,6 +127,39 @@ describe("resolveProjectModel", () => {
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);
 
+// Encodes SSE frames the way hono's streamSSE/writeSSE does (event: <name>\n
+// data: <json>\n\n) into a single chunk, then a terminal `done` read — enough
+// to exercise the line-buffering consumer in runRcaSession without a real stream.
+function sseBody(frames: Array<{ event?: string; data: unknown }>) {
+  const text = frames
+    .map((f) => `${f.event ? `event: ${f.event}\n` : ""}data: ${JSON.stringify(f.data)}\n\n`)
+    .join("");
+  const bytes = new TextEncoder().encode(text);
+  let delivered = false;
+  return {
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: () => {
+          if (!delivered) {
+            delivered = true;
+            return Promise.resolve({ done: false, value: bytes });
+          }
+          return Promise.resolve({ done: true, value: undefined });
+        },
+      }),
+    },
+  };
+}
+
+const textDeltaFrame = {
+  event: "message_update",
+  data: {
+    type: "message_update",
+    assistantMessageEvent: { type: "text_delta", delta: "Root cause: found it." },
+  },
+};
+
 describe("runRcaSession", () => {
   it("calls resolveProjectModel and builds message body", async () => {
     fetchProviderConfigMock.mockResolvedValue({
@@ -139,12 +172,7 @@ describe("runRcaSession", () => {
 
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        body: {
-          getReader: () => ({ read: () => Promise.resolve({ done: true, value: undefined }) }),
-        },
-      });
+      .mockResolvedValueOnce(sseBody([textDeltaFrame]));
 
     const { prisma: p } = await import("@traceroot/core");
     vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
@@ -164,6 +192,125 @@ describe("runRcaSession", () => {
 
     expect(result.sessionId).toBe("s1");
     expect(fetchProviderConfigMock).toHaveBeenCalledWith("ws1", "my-openai");
+  });
+
+  it("throws with the agent's message when the stream carries an `event: error` frame", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce(
+        sseBody([{ event: "error", data: { message: "Invalid API key for provider" } }]),
+      );
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+    await expect(
+      runRcaSession({
+        findingId: "f1",
+        projectId: "p1",
+        workspaceId: "ws1",
+        traceId: "t1",
+        findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+        hasGitHub: false,
+      }),
+    ).rejects.toThrow(/Invalid API key for provider/);
+  });
+
+  it('throws when message_end reports stopReason "error"', async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce(
+        sseBody([
+          {
+            event: "message_end",
+            data: {
+              type: "message_end",
+              message: { stopReason: "error", errorMessage: "Model overloaded" },
+            },
+          },
+        ]),
+      );
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+    await expect(
+      runRcaSession({
+        findingId: "f1",
+        projectId: "p1",
+        workspaceId: "ws1",
+        traceId: "t1",
+        findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+        hasGitHub: false,
+      }),
+    ).rejects.toThrow(/Model overloaded/);
+  });
+
+  it("throws when the stream ends with no accumulated text", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce(
+        sseBody([
+          {
+            event: "message_end",
+            data: { type: "message_end", message: { stopReason: "end_turn" } },
+          },
+        ]),
+      );
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+    await expect(
+      runRcaSession({
+        findingId: "f1",
+        projectId: "p1",
+        workspaceId: "ws1",
+        traceId: "t1",
+        findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+        hasGitHub: false,
+      }),
+    ).rejects.toThrow(/no output/i);
+  });
+
+  it("returns accumulated text unchanged for a healthy stream (regression guard)", async () => {
+    const { prisma: p } = await import("@traceroot/core");
+    vi.spyOn(p.detectorRca, "upsert").mockResolvedValue({} as any);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
+      .mockResolvedValueOnce(
+        sseBody([
+          textDeltaFrame,
+          {
+            event: "message_update",
+            data: {
+              type: "message_update",
+              assistantMessageEvent: { type: "text_delta", delta: " Code location: foo.ts:12." },
+            },
+          },
+          {
+            event: "message_end",
+            data: { type: "message_end", message: { stopReason: "end_turn" } },
+          },
+        ]),
+      );
+
+    const { runRcaSession } = await import("../detector-rca-processor.js");
+    const result = await runRcaSession({
+      findingId: "f1",
+      projectId: "p1",
+      workspaceId: "ws1",
+      traceId: "t1",
+      findings: [{ detectorName: "d1", summary: "s1", detectorId: "did1" }],
+      hasGitHub: false,
+    });
+
+    expect(result.result).toBe("Root cause: found it. Code location: foo.ts:12.");
+    expect(result.sessionId).toBe("s1");
   });
 });
 
@@ -188,12 +335,7 @@ describe("processRcaJob", () => {
 
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        body: {
-          getReader: () => ({ read: () => Promise.resolve({ done: true, value: undefined }) }),
-        },
-      });
+      .mockResolvedValueOnce(sseBody([textDeltaFrame]));
 
     const { processRcaJob } = await import("../detector-rca-processor.js");
     await processRcaJob({
@@ -297,15 +439,10 @@ describe("processRcaJob — digest scheduling at the flush seam", () => {
       alertConfig,
     } as any);
 
-    // Agent session create + empty SSE stream → RCA completes with "".
+    // Agent session create + a healthy SSE stream → RCA completes with text.
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        body: {
-          getReader: () => ({ read: () => Promise.resolve({ done: true, value: undefined }) }),
-        },
-      });
+      .mockResolvedValueOnce(sseBody([textDeltaFrame]));
 
     const { processRcaJob } = await import("../detector-rca-processor.js");
     await processRcaJob({
@@ -379,12 +516,7 @@ describe("processRcaJob — digest scheduling at the flush seam", () => {
 
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => ({ id: "s1" }) })
-      .mockResolvedValueOnce({
-        ok: true,
-        body: {
-          getReader: () => ({ read: () => Promise.resolve({ done: true, value: undefined }) }),
-        },
-      });
+      .mockResolvedValueOnce(sseBody([textDeltaFrame]));
 
     // RCA completes, then the digest enqueue fails on the success path.
     digestAddMock.mockRejectedValueOnce(new Error("redis down"));

--- a/frontend/worker/src/processors/__tests__/detector-run-processor.test.ts
+++ b/frontend/worker/src/processors/__tests__/detector-run-processor.test.ts
@@ -182,6 +182,42 @@ describe("processTrace — finding + RCA", () => {
     expect(mockQueueAdd.mock.calls[0][1].findingTimestamp).toBe(ts);
   });
 
+  it("enqueues the RCA job with retry attempts and backoff so transient agent failures retry", async () => {
+    mockFetches(60_000, '{"span":1}\n');
+    mockPrisma.detector.findMany.mockResolvedValue([
+      {
+        id: "d1",
+        name: "Slow",
+        prompt: "p",
+        outputSchema: [],
+        detectionModel: null,
+        detectionProvider: null,
+        detectionSource: "system",
+        enableRca: true,
+      },
+    ]);
+    mockRunDetection.mockResolvedValue({
+      identified: true,
+      summary: "found it",
+      data: {},
+      inferenceCost: 0,
+      inferenceInputTokens: 0,
+      inferenceOutputTokens: 0,
+      inferenceSource: "system",
+      inferenceModel: "m",
+      inferenceProvider: "anthropic",
+    });
+
+    await processTrace("t1", "p1", ["d1"]);
+
+    expect(mockQueueAdd.mock.calls[0][2]).toEqual(
+      expect.objectContaining({
+        attempts: 3,
+        backoff: { type: "exponential", delay: 10000 },
+      }),
+    );
+  });
+
   it("writes no finding when nothing triggers", async () => {
     mockFetches(60_000, '{"span":1}\n');
     mockPrisma.detector.findMany.mockResolvedValue([

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -215,8 +215,15 @@ Output your findings in this format:
     throw new Error(`Failed to send RCA message: HTTP ${msgRes.status}`);
   }
 
-  // Consume SSE stream, accumulate assistant text
+  // Consume SSE stream, accumulate assistant text. The agent service reports
+  // mid-stream failures on the SSE `event:` field (an `error` frame, or a
+  // `message_end` whose message.stopReason is "error") — both arrive over an
+  // HTTP 200 stream, so they must be read from the frames, not the response
+  // status. Track the current `event:` name to recognize an `error` frame,
+  // since its data payload (just `{ message }`) carries no `type` of its own.
   let rcaResult = "";
+  let agentErrorMessage: string | undefined;
+  let currentEventName: string | undefined;
   const reader = msgRes.body!.getReader();
   const decoder = new TextDecoder();
   let remainder = "";
@@ -229,21 +236,38 @@ Output your findings in this format:
     const lines = text.split("\n");
     remainder = lines.pop() ?? ""; // last element: incomplete or empty
     for (const line of lines) {
-      if (line.startsWith("data: ")) {
+      if (line.startsWith("event: ")) {
+        currentEventName = line.slice(7).trim();
+      } else if (line.startsWith("data: ")) {
         try {
           const event = JSON.parse(line.slice(6));
-          if (
+          if (currentEventName === "error") {
+            agentErrorMessage = event?.message || "unknown agent error";
+          } else if (
             event.type === "message_update" &&
             event.assistantMessageEvent?.type === "text_delta" &&
             event.assistantMessageEvent.delta
           ) {
             rcaResult += event.assistantMessageEvent.delta;
+          } else if (event.type === "message_end" && event.message?.stopReason === "error") {
+            agentErrorMessage = event.message?.errorMessage || "unknown agent error";
           }
         } catch {
           // skip malformed SSE lines
         }
+      } else if (line === "") {
+        currentEventName = undefined;
       }
     }
+  }
+
+  if (agentErrorMessage) {
+    throw new Error(`RCA agent failed: ${agentErrorMessage}`);
+  }
+  // An empty-but-clean stream is indistinguishable from a swallowed failure,
+  // so it fails and retries deliberately rather than being recorded as done.
+  if (!rcaResult.trim()) {
+    throw new Error("RCA agent produced no output");
   }
 
   return { result: rcaResult, sessionId: session.id };

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -390,8 +390,16 @@ export async function processRcaJob(job: Job<DetectorRcaJob>) {
       },
     });
   } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
     await prisma.detectorRca
-      .update({ where: { findingId }, data: { status: "failed" } })
+      .update({
+        where: { findingId },
+        data: {
+          status: "failed",
+          result: `RCA failed: ${message}`,
+          completedAt: new Date(),
+        },
+      })
       .catch(() => {}); // best-effort
 
     await scheduleDigestFlush();

--- a/frontend/worker/src/processors/detector-rca-processor.ts
+++ b/frontend/worker/src/processors/detector-rca-processor.ts
@@ -239,21 +239,34 @@ Output your findings in this format:
       if (line.startsWith("event: ")) {
         currentEventName = line.slice(7).trim();
       } else if (line.startsWith("data: ")) {
-        try {
-          const event = JSON.parse(line.slice(6));
-          if (currentEventName === "error") {
-            agentErrorMessage = event?.message || "unknown agent error";
-          } else if (
-            event.type === "message_update" &&
-            event.assistantMessageEvent?.type === "text_delta" &&
-            event.assistantMessageEvent.delta
-          ) {
-            rcaResult += event.assistantMessageEvent.delta;
-          } else if (event.type === "message_end" && event.message?.stopReason === "error") {
-            agentErrorMessage = event.message?.errorMessage || "unknown agent error";
+        const raw = line.slice(6);
+        if (currentEventName === "error") {
+          // Our own onError handler sends JSON (`{ message }`), but hono's
+          // generic streamSSE `run()` wrapper — triggered when the route
+          // callback throws outside that handler — sends the raw
+          // Error.message string instead. Fall back to the raw line whenever
+          // it isn't JSON with a `.message` field, so that error isn't lost.
+          try {
+            const parsed = JSON.parse(raw);
+            agentErrorMessage = parsed?.message || raw || "unknown agent error";
+          } catch {
+            agentErrorMessage = raw || "unknown agent error";
           }
-        } catch {
-          // skip malformed SSE lines
+        } else {
+          try {
+            const event = JSON.parse(raw);
+            if (
+              event.type === "message_update" &&
+              event.assistantMessageEvent?.type === "text_delta" &&
+              event.assistantMessageEvent.delta
+            ) {
+              rcaResult += event.assistantMessageEvent.delta;
+            } else if (event.type === "message_end" && event.message?.stopReason === "error") {
+              agentErrorMessage = event.message?.errorMessage || "unknown agent error";
+            }
+          } catch {
+            // skip malformed SSE lines
+          }
         }
       } else if (line === "") {
         currentEventName = undefined;
@@ -265,7 +278,10 @@ Output your findings in this format:
     throw new Error(`RCA agent failed: ${agentErrorMessage}`);
   }
   // An empty-but-clean stream is indistinguishable from a swallowed failure,
-  // so it fails and retries deliberately rather than being recorded as done.
+  // so it fails deliberately rather than being recorded as done. BullMQ
+  // retries this per the `attempts`/`backoff` set on the RCA job enqueue
+  // (detector-run-processor.ts), which is what actually catches transient
+  // causes like rate limits or provider 5xx.
   if (!rcaResult.trim()) {
     throw new Error("RCA agent produced no output");
   }

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -473,7 +473,16 @@ async function evaluateTrace(
         findings: rcaFindings,
         findingTimestamp,
       },
-      { jobId: `rca-${findingId}`, removeOnComplete: 100, removeOnFail: 50 },
+      {
+        jobId: `rca-${findingId}`,
+        removeOnComplete: 100,
+        removeOnFail: 50,
+        // Modest attempts: each retry re-invokes the agent (LLM cost), but a
+        // thrown RCA run is meant to retry through transient causes (rate
+        // limits, provider 5xx) rather than land permanently failed on one shot.
+        attempts: 3,
+        backoff: { type: "exponential", delay: 10000 },
+      },
     );
   } else {
     console.log(


### PR DESCRIPTION
## Summary

Fixes #1568 

An agent-side RCA failure was recorded as a **successful** run. When the agent service errors mid-stream (bad/missing provider key, provider 5xx, rate limit), it emits an `event: "error"` SSE frame on an HTTP 200 stream — but the RCA processor's consumer only read `data:` text deltas, so the error was silently discarded. `runRcaSession` returned `{ result: "" }`, `processRcaJob` wrote `status: "done"` with an empty result, nothing threw, and the job was never retried. Users saw a completed analysis with no content (observed live: `detector_rcas` rows marked `done` 40–200 ms after creation with empty results and prompt-only agent sessions).

This PR makes the RCA path fail closed and actually retry: agent errors and empty output now throw, the failure reason is recorded on the row, and the RCA job is enqueued with retry attempts.

## How it works

```
processRcaJob
  → runRcaSession consumes the agent SSE stream
      tracks the SSE event: field per frame
      event: error frame            → captures message (JSON {message} or raw string)
      message_end stopReason=error  → captures errorMessage
      stream ends:
        captured error   → throw "RCA agent failed: <message>"
        empty result     → throw "RCA agent produced no output"
        otherwise        → return accumulated analysis (unchanged)
  → catch: detector_rcas row = status "failed", result "RCA failed: <message>", completedAt
  → re-throw → BullMQ retries (attempts: 3, exponential backoff — newly configured on the
    RCA job enqueue; previously the job defaulted to a single attempt)
```

Design note: an empty-but-clean stream is indistinguishable from a swallowed failure, so it deliberately fails and retries rather than being recorded as a silent success. The digest alert is still scheduled on the failure path, so findings keep alerting even when RCA fails.

## What's included

### Worker (TypeScript)
- `frontend/worker/src/processors/detector-rca-processor.ts`
  - SSE consumer tracks `event:` lines; captures `event: error` frames (both the agent's `{message}` JSON shape and hono's raw-string wrapper shape) and `message_end` with `stopReason: "error"`.
  - Throws on captured agent errors and on empty accumulated output; healthy streaming path unchanged.
  - `processRcaJob`'s catch now records `result: "RCA failed: <message>"` and `completedAt` alongside `status: "failed"` (mirroring the existing free-plan-cap pattern), then re-throws for retry.
- `frontend/worker/src/processors/detector-run-processor.ts` — the RCA job enqueue now sets `attempts: 3` with exponential backoff so transient agent failures actually retry (previously one attempt).

### Tests
- SSE fixtures encode frames exactly as hono's `writeSSE` serializes them; chunked-delivery helper splits frames across `read()` chunks at hostile boundaries (event/data split, mid-JSON split).
- New cases: error frame throws with the agent's message (JSON and raw-string shapes, single-chunk and chunked); `message_end` `stopReason: "error"` throws; empty stream throws "no output"; event-less data frame after an error frame doesn't inherit the stale event name; healthy multi-delta stream returns identical output chunked vs single-chunk; failure paths schedule the digest flush; failed rows carry the failure reason and the job re-throws; RCA enqueue carries the retry options.
- Pre-existing fixtures that modeled an empty stream as a successful run (the bug itself) were updated to healthy streams while keeping their original assertions.

## Test plan
- [x] Worker suite: 177 passed (18 files), tsc build clean, lint clean, prettier clean
- [x] TDD throughout: each new test observed failing against the unfixed code first
- [x] E2E over real HTTP: drove the real `runRcaSession` (real fetch/stream parsing, real Prisma against live Postgres) against a stub agent service streaming hono-format SSE — healthy stream returns the accumulated analysis; error frame throws with the agent's message; empty stream throws "produced no output"
- [x] Verified the SSE frame format against the installed hono source and the agent service's actual `writeSSE` calls


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
RCA runs now fail and retry when the agent SSE stream reports an error or returns no text, preventing empty “successful” analyses. We also record the failure reason on the RCA row and trigger retries for transient issues.

- **Bug Fixes**
  - Stream consumer tracks the SSE `event:` field and handles `event: error` and `message_end` with `stopReason: "error"`; parses JSON `{message}` or raw string and throws; also throws on empty output.
  - On failure, `processRcaJob` updates the row to `failed`, stores `RCA failed: <message>`, sets `completedAt`, then rethrows so `BullMQ` can retry; digest flush still runs on failure.
  - RCA jobs are enqueued with `attempts: 3` and exponential backoff (10s base) to retry transient provider or rate-limit errors.

<sup>Written for commit 5cb85e5033d17b8b71e61a38edb5f3c8cbd0d7ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

