### PR TITLE
Fix BYOK Test Connection to Honor Custom Base URL

### DIFF
--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -214,7 +214,7 @@ describe("POST model-providers/test - network providers succeed", () => {
     },
     {
       name: "openai with baseUrl",
-      body: { adapter: "openai", apiKey: "k", baseUrl: "https://proxy.test/" },
+      body: { adapter: "openai", apiKey: "k", baseUrl: "https://proxy.test/v1/" },
       url: "https://proxy.test/v1/models",
     },
     {

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -23,6 +23,7 @@ vi.mock("@traceroot/core", () => ({
     ZAI: "zai",
   },
   ADAPTER_DEFAULT_BASE_URL: {
+    openai: "https://api.openai.com/v1",
     anthropic: "https://api.anthropic.com",
     google: "https://generativelanguage.googleapis.com/v1alpha",
     openrouter: "https://openrouter.ai/api/v1",

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -219,7 +219,7 @@ describe("POST model-providers/test - network providers succeed", () => {
     {
       name: "google",
       body: { adapter: "google", apiKey: "k" },
-      url: "https://generativelanguage.googleapis.com/v1beta/models",
+      url: "https://generativelanguage.googleapis.com/v1alpha/models",
     },
     {
       name: "openrouter",

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts
@@ -23,6 +23,9 @@ vi.mock("@traceroot/core", () => ({
     ZAI: "zai",
   },
   ADAPTER_DEFAULT_BASE_URL: {
+    anthropic: "https://api.anthropic.com",
+    google: "https://generativelanguage.googleapis.com/v1alpha",
+    openrouter: "https://openrouter.ai/api/v1",
     deepseek: "https://api.deepseek.com/v1",
     xai: "https://api.x.ai/v1",
     moonshot: "https://api.moonshot.ai/v1",
@@ -265,6 +268,49 @@ describe("POST model-providers/test - network providers succeed", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://api.anthropic.com/v1/messages",
       expect.objectContaining({ method: "POST", signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("anthropic with baseUrl posts to the custom endpoint", async () => {
+    fetchMock.mockResolvedValue(okResponse());
+    const res = await POST(
+      makeRequest({ adapter: "anthropic", apiKey: "k", baseUrl: "https://proxy.test/" }),
+      makeParams(),
+    );
+    expect(await res.json()).toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://proxy.test/v1/messages",
+      expect.objectContaining({ method: "POST", signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("google with baseUrl checks models on the custom endpoint", async () => {
+    fetchMock.mockResolvedValue(okResponse());
+    const res = await POST(
+      makeRequest({ adapter: "google", apiKey: "k", baseUrl: "https://proxy.test/v1alpha/" }),
+      makeParams(),
+    );
+    expect(await res.json()).toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://proxy.test/v1alpha/models",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("openrouter with baseUrl checks models on the custom endpoint", async () => {
+    fetchMock.mockResolvedValue(okResponse());
+    const res = await POST(
+      makeRequest({
+        adapter: "openrouter",
+        apiKey: "k",
+        baseUrl: "https://proxy.test/api/v1/",
+      }),
+      makeParams(),
+    );
+    expect(await res.json()).toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://proxy.test/api/v1/models",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -186,10 +186,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
       case "google": {
         const googleBase = adapterBaseUrl(adapter, baseUrl);
-        const check = await checkEndpoint(
-          `${googleBase}/models`,
-          { "x-goog-api-key": apiKey || "" },
-        );
+        const check = await checkEndpoint(`${googleBase}/models`, {
+          "x-goog-api-key": apiKey || "",
+        });
         if (!check.ok)
           return successResponse({ success: false, error: check.error, detail: check.detail });
         break;

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -147,9 +147,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     switch (adapter) {
       case "openai": {
-        const url = baseUrl
-          ? `${baseUrl.replace(/\/$/, "")}/v1/models`
-          : "https://api.openai.com/v1/models";
+        const openaiBase = baseUrl
+          ? `${adapterBaseUrl(adapter, baseUrl)}/v1`
+          : adapterBaseUrl(adapter, baseUrl);
+        const url = `${openaiBase}/models`;
         const check = await checkEndpoint(url, { Authorization: `Bearer ${apiKey}` });
         if (!check.ok)
           return successResponse({ success: false, error: check.error, detail: check.detail });
@@ -202,10 +203,10 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           });
         }
         const apiVersion = "2024-06-01";
-        const check = await checkEndpoint(
-          `${baseUrl.replace(/\/$/, "")}/models?api-version=${apiVersion}`,
-          { "api-key": apiKey || "" },
-        );
+        const azureBase = adapterBaseUrl(adapter, baseUrl);
+        const check = await checkEndpoint(`${azureBase}/models?api-version=${apiVersion}`, {
+          "api-key": apiKey || "",
+        });
         if (!check.ok)
           return successResponse({ success: false, error: check.error, detail: check.detail });
         break;
@@ -234,8 +235,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "deepseek": {
-        const deepseekBase = baseUrl || ADAPTER_DEFAULT_BASE_URL.deepseek;
-        const check = await checkEndpoint(`${deepseekBase.replace(/\/$/, "")}/models`, {
+        const deepseekBase = adapterBaseUrl(adapter, baseUrl);
+        const check = await checkEndpoint(`${deepseekBase}/models`, {
           Authorization: `Bearer ${apiKey}`,
         });
         if (!check.ok)
@@ -254,8 +255,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "xai": {
-        const xaiBase = baseUrl || ADAPTER_DEFAULT_BASE_URL.xai;
-        const check = await checkEndpoint(`${xaiBase.replace(/\/$/, "")}/models`, {
+        const xaiBase = adapterBaseUrl(adapter, baseUrl);
+        const check = await checkEndpoint(`${xaiBase}/models`, {
           Authorization: `Bearer ${apiKey}`,
         });
         if (!check.ok)
@@ -264,8 +265,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "moonshot": {
-        const moonshotBase = baseUrl || ADAPTER_DEFAULT_BASE_URL.moonshot;
-        const check = await checkEndpoint(`${moonshotBase.replace(/\/$/, "")}/models`, {
+        const moonshotBase = adapterBaseUrl(adapter, baseUrl);
+        const check = await checkEndpoint(`${moonshotBase}/models`, {
           Authorization: `Bearer ${apiKey}`,
         });
         if (!check.ok)
@@ -274,8 +275,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "zai": {
-        const zaiBase = baseUrl || ADAPTER_DEFAULT_BASE_URL.zai;
-        const check = await checkEndpoint(`${zaiBase.replace(/\/$/, "")}/models`, {
+        const zaiBase = adapterBaseUrl(adapter, baseUrl);
+        const check = await checkEndpoint(`${zaiBase}/models`, {
           Authorization: `Bearer ${apiKey}`,
         });
         if (!check.ok)

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -99,6 +99,10 @@ async function checkEndpoint(
   });
 }
 
+function adapterBaseUrl(adapter: string, baseUrl?: string): string {
+  return (baseUrl || ADAPTER_DEFAULT_BASE_URL[adapter]).replace(/\/$/, "");
+}
+
 // POST /api/workspaces/[workspaceId]/model-providers/test
 export async function POST(request: NextRequest, { params }: RouteParams) {
   const { workspaceId } = await params;
@@ -155,8 +159,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       case "anthropic": {
         // Anthropic has no list-models endpoint; a minimal message call only
         // distinguishes an invalid key (401) from a reachable provider.
+        const anthropicBase = adapterBaseUrl(adapter, baseUrl);
         const check = await withTimeout(async (signal) => {
-          const res = await fetch("https://api.anthropic.com/v1/messages", {
+          const res = await fetch(`${anthropicBase}/v1/messages`, {
             method: "POST",
             headers: {
               "x-api-key": apiKey || "",
@@ -180,8 +185,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "google": {
+        const googleBase = adapterBaseUrl(adapter, baseUrl);
         const check = await checkEndpoint(
-          "https://generativelanguage.googleapis.com/v1beta/models",
+          `${googleBase}/models`,
           { "x-goog-api-key": apiKey || "" },
         );
         if (!check.ok)
@@ -239,7 +245,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
 
       case "openrouter": {
-        const check = await checkEndpoint("https://openrouter.ai/api/v1/models", {
+        const openrouterBase = adapterBaseUrl(adapter, baseUrl);
+        const check = await checkEndpoint(`${openrouterBase}/models`, {
           Authorization: `Bearer ${apiKey}`,
         });
         if (!check.ok)

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/model-providers/test/route.ts
@@ -147,9 +147,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     switch (adapter) {
       case "openai": {
-        const openaiBase = baseUrl
-          ? `${adapterBaseUrl(adapter, baseUrl)}/v1`
-          : adapterBaseUrl(adapter, baseUrl);
+        const openaiBase = adapterBaseUrl(adapter, baseUrl);
         const url = `${openaiBase}/models`;
         const check = await checkEndpoint(url, { Authorization: `Bearer ${apiKey}` });
         if (!check.ok)


### PR DESCRIPTION
Fixes #1559 

## Summary

Fixes BYOK model provider Test Connection so Anthropic, Google, and OpenRouter use the configured Base URL instead of always testing the real provider endpoint.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Updated Test Connection for Anthropic, Google, and OpenRouter to resolve endpoints from the configured Base URL first.
- Falls back to the shared adapter default Base URL when no custom Base URL is set.
- Added regression coverage for the affected providers.
- Aligned Google Test Connection with the shared Google adapter default.

Tested with:

`pnpm --filter traceroot-ui test -- src/app/api/workspaces/[workspaceId]/model-providers/test/route.test.ts`

Result: 57 tests passed.

## Screenshots / Recordings (if applicable)

Manually verified with fake proxy Base URLs. Test Connection now reports `Connection failed`, confirming it is testing the configured endpoint instead of the real provider.
<img width="1920" height="1080" alt="Screenshot (37)" src="https://github.com/user-attachments/assets/903dec1a-2404-4d10-97bb-ca6614b03ff4" />
<img width="1920" height="1080" alt="Screenshot (38)" src="https://github.com/user-attachments/assets/dd236f31-bd65-46b8-bc55-3c6338f39bbe" />
<img width="1920" height="1080" alt="Screenshot (40)" src="https://github.com/user-attachments/assets/2e35391f-ed3b-4c62-8453-feb87b9d9a90" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes BYOK Test Connection to honor the configured Base URL across all adapters and fall back to adapter defaults when not set. This ensures tests hit proxies instead of real provider endpoints.

- **Bug Fixes**
  - Use `adapterBaseUrl()` for OpenAI, Azure OpenAI, Anthropic, Google, OpenRouter, DeepSeek, xAI, Moonshot, and ZAI; normalizes trailing slashes and composes OpenAI `/v1` only once.
  - Endpoints: Anthropic `{base}/v1/messages`; others `{base}/models` (Google default base is `v1alpha`).
  - Tests: add coverage for custom base URLs and fallback behavior, including OpenAI default base in mocks.

<sup>Written for commit dcf9fd5d58c3f0f570ef5728d2b61296132a5d02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

