### PR TITLE
fix(ui): match trace-feed widget headers and errors to the trace list

### DIFF
--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
@@ -100,7 +100,7 @@ describe("TraceFeedWidget", () => {
     await waitFor(() => expect(screen.getByText("No traces in this time range")).toBeTruthy());
   });
 
-  it("renders a populated list with status chips, cost and time; a row click opens the trace", async () => {
+  it("renders a populated list with error counts, cost and time; a row click opens the trace", async () => {
     vi.mocked(getTraces).mockResolvedValue({
       data: [
         makeTrace({ trace_id: "err-trace", name: "errored-run", error_count: 2, total_cost: 0.5 }),
@@ -118,8 +118,9 @@ describe("TraceFeedWidget", () => {
 
     await waitFor(() => expect(screen.getByText("errored-run")).toBeTruthy());
 
-    expect(screen.getByText("ERROR")).toBeTruthy();
-    expect(screen.getAllByText("OK")).toHaveLength(2);
+    // err-trace has 2 errors → a red count badge; the two clean traces show 0.
+    expect(screen.getByText("2")).toBeTruthy();
+    expect(screen.getAllByText("0")).toHaveLength(2);
 
     // Cost renders through the shared formatCost: magnitude-adaptive
     // precision, "-" for missing/zero — same as every other cost in the app.

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
@@ -17,19 +17,17 @@ interface TraceFeedWidgetProps {
   range: TimeRange;
 }
 
-function StatusChip({ errorCount }: { errorCount: number }) {
+// Error count, styled to match the trace-list "Errors" column: a red count
+// badge when a trace recorded errors, a muted zero otherwise.
+function ErrorCount({ errorCount }: { errorCount: number }) {
   if (errorCount > 0) {
     return (
-      <span className="inline-flex rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
-        ERROR
+      <span className="inline-flex min-w-5 justify-center rounded bg-red-100 px-1.5 py-0.5 text-[10px] font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
+        {errorCount}
       </span>
     );
   }
-  return (
-    <span className="inline-flex rounded bg-emerald-100 px-1.5 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400">
-      OK
-    </span>
-  );
+  return <span className="text-muted-foreground">0</span>;
 }
 
 function fmtTime(iso: string): string {
@@ -91,10 +89,10 @@ export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps
     <div className="h-full overflow-auto">
       <table className="w-full text-[11.5px]">
         <thead>
-          <tr className="text-left text-[10px] uppercase tracking-wide text-muted-foreground">
-            <th className="pb-1.5 pr-3 font-medium">Time</th>
+          <tr className="text-left text-[11px] text-muted-foreground">
+            <th className="pb-1.5 pr-3 font-medium">Timestamp</th>
             <th className="pb-1.5 pr-3 font-medium">Name</th>
-            <th className="pb-1.5 pr-3 font-medium">Status</th>
+            <th className="pb-1.5 pr-3 font-medium">Errors</th>
             <th className="pb-1.5 pr-3 font-medium">Cost</th>
             <th className="pb-1.5 font-medium">Latency</th>
           </tr>
@@ -118,7 +116,7 @@ export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps
                   {trace.name}
                 </td>
                 <td className="py-1 pr-3">
-                  <StatusChip errorCount={trace.error_count} />
+                  <ErrorCount errorCount={trace.error_count} />
                 </td>
                 <td className="py-1 pr-3 tabular-nums text-muted-foreground">
                   {formatCost(trace.total_cost)}


### PR DESCRIPTION
Stacked on top of #1575 (`fix/legend-shape-and-dashboard-guards`).

The dashboard **Recent traces** / **Recent failures** trace-feed widgets rendered:
- **UPPERCASE** column headers (`text-[10px] uppercase tracking-wide`), which looked heavy and read inconsistently with the trace list; and
- a binary **OK / ERROR** status chip, when the useful signal is *how many* errors a trace had.

This makes them follow the trace-list section (`app/projects/[projectId]/traces/page.tsx`):

- Headers are normal-case and muted; `Time` → **`Timestamp`**.
- The `Status` column becomes **`Errors`**, rendering the error count as a red count badge (`min-w-5 … bg-red-100 … text-red-700` + dark variants) when `error_count > 0`, and a muted `0` otherwise — identical to the list's Errors cell.
- `StatusChip` → `ErrorCount`.

`error_count` was already threaded into the widget, so this is presentation-only — no data or query changes.



## Screenshots

<img width="1967" height="800" alt="Screenshot 2026-07-16 at 11 40 08 AM" src="https://github.com/user-attachments/assets/cb65b6be-0b18-43c9-8263-bca93d314240" />


## Test
- Updated `TraceFeedWidget.test.tsx` to assert the error-count rendering (a `2` badge and two `0`s) instead of the old `ERROR` / `OK` chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the dashboard “Recent traces” and “Recent failures” widgets to match the trace list. Headers use normal case, and the Status column now shows an error count for clearer signal.

- **Bug Fixes**
  - Headers now normal case; “Time” → “Timestamp”.
  - Replaced “Status” with “Errors”; render count badge when >0, muted “0” otherwise (matches trace list).
  - Renamed `StatusChip` to `ErrorCount` and updated tests; presentation-only with no data or query changes.

<sup>Written for commit e076bc595360e7f1198a2657ee50da8976986585. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



