### PR TITLE
Fix detector Agent Model dirty state for saved BYOK models

### DIFF
--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { getAvailableLLMModels } from "@/lib/api";
-import { flattenAvailableModels, pickDefaultModel } from "../lib/resolve-model";
+import { flattenAvailableModels, reconcileModelSelection } from "../lib/resolve-model";
 
 export interface ModelSelection {
   model: string;

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -13,7 +13,7 @@ export interface ModelSelection {
   model: string;
   provider: string;
   source: "system" | "byok";
-  adapter: string; // e.g. "anthropic" | "openai" — needed for SDK routing
+  adapter: string; // e.g. "anthropic" | "openai" - needed for SDK routing
 }
 
 interface ModelSelectorProps {
@@ -54,7 +54,7 @@ export function ModelSelector({
   const models = flattenAvailableModels(data, isPending);
 
   // Reconcile the incoming selection against the catalog:
-  //   1. exact match on (model, provider, source) → check adapter; backfill if empty/wrong
+  //   1. exact match on (model, provider, source): check adapter; backfill if empty/wrong
   //   2. model-id-only match (legacy/hydrated state where the parent only has
   //      `model` saved, e.g. `project.rca_model: string`) → backfill the rest
   //   3. no match → preserve the current selection if the user already picked
@@ -69,49 +69,14 @@ export function ModelSelector({
   useEffect(() => {
     if (isPending) return;
 
-    const exact = models.find(
-      (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,
-    );
-    // Prefer the selection's own source: the list is BYOK-first and not
-    // deduplicated, so a bare id could bind a system selection to a BYOK
-    // provider sharing that id — same name, different credentials at run time.
-    const modelOnly =
-      !exact && value.model && !value.provider
-        ? (models.find((m) => m.id === value.model && m.source === value.source) ??
-          models.find((m) => m.id === value.model))
-        : null;
-    const match = exact ?? modelOnly;
-
-    if (!match) {
-      if (!value.model && !defaultModelId) {
-        const pick = pickDefaultModel(models);
-        if (pick) {
-          onChange({
-            model: pick.id,
-            provider: pick.provider,
-            source: pick.source,
-            adapter: pick.adapter,
-          });
-        }
-      }
-      return;
-    }
-
-    // Match found — backfill any stale/empty fields (notably `adapter`, which
-    // legacy selections often store as `""` and which `currentExists`-style
-    // checks elsewhere ignore).
+    const next = reconcileModelSelection(value, models, { pickDefaultWhenEmpty: !defaultModelId });
     if (
-      match.id !== value.model ||
-      match.provider !== value.provider ||
-      match.source !== value.source ||
-      match.adapter !== value.adapter
+      next.model !== value.model ||
+      next.provider !== value.provider ||
+      next.source !== value.source ||
+      next.adapter !== value.adapter
     ) {
-      onChange({
-        model: match.id,
-        provider: match.provider,
-        source: match.source,
-        adapter: match.adapter,
-      });
+      onChange(next);
     }
   }, [models, value, onChange, isPending, defaultModelId]);
 
@@ -153,7 +118,7 @@ export function ModelSelector({
           {models.map((m) => {
             const key = modelKey(m);
             const isSelected = key === selectedKey;
-            // Show provider tag for BYOK models to distinguish from system ones
+            // Show provider tag for BYOK models to distinguish from system ones.
             const showProvider = m.source === "byok";
             return (
               <button

--- a/frontend/ui/src/features/ai-assistant/lib/resolve-model.ts
+++ b/frontend/ui/src/features/ai-assistant/lib/resolve-model.ts
@@ -97,7 +97,10 @@ export function reconcileModelSelection(
     (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,
   );
   const modelOnly =
-    !exact && value.model && !value.provider ? models.find((m) => m.id === value.model) : null;
+    !exact && value.model && !value.provider
+      ? (models.find((m) => m.id === value.model && m.source === value.source) ??
+        models.find((m) => m.id === value.model))
+      : null;
   const match = exact ?? modelOnly;
 
   if (match) {

--- a/frontend/ui/src/features/ai-assistant/lib/resolve-model.ts
+++ b/frontend/ui/src/features/ai-assistant/lib/resolve-model.ts
@@ -27,6 +27,13 @@ export interface ResolvedModel {
   supported?: boolean;
 }
 
+export interface ModelSelectionLike {
+  model: string;
+  provider: string;
+  source: "system" | "byok";
+  adapter: string;
+}
+
 const FALLBACK_MODELS: ResolvedModel[] = SYSTEM_MODELS.flatMap((s) =>
   s.models.map((m) => ({
     id: m.id,
@@ -77,4 +84,42 @@ export function pickDefaultModel(models: ResolvedModel[]): ResolvedModel | undef
     if (match) return match;
   }
   return usable[0];
+}
+
+export function reconcileModelSelection(
+  value: ModelSelectionLike,
+  models: ResolvedModel[],
+  options: { pickDefaultWhenEmpty?: boolean } = {},
+): ModelSelectionLike {
+  if (models.length === 0) return value;
+
+  const exact = models.find(
+    (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,
+  );
+  const modelOnly =
+    !exact && value.model && !value.provider ? models.find((m) => m.id === value.model) : null;
+  const match = exact ?? modelOnly;
+
+  if (match) {
+    return {
+      model: match.id,
+      provider: match.provider,
+      source: match.source,
+      adapter: match.adapter,
+    };
+  }
+
+  if (!value.model && options.pickDefaultWhenEmpty) {
+    const pick = pickDefaultModel(models);
+    if (pick) {
+      return {
+        model: pick.id,
+        provider: pick.provider,
+        source: pick.source,
+        adapter: pick.adapter,
+      };
+    }
+  }
+
+  return value;
 }

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
@@ -43,6 +43,7 @@ const mocks = vi.hoisted(() => ({
     | ((value: ModelSelectionMock) => ModelSelectionMock)
     | undefined,
   selectModel: undefined as ModelSelectionMock | undefined,
+  getAvailableLLMModels: undefined as (() => Promise<unknown>) | undefined,
 }));
 
 vi.mock("@/features/projects/hooks", () => ({
@@ -50,7 +51,8 @@ vi.mock("@/features/projects/hooks", () => ({
 }));
 vi.mock("@/lib/api", () => ({
   updateProject: (...a: unknown[]) => mocks.updateProject(...a),
-  getAvailableLLMModels: () => Promise.resolve(mocks.llmModels),
+  getAvailableLLMModels: () =>
+    mocks.getAvailableLLMModels?.() ?? Promise.resolve(mocks.llmModels),
 }));
 vi.mock("@/features/integrations/hooks/useSlackIntegration", () => ({
   useSlackStatus: () => ({ data: undefined }),
@@ -162,6 +164,7 @@ afterEach(() => {
   mocks.llmModels.systemModels = [];
   mocks.modelSelectorReconcile = undefined;
   mocks.selectModel = undefined;
+  mocks.getAvailableLLMModels = undefined;
 });
 
 describe("DetectorsTab agent model", () => {
@@ -241,6 +244,33 @@ describe("DetectorsTab agent model", () => {
 
     const save = screen.getAllByRole("button", { name: "Save" })[0] as HTMLButtonElement;
     expect(save.disabled).toBe(false);
+  });
+
+  it("keeps Save disabled while the model query is still using the selector fallback catalog", async () => {
+    mocks.project.rca_model = "claude-opus-4-8";
+    mocks.project.rca_provider = null;
+    mocks.project.rca_source = null;
+    mocks.getAvailableLLMModels = () => new Promise(() => {});
+    mocks.modelSelectorReconcile = (value) =>
+      value.model === "claude-opus-4-8"
+        ? {
+            model: "claude-opus-4-8",
+            provider: "Anthropic",
+            source: "system",
+            adapter: "anthropic",
+          }
+        : value;
+
+    renderTab();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /agent model selector/i }).textContent).toContain(
+        "claude-opus-4-8",
+      ),
+    );
+
+    const save = screen.getAllByRole("button", { name: "Save" })[0] as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
   });
 });
 

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
@@ -9,6 +9,20 @@ const mocks = vi.hoisted(() => ({
     alert_window: "10m",
   } as any,
   updateProject: vi.fn().mockResolvedValue({}),
+  llmModels: {
+    byokProviders: [] as Array<{
+      provider: string;
+      adapter: string;
+      source: "byok";
+      models: Array<{ id: string; label: string; supported?: boolean }>;
+    }>,
+    systemModels: [] as Array<{
+      provider: string;
+      adapter: string;
+      source: "system";
+      models: Array<{ id: string; label: string; supported?: boolean }>;
+    }>,
+  },
   modelSelectorReconcile: undefined as
     | ((value: {
         model: string;
@@ -37,6 +51,7 @@ vi.mock("@/features/projects/hooks", () => ({
 }));
 vi.mock("@/lib/api", () => ({
   updateProject: (...a: any[]) => mocks.updateProject(...a),
+  getAvailableLLMModels: () => Promise.resolve(mocks.llmModels),
 }));
 vi.mock("@/features/integrations/hooks/useSlackIntegration", () => ({
   useSlackStatus: () => ({ data: undefined }),
@@ -144,6 +159,8 @@ afterEach(() => {
     rca_provider: undefined,
     rca_source: undefined,
   });
+  mocks.llmModels.byokProviders = [];
+  mocks.llmModels.systemModels = [];
   mocks.modelSelectorReconcile = undefined;
   mocks.selectModel = undefined;
 });
@@ -153,6 +170,14 @@ describe("DetectorsTab agent model", () => {
     mocks.project.rca_model = "claude-opus-4-8";
     mocks.project.rca_provider = null;
     mocks.project.rca_source = null;
+    mocks.llmModels.byokProviders = [
+      {
+        provider: "anthropic",
+        adapter: "anthropic",
+        source: "byok",
+        models: [{ id: "claude-opus-4-8", label: "claude-opus-4-8", supported: true }],
+      },
+    ];
     mocks.modelSelectorReconcile = (value) =>
       value.model === "claude-opus-4-8"
         ? {
@@ -171,14 +196,24 @@ describe("DetectorsTab agent model", () => {
       ),
     );
 
-    const save = screen.getAllByRole("button", { name: "Save" })[0] as HTMLButtonElement;
-    expect(save.disabled).toBe(true);
+    await waitFor(() => {
+      const save = screen.getAllByRole("button", { name: "Save" })[0] as HTMLButtonElement;
+      expect(save.disabled).toBe(true);
+    });
   });
 
   it("enables Save when the user selects a genuinely different model", async () => {
     mocks.project.rca_model = "claude-opus-4-8";
     mocks.project.rca_provider = null;
     mocks.project.rca_source = null;
+    mocks.llmModels.byokProviders = [
+      {
+        provider: "anthropic",
+        adapter: "anthropic",
+        source: "byok",
+        models: [{ id: "claude-opus-4-8", label: "claude-opus-4-8", supported: true }],
+      },
+    ];
     mocks.modelSelectorReconcile = (value) =>
       value.model === "claude-opus-4-8"
         ? {

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
@@ -51,8 +51,7 @@ vi.mock("@/features/projects/hooks", () => ({
 }));
 vi.mock("@/lib/api", () => ({
   updateProject: (...a: unknown[]) => mocks.updateProject(...a),
-  getAvailableLLMModels: () =>
-    mocks.getAvailableLLMModels?.() ?? Promise.resolve(mocks.llmModels),
+  getAvailableLLMModels: () => mocks.getAvailableLLMModels?.() ?? Promise.resolve(mocks.llmModels),
 }));
 vi.mock("@/features/integrations/hooks/useSlackIntegration", () => ({
   useSlackStatus: () => ({ data: undefined }),

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
@@ -9,6 +9,27 @@ const mocks = vi.hoisted(() => ({
     alert_window: "10m",
   } as any,
   updateProject: vi.fn().mockResolvedValue({}),
+  modelSelectorReconcile: undefined as
+    | ((value: {
+        model: string;
+        provider: string;
+        source: "system" | "byok";
+        adapter: string;
+      }) => {
+        model: string;
+        provider: string;
+        source: "system" | "byok";
+        adapter: string;
+      })
+    | undefined,
+  selectModel: undefined as
+    | {
+        model: string;
+        provider: string;
+        source: "system" | "byok";
+        adapter: string;
+      }
+    | undefined,
 }));
 
 vi.mock("@/features/projects/hooks", () => ({
@@ -20,8 +41,52 @@ vi.mock("@/lib/api", () => ({
 vi.mock("@/features/integrations/hooks/useSlackIntegration", () => ({
   useSlackStatus: () => ({ data: undefined }),
 }));
-vi.mock("@/features/ai-assistant/components/model-selector", () => ({
-  ModelSelector: () => null,
+vi.mock("@/features/ai-assistant/components/model-selector", async () => {
+  const React = await import("react");
+  return {
+    ModelSelector: ({
+      value,
+      onChange,
+    }: {
+      value: {
+        model: string;
+        provider: string;
+        source: "system" | "byok";
+        adapter: string;
+      };
+      onChange: (value: {
+        model: string;
+        provider: string;
+        source: "system" | "byok";
+        adapter: string;
+      }) => void;
+    }) => {
+      React.useEffect(() => {
+        const next = mocks.modelSelectorReconcile?.(value);
+        if (
+          next &&
+          (next.model !== value.model ||
+            next.provider !== value.provider ||
+            next.source !== value.source ||
+            next.adapter !== value.adapter)
+        ) {
+          onChange(next);
+        }
+      }, [value, onChange]);
+
+      return (
+        <button
+          type="button"
+          aria-label="agent model selector"
+          onClick={() => {
+            if (mocks.selectModel) onChange(mocks.selectModel);
+          }}
+        >
+          {value.model || "Select model"}
+        </button>
+      );
+    },
+  };
 }));
 vi.mock("@/features/detectors/components/alert-channels-editor", () => ({
   AlertChannelsEditor: () => null,
@@ -71,7 +136,78 @@ function renderTab() {
 afterEach(() => {
   cleanup();
   mocks.updateProject.mockReset().mockResolvedValue({});
-  mocks.project.alert_window = "10m";
+  Object.assign(mocks.project, {
+    workspace_id: "w1",
+    alert_emails: [],
+    alert_window: "10m",
+    rca_model: undefined,
+    rca_provider: undefined,
+    rca_source: undefined,
+  });
+  mocks.modelSelectorReconcile = undefined;
+  mocks.selectModel = undefined;
+});
+
+describe("DetectorsTab agent model", () => {
+  it("keeps Save disabled when a legacy id-only saved BYOK model reconciles to the displayed selection", async () => {
+    mocks.project.rca_model = "claude-opus-4-8";
+    mocks.project.rca_provider = null;
+    mocks.project.rca_source = null;
+    mocks.modelSelectorReconcile = (value) =>
+      value.model === "claude-opus-4-8"
+        ? {
+            model: "claude-opus-4-8",
+            provider: "anthropic",
+            source: "byok",
+            adapter: "anthropic",
+          }
+        : value;
+
+    renderTab();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /agent model selector/i }).textContent).toContain(
+        "claude-opus-4-8",
+      ),
+    );
+
+    const save = screen.getAllByRole("button", { name: "Save" })[0] as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
+
+  it("enables Save when the user selects a genuinely different model", async () => {
+    mocks.project.rca_model = "claude-opus-4-8";
+    mocks.project.rca_provider = null;
+    mocks.project.rca_source = null;
+    mocks.modelSelectorReconcile = (value) =>
+      value.model === "claude-opus-4-8"
+        ? {
+            model: "claude-opus-4-8",
+            provider: "anthropic",
+            source: "byok",
+            adapter: "anthropic",
+          }
+        : value;
+    mocks.selectModel = {
+      model: "gpt-5",
+      provider: "openai",
+      source: "system",
+      adapter: "openai",
+    };
+
+    renderTab();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /agent model selector/i }).textContent).toContain(
+        "claude-opus-4-8",
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /agent model selector/i }));
+
+    const save = screen.getAllByRole("button", { name: "Save" })[0] as HTMLButtonElement;
+    expect(save.disabled).toBe(false);
+  });
 });
 
 describe("DetectorsTab alert window", () => {

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
@@ -87,7 +87,7 @@ vi.mock("@/features/ai-assistant/components/model-selector", async () => {
       );
     },
   };
-}));
+});
 vi.mock("@/features/detectors/components/alert-channels-editor", () => ({
   AlertChannelsEditor: () => null,
 }));

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
@@ -2,12 +2,28 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
 
+type ProjectMock = {
+  workspace_id: string;
+  alert_emails: string[];
+  alert_window: string;
+  rca_model?: string | null;
+  rca_provider?: string | null;
+  rca_source?: string | null;
+};
+
+type ModelSelectionMock = {
+  model: string;
+  provider: string;
+  source: "system" | "byok";
+  adapter: string;
+};
+
 const mocks = vi.hoisted(() => ({
   project: {
     workspace_id: "w1",
     alert_emails: [] as string[],
     alert_window: "10m",
-  } as any,
+  } as ProjectMock,
   updateProject: vi.fn().mockResolvedValue({}),
   llmModels: {
     byokProviders: [] as Array<{
@@ -24,33 +40,16 @@ const mocks = vi.hoisted(() => ({
     }>,
   },
   modelSelectorReconcile: undefined as
-    | ((value: {
-        model: string;
-        provider: string;
-        source: "system" | "byok";
-        adapter: string;
-      }) => {
-        model: string;
-        provider: string;
-        source: "system" | "byok";
-        adapter: string;
-      })
+    | ((value: ModelSelectionMock) => ModelSelectionMock)
     | undefined,
-  selectModel: undefined as
-    | {
-        model: string;
-        provider: string;
-        source: "system" | "byok";
-        adapter: string;
-      }
-    | undefined,
+  selectModel: undefined as ModelSelectionMock | undefined,
 }));
 
 vi.mock("@/features/projects/hooks", () => ({
   useProject: () => ({ data: mocks.project, isLoading: false }),
 }));
 vi.mock("@/lib/api", () => ({
-  updateProject: (...a: any[]) => mocks.updateProject(...a),
+  updateProject: (...a: unknown[]) => mocks.updateProject(...a),
   getAvailableLLMModels: () => Promise.resolve(mocks.llmModels),
 }));
 vi.mock("@/features/integrations/hooks/useSlackIntegration", () => ({

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.test.tsx
@@ -250,15 +250,6 @@ describe("DetectorsTab agent model", () => {
     mocks.project.rca_provider = null;
     mocks.project.rca_source = null;
     mocks.getAvailableLLMModels = () => new Promise(() => {});
-    mocks.modelSelectorReconcile = (value) =>
-      value.model === "claude-opus-4-8"
-        ? {
-            model: "claude-opus-4-8",
-            provider: "Anthropic",
-            source: "system",
-            adapter: "anthropic",
-          }
-        : value;
 
     renderTab();
 

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { ArrowUpRight, Clock, Mail } from "lucide-react";
 import { FaSlack } from "react-icons/fa";
@@ -14,13 +14,17 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { ALERT_WINDOWS, DEFAULT_ALERT_WINDOW, type AlertWindow } from "@traceroot/core";
-import { updateProject } from "@/lib/api";
+import { getAvailableLLMModels, updateProject } from "@/lib/api";
 import { useProject } from "@/features/projects/hooks";
 import { useSlackStatus } from "@/features/integrations/hooks/useSlackIntegration";
 import {
   ModelSelector,
   type ModelSelection,
 } from "@/features/ai-assistant/components/model-selector";
+import {
+  flattenAvailableModels,
+  reconcileModelSelection,
+} from "@/features/ai-assistant/lib/resolve-model";
 import { AlertChannelsEditor } from "@/features/detectors/components/alert-channels-editor";
 
 interface DetectorsTabProps {
@@ -31,6 +35,11 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
   const queryClient = useQueryClient();
   const { data: project, isLoading } = useProject(projectId);
   const { data: slack } = useSlackStatus(project?.workspace_id);
+  const { data: llmModelData } = useQuery({
+    queryKey: ["llm-models", project?.workspace_id],
+    queryFn: () => getAvailableLLMModels(project!.workspace_id!),
+    enabled: !!project?.workspace_id,
+  });
 
   const [agentModelSelection, setAgentModelSelection] = useState<ModelSelection>({
     model: "",
@@ -90,10 +99,20 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
     },
   });
 
+  const savedAgentModelSelection: ModelSelection = {
+    model: project?.rca_model ?? "",
+    provider: project?.rca_provider ?? "",
+    source: (project?.rca_source as "system" | "byok") ?? "system",
+    adapter: "",
+  };
+  const savedAgentModelBaseline = reconcileModelSelection(
+    savedAgentModelSelection,
+    llmModelData ? flattenAvailableModels(llmModelData) : [],
+  );
   const isModelDirty =
-    agentModelSelection.model !== (project?.rca_model ?? "") ||
-    agentModelSelection.provider !== (project?.rca_provider ?? "") ||
-    agentModelSelection.source !== (project?.rca_source ?? "system");
+    agentModelSelection.model !== savedAgentModelBaseline.model ||
+    agentModelSelection.provider !== savedAgentModelBaseline.provider ||
+    agentModelSelection.source !== savedAgentModelBaseline.source;
   const savedEmails = project?.alert_emails ?? [];
   const isEmailsDirty =
     emailAddresses.length !== savedEmails.length ||

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
@@ -107,7 +107,7 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
   };
   const savedAgentModelBaseline = reconcileModelSelection(
     savedAgentModelSelection,
-    llmModelData ? flattenAvailableModels(llmModelData) : [],
+    flattenAvailableModels(llmModelData),
   );
   const isModelDirty =
     agentModelSelection.model !== savedAgentModelBaseline.model ||

--- a/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
+++ b/frontend/ui/src/features/settings/project/components/DetectorsTab.tsx
@@ -35,7 +35,7 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
   const queryClient = useQueryClient();
   const { data: project, isLoading } = useProject(projectId);
   const { data: slack } = useSlackStatus(project?.workspace_id);
-  const { data: llmModelData } = useQuery({
+  const { data: llmModelData, isPending: isLlmModelPending } = useQuery({
     queryKey: ["llm-models", project?.workspace_id],
     queryFn: () => getAvailableLLMModels(project!.workspace_id!),
     enabled: !!project?.workspace_id,
@@ -105,10 +105,12 @@ export function DetectorsTab({ projectId }: DetectorsTabProps) {
     source: (project?.rca_source as "system" | "byok") ?? "system",
     adapter: "",
   };
-  const savedAgentModelBaseline = reconcileModelSelection(
-    savedAgentModelSelection,
-    flattenAvailableModels(llmModelData),
-  );
+  const savedAgentModelBaseline = isLlmModelPending
+    ? savedAgentModelSelection
+    : reconcileModelSelection(
+        savedAgentModelSelection,
+        flattenAvailableModels(llmModelData, isLlmModelPending),
+      );
   const isModelDirty =
     agentModelSelection.model !== savedAgentModelBaseline.model ||
     agentModelSelection.provider !== savedAgentModelBaseline.provider ||


### PR DESCRIPTION
Fixes #1585

## Summary

Fixes the Detectors settings Agent Model Save button staying enabled when a saved BYOK model is already correctly selected.

## Type of Change

- [ ] feat - A new feature
- [x] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

The Agent Model selector can backfill provider/source details for older saved project values that only have `rca_model`.

Before this change, Detectors settings compared the reconciled selector value against the raw project fields, so Save appeared enabled even when the displayed model was already saved.

This change compares against the same reconciled model selection, so Save stays disabled on load when there are no real changes. Selecting a different model still enables Save.

## Screenshots / Recordings (if applicable)

<img width="1920" height="1080" alt="Screenshot (56)" src="https://github.com/user-attachments/assets/0511be85-9fad-4537-affe-c4861923ff59" />
<img width="1920" height="1080" alt="Screenshot (57)" src="https://github.com/user-attachments/assets/73e4f897-60b8-40cd-8ada-db1e8e2ebe11" />


## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Agent Model Save button so it only enables on real changes, including legacy BYOK values. Save stays disabled while the LLM model catalog is loading and until the saved selection is reconciled.

- **Bug Fixes**
  - Added `reconcileModelSelection` in `resolve-model.ts` and used it in `ModelSelector` to normalize selections (exact or model-only) and backfill `adapter/provider/source`, with an optional default when empty.
  - `DetectorsTab` now fetches models via `getAvailableLLMModels`, flattens with `flattenAvailableModels(llmModelData, isLlmModelPending)`, and reconciles the saved selection before dirty checks so the selector fallback is respected and Save stays disabled until the real catalog resolves.
  - Expanded tests to cover id-only BYOK reconciliation, switching to a different model enabling Save, and a never-resolving catalog keeping Save disabled; tightened mock typing.

<sup>Written for commit 9ae10b4fce5dd8111fd3a8461d99cccfd09de5f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

