### PR TITLE
fix(ui): use lucide Check in model picker selected indicator

### DIFF
--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen } from "@testing-library/react";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   models: undefined as
@@ -91,5 +91,45 @@ describe("ModelSelector", () => {
       source: "system",
       adapter: "anthropic",
     });
+  });
+
+  it("renders the selected model indicator as an icon instead of a Unicode checkmark", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [
+            { id: "claude-4", label: "Claude 4" },
+            { id: "claude-3-5", label: "Claude 3.5" },
+          ],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{
+          model: "claude-4",
+          provider: "anthropic",
+          source: "system",
+          adapter: "anthropic",
+        }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /claude 4/i }));
+
+    const selectedOption = screen
+      .getAllByRole("button", { name: /claude 4/i })
+      .find((button) => button.className.includes("w-full"));
+    expect(selectedOption).toBeDefined();
+
+    expect(selectedOption.textContent).not.toContain("✓");
+    expect(selectedOption.querySelector("svg")).not.toBeNull();
   });
 });

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -432,7 +432,9 @@ describe("ModelSelector", () => {
     expect(screen.getByRole("button").textContent).not.toContain("Claude 4");
 
     fireEvent.click(screen.getByRole("button"));
-    const ticked = screen.getAllByRole("button").filter((b) => b.querySelector("svg") !== null && !b.hasAttribute("aria-haspopup"));
+    const ticked = screen
+      .getAllByRole("button")
+      .filter((b) => b.querySelector("svg") !== null && !b.hasAttribute("aria-haspopup"));
     expect(ticked).toHaveLength(0);
   });
 
@@ -548,7 +550,12 @@ describe("ModelSelector", () => {
 
     const ticked = screen
       .getAllByRole("button")
-      .filter((b) => b.querySelector("svg") !== null && b.textContent?.includes("Claude 4") && !b.hasAttribute("aria-haspopup"));
+      .filter(
+        (b) =>
+          b.querySelector("svg") !== null &&
+          b.textContent?.includes("Claude 4") &&
+          !b.hasAttribute("aria-haspopup"),
+      );
     expect(ticked).toHaveLength(1);
     // The BYOK row is the one carrying the provider tag.
     expect(ticked[0].textContent).not.toContain("My Anthropic");

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { ChevronDown } from "lucide-react";
+import { Check, ChevronDown } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -134,7 +134,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
                 }}
               >
                 <span className="flex items-center gap-1.5">
-                  {isSelected && <span className="text-[11px]">&#10003;</span>}
+                  {isSelected && <Check aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />}
                   {m.label}
                   {m.source === "byok" && !m.supported && (
                     <span className="text-[10px] text-yellow-600">(unsupported)</span>


### PR DESCRIPTION
Fixes #1584

## Summary

The AI model picker still used a Unicode ✓ for the selected item, while other dropdowns use lucide Check. This swaps that indicator to lucide Check so it matches the rest of the UI.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

- Replaced the Unicode check (`✓`) in `model-selector.tsx` with lucide `Check`
- Added a regression test to confirm the selected option renders an SVG icon, not a Unicode checkmark
- Left status badges (`CheckCircle2`) and the optional Slack toast alone

## Screenshots / Recordings (if applicable)

<img width="1920" height="1080" alt="Screenshot (53)" src="https://github.com/user-attachments/assets/2134ad43-8a3e-4648-91dd-4c526ea005cf" />
<img width="1920" height="1080" alt="Screenshot (54)" src="https://github.com/user-attachments/assets/90289172-65a5-4edb-85b5-ff3b8e2d7c0b" />

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary
