### PR TITLE
feat(ui): make trace-feed widget rows fully clickable

### DIFF
--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
@@ -1,15 +1,15 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TraceListItem } from "@/types/api";
 import type { TimeRange } from "../types";
 import { TraceFeedWidget } from "./TraceFeedWidget";
 
-vi.mock("next/link", () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
-  ),
+const push = vi.fn();
+const prefetch = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, prefetch }),
 }));
 
 // Mutable so individual tests can put the session into its resolving state.
@@ -31,6 +31,7 @@ import { getTraces } from "@/lib/api/traces";
 
 afterEach(() => {
   cleanup();
+  push.mockReset();
   vi.mocked(getTraces).mockReset();
   auth.data = { user: { id: "u1", email: "u@example.com" } };
   auth.isPending = false;
@@ -99,7 +100,7 @@ describe("TraceFeedWidget", () => {
     await waitFor(() => expect(screen.getByText("No traces in this time range")).toBeTruthy());
   });
 
-  it("renders a populated list with status chips, cost, time and links", async () => {
+  it("renders a populated list with status chips, cost and time; a row click opens the trace", async () => {
     vi.mocked(getTraces).mockResolvedValue({
       data: [
         makeTrace({ trace_id: "err-trace", name: "errored-run", error_count: 2, total_cost: 0.5 }),
@@ -125,19 +126,18 @@ describe("TraceFeedWidget", () => {
     expect(screen.getByText("$0.5000")).toBeTruthy();
     expect(screen.getAllByText("-")).toHaveLength(2);
 
-    const nameLink = screen.getByText("errored-run").closest("a");
-    expect(nameLink?.getAttribute("href")).toBe("/projects/p1/traces?traceId=err-trace");
-
     const expectedTime = new Date("2026-06-01T12:00:00Z").toLocaleTimeString(undefined, {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
     });
-    const timeLinks = screen.getAllByText(expectedTime);
-    expect(timeLinks.length).toBeGreaterThan(0);
-    expect(timeLinks[0].closest("a")?.getAttribute("href")).toBe(
-      "/projects/p1/traces?traceId=err-trace",
-    );
+    expect(screen.getAllByText(expectedTime).length).toBeGreaterThan(0);
+
+    // the WHOLE row navigates — clicking any cell opens the trace detail
+    fireEvent.click(screen.getByText("$0.5000"));
+    expect(push).toHaveBeenCalledWith("/projects/p1/traces?traceId=err-trace");
+    fireEvent.click(screen.getByText("clean-run"));
+    expect(push).toHaveBeenCalledWith("/projects/p1/traces?traceId=ok-trace");
   });
 
   it("passes spec.limit and the range bounds to getTraces", async () => {

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useTraceApiUser } from "@/lib/hooks/use-trace-api-user";
 import { getTraces } from "@/lib/api/traces";
@@ -41,6 +41,7 @@ function fmtTime(iso: string): string {
 }
 
 export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps) {
+  const router = useRouter();
   const limit = spec.limit ?? 10;
   const filters = (spec.filters ?? []).filter(isValidPredicate);
   const { user, sessionReady } = useTraceApiUser();
@@ -99,36 +100,35 @@ export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps
           </tr>
         </thead>
         <tbody>
-          {traces.map((trace: TraceListItem) => (
-            <tr key={trace.trace_id} className="border-t border-border/60">
-              <td className="whitespace-nowrap py-1 pr-3 text-muted-foreground">
-                <Link
-                  href={`/projects/${projectId}/traces?traceId=${trace.trace_id}`}
-                  className="hover:underline"
-                >
+          {traces.map((trace: TraceListItem) => {
+            const href = `/projects/${projectId}/traces?traceId=${trace.trace_id}`;
+            return (
+              <tr
+                key={trace.trace_id}
+                // The whole row opens the trace, like the list pages' rows; the
+                // hover prefetch stands in for the removed links' viewport prefetch.
+                onClick={() => router.push(href)}
+                onMouseEnter={() => router.prefetch(href)}
+                className="cursor-pointer border-t border-border/60 transition-colors hover:bg-muted/50"
+              >
+                <td className="whitespace-nowrap py-1 pr-3 text-muted-foreground">
                   {fmtTime(trace.trace_start_time)}
-                </Link>
-              </td>
-              <td className="max-w-[120px] truncate py-1 pr-3">
-                <Link
-                  href={`/projects/${projectId}/traces?traceId=${trace.trace_id}`}
-                  className="hover:underline"
-                  title={trace.name}
-                >
+                </td>
+                <td className="max-w-[120px] truncate py-1 pr-3" title={trace.name}>
                   {trace.name}
-                </Link>
-              </td>
-              <td className="py-1 pr-3">
-                <StatusChip errorCount={trace.error_count} />
-              </td>
-              <td className="py-1 pr-3 tabular-nums text-muted-foreground">
-                {formatCost(trace.total_cost)}
-              </td>
-              <td className="py-1 tabular-nums text-muted-foreground">
-                {formatDuration(trace.duration_ms)}
-              </td>
-            </tr>
-          ))}
+                </td>
+                <td className="py-1 pr-3">
+                  <StatusChip errorCount={trace.error_count} />
+                </td>
+                <td className="py-1 pr-3 tabular-nums text-muted-foreground">
+                  {formatCost(trace.total_cost)}
+                </td>
+                <td className="py-1 tabular-nums text-muted-foreground">
+                  {formatDuration(trace.duration_ms)}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
## What

The Recent traces / Recent failures feed widgets only linked their Time and Name cells; clicking the status, cost, or latency cells did nothing. The entire row now navigates to the trace detail — the same row-as-target behavior as the app's list pages — with the house cursor/hover treatment, plus a hover prefetch standing in for the removed links' viewport prefetch.

Known trade-off, consistent with the existing row-click convention (detectors list, dashboards list): row `onClick` loses cmd/ctrl-click-to-new-tab and keyboard reachability that anchors gave; if the app ever addresses that pattern, these rows should be included.

## Testing

Tests converted from href assertions to behavioral row-click assertions — clicking one row's cost cell and another row's name each assert navigation to their own trace. Full frontend suite passes; diff coverage 100% on changed lines.

Stacked on the Duplicate-removal PR; merge order follows the stack.

Part of the project dashboards epic: #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Recent traces/Recent failures widget rows fully clickable to open the trace detail, matching list pages and improving navigation. Related to Linear #1460.

- **New Features**
  - Entire row opens the trace; all cells clickable. Adds cursor and hover highlight, plus hover prefetch.
  - Replaces `next/link` cell anchors with row handlers using `useRouter().push()` and `useRouter().prefetch()` from `next/navigation`.
  - Trade-off: no cmd/ctrl-click or link keyboard navigation, consistent with other list rows.

<sup>Written for commit c7daf5159edcc671aa6b289cac94ed6a9a9816fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

