### PR TITLE
feat: support Kimi K3 in BYOK model catalog

### DIFF
--- a/frontend/packages/core/src/llm-providers.ts
+++ b/frontend/packages/core/src/llm-providers.ts
@@ -197,6 +197,7 @@ export const ADAPTER_MODELS: Partial<Record<LLMAdapter, LLMModelDef[]>> = {
     { id: "grok-4", label: "grok-4" },
   ],
   moonshot: [
+    { id: "kimi-k3", label: "kimi-k3" },
     { id: "kimi-k2.6", label: "kimi-k2.6" },
     { id: "kimi-k2.5", label: "kimi-k2.5" },
     { id: "kimi-k2-thinking", label: "kimi-k2-thinking" },

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -1057,5 +1057,17 @@
       "cacheRead": 0,
       "cacheWrite": null
     }
+  },
+  {
+    "id": "tr-kimi-k3",
+    "modelName": "kimi-k3",
+    "matchPattern": "(?i)^(moonshot\\/)?kimi-k3(-[\\d-]+)?$",
+    "provider": "moonshot",
+    "prices": {
+      "input": 0.000003,
+      "output": 0.000015,
+      "cacheRead": 0.0000003,
+      "cacheWrite": null
+    }
   }
 ]

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -173,6 +173,12 @@ DEEPSEEK_MODEL_CASES = [
     ("deepseek-v4-pro-20260424", "deepseek-v4-pro"),
 ]
 
+KIMI_MODEL_CASES = [
+    ("kimi-k3", "kimi-k3"),
+    ("moonshot/kimi-k3", "kimi-k3"),
+    ("kimi-k3-20260716", "kimi-k3"),
+]
+
 
 @patch("worker.tokens.pricing._load_cache", _mock_load_cache)
 class TestGetModelPrice:
@@ -266,6 +272,30 @@ class TestDeepSeekModelIds:
     def test_deepseek_v4_pro_calculates_cost(self, real_cache):
         with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
             result = calculate_cost("deepseek-v4-pro", "Hello world", "Hi there")
+
+        assert result["input_tokens"] is not None
+        assert result["input_tokens"] > 0
+        assert result["output_tokens"] is not None
+        assert result["output_tokens"] > 0
+        assert result["cost"] is not None
+        assert result["cost"] > 0
+
+
+class TestKimiModelIds:
+    @pytest.mark.parametrize("model_id,expected_name", KIMI_MODEL_CASES)
+    def test_matches_expected_model(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert "input" in price and "output" in price
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched a different entry than {expected_name}"
+        )
+
+    def test_kimi_k3_calculates_cost(self, real_cache):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            result = calculate_cost("kimi-k3", "Hello world", "Hi there")
 
         assert result["input_tokens"] is not None
         assert result["input_tokens"] > 0


### PR DESCRIPTION
## Summary
Kimi K3 is Moonshot's latest SOTA reasoning model [[API Docs]](https://platform.kimi.ai/docs/guide/kimi-k3-quickstart)
Adds Kimi K3 to the BYOK model catalog and gives it a pricing entry.
<img width="818" height="370" alt="image" src="https://github.com/user-attachments/assets/089bb6ef-8506-4c3f-bf24-c21e93d165f4" />

The new entry goes at the top of the Moonshot list, which also makes it the default for any existing Moonshot BYOK row that is not pinned to a specific model. That is worth knowing, but it is not blocking.

Pricing maps cleanly onto the existing schema because K3 caching uses automatic hit/miss discounting like DeepSeek, rather than a paid cache-write model like GPT-5.6.

|  | Price per 1M tokens |
|---|---|
| Input (cache hit) | $0.30 |
| Input (cache miss) | $3.00 |
| Output | $15.00 |

## Type of Change
- [x] feat - A new feature

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
