### PR TITLE
Move billing Last updated above usage tables and label the usage window

### DIFF
--- a/frontend/ui/src/ee/features/billing/BillingTab.test.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.test.tsx
@@ -95,4 +95,49 @@ describe("BillingTab", () => {
     expect(screen.queryByText("unknown")).toBeNull();
     expect(screen.getByText("claude-opus-4-8")).toBeTruthy();
   });
+
+  it("shows Last updated once above usage sections", () => {
+    const usage: UsageStats = {
+      traces: 0,
+      spans: 0,
+      tokens: 0,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    };
+
+    render(<BillingTab workspaceId="ws_1" currentPlan={PlanType.PRO} currentUsage={usage} />);
+
+    expect(screen.getAllByText(/Last updated:/)).toHaveLength(1);
+  });
+
+  it("labels the usage window as all-time on the free plan", () => {
+    const usage: UsageStats = {
+      traces: 0,
+      spans: 0,
+      tokens: 0,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    };
+
+    render(<BillingTab workspaceId="ws_1" currentPlan={PlanType.FREE} currentUsage={usage} />);
+
+    expect(screen.getByText(/Covers: all-time/)).toBeTruthy();
+  });
+
+  it("labels the usage window as this billing period on paid plans", () => {
+    const usage: UsageStats = {
+      traces: 0,
+      spans: 0,
+      tokens: 0,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    };
+
+    render(<BillingTab workspaceId="ws_1" currentPlan={PlanType.PRO} currentUsage={usage} />);
+
+    expect(screen.getByText(/Covers: this billing period/)).toBeTruthy();
+  });
+
+  it("hides Last updated when usage has no updatedAt", () => {
+    render(<BillingTab workspaceId="ws_1" currentPlan={PlanType.PRO} currentUsage={null} />);
+
+    expect(screen.queryByText(/Last updated:/)).toBeNull();
+  });
 });

--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -253,6 +253,8 @@ export function BillingTab({
       {currentUsage?.updatedAt && (
         <p className="text-xs text-muted-foreground">
           Last updated: {new Date(currentUsage.updatedAt).toLocaleString()}
+          {" · "}
+          Covers: {currentPlan === PlanType.FREE ? "all-time" : "this billing period"}
         </p>
       )}
 

--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -250,6 +250,12 @@ export function BillingTab({
         </div>
       </div>
 
+      {currentUsage?.updatedAt && (
+        <p className="text-xs text-muted-foreground">
+          Last updated: {new Date(currentUsage.updatedAt).toLocaleString()}
+        </p>
+      )}
+
       {/* Event Usage Section */}
       <div className="border">
         <div className="border-b bg-muted/30 px-4 py-3">
@@ -282,11 +288,6 @@ export function BillingTab({
               </span>
             </div>
           </div>
-          {currentUsage?.updatedAt && (
-            <p className="mt-2 text-xs text-muted-foreground">
-              Last updated: {new Date(currentUsage.updatedAt).toLocaleString()}
-            </p>
-          )}
         </div>
       </div>
 


### PR DESCRIPTION
Fixes #1571

## Summary

Moves the existing Last updated line out of the Event Usage box and places it once above all usage sections (Event, Chat, Detector, RCA), so it clearly applies to the whole cached snapshot. Adds a window label (all-time on Free, this billing period on paid plans) on the same line. Leaves the Stripe billing-period date range unchanged.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Removed Last updated from inside the Event Usage section in BillingTab.tsx
- Added one shared metadata line above all four usage tables using currentUsage.updatedAt
- Added Covers: all-time for Free and Covers: this billing period for paid plans
- Kept this separate from the Stripe-sourced “Current billing period” range
- Added tests for placement, window labels, and missing updatedAt behavior

## Screenshots / Recordings (if applicable)

<img width="1920" height="1080" alt="Screenshot (47)" src="https://github.com/user-attachments/assets/039ff40e-7116-4a7c-9bcd-85982452064d" />
<img width="1920" height="1080" alt="Screenshot (49)" src="https://github.com/user-attachments/assets/de8c4fc1-162f-44a1-98f6-588084cb857e" />
<img width="1920" height="1080" alt="Screenshot (48)" src="https://github.com/user-attachments/assets/5927f3d6-4884-4ab6-b4df-4f31a240836a" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the billing "Last updated" timestamp above all usage tables and added a coverage label. Clarifies that the snapshot applies to Event, Chat, Detector, and RCA usage and whether it covers all-time (Free) or this billing period (paid).

- **Bug Fixes**
  - Show "Last updated" once above all usage tables to reflect the shared snapshot.
  - Add "Covers: all-time" on Free and "Covers: this billing period" on paid; Stripe billing-period range is unchanged.
  - Hide the timestamp when usage has no updatedAt and add tests for placement, labels, and missing-updatedAt behavior.

<sup>Written for commit ae7c8c34b880ea7b1262e4fd63bc85ae119cc2a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

