### PR TITLE
chore: drop the not-equals operator from widget filters

### DIFF
--- a/backend/rest/schemas/dashboards.py
+++ b/backend/rest/schemas/dashboards.py
@@ -26,7 +26,7 @@ class WidgetFilter(_StrictModel):
     """A single filter predicate applied to a widget query."""
 
     field: str
-    op: Literal["=", "!=", "contains", ">", ">=", "<", "<="]
+    op: Literal["=", "contains", ">", ">=", "<", "<="]
     # min_length mirrors the frontend schema: an empty value means the filter
     # was never completed and would silently match only empty-valued rows.
     value: Annotated[str, StringConstraints(min_length=1)] | float

--- a/backend/rest/services/widget_query.py
+++ b/backend/rest/services/widget_query.py
@@ -40,7 +40,6 @@ _NON_ADDITIVE_AGGS = frozenset({"avg", "min", "max", "p50", "p95", "p99"})
 
 _OP_SQL = {
     "=": "{expr} = {{{p}:{t}}}",
-    "!=": "{expr} != {{{p}:{t}}}",
     ">": "{expr} > {{{p}:{t}}}",
     ">=": "{expr} >= {{{p}:{t}}}",
     "<": "{expr} < {{{p}:{t}}}",

--- a/backend/rest/services/widget_registry.py
+++ b/backend/rest/services/widget_registry.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-FILTER_OPS_STRING = ("=", "!=", "contains")
-FILTER_OPS_NUMBER = (">", ">=", "<", "<=", "=", "!=")
+FILTER_OPS_STRING = ("=", "contains")
+FILTER_OPS_NUMBER = (">", ">=", "<", "<=", "=")
 AGGS_NUMBER = ("sum", "avg", "min", "max", "p50", "p95", "p99")
 
 

--- a/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
@@ -10,14 +10,14 @@ import { useWidgetFieldValues } from "../hooks/use-widget-data";
 const stringField: WidgetSchemaField = {
   type: "string",
   label: "Model",
-  filterOps: ["=", "!=", "contains"],
+  filterOps: ["=", "contains"],
   groupable: true,
   aggs: [],
 };
 const numberField: WidgetSchemaField = {
   type: "number",
   label: "Cost",
-  filterOps: [">", ">=", "<", "<=", "=", "!="],
+  filterOps: [">", ">=", "<", "<=", "="],
   groupable: false,
   aggs: ["sum"],
 };
@@ -153,10 +153,11 @@ describe("FilterRow value input", () => {
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: "is" }));
-    expect(screen.getByRole("option", { name: "is not" })).toBeTruthy();
+    // same vocabulary as the trace-list filter: no "is not"
+    expect(screen.queryByRole("option", { name: "is not" })).toBeNull();
     expect(screen.getByRole("option", { name: "contains" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("option", { name: "is not" }));
-    expect(onChange).toHaveBeenCalledWith(0, { op: "!=" });
+    fireEvent.click(screen.getByRole("option", { name: "contains" }));
+    expect(onChange).toHaveBeenCalledWith(0, { op: "contains" });
   });
 
   it("adorns cost and duration values with their unit like the trace-list builder", () => {

--- a/frontend/ui/src/features/dashboards/components/FilterRow.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.tsx
@@ -88,7 +88,7 @@ export function FilterRow({
           }
         />
 
-        {/* op — labeled with the trace-list filter vocabulary (is / is not / ≥ / ≤ / ≠) */}
+        {/* op — labeled with the trace-list filter vocabulary (is / ≥ / ≤) */}
         <Dropdown
           disabled={!fieldMeta}
           trigger={

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -42,7 +42,7 @@ const SCHEMA = {
       model_name: {
         type: "string",
         label: "Model",
-        filterOps: ["=", "!=", "contains"],
+        filterOps: ["=", "contains"],
         groupable: true,
         aggs: [],
       },

--- a/frontend/ui/src/features/dashboards/types.test.ts
+++ b/frontend/ui/src/features/dashboards/types.test.ts
@@ -78,7 +78,7 @@ describe("isEnumerableFilter", () => {
   const stringField = {
     type: "string" as const,
     label: "Model",
-    filterOps: ["=", "!=", "contains"],
+    filterOps: ["=", "contains"],
     groupable: true,
     aggs: [],
   };
@@ -86,7 +86,9 @@ describe("isEnumerableFilter", () => {
 
   it("true for string equality ops (dropdown of stored values)", () => {
     expect(isEnumerableFilter(stringField, "=")).toBe(true);
-    expect(isEnumerableFilter(stringField, "!=")).toBe(true);
+    // != left the widget vocabulary when it was reconciled with the
+    // trace-list filter, which has no not-equals
+    expect(isEnumerableFilter(stringField, "!=")).toBe(false);
   });
   it("false for contains (free text) and numeric fields", () => {
     expect(isEnumerableFilter(stringField, "contains")).toBe(false);
@@ -102,7 +104,7 @@ describe("filterOpLabel", () => {
   const stringField = {
     type: "string" as const,
     label: "Model",
-    filterOps: ["=", "!=", "contains"],
+    filterOps: ["=", "contains"],
     groupable: true,
     aggs: [],
   };
@@ -110,13 +112,12 @@ describe("filterOpLabel", () => {
 
   it("words string equality like the trace-list filter builder", () => {
     expect(filterOpLabel(stringField, "=")).toBe("is");
-    expect(filterOpLabel(stringField, "!=")).toBe("is not");
     expect(filterOpLabel(stringField, "contains")).toBe("contains");
   });
   it("uses the trace-list comparison symbols for numeric ops", () => {
     expect(filterOpLabel(numberField, ">=")).toBe("≥");
     expect(filterOpLabel(numberField, "<=")).toBe("≤");
-    expect(filterOpLabel(numberField, "!=")).toBe("≠");
+
     expect(filterOpLabel(numberField, "=")).toBe("=");
     expect(filterOpLabel(numberField, ">")).toBe(">");
     expect(filterOpLabel(numberField, "<")).toBe("<");

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -25,7 +25,7 @@ export const AGGS = ["count", "sum", "avg", "min", "max", "p50", "p95", "p99"] a
 
 export const WidgetFilterSchema = z.object({
   field: z.string().min(1),
-  op: z.enum(["=", "!=", "contains", ">", ">=", "<", "<="]),
+  op: z.enum(["=", "contains", ">", ">=", "<", "<="]),
   // min(1): a filter whose value was never picked (the builder's rows start
   // at "") must keep the spec incomplete, not save a widget that silently
   // matches only empty-valued rows.
@@ -149,21 +149,20 @@ export interface WidgetFieldValuesResponse {
  * `contains` stays free text and numeric fields take a number input.
  */
 export function isEnumerableFilter(field: WidgetSchemaField | undefined, op: string): boolean {
-  return !!field && field.type === "string" && (op === "=" || op === "!=");
+  return !!field && field.type === "string" && op === "=";
 }
 
 // Numeric comparison symbols shared with the trace-list filter chips.
-const NUMERIC_OP_SYMBOL: Record<string, string> = { ">=": "≥", "<=": "≤", "!=": "≠" };
+const NUMERIC_OP_SYMBOL: Record<string, string> = { ">=": "≥", "<=": "≤" };
 
 /**
  * Display label for a filter operator, matching the trace-list filter builder's
- * vocabulary: string equality reads as "is" / "is not"; numeric comparisons use
- * the same symbols (≥ ≤ ≠). Presentation only — the wire op is unchanged.
+ * vocabulary: string equality reads as "is"; numeric comparisons use the same
+ * symbols (≥ ≤). Presentation only — the wire op is unchanged.
  */
 export function filterOpLabel(field: WidgetSchemaField | undefined, op: string): string {
   if (field?.type === "string") {
     if (op === "=") return "is";
-    if (op === "!=") return "is not";
     return op;
   }
   return NUMERIC_OP_SYMBOL[op] ?? op;


### PR DESCRIPTION
## What

Removes `!=` from the widget filter vocabulary end to end, so the widget builder and the trace-list filter offer the same operator set:

- Backend: the registry's `filter_ops` tuples, the SQL compiler's op mapping, and the spec schema's op literal.
- Frontend: the zod op enum, `isEnumerableFilter` (equality-only stored-values dropdown), and the "is not" label / ≠ symbol.

The detector-trigger `!=` (worker condition evaluation + trigger editor) is a separate feature and is untouched.

## Why

The widget vocabulary carried a not-equals the trace-list filter language never had. When the two filter UIs were reconciled onto shared controls, `!=` survived because the operator set is data-driven from the backend registry and removing it looked risky for saved specs — but the dashboards feature is unreleased, so there are no saved widgets to protect.

## Testing

Frontend tests assert the op is gone (no "is not" option, `isEnumerableFilter("!=") === false` kept as an explicit regression guard); backend suite passes untouched — no backend test ever asserted `!=` compilation. Both diff-coverage gates pass.

Stacked on the clickable-feed-rows PR; merge order follows the stack.

Part of the project dashboards epic: #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `!=` operator from widget filters across backend and frontend to match the trace-list filter. Aligns both filter UIs and simplifies the builder. Part of dashboards epic #1460.

- **Refactors**
  - Backend: removed `!=` from registry filter ops, `WidgetFilter.op` schema, and SQL op mapping.
  - Frontend: removed `!=` from zod enum and `isEnumerableFilter`; updated labels to drop "is not"/"≠".
  - Tests: updated to assert the option is gone; kept a regression check for `isEnumerableFilter("!=") === false`.
  - Note: detector-trigger `!=` support is unchanged.

<sup>Written for commit fd996d7f9403477d5eb374748554c99f651660f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

