### PR TITLE
fix(api): rate-limit the widget query + field-values reads

### DIFF
--- a/backend/rest/routers/dashboards.py
+++ b/backend/rest/routers/dashboards.py
@@ -8,9 +8,16 @@ the field registry that drives the builder UI.
 import logging
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException, Query, status
+from fastapi import APIRouter, HTTPException, Query, Request, status
 
-from rest.routers.deps import ProjectAccess
+from rest.rate_limit import (
+    BUCKET_READ,
+    is_request_rate_limit_exempt,
+    key_read,
+    limiter,
+    resolve_limit,
+)
+from rest.routers.deps import ProjectAccess, RateLimitedProjectAccess
 from rest.schemas.dashboards import WidgetQueryRequest, WidgetQueryResponse
 from rest.schemas.traces import FilterValuesResponse
 from rest.services.trace_reader import get_trace_reader_service
@@ -23,11 +30,15 @@ router = APIRouter(prefix="/projects/{project_id}/widgets", tags=["Dashboards"])
 
 
 @router.get("/field-values/{view}/{field}", response_model=FilterValuesResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def get_widget_field_values(
+    request: Request,
     project_id: str,
     view: str,
     field: str,
-    _access: ProjectAccess,
+    _access: RateLimitedProjectAccess,
     start_time: datetime | None = Query(
         None, description="Only consider rows whose event time is at or after this timestamp"
     ),
@@ -45,7 +56,8 @@ async def get_widget_field_values(
         project_id (str): Project that owns the data; server-bound for isolation.
         view (str): The widget view (``spans`` or ``traces``) whose table is scanned.
         field (str): The string dimension to enumerate.
-        _access (ProjectAccess): Validates the caller's access to the project.
+        request (Request): Injected so the shared read limiter can key the request.
+        _access (RateLimitedProjectAccess): Validates access + sets the rate-limit identity.
         start_time (datetime | None): Lower bound of the active dashboard window.
         end_time (datetime | None): Upper bound (exclusive) of the active window.
 
@@ -101,10 +113,14 @@ async def get_widget_schema(project_id: str, _access: ProjectAccess) -> dict:
 
 
 @router.post("/query", response_model=WidgetQueryResponse)
+@limiter.shared_limit(
+    resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
+)
 async def query_widget_data(
+    request: Request,
     project_id: str,
     body: WidgetQueryRequest,
-    _access: ProjectAccess,
+    _access: RateLimitedProjectAccess,
 ):
     """Execute a widget spec. Stateless: used by saved widgets and builder previews."""
     try:

--- a/backend/rest/schemas/dashboards.py
+++ b/backend/rest/schemas/dashboards.py
@@ -26,7 +26,7 @@ class WidgetFilter(_StrictModel):
     """A single filter predicate applied to a widget query."""
 
     field: str
-    op: Literal["=", "!=", "contains", ">", ">=", "<", "<="]
+    op: Literal["=", "contains", ">", ">=", "<", "<="]
     # min_length mirrors the frontend schema: an empty value means the filter
     # was never completed and would silently match only empty-valued rows.
     value: Annotated[str, StringConstraints(min_length=1)] | float

--- a/backend/rest/services/widget_query.py
+++ b/backend/rest/services/widget_query.py
@@ -40,7 +40,6 @@ _NON_ADDITIVE_AGGS = frozenset({"avg", "min", "max", "p50", "p95", "p99"})
 
 _OP_SQL = {
     "=": "{expr} = {{{p}:{t}}}",
-    "!=": "{expr} != {{{p}:{t}}}",
     ">": "{expr} > {{{p}:{t}}}",
     ">=": "{expr} >= {{{p}:{t}}}",
     "<": "{expr} < {{{p}:{t}}}",

--- a/backend/rest/services/widget_query.py
+++ b/backend/rest/services/widget_query.py
@@ -31,6 +31,12 @@ _AGG_SQL = {
     "p99": "quantile(0.99)({expr})",
 }
 
+# Aggregations where an empty time bucket has no meaningful value: count/sum
+# of nothing is honestly 0, but the average or a percentile of nothing is a
+# gap, not a zero. Drives Nullable metrics on time series so WITH FILL rows
+# come back NULL and charts render gaps instead of false drops to zero.
+_NON_ADDITIVE_AGGS = frozenset({"avg", "min", "max", "p50", "p95", "p99"})
+
 _OP_SQL = {
     "=": "{expr} = {{{p}:{t}}}",
     "!=": "{expr} != {{{p}:{t}}}",
@@ -161,6 +167,12 @@ def compile_widget_query(
     order_by = ""
 
     is_timeseries = spec.display.type in ("line", "area")
+    if is_timeseries and spec.metric.agg in _NON_ADDITIVE_AGGS:
+        # For count/sum an empty bucket genuinely is zero, but for averages
+        # and percentiles it has NO value — a filled 0 would render as a false
+        # collapse (a p95 latency line dipping to nothing). Nullable makes the
+        # WITH FILL rows below carry NULL, which the chart draws as a gap.
+        metric_sql = f"toNullable({metric_sql})"
     # Bound unconditionally: both the bucketing branch and the row-cap branch
     # below key off is_timeseries, and an implicit binding would let them drift.
     gran = _pick_granularity(start_time, end_time)

--- a/backend/rest/services/widget_query.py
+++ b/backend/rest/services/widget_query.py
@@ -19,6 +19,7 @@ MAX_TABLE_ROWS = 1000
 HISTOGRAM_BINS = 20
 QUERY_TIMEOUT_S = 10
 HOUR_BUCKET_MAX = timedelta(days=2)
+GROUP_BY_SPILL_BYTES = 1 * 1024**3  # aggregation memory ceiling before disk spill
 
 _AGG_SQL = {
     "count": "count({expr})",
@@ -274,7 +275,16 @@ def run_widget_query(
     result = client.query(
         sql,
         parameters=params,
-        settings={"readonly": 1, "max_execution_time": QUERY_TIMEOUT_S},
+        settings={
+            "readonly": 1,
+            "max_execution_time": QUERY_TIMEOUT_S,
+            # Large breakdown GROUP BYs spill to disk past this threshold
+            # instead of ballooning server memory: slower beats OOM for a
+            # dashboard tile. (use_query_condition_cache would help the
+            # repeated same-window scans too, but it needs ClickHouse >= 25.4
+            # — the current server rejects it as an unknown setting.)
+            "max_bytes_before_external_group_by": GROUP_BY_SPILL_BYTES,
+        },
     )
     meta: dict[str, Any] = {}
     if spec.display.type in ("line", "area"):

--- a/backend/rest/services/widget_registry.py
+++ b/backend/rest/services/widget_registry.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-FILTER_OPS_STRING = ("=", "!=", "contains")
-FILTER_OPS_NUMBER = (">", ">=", "<", "<=", "=", "!=")
+FILTER_OPS_STRING = ("=", "contains")
+FILTER_OPS_NUMBER = (">", ">=", "<", "<=", "=")
 AGGS_NUMBER = ("sum", "avg", "min", "max", "p50", "p95", "p99")
 
 

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
@@ -8,6 +8,7 @@ vi.mock("next/server", () => ({ NextRequest: class {} }));
 vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
 
 const dashboardFindFirstMock = vi.fn();
+const dashboardCountMock = vi.fn();
 const dashboardUpdateMock = vi.fn();
 const dashboardDeleteMock = vi.fn();
 const widgetFindFirstMock = vi.fn();
@@ -20,6 +21,7 @@ vi.mock("@traceroot/core", () => ({
   prisma: {
     dashboard: {
       findFirst: (...args: unknown[]) => dashboardFindFirstMock(...args),
+      count: (...args: unknown[]) => dashboardCountMock(...args),
       update: (...args: unknown[]) => dashboardUpdateMock(...args),
       delete: (...args: unknown[]) => dashboardDeleteMock(...args),
     },
@@ -86,8 +88,12 @@ const fakeWidget = {
 
 beforeEach(() => {
   dashboardFindFirstMock.mockReset();
+  dashboardCountMock.mockReset();
   dashboardUpdateMock.mockReset();
   dashboardDeleteMock.mockReset();
+  // Default: the project has other dashboards, so DELETE's last-dashboard
+  // guard doesn't trip.
+  dashboardCountMock.mockResolvedValue(2);
   widgetFindFirstMock.mockReset();
   widgetCreateMock.mockReset();
   widgetUpdateMock.mockReset();
@@ -267,6 +273,18 @@ describe("DELETE /dashboards/[dashboardId]", () => {
     const res = (await DELETE(makeRequest(), makeParams("proj-1", "dash-999"))) as MockResponse;
     expect(res.status).toBe(404);
     expect(dashboardDeleteMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 for the project's last dashboard (deleting it would only trigger a reseed)", async () => {
+    dashboardFindFirstMock.mockResolvedValue(fakeDashboard);
+    dashboardCountMock.mockResolvedValue(1);
+
+    const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
+    expect(res.status).toBe(409);
+    expect(dashboardDeleteMock).not.toHaveBeenCalled();
+    // The count is scoped to the project, not global.
+    const [call] = dashboardCountMock.mock.calls;
+    expect((call[0] as { where: Record<string, unknown> }).where.projectId).toBe("proj-1");
   });
 
   it("returns 401 when unauthenticated", async () => {

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.test.ts
@@ -459,50 +459,35 @@ describe("DELETE /dashboards/[dashboardId]/widgets/[widgetId]", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Default dashboard is read-only
+// Default dashboard is editable like any other dashboard
 // ---------------------------------------------------------------------------
-describe("default dashboard is read-only", () => {
+describe("default dashboard is editable", () => {
   const defaultDashboard = { ...fakeDashboard, isDefault: true };
 
-  it("PATCH /dashboards/[dashboardId] returns 403", async () => {
+  it("PATCH /dashboards/[dashboardId] renames it", async () => {
     dashboardFindFirstMock.mockResolvedValue(defaultDashboard);
+    dashboardUpdateMock.mockResolvedValue({ ...defaultDashboard, name: "renamed" });
     const res = (await PATCH(makeRequest({ name: "renamed" }), makeParams())) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(dashboardUpdateMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(dashboardUpdateMock).toHaveBeenCalledTimes(1);
   });
 
-  it("DELETE /dashboards/[dashboardId] returns 403", async () => {
+  it("DELETE /dashboards/[dashboardId] deletes it", async () => {
     dashboardFindFirstMock.mockResolvedValue(defaultDashboard);
     const res = (await DELETE(makeRequest(), makeParams())) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(dashboardDeleteMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    expect(dashboardDeleteMock).toHaveBeenCalledTimes(1);
   });
 
-  it("POST .../widgets returns 403", async () => {
+  it("POST .../widgets adds a widget", async () => {
     dashboardFindFirstMock.mockResolvedValue(defaultDashboard);
+    widgetCreateMock.mockResolvedValue(fakeWidget);
     const res = (await widgetPOST(
-      makeRequest({ title: "t", type: "query", spec: {} }),
+      makeRequest({ title: "My Widget", type: "query", spec: { sql: "SELECT 1" } }),
       makeParams(),
     )) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(widgetCreateMock).not.toHaveBeenCalled();
-  });
-
-  it("PATCH .../widgets/[widgetId] returns 403", async () => {
-    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: true } });
-    const res = (await widgetPATCH(
-      makeRequest({ title: "renamed" }),
-      makeWidgetParams(),
-    )) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(widgetUpdateMock).not.toHaveBeenCalled();
-  });
-
-  it("DELETE .../widgets/[widgetId] returns 403", async () => {
-    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: true } });
-    const res = (await widgetDELETE(makeRequest(), makeWidgetParams())) as MockResponse;
-    expect(res.status).toBe(403);
-    expect(widgetDeleteMock).not.toHaveBeenCalled();
+    expect(res.status).toBe(201);
+    expect(widgetCreateMock).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -610,7 +595,7 @@ describe("mutation hardening", () => {
     )) as MockResponse;
     expect(post.status).toBe(400);
 
-    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: false } });
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
     const patch = (await widgetPATCH(
       makeRequest({ title: "x".repeat(101) }),
       makeWidgetParams(),
@@ -635,7 +620,7 @@ describe("mutation hardening", () => {
     const del = (await DELETE(makeRequest(), makeParams())) as MockResponse;
     expect(del.status).toBe(404);
 
-    widgetFindFirstMock.mockResolvedValue({ ...fakeWidget, dashboard: { isDefault: false } });
+    widgetFindFirstMock.mockResolvedValue(fakeWidget);
     widgetUpdateMock.mockRejectedValue(gone);
     const wpatch = (await widgetPATCH(
       makeRequest({ title: "renamed" }),

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
@@ -111,6 +111,14 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
   });
   if (!existing) return errorResponse("Dashboard not found", 404);
 
+  // The list endpoint reseeds the default dashboard whenever a project has
+  // zero dashboards, so deleting the last one would just resurrect a fresh
+  // seeded copy — block it instead (the list UI disables this path too).
+  const remaining = await prisma.dashboard.count({ where: { projectId } });
+  if (remaining <= 1) {
+    return errorResponse("Cannot delete a project's last dashboard", 409);
+  }
+
   try {
     await prisma.dashboard.delete({ where: { id: dashboardId } });
   } catch (e) {

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/route.ts
@@ -87,7 +87,6 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     where: { id: dashboardId, projectId },
   });
   if (!existing) return errorResponse("Dashboard not found", 404);
-  if (existing.isDefault) return errorResponse("The default dashboard is read-only", 403);
 
   try {
     const dashboard = await prisma.dashboard.update({
@@ -111,7 +110,6 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
     where: { id: dashboardId, projectId },
   });
   if (!existing) return errorResponse("Dashboard not found", 404);
-  if (existing.isDefault) return errorResponse("The default dashboard is read-only", 403);
 
   try {
     await prisma.dashboard.delete({ where: { id: dashboardId } });

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/[widgetId]/route.ts
@@ -11,7 +11,6 @@ type RouteParams = {
 async function findWidget(dashboardId: string, widgetId: string, projectId: string) {
   return prisma.widget.findFirst({
     where: { id: widgetId, dashboardId, dashboard: { projectId } },
-    include: { dashboard: { select: { isDefault: true } } },
   });
 }
 
@@ -22,9 +21,6 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
 
   const existing = await findWidget(dashboardId, widgetId, projectId);
   if (!existing) return errorResponse("Widget not found", 404);
-  if (existing.dashboard?.isDefault) {
-    return errorResponse("The default dashboard is read-only", 403);
-  }
 
   const parsed = await parseJsonObject(req);
   if (parsed.error) return parsed.error;
@@ -78,9 +74,6 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
 
   const existing = await findWidget(dashboardId, widgetId, projectId);
   if (!existing) return errorResponse("Widget not found", 404);
-  if (existing.dashboard?.isDefault) {
-    return errorResponse("The default dashboard is read-only", 403);
-  }
 
   try {
     await prisma.widget.delete({ where: { id: widgetId } });

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/[dashboardId]/widgets/route.ts
@@ -18,7 +18,6 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     where: { id: dashboardId, projectId },
   });
   if (!dashboard) return errorResponse("Dashboard not found", 404);
-  if (dashboard.isDefault) return errorResponse("The default dashboard is read-only", 403);
 
   const parsed = await parseJsonObject(req);
   if (parsed.error) return parsed.error;

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.test.ts
@@ -7,12 +7,16 @@ vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
 
 const dashboardFindManyMock = vi.fn();
 const dashboardCreateMock = vi.fn();
+const userFindManyMock = vi.fn();
 vi.mock("@traceroot/core", () => ({
   Role: { VIEWER: "VIEWER", MEMBER: "MEMBER", ADMIN: "ADMIN" },
   prisma: {
     dashboard: {
       findMany: (...args: unknown[]) => dashboardFindManyMock(...args),
       create: (...args: unknown[]) => dashboardCreateMock(...args),
+    },
+    user: {
+      findMany: (...args: unknown[]) => userFindManyMock(...args),
     },
   },
 }));
@@ -51,6 +55,8 @@ function makeParams(projectId = "proj-1") {
 beforeEach(() => {
   dashboardFindManyMock.mockReset();
   dashboardCreateMock.mockReset();
+  userFindManyMock.mockReset();
+  userFindManyMock.mockResolvedValue([]);
   requireAuthMock.mockReset();
   requireProjectAccessMock.mockReset();
   // Default: authenticated with project access.
@@ -66,19 +72,55 @@ describe("GET /dashboards — existing dashboards", () => {
         name: "Overview",
         description: null,
         isDefault: true,
+        createdBy: "user-1",
+        updateTime: new Date(),
+      },
+      {
+        id: "dash-2",
+        name: "Costs",
+        description: null,
+        isDefault: false,
+        createdBy: "user-gone",
         updateTime: new Date(),
       },
     ];
     dashboardFindManyMock.mockResolvedValue(existing);
+    userFindManyMock.mockResolvedValue([{ id: "user-1", name: "Ada", email: "ada@example.com" }]);
 
     const res = await GET(makeGetRequest(), makeParams());
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { data: unknown[] };
-    expect(body.data).toHaveLength(1);
+    const body = (await res.json()) as {
+      data: { creator: string | null; createdBy?: string }[];
+    };
+    expect(body.data).toHaveLength(2);
+    // creator ids resolve to display names in one batch; a deleted account
+    // resolves to null, and the raw id never leaves the API
+    expect(userFindManyMock).toHaveBeenCalledTimes(1);
+    expect(body.data[0].creator).toBe("Ada");
+    expect(body.data[1].creator).toBeNull();
+    expect(body.data[0].createdBy).toBeUndefined();
     // create must never have been called
     expect(dashboardCreateMock).not.toHaveBeenCalled();
     // findMany called exactly once (no re-read needed)
     expect(dashboardFindManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the creator's email when the account has no name", async () => {
+    dashboardFindManyMock.mockResolvedValue([
+      {
+        id: "dash-1",
+        name: "Overview",
+        description: null,
+        isDefault: true,
+        createdBy: "user-1",
+        updateTime: new Date(),
+      },
+    ]);
+    userFindManyMock.mockResolvedValue([{ id: "user-1", name: null, email: "ada@example.com" }]);
+
+    const res = await GET(makeGetRequest(), makeParams());
+    const body = (await res.json()) as { data: { creator: string | null }[] };
+    expect(body.data[0].creator).toBe("ada@example.com");
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -109,6 +151,7 @@ describe("GET /dashboards — lazy seeding (no existing dashboards)", () => {
         name: "Overview",
         description: null,
         isDefault: true,
+        createdBy: "user-1",
         updateTime: new Date(),
       },
     ]);
@@ -129,7 +172,16 @@ describe("GET /dashboards — lazy seeding (no existing dashboards)", () => {
 
     expect(data.id).toBe("default_proj-1");
     expect(data.isDefault).toBe(true);
+    expect((data as { name?: string }).name).toBe("Default");
+    // The seeded Overview ships with a purpose note like any user dashboard.
+    expect((data as { description?: string }).description).toMatch(/overview/i);
     expect(data.widgets.create.length).toBeGreaterThanOrEqual(7);
+
+    // The failures feed filters on the trace-list errors predicate.
+    const failures = (
+      data.widgets.create as unknown as Array<{ title: string; spec: { filters?: unknown[] } }>
+    ).find((w) => w.title === "Recent failures");
+    expect(failures?.spec.filters).toEqual([{ field: "errors", op: "gt", value: 0 }]);
 
     // Every layout[i].i must equal widgets.create[i].id
     data.layout.forEach((layoutItem, idx) => {
@@ -149,6 +201,7 @@ describe("GET /dashboards — lazy seeding (no existing dashboards)", () => {
         name: "Overview",
         description: null,
         isDefault: true,
+        createdBy: "user-1",
         updateTime: new Date(),
       },
     ]);

--- a/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/dashboards/route.ts
@@ -11,11 +11,37 @@ type RouteParams = { params: Promise<{ projectId: string }> };
 const listArgs = (projectId: string) => ({
   where: { projectId },
   orderBy: [{ isDefault: "desc" as const }, { createTime: "asc" as const }],
-  select: { id: true, name: true, description: true, isDefault: true, updateTime: true },
+  select: {
+    id: true,
+    name: true,
+    description: true,
+    isDefault: true,
+    createdBy: true,
+    createTime: true,
+    updateTime: true,
+  },
 });
 
+// Dashboards are shared across a project's members, so the list shows who
+// created each one. createdBy holds a bare user id (no relation on the
+// model); resolve the display names in one batch and swap them in — a
+// deleted account resolves to null and renders as "—".
+async function withCreators<T extends { createdBy: string }>(dashboards: T[]) {
+  const ids = [...new Set(dashboards.map((d) => d.createdBy))];
+  const users = await prisma.user.findMany({
+    where: { id: { in: ids } },
+    select: { id: true, name: true, email: true },
+  });
+  // || not ??: an empty-string name must fall through to the email too.
+  const byId = new Map(users.map((u) => [u.id, u.name || u.email]));
+  return dashboards.map(({ createdBy, ...d }) => ({
+    ...d,
+    creator: byId.get(createdBy) ?? null,
+  }));
+}
+
 // GET /api/projects/[projectId]/dashboards — list; lazily seeds the default
-// "Overview" dashboard the first time a project's dashboards are fetched.
+// "Default" dashboard the first time a project's dashboards are fetched.
 export async function GET(_req: NextRequest, { params }: RouteParams) {
   const auth = await requireProjectAuth(params);
   if (auth.error) return auth.error;
@@ -32,7 +58,8 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
         data: {
           id: defaultDashboardId(projectId),
           projectId,
-          name: "Overview",
+          name: "Default",
+          description: "Auto-created overview of traces, cost, tokens, and latency.",
           isDefault: true,
           createdBy: user.id,
           // layout keys MUST equal widget ids (react-grid-layout matches on `i`)
@@ -49,7 +76,7 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     dashboards = await prisma.dashboard.findMany(listArgs(projectId));
   }
 
-  return successResponse({ data: dashboards });
+  return successResponse({ data: await withCreators(dashboards) });
 }
 
 // POST /api/projects/[projectId]/dashboards — create a named dashboard

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -119,8 +119,8 @@ vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
 
 import { useDashboard, useDashboards } from "@/features/dashboards/hooks/use-dashboards";
 
-// The rendered dashboard (d1) is deliberately non-default: the default one is
-// read-only, which the dedicated tests below cover.
+// d1 is a user dashboard; d2 is the seeded default (Overview) — both are
+// fully editable, the default is just auto-created and tab-marked.
 const DASH_A: DashboardSummary = {
   id: "d1",
   name: "Custom",
@@ -251,20 +251,20 @@ describe("DashboardDetailPage", () => {
     expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d1/widgets/new");
   });
 
-  it("marks the grid read-only and hides both create-widget buttons on the default dashboard", () => {
+  it("shows the create-widget button and passes no readOnly prop for the default dashboard", () => {
     mockDetail({ ...DASH_B, layout: [], widgets: [WIDGET] });
     renderPage();
 
-    expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
-    expect(lastGridProps?.readOnly).toBe(true);
+    expect(screen.getAllByRole("button", { name: "＋ Create widget" }).length).toBe(1);
+    expect(lastGridProps?.readOnly).toBeUndefined();
   });
 
-  it("keeps the grid editable on a non-default dashboard", () => {
-    mockDetail({ ...DASH_A, layout: [], widgets: [WIDGET] });
+  it("holds the header edit controls until the dashboard detail loads", () => {
+    mockDetail(undefined);
     renderPage();
 
-    expect(screen.getAllByRole("button", { name: "＋ Create widget" }).length).toBe(1);
-    expect(lastGridProps?.readOnly).toBe(false);
+    expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
   });
 
   it("deletes the dashboard through the confirm dialog and navigates to the index", () => {
@@ -300,10 +300,10 @@ describe("DashboardDetailPage", () => {
     expect(removeDashboard.mutate).not.toHaveBeenCalled();
   });
 
-  it("hides the delete button on the read-only default dashboard", () => {
+  it("shows the delete button on the default dashboard", () => {
     mockDetail({ ...DASH_B, layout: [], widgets: [] });
     renderPage();
-    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Delete dashboard" })).toBeTruthy();
   });
 
   it("redirects to the dashboard index and invalidates the list cache when the dashboard is gone", () => {

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -39,12 +39,6 @@ vi.mock("next/link", () => ({
 }));
 vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
 
-const createDashboard: {
-  mutate: ReturnType<typeof vi.fn>;
-  reset: ReturnType<typeof vi.fn>;
-  isPending: boolean;
-  error: Error | null;
-} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, error: null };
 const updateLayout: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
   {
     mutate: vi.fn(),
@@ -63,22 +57,13 @@ const removeWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; erro
     isPending: false,
     error: null,
   };
-const removeDashboard: {
-  mutate: ReturnType<typeof vi.fn>;
-  isPending: boolean;
-  isError: boolean;
-  error: Error | null;
-} = { mutate: vi.fn(), isPending: false, isError: false, error: null };
 
 vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
-  useDashboards: vi.fn(),
   useDashboard: vi.fn(),
   useDashboardMutations: () => ({
-    createDashboard,
     updateLayout,
     createWidget,
     removeWidget,
-    removeDashboard,
   }),
 }));
 
@@ -117,15 +102,16 @@ vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
   },
 }));
 
-import { useDashboard, useDashboards } from "@/features/dashboards/hooks/use-dashboards";
+import { useDashboard } from "@/features/dashboards/hooks/use-dashboards";
 
 // d1 is a user dashboard; d2 is the seeded default (Overview) — both are
-// fully editable, the default is just auto-created and tab-marked.
+// fully editable, the default is just auto-created and home-marked.
 const DASH_A: DashboardSummary = {
   id: "d1",
   name: "Custom",
   description: null,
   isDefault: false,
+  createTime: "",
   updateTime: "",
 };
 const DASH_B: DashboardSummary = {
@@ -133,6 +119,7 @@ const DASH_B: DashboardSummary = {
   name: "Overview",
   description: null,
   isDefault: true,
+  createTime: "",
   updateTime: "",
 };
 
@@ -144,12 +131,6 @@ const WIDGET: Widget = {
   spec: { view: "spans" },
   displayConfig: {},
 };
-
-function mockLists(dashboards: DashboardSummary[] | undefined) {
-  vi.mocked(useDashboards).mockReturnValue({
-    data: dashboards,
-  } as ReturnType<typeof useDashboards>);
-}
 
 function mockDetail(data: DashboardDetail | undefined, error: unknown = null) {
   vi.mocked(useDashboard).mockReturnValue({ data, error } as ReturnType<typeof useDashboard>);
@@ -171,58 +152,30 @@ describe("DashboardDetailPage", () => {
   beforeEach(() => {
     push.mockReset();
     replace.mockReset();
-    createDashboard.mutate.mockReset();
     updateLayout.mutate.mockReset();
     createWidget.mutate.mockReset();
     removeWidget.mutate.mockReset();
-    removeDashboard.mutate.mockReset();
-    removeDashboard.isError = false;
-    removeDashboard.error = null;
     lastGridProps = null;
-    mockLists([DASH_A, DASH_B]);
     mockDetail({ ...DASH_A, layout: [], widgets: [] });
   });
 
-  it("renders dashboard tabs with the default marked and the current one highlighted", () => {
+  it("shows the dashboard's name in the header with a back link to the list", () => {
     renderPage();
 
-    const customTab = screen.getByRole("link", { name: "Custom" });
-    expect(customTab.textContent).not.toContain("⌂");
-    expect(customTab.getAttribute("aria-current")).toBe("page");
-
-    const overviewTab = screen.getByRole("link", { name: /Overview/ });
-    expect(overviewTab.textContent).toContain("⌂");
-    expect(overviewTab.getAttribute("aria-current")).toBeNull();
-
-    expect(screen.getByRole("button", { name: "＋ new" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Custom" })).toBeTruthy();
+    // the breadcrumb reads exactly like the list page's heading (no arrow)
+    const back = screen.getByRole("link", { name: "Dashboards" });
+    expect(back.getAttribute("href")).toBe("/projects/p1/dashboard?list=1");
+    // No tab strip: the other dashboard is not rendered here anymore.
+    expect(screen.queryByText("Overview")).toBeNull();
   });
 
-  it("opens the create-dashboard dialog and cancelling it does not create", () => {
+  it("shows the default dashboard's plain name in the header, no marker glyph", () => {
+    mockDetail({ ...DASH_B, layout: [], widgets: [] });
     renderPage();
 
-    expect(screen.queryByText("Create Dashboard")).toBeNull();
-    fireEvent.click(screen.getByRole("button", { name: "＋ new" }));
-    expect(screen.getByText("Create Dashboard")).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(createDashboard.mutate).not.toHaveBeenCalled();
-  });
-
-  it("creates a dashboard from the dialog and navigates to it on success", () => {
-    renderPage();
-
-    fireEvent.click(screen.getByRole("button", { name: "＋ new" }));
-    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
-      target: { value: "New dash" },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Create" }));
-
-    expect(createDashboard.mutate).toHaveBeenCalledTimes(1);
-    const [payload, options] = createDashboard.mutate.mock.calls[0];
-    expect(payload).toEqual({ name: "New dash" });
-
-    options.onSuccess({ dashboard: { id: "d9" } });
-    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d9");
+    expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+    expect(screen.queryByText("⌂")).toBeNull();
   });
 
   it("shows the active range preset label", () => {
@@ -259,51 +212,24 @@ describe("DashboardDetailPage", () => {
     expect(lastGridProps?.readOnly).toBeUndefined();
   });
 
-  it("holds the header edit controls until the dashboard detail loads", () => {
+  it("holds the create-widget button until the dashboard detail loads", () => {
     mockDetail(undefined);
     renderPage();
 
     expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
+  });
+
+  it("offers no delete affordance — deleting lives in the list page's row actions", () => {
+    renderPage();
     expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
+    expect(screen.queryByText("Delete Dashboard")).toBeNull();
   });
 
-  it("deletes the dashboard through the confirm dialog and navigates to the index", () => {
+  it("renders the create-widget button before the time-range control", () => {
     renderPage();
-
-    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
-    expect(screen.getByText("Delete Dashboard")).toBeTruthy();
-
-    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
-    expect(removeDashboard.mutate).toHaveBeenCalledTimes(1);
-    const [id, options] = removeDashboard.mutate.mock.calls[0];
-    expect(id).toBe("d1");
-
-    options.onSuccess();
-    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
-  });
-
-  it("shows the delete error inside the dialog when the mutation fails", () => {
-    removeDashboard.isError = true;
-    removeDashboard.error = new Error("boom");
-    renderPage();
-
-    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
-    expect(screen.getByText("boom")).toBeTruthy();
-  });
-
-  it("cancelling the delete dialog does not delete", () => {
-    renderPage();
-
-    fireEvent.click(screen.getByRole("button", { name: "Delete dashboard" }));
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
-
-    expect(removeDashboard.mutate).not.toHaveBeenCalled();
-  });
-
-  it("shows the delete button on the default dashboard", () => {
-    mockDetail({ ...DASH_B, layout: [], widgets: [] });
-    renderPage();
-    expect(screen.getByRole("button", { name: "Delete dashboard" })).toBeTruthy();
+    const create = screen.getAllByRole("button", { name: "＋ Create widget" })[0];
+    const range = screen.getByRole("button", { name: "Last 24 hours" });
+    expect(create.compareDocumentPosition(range) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("redirects to the dashboard index and invalidates the list cache when the dashboard is gone", () => {
@@ -341,7 +267,6 @@ describe("DashboardDetailPage", () => {
 
     expect(screen.getByText("Loading…")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Delete dashboard" })).toBeNull();
   });
 
   it("passes widgets, layout and range to the grid and wires edit/duplicate/delete", () => {

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -45,12 +45,6 @@ const updateLayout: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; erro
     isPending: false,
     error: null,
   };
-const createWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
-  {
-    mutate: vi.fn(),
-    isPending: false,
-    error: null,
-  };
 const removeWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
   {
     mutate: vi.fn(),
@@ -62,7 +56,6 @@ vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
   useDashboard: vi.fn(),
   useDashboardMutations: () => ({
     updateLayout,
-    createWidget,
     removeWidget,
   }),
 }));
@@ -73,7 +66,6 @@ let lastGridProps: {
   range: unknown;
   readOnly?: boolean;
   onEdit: (w: Widget) => void;
-  onDuplicate: (w: Widget) => void;
   onDelete: (w: Widget) => void;
 } | null = null;
 
@@ -84,7 +76,6 @@ vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
     range: unknown;
     readOnly?: boolean;
     onEdit: (w: Widget) => void;
-    onDuplicate: (w: Widget) => void;
     onDelete: (w: Widget) => void;
   }) => {
     lastGridProps = props;
@@ -93,7 +84,6 @@ vi.mock("@/features/dashboards/components/DashboardGrid", () => ({
         {props.widgets.map((w) => (
           <div key={w.id}>
             <button onClick={() => props.onEdit(w)}>{`edit-${w.id}`}</button>
-            <button onClick={() => props.onDuplicate(w)}>{`duplicate-${w.id}`}</button>
             <button onClick={() => props.onDelete(w)}>{`delete-${w.id}`}</button>
           </div>
         ))}
@@ -153,7 +143,6 @@ describe("DashboardDetailPage", () => {
     push.mockReset();
     replace.mockReset();
     updateLayout.mutate.mockReset();
-    createWidget.mutate.mockReset();
     removeWidget.mutate.mockReset();
     lastGridProps = null;
     mockDetail({ ...DASH_A, layout: [], widgets: [] });
@@ -269,7 +258,7 @@ describe("DashboardDetailPage", () => {
     expect(screen.queryByRole("button", { name: "＋ Create widget" })).toBeNull();
   });
 
-  it("passes widgets, layout and range to the grid and wires edit/duplicate/delete", () => {
+  it("passes widgets, layout and range to the grid and wires edit/delete", () => {
     mockDetail({
       ...DASH_A,
       layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }],
@@ -282,15 +271,6 @@ describe("DashboardDetailPage", () => {
     expect(lastGridProps?.layout).toEqual([{ i: "w1", x: 0, y: 0, w: 4, h: 4 }]);
     expect(lastGridProps?.range).toHaveProperty("start");
     expect(lastGridProps?.range).toHaveProperty("end");
-
-    fireEvent.click(screen.getByRole("button", { name: "duplicate-w1" }));
-    expect(createWidget.mutate).toHaveBeenCalledWith({
-      title: "Cost (copy)",
-      type: "query",
-      spec: WIDGET.spec,
-      // A duplicate carries the display settings too, not just the query.
-      displayConfig: WIDGET.displayConfig,
-    });
 
     fireEvent.click(screen.getByRole("button", { name: "delete-w1" }));
     expect(removeWidget.mutate).toHaveBeenCalledWith("w1");

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, DashboardSummary, Widget } from "@/features/dashboards/types";
+import { ApiError } from "@/lib/api/client";
 import DashboardDetailPage from "./page";
 
 class ResizeObserverStub {
@@ -52,7 +53,10 @@ const removeWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; erro
     error: null,
   };
 
-vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
+vi.mock("@/features/dashboards/hooks/use-dashboards", async (importOriginal) => ({
+  // Keep the real isDashboardGone: the redirect-on-gone behavior under test
+  // depends on its ApiError-status logic.
+  ...(await importOriginal<object>()),
   useDashboard: vi.fn(),
   useDashboardMutations: () => ({
     updateLayout,
@@ -222,15 +226,22 @@ describe("DashboardDetailPage", () => {
   });
 
   it("redirects to the dashboard index and invalidates the list cache when the dashboard is gone", () => {
-    mockDetail(undefined, new Error("Dashboard not found"));
+    mockDetail(undefined, new ApiError("Dashboard not found", 404));
     const { invalidateSpy } = renderPage();
 
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["dashboards", "p1"] });
   });
 
+  it("leaves the page when access is revoked instead of retrying a permanent 403", () => {
+    mockDetail(undefined, new ApiError("Not a member of this workspace", 403));
+    renderPage();
+
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+  });
+
   it("stays put and shows a failure notice on a transient load error", () => {
-    mockDetail(undefined, new Error("API error: 503"));
+    mockDetail(undefined, new ApiError("API error: 503", 503));
     const { invalidateSpy } = renderPage();
 
     expect(replace).not.toHaveBeenCalled();
@@ -238,10 +249,18 @@ describe("DashboardDetailPage", () => {
     expect(screen.getByText(/Failed to load the dashboard/)).toBeTruthy();
   });
 
+  it("stays put on an untyped error (network failure never has a status)", () => {
+    mockDetail(undefined, new Error("Failed to fetch"));
+    renderPage();
+
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText(/Failed to load the dashboard/)).toBeTruthy();
+  });
+
   it("keeps rendering the cached dashboard when a background poll fails", () => {
     mockDetail(
       { ...DASH_A, widgets: [WIDGET], layout: [{ i: "w1", x: 0, y: 0, w: 4, h: 4 }] },
-      new Error("API error: 503"),
+      new ApiError("API error: 503", 503),
     );
     renderPage();
 

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -5,7 +5,11 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import { useDashboard, useDashboardMutations } from "@/features/dashboards/hooks/use-dashboards";
+import {
+  isDashboardGone,
+  useDashboard,
+  useDashboardMutations,
+} from "@/features/dashboards/hooks/use-dashboards";
 import { DashboardGrid } from "@/features/dashboards/components/DashboardGrid";
 import type { TimeRange, Widget } from "@/features/dashboards/types";
 import { DateFilterSelect } from "@/components/date-filter-select";
@@ -64,15 +68,11 @@ export default function DashboardDetailPage() {
     router.push(`/projects/${projectId}/dashboard/${dashboardId}/widgets/${w.id}/edit`);
 
   // ── deleted / missing dashboard redirect ─────────────────────────────────────
-  // fetchNextApi doesn't carry the HTTP status, so gone-ness is detected from
-  // the API's error message. The exact match keeps "Project not found" (a
-  // deleted project) and auth failures from redirecting; only a genuinely
-  // missing dashboard leaves the page. Everything else keeps the user here —
-  // the detail query's 30s poll retries, with a failure notice while empty.
-  const dashboardGone =
-    dashboardError instanceof Error &&
-    (dashboardError.message === "Dashboard not found" ||
-      /API error: 404/i.test(dashboardError.message));
+  // Any permanent failure leaves the page: the dashboard or its project was
+  // deleted (404), or access was revoked (403) — the 30s poll can never
+  // recover from those, so retrying in place would strand the user. Transient
+  // failures keep the user here with a failure notice while the poll retries.
+  const dashboardGone = isDashboardGone(dashboardError);
   useEffect(() => {
     if (dashboardGone) {
       // Invalidate the list so a stale cache can't bounce the user back here.

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -5,27 +5,12 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { ProjectBreadcrumb } from "@/features/projects/components";
-import {
-  useDashboards,
-  useDashboard,
-  useDashboardMutations,
-} from "@/features/dashboards/hooks/use-dashboards";
+import { useDashboard, useDashboardMutations } from "@/features/dashboards/hooks/use-dashboards";
 import { DashboardGrid } from "@/features/dashboards/components/DashboardGrid";
-import { CreateDashboardDialog } from "@/features/dashboards/components/CreateDashboardDialog";
 import type { TimeRange, Widget } from "@/features/dashboards/types";
 import { DateFilterSelect } from "@/components/date-filter-select";
 import { useUrlDateFilter } from "@/lib/hooks/use-url-date-filter";
 import { Button } from "@/components/ui/button";
-import { DeleteIconButton } from "@/components/ui/delete-button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { cn } from "@/lib/utils";
 
 export default function DashboardDetailPage() {
   const params = useParams();
@@ -35,10 +20,9 @@ export default function DashboardDetailPage() {
   const dashboardId = params.dashboardId as string;
 
   // ── remote data ──────────────────────────────────────────────────────────────
-  const { data: dashboards } = useDashboards(projectId);
   const { data: dashboard, error: dashboardError } = useDashboard(projectId, dashboardId);
 
-  const { updateLayout, createWidget, removeWidget, removeDashboard } = useDashboardMutations(
+  const { updateLayout, createWidget, removeWidget } = useDashboardMutations(
     projectId,
     dashboardId,
   );
@@ -104,21 +88,6 @@ export default function DashboardDetailPage() {
   // its error field; the redirect above handles gone dashboards, so the render
   // below only needs the loading and failure branches.
 
-  // ── new dashboard ────────────────────────────────────────────────────────────
-  const [createDashboardOpen, setCreateDashboardOpen] = useState(false);
-
-  // ── delete dashboard ─────────────────────────────────────────────────────────
-  const [deleteOpen, setDeleteOpen] = useState(false);
-  const handleDeleteDashboard = () => {
-    removeDashboard.mutate(dashboardId, {
-      onSuccess: () => {
-        setDeleteOpen(false);
-        // The index route resolves to the default dashboard.
-        router.replace(`/projects/${projectId}/dashboard`);
-      },
-    });
-  };
-
   // ── layout change ────────────────────────────────────────────────────────────
   const handleLayoutChange = useCallback(
     (layout: Parameters<typeof updateLayout.mutate>[0]) => {
@@ -156,79 +125,39 @@ export default function DashboardDetailPage() {
     <div className="relative flex h-full text-[13px]">
       <ProjectBreadcrumb projectId={projectId} />
 
-      <CreateDashboardDialog
-        projectId={projectId}
-        open={createDashboardOpen}
-        onOpenChange={setCreateDashboardOpen}
-      />
-
-      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete Dashboard</DialogTitle>
-            <DialogDescription>
-              Permanently delete “{dashboard?.name}” and all of its widgets? This cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          {removeDashboard.isError && (
-            <p className="text-sm text-destructive">{removeDashboard.error.message}</p>
-          )}
-          <DialogFooter>
-            <Button
-              variant="outline"
-              onClick={() => setDeleteOpen(false)}
-              disabled={removeDashboard.isPending}
-            >
-              Cancel
-            </Button>
-            <Button
-              variant="destructive"
-              onClick={handleDeleteDashboard}
-              disabled={removeDashboard.isPending}
-            >
-              {removeDashboard.isPending ? "Deleting..." : "Delete"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
       <div className="flex flex-1 flex-col overflow-hidden">
         {/* Page header */}
-        <div className="flex items-center justify-between border-b border-border px-4 py-2">
-          {/* Left: title + dashboard tabs */}
-          <div className="flex items-center gap-3">
-            <h1 className="text-[13px] font-medium">Dashboard</h1>
-            <div className="flex items-center gap-0.5">
-              {dashboards?.map((d) => (
-                <Link
-                  key={d.id}
-                  href={`/projects/${projectId}/dashboard/${d.id}`}
-                  aria-current={d.id === dashboardId ? "page" : undefined}
-                  className={cn(
-                    "flex items-center gap-1 rounded px-2 py-0.5 text-[12px] transition-colors",
-                    d.id === dashboardId
-                      ? "border-b-2 border-foreground font-medium text-foreground"
-                      : "text-muted-foreground hover:bg-muted hover:text-foreground",
-                  )}
-                >
-                  {d.isDefault && <span className="text-[10px]">⌂</span>}
-                  <span className="max-w-[10rem] truncate" title={d.name}>
-                    {d.name}
-                  </span>
-                </Link>
-              ))}
-              <button
-                type="button"
-                onClick={() => setCreateDashboardOpen(true)}
-                className="rounded px-2 py-0.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                ＋ new
-              </button>
-            </div>
+        <div className="flex h-[45px] shrink-0 items-center justify-between border-b border-border px-4">
+          {/* Left: breadcrumb back to the list + the dashboard's identity
+              (the tabs are gone; the list page is the way to switch).
+              "Dashboards" renders exactly like the list page's heading. */}
+          <div className="flex min-w-0 items-center gap-2">
+            <Link
+              // ?list=1 pins the index on the list: without it a project with
+              // a single dashboard would auto-open right back here.
+              href={`/projects/${projectId}/dashboard?list=1`}
+              className="shrink-0 text-[13px] font-medium hover:underline"
+            >
+              Dashboards
+            </Link>
+            <span className="shrink-0 text-muted-foreground">/</span>
+            <h1 className="min-w-0 text-[13px] font-medium">
+              <span className="block max-w-[16rem] truncate" title={dashboard?.name}>
+                {dashboard?.name ?? "Dashboard"}
+              </span>
+            </h1>
           </div>
 
-          {/* Right: time range, create widget */}
+          {/* Right: create widget, then the time range. Deleting a dashboard
+              lives only in the list page's row actions. */}
           <div className="flex items-center gap-2">
+            {/* Held back until the detail loads so it can't act on a
+                dashboard the app doesn't know yet. */}
+            {dashboard && (
+              <Button size="sm" className="h-7 text-[12px]" onClick={openCreate}>
+                ＋ Create widget
+              </Button>
+            )}
             <DateFilterSelect
               dateFilter={dateFilter}
               customStartDate={customStartDate}
@@ -236,20 +165,6 @@ export default function DashboardDetailPage() {
               onDateFilterChange={setDateFilter}
               onCustomRangeChange={setCustomRange}
             />
-
-            {/* Held back until the detail loads so edit controls don't act
-                on a dashboard the app doesn't know yet. */}
-            {dashboard && (
-              <>
-                <Button size="sm" className="h-7 text-[12px]" onClick={openCreate}>
-                  ＋ Create widget
-                </Button>
-                <DeleteIconButton
-                  aria-label="Delete dashboard"
-                  onClick={() => setDeleteOpen(true)}
-                />
-              </>
-            )}
           </div>
         </div>
 

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -151,11 +151,6 @@ export default function DashboardDetailPage() {
   // ── render ───────────────────────────────────────────────────────────────────
   const widgets = dashboard?.widgets ?? [];
   const layout = dashboard?.layout ?? [];
-  // The seeded default dashboard is read-only: custom dashboards start from
-  // "＋ new" instead. The API enforces the same rule. Treated as read-only
-  // while the detail is still loading so edit controls never flash on the
-  // Overview before the app knows which dashboard this is.
-  const readOnly = dashboard ? dashboard.isDefault : true;
 
   return (
     <div className="relative flex h-full text-[13px]">
@@ -242,7 +237,9 @@ export default function DashboardDetailPage() {
               onCustomRangeChange={setCustomRange}
             />
 
-            {!readOnly && (
+            {/* Held back until the detail loads so edit controls don't act
+                on a dashboard the app doesn't know yet. */}
+            {dashboard && (
               <>
                 <Button size="sm" className="h-7 text-[12px]" onClick={openCreate}>
                   ＋ Create widget
@@ -271,11 +268,9 @@ export default function DashboardDetailPage() {
           ) : widgets.length === 0 ? (
             <div className="flex h-64 flex-col items-center justify-center gap-3">
               <p className="text-[13px] text-muted-foreground">No widgets yet.</p>
-              {!readOnly && (
-                <Button size="sm" className="text-[12px]" onClick={openCreate}>
-                  ＋ Create widget
-                </Button>
-              )}
+              <Button size="sm" className="text-[12px]" onClick={openCreate}>
+                ＋ Create widget
+              </Button>
             </div>
           ) : (
             <DashboardGrid
@@ -284,7 +279,6 @@ export default function DashboardDetailPage() {
               layout={layout}
               range={range}
               width={width}
-              readOnly={readOnly}
               onLayoutChange={handleLayoutChange}
               onEdit={openEdit}
               onDuplicate={handleDuplicate}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/[dashboardId]/page.tsx
@@ -22,10 +22,7 @@ export default function DashboardDetailPage() {
   // ── remote data ──────────────────────────────────────────────────────────────
   const { data: dashboard, error: dashboardError } = useDashboard(projectId, dashboardId);
 
-  const { updateLayout, createWidget, removeWidget } = useDashboardMutations(
-    projectId,
-    dashboardId,
-  );
+  const { updateLayout, removeWidget } = useDashboardMutations(projectId, dashboardId);
 
   // ── time range — the same URL-synced filter AND default the trace list uses ──
   const { dateFilter, customStartDate, customEndDate, setDateFilter, setCustomRange, timestamps } =
@@ -94,19 +91,6 @@ export default function DashboardDetailPage() {
       updateLayout.mutate(layout);
     },
     [updateLayout],
-  );
-
-  // ── duplicate widget ─────────────────────────────────────────────────────────
-  const handleDuplicate = useCallback(
-    (w: Widget) => {
-      createWidget.mutate({
-        title: `${w.title} (copy)`,
-        type: w.type,
-        spec: w.spec,
-        displayConfig: w.displayConfig,
-      });
-    },
-    [createWidget],
   );
 
   // ── delete widget ────────────────────────────────────────────────────────────
@@ -196,7 +180,6 @@ export default function DashboardDetailPage() {
               width={width}
               onLayoutChange={handleLayoutChange}
               onEdit={openEdit}
-              onDuplicate={handleDuplicate}
               onDelete={handleDelete}
             />
           )}

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
@@ -1,13 +1,40 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { DashboardSummary } from "@/features/dashboards/types";
+import type { DashboardListItem } from "@/features/dashboards/types";
 import DashboardIndexPage from "./page";
 
 const replace = vi.fn();
+const push = vi.fn();
+let searchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useParams: () => ({ projectId: "p1" }),
-  useRouter: () => ({ replace }),
+  useRouter: () => ({ replace, push }),
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+// The dialogs carry their own tests; here they only need to mount.
+vi.mock("@/features/dashboards/components/CreateDashboardDialog", () => ({
+  CreateDashboardDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="create-dialog" /> : null,
+}));
+vi.mock("@/features/dashboards/components/EditDashboardDialog", () => ({
+  EditDashboardDialog: ({
+    target,
+  }: {
+    target: { name: string; description: string | null } | null;
+  }) =>
+    target ? (
+      <div data-testid="edit-dialog">
+        {target.name}:{target.description ?? "∅"}
+      </div>
+    ) : null,
+}));
+vi.mock("@/features/dashboards/components/DeleteDashboardDialog", () => ({
+  DeleteDashboardDialog: ({ target }: { target: { name: string } | null }) =>
+    target ? <div data-testid="delete-dialog">{target.name}</div> : null,
 }));
 
 const refetch = vi.fn();
@@ -17,7 +44,7 @@ vi.mock("@/features/dashboards/hooks/use-dashboards", () => ({
 
 import { useDashboards } from "@/features/dashboards/hooks/use-dashboards";
 
-function mockDashboards(data: DashboardSummary[] | undefined, error: unknown = null) {
+function mockDashboards(data: DashboardListItem[] | undefined, error: unknown = null) {
   vi.mocked(useDashboards).mockReturnValue({
     data,
     error,
@@ -25,26 +52,32 @@ function mockDashboards(data: DashboardSummary[] | undefined, error: unknown = n
   } as unknown as ReturnType<typeof useDashboards>);
 }
 
-const DASH_A: DashboardSummary = {
+const OVERVIEW: DashboardListItem = {
   id: "d1",
   name: "Overview",
   description: null,
-  isDefault: false,
-  updateTime: "",
+  isDefault: true,
+  creator: "Ada",
+  createTime: "2026-06-01T10:00:00Z",
+  updateTime: "2026-07-01T10:00:00Z",
 };
-const DASH_B: DashboardSummary = {
+const COSTS: DashboardListItem = {
   id: "d2",
   name: "Costs",
-  description: null,
-  isDefault: true,
-  updateTime: "",
+  description: "Cost breakdowns",
+  isDefault: false,
+  creator: null,
+  createTime: "2026-06-02T10:00:00Z",
+  updateTime: "2026-07-02T10:00:00Z",
 };
 
 describe("DashboardIndexPage", () => {
   afterEach(cleanup);
   beforeEach(() => {
     replace.mockReset();
+    push.mockReset();
     refetch.mockReset();
+    searchParams = new URLSearchParams();
   });
 
   it("shows a loading state while the dashboard list is in flight", () => {
@@ -54,19 +87,90 @@ describe("DashboardIndexPage", () => {
     expect(replace).not.toHaveBeenCalled();
   });
 
-  it("redirects to the default dashboard once the list resolves", () => {
-    mockDashboards([DASH_A, DASH_B]);
+  it("auto-opens the only dashboard instead of listing it", () => {
+    mockDashboards([OVERVIEW]);
+    render(<DashboardIndexPage />);
+    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+    // No list flashes while the redirect is in flight.
+    expect(screen.queryByText("Dashboards")).toBeNull();
+    expect(screen.getByText("Loading dashboards…")).toBeTruthy();
+  });
+
+  it("auto-opens a sole non-default dashboard too (the rule is count-based)", () => {
+    mockDashboards([{ ...COSTS, isDefault: false }]);
     render(<DashboardIndexPage />);
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d2");
   });
 
-  it("redirects to the first dashboard when none is marked default", () => {
-    mockDashboards([
-      { ...DASH_A, isDefault: false },
-      { ...DASH_B, isDefault: false },
-    ]);
+  it("lists dashboards when there is more than one, without redirecting", () => {
+    mockDashboards([OVERVIEW, COSTS]);
     render(<DashboardIndexPage />);
-    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText("Dashboards")).toBeTruthy();
+    expect(screen.getByText("Overview")).toBeTruthy();
+    expect(screen.getByText("Costs")).toBeTruthy();
+    // description column: value for Costs, em-dash for the description-less
+    expect(screen.getByText("Cost breakdowns")).toBeTruthy();
+    // owner and created sit between Description and Updated (Updated stays last)
+    const headers = screen.getAllByRole("columnheader").map((h) => h.textContent);
+    expect(headers.slice(1)).toEqual(["Description", "Owner", "Created", "Updated", ""]);
+    expect(screen.getByText("Ada")).toBeTruthy();
+    // em-dashes: Overview's missing description, Costs' deleted creator
+    expect(screen.getAllByText("—")).toHaveLength(2);
+    // no marker glyph on the default dashboard — its row reads like any other
+    expect(screen.queryByText("⌂")).toBeNull();
+  });
+
+  it("keeps showing the list when a delete brings it down to one row", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    const { rerender } = render(<DashboardIndexPage />);
+    expect(screen.getByText("Costs")).toBeTruthy();
+
+    mockDashboards([OVERVIEW]);
+    rerender(<DashboardIndexPage />);
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText("Overview")).toBeTruthy();
+  });
+
+  it("navigates into a dashboard on row click", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getByText("Costs"));
+    expect(push).toHaveBeenCalledWith("/projects/p1/dashboard/d2");
+  });
+
+  it("opens the create dialog from the header button", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getByRole("button", { name: "＋ New dashboard" }));
+    expect(screen.getByTestId("create-dialog")).toBeTruthy();
+  });
+
+  it("opens the edit dialog from a row's actions with the row's fields, without navigating", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getAllByRole("button", { name: "Dashboard actions" })[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    expect(screen.getByTestId("edit-dialog").textContent).toBe("Costs:Cost breakdowns");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("opens the delete confirm from a row's actions without navigating", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getAllByRole("button", { name: "Dashboard actions" })[1]);
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(screen.getByTestId("delete-dialog").textContent).toBe("Costs");
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("?list=1 pins the list even for a sole dashboard, keeping create reachable", () => {
+    searchParams = new URLSearchParams("list=1");
+    mockDashboards([OVERVIEW]);
+    render(<DashboardIndexPage />);
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText("Overview")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "＋ New dashboard" })).toBeTruthy();
   });
 
   it("shows a retry button on error and refetches on click", () => {

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.test.tsx
@@ -173,6 +173,25 @@ describe("DashboardIndexPage", () => {
     expect(screen.getByRole("button", { name: "＋ New dashboard" })).toBeTruthy();
   });
 
+  it("disables Delete for a sole dashboard — the API would reject it anyway", () => {
+    searchParams = new URLSearchParams("list=1");
+    mockDashboards([OVERVIEW]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Dashboard actions" }));
+    const del = screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement;
+    expect(del.disabled).toBe(true);
+    fireEvent.click(del);
+    expect(screen.queryByTestId("delete-dialog")).toBeNull();
+  });
+
+  it("keeps Delete enabled when other dashboards remain", () => {
+    mockDashboards([OVERVIEW, COSTS]);
+    render(<DashboardIndexPage />);
+    fireEvent.click(screen.getAllByRole("button", { name: "Dashboard actions" })[0]);
+    const del = screen.getByRole("button", { name: "Delete" }) as HTMLButtonElement;
+    expect(del.disabled).toBe(false);
+  });
+
   it("shows a retry button on error and refetches on click", () => {
     mockDashboards(undefined, new Error("boom"));
     render(<DashboardIndexPage />);

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
@@ -183,7 +183,15 @@ export default function DashboardIndexPage() {
                           Edit
                         </button>
                         <button
-                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10"
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10 disabled:opacity-50 disabled:hover:bg-transparent"
+                          // The DELETE route rejects removing a project's last
+                          // dashboard (the list endpoint would only reseed it).
+                          disabled={dashboards.length === 1}
+                          title={
+                            dashboards.length === 1
+                              ? "Projects keep at least one dashboard"
+                              : undefined
+                          }
                           onClick={(e) => {
                             e.stopPropagation();
                             setDeleteTarget({ id: d.id, name: d.name });

--- a/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/dashboard/page.tsx
@@ -1,23 +1,53 @@
 "use client";
 
-import { useEffect } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { ProjectBreadcrumb } from "@/features/projects/components";
 import { useDashboards } from "@/features/dashboards/hooks/use-dashboards";
+import { CreateDashboardDialog } from "@/features/dashboards/components/CreateDashboardDialog";
+import { DeleteDashboardDialog } from "@/features/dashboards/components/DeleteDashboardDialog";
+import { EditDashboardDialog } from "@/features/dashboards/components/EditDashboardDialog";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { formatDate } from "@/lib/utils";
 
+/**
+ * The dashboards entry point. A project with a single dashboard (the common
+ * case — the list endpoint lazily seeds the default Overview, so there is
+ * always at least one) opens straight into it; with several, this renders a
+ * list page in the house table style, one row per dashboard.
+ */
 export default function DashboardIndexPage() {
   const params = useParams();
   const router = useRouter();
   const projectId = params.projectId as string;
+  // The detail page's back link arrives with ?list=1: without it a project
+  // with a single dashboard would auto-open right back, making the list (and
+  // its "New dashboard" button) unreachable from a sole dashboard.
+  const wantList = useSearchParams().has("list");
   const { data: dashboards, error, refetch } = useDashboards(projectId);
 
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<{
+    id: string;
+    name: string;
+    description: string | null;
+  } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<{ id: string; name: string } | null>(null);
+  const [actionsOpen, setActionsOpen] = useState<string | null>(null);
+
+  // Auto-open applies on ENTRY only: once the list has been shown, deleting
+  // down to one row must not yank the user into the survivor mid-interaction.
+  const [listPinned, setListPinned] = useState(false);
+  // One derivation drives both the redirect effect and the loading branch
+  // below, so they can't drift apart.
+  const autoOpening = !!dashboards && dashboards.length === 1 && !wantList && !listPinned;
   useEffect(() => {
-    // The list endpoint lazily seeds the default Overview, so there is always
-    // at least one dashboard once the query resolves.
-    if (dashboards && dashboards.length > 0) {
-      const target = dashboards.find((d) => d.isDefault) ?? dashboards[0];
-      router.replace(`/projects/${projectId}/dashboard/${target.id}`);
-    }
-  }, [dashboards, projectId, router]);
+    if (!dashboards || dashboards.length === 0) return;
+    if (autoOpening) router.replace(`/projects/${projectId}/dashboard/${dashboards[0].id}`);
+    else setListPinned(true);
+  }, [autoOpening, dashboards, projectId, router]);
 
   if (error) {
     return (
@@ -34,9 +64,144 @@ export default function DashboardIndexPage() {
     );
   }
 
+  // Loading, or a single dashboard about to be auto-opened by the effect.
+  if (!dashboards || dashboards.length === 0 || autoOpening) {
+    return (
+      <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
+        Loading dashboards…
+      </div>
+    );
+  }
+
   return (
-    <div className="flex h-full items-center justify-center text-[13px] text-muted-foreground">
-      Loading dashboards…
+    <div className="relative flex h-full text-[13px]">
+      <ProjectBreadcrumb projectId={projectId} />
+
+      <CreateDashboardDialog projectId={projectId} open={createOpen} onOpenChange={setCreateOpen} />
+
+      {/* The dialog seeds its drafts on mount, so callers must key it by the
+          target's id to reset them per row. */}
+      <EditDashboardDialog
+        key={editTarget?.id ?? "closed"}
+        projectId={projectId}
+        target={editTarget}
+        onClose={() => setEditTarget(null)}
+      />
+
+      <DeleteDashboardDialog
+        projectId={projectId}
+        target={deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+      />
+
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {/* Page header */}
+        <div className="flex h-[45px] shrink-0 items-center justify-between border-b border-border px-4">
+          <h1 className="text-[13px] font-medium">Dashboards</h1>
+          <Button size="sm" className="h-7 text-[12px]" onClick={() => setCreateOpen(true)}>
+            ＋ New dashboard
+          </Button>
+        </div>
+
+        {/* List */}
+        <div className="flex-1 overflow-auto bg-background">
+          <table className="w-full">
+            <thead className="sticky top-0 bg-background">
+              <tr className="border-b border-border bg-muted/50">
+                <th className="w-[16rem] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Name
+                </th>
+                <th className="border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Description
+                </th>
+                <th className="w-[12rem] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Owner
+                </th>
+                <th className="w-[10rem] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Created
+                </th>
+                <th className="w-[10rem] border-r border-border/50 px-3 py-1.5 text-left text-[12px] font-medium text-muted-foreground">
+                  Updated
+                </th>
+                <th className="w-10 px-2 py-1.5" />
+              </tr>
+            </thead>
+            <tbody>
+              {dashboards.map((d) => (
+                <tr
+                  key={d.id}
+                  onClick={() => router.push(`/projects/${projectId}/dashboard/${d.id}`)}
+                  className="cursor-pointer border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
+                >
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-foreground">
+                    <span className="block truncate" title={d.name}>
+                      {d.name}
+                    </span>
+                  </td>
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                    <span className="block truncate" title={d.description ?? undefined}>
+                      {d.description || "—"}
+                    </span>
+                  </td>
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                    <span className="block truncate" title={d.creator ?? undefined}>
+                      {d.creator ?? "—"}
+                    </span>
+                  </td>
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                    {formatDate(d.createTime)}
+                  </td>
+                  <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
+                    {formatDate(d.updateTime)}
+                  </td>
+                  <td className="px-2 text-right">
+                    <Popover
+                      open={actionsOpen === d.id}
+                      onOpenChange={(open) => setActionsOpen(open ? d.id : null)}
+                    >
+                      <PopoverTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          aria-label="Dashboard actions"
+                          className="h-5 w-6 p-0 text-muted-foreground hover:text-foreground"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <MoreHorizontal className="h-3.5 w-3.5" />
+                        </Button>
+                      </PopoverTrigger>
+                      <PopoverContent align="end" className="w-36 p-1">
+                        <button
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] hover:bg-muted/60"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setEditTarget({ id: d.id, name: d.name, description: d.description });
+                            setActionsOpen(null);
+                          }}
+                        >
+                          <Pencil className="h-3.5 w-3.5 text-muted-foreground" />
+                          Edit
+                        </button>
+                        <button
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-[12px] text-destructive hover:bg-destructive/10"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteTarget({ id: d.id, name: d.name });
+                            setActionsOpen(null);
+                          }}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                          Delete
+                        </button>
+                      </PopoverContent>
+                    </Popover>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/ui/src/features/dashboards/api.ts
+++ b/frontend/ui/src/features/dashboards/api.ts
@@ -1,6 +1,7 @@
 import { fetchNextApi, fetchTraceApi, type TraceApiUser } from "@/lib/api/client";
 import type {
   DashboardDetail,
+  DashboardListItem,
   DashboardSummary,
   LayoutItem,
   TimeRange,
@@ -12,7 +13,7 @@ import type {
 } from "./types";
 
 export function listDashboards(projectId: string) {
-  return fetchNextApi<{ data: DashboardSummary[] }>(`/projects/${projectId}/dashboards`);
+  return fetchNextApi<{ data: DashboardListItem[] }>(`/projects/${projectId}/dashboards`);
 }
 
 export function getDashboard(projectId: string, dashboardId: string) {

--- a/frontend/ui/src/features/dashboards/components/ChartLegend.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/ChartLegend.test.tsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChartLegend, type LegendEntry } from "./ChartLegend";
+
+afterEach(cleanup);
+
+const fmt = (v: number | null) => (v === null ? "—" : `#${v}`);
+
+function makeEntries(n: number): LegendEntry[] {
+  // ascending values so sorting is observable
+  return Array.from({ length: n }, (_, i) => ({
+    key: `s${i}`,
+    label: `series-${i}`,
+    color: `rgb(${i}, 0, 0)`,
+    value: i * 10,
+  }));
+}
+
+describe("ChartLegend", () => {
+  it("sorts rows by value descending and keeps each entry's own color", () => {
+    render(
+      <ChartLegend
+        entries={makeEntries(3)}
+        total={30}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    const rows = screen.getAllByRole("listitem");
+    expect(rows.map((r) => r.textContent)).toEqual([
+      "Total#30",
+      "series-2#20",
+      "series-1#10",
+      "series-0#0",
+    ]);
+    // color follows the entry (its chart pivot index), not the sorted position
+    const swatch = rows[1].querySelector("div[style]") as HTMLElement;
+    expect(swatch.style.backgroundColor).toBe("rgb(2, 0, 0)");
+  });
+
+  it("shows a Total row only when a total is given", () => {
+    const { unmount } = render(
+      <ChartLegend
+        entries={makeEntries(2)}
+        total={99}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Total")).toBeTruthy();
+    expect(screen.getByText("#99")).toBeTruthy();
+    unmount();
+
+    render(
+      <ChartLegend
+        entries={makeEntries(2)}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Total")).toBeNull();
+  });
+
+  it("caps visible rows and expands the full list in a popover", () => {
+    render(
+      <ChartLegend
+        entries={makeEntries(8)}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    const more = screen.getByRole("button", { name: "5 more" });
+
+    fireEvent.click(more);
+    const panel = screen.getByRole("dialog");
+    expect(panel.textContent).toContain("series-0");
+    expect(panel.textContent).toContain("series-7");
+    // The tile rows stay in the DOM behind the popover but leave the
+    // accessibility tree (aria-hidden), so only the popover's 8 rows count.
+    expect(screen.getAllByRole("listitem")).toHaveLength(8);
+
+    fireEvent.click(screen.getByRole("button", { name: "show less" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("clears the hover whenever the popover closes (Escape or the toggle)", () => {
+    // Outside-click and Escape dismissal are Radix Popover's own behavior; what
+    // we own is that a close — however triggered — clears the hover, or a row
+    // that unmounted mid-hover would leave the chart dimmed.
+    const onHoverKey = vi.fn();
+    render(
+      <ChartLegend
+        entries={makeEntries(5)}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={onHoverKey}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "2 more" }));
+    const panel = screen.getByRole("dialog");
+    fireEvent.mouseEnter(panel.querySelectorAll('[role="listitem"]')[4]!);
+    expect(onHoverKey).toHaveBeenLastCalledWith("s0");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(onHoverKey).toHaveBeenLastCalledWith(null);
+
+    // reopen, hover, then collapse via the toggle — hover clears again
+    fireEvent.click(screen.getByRole("button", { name: "2 more" }));
+    fireEvent.mouseEnter(screen.getByRole("dialog").querySelectorAll('[role="listitem"]')[0]!);
+    fireEvent.click(screen.getByRole("button", { name: "show less" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(onHoverKey).toHaveBeenLastCalledWith(null);
+  });
+
+  it("reports hover enter/leave so the chart can dim other series", () => {
+    const onHoverKey = vi.fn();
+    render(
+      <ChartLegend
+        entries={makeEntries(2)}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={onHoverKey}
+      />,
+    );
+    const [first] = screen.getAllByRole("listitem");
+    fireEvent.mouseEnter(first);
+    expect(onHoverKey).toHaveBeenLastCalledWith("s1"); // sorted first (value 10)
+    fireEvent.mouseLeave(first);
+    expect(onHoverKey).toHaveBeenLastCalledWith(null);
+  });
+
+  it("formats null values through the caller's formatter", () => {
+    render(
+      <ChartLegend
+        entries={[{ key: "a", label: "a", color: "red", value: null }]}
+        total={null}
+        format={fmt}
+        hoveredKey={null}
+        onHoverKey={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/ChartLegend.tsx
+++ b/frontend/ui/src/features/dashboards/components/ChartLegend.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+export interface LegendEntry {
+  /** Series key, as the chart knows it (dataKey / category name). */
+  key: string;
+  label: string;
+  /** The chart's color for this series — bound to its pivot index, not the
+   * legend's sorted position. */
+  color: string;
+  value: number | null;
+}
+
+// The tile shows this many rows; the rest live behind "N more".
+const VISIBLE_ROWS = 3;
+
+/**
+ * Per-series legend under a chart: swatch · label · right-aligned value,
+ * sorted by value, with a Total row for additive measures. The tile shows the
+ * top rows; "N more" opens the full list in a popover anchored to that button
+ * (portaled out of the widget card, so it neither covers the chart nor shrinks
+ * the tile, and flips above near the viewport edge). Hovering a row highlights
+ * its series via onHoverKey.
+ */
+export function ChartLegend({
+  entries,
+  total,
+  format,
+  hoveredKey,
+  onHoverKey,
+}: {
+  entries: LegendEntry[];
+  /** Window total across series; null for non-additive measures (no honest total). */
+  total: number | null;
+  format: (v: number | null) => string;
+  hoveredKey: string | null;
+  onHoverKey: (key: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  // Closing can unmount a hovered row without its mouseleave firing — clear
+  // the hover with it, or the chart stays dimmed.
+  const handleOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) onHoverKey(null);
+  };
+
+  const sorted = [...entries].sort((a, b) => (b.value ?? -Infinity) - (a.value ?? -Infinity));
+  const shown = sorted.slice(0, VISIBLE_ROWS);
+  const hiddenCount = sorted.length - shown.length;
+
+  const totalRow =
+    total === null ? null : (
+      <div role="listitem" className="flex w-full items-center gap-2 rounded px-1 py-0.5">
+        <div className="h-2.5 w-2.5 shrink-0" />
+        <div className="flex min-w-0 flex-1 items-center justify-between gap-x-3 leading-tight">
+          <span className="truncate text-muted-foreground">Total</span>
+          <span className="shrink-0 whitespace-nowrap font-mono font-medium tabular-nums text-foreground">
+            {format(total)}
+          </span>
+        </div>
+      </div>
+    );
+
+  const row = (e: LegendEntry) => (
+    <div
+      key={e.key}
+      role="listitem"
+      onMouseEnter={() => onHoverKey(e.key)}
+      onMouseLeave={() => onHoverKey(null)}
+      className={cn(
+        "flex w-full items-center gap-2 rounded px-1 py-0.5",
+        hoveredKey === e.key && "bg-muted/50",
+      )}
+    >
+      <div className="h-2.5 w-2.5 shrink-0 rounded-[2px]" style={{ backgroundColor: e.color }} />
+      <div className="flex min-w-0 flex-1 items-center justify-between gap-x-3 leading-tight">
+        <span className="truncate text-muted-foreground" title={e.label}>
+          {e.label}
+        </span>
+        <span className="shrink-0 whitespace-nowrap font-mono tabular-nums text-foreground">
+          {format(e.value)}
+        </span>
+      </div>
+    </div>
+  );
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <div className="shrink-0 pt-1 text-[11px]">
+        {/* Tile rows hide from assistive tech while the popover mirrors them. */}
+        <div role="list" aria-label="Chart legend" aria-hidden={open || undefined}>
+          {totalRow}
+          {shown.map(row)}
+        </div>
+        {/* Keep the trigger mounted while open: a background refresh can
+            shrink the list below the cap, and unmounting the trigger would
+            strand the portaled popover with no anchor or toggle. */}
+        {(hiddenCount > 0 || open) && (
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="rounded px-1 py-0.5 text-[10.5px] text-muted-foreground hover:text-foreground"
+            >
+              {open ? "show less" : `${hiddenCount} more`}
+            </button>
+          </PopoverTrigger>
+        )}
+      </div>
+      <PopoverContent
+        align="start"
+        className="max-h-64 w-56 overflow-auto p-1 text-[11px] shadow-xl"
+      >
+        <div role="list" aria-label="Chart legend (all series)">
+          {totalRow}
+          {sorted.map(row)}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/CreateDashboardDialog.test.tsx
@@ -64,6 +64,24 @@ describe("CreateDashboardDialog", () => {
     expect(create.hasAttribute("disabled")).toBe(false);
   });
 
+  it("omits an empty description and sends a filled one trimmed", () => {
+    renderDialog();
+    fireEvent.change(screen.getByPlaceholderText("Dashboard name"), {
+      target: { value: "Spend" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(createDashboard.mutate.mock.calls[0][0]).toEqual({ name: "Spend" });
+
+    fireEvent.change(screen.getByLabelText("Dashboard description"), {
+      target: { value: "  Monthly spend  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+    expect(createDashboard.mutate.mock.calls[1][0]).toEqual({
+      name: "Spend",
+      description: "Monthly spend",
+    });
+  });
+
   it("submits the trimmed name, then closes and navigates on success", () => {
     const { onOpenChange } = renderDialog();
 

--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
@@ -73,7 +73,6 @@ describe("DashboardGrid", () => {
           width={1000}
           onLayoutChange={vi.fn()}
           onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
           onDelete={vi.fn()}
         />,
       );
@@ -99,7 +98,6 @@ describe("DashboardGrid", () => {
           width={1000}
           onLayoutChange={vi.fn()}
           onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
           onDelete={vi.fn()}
         />,
       );
@@ -118,7 +116,6 @@ describe("DashboardGrid", () => {
           width={1000}
           onLayoutChange={vi.fn()}
           onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
           onDelete={vi.fn()}
         />,
       );
@@ -146,7 +143,6 @@ describe("DashboardGrid", () => {
           width={1000}
           onLayoutChange={onLayoutChange}
           onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
           onDelete={vi.fn()}
         />,
       );

--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.test.tsx
@@ -107,36 +107,6 @@ describe("DashboardGrid", () => {
       expect(latestProps().layout).toEqual([{ i: "w1", x: 0, y: 0, w: 4, h: 4, minW: 2, minH: 2 }]);
     });
 
-    it("marks every item static and never persists layout changes when read-only", () => {
-      vi.useFakeTimers();
-      const onLayoutChange = vi.fn();
-      render(
-        <DashboardGrid
-          projectId="p1"
-          widgets={[widget("w1")]}
-          layout={[{ i: "w1", x: 0, y: 0, w: 4, h: 4 }]}
-          range={RANGE}
-          width={1000}
-          readOnly
-          onLayoutChange={onLayoutChange}
-          onEdit={vi.fn()}
-          onDuplicate={vi.fn()}
-          onDelete={vi.fn()}
-        />,
-      );
-
-      const { layout: fullLayout, onLayoutChange: onChange } = latestProps();
-      expect(fullLayout).toEqual([
-        { i: "w1", x: 0, y: 0, w: 4, h: 4, minW: 2, minH: 2, static: true },
-      ]);
-
-      // Even if the grid fires (e.g. mount-fire compaction), nothing goes upstream.
-      onChange([{ i: "w1", x: 2, y: 0, w: 4, h: 4 }]);
-      vi.advanceTimersByTime(600);
-      expect(onLayoutChange).not.toHaveBeenCalled();
-      vi.useRealTimers();
-    });
-
     it("stamps the minimum size on every item so widgets can't be shrunk into clipping", () => {
       const widgets = [widget("w1"), widget("w2")];
       render(

--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
@@ -20,7 +20,6 @@ export function DashboardGrid({
   layout,
   range,
   width,
-  readOnly = false,
   onLayoutChange,
   onEdit,
   onDuplicate,
@@ -31,8 +30,6 @@ export function DashboardGrid({
   layout: LayoutItem[];
   range: TimeRange;
   width: number;
-  /** Read-only dashboards (the seeded default) can't be rearranged or resized. */
-  readOnly?: boolean;
   onLayoutChange: (layout: LayoutItem[]) => void;
   onEdit: (w: Widget) => void;
   onDuplicate: (w: Widget) => void;
@@ -44,10 +41,7 @@ export function DashboardGrid({
   const fullLayout: RGLLayoutItem[] = useMemo(() => {
     const known = new Map(layout.map((l) => [l.i, l]));
     let maxY = Math.max(0, ...layout.map((l) => l.y + l.h));
-    // `static` items can't be dragged or resized.
-    const constraints = readOnly
-      ? { minW: MIN_W, minH: MIN_H, static: true }
-      : { minW: MIN_W, minH: MIN_H };
+    const constraints = { minW: MIN_W, minH: MIN_H };
     return widgets.map((w) => {
       const item = known.get(w.id);
       if (item) return { ...item, ...constraints };
@@ -55,7 +49,7 @@ export function DashboardGrid({
       maxY += 4;
       return fresh;
     });
-  }, [widgets, layout, readOnly]);
+  }, [widgets, layout]);
 
   // Snapshot of the last layout sent upstream, used to skip no-op PATCH calls.
   // react-grid-layout fires onLayoutChange on mount with the initial layout, so
@@ -89,9 +83,6 @@ export function DashboardGrid({
   );
 
   const handleChange = (next: Layout) => {
-    // Static items can still be re-compacted on mount; never persist from a
-    // read-only grid.
-    if (readOnly) return;
     const mapped: LayoutItem[] = next.map(({ i, x, y, w, h }) => ({ i, x, y, w, h }));
 
     // Lazy-init: on the first call (mount-fire from react-grid-layout) treat the
@@ -129,7 +120,6 @@ export function DashboardGrid({
             projectId={projectId}
             widget={w}
             range={range}
-            readOnly={readOnly}
             onEdit={() => onEdit(w)}
             onDuplicate={() => onDuplicate(w)}
             onDelete={() => onDelete(w)}

--- a/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
+++ b/frontend/ui/src/features/dashboards/components/DashboardGrid.tsx
@@ -22,7 +22,6 @@ export function DashboardGrid({
   width,
   onLayoutChange,
   onEdit,
-  onDuplicate,
   onDelete,
 }: {
   projectId: string;
@@ -32,7 +31,6 @@ export function DashboardGrid({
   width: number;
   onLayoutChange: (layout: LayoutItem[]) => void;
   onEdit: (w: Widget) => void;
-  onDuplicate: (w: Widget) => void;
   onDelete: (w: Widget) => void;
 }) {
   // Widgets missing from layout (e.g. just created) get appended at the bottom.
@@ -121,7 +119,6 @@ export function DashboardGrid({
             widget={w}
             range={range}
             onEdit={() => onEdit(w)}
-            onDuplicate={() => onDuplicate(w)}
             onDelete={() => onDelete(w)}
           />
         </div>

--- a/frontend/ui/src/features/dashboards/components/DeleteDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/DeleteDashboardDialog.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeleteDashboardDialog } from "./DeleteDashboardDialog";
+
+const removeDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false, error: null };
+
+vi.mock("../hooks/use-dashboards", () => ({
+  useDashboardMutations: () => ({ removeDashboard }),
+}));
+
+const TARGET = { id: "d2", name: "Costs" };
+
+describe("DeleteDashboardDialog", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    removeDashboard.mutate.mockReset();
+    removeDashboard.reset.mockReset();
+    removeDashboard.isPending = false;
+    removeDashboard.isError = false;
+    removeDashboard.error = null;
+  });
+
+  it("deletes the target and closes on success", () => {
+    const onClose = vi.fn();
+    render(<DeleteDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    expect(screen.getByText(/Permanently delete “Costs”/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    expect(removeDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [id, options] = removeDashboard.mutate.mock.calls[0];
+    expect(id).toBe("d2");
+    options.onSuccess();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancel closes and resets the mutation so a stale error can't leak to the next target", () => {
+    const onClose = vi.fn();
+    render(<DeleteDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(removeDashboard.mutate).not.toHaveBeenCalled();
+    expect(removeDashboard.reset).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the mutation error and locks the dialog while deleting is in flight", () => {
+    removeDashboard.isError = true;
+    removeDashboard.error = new Error("boom");
+    removeDashboard.isPending = true;
+    const onClose = vi.fn();
+    render(<DeleteDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    expect(screen.getByText("boom")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveProperty("disabled", true);
+    // Radix close paths (Escape) are ignored while the delete is pending.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when there is no target", () => {
+    render(<DeleteDashboardDialog projectId="p1" target={null} onClose={vi.fn()} />);
+    expect(screen.queryByText("Delete Dashboard")).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/DeleteDashboardDialog.tsx
+++ b/frontend/ui/src/features/dashboards/components/DeleteDashboardDialog.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useDashboardMutations } from "../hooks/use-dashboards";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+/**
+ * Confirm-delete for a dashboard, opened from the list page's row actions.
+ * `target` doubles as the open state.
+ */
+export function DeleteDashboardDialog({
+  projectId,
+  target,
+  onClose,
+}: {
+  projectId: string;
+  target: { id: string; name: string } | null;
+  onClose: () => void;
+}) {
+  const { removeDashboard } = useDashboardMutations(projectId);
+
+  const handleOpenChange = (next: boolean) => {
+    // Radix close paths (Escape, overlay click) bypass the disabled Cancel
+    // button — ignore them while the delete is in flight.
+    if (!next && removeDashboard.isPending) return;
+    if (!next) {
+      // Reset so a failed delete of one dashboard doesn't show its error the
+      // next time the dialog opens for another.
+      removeDashboard.reset();
+      onClose();
+    }
+  };
+
+  const handleDelete = () => {
+    if (!target) return;
+    removeDashboard.mutate(target.id, {
+      onSuccess: () => {
+        removeDashboard.reset();
+        onClose();
+      },
+    });
+  };
+
+  return (
+    <Dialog open={target !== null} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Delete Dashboard</DialogTitle>
+          <DialogDescription>
+            Permanently delete “{target?.name}” and all of its widgets? This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        {removeDashboard.isError && (
+          <p className="text-sm text-destructive">{removeDashboard.error.message}</p>
+        )}
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={removeDashboard.isPending}
+          >
+            Cancel
+          </Button>
+          <Button variant="destructive" onClick={handleDelete} disabled={removeDashboard.isPending}>
+            {removeDashboard.isPending ? "Deleting..." : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/ui/src/features/dashboards/components/EditDashboardDialog.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/EditDashboardDialog.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EditDashboardDialog } from "./EditDashboardDialog";
+
+const renameDashboard: {
+  mutate: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+} = { mutate: vi.fn(), reset: vi.fn(), isPending: false, isError: false, error: null };
+
+vi.mock("../hooks/use-dashboards", () => ({
+  useDashboardMutations: vi.fn(() => ({ renameDashboard })),
+}));
+import { useDashboardMutations } from "../hooks/use-dashboards";
+
+const TARGET = { id: "d2", name: "Costs", description: "Cost breakdowns" };
+
+describe("EditDashboardDialog", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    renameDashboard.mutate.mockReset();
+    renameDashboard.reset.mockReset();
+    renameDashboard.isPending = false;
+    renameDashboard.isError = false;
+    renameDashboard.error = null;
+  });
+
+  it("prefills both fields and saves trimmed values, closing on success", () => {
+    const onClose = vi.fn();
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    // the mutation hook is bound to the row being edited
+    expect(vi.mocked(useDashboardMutations)).toHaveBeenCalledWith("p1", "d2");
+
+    const name = screen.getByLabelText("Dashboard name") as HTMLInputElement;
+    const description = screen.getByLabelText("Dashboard description") as HTMLTextAreaElement;
+    expect(name.value).toBe("Costs");
+    expect(description.value).toBe("Cost breakdowns");
+
+    fireEvent.change(name, { target: { value: "  Spend  " } });
+    fireEvent.change(description, { target: { value: "  Monthly spend  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(renameDashboard.mutate).toHaveBeenCalledTimes(1);
+    const [payload, options] = renameDashboard.mutate.mock.calls[0];
+    expect(payload).toEqual({ name: "Spend", description: "Monthly spend" });
+    options.onSuccess();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clearing the description saves null so the stored one is removed", () => {
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Dashboard description"), { target: { value: "  " } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(renameDashboard.mutate.mock.calls[0][0]).toEqual({ name: "Costs", description: null });
+  });
+
+  it("prefills an empty draft for a description-less dashboard", () => {
+    render(
+      <EditDashboardDialog
+        projectId="p1"
+        target={{ ...TARGET, description: null }}
+        onClose={vi.fn()}
+      />,
+    );
+    expect((screen.getByLabelText("Dashboard description") as HTMLTextAreaElement).value).toBe("");
+  });
+
+  it("cancel closes and resets without saving", () => {
+    const onClose = vi.fn();
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(renameDashboard.mutate).not.toHaveBeenCalled();
+    expect(renameDashboard.reset).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables save for a blank name", () => {
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={vi.fn()} />);
+    fireEvent.change(screen.getByLabelText("Dashboard name"), { target: { value: "   " } });
+    expect(screen.getByRole("button", { name: "Save" })).toHaveProperty("disabled", true);
+  });
+
+  it("surfaces the mutation error and locks the dialog while saving is in flight", () => {
+    renameDashboard.isError = true;
+    renameDashboard.error = new Error("boom");
+    renameDashboard.isPending = true;
+    const onClose = vi.fn();
+    render(<EditDashboardDialog projectId="p1" target={TARGET} onClose={onClose} />);
+
+    expect(screen.getByText("boom")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Cancel" })).toHaveProperty("disabled", true);
+    // Radix close paths (Escape) are ignored while the save is pending.
+    fireEvent.keyDown(document.body, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when there is no target", () => {
+    render(<EditDashboardDialog projectId="p1" target={null} onClose={vi.fn()} />);
+    expect(screen.queryByText("Edit Dashboard")).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/dashboards/components/EditDashboardDialog.tsx
+++ b/frontend/ui/src/features/dashboards/components/EditDashboardDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { useDashboardMutations } from "../hooks/use-dashboards";
 import { DASHBOARD_DESCRIPTION_MAX, DASHBOARD_NAME_MAX } from "../types";
 import { Button } from "@/components/ui/button";
@@ -15,65 +14,64 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 
-export function CreateDashboardDialog({
+/**
+ * Edit a dashboard's name and description from the list page. `target`
+ * doubles as the open state: a row's Edit action sets it, closing clears it.
+ * The drafts seed on mount, so callers must key this component by the
+ * target's id to reset them per row.
+ */
+export function EditDashboardDialog({
   projectId,
-  open,
-  onOpenChange,
+  target,
+  onClose,
 }: {
   projectId: string;
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
+  target: { id: string; name: string; description: string | null } | null;
+  onClose: () => void;
 }) {
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const router = useRouter();
-  const { createDashboard } = useDashboardMutations(projectId);
+  const { renameDashboard } = useDashboardMutations(projectId, target?.id);
+  const [name, setName] = useState(target?.name ?? "");
+  const [description, setDescription] = useState(target?.description ?? "");
 
-  // Closing discards the draft: a cancelled name or stale error must not
-  // reappear the next time the dialog opens.
   const handleOpenChange = (next: boolean) => {
-    // Radix close paths (Escape, overlay click, the X) bypass the disabled
-    // Cancel button — ignore them while a create is in flight, so the pending
-    // mutation can't be reset mid-request and resubmitted.
-    if (!next && createDashboard.isPending) return;
+    // Radix close paths (Escape, overlay click) bypass the disabled Cancel
+    // button — ignore them while the save is in flight.
+    if (!next && renameDashboard.isPending) return;
     if (!next) {
-      setName("");
-      setDescription("");
-      createDashboard.reset();
+      renameDashboard.reset();
+      onClose();
     }
-    onOpenChange(next);
   };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
-    createDashboard.mutate(
-      { name: name.trim(), ...(description.trim() ? { description: description.trim() } : {}) },
-      {
-        onSuccess: (res) => {
-          handleOpenChange(false);
-          router.push(`/projects/${projectId}/dashboard/${res.dashboard.id}`);
-        },
-      },
+    renameDashboard.mutate(
+      // An emptied description clears the stored one, not just the draft.
+      { name: name.trim(), description: description.trim() || null },
+      { onSuccess: () => onClose() },
     );
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={target !== null} onOpenChange={handleOpenChange}>
       <DialogContent>
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>Create Dashboard</DialogTitle>
-            <DialogDescription>Create a new dashboard to organize your widgets.</DialogDescription>
+            <DialogTitle>Edit Dashboard</DialogTitle>
+            <DialogDescription>
+              Update the name and description of “{target?.name}”.
+            </DialogDescription>
           </DialogHeader>
           <div className="flex flex-col gap-3 py-4">
             <Input
               autoFocus
+              aria-label="Dashboard name"
               maxLength={DASHBOARD_NAME_MAX}
               placeholder="Dashboard name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              disabled={createDashboard.isPending}
+              disabled={renameDashboard.isPending}
             />
             <textarea
               aria-label="Dashboard description"
@@ -82,11 +80,11 @@ export function CreateDashboardDialog({
               placeholder="Describe the purpose of this dashboard (optional)"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              disabled={createDashboard.isPending}
+              disabled={renameDashboard.isPending}
               className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
             />
-            {createDashboard.isError && (
-              <p className="text-sm text-destructive">{createDashboard.error.message}</p>
+            {renameDashboard.isError && (
+              <p className="text-sm text-destructive">{renameDashboard.error.message}</p>
             )}
           </div>
           <DialogFooter>
@@ -94,12 +92,12 @@ export function CreateDashboardDialog({
               type="button"
               variant="outline"
               onClick={() => handleOpenChange(false)}
-              disabled={createDashboard.isPending}
+              disabled={renameDashboard.isPending}
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={!name.trim() || createDashboard.isPending}>
-              {createDashboard.isPending ? "Creating..." : "Create"}
+            <Button type="submit" disabled={!name.trim() || renameDashboard.isPending}>
+              {renameDashboard.isPending ? "Saving..." : "Save"}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
@@ -10,14 +10,14 @@ import { useWidgetFieldValues } from "../hooks/use-widget-data";
 const stringField: WidgetSchemaField = {
   type: "string",
   label: "Model",
-  filterOps: ["=", "!=", "contains"],
+  filterOps: ["=", "contains"],
   groupable: true,
   aggs: [],
 };
 const numberField: WidgetSchemaField = {
   type: "number",
   label: "Cost",
-  filterOps: [">", ">=", "<", "<=", "=", "!="],
+  filterOps: [">", ">=", "<", "<=", "="],
   groupable: false,
   aggs: ["sum"],
 };
@@ -153,10 +153,11 @@ describe("FilterRow value input", () => {
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: "is" }));
-    expect(screen.getByRole("option", { name: "is not" })).toBeTruthy();
+    // same vocabulary as the trace-list filter: no "is not"
+    expect(screen.queryByRole("option", { name: "is not" })).toBeNull();
     expect(screen.getByRole("option", { name: "contains" })).toBeTruthy();
-    fireEvent.click(screen.getByRole("option", { name: "is not" }));
-    expect(onChange).toHaveBeenCalledWith(0, { op: "!=" });
+    fireEvent.click(screen.getByRole("option", { name: "contains" }));
+    expect(onChange).toHaveBeenCalledWith(0, { op: "contains" });
   });
 
   it("adorns cost and duration values with their unit like the trace-list builder", () => {

--- a/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.test.tsx
@@ -55,11 +55,10 @@ describe("FilterRow value input", () => {
         filter={{ field: "model_name", op: "=", value: "" }}
       />,
     );
-    // field + op selects; the value control is the trace-list popover dropdown
-    expect(screen.getAllByRole("combobox")).toHaveLength(2);
+    // the value control is the trace-list popover dropdown, not a free input
     expect(screen.queryByRole("textbox")).toBeNull();
 
-    fireEvent.click(screen.getByRole("button", { name: "Value" }));
+    fireEvent.click(screen.getByRole("button", { name: "Enter value" }));
     const option = screen.getByRole("option", { name: /gpt-4o/ });
     // the stored value's occurrence count is shown alongside it
     expect(option.textContent).toContain("3");
@@ -72,7 +71,6 @@ describe("FilterRow value input", () => {
     render(
       <FilterRow {...baseProps} filter={{ field: "model_name", op: "contains", value: "gp" }} />,
     );
-    expect(screen.getAllByRole("combobox")).toHaveLength(2);
     expect(screen.getByRole("textbox")).toBeTruthy();
     // the hook is parked while the op is not enumerable
     expect(vi.mocked(useWidgetFieldValues).mock.lastCall?.[4]).toBe(false);
@@ -81,15 +79,55 @@ describe("FilterRow value input", () => {
   it("falls back to free text when no stored values exist", () => {
     vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
     render(<FilterRow {...baseProps} filter={{ field: "model_name", op: "=", value: "" }} />);
-    expect(screen.getAllByRole("combobox")).toHaveLength(2);
     expect(screen.getByRole("textbox")).toBeTruthy();
   });
 
   it("keeps the number input for numeric fields", () => {
     vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
     render(<FilterRow {...baseProps} filter={{ field: "cost", op: ">", value: 5 }} />);
-    expect(screen.getByRole("spinbutton")).toBeTruthy();
+    const input = screen.getByRole("spinbutton");
+    expect(input).toBeTruthy();
+    // the widget builder hosts the shared controls at its compact 12px size
+    expect(input.className).toContain("text-[12px]");
     expect(vi.mocked(useWidgetFieldValues).mock.lastCall?.[4]).toBe(false);
+  });
+
+  it("rejects negative numeric input like the trace-list builder", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    const onChange = vi.fn();
+    render(
+      <FilterRow
+        {...baseProps}
+        onChange={onChange}
+        filter={{ field: "cost", op: ">", value: "" }}
+      />,
+    );
+    const input = screen.getByRole("spinbutton");
+    // typed negative values are dropped instead of propagating into the spec
+    fireEvent.change(input, { target: { value: "-5" } });
+    expect(onChange).not.toHaveBeenCalled();
+    // a non-negative value still propagates as a number
+    fireEvent.change(input, { target: { value: "5" } });
+    expect(onChange).toHaveBeenCalledWith(0, { value: 5 });
+  });
+
+  it("picking a field auto-selects its first operator, like the trace-list builder", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    const onChange = vi.fn();
+    render(
+      <FilterRow {...baseProps} onChange={onChange} filter={{ field: "", op: "", value: "" }} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Field" }));
+    fireEvent.click(screen.getByRole("option", { name: /Cost/ }));
+    expect(onChange).toHaveBeenCalledWith(0, { field: "cost", op: ">", value: "" });
+  });
+
+  it("disables the op and value controls until a field is picked", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    render(<FilterRow {...baseProps} filter={{ field: "", op: "", value: "" }} />);
+    // op trigger shows the placeholder "is" and is disabled; value is a parked input
+    expect(screen.getByRole("button", { name: "is" })).toHaveProperty("disabled", true);
+    expect(screen.getByPlaceholderText("Enter value")).toHaveProperty("disabled", true);
   });
 
   it("shows trace-list wording for string ops and symbols for numeric ops", () => {
@@ -102,6 +140,23 @@ describe("FilterRow value input", () => {
 
     render(<FilterRow {...baseProps} filter={{ field: "cost", op: ">=", value: 5 }} />);
     expect(screen.getByText("≥")).toBeTruthy();
+  });
+
+  it("lists the field's ops in the operator dropdown with shared labels", () => {
+    vi.mocked(useWidgetFieldValues).mockReturnValue({ values: [], isLoading: false });
+    const onChange = vi.fn();
+    render(
+      <FilterRow
+        {...baseProps}
+        onChange={onChange}
+        filter={{ field: "model_name", op: "=", value: "" }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "is" }));
+    expect(screen.getByRole("option", { name: "is not" })).toBeTruthy();
+    expect(screen.getByRole("option", { name: "contains" })).toBeTruthy();
+    fireEvent.click(screen.getByRole("option", { name: "is not" }));
+    expect(onChange).toHaveBeenCalledWith(0, { op: "!=" });
   });
 
   it("adorns cost and duration values with their unit like the trace-list builder", () => {

--- a/frontend/ui/src/features/dashboards/components/FilterRow.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.tsx
@@ -88,7 +88,7 @@ export function FilterRow({
           }
         />
 
-        {/* op — labeled with the trace-list filter vocabulary (is / is not / ≥ / ≤ / ≠) */}
+        {/* op — labeled with the trace-list filter vocabulary (is / ≥ / ≤) */}
         <Dropdown
           disabled={!fieldMeta}
           trigger={

--- a/frontend/ui/src/features/dashboards/components/FilterRow.tsx
+++ b/frontend/ui/src/features/dashboards/components/FilterRow.tsx
@@ -2,19 +2,20 @@
 
 import { useMemo } from "react";
 import { X } from "lucide-react";
-import { Input } from "@/components/ui/input";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { ValueDropdown } from "@/features/filters/filter-builder";
+  Dropdown,
+  DropdownItem,
+  FIELD_UNIT,
+  FieldDropdown,
+  FilterControlSizeProvider,
+  NumberField,
+  ParkedValueField,
+  TextField,
+  ValueDropdown,
+} from "@/features/filters/filter-controls";
 import { fieldIcon } from "./field-icons";
 import { useWidgetFieldValues } from "../hooks/use-widget-data";
 import {
-  FIELD_UNIT,
   filterOpLabel,
   isEnumerableFilter,
   type TimeRange,
@@ -46,7 +47,6 @@ export function FilterRow({
   range: TimeRange;
 }) {
   const fieldMeta = fieldsMap[filter.field];
-  const ops = fieldMeta?.filterOps ?? [];
   const isNumeric = fieldMeta?.type === "number";
 
   // Equality on a string dimension offers the field's stored values as a
@@ -71,96 +71,87 @@ export function FilterRow({
   const showValueDropdown = enumerable && (options.length > 0 || isLoading);
 
   return (
-    <div className="flex items-center gap-1.5">
-      {/* field */}
-      <Select
-        value={filter.field}
-        onValueChange={(v) => onChange(index, { field: v, op: "", value: "" })}
-      >
-        <SelectTrigger className="h-7 flex-1 text-[12px]">
-          <SelectValue placeholder="Field" />
-        </SelectTrigger>
-        <SelectContent>
-          {filterableFields.map(([key, meta]) => {
-            const Icon = fieldIcon(key);
-            return (
-              <SelectItem
-                key={key}
-                value={key}
-                className="text-[12px]"
-                icon={<Icon className="h-3.5 w-3.5 text-muted-foreground" />}
-              >
-                {meta.label}
-              </SelectItem>
-            );
-          })}
-        </SelectContent>
-      </Select>
-
-      {/* op — labeled with the trace-list filter vocabulary (is / is not / ≥ / ≤ / ≠) */}
-      <Select
-        value={filter.op}
-        onValueChange={(v) => onChange(index, { op: v })}
-        disabled={!filter.field}
-      >
-        <SelectTrigger className="h-7 w-24 text-[12px]">
-          <SelectValue placeholder="Op">
-            {filter.op ? filterOpLabel(fieldMeta, filter.op) : undefined}
-          </SelectValue>
-        </SelectTrigger>
-        <SelectContent>
-          {ops.map((op) => (
-            <SelectItem key={op} value={op} className="text-[12px]">
-              {filterOpLabel(fieldMeta, op)}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-
-      {/* value — the trace-list stored-values picker, counts included */}
-      {showValueDropdown ? (
-        <ValueDropdown
-          value={String(filter.value)}
-          options={options}
-          onValue={(v) => onChange(index, { value: v })}
-          placeholder={isLoading ? "Loading…" : "Value"}
-          triggerClassName="text-[12px]"
+    // The widget builder's config column runs at 12px, so the shared controls
+    // render at their compact size here.
+    <FilterControlSizeProvider size="sm">
+      <div className="flex items-center gap-1">
+        <FieldDropdown
+          options={filterableFields.map(([key, meta]) => ({
+            key,
+            label: meta.label,
+            icon: fieldIcon(key),
+          }))}
+          valueKey={filter.field || null}
+          // Picking a field selects its first operator, like the trace-list builder.
+          onPick={(key) =>
+            onChange(index, { field: key, op: fieldsMap[key]?.filterOps[0] ?? "", value: "" })
+          }
         />
-      ) : (
-        <div className="flex flex-1 items-center gap-1">
-          {isNumeric && FIELD_UNIT[filter.field]?.prefix && (
-            <span className="shrink-0 text-[11px] text-muted-foreground">
-              {FIELD_UNIT[filter.field].prefix}
-            </span>
-          )}
-          <Input
-            className="h-7 flex-1 text-[12px]"
-            placeholder="Value"
-            type={isNumeric ? "number" : "text"}
-            value={String(filter.value)}
-            onChange={(e) => {
-              const raw = e.target.value;
-              onChange(index, { value: isNumeric && raw !== "" ? Number(raw) : raw });
-            }}
-            disabled={!filter.field}
-          />
-          {isNumeric && FIELD_UNIT[filter.field]?.suffix && (
-            <span className="shrink-0 text-[11px] text-muted-foreground">
-              {FIELD_UNIT[filter.field].suffix}
-            </span>
-          )}
-        </div>
-      )}
 
-      {/* remove */}
-      <button
-        type="button"
-        onClick={() => onRemove(index)}
-        className="rounded p-0.5 text-muted-foreground hover:text-foreground"
-        aria-label="Remove filter"
-      >
-        <X className="h-3.5 w-3.5" />
-      </button>
-    </div>
+        {/* op — labeled with the trace-list filter vocabulary (is / is not / ≥ / ≤ / ≠) */}
+        <Dropdown
+          disabled={!fieldMeta}
+          trigger={
+            <span className="whitespace-nowrap">
+              {fieldMeta && filter.op ? filterOpLabel(fieldMeta, filter.op) : "is"}
+            </span>
+          }
+          triggerClassName="min-w-[3.5rem] shrink-0"
+          contentClassName="w-28"
+        >
+          {(close) =>
+            (fieldMeta?.filterOps ?? []).map((op) => (
+              <DropdownItem
+                key={op}
+                active={op === filter.op}
+                onClick={() => {
+                  onChange(index, { op });
+                  close();
+                }}
+              >
+                {filterOpLabel(fieldMeta, op)}
+              </DropdownItem>
+            ))
+          }
+        </Dropdown>
+
+        {/* value — same controls as the trace-list builder's ValueControl */}
+        {!fieldMeta ? (
+          <ParkedValueField />
+        ) : showValueDropdown ? (
+          <ValueDropdown
+            value={String(filter.value)}
+            options={options}
+            onValue={(v) => onChange(index, { value: v })}
+            placeholder={isLoading ? "Loading…" : undefined}
+          />
+        ) : isNumeric ? (
+          <NumberField
+            ariaLabel="value"
+            placeholder="Enter value"
+            value={String(filter.value)}
+            onChange={(v) => onChange(index, { value: v === "" ? "" : Number(v) })}
+            unit={FIELD_UNIT[filter.field]}
+          />
+        ) : (
+          <TextField
+            ariaLabel="value"
+            placeholder="Enter value"
+            value={String(filter.value)}
+            onChange={(v) => onChange(index, { value: v })}
+          />
+        )}
+
+        {/* remove */}
+        <button
+          type="button"
+          onClick={() => onRemove(index)}
+          className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+          aria-label="Remove filter"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </div>
+    </FilterControlSizeProvider>
   );
 }

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
@@ -46,7 +46,7 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
-function renderWidget(spec: { limit?: number } = {}) {
+function renderWidget(spec: React.ComponentProps<typeof TraceFeedWidget>["spec"] = {}) {
   return render(<TraceFeedWidget projectId="p1" spec={spec} range={RANGE} />, { wrapper });
 }
 
@@ -152,11 +152,30 @@ describe("TraceFeedWidget", () => {
       {
         page: 0,
         limit: 25,
+        filters: [],
         start_after: RANGE.start.toISOString(),
         end_before: RANGE.end.toISOString(),
       },
       { id: "u1", email: "u@example.com" },
     );
+  });
+
+  it("passes spec.filters through as trace-list predicates, dropping invalid entries", async () => {
+    vi.mocked(getTraces).mockResolvedValue({
+      data: [makeTrace()],
+      meta: { page: 0, limit: 10, total: 1 },
+    });
+    renderWidget({
+      filters: [
+        { field: "errors", op: "gt", value: 0 },
+        // Stored specs are arbitrary JSON — a malformed entry must not reach the API.
+        { field: "errors", op: "gt", value: Number.NaN },
+      ],
+    });
+
+    await waitFor(() => expect(getTraces).toHaveBeenCalled());
+    const options = vi.mocked(getTraces).mock.calls[0][2];
+    expect(options?.filters).toEqual([{ field: "errors", op: "gt", value: 0 }]);
   });
 
   it("defaults the limit to 10 when spec.limit is not provided", async () => {

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.test.tsx
@@ -1,15 +1,15 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { TraceListItem } from "@/types/api";
 import type { TimeRange } from "../types";
 import { TraceFeedWidget } from "./TraceFeedWidget";
 
-vi.mock("next/link", () => ({
-  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
-    <a href={href}>{children}</a>
-  ),
+const push = vi.fn();
+const prefetch = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, prefetch }),
 }));
 
 // Mutable so individual tests can put the session into its resolving state.
@@ -31,6 +31,7 @@ import { getTraces } from "@/lib/api/traces";
 
 afterEach(() => {
   cleanup();
+  push.mockReset();
   vi.mocked(getTraces).mockReset();
   auth.data = { user: { id: "u1", email: "u@example.com" } };
   auth.isPending = false;
@@ -99,7 +100,7 @@ describe("TraceFeedWidget", () => {
     await waitFor(() => expect(screen.getByText("No traces in this time range")).toBeTruthy());
   });
 
-  it("renders a populated list with status chips, cost, time and links", async () => {
+  it("renders a populated list with status chips, cost and time; a row click opens the trace", async () => {
     vi.mocked(getTraces).mockResolvedValue({
       data: [
         makeTrace({ trace_id: "err-trace", name: "errored-run", error_count: 2, total_cost: 0.5 }),
@@ -123,19 +124,18 @@ describe("TraceFeedWidget", () => {
     expect(screen.getByText("$0.5000")).toBeTruthy();
     expect(screen.getAllByText("—")).toHaveLength(2);
 
-    const nameLink = screen.getByText("errored-run").closest("a");
-    expect(nameLink?.getAttribute("href")).toBe("/projects/p1/traces?traceId=err-trace");
-
     const expectedTime = new Date("2026-06-01T12:00:00Z").toLocaleTimeString(undefined, {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
     });
-    const timeLinks = screen.getAllByText(expectedTime);
-    expect(timeLinks.length).toBeGreaterThan(0);
-    expect(timeLinks[0].closest("a")?.getAttribute("href")).toBe(
-      "/projects/p1/traces?traceId=err-trace",
-    );
+    expect(screen.getAllByText(expectedTime).length).toBeGreaterThan(0);
+
+    // the WHOLE row navigates — clicking any cell opens the trace detail
+    fireEvent.click(screen.getByText("$0.5000"));
+    expect(push).toHaveBeenCalledWith("/projects/p1/traces?traceId=err-trace");
+    fireEvent.click(screen.getByText("clean-run"));
+    expect(push).toHaveBeenCalledWith("/projects/p1/traces?traceId=ok-trace");
   });
 
   it("passes spec.limit and the range bounds to getTraces", async () => {

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { useTraceApiUser } from "@/lib/hooks/use-trace-api-user";
 import { getTraces } from "@/lib/api/traces";
@@ -46,6 +46,7 @@ function fmtTime(iso: string): string {
 }
 
 export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps) {
+  const router = useRouter();
   const limit = spec.limit ?? 10;
   const filters = (spec.filters ?? []).filter(isValidPredicate);
   const { user, sessionReady } = useTraceApiUser();
@@ -104,36 +105,35 @@ export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps
           </tr>
         </thead>
         <tbody>
-          {traces.map((trace: TraceListItem) => (
-            <tr key={trace.trace_id} className="border-t border-border/60">
-              <td className="whitespace-nowrap py-1 pr-3 text-muted-foreground">
-                <Link
-                  href={`/projects/${projectId}/traces?traceId=${trace.trace_id}`}
-                  className="hover:underline"
-                >
+          {traces.map((trace: TraceListItem) => {
+            const href = `/projects/${projectId}/traces?traceId=${trace.trace_id}`;
+            return (
+              <tr
+                key={trace.trace_id}
+                // The whole row opens the trace, like the list pages' rows; the
+                // hover prefetch stands in for the removed links' viewport prefetch.
+                onClick={() => router.push(href)}
+                onMouseEnter={() => router.prefetch(href)}
+                className="cursor-pointer border-t border-border/60 transition-colors hover:bg-muted/50"
+              >
+                <td className="whitespace-nowrap py-1 pr-3 text-muted-foreground">
                   {fmtTime(trace.trace_start_time)}
-                </Link>
-              </td>
-              <td className="max-w-[120px] truncate py-1 pr-3">
-                <Link
-                  href={`/projects/${projectId}/traces?traceId=${trace.trace_id}`}
-                  className="hover:underline"
-                  title={trace.name}
-                >
+                </td>
+                <td className="max-w-[120px] truncate py-1 pr-3" title={trace.name}>
                   {trace.name}
-                </Link>
-              </td>
-              <td className="py-1 pr-3">
-                <StatusChip errorCount={trace.error_count} />
-              </td>
-              <td className="py-1 pr-3 tabular-nums text-muted-foreground">
-                {fmtCost(trace.total_cost)}
-              </td>
-              <td className="py-1 tabular-nums text-muted-foreground">
-                {formatDuration(trace.duration_ms)}
-              </td>
-            </tr>
-          ))}
+                </td>
+                <td className="py-1 pr-3">
+                  <StatusChip errorCount={trace.error_count} />
+                </td>
+                <td className="py-1 pr-3 tabular-nums text-muted-foreground">
+                  {fmtCost(trace.total_cost)}
+                </td>
+                <td className="py-1 tabular-nums text-muted-foreground">
+                  {formatDuration(trace.duration_ms)}
+                </td>
+              </tr>
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
+++ b/frontend/ui/src/features/dashboards/components/TraceFeedWidget.tsx
@@ -4,13 +4,16 @@ import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { useTraceApiUser } from "@/lib/hooks/use-trace-api-user";
 import { getTraces } from "@/lib/api/traces";
-import type { TraceListItem } from "@/types/api";
+import type { Predicate, TraceListItem } from "@/types/api";
+import { canonicalizeFilters, isValidPredicate } from "@/features/filters/predicate";
 import { formatDuration } from "@/lib/utils";
 import type { TimeRange } from "../types";
 
 interface TraceFeedWidgetProps {
   projectId: string;
-  spec: { limit?: number };
+  // Filters use the trace-list predicate wire format; the spec is stored
+  // JSON, so entries are validated before they reach the query.
+  spec: { limit?: number; filters?: Predicate[] };
   range: TimeRange;
 }
 
@@ -44,10 +47,18 @@ function fmtTime(iso: string): string {
 
 export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps) {
   const limit = spec.limit ?? 10;
+  const filters = (spec.filters ?? []).filter(isValidPredicate);
   const { user, sessionReady } = useTraceApiUser();
 
   const { data, isPending, isError } = useQuery({
-    queryKey: ["trace-feed", projectId, limit, range.start.getTime(), range.end.getTime()],
+    queryKey: [
+      "trace-feed",
+      projectId,
+      limit,
+      canonicalizeFilters(filters),
+      range.start.getTime(),
+      range.end.getTime(),
+    ],
     queryFn: () =>
       getTraces(
         projectId,
@@ -55,6 +66,7 @@ export function TraceFeedWidget({ projectId, spec, range }: TraceFeedWidgetProps
         {
           page: 0,
           limit,
+          filters,
           start_after: range.start.toISOString(),
           end_before: range.end.toISOString(),
         },

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -42,7 +42,7 @@ const SCHEMA = {
       model_name: {
         type: "string",
         label: "Model",
-        filterOps: ["=", "!=", "contains"],
+        filterOps: ["=", "contains"],
         groupable: true,
         aggs: [],
       },

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, Widget } from "../types";
 import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
@@ -285,6 +285,37 @@ describe("WidgetBuilderPage", () => {
 
     expect(screen.getByText(/can't be histogrammed/)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Save widget" })).toHaveProperty("disabled", true);
+  });
+
+  it("pauses the preview query while the histogram draft is blocked", () => {
+    vi.useFakeTimers();
+    try {
+      // count is flagged histogrammable: false in the schema, so this saved
+      // spec is complete but permanently rejected by the query engine.
+      const blockedWidget = {
+        ...WIDGET,
+        spec: {
+          ...WIDGET.spec,
+          metric: { measure: "count", agg: "count" },
+          display: { type: "histogram" },
+        },
+      };
+      mockDashboard({ ...DASHBOARD, widgets: [blockedWidget] });
+      // A disabled query reports isPending — the paused branch must outrank it.
+      mockPreview({ isPending: true });
+      render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+      // Let the 400ms draft debounce settle so the gate sees the blocked spec.
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
+      // The hook receives null instead of the doomed draft — no request fires.
+      expect(vi.mocked(useWidgetPreview).mock.lastCall?.[1]).toBeNull();
+      // And the pane names the blocker instead of sitting on "Running…".
+      expect(screen.getByText(/Preview paused/)).toBeTruthy();
+      expect(screen.queryByText("Running…")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("warns and blocks save when pie/bar is picked without a breakdown", async () => {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, Widget } from "../types";
 import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
@@ -453,18 +453,30 @@ describe("WidgetBuilderPage", () => {
   });
 
   it("renders the query result once preview data resolves", () => {
-    vi.useFakeTimers();
-    try {
-      mockPreview({ data: { columns: ["value"], rows: [[42]], meta: {} } });
-      render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
-      // The preview draft is debounced 400ms before the renderer picks it up.
-      act(() => {
-        vi.advanceTimersByTime(400);
-      });
-      // cost measure carries its $ unit through the preview renderer
-      expect(screen.getByText("$42")).toBeTruthy();
-    } finally {
-      vi.useRealTimers();
-    }
+    // The renderer draws straight from the preview data (spec + rows), so no
+    // debounce needs to elapse first.
+    mockPreview({
+      data: { spec: WIDGET.spec, result: { columns: ["value"], rows: [[42]], meta: {} } },
+    });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    // cost measure carries its $ unit through the preview renderer
+    expect(screen.getByText("$42")).toBeTruthy();
+  });
+
+  it("renders the preview from the spec that produced the data, not the live draft", () => {
+    // keepPreviousData can leave the previous query's rows on screen while a
+    // new draft is fetching; the renderer must label them with the spec that
+    // produced them. Here the stored widget measures duration, but the data
+    // came from a cost spec — the $ unit must follow the data.
+    const durationWidget = {
+      ...WIDGET,
+      spec: { ...WIDGET.spec, metric: { measure: "duration_ms", agg: "avg" } },
+    };
+    mockDashboard({ ...DASHBOARD, widgets: [durationWidget] });
+    mockPreview({
+      data: { spec: WIDGET.spec, result: { columns: ["value"], rows: [[42]], meta: {} } },
+    });
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" widgetId="w1" />);
+    expect(screen.getByText("$42")).toBeTruthy();
   });
 });

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -219,10 +219,11 @@ describe("WidgetBuilderPage", () => {
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
   });
 
-  it("redirects back to the read-only default dashboard instead of opening the builder", () => {
+  it("opens the builder for the default dashboard like any other", () => {
     mockDashboard({ ...DASHBOARD, isDefault: true });
     render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
-    expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
+    expect(replace).not.toHaveBeenCalled();
+    expect(screen.getByText("New widget")).toBeTruthy();
   });
 
   function openSelect(currentText: string) {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -2,6 +2,7 @@
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DashboardDetail, Widget } from "../types";
+import { ApiError } from "@/lib/api/client";
 import { dateFilterStorageKey, readStoredDateFilter } from "@/lib/date-filter-storage";
 import { WidgetBuilderPage } from "./WidgetBuilderPage";
 
@@ -24,7 +25,10 @@ const createWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; erro
   { mutate: vi.fn(), isPending: false, error: null };
 const updateWidget: { mutate: ReturnType<typeof vi.fn>; isPending: boolean; error: Error | null } =
   { mutate: vi.fn(), isPending: false, error: null };
-vi.mock("../hooks/use-dashboards", () => ({
+vi.mock("../hooks/use-dashboards", async (importOriginal) => ({
+  // Keep the real isDashboardGone: the redirect-on-gone behavior under test
+  // depends on its ApiError-status logic.
+  ...(await importOriginal<object>()),
   useDashboard: vi.fn(),
   useDashboardMutations: () => ({ createWidget, updateWidget }),
 }));
@@ -212,10 +216,16 @@ describe("WidgetBuilderPage", () => {
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard/d1");
   });
 
-  it("redirects to the dashboard index when the dashboard failed to load", () => {
-    mockDashboard(undefined, new Error("404"));
+  it("redirects to the dashboard index when the dashboard is permanently gone", () => {
+    mockDashboard(undefined, new ApiError("Dashboard not found", 404));
     render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
     expect(replace).toHaveBeenCalledWith("/projects/p1/dashboard");
+  });
+
+  it("stays in the builder on a transient load error — a blip must not dump the draft", () => {
+    mockDashboard(undefined, new ApiError("API error: 503", 503));
+    render(<WidgetBuilderPage projectId="p1" dashboardId="d1" />);
+    expect(replace).not.toHaveBeenCalled();
   });
 
   it("opens the builder for the default dashboard like any other", () => {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.test.tsx
@@ -98,13 +98,12 @@ const WIDGET: Widget = {
   displayConfig: {},
 };
 
-// Non-default: the builder is only reachable for editable dashboards — the
-// default one redirects away, which its dedicated test covers.
 const DASHBOARD = {
   id: "d1",
   name: "Custom",
   description: null,
   isDefault: false,
+  createTime: "",
   updateTime: "",
   layout: [],
   widgets: [WIDGET],

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -20,7 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useDashboard, useDashboardMutations } from "../hooks/use-dashboards";
+import { isDashboardGone, useDashboard, useDashboardMutations } from "../hooks/use-dashboards";
 import { useWidgetPreview, useWidgetSchema } from "../hooks/use-widget-data";
 import { DEFAULT_RANGE_ID, RANGE_PRESETS, makeRange } from "../range-presets";
 import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-storage";
@@ -122,7 +122,9 @@ export function WidgetBuilderPage({
   }, [isEdit, hydrated, widget]);
 
   useEffect(() => {
-    if (dashboardError) router.replace(`/projects/${projectId}/dashboard`);
+    // Leave only when the dashboard is permanently gone; a transient blip
+    // must not dump the user's draft — the detail query's poll retries.
+    if (isDashboardGone(dashboardError)) router.replace(`/projects/${projectId}/dashboard`);
   }, [dashboardError, projectId, router]);
 
   useEffect(() => {

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -245,7 +245,6 @@ export function WidgetBuilderPage({
   // ── preview ───────────────────────────────────────────────────────────────
   const debouncedDraft = useDebounced(draft, 400);
   const preview = useWidgetPreview(projectId, debouncedDraft, range);
-  const debouncedSpec = useMemo(() => parseSpec(debouncedDraft), [debouncedDraft]);
 
   // ── save ──────────────────────────────────────────────────────────────────
   const specComplete = isSpecComplete(draft);
@@ -553,12 +552,18 @@ export function WidgetBuilderPage({
               <div className="flex h-full items-start justify-center pt-8 text-[12px] text-red-600">
                 {preview.error instanceof Error ? preview.error.message : "Query failed"}
               </div>
-            ) : preview.data && debouncedSpec ? (
+            ) : preview.data ? (
+              // Everything spec-derived comes from the spec that produced the
+              // rows (preview.data.spec, not the live draft): keepPreviousData
+              // can show the previous result while a new query is in flight,
+              // and mixing old rows with the new draft's display/unit/agg
+              // would briefly mislabel them.
               <QueryWidgetRenderer
-                display={debouncedSpec.display.type}
-                result={preview.data}
-                unit={FIELD_UNIT[debouncedSpec.metric.measure]}
-                seriesLabel={debouncedSpec.metric.measure}
+                display={preview.data.spec.display.type}
+                result={preview.data.result}
+                unit={FIELD_UNIT[preview.data.spec.metric.measure]}
+                seriesLabel={preview.data.spec.metric.measure}
+                agg={preview.data.spec.metric.agg}
               />
             ) : null}
           </div>

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -244,7 +244,15 @@ export function WidgetBuilderPage({
 
   // ── preview ───────────────────────────────────────────────────────────────
   const debouncedDraft = useDebounced(draft, 400);
-  const preview = useWidgetPreview(projectId, debouncedDraft, range);
+  const debouncedSpec = useMemo(() => parseSpec(debouncedDraft), [debouncedDraft]);
+  // The engine permanently rejects histogramming a non-histogrammable measure
+  // (reachable by picking the measure after the display) — pause the preview
+  // query instead of sending a request that can only fail. Derived from the
+  // debounced draft so the gate and the query key always agree.
+  const previewBlocked =
+    debouncedSpec?.display.type === "histogram" &&
+    schema?.[debouncedSpec.view]?.fields[debouncedSpec.metric.measure]?.histogrammable === false;
+  const preview = useWidgetPreview(projectId, previewBlocked ? null : debouncedDraft, range);
 
   // ── save ──────────────────────────────────────────────────────────────────
   const specComplete = isSpecComplete(draft);
@@ -543,6 +551,12 @@ export function WidgetBuilderPage({
             {!specComplete ? (
               <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
                 Complete the data selection and display to preview
+              </div>
+            ) : histogramBlocked || previewBlocked ? (
+              // The paused query would otherwise sit in isPending forever and
+              // show "Running…" — name the actual blocker instead.
+              <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
+                Preview paused — histogram isn&apos;t available for this measure
               </div>
             ) : preview.isPending ? (
               <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -27,13 +27,13 @@ import { readStoredDateFilter, writeStoredDateFilter } from "@/lib/date-filter-s
 import {
   BREAKDOWN_REQUIRED_DISPLAYS,
   DISPLAY_TYPES,
-  FIELD_UNIT,
   generateWidgetTitle,
   isSpecComplete,
   parseSpec,
   type DraftSpec,
   type WidgetSchemaField,
 } from "../types";
+import { FIELD_UNIT } from "@/features/filters/filter-controls";
 import { fieldIcon } from "./field-icons";
 import { FilterRow } from "./FilterRow";
 import { QueryWidgetRenderer } from "./renderers";

--- a/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetBuilderPage.tsx
@@ -131,12 +131,6 @@ export function WidgetBuilderPage({
     }
   }, [isEdit, dashboard, widget, dashboardUrl, router]);
 
-  // The default dashboard is read-only — widgets can be neither added nor
-  // edited, so bounce straight back. The API enforces the same rule.
-  useEffect(() => {
-    if (dashboard?.isDefault) router.replace(dashboardUrl);
-  }, [dashboard, dashboardUrl, router]);
-
   // ── schema-driven field lists (same derivation as the old modal) ──────────
   const { data: schema } = useWidgetSchema(projectId);
   const view = draft.view as View | undefined;

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
@@ -51,7 +51,6 @@ function makeWidget(overrides: Partial<Widget> = {}): Widget {
 function renderCard(
   widget: Widget,
   callbacks: Partial<{ onEdit: () => void; onDuplicate: () => void; onDelete: () => void }> = {},
-  readOnly = false,
 ) {
   const onEdit = callbacks.onEdit ?? vi.fn();
   const onDuplicate = callbacks.onDuplicate ?? vi.fn();
@@ -61,7 +60,6 @@ function renderCard(
       projectId="p1"
       widget={widget}
       range={RANGE}
-      readOnly={readOnly}
       onEdit={onEdit}
       onDuplicate={onDuplicate}
       onDelete={onDelete}
@@ -90,16 +88,6 @@ describe("WidgetCard menu gating", () => {
     fireEvent.click(edit);
 
     expect(onEdit).toHaveBeenCalledTimes(1);
-  });
-
-  it("hides the options menu and drag handle entirely when read-only", () => {
-    useWidgetData.mockReturnValue({ data: undefined, isPending: false, error: null });
-    renderCard(makeWidget(), {}, true);
-
-    expect(screen.queryByRole("button", { name: "Widget options" })).toBeNull();
-    expect(screen.queryByText("⠿")).toBeNull();
-    // The widget body still renders.
-    expect(screen.getByText("My widget")).toBeTruthy();
   });
 
   it("hides Edit for a non-query widget", async () => {

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.test.tsx
@@ -50,22 +50,14 @@ function makeWidget(overrides: Partial<Widget> = {}): Widget {
 
 function renderCard(
   widget: Widget,
-  callbacks: Partial<{ onEdit: () => void; onDuplicate: () => void; onDelete: () => void }> = {},
+  callbacks: Partial<{ onEdit: () => void; onDelete: () => void }> = {},
 ) {
   const onEdit = callbacks.onEdit ?? vi.fn();
-  const onDuplicate = callbacks.onDuplicate ?? vi.fn();
   const onDelete = callbacks.onDelete ?? vi.fn();
   render(
-    <WidgetCard
-      projectId="p1"
-      widget={widget}
-      range={RANGE}
-      onEdit={onEdit}
-      onDuplicate={onDuplicate}
-      onDelete={onDelete}
-    />,
+    <WidgetCard projectId="p1" widget={widget} range={RANGE} onEdit={onEdit} onDelete={onDelete} />,
   );
-  return { onEdit, onDuplicate, onDelete };
+  return { onEdit, onDelete };
 }
 
 async function openMenu() {
@@ -97,29 +89,21 @@ describe("WidgetCard menu gating", () => {
     expect(screen.queryByRole("menuitem", { name: "Edit" })).toBeNull();
   });
 
-  it("always shows Duplicate and Delete, wired to their callbacks", async () => {
+  it("always shows Delete wired to its callback, and no Duplicate item", async () => {
     useWidgetData.mockReturnValue({ data: undefined, isPending: false, error: null });
-    const { onDuplicate, onDelete } = renderCard(makeWidget());
+    const { onDelete } = renderCard(makeWidget());
 
     await openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
-    expect(onDuplicate).toHaveBeenCalledTimes(1);
-
-    await openMenu();
+    expect(screen.queryByRole("menuitem", { name: "Duplicate" })).toBeNull();
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
 
-  it("still shows Duplicate and Delete for a non-query widget", async () => {
-    const { onDuplicate, onDelete } = renderCard(
-      makeWidget({ type: "trace_feed", spec: { limit: 5 } }),
-    );
+  it("still shows Delete for a non-query widget", async () => {
+    const { onDelete } = renderCard(makeWidget({ type: "trace_feed", spec: { limit: 5 } }));
 
     await openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Duplicate" }));
-    expect(onDuplicate).toHaveBeenCalledTimes(1);
-
-    await openMenu();
+    expect(screen.queryByRole("menuitem", { name: "Duplicate" })).toBeNull();
     fireEvent.click(screen.getByRole("menuitem", { name: "Delete" }));
     expect(onDelete).toHaveBeenCalledTimes(1);
   });

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -73,14 +73,12 @@ export function WidgetCard({
   widget,
   range,
   onEdit,
-  onDuplicate,
   onDelete,
 }: {
   projectId: string;
   widget: Widget;
   range: TimeRange;
   onEdit: () => void;
-  onDuplicate: () => void;
   onDelete: () => void;
 }) {
   return (
@@ -102,7 +100,6 @@ export function WidgetCard({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
             {widget.type === "query" && <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>}
-            <DropdownMenuItem onSelect={onDuplicate}>Duplicate</DropdownMenuItem>
             <DropdownMenuItem onSelect={onDelete} className="text-red-600 focus:text-red-600">
               Delete
             </DropdownMenuItem>

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -62,6 +62,7 @@ function QueryWidgetBody({
       result={data}
       unit={FIELD_UNIT[spec.metric.measure]}
       seriesLabel={spec.metric.measure}
+      agg={spec.metric.agg}
     />
   );
 }

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -71,7 +71,6 @@ export function WidgetCard({
   projectId,
   widget,
   range,
-  readOnly = false,
   onEdit,
   onDuplicate,
   onDelete,
@@ -79,8 +78,6 @@ export function WidgetCard({
   projectId: string;
   widget: Widget;
   range: TimeRange;
-  /** Read-only dashboards (the seeded default) hide the drag handle and menu. */
-  readOnly?: boolean;
   onEdit: () => void;
   onDuplicate: () => void;
   onDelete: () => void;
@@ -89,33 +86,27 @@ export function WidgetCard({
     <div className="flex h-full flex-col rounded-md border bg-background p-3">
       {/* Header: drag handle + title + menu */}
       <div className="mb-2 flex items-center gap-1.5">
-        {!readOnly && (
-          <span className="drag-handle cursor-move select-none text-muted-foreground/50">⠿</span>
-        )}
+        <span className="drag-handle cursor-move select-none text-muted-foreground/50">⠿</span>
         <span className="flex-1 truncate text-[12px] font-medium" title={widget.title}>
           {widget.title}
         </span>
-        {!readOnly && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted focus:opacity-100 group-hover:opacity-100"
-                aria-label="Widget options"
-              >
-                <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              {widget.type === "query" && (
-                <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>
-              )}
-              <DropdownMenuItem onSelect={onDuplicate}>Duplicate</DropdownMenuItem>
-              <DropdownMenuItem onSelect={onDelete} className="text-red-600 focus:text-red-600">
-                Delete
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        )}
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              className="shrink-0 rounded p-0.5 opacity-0 transition-opacity hover:bg-muted focus:opacity-100 group-hover:opacity-100"
+              aria-label="Widget options"
+            >
+              <MoreVertical className="h-3.5 w-3.5 text-muted-foreground" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {widget.type === "query" && <DropdownMenuItem onSelect={onEdit}>Edit</DropdownMenuItem>}
+            <DropdownMenuItem onSelect={onDuplicate}>Duplicate</DropdownMenuItem>
+            <DropdownMenuItem onSelect={onDelete} className="text-red-600 focus:text-red-600">
+              Delete
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       {/* Body */}

--- a/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
+++ b/frontend/ui/src/features/dashboards/components/WidgetCard.tsx
@@ -8,7 +8,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useWidgetData } from "../hooks/use-widget-data";
-import { FIELD_UNIT, parseSpec, type TimeRange, type Widget } from "../types";
+import { FIELD_UNIT } from "@/features/filters/filter-controls";
+import { parseSpec, type TimeRange, type Widget } from "../types";
 import { QueryWidgetRenderer } from "./renderers";
 import { TraceFeedWidget } from "./TraceFeedWidget";
 

--- a/frontend/ui/src/features/dashboards/components/field-icons.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.ts
@@ -10,7 +10,7 @@ import {
   Workflow,
   type LucideIcon,
 } from "lucide-react";
-import { FIELD_ICONS } from "@/features/filters/filter-builder";
+import { FIELD_ICONS } from "@/features/filters/filter-controls";
 
 // The trace-list filter icons, extended with the widget registry's field
 // names the trace list spells differently (errors -> error_count), the token

--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -152,6 +152,56 @@ describe("QueryWidgetRenderer", () => {
       expect(screen.getByText("No data in range")).toBeTruthy();
       expect(container.querySelectorAll(".recharts-line-curve").length).toBe(0);
     });
+
+    it("draws a non-additive series through NULL gap buckets instead of dropping to 0", () => {
+      // p95 over a window with an empty middle bucket: the backend's Nullable
+      // WITH FILL row carries null, and the line must bridge it (connectNulls)
+      // rather than chart a false collapse. Both flanking points survive.
+      const result = makeResult(
+        ["bucket", "value"],
+        [
+          ["2026-06-01T00:00:00", 120],
+          ["2026-06-02T00:00:00", null],
+          ["2026-06-03T00:00:00", 90],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(
+        <QueryWidgetRenderer display="line" result={result} agg="p95" />,
+      );
+      const [curve] = Array.from(container.querySelectorAll(".recharts-line-curve"));
+      expect(curve).toBeTruthy();
+      // One unbroken path: a broken (per-segment) render or a dip to the
+      // 0-baseline would betray the gap handling. The path must span from the
+      // first bucket to the last.
+      const d = curve.getAttribute("d") ?? "";
+      expect(d.length).toBeGreaterThan(0);
+      expect((d.match(/M/g) ?? []).length).toBe(1);
+    });
+
+    it("keeps a non-additive AREA off the zero baseline over gap buckets", () => {
+      // Stacked areas are the trap: recharts' stack accessor coerces null to
+      // 0 BEFORE connectNulls is consulted, redrawing the false collapse. A
+      // non-additive area therefore renders unstacked — its bridged curve has
+      // exactly two points (M + one L); a baseline dip would add a third.
+      const result = makeResult(
+        ["bucket", "value"],
+        [
+          ["2026-06-01T00:00:00", 120],
+          ["2026-06-02T00:00:00", null],
+          ["2026-06-03T00:00:00", 90],
+        ],
+        { granularity: "day" },
+      );
+      const { container } = render(
+        <QueryWidgetRenderer display="area" result={result} agg="p95" />,
+      );
+      const [curve] = Array.from(container.querySelectorAll(".recharts-area-curve"));
+      expect(curve).toBeTruthy();
+      const d = curve.getAttribute("d") ?? "";
+      expect((d.match(/M/g) ?? []).length).toBe(1);
+      expect((d.match(/L/g) ?? []).length).toBe(1);
+    });
   });
 
   describe("line/area empty-breakdown fallback", () => {

--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -337,6 +337,22 @@ describe("ChartTip", () => {
     expect(empty.firstChild).toBeNull();
   });
 
+  it("applies the measure unit to every value row", () => {
+    render(
+      <ChartTip
+        active
+        payload={[
+          { name: "gpt-4o", value: "0.0034", color: "#a78bfa" },
+          { name: "haiku", value: null, color: "#60a5fa" },
+        ]}
+        unit={{ prefix: "$" }}
+      />,
+    );
+    expect(screen.getByText("$0.0034")).toBeTruthy();
+    // A gap bucket stays a bare dash — no unit on nothing.
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
   it("renders the label header and one swatch+name+value row per series", () => {
     const { container } = render(
       <ChartTip
@@ -395,5 +411,33 @@ describe("fmtStatNumber", () => {
     expect(fmtStatNumber("12.5")).toBe("12.5");
     expect(fmtStatNumber(99999)).toBe("99,999");
     expect(fmtStatNumber(0.0004)).toBe("0.0004");
+  });
+});
+
+describe("unit formatting on charts and tables", () => {
+  afterEach(cleanup);
+
+  it("applies the measure unit to the table's metric column", () => {
+    const result = makeResult(["model_name", "value"], [["gpt-4o", "0.0034"]]);
+    render(<QueryWidgetRenderer display="table" result={result} unit={{ prefix: "$" }} />);
+    expect(screen.getByText("$0.0034")).toBeTruthy();
+    // Dimension cells stay verbatim — no unit, no numeric reformatting.
+    expect(screen.getByText("gpt-4o")).toBeTruthy();
+  });
+
+  it("applies the measure unit to time-series axis ticks", () => {
+    const result = makeResult(
+      ["bucket", "value"],
+      [
+        ["2026-06-01T00:00:00", 100],
+        ["2026-06-02T00:00:00", 200],
+      ],
+      { granularity: "day" },
+    );
+    const { container } = render(
+      <QueryWidgetRenderer display="line" result={result} unit={{ suffix: "ms" }} />,
+    );
+    const ticks = Array.from(container.querySelectorAll(".recharts-cartesian-axis-tick-value"));
+    expect(ticks.some((t) => t.textContent?.includes("ms"))).toBe(true);
   });
 });

--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { cloneElement, isValidElement } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WidgetQueryResult } from "../types";
@@ -247,9 +247,10 @@ describe("QueryWidgetRenderer", () => {
       const { container } = render(<QueryWidgetRenderer display="bar" result={result} />);
       const cells = container.querySelectorAll(".recharts-bar-rectangle");
       expect(cells.length).toBe(3);
-      expect(screen.getByText("api")).toBeTruthy();
-      expect(screen.getByText("worker")).toBeTruthy();
-      expect(screen.getByText("frontend")).toBeTruthy();
+      // each category shows exactly twice: on the axis AND in the legend row
+      for (const name of ["api", "worker", "frontend"]) {
+        expect(screen.getAllByText(name)).toHaveLength(2);
+      }
     });
   });
 
@@ -439,5 +440,72 @@ describe("unit formatting on charts and tables", () => {
     );
     const ticks = Array.from(container.querySelectorAll(".recharts-cartesian-axis-tick-value"));
     expect(ticks.some((t) => t.textContent?.includes("ms"))).toBe(true);
+  });
+});
+
+describe("chart legend", () => {
+  // RTL auto-cleanup needs vitest globals, which this config doesn't enable.
+  afterEach(cleanup);
+
+  it("multi-series line: legend lists series sorted with a window Total, single series gets none", () => {
+    const multi = makeResult(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt", 10],
+        ["2026-06-01T00:00:00", "claude", 30],
+        ["2026-06-01T01:00:00", "gpt", 5],
+      ],
+    );
+    const { unmount } = render(<QueryWidgetRenderer display="line" result={multi} agg="sum" />);
+    const legend = screen.getByRole("list", { name: "Chart legend" });
+    expect(legend).toBeTruthy();
+    const rows = screen.getAllByRole("listitem").map((r) => r.textContent);
+    // Total 45 leads, then series sorted descending: claude 30, gpt 15
+    expect(rows[0]).toContain("Total");
+    expect(rows[0]).toContain("45");
+    expect(rows[1]).toContain("claude");
+    expect(rows[1]).toContain("30");
+    expect(rows[2]).toContain("gpt");
+    expect(rows[2]).toContain("15");
+    unmount();
+
+    const single = makeResult(["bucket", "value"], [["2026-06-01T00:00:00", 10]]);
+    render(<QueryWidgetRenderer display="line" result={single} agg="sum" />);
+    expect(screen.queryByRole("list", { name: "Chart legend" })).toBeNull();
+  });
+
+  it("non-additive series legend shows per-series bucket averages and no Total", () => {
+    const multi = makeResult(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt", 100],
+        ["2026-06-01T01:00:00", "gpt", 200],
+        ["2026-06-01T00:00:00", "claude", 50],
+      ],
+    );
+    render(<QueryWidgetRenderer display="line" result={multi} agg="p95" />);
+    const legend = screen.getByRole("list", { name: "Chart legend" });
+    // gpt averages its two buckets (150); claude's gap bucket stays out of its average
+    expect(legend.textContent).toContain("150");
+    expect(legend.textContent).not.toContain("Total");
+  });
+  it("bar legend hover dims the other categories", () => {
+    const result = makeResult(
+      ["service", "value"],
+      [
+        ["api", 10],
+        ["worker", 20],
+      ],
+    );
+    const { container } = render(<QueryWidgetRenderer display="bar" result={result} />);
+    const rows = screen.getAllByRole("listitem");
+    // rows[0] is the Total row; rows[1] is "worker" (sorted first at 20)
+    fireEvent.mouseEnter(rows[1]);
+    const dimmed = container.querySelectorAll('.recharts-bar-rectangle path[fill-opacity="0.14"]');
+    expect(dimmed.length).toBe(1); // "api" dimmed (0.7 * 0.2)
+    fireEvent.mouseLeave(rows[1]);
+    expect(
+      container.querySelectorAll('.recharts-bar-rectangle path[fill-opacity="0.14"]').length,
+    ).toBe(0);
   });
 });

--- a/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.charts.test.tsx
@@ -489,6 +489,42 @@ describe("chart legend", () => {
     expect(legend.textContent).toContain("150");
     expect(legend.textContent).not.toContain("Total");
   });
+  it("builds no legend from a stale bucketed result on a categorical display", () => {
+    // keepPreviousData hands the pie/bar renderer the previous line query's
+    // bucketed rows for a beat after a display switch; those rows have no
+    // `name`, which used to render literal "undefined" legend labels.
+    const bucketed = makeResult(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt", 10],
+        ["2026-06-01T00:00:00", "claude", 30],
+        ["2026-06-01T01:00:00", "gpt", 5],
+      ],
+    );
+    const { unmount } = render(<QueryWidgetRenderer display="pie" result={bucketed} agg="sum" />);
+    expect(screen.queryByText("undefined")).toBeNull();
+    expect(screen.queryByRole("list", { name: "Chart legend" })).toBeNull();
+    unmount();
+
+    // Same for a no-breakdown bucketed shape ([bucket, value]).
+    const single = makeResult(["bucket", "value"], [["2026-06-01T00:00:00", 10]]);
+    render(<QueryWidgetRenderer display="bar" result={single} agg="sum" />);
+    expect(screen.queryByText("undefined")).toBeNull();
+    expect(screen.queryByRole("list", { name: "Chart legend" })).toBeNull();
+  });
+
+  it("builds no legend from a stale categorical result on a timeseries display", () => {
+    const categorical = makeResult(
+      ["service", "value"],
+      [
+        ["api", 10],
+        ["worker", 20],
+      ],
+    );
+    render(<QueryWidgetRenderer display="line" result={categorical} agg="sum" />);
+    expect(screen.queryByRole("list", { name: "Chart legend" })).toBeNull();
+  });
+
   it("bar legend hover dims the other categories", () => {
     const result = makeResult(
       ["service", "value"],

--- a/frontend/ui/src/features/dashboards/components/renderers.test.ts
+++ b/frontend/ui/src/features/dashboards/components/renderers.test.ts
@@ -67,6 +67,26 @@ describe("pivotRows", () => {
     ]);
   });
 
+  it("fills bucket×series holes with null for non-additive aggs", () => {
+    // A percentile has no value for an empty bucket: the hole must be a gap
+    // (null), not a zero that would chart as a false collapse.
+    const out = pivotRows(
+      ["bucket", "model_name", "value"],
+      [
+        ["2026-06-01T00:00:00", "gpt-4o", 120],
+        ["2026-06-02T00:00:00", null, null], // WITH FILL gap row (Nullable metric)
+        ["2026-06-03T00:00:00", "gpt-4o", 90],
+      ],
+      null,
+    );
+    expect(out.seriesKeys).toEqual(["gpt-4o"]);
+    expect(out.data).toEqual([
+      { bucket: "2026-06-01T00:00:00", "gpt-4o": 120 },
+      { bucket: "2026-06-02T00:00:00", "gpt-4o": null },
+      { bucket: "2026-06-03T00:00:00", "gpt-4o": 90 },
+    ]);
+  });
+
   it("keeps a genuine empty-string dim with a nonzero value as a real series", () => {
     const out = pivotRows(["bucket", "model_name", "value"], [["2026-06-01T00:00:00", "", 2]]);
     expect(out.seriesKeys).toEqual([""]);

--- a/frontend/ui/src/features/dashboards/components/renderers.test.ts
+++ b/frontend/ui/src/features/dashboards/components/renderers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { fmtNumber, pivotRows } from "./renderers";
+import { fmtNumber, fmtValueWithUnit, pivotRows } from "./renderers";
 
 describe("fmtNumber", () => {
   it("formats a numeric string (Decimal from ClickHouse) as a formatted number", () => {
@@ -172,5 +172,20 @@ describe("pivotRows", () => {
     expect(d[0]["rare-model"]).toBe(0); // first bucket: zero-filled
     expect(d[2]["rare-model"]).toBe(0); // last bucket: zero-filled
     expect(d[1]["rare-model"]).toBe(5); // middle bucket: real value
+  });
+});
+
+describe("fmtValueWithUnit", () => {
+  it("applies prefix and suffix units around the formatted number", () => {
+    expect(fmtValueWithUnit(0.0034, { prefix: "$" })).toBe("$0.0034");
+    expect(fmtValueWithUnit(1500, { suffix: "ms" })).toBe("1,500 ms");
+  });
+
+  it("passes through unadorned without a unit", () => {
+    expect(fmtValueWithUnit(1500)).toBe("1,500");
+  });
+
+  it("keeps gap values a bare dash — no unit on nothing", () => {
+    expect(fmtValueWithUnit(null, { prefix: "$" })).toBe("—");
   });
 });

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -17,7 +17,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { DisplayType, FieldUnit, WidgetQueryResult } from "../types";
+import { type DisplayType, type FieldUnit, type WidgetQueryResult, AGGS } from "../types";
 
 // Pastel series palette mirroring the span-kind tints
 // (violet=llm, blue=agent, amber=tool, slate=span), then softened extras.
@@ -46,7 +46,14 @@ const CHART_FOCUS_RESET =
 const coerceNumeric = (v: unknown): unknown =>
   typeof v === "string" && v.trim() !== "" && Number.isFinite(Number(v)) ? Number(v) : v;
 
-export function pivotRows(columns: string[], rows: WidgetQueryResult["rows"]) {
+export function pivotRows(
+  columns: string[],
+  rows: WidgetQueryResult["rows"],
+  // What a bucket×series hole means: 0 for additive aggs (a count/sum of
+  // nothing IS zero), null for non-additive ones (an empty bucket has no
+  // average or percentile — charts draw the null as a gap, not a collapse).
+  gapValue: 0 | null = 0,
+) {
   // Shapes: [value] | [bucket, value] | [dim, value] | [bucket, dim, value]
   const valueIdx = columns.length - 1;
   const hasBucket = columns[0] === "bucket";
@@ -84,8 +91,9 @@ export function pivotRows(columns: string[], rows: WidgetQueryResult["rows"]) {
     const rawDim = r[dimIdx];
     // The query's WITH FILL synthesizes rows for empty buckets, carrying the
     // breakdown column's default ('' — or NULL if a Nullable expr ever slips
-    // past the compiler's type pin) and a zero value. They extend the x-axis
-    // domain but are not a series: register the bucket and move on.
+    // past the compiler's type pin) and a zero or NULL value (NULL for the
+    // Nullable non-additive metrics). They extend the x-axis domain but are
+    // not a series: register the bucket and move on.
     if ((rawDim === "" || rawDim == null) && !Number(r[valueIdx])) {
       if (!byBucket.has(bucket)) byBucket.set(bucket, { bucket });
       continue;
@@ -103,13 +111,12 @@ export function pivotRows(columns: string[], rows: WidgetQueryResult["rows"]) {
     byBucket.get(bucket)![dim] = coerceNumeric(r[valueIdx]);
   }
 
-  // Uniform zero-fill: missing series keys per bucket are set to 0 so
-  // line/area charts tell the same story. Honest for count/sum (the dominant
-  // dashboard aggregations), slightly lossy for percentile gaps — accepted tradeoff.
+  // Uniform fill: missing series keys per bucket get the agg-appropriate gap
+  // value so line/area charts tell the same story across series.
   const data = [...byBucket.values()].map((row) => {
     const filled = { ...row };
     for (const k of seriesKeys) {
-      if (!Object.hasOwn(filled, k)) filled[k] = 0;
+      if (!Object.hasOwn(filled, k)) filled[k] = gapValue;
     }
     return filled;
   });
@@ -210,12 +217,18 @@ function TimeSeries({
   result,
   area,
   seriesLabel,
+  additive = true,
 }: {
   result: WidgetQueryResult;
   area: boolean;
   seriesLabel?: string;
+  /** False for avg/percentile series: empty buckets render as gaps, not 0. */
+  additive?: boolean;
 }) {
-  const { seriesKeys, data } = useMemo(() => pivotRows(result.columns, result.rows), [result]);
+  const { seriesKeys, data } = useMemo(
+    () => pivotRows(result.columns, result.rows, additive ? 0 : null),
+    [result, additive],
+  );
   const Chart = area ? AreaChart : LineChart;
   const granularity = result.meta.granularity;
 
@@ -243,8 +256,12 @@ function TimeSeries({
         <CartesianGrid strokeOpacity={0.15} vertical={false} />
         <XAxis dataKey="bucket" tick={{ fontSize: 10 }} tickFormatter={tickFormatter} />
         <YAxis tick={{ fontSize: 10 }} width={42} />
+        {/* filterNull: recharts strips null payload items by default, which
+            would drop a non-additive series' row from the tooltip on its empty
+            (gap) buckets — keep them so ChartTip shows an em-dash instead. */}
         <Tooltip
           isAnimationActive={false}
+          filterNull={false}
           content={
             <ChartTip
               nameFormatter={seriesNameFormatter(seriesLabel)}
@@ -255,16 +272,24 @@ function TimeSeries({
         {/* isAnimationActive={false} on every mark (here and in the other
             charts): the default ~1.4s geometry morph makes charts visibly lag
             behind their tile during grid resizes and data refreshes. */}
+        {/* A non-additive series carries NULL for empty buckets (backend
+            WITH FILL + the pivot's gap fill): connectNulls bridges them so one
+            readable line survives without inventing zeros. Areas additionally
+            drop stacking for non-additive aggs — recharts' stack accessor
+            coerces null to 0 BEFORE connectNulls is consulted, which would
+            redraw the false collapse (and stacking percentiles is
+            meaningless anyway). */}
         {seriesKeys.map((k, i) =>
           area ? (
             <Area
               key={k}
               dataKey={k}
-              stackId="1"
+              stackId={additive ? "1" : undefined}
               stroke={seriesColor(i)}
               fill={seriesColor(i)}
               fillOpacity={0.35}
               isAnimationActive={false}
+              connectNulls={!additive}
             />
           ) : (
             <Line
@@ -274,6 +299,7 @@ function TimeSeries({
               dot={false}
               strokeWidth={1.5}
               isAnimationActive={false}
+              connectNulls={!additive}
             />
           ),
         )}
@@ -421,18 +447,29 @@ function HistogramView({
   );
 }
 
+// Aggs whose empty buckets have no value (no average or percentile of
+// nothing): their series shows a gap instead of a false drop to 0. Mirrors
+// the backend's _NON_ADDITIVE_AGGS — same polarity, so an agg added to one
+// list but not the other degrades to the additive (zero-filled) treatment on
+// both sides rather than diverging. Absent agg = additive (legacy callers).
+const NON_ADDITIVE_AGGS = new Set<string>(["avg", "min", "max", "p50", "p95", "p99"]);
+
 export function QueryWidgetRenderer({
   display,
   result,
   unit,
   seriesLabel,
+  agg,
 }: {
   display: DisplayType;
   result: WidgetQueryResult;
   unit?: FieldUnit;
   /** Measure name from the widget spec, shown as the single-series tooltip row name. */
   seriesLabel?: string;
+  /** Aggregation from the widget spec; decides how empty buckets render. */
+  agg?: (typeof AGGS)[number];
 }) {
+  const additive = agg === undefined || !NON_ADDITIVE_AGGS.has(agg);
   if (result.rows.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
@@ -442,9 +479,11 @@ export function QueryWidgetRenderer({
   }
   switch (display) {
     case "line":
-      return <TimeSeries result={result} area={false} seriesLabel={seriesLabel} />;
+      return (
+        <TimeSeries result={result} area={false} seriesLabel={seriesLabel} additive={additive} />
+      );
     case "area":
-      return <TimeSeries result={result} area seriesLabel={seriesLabel} />;
+      return <TimeSeries result={result} area seriesLabel={seriesLabel} additive={additive} />;
     case "bar":
       return <Bars result={result} seriesLabel={seriesLabel} />;
     case "pie":

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Area,
   AreaChart,
@@ -18,29 +18,39 @@ import {
   YAxis,
 } from "recharts";
 import type { FieldUnit } from "@/features/filters/filter-controls";
+import { ChartLegend, type LegendEntry } from "./ChartLegend";
 import { type DisplayType, type WidgetQueryResult, AGGS } from "../types";
 
-// Pastel series palette mirroring the span-kind tints
-// (violet=llm, blue=agent, amber=tool, slate=span), then softened extras.
+// Categorical series palette: 12 hues spread evenly round the wheel and
+// ORDERED so consecutive series sit on opposite sides of it — a 2-3 series
+// chart (the common case) gets maximally separated colors, and breakdowns up
+// to a dozen categories stay distinct. No gray in the rotation: a gray series
+// reads as muted/"other", not as real data. Amber and cyan are the -500 shades
+// so thin line strokes keep contrast on a light background.
 export const SERIES_COLORS = [
-  "#a78bfa",
-  "#60a5fa",
-  "#fbbf24",
-  "#94a3b8",
-  "#34d399",
-  "#f472b6",
-  "#22d3ee",
-  "#fb923c",
+  "#fb7185", // rose
+  "#06b6d4", // cyan
+  "#4ade80", // green
+  "#a78bfa", // violet
+  "#fb923c", // orange
+  "#60a5fa", // blue
+  "#10b981", // emerald
+  "#e879f9", // fuchsia
+  "#f59e0b", // amber
+  "#818cf8", // indigo
+  "#2dd4bf", // teal
+  "#f472b6", // pink
 ];
 
 const seriesColor = (i: number) => SERIES_COLORS[i % SERIES_COLORS.length];
 
-// Recharts marks its wrapper and SVG internals keyboard-focusable, so clicking
-// anywhere in a chart paints the browser's focus outline around the clicked
-// wrapper/layer/sector — suppress it on every chart surface.
-const CHART_FOCUS_RESET =
-  "[&_.recharts-wrapper]:outline-none [&_.recharts-surface]:outline-none " +
-  "[&_.recharts-layer]:outline-none [&_.recharts-sector]:outline-none";
+// Recharts makes its wrapper, SVG, and individual marks (bar rects, line/area
+// paths, pie sectors) keyboard-focusable, so a click paints the browser's focus
+// outline around whatever was clicked. Suppress the outline on every focused
+// descendant — charts here have no keyboard-interaction model, so there's no
+// focus affordance to preserve. (The legend rows and buttons live outside this
+// wrapper and keep their focus rings.)
+const CHART_FOCUS_RESET = "[&_*:focus]:outline-none [&_*:focus-visible]:outline-none";
 
 // ClickHouse returns Decimal columns as strings; coerce them before charting
 // or formatting — recharts (the pie especially) can't plot string values.
@@ -225,6 +235,55 @@ export function ChartTip({
   );
 }
 
+// Legend hover dims every OTHER series so the hovered one stands out.
+const seriesOpacity = (hovered: string | null, key: string, base = 1) =>
+  hovered !== null && hovered !== key ? Number((base * 0.2).toFixed(3)) : base;
+
+/**
+ * Per-series aggregates for the legend, from the same pivot the charts draw.
+ * Additive measures sum across buckets (a true window total); non-additive
+ * ones average their non-null buckets — an approximation (bucketed
+ * percentiles can't be re-aggregated), so those get no Total row.
+ * Single-series charts (no breakdown) return null: nothing to disambiguate.
+ */
+function legendFor(
+  result: WidgetQueryResult,
+  additive: boolean,
+): { entries: LegendEntry[]; total: number | null } | null {
+  const { seriesKeys, data } = pivotRows(result.columns, result.rows, additive ? 0 : null);
+  if (seriesKeys.length <= 1) return null;
+  const entries = seriesKeys.map((k, i) => {
+    const nums = data
+      .map((r) => (r as Record<string, unknown>)[k])
+      .filter((v): v is number => typeof v === "number");
+    const sum = nums.reduce((a, b) => a + b, 0);
+    const value = nums.length === 0 ? null : additive ? sum : sum / nums.length;
+    return { key: k, label: k, color: seriesColor(i), value };
+  });
+  const total = additive ? entries.reduce((a, e) => a + (e.value ?? 0), 0) : null;
+  return { entries, total };
+}
+
+/** Categorical charts (bar/pie): one legend entry per category row. */
+function categoricalLegend(
+  result: WidgetQueryResult,
+  additive: boolean,
+): { entries: LegendEntry[]; total: number | null } | null {
+  const { data } = pivotRows(result.columns, result.rows);
+  if (data.length <= 1) return null;
+  const entries = data.map((r, i) => {
+    const v = r.value;
+    return {
+      key: String(r.name),
+      label: String(r.name),
+      color: seriesColor(i),
+      value: typeof v === "number" ? v : null,
+    };
+  });
+  const total = additive ? entries.reduce((a, e) => a + (e.value ?? 0), 0) : null;
+  return { entries, total };
+}
+
 // Categorical rows tinted per-index; the `fill` on each row is also what the
 // tooltip payload reads for its swatch.
 function useColoredRows(result: WidgetQueryResult) {
@@ -244,6 +303,7 @@ function TimeSeries({
   seriesLabel,
   additive = true,
   unit,
+  hovered = null,
 }: {
   result: WidgetQueryResult;
   area: boolean;
@@ -251,6 +311,8 @@ function TimeSeries({
   /** False for avg/percentile series: empty buckets render as gaps, not 0. */
   additive?: boolean;
   unit?: FieldUnit;
+  /** Legend-hovered series key; the others render dimmed. */
+  hovered?: string | null;
 }) {
   const { seriesKeys, data } = useMemo(
     () => pivotRows(result.columns, result.rows, additive ? 0 : null),
@@ -318,8 +380,9 @@ function TimeSeries({
               dataKey={k}
               stackId={additive ? "1" : undefined}
               stroke={seriesColor(i)}
+              strokeOpacity={seriesOpacity(hovered, k)}
               fill={seriesColor(i)}
-              fillOpacity={0.35}
+              fillOpacity={seriesOpacity(hovered, k, 0.35)}
               isAnimationActive={false}
               connectNulls={!additive}
             />
@@ -328,6 +391,7 @@ function TimeSeries({
               key={k}
               dataKey={k}
               stroke={seriesColor(i)}
+              strokeOpacity={seriesOpacity(hovered, k)}
               dot={false}
               strokeWidth={1.5}
               isAnimationActive={false}
@@ -344,10 +408,12 @@ function Bars({
   result,
   seriesLabel,
   unit,
+  hovered = null,
 }: {
   result: WidgetQueryResult;
   seriesLabel?: string;
   unit?: FieldUnit;
+  hovered?: string | null;
 }) {
   const data = useColoredRows(result);
   return (
@@ -365,8 +431,14 @@ function Bars({
           content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} unit={unit} />}
         />
         <Bar dataKey="value" isAnimationActive={false}>
-          {data.map((_, i) => (
-            <Cell key={i} fill={seriesColor(i)} fillOpacity={0.7} stroke={seriesColor(i)} />
+          {data.map((d, i) => (
+            <Cell
+              key={i}
+              fill={seriesColor(i)}
+              fillOpacity={seriesOpacity(hovered, String((d as { name?: unknown }).name), 0.7)}
+              stroke={seriesColor(i)}
+              strokeOpacity={seriesOpacity(hovered, String((d as { name?: unknown }).name))}
+            />
           ))}
         </Bar>
       </BarChart>
@@ -374,13 +446,20 @@ function Bars({
   );
 }
 
-function PieView({ result, unit }: { result: WidgetQueryResult; unit?: FieldUnit }) {
+function PieView({
+  result,
+  unit,
+  hovered = null,
+}: {
+  result: WidgetQueryResult;
+  unit?: FieldUnit;
+  hovered?: string | null;
+}) {
   const data = useColoredRows(result);
   return (
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
       <PieChart>
         <Tooltip isAnimationActive={false} content={<ChartTip unit={unit} />} />
-        {/* Pie reads each sector's fill from its data row — no Cells needed. */}
         <Pie
           data={data}
           dataKey="value"
@@ -388,7 +467,16 @@ function PieView({ result, unit }: { result: WidgetQueryResult; unit?: FieldUnit
           innerRadius="45%"
           outerRadius="80%"
           isAnimationActive={false}
-        />
+        >
+          {/* Explicit Cells so legend hover can dim the other sectors. */}
+          {data.map((d, i) => (
+            <Cell
+              key={i}
+              fill={seriesColor(i)}
+              fillOpacity={seriesOpacity(hovered, String((d as { name?: unknown }).name))}
+            />
+          ))}
+        </Pie>
       </PieChart>
     </ResponsiveContainer>
   );
@@ -520,6 +608,26 @@ export function QueryWidgetRenderer({
   agg?: (typeof AGGS)[number];
 }) {
   const additive = agg === undefined || !NON_ADDITIVE_AGGS.has(agg);
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+  // Multi-series charts get a legend under the plot; everything else
+  // (single series, stat tiles, tables, histograms) stays legend-free.
+  const legend = useMemo(() => {
+    if (result.rows.length === 0) return null;
+    if (display === "line" || display === "area") return legendFor(result, additive);
+    if (display === "bar" || display === "pie") return categoricalLegend(result, additive);
+    return null;
+  }, [display, result, additive]);
+  // A background refresh can drop the hovered series between renders; a stale
+  // key matches nothing and would dim EVERY series — treat it as no hover.
+  const hoveredInLegend =
+    hoveredKey !== null && (legend?.entries.some((e) => e.key === hoveredKey) ?? false);
+  // Mask a stale key this render, and clear it from state so a series that
+  // RETURNS in a later refresh doesn't resurrect the dim with no row hovered.
+  useEffect(() => {
+    if (hoveredKey !== null && !hoveredInLegend) setHoveredKey(null);
+  }, [hoveredKey, hoveredInLegend]);
+  const hovered = hoveredInLegend ? hoveredKey : null;
+
   if (result.rows.length === 0) {
     return (
       <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
@@ -527,36 +635,55 @@ export function QueryWidgetRenderer({
       </div>
     );
   }
-  switch (display) {
-    case "line":
-      return (
-        <TimeSeries
-          result={result}
-          area={false}
-          seriesLabel={seriesLabel}
-          additive={additive}
-          unit={unit}
-        />
-      );
-    case "area":
-      return (
-        <TimeSeries
-          result={result}
-          area
-          seriesLabel={seriesLabel}
-          additive={additive}
-          unit={unit}
-        />
-      );
-    case "bar":
-      return <Bars result={result} seriesLabel={seriesLabel} unit={unit} />;
-    case "pie":
-      return <PieView result={result} unit={unit} />;
-    case "number":
-      return <NumberView result={result} unit={unit} />;
-    case "table":
-      return <TableView result={result} unit={unit} />;
-    case "histogram":
-      return <HistogramView result={result} seriesLabel={seriesLabel} />;
-  }
+
+  const chart = (() => {
+    switch (display) {
+      case "line":
+        return (
+          <TimeSeries
+            result={result}
+            area={false}
+            seriesLabel={seriesLabel}
+            additive={additive}
+            unit={unit}
+            hovered={hovered}
+          />
+        );
+      case "area":
+        return (
+          <TimeSeries
+            result={result}
+            area
+            seriesLabel={seriesLabel}
+            additive={additive}
+            unit={unit}
+            hovered={hovered}
+          />
+        );
+      case "bar":
+        return <Bars result={result} seriesLabel={seriesLabel} unit={unit} hovered={hovered} />;
+      case "pie":
+        return <PieView result={result} unit={unit} hovered={hovered} />;
+      case "number":
+        return <NumberView result={result} unit={unit} />;
+      case "table":
+        return <TableView result={result} unit={unit} />;
+      case "histogram":
+        return <HistogramView result={result} seriesLabel={seriesLabel} />;
+    }
+  })();
+
+  if (!legend) return chart;
+  return (
+    <div className="flex h-full flex-col">
+      <div className="min-h-0 flex-1">{chart}</div>
+      <ChartLegend
+        entries={legend.entries}
+        total={legend.total}
+        format={(v) => fmtValueWithUnit(v, unit)}
+        hoveredKey={hovered}
+        onHoverKey={setHoveredKey}
+      />
+    </div>
+  );
 }

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -143,6 +143,27 @@ export const fmtNumber = (v: unknown) => {
 export const seriesNameFormatter = (seriesLabel?: string) => (name: string) =>
   name === "value" && seriesLabel ? seriesLabel : name;
 
+// Unit-aware metric formatting for tooltips, axis ticks, and table cells:
+// "$0.0034", "1,500 ms". Gap values stay a bare "—" — a unit on nothing
+// ("$—") reads wrong.
+export const fmtValueWithUnit = (v: unknown, unit?: FieldUnit) => {
+  const text = fmtNumber(v);
+  if (!unit || text === "—") return text;
+  return `${unit.prefix ?? ""}${text}${unit.suffix ? ` ${unit.suffix}` : ""}`;
+};
+
+// Y-axis ticks live in a fixed gutter, and recharts right-anchors them: an
+// overflowing label clips its LEADING digits and reads as a wrong number.
+// Compact notation bounds the glyph count at any magnitude ("100000" →
+// "100K", "$1.2M"), so the gutter widths below hold for every tick.
+const Y_AXIS_WIDTH = 42;
+const Y_AXIS_WIDTH_WITH_UNIT = 58;
+export const fmtAxisTick = (v: unknown, unit?: FieldUnit) => {
+  const text = fmtStatNumber(v);
+  if (!unit || text === "—") return text;
+  return `${unit.prefix ?? ""}${text}${unit.suffix ? ` ${unit.suffix}` : ""}`;
+};
+
 // Bucket keys come back ISO-ish ("2026-06-01T00:00:00"); a space reads better
 // in the tooltip header than the "T" separator.
 export const bucketLabel = (label: unknown) => String(label).replace("T", " ");
@@ -157,6 +178,7 @@ export function ChartTip({
   label,
   nameFormatter,
   labelFormatter,
+  unit,
 }: {
   active?: boolean;
   payload?: {
@@ -168,6 +190,8 @@ export function ChartTip({
   label?: unknown;
   nameFormatter?: (name: string) => string;
   labelFormatter?: (label: unknown) => string;
+  /** Measure unit ($, ms) applied to every value row. */
+  unit?: FieldUnit;
 }) {
   if (!active || !payload?.length) return null;
   return (
@@ -189,7 +213,7 @@ export function ChartTip({
                   {nameFormatter ? nameFormatter(rawName) : rawName}
                 </span>
                 <span className="shrink-0 whitespace-nowrap font-mono font-medium tabular-nums text-foreground">
-                  {fmtNumber(item.value)}
+                  {fmtValueWithUnit(item.value, unit)}
                 </span>
               </div>
             </div>
@@ -218,12 +242,14 @@ function TimeSeries({
   area,
   seriesLabel,
   additive = true,
+  unit,
 }: {
   result: WidgetQueryResult;
   area: boolean;
   seriesLabel?: string;
   /** False for avg/percentile series: empty buckets render as gaps, not 0. */
   additive?: boolean;
+  unit?: FieldUnit;
 }) {
   const { seriesKeys, data } = useMemo(
     () => pivotRows(result.columns, result.rows, additive ? 0 : null),
@@ -255,7 +281,11 @@ function TimeSeries({
       <Chart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
         <CartesianGrid strokeOpacity={0.15} vertical={false} />
         <XAxis dataKey="bucket" tick={{ fontSize: 10 }} tickFormatter={tickFormatter} />
-        <YAxis tick={{ fontSize: 10 }} width={42} />
+        <YAxis
+          tick={{ fontSize: 10 }}
+          width={unit ? Y_AXIS_WIDTH_WITH_UNIT : Y_AXIS_WIDTH}
+          tickFormatter={(v: unknown) => fmtAxisTick(v, unit)}
+        />
         {/* filterNull: recharts strips null payload items by default, which
             would drop a non-additive series' row from the tooltip on its empty
             (gap) buckets — keep them so ChartTip shows an em-dash instead. */}
@@ -266,6 +296,7 @@ function TimeSeries({
             <ChartTip
               nameFormatter={seriesNameFormatter(seriesLabel)}
               labelFormatter={bucketLabel}
+              unit={unit}
             />
           }
         />
@@ -308,17 +339,29 @@ function TimeSeries({
   );
 }
 
-function Bars({ result, seriesLabel }: { result: WidgetQueryResult; seriesLabel?: string }) {
+function Bars({
+  result,
+  seriesLabel,
+  unit,
+}: {
+  result: WidgetQueryResult;
+  seriesLabel?: string;
+  unit?: FieldUnit;
+}) {
   const data = useColoredRows(result);
   return (
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
       <BarChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
         <CartesianGrid strokeOpacity={0.15} vertical={false} />
         <XAxis dataKey="name" tick={{ fontSize: 10 }} />
-        <YAxis tick={{ fontSize: 10 }} width={42} />
+        <YAxis
+          tick={{ fontSize: 10 }}
+          width={unit ? Y_AXIS_WIDTH_WITH_UNIT : Y_AXIS_WIDTH}
+          tickFormatter={(v: unknown) => fmtAxisTick(v, unit)}
+        />
         <Tooltip
           isAnimationActive={false}
-          content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} />}
+          content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} unit={unit} />}
         />
         <Bar dataKey="value" isAnimationActive={false}>
           {data.map((_, i) => (
@@ -330,12 +373,12 @@ function Bars({ result, seriesLabel }: { result: WidgetQueryResult; seriesLabel?
   );
 }
 
-function PieView({ result }: { result: WidgetQueryResult }) {
+function PieView({ result, unit }: { result: WidgetQueryResult; unit?: FieldUnit }) {
   const data = useColoredRows(result);
   return (
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
       <PieChart>
-        <Tooltip isAnimationActive={false} content={<ChartTip />} />
+        <Tooltip isAnimationActive={false} content={<ChartTip unit={unit} />} />
         {/* Pie reads each sector's fill from its data row — no Cells needed. */}
         <Pie
           data={data}
@@ -379,7 +422,7 @@ function NumberView({ result, unit }: { result: WidgetQueryResult; unit?: FieldU
   );
 }
 
-function TableView({ result }: { result: WidgetQueryResult }) {
+function TableView({ result, unit }: { result: WidgetQueryResult; unit?: FieldUnit }) {
   // Only the metric column (always last, aliased "value" by the compiler) is
   // numeric — formatting every cell reformats string dimensions too, and a
   // numeric-looking identifier (user_id, session_id) silently loses digits
@@ -402,7 +445,7 @@ function TableView({ result }: { result: WidgetQueryResult }) {
             <tr key={i} className="border-t border-border/60">
               {r.map((v, j) => (
                 <td key={j} className="py-1 pr-3">
-                  {j === valueIdx ? fmtNumber(v) : v == null ? "—" : String(v)}
+                  {j === valueIdx ? fmtValueWithUnit(v, unit) : v == null ? "—" : String(v)}
                 </td>
               ))}
             </tr>
@@ -430,7 +473,13 @@ function HistogramView({
     <ResponsiveContainer width="100%" height="100%" className={CHART_FOCUS_RESET}>
       <BarChart data={data} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
         <XAxis dataKey="name" tick={{ fontSize: 9 }} interval="preserveStartEnd" />
-        <YAxis tick={{ fontSize: 10 }} width={42} />
+        {/* The y-axis counts rows per bin (no unit), but large counts clip in
+            the fixed gutter just like the other charts — compact them too. */}
+        <YAxis
+          tick={{ fontSize: 10 }}
+          width={Y_AXIS_WIDTH}
+          tickFormatter={(v: unknown) => fmtAxisTick(v)}
+        />
         <Tooltip
           isAnimationActive={false}
           content={<ChartTip nameFormatter={seriesNameFormatter(seriesLabel)} />}
@@ -480,18 +529,32 @@ export function QueryWidgetRenderer({
   switch (display) {
     case "line":
       return (
-        <TimeSeries result={result} area={false} seriesLabel={seriesLabel} additive={additive} />
+        <TimeSeries
+          result={result}
+          area={false}
+          seriesLabel={seriesLabel}
+          additive={additive}
+          unit={unit}
+        />
       );
     case "area":
-      return <TimeSeries result={result} area seriesLabel={seriesLabel} additive={additive} />;
+      return (
+        <TimeSeries
+          result={result}
+          area
+          seriesLabel={seriesLabel}
+          additive={additive}
+          unit={unit}
+        />
+      );
     case "bar":
-      return <Bars result={result} seriesLabel={seriesLabel} />;
+      return <Bars result={result} seriesLabel={seriesLabel} unit={unit} />;
     case "pie":
-      return <PieView result={result} />;
+      return <PieView result={result} unit={unit} />;
     case "number":
       return <NumberView result={result} unit={unit} />;
     case "table":
-      return <TableView result={result} />;
+      return <TableView result={result} unit={unit} />;
     case "histogram":
       return <HistogramView result={result} seriesLabel={seriesLabel} />;
   }

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -250,6 +250,10 @@ function legendFor(
   result: WidgetQueryResult,
   additive: boolean,
 ): { entries: LegendEntry[]; total: number | null } | null {
+  // Guard the result's shape, not just the display: keepPreviousData serves
+  // the previous spec's result for a beat after a display/spec switch, and
+  // pivoting a categorical result here would fabricate series entries.
+  if (result.columns[0] !== "bucket") return null;
   const { seriesKeys, data } = pivotRows(result.columns, result.rows, additive ? 0 : null);
   if (seriesKeys.length <= 1) return null;
   const entries = seriesKeys.map((k, i) => {
@@ -269,6 +273,10 @@ function categoricalLegend(
   result: WidgetQueryResult,
   additive: boolean,
 ): { entries: LegendEntry[]; total: number | null } | null {
+  // Categorical results are exactly [dim, value]; anything else is a stale
+  // mismatched shape (see legendFor) whose rows have no `name` and would
+  // render literal "undefined" labels.
+  if (result.columns.length !== 2 || result.columns[0] === "bucket") return null;
   const { data } = pivotRows(result.columns, result.rows);
   if (data.length <= 1) return null;
   const entries = data.map((r, i) => {

--- a/frontend/ui/src/features/dashboards/components/renderers.tsx
+++ b/frontend/ui/src/features/dashboards/components/renderers.tsx
@@ -17,7 +17,8 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { type DisplayType, type FieldUnit, type WidgetQueryResult, AGGS } from "../types";
+import type { FieldUnit } from "@/features/filters/filter-controls";
+import { type DisplayType, type WidgetQueryResult, AGGS } from "../types";
 
 // Pastel series palette mirroring the span-kind tints
 // (violet=llm, blue=agent, amber=tool, slate=span), then softened extras.

--- a/frontend/ui/src/features/dashboards/hooks/use-dashboards.test.tsx
+++ b/frontend/ui/src/features/dashboards/hooks/use-dashboards.test.tsx
@@ -31,6 +31,7 @@ const fakeSummary: DashboardSummary = {
   name: "Overview",
   description: null,
   isDefault: true,
+  createTime: "2026-05-01T00:00:00Z",
   updateTime: "2026-06-01T00:00:00Z",
 };
 
@@ -66,11 +67,12 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 describe("useDashboards", () => {
   it("unwraps the data array from the list response", async () => {
-    vi.mocked(api.listDashboards).mockResolvedValue({ data: [fakeSummary] });
+    const listItem = { ...fakeSummary, creator: "Ada" };
+    vi.mocked(api.listDashboards).mockResolvedValue({ data: [listItem] });
     const { wrapper } = makeWrapper();
 
     const { result } = renderHook(() => useDashboards("proj-1"), { wrapper });
-    await waitFor(() => expect(result.current.data).toEqual([fakeSummary]));
+    await waitFor(() => expect(result.current.data).toEqual([listItem]));
     expect(api.listDashboards).toHaveBeenCalledWith("proj-1");
   });
 

--- a/frontend/ui/src/features/dashboards/hooks/use-dashboards.ts
+++ b/frontend/ui/src/features/dashboards/hooks/use-dashboards.ts
@@ -1,7 +1,18 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "@/lib/api/client";
 import { broadcastQueryInvalidation } from "@/lib/cross-tab-sync";
 import * as api from "../api";
 import type { LayoutItem, Widget } from "../types";
+
+/**
+ * Whether a dashboard fetch failed permanently: the dashboard or its project
+ * was deleted (404), or the viewer's access was revoked (403). Transient
+ * failures (5xx, network) return false so pollers retry in place instead of
+ * bouncing the user.
+ */
+export function isDashboardGone(error: unknown): boolean {
+  return error instanceof ApiError && (error.status === 404 || error.status === 403);
+}
 
 export function useDashboards(projectId: string) {
   return useQuery({

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "../api";
 import type { DraftSpec, TimeRange, WidgetSpec } from "../types";
 import {
+  quantizeRange,
   useWidgetData,
   useWidgetFieldValues,
   useWidgetPreview,
@@ -120,6 +121,69 @@ describe("useWidgetData", () => {
   it("stays disabled without a widgetId", () => {
     renderHook(() => useWidgetData("p1", "", SPEC, RANGE), { wrapper });
     expect(api.runWidgetQuery).not.toHaveBeenCalled();
+  });
+
+  it("floors the window to the minute for the request", async () => {
+    vi.mocked(api.runWidgetQuery).mockResolvedValue({ columns: [], rows: [], meta: {} });
+    const ragged: TimeRange = {
+      start: new Date("2026-06-01T00:00:10.500Z"),
+      end: new Date("2026-06-02T00:00:42.900Z"),
+    };
+    renderHook(() => useWidgetData("p1", "w1", SPEC, ragged), { wrapper });
+
+    await waitFor(() => expect(api.runWidgetQuery).toHaveBeenCalled());
+    const [, , window] = vi.mocked(api.runWidgetQuery).mock.calls[0];
+    expect(window.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    expect(window.end.toISOString()).toBe("2026-06-02T00:00:00.000Z");
+  });
+
+  it("serves a same-minute remount from cache without refetching", async () => {
+    // Relative presets recompute end="now" per mount: raw millisecond keys
+    // would refire every widget on every dashboard round-trip. Same client
+    // across two mounts = the navigation case.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const sharedWrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    vi.mocked(api.runWidgetQuery).mockResolvedValue({ columns: [], rows: [], meta: {} });
+
+    const first = renderHook(
+      () =>
+        useWidgetData("p1", "w1", SPEC, {
+          start: new Date("2026-06-01T00:00:05Z"),
+          end: new Date("2026-06-02T00:00:05Z"),
+        }),
+      { wrapper: sharedWrapper },
+    );
+    await waitFor(() => expect(api.runWidgetQuery).toHaveBeenCalledTimes(1));
+    first.unmount();
+
+    // Seconds later the remounted page computes a slightly different raw
+    // window — same floored minute, so the cache answers with zero requests.
+    const second = renderHook(
+      () =>
+        useWidgetData("p1", "w1", SPEC, {
+          start: new Date("2026-06-01T00:00:25Z"),
+          end: new Date("2026-06-02T00:00:25Z"),
+        }),
+      { wrapper: sharedWrapper },
+    );
+    await waitFor(() => expect(second.result.current.data).toBeTruthy());
+    expect(api.runWidgetQuery).toHaveBeenCalledTimes(1);
+    client.clear();
+  });
+});
+
+describe("quantizeRange", () => {
+  it("widens a sub-minute window to one minute instead of an empty range", () => {
+    const q = quantizeRange({
+      start: new Date("2026-06-01T00:00:10Z"),
+      end: new Date("2026-06-01T00:00:40Z"),
+    });
+    expect(q.start.toISOString()).toBe("2026-06-01T00:00:00.000Z");
+    // Both bounds floor to the same minute; the end must stay one step ahead
+    // or the backend would reject end <= start.
+    expect(q.end.toISOString()).toBe("2026-06-01T00:01:00.000Z");
   });
 });
 

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.test.tsx
@@ -142,19 +142,20 @@ describe("useWidgetPreview", () => {
     };
     const queryResult = { columns: ["count"], rows: [[1]], meta: {} };
     vi.mocked(api.runWidgetQuery).mockResolvedValue(queryResult);
+    const parsed = {
+      view: "spans",
+      filters: [],
+      metric: { measure: "count", agg: "count" },
+      breakdown: null,
+      display: { type: "number" },
+    };
     const { result } = renderHook(() => useWidgetPreview("p1", draft, RANGE), { wrapper });
-    await waitFor(() => expect(result.current.data).toEqual(queryResult));
-    expect(api.runWidgetQuery).toHaveBeenCalledWith(
-      "p1",
-      {
-        view: "spans",
-        filters: [],
-        metric: { measure: "count", agg: "count" },
-        breakdown: null,
-        display: { type: "number" },
-      },
-      RANGE,
-      { id: "u1", email: "u@example.com" },
-    );
+    // The result carries the spec that produced it so the preview can render
+    // kept-previous data with matching display/unit/agg semantics.
+    await waitFor(() => expect(result.current.data).toEqual({ spec: parsed, result: queryResult }));
+    expect(api.runWidgetQuery).toHaveBeenCalledWith("p1", parsed, RANGE, {
+      id: "u1",
+      email: "u@example.com",
+    });
   });
 });

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
@@ -21,6 +21,22 @@ export function useWidgetSchema(projectId: string) {
   });
 }
 
+const MINUTE = 60_000;
+
+// Relative presets recompute end="now" on every page mount, so raw
+// millisecond bounds would mint a fresh cache key per visit and refire every
+// widget query. Flooring the window to the minute (the same keying the
+// server's distinct-values cache uses) keeps keys stable within a minute, and
+// the matching staleTime serves those remounts from cache with zero requests.
+// Cost: charts lag "now" by up to 60s — the right trade for a dashboard.
+// A sub-minute custom window floors to an empty range; keep it one minute
+// wide rather than compiling an end<=start query the backend rejects.
+export function quantizeRange(range: TimeRange): TimeRange {
+  const start = Math.floor(range.start.getTime() / MINUTE) * MINUTE;
+  const end = Math.floor(range.end.getTime() / MINUTE) * MINUTE;
+  return { start: new Date(start), end: new Date(Math.max(end, start + MINUTE)) };
+}
+
 export function useWidgetData(
   projectId: string,
   widgetId: string,
@@ -29,6 +45,7 @@ export function useWidgetData(
   enabled = true,
 ) {
   const { user, sessionReady } = useTraceApiUser();
+  const floored = quantizeRange(range);
 
   return useQuery({
     queryKey: [
@@ -36,12 +53,13 @@ export function useWidgetData(
       projectId,
       widgetId,
       JSON.stringify(spec),
-      range.start.getTime(),
-      range.end.getTime(),
+      floored.start.getTime(),
+      floored.end.getTime(),
     ],
-    queryFn: () => api.runWidgetQuery(projectId, spec, range, user),
+    queryFn: () => api.runWidgetQuery(projectId, spec, floored, user),
     enabled: enabled && sessionReady && !!projectId && !!widgetId,
     retry: 1,
+    staleTime: MINUTE,
     placeholderData: keepPreviousData,
   });
 }
@@ -59,6 +77,7 @@ export function useWidgetFieldValues(
   enabled: boolean,
 ): { values: WidgetFieldValue[]; isLoading: boolean } {
   const { user, sessionReady } = useTraceApiUser();
+  const floored = quantizeRange(range);
 
   const active = enabled && sessionReady && !!projectId && !!view && !!field;
   const { data, isLoading } = useQuery({
@@ -67,10 +86,10 @@ export function useWidgetFieldValues(
       projectId,
       view ?? null,
       field,
-      range.start.getTime(),
-      range.end.getTime(),
+      floored.start.getTime(),
+      floored.end.getTime(),
     ],
-    queryFn: () => api.fetchWidgetFieldValues(projectId, view!, field, range, user),
+    queryFn: () => api.fetchWidgetFieldValues(projectId, view!, field, floored, user),
     enabled: active,
     staleTime: 30_000,
   });
@@ -91,18 +110,19 @@ export interface WidgetPreviewData {
 
 export function useWidgetPreview(projectId: string, draft: unknown, range: TimeRange) {
   const { user, sessionReady } = useTraceApiUser();
+  const floored = quantizeRange(range);
 
   return useQuery({
     queryKey: [
       "widget-preview",
       projectId,
       JSON.stringify(draft),
-      range.start.getTime(),
-      range.end.getTime(),
+      floored.start.getTime(),
+      floored.end.getTime(),
     ],
     queryFn: async (): Promise<WidgetPreviewData> => {
       const spec = parseSpec(draft)!;
-      return { spec, result: await api.runWidgetQuery(projectId, spec, range, user) };
+      return { spec, result: await api.runWidgetQuery(projectId, spec, floored, user) };
     },
     enabled: sessionReady && !!projectId && isSpecComplete(draft),
     staleTime: 10_000,

--- a/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
+++ b/frontend/ui/src/features/dashboards/hooks/use-widget-data.ts
@@ -6,6 +6,7 @@ import {
   parseSpec,
   type TimeRange,
   type WidgetFieldValue,
+  type WidgetQueryResult,
   type WidgetSpec,
 } from "../types";
 
@@ -78,6 +79,16 @@ export function useWidgetFieldValues(
   return active ? { values: data?.values ?? [], isLoading } : { values: [], isLoading: false };
 }
 
+// The preview pairs each result with the spec that produced it: keepPreviousData
+// shows the previous rows while a new query is in flight, and rendering those
+// rows with the NEW draft's display/unit/aggregation would briefly mislabel
+// them (e.g. an old additive sum series drawn with avg's gap semantics).
+// Rendering from data.spec keeps every frame internally consistent.
+export interface WidgetPreviewData {
+  spec: WidgetSpec;
+  result: WidgetQueryResult;
+}
+
 export function useWidgetPreview(projectId: string, draft: unknown, range: TimeRange) {
   const { user, sessionReady } = useTraceApiUser();
 
@@ -89,7 +100,10 @@ export function useWidgetPreview(projectId: string, draft: unknown, range: TimeR
       range.start.getTime(),
       range.end.getTime(),
     ],
-    queryFn: () => api.runWidgetQuery(projectId, parseSpec(draft)!, range, user),
+    queryFn: async (): Promise<WidgetPreviewData> => {
+      const spec = parseSpec(draft)!;
+      return { spec, result: await api.runWidgetQuery(projectId, spec, range, user) };
+    },
     enabled: sessionReady && !!projectId && isSpecComplete(draft),
     staleTime: 10_000,
     retry: false,

--- a/frontend/ui/src/features/dashboards/types.test.ts
+++ b/frontend/ui/src/features/dashboards/types.test.ts
@@ -78,7 +78,7 @@ describe("isEnumerableFilter", () => {
   const stringField = {
     type: "string" as const,
     label: "Model",
-    filterOps: ["=", "!=", "contains"],
+    filterOps: ["=", "contains"],
     groupable: true,
     aggs: [],
   };
@@ -86,7 +86,9 @@ describe("isEnumerableFilter", () => {
 
   it("true for string equality ops (dropdown of stored values)", () => {
     expect(isEnumerableFilter(stringField, "=")).toBe(true);
-    expect(isEnumerableFilter(stringField, "!=")).toBe(true);
+    // != left the widget vocabulary when it was reconciled with the
+    // trace-list filter, which has no not-equals
+    expect(isEnumerableFilter(stringField, "!=")).toBe(false);
   });
   it("false for contains (free text) and numeric fields", () => {
     expect(isEnumerableFilter(stringField, "contains")).toBe(false);
@@ -102,7 +104,7 @@ describe("filterOpLabel", () => {
   const stringField = {
     type: "string" as const,
     label: "Model",
-    filterOps: ["=", "!=", "contains"],
+    filterOps: ["=", "contains"],
     groupable: true,
     aggs: [],
   };
@@ -110,13 +112,12 @@ describe("filterOpLabel", () => {
 
   it("words string equality like the trace-list filter builder", () => {
     expect(filterOpLabel(stringField, "=")).toBe("is");
-    expect(filterOpLabel(stringField, "!=")).toBe("is not");
     expect(filterOpLabel(stringField, "contains")).toBe("contains");
   });
   it("uses the trace-list comparison symbols for numeric ops", () => {
     expect(filterOpLabel(numberField, ">=")).toBe("≥");
     expect(filterOpLabel(numberField, "<=")).toBe("≤");
-    expect(filterOpLabel(numberField, "!=")).toBe("≠");
+
     expect(filterOpLabel(numberField, "=")).toBe("=");
     expect(filterOpLabel(numberField, ">")).toBe(">");
     expect(filterOpLabel(numberField, "<")).toBe("<");

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -25,7 +25,7 @@ export const AGGS = ["count", "sum", "avg", "min", "max", "p50", "p95", "p99"] a
 
 export const WidgetFilterSchema = z.object({
   field: z.string().min(1),
-  op: z.enum(["=", "!=", "contains", ">", ">=", "<", "<="]),
+  op: z.enum(["=", "contains", ">", ">=", "<", "<="]),
   // min(1): a filter whose value was never picked (the builder's rows start
   // at "") must keep the spec incomplete, not save a widget that silently
   // matches only empty-valued rows.
@@ -149,21 +149,20 @@ export interface WidgetFieldValuesResponse {
  * `contains` stays free text and numeric fields take a number input.
  */
 export function isEnumerableFilter(field: WidgetSchemaField | undefined, op: string): boolean {
-  return !!field && field.type === "string" && (op === "=" || op === "!=");
+  return !!field && field.type === "string" && op === "=";
 }
 
 // Numeric comparison symbols shared with the trace-list filter chips.
-const NUMERIC_OP_SYMBOL: Record<string, string> = { ">=": "≥", "<=": "≤", "!=": "≠" };
+const NUMERIC_OP_SYMBOL: Record<string, string> = { ">=": "≥", "<=": "≤" };
 
 /**
  * Display label for a filter operator, matching the trace-list filter builder's
- * vocabulary: string equality reads as "is" / "is not"; numeric comparisons use
- * the same symbols (≥ ≤ ≠). Presentation only — the wire op is unchanged.
+ * vocabulary: string equality reads as "is"; numeric comparisons use the same
+ * symbols (≥ ≤). Presentation only — the wire op is unchanged.
  */
 export function filterOpLabel(field: WidgetSchemaField | undefined, op: string): string {
   if (field?.type === "string") {
     if (op === "=") return "is";
-    if (op === "!=") return "is not";
     return op;
   }
   return NUMERIC_OP_SYMBOL[op] ?? op;

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -143,20 +143,6 @@ export function isEnumerableFilter(field: WidgetSchemaField | undefined, op: str
   return !!field && field.type === "string" && (op === "=" || op === "!=");
 }
 
-export interface FieldUnit {
-  prefix?: string;
-  suffix?: string;
-}
-
-// Units for fields that carry one — shared by the builder's filter inputs and
-// every widget renderer (stat tile, chart tooltips and axes, table cells).
-// Moving these into the backend registry's schema is a tracked follow-up;
-// until then this map is the frontend's single copy.
-export const FIELD_UNIT: Record<string, FieldUnit> = {
-  cost: { prefix: "$" },
-  duration_ms: { suffix: "ms" },
-};
-
 // Numeric comparison symbols shared with the trace-list filter chips.
 const NUMERIC_OP_SYMBOL: Record<string, string> = { ">=": "≥", "<=": "≤", "!=": "≠" };
 

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -149,8 +149,9 @@ export interface FieldUnit {
 }
 
 // Units for fields that carry one — shared by the builder's filter inputs and
-// the stat renderer. Moving these into the backend registry's schema is a
-// tracked follow-up; until then this map is the frontend's single copy.
+// every widget renderer (stat tile, chart tooltips and axes, table cells).
+// Moving these into the backend registry's schema is a tracked follow-up;
+// until then this map is the frontend's single copy.
 export const FIELD_UNIT: Record<string, FieldUnit> = {
   cost: { prefix: "$" },
   duration_ms: { suffix: "ms" },

--- a/frontend/ui/src/features/dashboards/types.ts
+++ b/frontend/ui/src/features/dashboards/types.ts
@@ -76,7 +76,16 @@ export interface DashboardSummary {
   name: string;
   description: string | null;
   isDefault: boolean;
+  createTime: string;
   updateTime: string;
+}
+
+// A dashboards-list row: the summary plus the creator's display name (or
+// email), which only the list route resolves — dashboards are shared across
+// a project's members, so the list shows who made each one. Null when the
+// creating account is gone.
+export interface DashboardListItem extends DashboardSummary {
+  creator: string | null;
 }
 
 export interface LayoutItem {

--- a/frontend/ui/src/features/filters/filter-builder.tsx
+++ b/frontend/ui/src/features/filters/filter-builder.tsx
@@ -8,48 +8,27 @@
  * equals / greater-than-or-equal / less-than-or-equal all emit a `between` predicate with
  * the right (possibly null) bounds, and categorical `is` emits a one-element `in`. "Add
  * filter" emits one predicate (the parent appends it as a chip) and resets the row.
+ *
+ * The field/operator/value controls live in `filter-controls` and are shared
+ * with the dashboard widget builder's filter rows.
  */
 import { useState } from "react";
-import {
-  AlertCircle,
-  Box,
-  ChevronDown,
-  CircleDollarSign,
-  CircleStop,
-  Clock,
-  Globe,
-  Hash,
-  type LucideIcon,
-} from "lucide-react";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
 import type { Predicate } from "@/types/api";
 import { useFilterValues } from "./hooks";
 import type { FilterFieldDef } from "./registry";
 import { buildInPredicate, buildNumericPredicate, buildTextPredicate } from "./predicate-ui";
-
-// Icons mirror the trace detail / list UI for consistency; the model and environment
-// fields, which have no trace-detail icon, use a generic one. Exported so the
-// dashboard widget builder shows the same symbols for the same fields.
-export const FIELD_ICONS: Record<string, LucideIcon> = {
-  trace_id: Hash,
-  cost: CircleDollarSign,
-  total_tokens: CircleStop,
-  duration_ms: Clock,
-  errors: AlertCircle,
-  model_name: Box,
-  environment: Globe,
-};
-
-// Unit shown inside the value input so it's clear what a numeric filter is measured in.
-// Only the short units ($ and ms) are shown; a "tokens" suffix is long enough to crowd
-// out the "Enter value" placeholder, and the Tokens field name already makes it clear.
-const FIELD_UNIT: Record<string, { prefix?: string; suffix?: string }> = {
-  cost: { prefix: "$" },
-  duration_ms: { suffix: "ms" },
-};
+import {
+  Dropdown,
+  DropdownItem,
+  FIELD_ICONS,
+  FIELD_UNIT,
+  FieldDropdown,
+  NumberField,
+  ParkedValueField,
+  TextField,
+  ValueDropdown,
+} from "./filter-controls";
 
 type UiOp = "is" | "eq" | "gt" | "gte" | "lt" | "lte" | "contains";
 const OP_LABEL: Record<UiOp, string> = {
@@ -140,7 +119,14 @@ export function FilterBuilder({
 
   return (
     <div className="flex items-center gap-1 p-1.5">
-      <FieldDropdown fields={fields} value={field} onPick={pickField} />
+      <FieldDropdown
+        options={fields.map((f) => ({ key: f.field, label: f.label, icon: FIELD_ICONS[f.field] }))}
+        valueKey={field?.field ?? null}
+        onPick={(key) => {
+          const f = fields.find((x) => x.field === key);
+          if (f) pickField(f);
+        }}
+      />
       <Dropdown
         disabled={!field}
         trigger={<span className="whitespace-nowrap">{field ? OP_LABEL[op] : "is"}</span>}
@@ -203,15 +189,7 @@ function ValueControl({
   onEnter: () => void;
 }) {
   if (!field) {
-    return (
-      <Input
-        disabled
-        readOnly
-        value=""
-        placeholder="Enter value"
-        className="h-7 min-w-0 flex-1 rounded-md text-[13px]"
-      />
-    );
+    return <ParkedValueField />;
   }
   if (field.type === "categorical") {
     return (
@@ -249,82 +227,6 @@ function ValueControl({
   );
 }
 
-function TextField({
-  ariaLabel,
-  placeholder,
-  value,
-  onChange,
-  onEnter,
-}: {
-  ariaLabel: string;
-  placeholder: string;
-  value: string;
-  onChange: (v: string) => void;
-  onEnter: () => void;
-}) {
-  return (
-    <Input
-      aria-label={ariaLabel}
-      placeholder={placeholder}
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") onEnter();
-      }}
-      className="h-7 min-w-0 flex-1 rounded-md text-[13px]"
-    />
-  );
-}
-
-function NumberField({
-  ariaLabel,
-  placeholder,
-  value,
-  onChange,
-  onEnter,
-  unit,
-  integer = false,
-}: {
-  ariaLabel: string;
-  placeholder: string;
-  value: string;
-  onChange: (v: string) => void;
-  onEnter: () => void;
-  unit?: { prefix?: string; suffix?: string };
-  // Integer-typed fields (tokens/latency/errors) can't bind a fractional value in
-  // ClickHouse, so restrict the input to whole numbers.
-  integer?: boolean;
-}) {
-  return (
-    <div className="flex h-7 min-w-0 flex-1 items-center gap-1 rounded-md border border-input bg-transparent px-2 text-[13px] focus-within:ring-1 focus-within:ring-ring">
-      {unit?.prefix && <span className="shrink-0 text-muted-foreground">{unit.prefix}</span>}
-      <input
-        type="number"
-        min={0}
-        step={integer ? 1 : "any"}
-        aria-label={ariaLabel}
-        placeholder={placeholder}
-        value={value}
-        onChange={(e) => {
-          // The filterable metrics are all non-negative — reject negative input; and for
-          // integer fields, reject a fractional value (it can't bind as Int64/UInt64).
-          const v = e.target.value;
-          if (v.startsWith("-") || Number(v) < 0) return;
-          if (integer && v.includes(".")) return;
-          onChange(v);
-        }}
-        onKeyDown={(e) => {
-          // Block a minus sign always, and a decimal point on integer fields.
-          if (e.key === "-" || (integer && e.key === ".")) e.preventDefault();
-          else if (e.key === "Enter") onEnter();
-        }}
-        className="min-w-0 flex-1 bg-transparent text-[13px] outline-none [appearance:textfield] placeholder:text-muted-foreground [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-      />
-      {unit?.suffix && <span className="shrink-0 text-muted-foreground">{unit.suffix}</span>}
-    </div>
-  );
-}
-
 function CategoricalValue({
   projectId,
   field,
@@ -347,165 +249,4 @@ function CategoricalValue({
     : values.map((v) => ({ value: v.value, count: v.count }));
 
   return <ValueDropdown value={value} options={options} onValue={onValue} />;
-}
-
-/**
- * The stored-values picker: a dropdown of a field's values with per-value
- * occurrence counts on the right. Shared by the trace-list filter builder and
- * the dashboard widget filter rows.
- */
-export function ValueDropdown({
-  value,
-  options,
-  onValue,
-  placeholder = "Enter value",
-  triggerClassName,
-}: {
-  value: string;
-  options: { value: string; count?: number }[];
-  onValue: (v: string) => void;
-  placeholder?: string;
-  triggerClassName?: string;
-}) {
-  return (
-    <Dropdown
-      trigger={
-        <span className={cn("truncate", !value && "text-muted-foreground")}>
-          {value || placeholder}
-        </span>
-      }
-      triggerClassName={cn("min-w-0 flex-1", triggerClassName)}
-      contentClassName="w-[12rem]"
-    >
-      {(close) =>
-        options.length === 0 ? (
-          <div className="px-2 py-1.5 text-[13px] text-muted-foreground">No options</div>
-        ) : (
-          options.map((opt) => (
-            <DropdownItem
-              key={opt.value}
-              active={opt.value === value}
-              onClick={() => {
-                onValue(opt.value);
-                close();
-              }}
-            >
-              <span className="flex-1 truncate">{opt.value}</span>
-              {opt.count !== undefined && (
-                <span className="text-[11px] text-muted-foreground">{opt.count}</span>
-              )}
-            </DropdownItem>
-          ))
-        )
-      }
-    </Dropdown>
-  );
-}
-
-function FieldDropdown({
-  fields,
-  value,
-  onPick,
-}: {
-  fields: FilterFieldDef[];
-  value: FilterFieldDef | null;
-  onPick: (f: FilterFieldDef) => void;
-}) {
-  const Icon = value ? (FIELD_ICONS[value.field] ?? Box) : null;
-  return (
-    <Dropdown
-      trigger={
-        <span className="flex min-w-0 items-center gap-1.5">
-          {Icon && <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
-          <span className="truncate">{value ? value.label : "Field"}</span>
-        </span>
-      }
-      triggerClassName="w-[8.5rem] shrink-0"
-      contentClassName="w-[13rem]"
-    >
-      {(close) =>
-        fields.map((f) => {
-          const FIcon = FIELD_ICONS[f.field] ?? Box;
-          return (
-            <DropdownItem
-              key={f.field}
-              active={f.field === value?.field}
-              onClick={() => {
-                onPick(f);
-                close();
-              }}
-            >
-              <FIcon className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="flex-1 truncate">{f.label}</span>
-            </DropdownItem>
-          );
-        })
-      }
-    </Dropdown>
-  );
-}
-
-function Dropdown({
-  trigger,
-  children,
-  triggerClassName,
-  contentClassName,
-  disabled,
-}: {
-  trigger: React.ReactNode;
-  children: (close: () => void) => React.ReactNode;
-  triggerClassName?: string;
-  contentClassName?: string;
-  disabled?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          disabled={disabled}
-          className={cn(
-            "flex h-7 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 text-[13px] font-normal transition-colors",
-            "hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50",
-            triggerClassName,
-          )}
-        >
-          {trigger}
-          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-        </button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="start"
-        className={cn("max-h-64 overflow-y-auto p-1", contentClassName)}
-      >
-        {children(() => setOpen(false))}
-      </PopoverContent>
-    </Popover>
-  );
-}
-
-function DropdownItem({
-  active,
-  onClick,
-  children,
-}: {
-  active?: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      role="option"
-      aria-selected={active}
-      onClick={onClick}
-      className={cn(
-        "flex w-full items-center gap-2 rounded px-2 py-1 text-left text-[13px] transition-colors hover:bg-muted/50",
-        active && "bg-muted/40",
-      )}
-    >
-      {children}
-    </button>
-  );
 }

--- a/frontend/ui/src/features/filters/filter-controls.test.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { Hash } from "lucide-react";
+import {
+  FieldDropdown,
+  FilterControlSizeProvider,
+  NumberField,
+  TextField,
+  ValueDropdown,
+} from "./filter-controls";
+
+afterEach(cleanup);
+
+describe("NumberField", () => {
+  it("drops typed negative values and keeps non-negative ones", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberField ariaLabel="value" placeholder="Enter value" value="" onChange={onChange} />,
+    );
+    const input = screen.getByLabelText("value");
+    fireEvent.change(input, { target: { value: "-5" } });
+    expect(onChange).not.toHaveBeenCalled();
+    fireEvent.change(input, { target: { value: "5" } });
+    expect(onChange).toHaveBeenCalledWith("5");
+  });
+
+  it("blocks the minus key, and the decimal point on integer fields", () => {
+    const onChange = vi.fn();
+    render(
+      <NumberField
+        ariaLabel="value"
+        placeholder="Enter value"
+        value=""
+        onChange={onChange}
+        integer
+      />,
+    );
+    const input = screen.getByLabelText("value");
+    const minus = fireEvent.keyDown(input, { key: "-" });
+    const dot = fireEvent.keyDown(input, { key: "." });
+    // fireEvent returns false when preventDefault was called
+    expect(minus).toBe(false);
+    expect(dot).toBe(false);
+    fireEvent.change(input, { target: { value: "1.5" } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("submits on Enter when a handler is wired, and tolerates its absence", () => {
+    const onEnter = vi.fn();
+    const { unmount } = render(
+      <NumberField
+        ariaLabel="value"
+        placeholder="Enter value"
+        value="5"
+        onChange={vi.fn()}
+        onEnter={onEnter}
+      />,
+    );
+    fireEvent.keyDown(screen.getByLabelText("value"), { key: "Enter" });
+    expect(onEnter).toHaveBeenCalled();
+    unmount();
+
+    // without onEnter (the widget builder's rows) Enter must not throw
+    render(
+      <NumberField ariaLabel="value" placeholder="Enter value" value="5" onChange={vi.fn()} />,
+    );
+    fireEvent.keyDown(screen.getByLabelText("value"), { key: "Enter" });
+  });
+
+  it("renders the unit prefix and suffix around the input", () => {
+    render(
+      <NumberField
+        ariaLabel="value"
+        placeholder="Enter value"
+        value=""
+        onChange={vi.fn()}
+        unit={{ prefix: "$", suffix: "ms" }}
+      />,
+    );
+    expect(screen.getByText("$")).toBeTruthy();
+    expect(screen.getByText("ms")).toBeTruthy();
+  });
+});
+
+describe("TextField", () => {
+  it("propagates edits and tolerates Enter without a handler", () => {
+    const onChange = vi.fn();
+    render(<TextField ariaLabel="value" placeholder="Enter value" value="" onChange={onChange} />);
+    const input = screen.getByLabelText("value");
+    fireEvent.change(input, { target: { value: "abc" } });
+    expect(onChange).toHaveBeenCalledWith("abc");
+    fireEvent.keyDown(input, { key: "Enter" });
+  });
+});
+
+describe("ValueDropdown", () => {
+  it("shows an empty state when there are no options", () => {
+    render(<ValueDropdown value="" options={[]} onValue={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Enter value" }));
+    expect(screen.getByText("No options")).toBeTruthy();
+  });
+});
+
+describe("FieldDropdown", () => {
+  const options = [
+    { key: "trace_id", label: "Trace ID", icon: Hash },
+    { key: "mystery", label: "Mystery" }, // no icon → generic fallback
+  ];
+
+  it("shows the placeholder until a field is picked, then the field's label", () => {
+    const onPick = vi.fn();
+    const { rerender } = render(
+      <FieldDropdown options={options} valueKey={null} onPick={onPick} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Field" }));
+    fireEvent.click(screen.getByRole("option", { name: /Mystery/ }));
+    expect(onPick).toHaveBeenCalledWith("mystery");
+
+    rerender(<FieldDropdown options={options} valueKey="trace_id" onPick={onPick} />);
+    expect(screen.getByRole("button", { name: /Trace ID/ })).toBeTruthy();
+  });
+});
+
+describe("FilterControlSizeProvider", () => {
+  it("renders controls at 13px by default and 12px inside a compact host", () => {
+    const { unmount } = render(
+      <TextField ariaLabel="value" placeholder="Enter value" value="" onChange={vi.fn()} />,
+    );
+    expect(screen.getByLabelText("value").className).toContain("text-[13px]");
+    unmount();
+
+    render(
+      <FilterControlSizeProvider size="sm">
+        <TextField ariaLabel="value" placeholder="Enter value" value="" onChange={vi.fn()} />
+      </FilterControlSizeProvider>,
+    );
+    expect(screen.getByLabelText("value").className).toContain("text-[12px]");
+  });
+});

--- a/frontend/ui/src/features/filters/filter-controls.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.tsx
@@ -1,0 +1,343 @@
+"use client";
+
+/**
+ * The shared filter controls: the field / operator / value pieces of a filter
+ * row. The trace-list filter builder is the source of truth for how these look
+ * and validate; the dashboard widget builder renders the same controls so the
+ * two filter UIs stay identical.
+ */
+import { createContext, useContext, useState } from "react";
+import {
+  AlertCircle,
+  Box,
+  ChevronDown,
+  CircleDollarSign,
+  CircleStop,
+  Clock,
+  Globe,
+  Hash,
+  type LucideIcon,
+} from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+// Icons mirror the trace detail / list UI for consistency; the model and environment
+// fields, which have no trace-detail icon, use a generic one. The dashboard widget
+// builder extends this map with its registry's extra field names.
+export const FIELD_ICONS: Record<string, LucideIcon> = {
+  trace_id: Hash,
+  cost: CircleDollarSign,
+  total_tokens: CircleStop,
+  duration_ms: Clock,
+  errors: AlertCircle,
+  model_name: Box,
+  environment: Globe,
+};
+
+// Text sizing depends on where the filter lives: the trace-list search bar uses
+// the app's 13px control size, the widget builder's config column runs at 12px.
+// A context (set once by the host via FilterControlsSize) keeps the size out of
+// every control and dropdown-item callsite.
+export type FilterControlSize = "sm" | "md";
+const TEXT_SIZE: Record<FilterControlSize, string> = { sm: "text-[12px]", md: "text-[13px]" };
+const SizeContext = createContext<FilterControlSize>("md");
+const useTextSize = () => TEXT_SIZE[useContext(SizeContext)];
+
+export function FilterControlSizeProvider({
+  size,
+  children,
+}: {
+  size: FilterControlSize;
+  children: React.ReactNode;
+}) {
+  return <SizeContext.Provider value={size}>{children}</SizeContext.Provider>;
+}
+
+/** The disabled value input a filter row parks in until a field is picked. */
+export function ParkedValueField() {
+  return (
+    <Input
+      disabled
+      readOnly
+      value=""
+      placeholder="Enter value"
+      className={cn("h-7 min-w-0 flex-1 rounded-md", useTextSize())}
+    />
+  );
+}
+
+export interface FieldUnit {
+  prefix?: string;
+  suffix?: string;
+}
+
+// Unit shown inside a numeric value input — and by every widget renderer
+// (stat tile, chart tooltips and axes, table cells) — so it's clear what the
+// number is measured in. Only the short units ($ and ms) are
+// shown; a "tokens" suffix is long enough to crowd out the "Enter value"
+// placeholder, and the Tokens field name already makes it clear. Moving these
+// into the backend registry's schema is a tracked follow-up; until then this
+// map is the frontend's single copy.
+export const FIELD_UNIT: Record<string, FieldUnit> = {
+  cost: { prefix: "$" },
+  duration_ms: { suffix: "ms" },
+};
+
+export function TextField({
+  ariaLabel,
+  placeholder,
+  value,
+  onChange,
+  onEnter,
+}: {
+  ariaLabel: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  onEnter?: () => void;
+}) {
+  const textSize = useTextSize();
+  return (
+    <Input
+      aria-label={ariaLabel}
+      placeholder={placeholder}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") onEnter?.();
+      }}
+      className={cn("h-7 min-w-0 flex-1 rounded-md", textSize)}
+    />
+  );
+}
+
+export function NumberField({
+  ariaLabel,
+  placeholder,
+  value,
+  onChange,
+  onEnter,
+  unit,
+  integer = false,
+}: {
+  ariaLabel: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  onEnter?: () => void;
+  unit?: FieldUnit;
+  // Integer-typed fields (tokens/latency/errors) can't bind a fractional value in
+  // ClickHouse, so restrict the input to whole numbers.
+  integer?: boolean;
+}) {
+  const textSize = useTextSize();
+  return (
+    <div
+      className={cn(
+        "flex h-7 min-w-0 flex-1 items-center gap-1 rounded-md border border-input bg-transparent px-2 focus-within:ring-1 focus-within:ring-ring",
+        textSize,
+      )}
+    >
+      {unit?.prefix && <span className="shrink-0 text-muted-foreground">{unit.prefix}</span>}
+      <input
+        type="number"
+        min={0}
+        step={integer ? 1 : "any"}
+        aria-label={ariaLabel}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => {
+          // The filterable metrics are all non-negative — reject negative input; and for
+          // integer fields, reject a fractional value (it can't bind as Int64/UInt64).
+          const v = e.target.value;
+          if (v.startsWith("-") || Number(v) < 0) return;
+          if (integer && v.includes(".")) return;
+          onChange(v);
+        }}
+        onKeyDown={(e) => {
+          // Block a minus sign always, and a decimal point on integer fields.
+          if (e.key === "-" || (integer && e.key === ".")) e.preventDefault();
+          else if (e.key === "Enter") onEnter?.();
+        }}
+        className={cn(
+          "min-w-0 flex-1 bg-transparent outline-none [appearance:textfield] placeholder:text-muted-foreground [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none",
+          textSize,
+        )}
+      />
+      {unit?.suffix && <span className="shrink-0 text-muted-foreground">{unit.suffix}</span>}
+    </div>
+  );
+}
+
+/**
+ * The stored-values picker: a dropdown of a field's values with per-value
+ * occurrence counts on the right.
+ */
+export function ValueDropdown({
+  value,
+  options,
+  onValue,
+  placeholder = "Enter value",
+  triggerClassName,
+}: {
+  value: string;
+  options: { value: string; count?: number }[];
+  onValue: (v: string) => void;
+  placeholder?: string;
+  triggerClassName?: string;
+}) {
+  const textSize = useTextSize();
+  return (
+    <Dropdown
+      trigger={
+        <span className={cn("truncate", !value && "text-muted-foreground")}>
+          {value || placeholder}
+        </span>
+      }
+      triggerClassName={cn("min-w-0 flex-1", triggerClassName)}
+      contentClassName="w-[12rem]"
+    >
+      {(close) =>
+        options.length === 0 ? (
+          <div className={cn("px-2 py-1.5 text-muted-foreground", textSize)}>No options</div>
+        ) : (
+          options.map((opt) => (
+            <DropdownItem
+              key={opt.value}
+              active={opt.value === value}
+              onClick={() => {
+                onValue(opt.value);
+                close();
+              }}
+            >
+              <span className="flex-1 truncate">{opt.value}</span>
+              {opt.count !== undefined && (
+                <span className="text-[11px] text-muted-foreground">{opt.count}</span>
+              )}
+            </DropdownItem>
+          ))
+        )
+      }
+    </Dropdown>
+  );
+}
+
+export interface FieldOption {
+  key: string;
+  label: string;
+  icon?: LucideIcon;
+}
+
+export function FieldDropdown({
+  options,
+  valueKey,
+  onPick,
+}: {
+  options: FieldOption[];
+  valueKey: string | null;
+  onPick: (key: string) => void;
+}) {
+  const selected = valueKey ? (options.find((o) => o.key === valueKey) ?? null) : null;
+  const Icon = selected ? (selected.icon ?? Box) : null;
+  return (
+    <Dropdown
+      trigger={
+        <span className="flex min-w-0 items-center gap-1.5">
+          {Icon && <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+          <span className="truncate">{selected ? selected.label : "Field"}</span>
+        </span>
+      }
+      triggerClassName="w-[8.5rem] shrink-0"
+      contentClassName="w-[13rem]"
+    >
+      {(close) =>
+        options.map((o) => {
+          const OIcon = o.icon ?? Box;
+          return (
+            <DropdownItem
+              key={o.key}
+              active={o.key === valueKey}
+              onClick={() => {
+                onPick(o.key);
+                close();
+              }}
+            >
+              <OIcon className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="flex-1 truncate">{o.label}</span>
+            </DropdownItem>
+          );
+        })
+      }
+    </Dropdown>
+  );
+}
+
+export function Dropdown({
+  trigger,
+  children,
+  triggerClassName,
+  contentClassName,
+  disabled,
+}: {
+  trigger: React.ReactNode;
+  children: (close: () => void) => React.ReactNode;
+  triggerClassName?: string;
+  contentClassName?: string;
+  disabled?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const textSize = useTextSize();
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "flex h-7 items-center justify-between gap-1 rounded-md border border-border bg-background px-2 font-normal transition-colors",
+            "hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50",
+            textSize,
+            triggerClassName,
+          )}
+        >
+          {trigger}
+          <ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className={cn("max-h-64 overflow-y-auto p-1", contentClassName)}
+      >
+        {children(() => setOpen(false))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export function DropdownItem({
+  active,
+  onClick,
+  children,
+}: {
+  active?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  const textSize = useTextSize();
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 rounded px-2 py-1 text-left transition-colors hover:bg-muted/50",
+        textSize,
+        active && "bg-muted/40",
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/frontend/ui/src/lib/api/client.ts
+++ b/frontend/ui/src/lib/api/client.ts
@@ -8,6 +8,21 @@ import { clientEnv } from "@/env.client";
 const TRACE_API_BASE = clientEnv.NEXT_PUBLIC_API_URL;
 
 /**
+ * Error thrown for non-ok Next.js API responses. Carries the HTTP status so
+ * callers can tell permanent failures (403/404) from transient ones without
+ * matching on server error copy.
+ */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/**
  * Fetch from Next.js API routes (no auth headers needed, uses cookies)
  */
 export async function fetchNextApi<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
@@ -21,7 +36,7 @@ export async function fetchNextApi<T>(endpoint: string, options: RequestInit = {
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: "Unknown error" }));
-    throw new Error(error.error || `API error: ${response.status}`);
+    throw new ApiError(error.error || `API error: ${response.status}`, response.status);
   }
 
   if (response.status === 204) {

--- a/frontend/ui/src/lib/dashboard-seed.ts
+++ b/frontend/ui/src/lib/dashboard-seed.ts
@@ -1,4 +1,4 @@
-// Widget definitions for the lazily-created default "Overview" dashboard.
+// Widget definitions for the lazily-created "Default" dashboard.
 // Created once per project on first dashboards fetch, then fully user-owned —
 // never re-seeded or force-updated.
 
@@ -96,7 +96,14 @@ export function seedWidgets(): SeedWidget[] {
       title: "Recent traces",
       type: "trace_feed",
       spec: { filters: [], limit: 10 },
-      layout: { x: 0, y: 8, w: 12, h: 4 },
+      layout: { x: 0, y: 8, w: 6, h: 4 },
+    },
+    {
+      title: "Recent failures",
+      type: "trace_feed",
+      // Trace-list predicate wire format: only traces that recorded errors.
+      spec: { filters: [{ field: "errors", op: "gt", value: 0 }], limit: 10 },
+      layout: { x: 6, y: 8, w: 6, h: 4 },
     },
   ];
 

--- a/tests/rest/test_widget_query.py
+++ b/tests/rest/test_widget_query.py
@@ -2,6 +2,7 @@
 
 from datetime import UTC, datetime
 from typing import get_args
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.encoders import jsonable_encoder
@@ -14,6 +15,7 @@ from rest.schemas.dashboards import (
     WidgetQueryResponse,
     WidgetSpec,
 )
+from rest.services import widget_query as wq
 from rest.services.widget_query import WidgetSpecError, compile_widget_query
 from rest.services.widget_registry import (
     AGGS_NUMBER,
@@ -429,3 +431,24 @@ def test_number_display_rejects_breakdown():
     with pytest.raises(WidgetSpecError) as exc:
         compile_widget_query(spec, "p1", START, END)
     assert exc.value.step == "breakdown"
+
+
+def test_run_widget_query_sets_execution_guards(monkeypatch):
+    """Every widget query runs read-only, time-capped, and with a GROUP BY
+    memory ceiling that spills to disk instead of OOMing the server."""
+    fake_result = MagicMock(column_names=["value"], result_rows=[(1,)])
+    fake_client = MagicMock()
+    fake_client.query.return_value = fake_result
+    monkeypatch.setattr(wq, "get_clickhouse_client", lambda: fake_client)
+
+    wq.run_widget_query(
+        spec=WidgetSpec.model_validate(make_spec()),
+        project_id="p1",
+        start_time=START,
+        end_time=END,
+    )
+
+    settings = fake_client.query.call_args.kwargs["settings"]
+    assert settings["readonly"] == 1
+    assert settings["max_execution_time"] == wq.QUERY_TIMEOUT_S
+    assert settings["max_bytes_before_external_group_by"] == wq.GROUP_BY_SPILL_BYTES

--- a/tests/rest/test_widget_query.py
+++ b/tests/rest/test_widget_query.py
@@ -305,6 +305,41 @@ def test_non_timeseries_has_no_fill():
         assert "WITH FILL" not in sql
 
 
+def test_non_additive_timeseries_metric_is_nullable():
+    """Percentile/average time series wrap the metric in toNullable.
+
+    WITH FILL rows carry the column default — 0 for a plain Float64 — which
+    would draw a false collapse for aggs where an empty bucket has no value.
+    Nullable makes the filled rows NULL, and the chart renders them as gaps.
+    """
+    for agg in ("avg", "min", "max", "p50", "p95", "p99"):
+        sql, _ = compile_(
+            make_spec(metric={"measure": "duration_ms", "agg": agg}, display={"type": "line"})
+        )
+        assert "toNullable(" in sql, agg
+
+
+def test_additive_timeseries_metric_stays_plain():
+    """count/sum of an empty bucket genuinely is zero — no Nullable wrapper."""
+    for metric in ({"measure": "count", "agg": "count"}, {"measure": "cost", "agg": "sum"}):
+        sql, _ = compile_(make_spec(metric=metric, display={"type": "line"}))
+        assert "toNullable(" not in sql, metric
+
+
+def test_non_additive_without_fill_stays_plain():
+    """The wrapper exists only for WITH FILL; number/table shapes skip it."""
+    for display in ({"type": "number"}, {"type": "table"}):
+        sql, _ = compile_(
+            make_spec(
+                metric={"measure": "duration_ms", "agg": "p95"},
+                display=display,
+                # Number rejects a breakdown outright; keep the shapes minimal.
+                breakdown=None,
+            )
+        )
+        assert "toNullable(" not in sql, display
+
+
 def test_other_fold_shape():
     """The 'other' fold uses a subquery with LIMIT 50 (MAX_GROUPS)."""
     sql, _ = compile_(make_spec(display={"type": "bar"}))


### PR DESCRIPTION
Stacked on #1575 (`fix/legend-shape-and-dashboard-guards`). Follow-up hardening from review.

`/widgets/query` and `/widgets/field-values` run ClickHouse-backed reads (aggregation scans + the distinct-values scan) but were declared with plain `ProjectAccess` and **no shared read limiter** — while every sibling ClickHouse-reading endpoint (`traces`, `sessions`, `users`) guards its reads with `RateLimitedProjectAccess` + `@limiter.shared_limit(scope=BUCKET_READ)`. `deps.get_rate_limited_project_access` is even documented as "used by dashboard read endpoints", so this was an oversight — the heaviest dashboard reads bypassed the per-workspace read bucket.

Applies the exact `traces.py` pattern to the two CH-backed widget reads:

- `POST /query` and `GET /field-values/{view}/{field}` → `RateLimitedProjectAccess` + `@limiter.shared_limit(resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt)` + an injected `request: Request`.
- Static `GET /schema` (no ClickHouse) is intentionally left on plain `ProjectAccess`.

Behavior is unchanged on self-host (the limiter is built `enabled=False` when `ENABLE_BILLING=false`).

## Test
No test changes needed — the limiter is disabled in the test env and `ProjectAccessInfo` defaults `workspace_id`/`billing_plan`, so the existing endpoint tests still pass through the rate-limited dep. Verified `dashboards.py` parses and the dependency chain stays override-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared read rate limiting to widget read endpoints to align with other ClickHouse-backed routes and enforce per-workspace quotas. Applies to `/widgets/query` and `/widgets/field-values`; `/widgets/schema` and self-host with billing off are unchanged.

- **Bug Fixes**
  - Switched to `RateLimitedProjectAccess` and added `@limiter.shared_limit(resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt)` on both endpoints.
  - Injected `Request` so the limiter can key the call.

<sup>Written for commit 6958b0986bb2e44b5069c65c2b22cb5abc05f782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

