### PR TITLE
fix(ui): show the chart legend for single-category breakdowns

### DIFF
--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -447,7 +447,7 @@ describe("chart legend", () => {
   // RTL auto-cleanup needs vitest globals, which this config doesn't enable.
   afterEach(cleanup);
 
-  it("multi-series line: legend lists series sorted with a window Total, single series gets none", () => {
+  it("multi-series line: legend lists series sorted with a window Total, no-breakdown gets none", () => {
     const multi = makeResult(
       ["bucket", "model_name", "value"],
       [
@@ -489,6 +489,29 @@ describe("chart legend", () => {
     expect(legend.textContent).toContain("150");
     expect(legend.textContent).not.toContain("Total");
   });
+  it("labels a single-series breakdown timeseries via the legend", () => {
+    // With one breakdown group the chart is a bare line — the legend is the
+    // only place the group's name (e.g. which model) can appear.
+    const single = makeResult(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt-4o-mini", 1],
+        ["2026-06-02T00:00:00", "gpt-4o-mini", 3],
+      ],
+    );
+    render(<QueryWidgetRenderer display="line" result={single} agg="sum" />);
+    const legend = screen.getByRole("list", { name: "Chart legend" });
+    expect(within(legend).getByText("gpt-4o-mini")).toBeTruthy();
+  });
+
+  it("labels a single-category pie via the legend", () => {
+    // A one-slice pie renders a full unlabeled circle without it.
+    const single = makeResult(["service", "value"], [["api", 10]]);
+    render(<QueryWidgetRenderer display="pie" result={single} agg="count" />);
+    const legend = screen.getByRole("list", { name: "Chart legend" });
+    expect(within(legend).getByText("api")).toBeTruthy();
+  });
+
   it("builds no legend from a stale bucketed result on a categorical display", () => {
     // keepPreviousData hands the pie/bar renderer the previous line query's
     // bucketed rows for a beat after a display switch; those rows have no

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -244,7 +244,8 @@ const seriesOpacity = (hovered: string | null, key: string, base = 1) =>
  * Additive measures sum across buckets (a true window total); non-additive
  * ones average their non-null buckets — an approximation (bucketed
  * percentiles can't be re-aggregated), so those get no Total row.
- * Single-series charts (no breakdown) return null: nothing to disambiguate.
+ * No-breakdown charts return null: their only series is the synthetic
+ * "value" key, and a legend row would just echo the widget title.
  */
 function legendFor(
   result: WidgetQueryResult,
@@ -253,9 +254,14 @@ function legendFor(
   // Guard the result's shape, not just the display: keepPreviousData serves
   // the previous spec's result for a beat after a display/spec switch, and
   // pivoting a categorical result here would fabricate series entries.
-  if (result.columns[0] !== "bucket") return null;
+  // Require the [bucket, dim, value] breakdown shape — [bucket, value] is the
+  // no-breakdown case.
+  if (result.columns[0] !== "bucket" || result.columns.length !== 3) return null;
   const { seriesKeys, data } = pivotRows(result.columns, result.rows, additive ? 0 : null);
-  if (seriesKeys.length <= 1) return null;
+  // A single genuine series still gets a legend — with one breakdown group the
+  // chart is a bare line, so the legend is the only place its name appears.
+  // Zero series means every row was a WITH FILL gap row (empty window).
+  if (seriesKeys.length === 0) return null;
   const entries = seriesKeys.map((k, i) => {
     const nums = data
       .map((r) => (r as Record<string, unknown>)[k])
@@ -278,7 +284,9 @@ function categoricalLegend(
   // render literal "undefined" labels.
   if (result.columns.length !== 2 || result.columns[0] === "bucket") return null;
   const { data } = pivotRows(result.columns, result.rows);
-  if (data.length <= 1) return null;
+  // A single category still gets a legend — a one-slice pie is otherwise an
+  // unlabeled full circle.
+  if (data.length === 0) return null;
   const entries = data.map((r, i) => {
     const v = r.value;
     return {
@@ -617,8 +625,8 @@ export function QueryWidgetRenderer({
 }) {
   const additive = agg === undefined || !NON_ADDITIVE_AGGS.has(agg);
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
-  // Multi-series charts get a legend under the plot; everything else
-  // (single series, stat tiles, tables, histograms) stays legend-free.
+  // Breakdown charts get a legend under the plot; everything else
+  // (no-breakdown series, stat tiles, tables, histograms) stays legend-free.
   const legend = useMemo(() => {
     if (result.rows.length === 0) return null;
     if (display === "line" || display === "area") return legendFor(result, additive);


### PR DESCRIPTION
## Problem

A breakdown widget whose window contains exactly one group renders no label anywhere:

- a single-series **line/area** chart is a bare unlabeled line — nothing says which model/user/service it is,
- a one-slice **pie** is an unlabeled full circle,
- **bar** only survives via its x-axis tick.

The legend builders bailed below two entries (`seriesKeys.length <= 1` / `data.length <= 1`), conflating "only one group" with "nothing to disambiguate".

## Fix

Key the legend guards on the presence of a breakdown dimension instead of the entry count:

- `legendFor` (timeseries) requires the `[bucket, dim, value]` breakdown shape but renders from a single series; zero series (a window of only WITH FILL gap rows) still yields no legend.
- `categoricalLegend` (bar/pie) only bails on zero rows.
- Plain no-breakdown series (`[bucket, value]`) intentionally keep no legend — their only series is the synthetic `value` key, which would just echo the widget title.

The stale-shape guards from the keepPreviousData fix are preserved (one is now structural: a categorical result can never satisfy the 3-column check).

## Notes

- One pre-existing test was renamed ("single series gets none" → "no-breakdown gets none"): its fixture was a no-breakdown shape, which is the case that still gets no legend.
- Known cosmetic redundancy, left as is for consistency: an additive single-entry legend shows a Total row equal to its one entry. Can suppress `Total` for single-entry legends in a follow-up if preferred.

## Testing

- New tests: single-series breakdown line gets a legend naming the series; single-category pie gets a legend row; no-breakdown series stays legend-free.
- Both new legend tests failed before the fix and pass after; full `frontend/ui` suite: 862/862.
- Diff coverage vs the base branch: 100% of changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing labels on single-group breakdown charts by showing the legend for single-series timeseries and one-slice pies/bars. No-breakdown charts still hide the legend.

- **Bug Fixes**
  - Legend now keys off the presence of a breakdown dimension, not entry count.
  - Timeseries (`line`/`area`): require `[bucket, dim, value]`; render with one series; skip for zero-series windows and `[bucket, value]` no-breakdown.
  - Categorical (`pie`/`bar`): render for a single category; skip only when empty or stale; tests added for single-series line and one-slice pie, and one test renamed to reflect the no-breakdown case.

<sup>Written for commit aa2083706504261b024321658911e83563238c2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

