### PR TITLE
fix(pricing): match Anthropic dot-version names and add fast rate cards

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -13,9 +13,22 @@
     }
   },
   {
+    "id": "tr-claude-opus-4-8-fast",
+    "modelName": "claude-opus-4-8-fast",
+    "matchPattern": "(?i)^(anthropic\\/)?claude-opus-4[-.]8-fast$",
+    "provider": "anthropic",
+    "prices": {
+      "input": 0.00001,
+      "output": 0.00005,
+      "cacheRead": 0.000001,
+      "cacheWrite": 0.0000125,
+      "cacheWrite1h": 0.00002
+    }
+  },
+  {
     "id": "tr-claude-opus-4-8",
     "modelName": "claude-opus-4-8",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-8(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-8-opus(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4[-.]8(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4[-.]8(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4[-.]8-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000005,
@@ -26,9 +39,22 @@
     }
   },
   {
+    "id": "tr-claude-opus-4-7-fast",
+    "modelName": "claude-opus-4-7-fast",
+    "matchPattern": "(?i)^(anthropic\\/)?claude-opus-4[-.]7-fast$",
+    "provider": "anthropic",
+    "prices": {
+      "input": 0.00003,
+      "output": 0.00015,
+      "cacheRead": 0.000003,
+      "cacheWrite": 0.0000375,
+      "cacheWrite1h": 0.00006
+    }
+  },
+  {
     "id": "tr-claude-opus-4-7",
     "modelName": "claude-opus-4-7",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-7(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-7-opus(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4[-.]7(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4[-.]7(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4[-.]7-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000005,
@@ -41,7 +67,7 @@
   {
     "id": "tr-claude-opus-4-6",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-6(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-6-opus(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4[-.]6(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4[-.]6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4[-.]6-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000005,
@@ -67,7 +93,7 @@
   {
     "id": "tr-claude-sonnet-4-6",
     "modelName": "claude-sonnet-4-6",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-6-sonnet(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4[-.]6(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4[-.]6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4[-.]6-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -80,7 +106,7 @@
   {
     "id": "tr-claude-opus-4-5",
     "modelName": "claude-opus-4-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-5(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-opus(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4[-.]5(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4[-.]5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4[-.]5-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000005,
@@ -93,7 +119,7 @@
   {
     "id": "tr-claude-sonnet-4-5",
     "modelName": "claude-sonnet-4-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-sonnet(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4[-.]5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4[-.]5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4[-.]5-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -106,7 +132,7 @@
   {
     "id": "tr-claude-haiku-4-5",
     "modelName": "claude-haiku-4-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-haiku-4-5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-haiku(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-haiku-4[-.]5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4[-.]5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4[-.]5-haiku(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000001,
@@ -659,7 +685,7 @@
   {
     "id": "tr-claude-3-5-sonnet",
     "modelName": "claude-3-5-sonnet",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-5-sonnet(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-sonnet(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-5-sonnet(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-3[-.]5-sonnet(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3[-.]5-sonnet(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3[-.]5-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -672,7 +698,7 @@
   {
     "id": "tr-claude-3-5-haiku",
     "modelName": "claude-3-5-haiku",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-5-haiku(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-haiku(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-5-haiku(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-3[-.]5-haiku(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3[-.]5-haiku(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3[-.]5-haiku(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.0000008,

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -394,6 +394,18 @@ CLAUDE_BEDROCK_VERTEX_CASES = [
     # Vertex AI — 3.x families keep number-first ordering, @date separator
     ("claude-3-5-sonnet@20241022", "claude-3-5-sonnet"),
     ("claude-3-5-haiku@20241022", "claude-3-5-haiku"),
+    # Dot-notation versions — gateways (e.g. OpenRouter) spell the version with a
+    # dot (4.8) where our slugs use a dash (4-8). Previously matched nothing and
+    # recorded $0. Issue #1581.
+    ("anthropic/claude-opus-4.8", "claude-opus-4-8"),
+    ("claude-opus-4.8", "claude-opus-4-8"),
+    ("anthropic/claude-opus-4.7", "claude-opus-4-7"),
+    ("anthropic/claude-opus-4.6", "claude-opus-4-6"),
+    ("anthropic/claude-opus-4.5", "claude-opus-4-5"),
+    ("anthropic/claude-sonnet-4.6", "claude-sonnet-4-6"),
+    ("anthropic/claude-sonnet-4.5", "claude-sonnet-4-5"),
+    ("anthropic/claude-haiku-4.5", "claude-haiku-4-5"),
+    ("anthropic/claude-3.5-sonnet", "claude-3-5-sonnet"),
 ]
 
 
@@ -413,6 +425,64 @@ class TestClaudeBedrockAndVertexIds:
     def test_unrelated_model_still_none(self, real_cache):
         with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
             assert get_model_price("totally-not-a-real-model-2099") is None
+
+
+# (model_id, expected fast modelName) — fast is a separately-priced tier that
+# must resolve to its OWN rate card, never the standard entry. Issue #1581.
+ANTHROPIC_FAST_CASES = [
+    ("anthropic/claude-opus-4.8-fast", "claude-opus-4-8-fast"),
+    ("anthropic/claude-opus-4-8-fast", "claude-opus-4-8-fast"),
+    ("claude-opus-4-8-fast", "claude-opus-4-8-fast"),
+    ("anthropic/claude-opus-4.7-fast", "claude-opus-4-7-fast"),
+    ("anthropic/claude-opus-4-7-fast", "claude-opus-4-7-fast"),
+]
+
+
+def _prices(cache: list[dict], model_name: str) -> dict:
+    return next(e["prices"] for e in cache if e["model_name"] == model_name)
+
+
+class TestAnthropicFastTier:
+    @pytest.mark.parametrize("model_id,expected_name", ANTHROPIC_FAST_CASES)
+    def test_fast_matches_its_own_rate_card(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+        assert price is not None, f"{model_id} should match a fast rate card"
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched {price[MATCHED_MODEL_NAME]}, expected {expected_name}"
+        )
+
+    def test_standard_traffic_never_hits_a_fast_card(self, real_cache):
+        # The critical guard: if a fast pattern swallowed non-fast traffic, 2x
+        # usage would bill at 1x — a silent undercharge, worse than the $0 the
+        # issue reports (a zero is visible; a half-price invoice is not).
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            for model_id in ("anthropic/claude-opus-4.8", "claude-opus-4-8"):
+                price = get_model_price(model_id)
+                assert price is not None
+                assert price[MATCHED_MODEL_NAME] == "claude-opus-4-8"
+
+    def test_opus_4_8_fast_rates(self, real_cache):
+        # Fast Opus 4.8 = 2x standard, verified against Anthropic's pricing page.
+        std = _prices(real_cache, "claude-opus-4-8")
+        fast = _prices(real_cache, "claude-opus-4-8-fast")
+        assert fast["input"] == 1e-05  # $10 / MTok
+        assert fast["output"] == 5e-05  # $50 / MTok
+        for key in ("input", "output", "cacheRead", "cacheWrite", "cacheWrite1h"):
+            assert fast[key] == pytest.approx(std[key] * 2), key
+
+    def test_opus_4_7_fast_is_6x_not_copied_from_4_8(self, real_cache):
+        # 4.7's premium is 6x; do NOT copy 4.8's 2x (or vice versa).
+        std = _prices(real_cache, "claude-opus-4-7")
+        fast = _prices(real_cache, "claude-opus-4-7-fast")
+        assert fast["input"] == 3e-05  # $30 / MTok
+        assert fast["output"] == 15e-05  # $150 / MTok
+        for key in ("input", "output", "cacheRead", "cacheWrite", "cacheWrite1h"):
+            assert fast[key] == pytest.approx(std[key] * 6), key
+
+    def test_opus_4_6_has_no_fast_card(self, real_cache):
+        # Opus 4.6 is not fast-capable; it must bill standard, not a fast rate.
+        assert all(e["model_name"] != "claude-opus-4-6-fast" for e in real_cache)
 
 
 def test_cost_from_buckets_prices_each_bucket_once():


### PR DESCRIPTION
## What

Two pricing gaps for Anthropic models sent through gateways, both in
`standard-model-prices.json`:

1. **Dot-notation versions** — gateways (e.g. OpenRouter) spell the version with
   a dot (`anthropic/claude-opus-4.8`), but the patterns only accept the dash
   form (`claude-opus-4-8`). So `get_model_price` returned `None` and the span
   recorded **$0** — affecting every current-generation Anthropic slug.
2. **No fast rate card** — fast is a separately-priced tier, not a cosmetic
   suffix, so `…-fast` traffic was also unpriced.

## Fix

- **Dot versions:** broaden the version separator to `[-.]` on the 9 affected
  Anthropic patterns (`claude-opus-4[-.]8`, …). This is surgical, per-entry — a
  blanket dot→dash normalization would corrupt `gpt-3.5-turbo`'s legitimate dot
  and Bedrock's separator dots (`us.anthropic.…`), so those are left untouched.
- **Fast tier:** add distinct rate cards `claude-opus-4-8-fast` (**2×** standard,
  $10/$50 per MTok) and `claude-opus-4-7-fast` (**6×**), each requiring the
  `-fast` suffix. Fast is a *dedicated* entry, never a relaxed pattern on the
  standard one: if a standard pattern swallowed `-fast`, 2× usage would bill at
  1× — a silent undercharge, worse than the visible $0. (Opus 4.6 is not
  fast-capable, so it gets no fast card and continues to bill standard.)

The JSON is the shared source for the Python worker (`worker/tokens/pricing`) and
the TS lookup (`packages/core/model-pricing`), which apply identical regex — so
one data fix covers both, and `sync-standard-prices.ts` upserts it on deploy.

## How validated

`tests/worker/tokens/test_pricing.py` (reads the real JSON via the `real_cache`
fixture — no DB, no LLM):

- **Dot versions** added to the Bedrock/Vertex matrix: `anthropic/claude-opus-4.8`
  → `claude-opus-4-8`, etc.; dash/Bedrock/Vertex forms still match.
- **New `TestAnthropicFastTier`:** each fast id resolves to its *own* card;
  standard traffic never hits a fast card; Opus 4.8 fast rates are exactly 2×
  (pinned to $10/$50) and Opus 4.7 fast is 6× (not copied from 4.8).

Results: `pytest tests/worker/tokens/test_pricing.py` → 200 passed; full backend
suite → 869 passed; TS `model-pricing.test.ts` → 11 passed; `ruff` clean.

## Scope

Covers the model-string case (OpenRouter puts the variant in the slug). The
Vercel AI Gateway / direct-API `speed: "fast"` paths can't be distinguished by
model string and have no affected customers today — out of scope, as the issue
notes.

Refs #1581


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zero-cost billing for Anthropic gateway slugs by matching dot-version model names, and adds dedicated fast-tier pricing for Opus 4.8 and 4.7 across both backends. Refs #1581.

- **Bug Fixes**
  - Broadened version separators to `[-.]` for nine Anthropic patterns (e.g., `claude-opus-4[-.]8`) so `anthropic/claude-opus-4.8` and similar slugs match and bill correctly; change is per-entry to avoid affecting other providers.

- **New Features**
  - Added fast-tier rate cards: `claude-opus-4-8-fast` (2× standard; $10/$50 per MTok) and `claude-opus-4-7-fast` (6×). `-fast` slugs resolve only to these cards; Opus 4.6 has no fast tier.

<sup>Written for commit 975e44921bba2a9778b3f252210c8a9ad304a776. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

