### PR TITLE
fix(ui): stale legend shapes, permanent-error redirects, and last-dashboard deletion

### DIFF
--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
@@ -8,6 +8,7 @@ vi.mock("next/server", () => ({ NextRequest: class {} }));
 vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
 
 const dashboardFindFirstMock = vi.fn();
+const dashboardCountMock = vi.fn();
 const dashboardUpdateMock = vi.fn();
 const dashboardDeleteMock = vi.fn();
 const widgetFindFirstMock = vi.fn();
@@ -20,6 +21,7 @@ vi.mock("@traceroot/core", () => ({
   prisma: {
     dashboard: {
       findFirst: (...args: unknown[]) => dashboardFindFirstMock(...args),
+      count: (...args: unknown[]) => dashboardCountMock(...args),
       update: (...args: unknown[]) => dashboardUpdateMock(...args),
       delete: (...args: unknown[]) => dashboardDeleteMock(...args),
     },
@@ -86,8 +88,12 @@ const fakeWidget = {
 
 beforeEach(() => {
   dashboardFindFirstMock.mockReset();
+  dashboardCountMock.mockReset();
   dashboardUpdateMock.mockReset();
   dashboardDeleteMock.mockReset();
+  // Default: the project has other dashboards, so DELETE's last-dashboard
+  // guard doesn't trip.
+  dashboardCountMock.mockResolvedValue(2);
   widgetFindFirstMock.mockReset();
   widgetCreateMock.mockReset();
   widgetUpdateMock.mockReset();
@@ -267,6 +273,18 @@ describe("DELETE /dashboards/[dashboardId]", () => {
     const res = (await DELETE(makeRequest(), makeParams("proj-1", "dash-999"))) as MockResponse;
     expect(res.status).toBe(404);
     expect(dashboardDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 for the project's last dashboard (deleting it would only trigger a reseed)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    dashboardCountMock.mockResolvedValue(1);
+
+    const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(409);
+    expect(dashboardDeleteMock).not.toHaveBeenCalled();
+    // The count is scoped to the project, not global.
+    const [call] = dashboardCountMock.mock.calls;
+    expect((call[0] as { where: Record<string, unknown> }).where.projectId).toBe("proj-1");
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
@@ -111,6 +111,14 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
   });
   if (!existing) return errorResponse("Dashboard not found", 404);
 
+  // The list endpoint reseeds the default dashboard whenever a project has
+  // zero dashboards, so deleting the last one would just resurrect a fresh
+  // seeded copy — block it instead (the list UI disables this path too).
+  const remaining = await prisma.dashboard.count({ where: { projectId } });
+  if (remaining <= 1) {
+    return errorResponse("Cannot delete a project's last dashboard", 409);
+  }
+
   try {
     await prisma.dashboard.delete({ where: { id: dashboardId } });
   } catch (e) {

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, DashboardSummary, Widget } from "@/features/dashboards/types";
+import { ApiError } from "@/lib/api/client";
 import DashboardDetailPage from "./page";
 
 class ResizeObserverStub {
@@ -52,7 +53,10 @@ const removeWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; erro
     error: null,
   };
 
-vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
+vi.mock("@/features/dashboards/hooks/use-dashboards", async (importOriginal) => ({
+  // Keep the real isDashboardGone: the redirect-on-gone behavior under test
+  // depends on its ApiError-status logic.
+  ...(await importOriginal<object>()),
   useDashboard: vi.fn(),
   useDashboardMutations: () => ({
     updateLayout,
@@ -222,15 +226,22 @@ describe("DashboardDetailPage", () => {
   });
 
   it("redirects to the dashboard index and invalidates the list cache when the dashboard is gone", () => {
-    mockDetail(undefined, new Error("Dashboard not found"));
+    mockDetail(undefined, new ApiError("Dashboard not found", 404));
     const { invalidateSpy } = renderPage();
 
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "p1"] });
   });
 
+  it("leaves the page when access is revoked instead of retrying a permanent 403", () => {
+    mockDetail(undefined, new ApiError("Not a member of this workspace", 403));
+    renderPage();
+
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+  });
+
   it("stays put and shows a failure notice on a transient load error", () => {
-    mockDetail(undefined, new Error("API error: 503"));
+    mockDetail(undefined, new ApiError("API error: 503", 503));
     const { invalidateSpy } = renderPage();
 
     expect(replace).not.toHaveBeenCalled();
@@ -238,10 +249,18 @@ describe("DashboardDetailPage", () => {
     expect(screen.getByText(/Failed to load the dashboard/)).toBeTruthy();
   });
 
+  it("stays put on an untyped error (network failure never has a status)", () => {
+    mockDetail(undefined, new Error("Failed to fetch"));
+    renderPage();
+
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText(/Failed to load the dashboard/)).toBeTruthy();
+  });
+
   it("keeps rendering the cached dashboard when a background poll fails", () => {
     mockDetail(
       { ...DASH_A, widgets: [WIDGET], layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }] },
-      new Error("API error: 503"),
+      new ApiError("API error: 503", 503),
     );
     renderPage();
 

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -5,7 +5,11 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import { useDashboard, useDashboardMutations } from "@/features/dashboards/hooks/use-dashboards";
+import {
+  isDashboardGone,
+  useDashboard,
+  useDashboardMutations,
+} from "@/features/dashboards/hooks/use-dashboards";
 import { DashboardGrid } from "@/features/dashboards/components/DashboardGrid";
 import type { TimeRange, Widget } from "@/features/dashboards/types";
 import { DateFilterSelect } from "@/components/date-filter-select";
@@ -64,15 +68,11 @@ export default function DashboardDetailPage() {
     router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/${w.id}/edit`);
 
   // ── deleted / missing dashboard redirect ─────────────────────────────────────
-  // fetchNextApi doesn't carry the HTTP status, so gone-ness is detected from
-  // the API's error message. The exact match keeps "Project not found" (a
-  // deleted project) and auth failures from redirecting; only a genuinely
-  // missing dashboard leaves the page. Everything else keeps the user here —
-  // the detail query's 30s poll retries, with a failure notice while empty.
-  const dashboardGone =
-    dashboardError instanceof Error &&
-    (dashboardError.message === "Dashboard not found" ||
-      /API error: 404/i.test(dashboardError.message));
+  // Any permanent failure leaves the page: the dashboard or its project was
+  // deleted (404), or access was revoked (403) — the 30s poll can never
+  // recover from those, so retrying in place would strand the user. Transient
+  // failures keep the user here with a failure notice while the poll retries.
+  const dashboardGone = isDashboardGone(dashboardError);
   useEffect(() => {
     if (dashboardGone) {
       // Invalidate the list so a stale cache can't bounce the user back here.

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
@@ -173,6 +173,25 @@ describe("DashboardIndexPage", () => {
     expect(screen.getByRole("button", { name: "＋ New dashboard" })).toBeTruthy();
   });
 
+  it("disables Delete for a sole dashboard — the API would reject it anyway", () => {
+    searchParams = new URLSearchParams("list=1");
+    mockDashboards([OVERVIEW]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Dashboard actions" }));
+    const del = screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement;
+    expect(del.disabled).toBe(true);
+    fireEvent.click(del);
+    expect(screen.queryByTestId("delete-dialog")).toBeNull();
+  });
+
+  it("keeps Delete enabled when other dashboards remain", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getAllByRole("button", { name: "Dashboard actions" })[0]);
+    const del = screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement;
+    expect(del.disabled).toBe(false);
+  });
+
   it("shows a retry button on error and refetches on click", () => {
     mockDashboards(undefined, new Error("boom"));
     render(<DashboardIndexPage />);

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
@@ -183,7 +183,15 @@ export default function DashboardIndexPage() {
                           Edit
                         </button>
                         <button
-                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10"
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10 disabled:opacity-50 disabled:hover:bg-transparent"
+                          // The DELETE route rejects removing a project's last
+                          // dashboard (the list endpoint would only reseed it).
+                          disabled={dashboards.length === 1}
+                          title={
+                            dashboards.length === 1
+                              ? "Projects keep at least one dashboard"
+                              : undefined
+                          }
                           onClick={(e) => {
                             e.stopPropagation();
                             setDeleteTarget({ id: d.id, name: d.name });

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -2,6 +2,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, Widget } from "../types";
+import { ApiError } from "@/lib/api/client";
 import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
 import { WidgetBuilderPage } from "./WidgetBuilderPage";
 
@@ -24,7 +25,10 @@ const createWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; erro
   { mutate: vi.fn(), isPending: false, error: null };
 const updateWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
   { mutate: vi.fn(), isPending: false, error: null };
-vi.mock("../hooks/use-dashboards", () => ({
+vi.mock("../hooks/use-dashboards", async (importOriginal) => ({
+  // Keep the real isDashboardGone: the redirect-on-gone behavior under test
+  // depends on its ApiError-status logic.
+  ...(await importOriginal<object>()),
   useDashboard: vi.fn(),
   useDashboardMutations: () => ({ createWidget, updateWidget }),
 }));
@@ -212,10 +216,16 @@ describe("WidgetBuilderPage", () => {
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
   });
 
-  it("redirects to the dashboard index when the dashboard failed to load", () => {
-    mockDashboard(undefined, new Error("404"));
+  it("redirects to the dashboard index when the dashboard is permanently gone", () => {
+    mockDashboard(undefined, new ApiError("Dashboard not found", 404));
     render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+  });
+
+  it("stays in the builder on a transient load error — a blip must not dump the draft", () => {
+    mockDashboard(undefined, new ApiError("API error: 503", 503));
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(replace).not.toHaveBeenCalled();
   });
 
   it("opens the builder for the default dashboard like any other", () => {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -20,7 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useDashboard, useDashboardMutations } from "../hooks/use-dashboards";
+import { isDashboardGone, useDashboard, useDashboardMutations } from "../hooks/use-dashboards";
 import { useWidgetPreview, useWidgetSchema } from "../hooks/use-widget-data";
 import { DEFAULT_RANGE_ID, RANGE_PRESETS, makeRange } from "../range-presets";
 import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-storage";
@@ -136,7 +136,9 @@ export function WidgetBuilderPage({
   }, [isEdit, hydrated, widget]);
 
   useEffect(() => {
-    if (dashboardError) router.replace(`/projects/${projectId}/dashboard`);
+    // Leave only when the dashboard is permanently gone; a transient blip
+    // must not dump the user's draft — the detail query's poll retries.
+    if (isDashboardGone(dashboardError)) router.replace(`/projects/${projectId}/dashboard`);
   }, [dashboardError, projectId, router]);
 
   useEffect(() => {

--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -489,6 +489,42 @@ describe("chart legend", () => {
     expect(legend.textContent).toContain("150");
     expect(legend.textContent).not.toContain("Total");
   });
+  it("builds no legend from a stale bucketed result on a categorical display", () => {
+    // keepPreviousData hands the pie/bar renderer the previous line query's
+    // bucketed rows for a beat after a display switch; those rows have no
+    // `name`, which used to render literal "undefined" legend labels.
+    const bucketed = makeResult(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt", 10],
+        ["2026-06-01T00:00:00", "claude", 30],
+        ["2026-06-01T01:00:00", "gpt", 5],
+      ],
+    );
+    const { unmount } = render(<QueryWidgetRenderer display="pie" result={bucketed} agg="sum" />);
+    expect(screen.queryByText("undefined")).toBeNull();
+    expect(screen.queryByRole("list", { name: "Chart legend" })).toBeNull();
+    unmount();
+
+    // Same for a no-breakdown bucketed shape ([bucket, value]).
+    const single = makeResult(["bucket", "value"], [["2026-06-01T00:00:00", 10]]);
+    render(<QueryWidgetRenderer display="bar" result={single} agg="sum" />);
+    expect(screen.queryByText("undefined")).toBeNull();
+    expect(screen.queryByRole("list", { name: "Chart legend" })).toBeNull();
+  });
+
+  it("builds no legend from a stale categorical result on a timeseries display", () => {
+    const categorical = makeResult(
+      ["service", "value"],
+      [
+        ["api", 10],
+        ["worker", 20],
+      ],
+    );
+    render(<QueryWidgetRenderer display="line" result={categorical} agg="sum" />);
+    expect(screen.queryByRole("list", { name: "Chart legend" })).toBeNull();
+  });
+
   it("bar legend hover dims the other categories", () => {
     const result = makeResult(
       ["service", "value"],

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -250,6 +250,10 @@ function legendFor(
   result: WidgetQueryResult,
   additive: boolean,
 ): { entries: LegendEntry[]; total: number | null } | null {
+  // Guard the result's shape, not just the display: keepPreviousData serves
+  // the previous spec's result for a beat after a display/spec switch, and
+  // pivoting a categorical result here would fabricate series entries.
+  if (result.columns[0] !== "bucket") return null;
   const { seriesKeys, data } = pivotRows(result.columns, result.rows, additive ? 0 : null);
   if (seriesKeys.length <= 1) return null;
   const entries = seriesKeys.map((k, i) => {
@@ -269,6 +273,10 @@ function categoricalLegend(
   result: WidgetQueryResult,
   additive: boolean,
 ): { entries: LegendEntry[]; total: number | null } | null {
+  // Categorical results are exactly [dim, value]; anything else is a stale
+  // mismatched shape (see legendFor) whose rows have no `name` and would
+  // render literal "undefined" labels.
+  if (result.columns.length !== 2 || result.columns[0] === "bucket") return null;
   const { data } = pivotRows(result.columns, result.rows);
   if (data.length <= 1) return null;
   const entries = data.map((r, i) => {

--- a/frontend/ui/src/features/dashboards/hooks/use-dashboards.ts
+++ b/frontend/ui/src/features/dashboards/hooks/use-dashboards.ts
@@ -1,7 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "@/lib/api/client";
 import { broadcastQueryInvalidation } from "@/lib/cross-tab-sync";
 import * as api from "../api";
 import type { LayoutItem, Widget } from "../types";
+
+/**
+ * Whether a dashboard fetch failed permanently: the dashboard or its project
+ * was deleted (404), or the viewer's access was revoked (403). Transient
+ * failures (5xx, network) return false so pollers retry in place instead of
+ * bouncing the user.
+ */
+export function isDashboardGone(error: unknown): boolean {
+  return error instanceof ApiError && (error.status === 404 || error.status === 403);
+}
 
 export function useDashboards(projectId: string) {
   return useQuery({

--- a/frontend/ui/src/lib/api/client.ts
+++ b/frontend/ui/src/lib/api/client.ts
@@ -8,6 +8,21 @@ import { clientEnv } from "@/env.client";
 const TRACE_API_BASE = clientEnv.NEXT_PUBLIC_API_URL;
 
 /**
+ * Error thrown for non-ok Next.js API responses. Carries the HTTP status so
+ * callers can tell permanent failures (403/404) from transient ones without
+ * matching on server error copy.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/**
  * Fetch from Next.js API routes (no auth headers needed, uses cookies)
  */
 export async function fetchNextApi<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
@@ -21,7 +36,7 @@ export async function fetchNextApi<T>(endpoint: string, options: RequestInit = {
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: "Unknown error" }));
-    throw new Error(error.error || `API error: ${response.status}`);
+    throw new ApiError(error.error || `API error: ${response.status}`, response.status);
   }
 
   if (response.status === 204) {


### PR DESCRIPTION
Three small hardening fixes for the dashboards stack, found in a full review of the feature. Stacked on #1574.

## 1. Chart legends ignore stale mismatched result shapes

`keepPreviousData` serves the previous spec's query result for a beat after a display/spec switch, so a pie/bar renderer can briefly receive a bucketed time-series result (and vice versa). `categoricalLegend` read `row.name` from rows that don't have one, rendering literal **"undefined"** legend labels until the new query resolved (visible as a flash; a refresh cleared it because a fresh page has no previous cache entry). Both legend builders now guard on the result's actual shape and render no legend for the mismatched beat.

## 2. Gone dashboards detected by HTTP status instead of error copy

`fetchNextApi` now throws a typed `ApiError` carrying the response status, and a shared `isDashboardGone` treats 403/404 as permanent.

- **Detail page**: previously only the exact message `"Dashboard not found"` redirected, so a revoked membership (403) or a deleted project (a 404 with different copy) parked the user on "Failed to load the dashboard — retrying automatically" while the 30s poll refetched a permanent error forever. **Note:** this deliberately widens the old exact-match semantics — any permanent 403/404 now leaves the page, since the poll can never recover from those.
- **Widget builder**: had the inverse bug — it redirected on *any* fetch error, so a transient 503 dumped the user's draft. It now leaves only when the dashboard is permanently gone.

## 3. Deleting a project's last dashboard is blocked

The dashboards list endpoint reseeds the default dashboard whenever a project has zero dashboards, so deleting the last one just resurrected a fresh seeded copy — the delete appeared broken, and a customized dashboard came back with seed content wiped back to defaults. DELETE now returns 409 for the project's last dashboard, and the list page disables that row's Delete action with a tooltip. (The count→delete pair isn't transactional; in the rare concurrent-delete race the reseed remains the backstop.)

## Verification

- Full frontend suite: 860/860 passing
- Diff coverage vs base: 96% (gate 80%); new tests cover both directions of every behavior change (403 redirects / untyped errors don't; builder stays on transient errors / leaves on gone; 409 with project-scoped count; both legend guard directions; enabled/disabled delete states)
- `tsc` no new errors, eslint clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three dashboard issues: legends no longer show stale labels, pages handle permanent 403/404 by status, and deleting a project’s last dashboard is blocked. Reduces flicker, avoids stuck retry loops, and prevents accidental reseeds.

- **Bug Fixes**
  - Chart legends: guard on result shape for both timeseries and categorical; ignore stale mismatches from `keepPreviousData` (no more "undefined" labels when switching displays).
  - Permanent errors: `fetchNextApi` now throws `ApiError(status)`; `isDashboardGone` treats 403/404 as permanent. Detail page redirects on 403/404 and invalidates the list; builder stays on transient errors and only leaves when the dashboard is gone.
  - Last dashboard deletion: API `DELETE` returns 409 if it’s the project’s sole dashboard; dashboards list disables Delete with a tooltip.

<sup>Written for commit 6b40de7ae84cd21668c97c77587aacbb778074c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

