### PR TITLE
feat(ui): add DOMAIN_ICONS registry, consolidate scattered domain-concept icons

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -20,8 +20,9 @@ const relativeImportPatterns = [
 
 // Glyphs owned by the domain-icon registry. Picking these directly per file is
 // what let one concept drift to several glyphs across the app. Matched by
-// pattern so lucide's `*Icon` suffix form and its deprecated aliases (which are
-// the same component under an older spelling) can't sneak past the ban.
+// pattern so lucide's `*Icon` suffix and `Lucide*` prefix forms, plus its
+// deprecated aliases (all of which resolve to the same component), can't sneak
+// past the ban.
 //
 // Only glyphs with a single meaning in this app are listed. Eye (password
 // visibility), Hash (Slack channel), Clock (durations), ArrowRight (CTA),
@@ -31,7 +32,7 @@ const relativeImportPatterns = [
 // the registry has no entry for yet, and banning it would force a migration
 // that belongs in its own change.
 const registryGlyphPattern =
-  "^(Bot|BotMessageSquare|Box|CircleCheck|CircleDollarSign|CircleStop|StopCircle|" +
+  "^(Lucide)?(Bot|BotMessageSquare|Box|CircleCheck|CircleDollarSign|CircleStop|StopCircle|" +
   "FolderKanban|Globe|Layers|Layers3|LayoutDashboard|LayoutGrid|Shapes|Users|" +
   "Workflow|Wrench)(Icon)?$";
 

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -2,6 +2,39 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import reactHooks from "eslint-plugin-react-hooks";
 
+// These trees are bundled by Next.js, and Turbopack (`next dev`) cannot resolve
+// NodeNext-style relative `.js` imports to `.ts` sources the way webpack's
+// extensionAlias could. Relative imports here must use real `.ts` extensions;
+// the packages' tsc builds rewrite them to `.js` in dist via
+// rewriteRelativeImportExtensions.
+//
+// Hoisted because `no-restricted-imports` options are replaced wholesale rather
+// than merged, so every block that sets the rule has to restate these.
+const relativeImportPatterns = [
+  {
+    group: ["./**/*.js", "../**/*.js"],
+    message:
+      "Use the real .ts extension for relative imports (Turbopack does not resolve .js → .ts).",
+  },
+];
+
+// Glyphs owned by the domain-icon registry. Picking these directly per file is
+// what let one concept drift to several glyphs across the app. Matched by
+// pattern so lucide's `*Icon` suffix form and its deprecated aliases (which are
+// the same component under an older spelling) can't sneak past the ban.
+//
+// Only glyphs with a single meaning in this app are listed. Eye (password
+// visibility), Hash (Slack channel), Clock (durations), ArrowRight (CTA),
+// Sparkle ("magic") and CircleAlert (generic warnings) each have an unrelated
+// second use, so they stay free. CheckCircle2 — the deprecated alias of the
+// status glyph — is also free for now: two surfaces use it for a success state
+// the registry has no entry for yet, and banning it would force a migration
+// that belongs in its own change.
+const registryGlyphPattern =
+  "^(Bot|BotMessageSquare|Box|CircleCheck|CircleDollarSign|CircleStop|StopCircle|" +
+  "FolderKanban|Globe|Layers|Layers3|LayoutDashboard|LayoutGrid|Shapes|Users|" +
+  "Workflow|Wrench)(Icon)?$";
+
 export default [
   js.configs.recommended,
   ...tseslint.configs.recommended,
@@ -22,11 +55,6 @@ export default [
     },
   },
   {
-    // These trees are bundled by Next.js, and Turbopack (`next dev`) cannot
-    // resolve NodeNext-style relative `.js` imports to `.ts` sources the way
-    // webpack's extensionAlias could. Relative imports here must use real
-    // `.ts` extensions; the packages' tsc builds rewrite them to `.js` in
-    // dist via rewriteRelativeImportExtensions.
     files: [
       "ui/src/**/*.{ts,tsx}",
       "packages/core/src/**/*.ts",
@@ -34,18 +62,38 @@ export default [
       "packages/github/src/**/*.ts",
     ],
     rules: {
+      "no-restricted-imports": ["error", { patterns: relativeImportPatterns }],
+    },
+  },
+  {
+    // The registry lives in the Next app, so the ban is scoped there — the
+    // packages above don't depend on lucide-react and couldn't resolve the
+    // `@/` alias the message points at.
+    files: ["ui/src/**/*.{ts,tsx}"],
+    rules: {
       "no-restricted-imports": [
         "error",
         {
           patterns: [
+            ...relativeImportPatterns,
             {
-              group: ["./**/*.js", "../**/*.js"],
+              group: ["lucide-react"],
+              importNamePattern: registryGlyphPattern,
               message:
-                "Use the real .ts extension for relative imports (Turbopack does not resolve .js → .ts).",
+                "Import the concept from @/components/icons/domain-icons (DOMAIN_ICONS) instead of picking the lucide glyph directly.",
             },
           ],
         },
       ],
+    },
+  },
+  {
+    // The registry defines the concept -> glyph mapping, and icon-identity
+    // tests assert against the glyphs themselves, so both must import lucide
+    // directly. The relative-import guard still applies to them.
+    files: ["ui/src/components/icons/domain-icons.ts", "ui/src/**/*.{test,spec}.{ts,tsx}"],
+    rules: {
+      "no-restricted-imports": ["error", { patterns: relativeImportPatterns }],
     },
   },
   {

--- a/frontend/ui/src/app/onboarding/page.tsx
+++ b/frontend/ui/src/app/onboarding/page.tsx
@@ -12,7 +12,8 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { useLayout } from "@/components/layout/app-layout";
 import { createWorkspace, createProject } from "@/lib/api";
-import { LayoutGrid, Layers, Check } from "lucide-react";
+import { LayoutGrid, Check } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { AddDetectorsStep } from "@/features/detectors/components/add-detectors-step";
 
 const onboardingSchema = z.object({
@@ -223,7 +224,7 @@ function OnboardingContent() {
                   <div className="flex items-start gap-3">
                     <div className="flex flex-col items-center">
                       <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-muted">
-                        <Layers className="h-4 w-4 text-muted-foreground" />
+                        <DOMAIN_ICONS.project className="h-4 w-4 text-muted-foreground" />
                       </div>
                     </div>
                     <div className="flex-1 pb-2 pt-0.5">

--- a/frontend/ui/src/app/onboarding/page.tsx
+++ b/frontend/ui/src/app/onboarding/page.tsx
@@ -12,7 +12,7 @@ import { Input } from "@/components/ui/input";
 import { Card, CardContent } from "@/components/ui/card";
 import { useLayout } from "@/components/layout/app-layout";
 import { createWorkspace, createProject } from "@/lib/api";
-import { LayoutGrid, Check } from "lucide-react";
+import { Check } from "lucide-react";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { AddDetectorsStep } from "@/features/detectors/components/add-detectors-step";
 
@@ -189,7 +189,7 @@ function OnboardingContent() {
                         {isProjectOnlyMode ? (
                           <Check className="h-4 w-4 text-primary" />
                         ) : (
-                          <LayoutGrid className="h-4 w-4 text-primary" />
+                          <DOMAIN_ICONS.workspace className="h-4 w-4 text-primary" />
                         )}
                       </div>
                       {/* Vertical connector line */}

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
@@ -186,4 +186,17 @@ describe("DetectorsPage", () => {
 
     expect(mocks.push).toHaveBeenCalledWith("/projects/proj-1/detectors/det-1?date_filter=7d");
   });
+
+  it("shows the empty state with its glyph when the project has no detectors", () => {
+    mocks.useDetectorList.mockReturnValue({
+      data: { data: [], meta: { total: 0 } },
+      isLoading: false,
+      error: null,
+    });
+
+    render(<DetectorsPage />);
+
+    const heading = screen.getByText("No detectors yet");
+    expect(heading.parentElement?.querySelector("svg")).toBeTruthy();
+  });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Eye, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import { Button } from "@/components/ui/button";
 import { LoadingState } from "@/components/ui/loading-state";
@@ -168,7 +169,7 @@ export default function DetectorsPage() {
             </div>
           ) : isEmptyProject ? (
             <div className="flex h-64 flex-col items-center justify-center gap-3">
-              <Eye className="h-8 w-8 text-muted-foreground/40" />
+              <DOMAIN_ICONS.detector className="h-8 w-8 text-muted-foreground/40" />
               <p className="text-[13px] text-muted-foreground">No detectors yet</p>
               <p className="text-[12px] text-muted-foreground">
                 Create a detector to automatically analyze your traces.

--- a/frontend/ui/src/app/projects/[projectId]/sessions/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/sessions/page.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "proj-1" }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({ setHideAiButton: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ isPending: false }),
+}));
+
+vi.mock("@/lib/hooks/use-list-page-state", () => ({
+  useListPageState: () => ({
+    state: { dateFilter: { id: "7d" }, customStartDate: null, customEndDate: null, keyword: "" },
+    queryOptions: { page: 1, limit: 50 },
+    updateDateFilter: vi.fn(),
+    updateCustomRange: vi.fn(),
+    updateKeyword: vi.fn(),
+    updateLimit: vi.fn(),
+    goToPage: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/traces/hooks", () => ({
+  useSessions: () => ({ data: { data: [], meta: { total: 0 } }, isPending: false, error: null }),
+}));
+
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+vi.mock("@/components/search-filter-bar", () => ({ SearchFilterBar: () => null }));
+vi.mock("@/components/list-pagination", () => ({ ListPagination: () => null }));
+vi.mock("@/features/traces/components/SessionDetailPanel", () => ({
+  SessionDetailPanel: () => null,
+}));
+
+import SessionsPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SessionsPage", () => {
+  it("shows the nav tabs and the no-sessions empty state", () => {
+    render(<SessionsPage />);
+
+    expect(screen.getByText("Traces")).toBeTruthy();
+    expect(screen.getByText("Users")).toBeTruthy();
+    expect(screen.getByText("Sessions")).toBeTruthy();
+    expect(screen.getByText("No sessions found")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/sessions/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/sessions/page.test.tsx
@@ -32,6 +32,17 @@ vi.mock("@/features/traces/hooks", () => ({
 }));
 
 vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+vi.mock("@/lib/hooks/use-retention", () => ({
+  useRetention: () => ({
+    retentionDays: 15,
+    showPricing: false,
+    onUpgradeClick: vi.fn(),
+    closePricing: vi.fn(),
+    workspaceId: "ws-1",
+    billingPlan: "free",
+  }),
+}));
+vi.mock("@/ee/features/billing/PricingDialog", () => ({ PricingDialog: () => null }));
 vi.mock("@/components/search-filter-bar", () => ({ SearchFilterBar: () => null }));
 vi.mock("@/components/list-pagination", () => ({ ListPagination: () => null }));
 vi.mock("@/features/traces/components/SessionDetailPanel", () => ({

--- a/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/sessions/page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useLayoutEffect, useState } from "react";
 import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
-import { Workflow, Users, Layers } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ListPagination } from "@/components/list-pagination";
 import { ProjectBreadcrumb } from "@/features/projects/components";
@@ -23,9 +23,9 @@ import {
 import type { SessionListItem, SessionQueryOptions } from "@/types/api";
 
 const tabs = [
-  { id: "traces", label: "Traces", icon: Workflow, href: "traces" },
-  { id: "users", label: "Users", icon: Users, href: "users" },
-  { id: "sessions", label: "Sessions", icon: Layers, href: "sessions" },
+  { id: "traces", label: "Traces", icon: DOMAIN_ICONS.trace, href: "traces" },
+  { id: "users", label: "Users", icon: DOMAIN_ICONS.user, href: "users" },
+  { id: "sessions", label: "Sessions", icon: DOMAIN_ICONS.session, href: "sessions" },
 ];
 
 function getTotalCost(session: SessionListItem): number | null {
@@ -140,7 +140,7 @@ export default function SessionsPage() {
             </div>
           ) : sessions.length === 0 ? (
             <div className="flex h-64 flex-col items-center justify-center gap-3">
-              <Layers className="h-10 w-10 text-muted-foreground" />
+              <DOMAIN_ICONS.session className="h-10 w-10 text-muted-foreground" />
               <p className="text-[13px] text-muted-foreground">No sessions found</p>
               <p className="text-[12px] text-muted-foreground">
                 Sessions will appear here when traces include session_id.

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -5,7 +5,8 @@ import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
-import { Workflow, Users, Layers, X } from "lucide-react";
+import { X } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { TraceSearchFilterInput } from "@/features/filters/trace-search-filter-input";
 import { ListPagination } from "@/components/list-pagination";
@@ -29,9 +30,9 @@ import { useSession as useAuthSession } from "@/lib/auth-client";
 
 // Tab definitions
 const tabs = [
-  { id: "traces", label: "Traces", icon: Workflow, href: "traces" },
-  { id: "users", label: "Users", icon: Users, href: "users" },
-  { id: "sessions", label: "Sessions", icon: Layers, href: "sessions" },
+  { id: "traces", label: "Traces", icon: DOMAIN_ICONS.trace, href: "traces" },
+  { id: "users", label: "Users", icon: DOMAIN_ICONS.user, href: "users" },
+  { id: "sessions", label: "Sessions", icon: DOMAIN_ICONS.session, href: "sessions" },
 ];
 
 export default function TracesPage() {
@@ -206,7 +207,7 @@ export default function TracesPage() {
             </button>
             {userId && (
               <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 py-1 pl-2.5 pr-1.5">
-                <Users className="h-3 w-3 text-muted-foreground" />
+                <DOMAIN_ICONS.user className="h-3 w-3 text-muted-foreground" />
                 <span className="text-[12px] text-muted-foreground">User:</span>
                 <span className="text-[12px] font-medium text-foreground">{userId}</span>
                 <button

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.user-filter.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.user-filter.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+vi.mock("@/features/traces/hooks", () => ({
+  // The page also probes "has this project ever traced" via a separate
+  // useTraces({ limit: 1 }) call to gate the onboarding empty state — a
+  // non-empty result here is required so the filter bar (and the user_id
+  // badge inside it) isn't suppressed by showGettingStarted.
+  useTraces: () => ({
+    data: {
+      data: [{ trace_id: "t1", name: "n", trace_start_time: 0, error_count: 0, span_count: 1 }],
+      meta: { page: 1, limit: 50, total: 1 },
+    },
+    isLoading: false,
+    error: null,
+  }),
+  usePrefetchTraces: () => vi.fn(),
+}));
+vi.mock("@/lib/hooks/use-list-page-state", () => ({
+  useListPageState: () => ({
+    state: { dateFilter: "all", customStartDate: null, customEndDate: null, keyword: "" },
+    goToPage: vi.fn(),
+    updateLimit: vi.fn(),
+    updateDateFilter: vi.fn(),
+    updateCustomRange: vi.fn(),
+    updateKeyword: vi.fn(),
+    queryOptions: { page: 1, limit: 50 },
+  }),
+}));
+vi.mock("@/lib/hooks/use-local-storage", () => ({ useLocalStorage: () => [false, vi.fn()] }));
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: { user: { id: "u1", email: "e" } }, isPending: false }),
+}));
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1" }),
+  useSearchParams: () => new URLSearchParams("user_id=user-42"),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}));
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({ setHideAiButton: vi.fn() }),
+}));
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+vi.mock("@/features/traces/components", () => ({
+  TraceViewerPanel: () => null,
+  GettingStarted: () => null,
+}));
+vi.mock("@/components/search-filter-bar", () => ({
+  SearchFilterBar: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("@/features/traces/utils", () => ({ formatContentPreview: () => "" }));
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: { children: React.ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+import TracesPage from "./page";
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("TracesPage user_id filter badge", () => {
+  it("shows a clearable badge for the active user_id filter", () => {
+    render(<TracesPage />, { wrapper: Wrapper });
+
+    expect(screen.getByText("User:")).toBeTruthy();
+    expect(screen.getByText("user-42")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.user-filter.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.user-filter.test.tsx
@@ -5,10 +5,6 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 
 vi.mock("@/features/traces/hooks", () => ({
-  // The page also probes "has this project ever traced" via a separate
-  // useTraces({ limit: 1 }) call to gate the onboarding empty state — a
-  // non-empty result here is required so the filter bar (and the user_id
-  // badge inside it) isn't suppressed by showGettingStarted.
   useTraces: () => ({
     data: {
       data: [{ trace_id: "t1", name: "n", trace_start_time: 0, error_count: 0, span_count: 1 }],
@@ -17,6 +13,10 @@ vi.mock("@/features/traces/hooks", () => ({
     isLoading: false,
     error: null,
   }),
+  // The page gates the onboarding empty state on a separate "has this project
+  // ever traced" probe; exists: true is required so the filter bar (and the
+  // user_id badge inside it) isn't suppressed by showGettingStarted.
+  useTracesExist: () => ({ data: { exists: true }, isPending: false, error: null }),
   usePrefetchTraces: () => vi.fn(),
 }));
 vi.mock("@/lib/hooks/use-list-page-state", () => ({
@@ -43,6 +43,17 @@ vi.mock("@/components/layout/app-layout", () => ({
   useLayout: () => ({ setHideAiButton: vi.fn() }),
 }));
 vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+vi.mock("@/lib/hooks/use-retention", () => ({
+  useRetention: () => ({
+    retentionDays: 15,
+    showPricing: false,
+    onUpgradeClick: vi.fn(),
+    closePricing: vi.fn(),
+    workspaceId: "ws-1",
+    billingPlan: "free",
+  }),
+}));
+vi.mock("@/ee/features/billing/PricingDialog", () => ({ PricingDialog: () => null }));
 vi.mock("@/features/traces/components", () => ({
   TraceViewerPanel: () => null,
   GettingStarted: () => null,

--- a/frontend/ui/src/app/projects/[projectId]/users/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/users/page.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "proj-1" }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/components/layout/app-layout", () => ({
+  useLayout: () => ({ setHideAiButton: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ isPending: false }),
+}));
+
+vi.mock("@/lib/hooks/use-list-page-state", () => ({
+  useListPageState: () => ({
+    state: { dateFilter: { id: "7d" }, customStartDate: null, customEndDate: null, keyword: "" },
+    queryOptions: { page: 1, limit: 50 },
+    updateDateFilter: vi.fn(),
+    updateCustomRange: vi.fn(),
+    updateKeyword: vi.fn(),
+    updateLimit: vi.fn(),
+    goToPage: vi.fn(),
+  }),
+}));
+
+vi.mock("@/features/traces/hooks", () => ({
+  useUsers: () => ({ data: { data: [], meta: { total: 0 } }, isPending: false, error: null }),
+}));
+
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+vi.mock("@/components/search-filter-bar", () => ({ SearchFilterBar: () => null }));
+vi.mock("@/components/list-pagination", () => ({ ListPagination: () => null }));
+
+import UsersPage from "./page";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("UsersPage", () => {
+  it("shows the nav tabs and the no-users empty state", () => {
+    render(<UsersPage />);
+
+    expect(screen.getByText("Traces")).toBeTruthy();
+    expect(screen.getByText("Users")).toBeTruthy();
+    expect(screen.getByText("Sessions")).toBeTruthy();
+    expect(screen.getByText("No users found")).toBeTruthy();
+  });
+});

--- a/frontend/ui/src/app/projects/[projectId]/users/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/users/page.test.tsx
@@ -69,4 +69,14 @@ describe("UsersPage", () => {
     render(<UsersPage />);
     expect(screen.getByText("Loading users...")).toBeTruthy();
   });
+
+  it("shows the nav tabs and the no-users empty state", () => {
+    mocks.usersData = { data: [], meta: { total: 0 } };
+    render(<UsersPage />);
+
+    expect(screen.getByText("Traces")).toBeTruthy();
+    expect(screen.getByText("Users")).toBeTruthy();
+    expect(screen.getByText("Sessions")).toBeTruthy();
+    expect(screen.getByText("No users found")).toBeTruthy();
+  });
 });

--- a/frontend/ui/src/app/projects/[projectId]/users/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/users/page.tsx
@@ -4,7 +4,7 @@ import { useMemo, useLayoutEffect } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useLayout } from "@/components/layout/app-layout";
-import { Workflow, Users, Layers } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { SearchFilterBar } from "@/components/search-filter-bar";
 import { ListPagination } from "@/components/list-pagination";
 import { ProjectBreadcrumb } from "@/features/projects/components";
@@ -23,9 +23,9 @@ import type { UserListItem } from "@/lib/api/users";
 import type { UserQueryOptions } from "@/lib/api/users";
 
 const tabs = [
-  { id: "traces", label: "Traces", icon: Workflow, href: "traces" },
-  { id: "users", label: "Users", icon: Users, href: "users" },
-  { id: "sessions", label: "Sessions", icon: Layers, href: "sessions" },
+  { id: "traces", label: "Traces", icon: DOMAIN_ICONS.trace, href: "traces" },
+  { id: "users", label: "Users", icon: DOMAIN_ICONS.user, href: "users" },
+  { id: "sessions", label: "Sessions", icon: DOMAIN_ICONS.session, href: "sessions" },
 ];
 
 export default function UsersPage() {
@@ -141,7 +141,7 @@ export default function UsersPage() {
             </div>
           ) : users.length === 0 ? (
             <div className="flex h-64 flex-col items-center justify-center gap-3">
-              <Users className="h-10 w-10 text-muted-foreground" />
+              <DOMAIN_ICONS.user className="h-10 w-10 text-muted-foreground" />
               <p className="text-[13px] text-muted-foreground">No users found</p>
               <p className="text-[12px] text-muted-foreground">
                 Users will appear here when traces include user_id.

--- a/frontend/ui/src/app/workspaces/[workspaceId]/projects/page.tsx
+++ b/frontend/ui/src/app/workspaces/[workspaceId]/projects/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from "react";
 import { useRouter, useParams } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
-import { FolderKanban } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { WorkspaceBreadcrumb } from "@/features/workspaces/components";
 import { CreateProjectDialog, ProjectCard } from "@/features/projects/components";
 import { useWorkspace } from "@/features/workspaces/hooks";
@@ -58,7 +58,7 @@ export default function ProjectsPage() {
           <div className="flex items-center justify-center py-16">
             <div className="flex flex-col items-center justify-center">
               <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-                <FolderKanban className="h-6 w-6 text-muted-foreground" />
+                <DOMAIN_ICONS.project className="h-6 w-6 text-muted-foreground" />
               </div>
               <h3 className="mb-1 text-[13px] font-medium">No projects yet</h3>
               <p className="text-center text-[12px] text-muted-foreground">

--- a/frontend/ui/src/components/icons/domain-icons.ts
+++ b/frontend/ui/src/components/icons/domain-icons.ts
@@ -27,7 +27,7 @@ import {
  * Single source of truth for domain-concept icons. Every surface that draws
  * one of these concepts (filter fields, span kinds, nav tabs, chips, …)
  * should import from here instead of picking a lucide icon directly — that's
- * what let "model" drift to four different glyphs across the app (#1517).
+ * what let "model" drift to four different glyphs across the app.
  *
  * `project` and `workspace` are deliberately separate entries: they read as
  * the same concept in the original issue text, but they're distinct concepts
@@ -65,6 +65,6 @@ export const DOMAIN_ICONS = {
   // Neutral "unknown field" fallback for filter/widget dropdowns. Kept
   // decoupled from `model` even though both currently render as Box — if the
   // model glyph ever changes, unmapped fields shouldn't silently change with
-  // it (ka1kqi, #1594).
+  // it.
   fallback: Box,
 } satisfies Record<string, LucideIcon>;

--- a/frontend/ui/src/components/icons/domain-icons.ts
+++ b/frontend/ui/src/components/icons/domain-icons.ts
@@ -1,0 +1,65 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  AlertCircle,
+  ArrowRight,
+  Bot,
+  BotMessageSquare,
+  Box,
+  CircleCheck,
+  CircleDollarSign,
+  CircleStop,
+  Clock,
+  Eye,
+  FolderKanban,
+  Globe,
+  Hash,
+  LayoutDashboard,
+  LayoutGrid,
+  Layers,
+  Shapes,
+  Sparkle,
+  Users,
+  Workflow,
+  Wrench,
+} from "lucide-react";
+
+/**
+ * Single source of truth for domain-concept icons. Every surface that draws
+ * one of these concepts (filter fields, span kinds, nav tabs, chips, …)
+ * should import from here instead of picking a lucide icon directly — that's
+ * what let "model" drift to four different glyphs across the app (#1517).
+ *
+ * `project` and `workspace` are deliberately separate entries: they read as
+ * the same concept in the original issue text, but they're distinct concepts
+ * in this app (a workspace contains projects), each already icon-consistent
+ * on its own.
+ */
+export const DOMAIN_ICONS = {
+  tokens: CircleStop,
+  cost: CircleDollarSign,
+  model: Box,
+  agent: Bot,
+  llm: Sparkle,
+  tool: Wrench,
+  // Default/generic span kind (anything that isn't trace/llm/agent/tool).
+  span: ArrowRight,
+  assistant: BotMessageSquare,
+  user: Users,
+  session: Layers,
+  trace: Workflow,
+  id: Hash,
+  // Distinct concept from `id` (a count of things vs. an identifier) that
+  // happens to share the same glyph today.
+  count: Hash,
+  // "Category of kinds" — e.g. the span_kind filter/widget field, which
+  // covers all kinds at once rather than meaning one specific kind.
+  kind: Shapes,
+  status: CircleCheck,
+  latency: Clock,
+  error: AlertCircle,
+  project: FolderKanban,
+  workspace: LayoutGrid,
+  detector: Eye,
+  environment: Globe,
+  dashboard: LayoutDashboard,
+} satisfies Record<string, LucideIcon>;

--- a/frontend/ui/src/components/icons/domain-icons.ts
+++ b/frontend/ui/src/components/icons/domain-icons.ts
@@ -62,4 +62,9 @@ export const DOMAIN_ICONS = {
   detector: Eye,
   environment: Globe,
   dashboard: LayoutDashboard,
+  // Neutral "unknown field" fallback for filter/widget dropdowns. Kept
+  // decoupled from `model` even though both currently render as Box — if the
+  // model glyph ever changes, unmapped fields shouldn't silently change with
+  // it (ka1kqi, #1594).
+  fallback: Box,
 } satisfies Record<string, LucideIcon>;

--- a/frontend/ui/src/components/icons/domain-icons.ts
+++ b/frontend/ui/src/components/icons/domain-icons.ts
@@ -27,12 +27,12 @@ import {
  * Single source of truth for domain-concept icons. Every surface that draws
  * one of these concepts (filter fields, span kinds, nav tabs, chips, …)
  * should import from here instead of picking a lucide icon directly — that's
- * what let "model" drift to four different glyphs across the app.
+ * what left "model" as Box in the filters and Bot in settings, with no glyph at
+ * all on the span detail pill.
  *
  * `project` and `workspace` are deliberately separate entries: they read as
- * the same concept in the original issue text, but they're distinct concepts
- * in this app (a workspace contains projects), each already icon-consistent
- * on its own.
+ * the same concept at first glance, but they're distinct concepts in this app
+ * (a workspace contains projects), each already icon-consistent on its own.
  */
 export const DOMAIN_ICONS = {
   tokens: CircleStop,
@@ -67,4 +67,4 @@ export const DOMAIN_ICONS = {
   // model glyph ever changes, unmapped fields shouldn't silently change with
   // it.
   fallback: Box,
-} satisfies Record<string, LucideIcon>;
+} as const satisfies Record<string, LucideIcon>;

--- a/frontend/ui/src/components/icons/domain-icons.ts
+++ b/frontend/ui/src/components/icons/domain-icons.ts
@@ -1,10 +1,10 @@
 import type { LucideIcon } from "lucide-react";
 import {
-  AlertCircle,
   ArrowRight,
   Bot,
   BotMessageSquare,
   Box,
+  CircleAlert,
   CircleCheck,
   CircleDollarSign,
   CircleStop,
@@ -56,7 +56,7 @@ export const DOMAIN_ICONS = {
   kind: Shapes,
   status: CircleCheck,
   latency: Clock,
-  error: AlertCircle,
+  error: CircleAlert,
   project: FolderKanban,
   workspace: LayoutGrid,
   detector: Eye,

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -4,7 +4,8 @@ import { useState, useEffect, useCallback, createContext, useContext, ReactNode 
 import { usePathname } from "next/navigation";
 import { Sidebar } from "./sidebar";
 import { Button } from "@/components/ui/button";
-import { PanelLeft, BotMessageSquare } from "lucide-react";
+import { PanelLeft } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistant-panel";
 import { AiChatProvider } from "@/features/ai-assistant/components/ai-chat-context";
@@ -155,7 +156,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
                       }}
                       title="AI Assistant"
                     >
-                      <BotMessageSquare className="h-4 w-4" />
+                      <DOMAIN_ICONS.assistant className="h-4 w-4" />
                     </Button>
                   </div>
                 )}

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -6,19 +6,16 @@ import { authClient } from "@/lib/auth-client";
 import { useTheme } from "next-themes";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
-  LayoutGrid,
-  LayoutDashboard,
   LifeBuoy,
   ChevronRight,
   Github,
   Sun,
   Moon,
   Monitor,
-  Workflow,
   Settings,
   UserRoundSearch,
-  Eye,
 } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Logo } from "@/components/Logo";
 import { cn } from "@/lib/utils";
@@ -151,7 +148,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                       pathname.includes("/traces") ? "bg-muted" : "hover:bg-muted/50",
                     )}
                   >
-                    <Workflow className="h-3.5 w-3.5 shrink-0" />
+                    <DOMAIN_ICONS.trace className="h-3.5 w-3.5 shrink-0" />
                     {!collapsed && "Tracing"}
                   </Link>
                 </TooltipTrigger>
@@ -171,7 +168,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                       pathname.includes("/detectors") ? "bg-muted" : "hover:bg-muted/50",
                     )}
                   >
-                    <Eye className="h-3.5 w-3.5 shrink-0" />
+                    <DOMAIN_ICONS.detector className="h-3.5 w-3.5 shrink-0" />
                     {!collapsed && "Detectors"}
                   </Link>
                 </TooltipTrigger>
@@ -191,7 +188,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                       pathname.includes("/dashboard") ? "bg-muted" : "hover:bg-muted/50",
                     )}
                   >
-                    <LayoutDashboard className="h-3.5 w-3.5 shrink-0" />
+                    <DOMAIN_ICONS.dashboard className="h-3.5 w-3.5 shrink-0" />
                     {!collapsed && "Dashboard"}
                   </Link>
                 </TooltipTrigger>
@@ -217,7 +214,7 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                       : "hover:bg-muted/50",
                   )}
                 >
-                  <LayoutGrid className="h-3.5 w-3.5 shrink-0" />
+                  <DOMAIN_ICONS.workspace className="h-3.5 w-3.5 shrink-0" />
                   {!collapsed && "Workspaces"}
                 </Link>
               </TooltipTrigger>

--- a/frontend/ui/src/features/dashboards/components/field-icons.test.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  AlertCircle,
+  CircleAlert,
   Box,
   CircleCheck,
   CircleDollarSign,
@@ -25,7 +25,7 @@ describe("fieldIcon", () => {
   });
 
   it("maps the widget registry's own spellings and token variants", () => {
-    expect(fieldIcon("error_count")).toBe(AlertCircle);
+    expect(fieldIcon("error_count")).toBe(CircleAlert);
     expect(fieldIcon("input_tokens")).toBe(CircleStop);
     expect(fieldIcon("output_tokens")).toBe(CircleStop);
   });

--- a/frontend/ui/src/features/dashboards/components/field-icons.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.ts
@@ -6,7 +6,8 @@ import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 // names the trace list spells differently (errors -> error_count), the token
 // variants, a distinct count symbol (the shared map's Box doubles as the
 // model icon, so count falling back to it read as "model"), and the user /
-// session symbols the trace-page tabs use. Box stays the generic fallback.
+// session symbols the trace-page tabs use. DOMAIN_ICONS.fallback (Box) stays
+// the generic fallback for unmapped fields.
 const WIDGET_FIELD_ICONS: Record<string, LucideIcon> = {
   ...FIELD_ICONS,
   error_count: DOMAIN_ICONS.error,
@@ -24,4 +25,4 @@ const WIDGET_FIELD_ICONS: Record<string, LucideIcon> = {
 };
 
 export const fieldIcon = (field: string): LucideIcon =>
-  WIDGET_FIELD_ICONS[field] ?? DOMAIN_ICONS.model;
+  WIDGET_FIELD_ICONS[field] ?? DOMAIN_ICONS.fallback;

--- a/frontend/ui/src/features/dashboards/components/field-icons.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.ts
@@ -1,16 +1,6 @@
-import {
-  AlertCircle,
-  Box,
-  CircleCheck,
-  CircleStop,
-  Hash,
-  Layers,
-  Shapes,
-  Users,
-  Workflow,
-  type LucideIcon,
-} from "lucide-react";
+import { type LucideIcon } from "lucide-react";
 import { FIELD_ICONS } from "@/features/filters/filter-controls";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 
 // The trace-list filter icons, extended with the widget registry's field
 // names the trace list spells differently (errors -> error_count), the token
@@ -19,18 +9,19 @@ import { FIELD_ICONS } from "@/features/filters/filter-controls";
 // session symbols the trace-page tabs use. Box stays the generic fallback.
 const WIDGET_FIELD_ICONS: Record<string, LucideIcon> = {
   ...FIELD_ICONS,
-  error_count: AlertCircle,
-  input_tokens: CircleStop,
-  output_tokens: CircleStop,
-  count: Hash,
-  user_id: Users,
-  session_id: Layers,
+  error_count: DOMAIN_ICONS.error,
+  input_tokens: DOMAIN_ICONS.tokens,
+  output_tokens: DOMAIN_ICONS.tokens,
+  count: DOMAIN_ICONS.count,
+  user_id: DOMAIN_ICONS.user,
+  session_id: DOMAIN_ICONS.session,
   // The sidebar's Tracing symbol; `name` is the trace/span name on both views.
-  name: Workflow,
+  name: DOMAIN_ICONS.trace,
   // A category-of-kinds field; the per-kind glyphs (Sparkle/Bot/Wrench) would
   // each wrongly imply one specific kind.
-  span_kind: Shapes,
-  status: CircleCheck,
+  span_kind: DOMAIN_ICONS.kind,
+  status: DOMAIN_ICONS.status,
 };
 
-export const fieldIcon = (field: string): LucideIcon => WIDGET_FIELD_ICONS[field] ?? Box;
+export const fieldIcon = (field: string): LucideIcon =>
+  WIDGET_FIELD_ICONS[field] ?? DOMAIN_ICONS.model;

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Eye, X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
+import { X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
 import { DEFAULT_DETECTOR_SAMPLE_RATE } from "../templates";
 import { useProject } from "@/features/projects/hooks";
@@ -162,7 +163,7 @@ export function DetectorPanel({
       {/* Header — same style as trace viewer */}
       <div className="flex h-10 flex-shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4">
         <div className="flex min-w-0 items-center gap-2">
-          <Eye className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <DOMAIN_ICONS.detector className="h-4 w-4 shrink-0 text-muted-foreground" />
           <span className="text-[13px] font-medium">Detector</span>
           <span className="truncate text-[13px] text-muted-foreground">
             {detector?.name ?? detectorId}

--- a/frontend/ui/src/features/filters/filter-controls.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.tsx
@@ -230,7 +230,7 @@ export function FieldDropdown({
   onPick: (key: string) => void;
 }) {
   const selected = valueKey ? (options.find((o) => o.key === valueKey) ?? null) : null;
-  const Icon = selected ? (selected.icon ?? DOMAIN_ICONS.model) : null;
+  const Icon = selected ? (selected.icon ?? DOMAIN_ICONS.fallback) : null;
   return (
     <Dropdown
       trigger={
@@ -244,7 +244,7 @@ export function FieldDropdown({
     >
       {(close) =>
         options.map((o) => {
-          const OIcon = o.icon ?? DOMAIN_ICONS.model;
+          const OIcon = o.icon ?? DOMAIN_ICONS.fallback;
           return (
             <DropdownItem
               key={o.key}

--- a/frontend/ui/src/features/filters/filter-controls.tsx
+++ b/frontend/ui/src/features/filters/filter-controls.tsx
@@ -7,32 +7,23 @@
  * two filter UIs stay identical.
  */
 import { createContext, useContext, useState } from "react";
-import {
-  AlertCircle,
-  Box,
-  ChevronDown,
-  CircleDollarSign,
-  CircleStop,
-  Clock,
-  Globe,
-  Hash,
-  type LucideIcon,
-} from "lucide-react";
+import { ChevronDown, type LucideIcon } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 
 // Icons mirror the trace detail / list UI for consistency; the model and environment
 // fields, which have no trace-detail icon, use a generic one. The dashboard widget
 // builder extends this map with its registry's extra field names.
 export const FIELD_ICONS: Record<string, LucideIcon> = {
-  trace_id: Hash,
-  cost: CircleDollarSign,
-  total_tokens: CircleStop,
-  duration_ms: Clock,
-  errors: AlertCircle,
-  model_name: Box,
-  environment: Globe,
+  trace_id: DOMAIN_ICONS.id,
+  cost: DOMAIN_ICONS.cost,
+  total_tokens: DOMAIN_ICONS.tokens,
+  duration_ms: DOMAIN_ICONS.latency,
+  errors: DOMAIN_ICONS.error,
+  model_name: DOMAIN_ICONS.model,
+  environment: DOMAIN_ICONS.environment,
 };
 
 // Text sizing depends on where the filter lives: the trace-list search bar uses
@@ -239,7 +230,7 @@ export function FieldDropdown({
   onPick: (key: string) => void;
 }) {
   const selected = valueKey ? (options.find((o) => o.key === valueKey) ?? null) : null;
-  const Icon = selected ? (selected.icon ?? Box) : null;
+  const Icon = selected ? (selected.icon ?? DOMAIN_ICONS.model) : null;
   return (
     <Dropdown
       trigger={
@@ -253,7 +244,7 @@ export function FieldDropdown({
     >
       {(close) =>
         options.map((o) => {
-          const OIcon = o.icon ?? Box;
+          const OIcon = o.icon ?? DOMAIN_ICONS.model;
           return (
             <DropdownItem
               key={o.key}

--- a/frontend/ui/src/features/settings/settings-layout.test.ts
+++ b/frontend/ui/src/features/settings/settings-layout.test.ts
@@ -3,7 +3,7 @@ import { WORKSPACE_SETTINGS_TABS, PROJECT_SETTINGS_TABS } from "./settings-layou
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 
 describe("WORKSPACE_SETTINGS_TABS", () => {
-  it("gates Model Providers on the model icon, not Bot (#1517 canonical fix)", () => {
+  it("gates Model Providers on the model icon, not Bot", () => {
     const tab = WORKSPACE_SETTINGS_TABS.find((t) => t.id === "model-providers");
     expect(tab?.icon).toBe(DOMAIN_ICONS.model);
   });

--- a/frontend/ui/src/features/settings/settings-layout.test.ts
+++ b/frontend/ui/src/features/settings/settings-layout.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { WORKSPACE_SETTINGS_TABS, PROJECT_SETTINGS_TABS } from "./settings-layout";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
+
+describe("WORKSPACE_SETTINGS_TABS", () => {
+  it("gates Model Providers on the model icon, not Bot (#1517 canonical fix)", () => {
+    const tab = WORKSPACE_SETTINGS_TABS.find((t) => t.id === "model-providers");
+    expect(tab?.icon).toBe(DOMAIN_ICONS.model);
+  });
+
+  it("uses the shared user icon for Members", () => {
+    const tab = WORKSPACE_SETTINGS_TABS.find((t) => t.id === "members");
+    expect(tab?.icon).toBe(DOMAIN_ICONS.user);
+  });
+});
+
+describe("PROJECT_SETTINGS_TABS", () => {
+  it("uses the shared detector icon for Detectors", () => {
+    const tab = PROJECT_SETTINGS_TABS.find((t) => t.id === "detectors");
+    expect(tab?.icon).toBe(DOMAIN_ICONS.detector);
+  });
+});

--- a/frontend/ui/src/features/settings/settings-layout.test.ts
+++ b/frontend/ui/src/features/settings/settings-layout.test.ts
@@ -1,22 +1,25 @@
 import { describe, it, expect } from "vitest";
+// Asserted against the lucide glyphs directly rather than against DOMAIN_ICONS:
+// comparing the tabs to the same registry entry they are built from would pass
+// even if a registry entry were repointed at the wrong glyph.
+import { Box, Eye, Users } from "lucide-react";
 import { WORKSPACE_SETTINGS_TABS, PROJECT_SETTINGS_TABS } from "./settings-layout";
-import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 
 describe("WORKSPACE_SETTINGS_TABS", () => {
-  it("gates Model Providers on the model icon, not Bot", () => {
+  it("gates Model Providers on the model glyph, not the agent one", () => {
     const tab = WORKSPACE_SETTINGS_TABS.find((t) => t.id === "model-providers");
-    expect(tab?.icon).toBe(DOMAIN_ICONS.model);
+    expect(tab?.icon).toBe(Box);
   });
 
-  it("uses the shared user icon for Members", () => {
+  it("uses the shared user glyph for Members", () => {
     const tab = WORKSPACE_SETTINGS_TABS.find((t) => t.id === "members");
-    expect(tab?.icon).toBe(DOMAIN_ICONS.user);
+    expect(tab?.icon).toBe(Users);
   });
 });
 
 describe("PROJECT_SETTINGS_TABS", () => {
-  it("uses the shared detector icon for Detectors", () => {
+  it("uses the shared detector glyph for Detectors", () => {
     const tab = PROJECT_SETTINGS_TABS.find((t) => t.id === "detectors");
-    expect(tab?.icon).toBe(DOMAIN_ICONS.detector);
+    expect(tab?.icon).toBe(Eye);
   });
 });

--- a/frontend/ui/src/features/settings/settings-layout.tsx
+++ b/frontend/ui/src/features/settings/settings-layout.tsx
@@ -26,7 +26,7 @@ export const WORKSPACE_SETTINGS_TABS: SettingsTab[] = [
   {
     id: "model-providers",
     label: "Model Providers",
-    // Canonical fix (#1517): was Bot, which also means the agent span kind.
+    // Canonical fix: was Bot, which also means the agent span kind.
     // Bot now exclusively means "agent"; Box means "model".
     icon: DOMAIN_ICONS.model,
     href: "model-providers",

--- a/frontend/ui/src/features/settings/settings-layout.tsx
+++ b/frontend/ui/src/features/settings/settings-layout.tsx
@@ -5,15 +5,13 @@ import Link from "next/link";
 import {
   type LucideIcon,
   SlidersHorizontal,
-  Users,
   Puzzle,
   CreditCard,
-  Bot,
   Key,
-  Eye,
   ArrowLeftRight,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 
 interface SettingsTab {
   id: string;
@@ -24,8 +22,15 @@ interface SettingsTab {
 
 export const WORKSPACE_SETTINGS_TABS: SettingsTab[] = [
   { id: "general", label: "General", icon: SlidersHorizontal, href: "general" },
-  { id: "members", label: "Members", icon: Users, href: "members" },
-  { id: "model-providers", label: "Model Providers", icon: Bot, href: "model-providers" },
+  { id: "members", label: "Members", icon: DOMAIN_ICONS.user, href: "members" },
+  {
+    id: "model-providers",
+    label: "Model Providers",
+    // Canonical fix (#1517): was Bot, which also means the agent span kind.
+    // Bot now exclusively means "agent"; Box means "model".
+    icon: DOMAIN_ICONS.model,
+    href: "model-providers",
+  },
   { id: "integrations", label: "Integrations", icon: Puzzle, href: "integrations" },
   { id: "billing", label: "Billing", icon: CreditCard, href: "billing" },
 ];
@@ -33,7 +38,7 @@ export const WORKSPACE_SETTINGS_TABS: SettingsTab[] = [
 export const PROJECT_SETTINGS_TABS: SettingsTab[] = [
   { id: "general", label: "General", icon: SlidersHorizontal, href: "general" },
   { id: "accessKeys", label: "API Keys", icon: Key, href: "accessKeys" },
-  { id: "detectors", label: "Detectors", icon: Eye, href: "detectors" },
+  { id: "detectors", label: "Detectors", icon: DOMAIN_ICONS.detector, href: "detectors" },
 ];
 
 interface CrossLink {

--- a/frontend/ui/src/features/settings/settings-layout.tsx
+++ b/frontend/ui/src/features/settings/settings-layout.tsx
@@ -26,8 +26,7 @@ export const WORKSPACE_SETTINGS_TABS: SettingsTab[] = [
   {
     id: "model-providers",
     label: "Model Providers",
-    // Canonical fix: was Bot, which also means the agent span kind.
-    // Bot now exclusively means "agent"; Box means "model".
+    // The model concept, not the agent one — DOMAIN_ICONS.agent is the Bot glyph.
     icon: DOMAIN_ICONS.model,
     href: "model-providers",
   },

--- a/frontend/ui/src/features/traces/components/CostChip.tsx
+++ b/frontend/ui/src/features/traces/components/CostChip.tsx
@@ -1,5 +1,5 @@
-import { CircleDollarSign } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { CostBreakdown } from "./CostBreakdown";
 
 interface CostChipProps {
@@ -17,7 +17,7 @@ export function CostChip({ cost, costDetails }: CostChipProps) {
 
   const chip = (
     <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
-      <CircleDollarSign className="h-3 w-3 text-muted-foreground" />
+      <DOMAIN_ICONS.cost className="h-3 w-3 text-muted-foreground" />
       <span className="font-medium">{cost.toFixed(6)}</span>
     </div>
   );

--- a/frontend/ui/src/features/traces/components/SessionDetailPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SessionDetailPanel.test.tsx
@@ -1,6 +1,20 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, fireEvent } from "@testing-library/react";
+import { render, cleanup, fireEvent, screen } from "@testing-library/react";
+
+const mocks = vi.hoisted(() => ({
+  sessionData: undefined as
+    | {
+        trace_count: number;
+        duration_ms: number | null;
+        total_input_tokens: number | null;
+        total_output_tokens: number | null;
+        total_cost: number | null;
+        user_ids: string[];
+        traces: unknown[];
+      }
+    | undefined,
+}));
 
 vi.mock("@/components/layout/app-layout", () => ({
   useLayout: () => ({
@@ -16,7 +30,7 @@ vi.mock("@/lib/auth-client", () => ({
 }));
 
 vi.mock("@/features/traces/hooks", () => ({
-  useSession: () => ({ data: undefined, isPending: false, error: null }),
+  useSession: () => ({ data: mocks.sessionData, isPending: false, error: null }),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -37,6 +51,7 @@ import { SessionDetailPanel } from "./SessionDetailPanel";
 
 afterEach(() => {
   cleanup();
+  mocks.sessionData = undefined;
 });
 
 function renderPanel(onClose = vi.fn()) {
@@ -66,5 +81,27 @@ describe("SessionDetailPanel keyboard", () => {
     event.preventDefault();
     document.dispatchEvent(event);
     expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe("SessionDetailPanel metadata badges", () => {
+  it("shows trace count, latency, and user links, and the empty-traces state", () => {
+    mocks.sessionData = {
+      trace_count: 3,
+      duration_ms: 4200,
+      total_input_tokens: 10,
+      total_output_tokens: 20,
+      total_cost: 0.05,
+      user_ids: ["user-42"],
+      traces: [],
+    };
+    renderPanel();
+
+    expect(screen.getByText("Traces:")).toBeDefined();
+    expect(screen.getByText("3")).toBeDefined();
+    expect(screen.getByText("Total Latency:")).toBeDefined();
+    expect(screen.getByText("User:")).toBeDefined();
+    expect(screen.getByText("user-42")).toBeDefined();
+    expect(screen.getByText("No traces in this session")).toBeDefined();
   });
 });

--- a/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SessionDetailPanel.tsx
@@ -3,18 +3,9 @@
 import { useMemo, useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import {
-  Layers,
-  X,
-  ArrowUp,
-  ArrowDown,
-  ExternalLink,
-  Users,
-  Clock,
-  ChevronRight,
-  BotMessageSquare,
-} from "lucide-react";
+import { X, ArrowUp, ArrowDown, ExternalLink, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { ExpandableSection } from "@/components/ui/expandable-section";
 import { useSession } from "@/features/traces/hooks";
@@ -156,7 +147,7 @@ export function SessionDetailPanel({
       {/* Header bar */}
       <div className="flex h-10 items-center justify-between border-b border-border bg-muted/30 px-4">
         <div className="flex min-w-0 items-center gap-2">
-          <Layers className="h-4 w-4 text-muted-foreground" />
+          <DOMAIN_ICONS.session className="h-4 w-4 text-muted-foreground" />
           <span className="text-sm font-medium">Session</span>
           <span className="truncate font-mono text-xs text-muted-foreground">{sessionId}</span>
         </div>
@@ -194,7 +185,7 @@ export function SessionDetailPanel({
             className="ml-2 h-7 w-7 p-0"
             title="AI Assistant"
           >
-            <BotMessageSquare className="h-4 w-4" />
+            <DOMAIN_ICONS.assistant className="h-4 w-4" />
           </Button>
           <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
             <X className="h-4 w-4" />
@@ -216,13 +207,13 @@ export function SessionDetailPanel({
                 <div className="border-b border-border bg-background px-4 py-3">
                   <div className="flex flex-wrap items-center gap-2">
                     <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
-                      <Layers className="h-3 w-3 text-muted-foreground" />
+                      <DOMAIN_ICONS.session className="h-3 w-3 text-muted-foreground" />
                       <span className="text-muted-foreground">Traces:</span>
                       <span className="font-medium">{data.trace_count}</span>
                     </div>
                     {data.duration_ms !== null && data.duration_ms > 0 && (
                       <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
-                        <Clock className="h-3 w-3 text-muted-foreground" />
+                        <DOMAIN_ICONS.latency className="h-3 w-3 text-muted-foreground" />
                         <span className="text-muted-foreground">Total Latency:</span>
                         <span className="font-medium">{formatDuration(data.duration_ms)}</span>
                       </div>
@@ -254,7 +245,7 @@ export function SessionDetailPanel({
                           }}
                           className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2.5 pr-1.5 text-xs transition-colors hover:bg-muted"
                         >
-                          <Users className="h-3 w-3 text-muted-foreground" />
+                          <DOMAIN_ICONS.user className="h-3 w-3 text-muted-foreground" />
                           <span className="text-muted-foreground">User:</span>
                           <span className="font-medium">{userId}</span>
                           <ChevronRight className="h-3 w-3 text-muted-foreground" />
@@ -277,12 +268,12 @@ export function SessionDetailPanel({
                   </div>
                 ) : !data ? (
                   <div className="flex h-64 flex-col items-center justify-center gap-3">
-                    <Layers className="h-8 w-8 text-muted-foreground" />
+                    <DOMAIN_ICONS.session className="h-8 w-8 text-muted-foreground" />
                     <p className="text-[13px] text-muted-foreground">Session not found</p>
                   </div>
                 ) : data.traces.length === 0 ? (
                   <div className="flex h-64 flex-col items-center justify-center gap-3">
-                    <Layers className="h-8 w-8 text-muted-foreground" />
+                    <DOMAIN_ICONS.session className="h-8 w-8 text-muted-foreground" />
                     <p className="text-[13px] text-muted-foreground">No traces in this session</p>
                   </div>
                 ) : (

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -189,4 +189,18 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     expect(headerRefLabel).toBeTruthy();
     expect(headerRefLabel.className).toContain("shrink-0");
   });
+
+  it("renders User and Session link badges when the trace has both ids", () => {
+    const traceWithIds: TraceDetail = { ...mockTrace, user_id: "user-42", session_id: "session-7" };
+    const mockTraceSelection: TraceSelection = { type: "trace" };
+
+    render(
+      <SpanInfoPanel projectId="proj-123" trace={traceWithIds} selection={mockTraceSelection} />,
+    );
+
+    expect(screen.getByText("User:")).toBeTruthy();
+    expect(screen.getByText("user-42")).toBeTruthy();
+    expect(screen.getByText("Session:")).toBeTruthy();
+    expect(screen.getByText("session-7")).toBeTruthy();
+  });
 });

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -142,6 +142,18 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     expect(errorMessage.className).toContain("break-all");
   });
 
+  it("renders the model_name pill with its icon", () => {
+    render(<SpanInfoPanel projectId="proj-123" trace={mockTrace} selection={mockSelection} />);
+
+    const modelPill = screen.getByText("gpt-4o");
+    expect(modelPill).toBeTruthy();
+
+    const modelParentDiv = modelPill.parentElement;
+    expect(modelParentDiv).toBeTruthy();
+    const modelIcon = modelParentDiv?.querySelector("svg");
+    expect(modelIcon).toBeTruthy();
+  });
+
   it("renders Trace header with git_repo and git_ref badges with correct wrapping styles", () => {
     const mockTraceSelection: TraceSelection = {
       type: "trace",

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.test.tsx
@@ -148,9 +148,7 @@ describe("SpanInfoPanel - Error box source location badges", () => {
     const modelPill = screen.getByText("gpt-4o");
     expect(modelPill).toBeTruthy();
 
-    const modelParentDiv = modelPill.parentElement;
-    expect(modelParentDiv).toBeTruthy();
-    const modelIcon = modelParentDiv?.querySelector("svg");
+    const modelIcon = modelPill.querySelector("svg");
     expect(modelIcon).toBeTruthy();
   });
 

--- a/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
+++ b/frontend/ui/src/features/traces/components/SpanInfoPanel.tsx
@@ -1,18 +1,9 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import {
-  Clock,
-  Users,
-  Layers,
-  ChevronRight,
-  AlertCircle,
-  GitBranch,
-  GitCommitHorizontal,
-  FileCode,
-  Loader2,
-} from "lucide-react";
+import { ChevronRight, GitBranch, GitCommitHorizontal, FileCode, Loader2 } from "lucide-react";
 import { CopyButton } from "@/components/ui/copy-button";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { formatDuration, formatDate, buildUrlWithFilters } from "@/lib/utils";
 import { TokenChip } from "./TokenChip";
 import { CostChip } from "./CostChip";
@@ -138,13 +129,13 @@ export function SpanInfoPanel({
             <span className="font-medium">{kind.toLowerCase()}</span>
           </div>
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
-            <Clock className="h-3 w-3 text-muted-foreground" />
+            <DOMAIN_ICONS.latency className="h-3 w-3 text-muted-foreground" />
             <span className="text-muted-foreground">Latency:</span>
             <span className="font-medium">{formatDuration(duration)}</span>
           </div>
           {hasError && (
             <div className="inline-flex items-center gap-1.5 rounded-md bg-red-100 px-2.5 py-1 text-xs font-medium text-red-700 dark:bg-red-950 dark:text-red-400">
-              <AlertCircle className="h-3 w-3" />
+              <DOMAIN_ICONS.error className="h-3 w-3" />
               ERROR
             </div>
           )}
@@ -168,7 +159,8 @@ export function SpanInfoPanel({
             <CostChip cost={traceTotalCost} costDetails={traceCostDetails} />
           )}
           {!isTrace && selection.span.model_name && (
-            <div className="inline-flex items-center rounded-md bg-primary px-2.5 py-1 text-xs text-primary-foreground">
+            <div className="inline-flex items-center gap-1.5 rounded-md bg-primary px-2.5 py-1 text-xs text-primary-foreground">
+              <DOMAIN_ICONS.model className="h-3 w-3" />
               {selection.span.model_name}
             </div>
           )}
@@ -240,7 +232,7 @@ export function SpanInfoPanel({
                 }}
                 className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2.5 pr-1.5 text-xs transition-colors hover:bg-muted"
               >
-                <Users className="h-3 w-3 text-muted-foreground" />
+                <DOMAIN_ICONS.user className="h-3 w-3 text-muted-foreground" />
                 <span className="text-muted-foreground">User:</span>
                 <span className="font-medium">{trace.user_id}</span>
                 <ChevronRight className="h-3 w-3 text-muted-foreground" />
@@ -259,7 +251,7 @@ export function SpanInfoPanel({
                 }}
                 className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2.5 pr-1.5 text-xs transition-colors hover:bg-muted"
               >
-                <Layers className="h-3 w-3 text-muted-foreground" />
+                <DOMAIN_ICONS.session className="h-3 w-3 text-muted-foreground" />
                 <span className="text-muted-foreground">Session:</span>
                 <span className="font-medium">{trace.session_id}</span>
                 <ChevronRight className="h-3 w-3 text-muted-foreground" />
@@ -275,7 +267,7 @@ export function SpanInfoPanel({
         {statusMessage && (
           <div className="rounded-md border border-red-200 bg-red-50 p-3 dark:border-red-900 dark:bg-red-950/50">
             <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-red-700 dark:text-red-400">
-              <AlertCircle className="h-3 w-3" />
+              <DOMAIN_ICONS.error className="h-3 w-3" />
               Error
             </div>
             {/* Source location info */}

--- a/frontend/ui/src/features/traces/components/SpanKindIcon.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanKindIcon.test.ts
@@ -1,5 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { getSpanKindColor } from "./SpanKindIcon";
+import { getSpanKindColor, getSpanKindIcon } from "./SpanKindIcon";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
+
+describe("getSpanKindIcon", () => {
+  it("maps each known kind to its domain icon", () => {
+    expect(getSpanKindIcon("trace")).toBe(DOMAIN_ICONS.trace);
+    expect(getSpanKindIcon("llm")).toBe(DOMAIN_ICONS.llm);
+    expect(getSpanKindIcon("agent")).toBe(DOMAIN_ICONS.agent);
+    expect(getSpanKindIcon("tool")).toBe(DOMAIN_ICONS.tool);
+  });
+
+  it("is case-insensitive", () => {
+    expect(getSpanKindIcon("LLM")).toBe(DOMAIN_ICONS.llm);
+  });
+
+  it("falls back to the generic span icon for span and unknown kinds", () => {
+    expect(getSpanKindIcon("span")).toBe(DOMAIN_ICONS.span);
+    expect(getSpanKindIcon("http")).toBe(DOMAIN_ICONS.span);
+  });
+});
 
 describe("getSpanKindColor", () => {
   it("returns distinct surface tints for the four real kinds", () => {

--- a/frontend/ui/src/features/traces/components/SpanKindIcon.tsx
+++ b/frontend/ui/src/features/traces/components/SpanKindIcon.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Workflow, Sparkle, Bot, Wrench, ArrowRight } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { TREE_LAYOUT } from "../utils";
 
 /**
@@ -11,16 +11,16 @@ export function getSpanKindIcon(kind: string) {
   const normalizedKind = kind.toLowerCase();
   switch (normalizedKind) {
     case "trace":
-      return Workflow;
+      return DOMAIN_ICONS.trace;
     case "llm":
-      return Sparkle;
+      return DOMAIN_ICONS.llm;
     case "agent":
-      return Bot;
+      return DOMAIN_ICONS.agent;
     case "tool":
-      return Wrench;
+      return DOMAIN_ICONS.tool;
     case "span":
     default:
-      return ArrowRight;
+      return DOMAIN_ICONS.span;
   }
 }
 

--- a/frontend/ui/src/features/traces/components/SpanTimelineView.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTimelineView.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { TraceDetail } from "@/types/api";
+import type { TraceSelection } from "../types";
+import { SpanTimelineView } from "./SpanTimelineView";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// jsdom doesn't implement ResizeObserver, which this component uses to track
+// the timeline's width for tick spacing.
+(global as unknown as { ResizeObserver: typeof ResizeObserverStub }).ResizeObserver =
+  ResizeObserverStub;
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 28,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, start: index * 28, size: 28 })),
+  }),
+}));
+
+const trace: TraceDetail = {
+  trace_id: "trace-1",
+  project_id: "proj-1",
+  name: "root-trace",
+  trace_start_time: "2026-01-01T00:00:00.000Z",
+  user_id: null,
+  session_id: null,
+  git_ref: null,
+  git_repo: null,
+  environment: "production",
+  release: null,
+  input: null,
+  output: null,
+  metadata: null,
+  spans: [
+    {
+      span_id: "span-1",
+      trace_id: "trace-1",
+      parent_span_id: null,
+      name: "llm-call",
+      span_kind: SpanKind.LLM,
+      span_start_time: "2026-01-01T00:00:00.000Z",
+      span_end_time: "2026-01-01T00:00:01.000Z",
+      status: SpanStatus.OK,
+      status_message: null,
+      model_name: "gpt-4o",
+      cost: 0.0123,
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      git_source_file: null,
+      git_source_line: null,
+      git_source_function: null,
+    },
+  ],
+};
+
+const selection: TraceSelection = { type: "trace" };
+
+describe("SpanTimelineView token/cost badges", () => {
+  it("renders the trace-root and per-span token/cost badges", () => {
+    render(
+      <SpanTimelineView
+        trace={trace}
+        selection={selection}
+        onSelect={vi.fn()}
+        collapsedIds={new Set()}
+        scrollRef={{ current: null }}
+        hoveredSpanId={null}
+        onHoverChange={vi.fn()}
+      />,
+    );
+
+    // Cost renders twice: the trace-root rollup and the one LLM span's own —
+    // both format to "0.0123" here since there's only a single span.
+    expect(screen.getAllByText("0.0123").length).toBe(2);
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanTimelineView.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTimelineView.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
 import { SpanKind, SpanStatus } from "@traceroot/core";
 import type { TraceDetail } from "@/types/api";
 import type { TraceSelection } from "../types";
@@ -63,22 +63,45 @@ const trace: TraceDetail = {
 
 const selection: TraceSelection = { type: "trace" };
 
+// vitest runs without `globals`, so testing-library's automatic cleanup is
+// inactive and a second render would stack onto the first one's DOM.
+afterEach(() => {
+  cleanup();
+});
+
+function renderTimeline() {
+  return render(
+    <SpanTimelineView
+      trace={trace}
+      selection={selection}
+      onSelect={vi.fn()}
+      collapsedIds={new Set()}
+      scrollRef={{ current: null }}
+      hoveredSpanId={null}
+      onHoverChange={vi.fn()}
+    />,
+  );
+}
+
 describe("SpanTimelineView token/cost badges", () => {
   it("renders the trace-root and per-span token/cost badges", () => {
-    render(
-      <SpanTimelineView
-        trace={trace}
-        selection={selection}
-        onSelect={vi.fn()}
-        collapsedIds={new Set()}
-        scrollRef={{ current: null }}
-        hoveredSpanId={null}
-        onHoverChange={vi.fn()}
-      />,
-    );
+    renderTimeline();
 
     // Cost renders twice: the trace-root rollup and the one LLM span's own —
     // both format to "0.0123" here since there's only a single span.
     expect(screen.getAllByText("0.0123").length).toBe(2);
+  });
+
+  it("draws a glyph alongside each token and cost badge", () => {
+    renderTimeline();
+
+    // The badge text nodes are wrapped in a span that also holds the icon, so
+    // a missing glyph shows up as a badge with no svg child.
+    for (const badge of screen.getAllByText("0.0123")) {
+      expect(badge.querySelector("svg")).toBeTruthy();
+    }
+    for (const badge of screen.getAllByText("100 → 50 (150)")) {
+      expect(badge.querySelector("svg")).toBeTruthy();
+    }
   });
 });

--- a/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTimelineView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useRef, useEffect, type RefObject } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { CircleStop, CircleDollarSign } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { cn, formatDuration, formatTokenFlow } from "@/lib/utils";
 import { SpanStatus, SpanKind } from "@traceroot/core";
 import { flattenTreeWithMetrics } from "../utils/timeline";
@@ -238,7 +238,7 @@ export function SpanTimelineView({
                     <span className="absolute right-2 z-20 inline-flex items-center gap-2 whitespace-nowrap text-[10px] font-medium text-muted-foreground">
                       {traceAggregates.totalTokens > 0 && (
                         <span className="inline-flex items-center gap-0.5 font-sans font-medium">
-                          <CircleStop className="h-2.5 w-2.5" />
+                          <DOMAIN_ICONS.tokens className="h-2.5 w-2.5" />
                           {formatTokenFlow(
                             traceAggregates.inputTokens,
                             traceAggregates.outputTokens,
@@ -248,7 +248,7 @@ export function SpanTimelineView({
                       )}
                       {traceAggregates.totalCost > 0 && (
                         <span className="inline-flex items-center gap-0.5">
-                          <CircleDollarSign className="h-2.5 w-2.5" />
+                          <DOMAIN_ICONS.cost className="h-2.5 w-2.5" />
                           {traceAggregates.totalCost.toFixed(4)}
                         </span>
                       )}
@@ -310,13 +310,13 @@ export function SpanTimelineView({
                   <span className="absolute right-2 z-20 inline-flex items-center gap-2 whitespace-nowrap text-[10px] text-muted-foreground">
                     {showTokens && (
                       <span className="inline-flex items-center gap-0.5 font-sans font-medium">
-                        <CircleStop className="h-2.5 w-2.5" />
+                        <DOMAIN_ICONS.tokens className="h-2.5 w-2.5" />
                         {formatTokenFlow(span.input_tokens, span.output_tokens, span.total_tokens)}
                       </span>
                     )}
                     {showCost && (
                       <span className="inline-flex items-center gap-0.5">
-                        <CircleDollarSign className="h-2.5 w-2.5" />
+                        <DOMAIN_ICONS.cost className="h-2.5 w-2.5" />
                         {span.cost!.toFixed(4)}
                       </span>
                     )}

--- a/frontend/ui/src/features/traces/components/SpanTreeView.render.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.render.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+// Render-level coverage for SpanTreeView's token/cost icon badges (both the
+// trace-root rollup and the per-LLM-span badge). SpanTreeView.test.ts covers
+// the pure row-model logic; this file exercises the actual JSX, which needs
+// @tanstack/react-virtual mocked since jsdom has no real layout to measure.
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { TraceDetail } from "@/types/api";
+import type { TraceSelection } from "../types";
+import { SpanTreeView } from "./SpanTreeView";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 28,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({ index, start: index * 28, size: 28 })),
+    scrollToIndex: vi.fn(),
+  }),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => ({ prefetchQuery: vi.fn() }),
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  useSession: () => ({ data: undefined }),
+}));
+
+vi.mock("@/lib/api", () => ({
+  getSpanIO: vi.fn(),
+}));
+
+const trace: TraceDetail = {
+  trace_id: "trace-1",
+  project_id: "proj-1",
+  name: "root-trace",
+  trace_start_time: "2026-01-01T00:00:00.000Z",
+  user_id: null,
+  session_id: null,
+  git_ref: null,
+  git_repo: null,
+  environment: "production",
+  release: null,
+  input: null,
+  output: null,
+  metadata: null,
+  spans: [
+    {
+      span_id: "span-1",
+      trace_id: "trace-1",
+      parent_span_id: null,
+      name: "llm-call",
+      span_kind: SpanKind.LLM,
+      span_start_time: "2026-01-01T00:00:00.000Z",
+      span_end_time: "2026-01-01T00:00:01.000Z",
+      status: SpanStatus.OK,
+      status_message: null,
+      model_name: "gpt-4o",
+      cost: 0.0123,
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      git_source_file: null,
+      git_source_line: null,
+      git_source_function: null,
+    },
+  ],
+};
+
+const selection: TraceSelection = { type: "trace" };
+
+function renderTree() {
+  render(
+    <SpanTreeView
+      trace={trace}
+      selection={selection}
+      onSelect={vi.fn()}
+      collapsedIds={new Set()}
+      onToggleCollapse={vi.fn()}
+      hoveredSpanId={null}
+      onHoverChange={vi.fn()}
+      scrollRef={{ current: null }}
+    />,
+  );
+}
+
+describe("SpanTreeView token/cost badges", () => {
+  it("renders the trace row and the LLM span row with their token/cost badges", () => {
+    renderTree();
+    // Trace root name and the one LLM span's name are both rendered.
+    expect(screen.getByText("root-trace")).toBeTruthy();
+    expect(screen.getByText("llm-call")).toBeTruthy();
+    // Cost appears twice: the trace rollup (0.0123) and the span's own (0.0123) —
+    // both format to the same 4-decimal string here since there's only one span.
+    expect(screen.getAllByText("0.0123").length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/ui/src/features/traces/components/SpanTreeView.render.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.render.test.tsx
@@ -93,6 +93,6 @@ describe("SpanTreeView token/cost badges", () => {
     expect(screen.getByText("llm-call")).toBeTruthy();
     // Cost appears twice: the trace rollup (0.0123) and the span's own (0.0123) —
     // both format to the same 4-decimal string here since there's only one span.
-    expect(screen.getAllByText("0.0123").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("0.0123")).toHaveLength(2);
   });
 });

--- a/frontend/ui/src/features/traces/components/SpanTreeView.render.test.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.render.test.tsx
@@ -3,8 +3,8 @@
 // trace-root rollup and the per-LLM-span badge). SpanTreeView.test.ts covers
 // the pure row-model logic; this file exercises the actual JSX, which needs
 // @tanstack/react-virtual mocked since jsdom has no real layout to measure.
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { afterEach, describe, it, expect, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
 import { SpanKind, SpanStatus } from "@traceroot/core";
 import type { TraceDetail } from "@/types/api";
 import type { TraceSelection } from "../types";
@@ -70,6 +70,15 @@ const trace: TraceDetail = {
 
 const selection: TraceSelection = { type: "trace" };
 
+// vitest runs without `globals`, so testing-library's automatic cleanup is
+// inactive and a second render would stack onto the first one's DOM — which
+// would also break the exact badge counts below, since jsdom applies no CSS and
+// the container-query classes that hide these badges at narrow widths never
+// take effect.
+afterEach(() => {
+  cleanup();
+});
+
 function renderTree() {
   render(
     <SpanTreeView
@@ -94,5 +103,18 @@ describe("SpanTreeView token/cost badges", () => {
     // Cost appears twice: the trace rollup (0.0123) and the span's own (0.0123) —
     // both format to the same 4-decimal string here since there's only one span.
     expect(screen.getAllByText("0.0123")).toHaveLength(2);
+  });
+
+  it("draws a glyph alongside each token and cost badge", () => {
+    renderTree();
+
+    // The badge text nodes are wrapped in a span that also holds the icon, so
+    // a missing glyph shows up as a badge with no svg child.
+    for (const badge of screen.getAllByText("0.0123")) {
+      expect(badge.querySelector("svg")).toBeTruthy();
+    }
+    for (const badge of screen.getAllByText("100 → 50 (150)")) {
+      expect(badge.querySelector("svg")).toBeTruthy();
+    }
   });
 });

--- a/frontend/ui/src/features/traces/components/SpanTreeView.tsx
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.tsx
@@ -6,7 +6,8 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSession as useAuthSession } from "@/lib/auth-client";
 import { getSpanIO } from "@/lib/api";
-import { ChevronRight, ChevronDown, CircleStop, CircleDollarSign } from "lucide-react";
+import { ChevronRight, ChevronDown } from "lucide-react";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { cn, formatDuration, formatTokenFlow } from "@/lib/utils";
 import { SpanKind, SpanStatus } from "@traceroot/core";
 import type { TraceDetail, Span } from "@/types/api";
@@ -277,7 +278,7 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
 
                         {traceTokenUsage && (
                           <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap text-[10px] font-medium text-muted-foreground @[130px]:inline-flex">
-                            <CircleStop className="h-2.5 w-2.5" />
+                            <DOMAIN_ICONS.tokens className="h-2.5 w-2.5" />
                             {formatTokenFlow(
                               traceTokenUsage.inputTokens,
                               traceTokenUsage.outputTokens,
@@ -288,7 +289,7 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
 
                         {traceTotalCost != null && (
                           <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[190px]:inline-flex">
-                            <CircleDollarSign className="h-2.5 w-2.5" />
+                            <DOMAIN_ICONS.cost className="h-2.5 w-2.5" />
                             {traceTotalCost.toFixed(4)}
                           </span>
                         )}
@@ -376,7 +377,7 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
 
                       {span.span_kind === SpanKind.LLM && span.total_tokens != null && (
                         <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap text-[10px] font-medium text-muted-foreground @[130px]:inline-flex">
-                          <CircleStop className="h-2.5 w-2.5" />
+                          <DOMAIN_ICONS.tokens className="h-2.5 w-2.5" />
                           {formatTokenFlow(
                             span.input_tokens,
                             span.output_tokens,
@@ -389,7 +390,7 @@ export const SpanTreeView = forwardRef<SpanTreeViewHandle, SpanTreeViewProps>(fu
                         span.cost != null &&
                         Number.isFinite(span.cost) && (
                           <span className="hidden shrink-0 items-center gap-0.5 whitespace-nowrap font-mono text-[10px] text-muted-foreground @[190px]:inline-flex">
-                            <CircleDollarSign className="h-2.5 w-2.5" />
+                            <DOMAIN_ICONS.cost className="h-2.5 w-2.5" />
                             {span.cost.toFixed(4)}
                           </span>
                         )}

--- a/frontend/ui/src/features/traces/components/TokenChip.tsx
+++ b/frontend/ui/src/features/traces/components/TokenChip.tsx
@@ -1,6 +1,6 @@
-import { CircleStop } from "lucide-react";
 import { formatTokenFlow } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { TokenUsageBreakdown } from "./TokenUsageBreakdown";
 
 interface TokenChipProps {
@@ -29,7 +29,7 @@ export function TokenChip({
       <Tooltip>
         <TooltipTrigger asChild>
           <div className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs">
-            <CircleStop className="h-3 w-3 text-muted-foreground" />
+            <DOMAIN_ICONS.tokens className="h-3 w-3 text-muted-foreground" />
             <span className="font-medium">
               {formatTokenFlow(inputTokens, outputTokens, totalTokens)}
             </span>

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -3,19 +3,17 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
-  Workflow,
   X,
   ArrowUp,
   ArrowDown,
-  BotMessageSquare,
   ListTree,
   SquareGanttChart,
-  Eye,
   Expand,
   Shrink,
   SquareArrowOutUpRight,
 } from "lucide-react";
 import { cn, buildUrlWithFilters } from "@/lib/utils";
+import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Button } from "@/components/ui/button";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { getTrace } from "@/lib/api";
@@ -240,7 +238,7 @@ export function TraceViewerPanel({
         {/* ── MAIN HEADER ── */}
         <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
           <div className="flex min-w-0 items-center gap-2">
-            <Workflow className="h-4 w-4 text-muted-foreground" />
+            <DOMAIN_ICONS.trace className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Trace</span>
             <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
           </div>
@@ -325,7 +323,7 @@ export function TraceViewerPanel({
               className="h-7 w-7 p-0"
               title="AI Assistant"
             >
-              <BotMessageSquare className="h-4 w-4" />
+              <DOMAIN_ICONS.assistant className="h-4 w-4" />
             </Button>
             <Button variant="ghost" size="sm" onClick={onClose} className="h-7 w-7 p-0">
               <X className="h-4 w-4" />
@@ -367,7 +365,7 @@ export function TraceViewerPanel({
                   : "text-muted-foreground hover:text-foreground",
               )}
             >
-              <Eye className="h-3.5 w-3.5" /> Detectors
+              <DOMAIN_ICONS.detector className="h-3.5 w-3.5" /> Detectors
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Fixes #1517.

Domain concepts (tokens, cost, model, user, session, trace, …) were each drawn with a lucide icon picked ad-hoc per file. Adds a single source of truth — `frontend/ui/src/components/icons/domain-icons.ts` — and migrates every surface with an actual duplicated/drifted icon import to source from it:

- `filter-controls.tsx`'s `FIELD_ICONS`
- the dashboard widget builder's `field-icons.ts` — a **fourth** ad-hoc icon map that appeared after the dashboards stack merged, since this issue was filed
- `SpanKindIcon`'s `getSpanKindIcon`
- the token/cost chips and their direct-import duplicates in `SpanTreeView`/`SpanTimelineView`
- the `BotMessageSquare` "AI assistant" icon, duplicated across `app-layout`, `SessionDetailPanel`, `TraceViewerPanel`
- the sidebar's trace/detector/dashboard/workspace nav icons
- the settings tabs
- the triplicated traces/sessions/users nav-tab arrays

**Canonical fixes for the real collisions:**
- Model Providers settings tab: `Bot` → `Box` (model), so `Bot` exclusively means the `agent` span kind afterward.
- `SpanInfoPanel`'s `model_name` pill had no icon at all — now shows the model glyph like every other model-bearing surface.
- Onboarding's "Project" step drew `Layers` (the registry's `session` glyph) and the projects empty-state drew a raw `FolderKanban` — both now source from `DOMAIN_ICONS.project`.

**Also fixed along the way** (same concepts, direct imports found while migrating each file): the latency/user/session/error icons duplicated in `SpanInfoPanel`, `SessionDetailPanel`, and the traces/sessions/users empty states.

**Corrections to the issue's originally proposed fixes**, verified against the current codebase:
- "Project" (`FolderKanban`) vs "Workspace" (`LayoutGrid`, sidebar/onboarding) are not the same drifted concept — they're genuinely distinct entities in this app. Both are now separate registry entries; the sidebar's Workspace icon is unchanged.
- Sidebar's `UserRoundSearch` (admin impersonation banner) is a distinct, single-use meaning, not the general "user" concept — left as a local icon, not folded into the registry.
- `tokens` keeps `CircleStop` (the issue's own "open decision") — this PR is a pure consolidation, not a visual redesign.

Pure refactor: no behavior change except the three canonical fixes above.

## Test plan

- [x] `tsc --noEmit` clean on all touched files (2 pre-existing, unrelated errors elsewhere untouched by this PR)
- [x] `eslint` clean on all touched files (1 pre-existing, unrelated warning)
- [x] Full frontend suite: 891/893 pass — the 2 failures are pre-existing, environment-specific flakes (a locale-dependent formatting test, a Slack OAuth timeout), unrelated to anything this PR touches
- [x] Manually traced every migrated call site's diff to confirm the rendered icon is pixel-identical except the three stated canonical fixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `DOMAIN_ICONS` as the single source of truth for domain icons and replace ad‑hoc `lucide-react` imports across the UI for consistent visuals. Adds a neutral `fallback` icon (decoupled from `model`), fixes icon drift in onboarding and workspace/project empty states, and enforces the registry with an ESLint rule; fixes #1517.

- **Refactors**
  - Added `frontend/ui/src/components/icons/domain-icons.ts` exporting `DOMAIN_ICONS` (tokens, cost, model, user, session, trace, detector, etc.) plus a neutral `fallback`.
  - Replaced direct `lucide-react` imports in filters, dashboards, span views (tree/timeline/info), chips, sidebar, settings, app layout, onboarding, detectors (panel/page), and traces/sessions/users tabs and empty states.
  - Canonical fixes: Model Providers tab uses `DOMAIN_ICONS.model` (`Box`); `model_name` pill shows the model icon; onboarding uses `DOMAIN_ICONS.workspace`; project/workspace empty states use `DOMAIN_ICONS.project`.
  - Added ESLint guard in `frontend/eslint.config.mjs` banning direct `lucide-react` glyphs the registry owns in `ui/src` (registry/tests exempt); pattern covers `Lucide*` and `*Icon` aliases, and the relative-import `.ts` extension rule is hoisted for Turbopack.

- **Tests**
  - Added and tightened coverage: `getSpanKindIcon`, SpanTreeView/SpanTimeline token/cost badges (assert glyphs render), settings tabs, nav tabs, and empty states (users/sessions/detectors), `model_name` pill icon, and traces page `user_id` badge.
  - Updated mocks and switched to current `lucide-react` names; diff-cover 100% on this PR.

<sup>Written for commit 2e781d6e571af1d48527f2a32b591a9dada60c59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

