### PR TITLE
fix(pricing): price fast-mode and dot-notation Anthropic model ids

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -39,6 +39,19 @@
     }
   },
   {
+    "id": "tr-claude-opus-4-7-fast",
+    "modelName": "claude-opus-4-7-fast",
+    "matchPattern": "(?i)^(anthropic\\/)?claude-opus-4[.-]7-fast$",
+    "provider": "anthropic",
+    "prices": {
+      "input": 0.00003,
+      "output": 0.00015,
+      "cacheRead": 0.000003,
+      "cacheWrite": 0.0000375,
+      "cacheWrite1h": 0.00006
+    }
+  },
+  {
     "id": "tr-claude-opus-4-7",
     "modelName": "claude-opus-4-7",
     "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4[.-]7(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-7-opus(@[\\d-]+)?)$",
@@ -672,7 +685,7 @@
   {
     "id": "tr-claude-3-5-sonnet",
     "modelName": "claude-3-5-sonnet",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-5-sonnet(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-sonnet(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-5-sonnet(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-3[.-]5-sonnet(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-sonnet(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-5-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -685,7 +698,7 @@
   {
     "id": "tr-claude-3-5-haiku",
     "modelName": "claude-3-5-haiku",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-3-5-haiku(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-haiku(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-5-haiku(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-3[.-]5-haiku(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-3-5-haiku(-[\\d-]+)?(-v\\d+:\\d+)?|claude-3-5-haiku(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.0000008,

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -13,9 +13,22 @@
     }
   },
   {
+    "id": "tr-claude-opus-4-8-fast",
+    "modelName": "claude-opus-4-8-fast",
+    "matchPattern": "(?i)^(anthropic\\/)?claude-opus-4[.-]8-fast$",
+    "provider": "anthropic",
+    "prices": {
+      "input": 0.00001,
+      "output": 0.00005,
+      "cacheRead": 0.000001,
+      "cacheWrite": 0.0000125,
+      "cacheWrite1h": 0.00002
+    }
+  },
+  {
     "id": "tr-claude-opus-4-8",
     "modelName": "claude-opus-4-8",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-8(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-8-opus(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4[.-]8(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-8(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-8-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000005,
@@ -28,7 +41,7 @@
   {
     "id": "tr-claude-opus-4-7",
     "modelName": "claude-opus-4-7",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-7(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-7-opus(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4[.-]7(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-7(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-7-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000005,
@@ -41,7 +54,7 @@
   {
     "id": "tr-claude-opus-4-6",
     "modelName": "claude-opus-4-6",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-6(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-6-opus(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4[.-]6(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-6-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000005,
@@ -67,7 +80,7 @@
   {
     "id": "tr-claude-sonnet-4-6",
     "modelName": "claude-sonnet-4-6",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-6(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-6-sonnet(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4[.-]6(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-6(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-6-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -80,7 +93,7 @@
   {
     "id": "tr-claude-opus-4-5",
     "modelName": "claude-opus-4-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4-5(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-opus(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-4[.-]5(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000005,
@@ -93,7 +106,7 @@
   {
     "id": "tr-claude-sonnet-4-5",
     "modelName": "claude-sonnet-4-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4-5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-sonnet(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-sonnet-4[.-]5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-sonnet-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-sonnet(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000003,
@@ -106,7 +119,7 @@
   {
     "id": "tr-claude-haiku-4-5",
     "modelName": "claude-haiku-4-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-haiku-4-5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-haiku(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-haiku-4[.-]5(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-haiku-4-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-4-5-haiku(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000001,

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -438,6 +438,12 @@ CLAUDE_FAST_AND_DOT_CASES = [
     ("anthropic/claude-sonnet-4.6", "claude-sonnet-4-6"),
     ("claude-sonnet-4.5", "claude-sonnet-4-5"),
     ("claude-haiku-4.5", "claude-haiku-4-5"),
+    # Fast mode on Opus 4.7 — separately priced at 6x standard (not 4.8's 2x)
+    ("anthropic/claude-opus-4.7-fast", "claude-opus-4-7-fast"),
+    ("claude-opus-4-7-fast", "claude-opus-4-7-fast"),
+    # Dot notation on legacy 3.x first-party ids
+    ("anthropic/claude-3.5-sonnet", "claude-3-5-sonnet"),
+    ("claude-3.5-haiku", "claude-3-5-haiku"),
 ]
 
 
@@ -467,6 +473,18 @@ class TestClaudeFastAndDotNotationIds:
         std = next(e for e in real_cache if e["model_name"] == "claude-opus-4-8")
         for key in ("input", "output", "cacheRead", "cacheWrite", "cacheWrite1h"):
             assert fast["prices"][key] == pytest.approx(std["prices"][key] * 2), key
+
+    def test_opus_4_7_fast_is_6x_not_copied_from_4_8(self, real_cache):
+        fast = next(e for e in real_cache if e["model_name"] == "claude-opus-4-7-fast")
+        std = next(e for e in real_cache if e["model_name"] == "claude-opus-4-7")
+        assert fast["prices"]["input"] == 3e-05  # $30 / MTok
+        assert fast["prices"]["output"] == 15e-05  # $150 / MTok
+        for key in ("input", "output", "cacheRead", "cacheWrite", "cacheWrite1h"):
+            assert fast["prices"][key] == pytest.approx(std["prices"][key] * 6), key
+
+    def test_opus_4_6_has_no_fast_card(self, real_cache):
+        # Opus 4.6 fast bills standard upstream; a 4.6 fast entry would over-charge.
+        assert all(e["model_name"] != "claude-opus-4-6-fast" for e in real_cache)
 
 
 def test_cost_from_buckets_prices_each_bucket_once():

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -1,6 +1,7 @@
 """Unit tests for model pricing and cost calculation."""
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import patch
 
@@ -413,6 +414,59 @@ class TestClaudeBedrockAndVertexIds:
     def test_unrelated_model_still_none(self, real_cache):
         with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
             assert get_model_price("totally-not-a-real-model-2099") is None
+
+
+# ---------------------------------------------------------------------------
+# Fast-mode variant + dot-notation model ids.
+# Some gateways spell versions with dots (claude-opus-4.8) and expose fast
+# mode as a distinct -fast slug billed at 2x standard.
+# ---------------------------------------------------------------------------
+
+
+CLAUDE_FAST_AND_DOT_CASES = [
+    # Fast mode — gateway slug, bare dot form, dashed canonical form
+    ("anthropic/claude-opus-4.8-fast", "claude-opus-4-8-fast"),
+    ("claude-opus-4.8-fast", "claude-opus-4-8-fast"),
+    ("claude-opus-4-8-fast", "claude-opus-4-8-fast"),
+    # Dot notation on current-gen first-party ids
+    ("anthropic/claude-opus-4.8", "claude-opus-4-8"),
+    ("claude-opus-4.8", "claude-opus-4-8"),
+    ("claude-opus-4.8[1m]", "claude-opus-4-8"),
+    ("claude-opus-4.7", "claude-opus-4-7"),
+    ("claude-opus-4.6", "claude-opus-4-6"),
+    ("claude-opus-4.5", "claude-opus-4-5"),
+    ("anthropic/claude-sonnet-4.6", "claude-sonnet-4-6"),
+    ("claude-sonnet-4.5", "claude-sonnet-4-5"),
+    ("claude-haiku-4.5", "claude-haiku-4-5"),
+]
+
+
+class TestClaudeFastAndDotNotationIds:
+    @pytest.mark.parametrize("model_id,expected_name", CLAUDE_FAST_AND_DOT_CASES)
+    def test_matches_expected_model(self, real_cache, model_id, expected_name):
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            price = get_model_price(model_id)
+        assert price is not None, f"{model_id} should match a pricing entry but returned None"
+        assert price[MATCHED_MODEL_NAME] == expected_name, (
+            f"{model_id} matched a different entry than {expected_name}"
+        )
+
+    @pytest.mark.parametrize("model_id,expected_name", CLAUDE_FAST_AND_DOT_CASES)
+    def test_matches_exactly_one_entry(self, real_cache, model_id, expected_name):
+        matching = [
+            e["model_name"]
+            for e in real_cache
+            if re.search(e["match_pattern"], model_id, re.IGNORECASE)
+        ]
+        assert matching == [expected_name], (
+            f"{model_id} must match exactly the {expected_name} pattern, got {matching}"
+        )
+
+    def test_fast_prices_are_double_standard(self, real_cache):
+        fast = next(e for e in real_cache if e["model_name"] == "claude-opus-4-8-fast")
+        std = next(e for e in real_cache if e["model_name"] == "claude-opus-4-8")
+        for key in ("input", "output", "cacheRead", "cacheWrite", "cacheWrite1h"):
+            assert fast["prices"][key] == pytest.approx(std["prices"][key] * 2), key
 
 
 def test_cost_from_buckets_prices_each_bucket_once():


### PR DESCRIPTION
Fixes #1581

## Problem

A customer's `anthropic/claude-opus-4.8-fast` spans recorded no cost. Two independent causes:

1. **No fast rate card.** Fast mode is a real, separately priced tier — $10/$50 per MTok on Opus 4.8, exactly 2x standard — that some gateways expose as a distinct `-fast` model slug. No entry matched it.
2. **Dot notation.** Gateways spell versions with dots (`claude-opus-4.8`); our first-party patterns only accepted dashes. This zeroed costs for every current-gen Anthropic model for that customer, not just fast traffic.

## Change

- New `claude-opus-4-8-fast` entry: input/output/cacheRead/cacheWrite/cacheWrite1h all exactly 2x the standard Opus 4.8 entry, matching Anthropic's published fast-mode rates (cache multipliers apply on top of the fast base, per their pricing docs).
- Dot-tolerant first-party patterns (`4[.-]8` etc.) on the 7 current-gen Anthropic entries. Bedrock/Vertex pattern branches keep dashes (those platforms genuinely use dashes).

Also adopted from #1587 by @hassaanch23 (co-author credit on the commit), who independently built the same fix and caught two things this PR originally lacked:
- An **Opus 4.7 fast** entry ($30/$150 = 6x standard, cache derived from the fast base) — prices historical fast spans from before Anthropic's 2026-07-24 removal of 4.7 fast. A dedicated test locks it at 6x so neither tier's rate can be copy-forwarded to the other.
- **Legacy 3.x dot tolerance** (`claude-3.5-sonnet` / `claude-3.5-haiku` are real old gateway slugs), first-party alternative only.

Deliberately excluded: Opus 4.6 fast (bills standard since 2026-06-29; adding it would over-charge — now enforced by a `test_opus_4_6_has_no_fast_card` guard, also adopted from #1587).

Complementary to #1566 (gateway prefix stripping, #1556) and independent of it: that PR normalizes `openrouter/anthropic/...` prefixes, this one adds the fast rate card and dot tolerance those normalized strings still need.

Note on rollout: prices reach the backend via the startup sync (`syncStandardPrices`) into Postgres, so the new entry takes effect when the worker/agent services next start — no manual migration needed.

## Tests

- `TestClaudeFastAndDotNotationIds`: 12 model-id cases — including all four repro strings from #1581 (`anthropic/claude-opus-4.8-fast`, `anthropic/claude-opus-4.8`, `anthropic/claude-sonnet-4.6`, and the dash form) — each asserting resolution to the exact expected entry **and** that exactly one pattern matches (guards the undercharge trap where a loosened pattern could swallow `-fast` into the standard entry), plus a lock that every fast price stays exactly 2x standard.
- Full suite: `uv run pytest tests/worker/tokens/ -q` — 241 passed.

## Runtime verification

Exercised the real deploy pipeline against a throwaway database: prisma migrations → actual `syncStandardPrices()` run (88 models synced, fast entry landed with all 5 price rows) → Python worker's DB-backed lookup. All customer strings priced correctly, `calculate_cost` fast/standard ratio exactly 2.000, and adversarial probes held (`-fastest` no-match, gateway-prefixed strings left to the prefix-stripping PR, Bedrock/Vertex ids unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zero-cost Anthropic spans by pricing fast mode and accepting dot-notation model ids. Also logs a warning once per unmatched model id so unpriced spans are visible.

- **Bug Fixes**
  - Added `claude-opus-4-8-fast` at exactly 2x `claude-opus-4-8` for input/output/cache.
  - Added `claude-opus-4-7-fast` at 6x `claude-opus-4-7` for historical fast spans.
  - First‑party Anthropic patterns accept dot or dash in versions (e.g., `4[.-]8`, `3[.-]5`); Bedrock/Vertex branches stay dashed.
  - Warn once per unmatched model id (bounded) when no pricing entry matches.

- **Migration**
  - No manual steps. Prices sync on startup via `syncStandardPrices`; restart worker/agent services.

<sup>Written for commit 7b4e4f92630f7e746ba271b3ace5a3d48b69aeba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
