### PR TITLE
feat(ingest): extract manually reported LLM usage into the token pipeline

### DIFF
--- a/backend/shared/span_attributes.py
+++ b/backend/shared/span_attributes.py
@@ -8,7 +8,8 @@ only when they end), and these attributes let the client synthesize the missing
 ancestors instead of pinning their children to the root as orphans.
 
 They reach the client through the span `metadata` column: the worker's
-`_KNOWN_ATTRIBUTE_PREFIXES` deliberately does NOT cover them, so they fall
+`_KNOWN_ATTRIBUTE_PREFIXES`/`_KNOWN_ATTRIBUTE_EXACT` deliberately do NOT cover
+them, so they fall
 through to the leftover-attribute bag that becomes `metadata` (see
 `worker/otel_transform.py`). Renaming one — or adding it to that prefix set —
 silently disables live-tree repair, so both sides reference these constants

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -184,9 +184,12 @@ def int_or_zero(value: Any) -> int:
         return 0
 
 
-# Fields recognized in the SDKs' manual usage dict (Python
-# ``update_current_span(usage=...)`` / TS ``updateCurrentSpan({usage})``), which
-# both serialize as JSON into the ``traceroot.llm.usage`` span attribute.
+# Fields recognized in the Python SDK's manual usage dict
+# (``update_current_span(usage=...)``), serialized as JSON into the
+# ``traceroot.llm.usage`` span attribute. The TypeScript SDK writes that blob too
+# but with its own vocabulary (``input``/``output``/``cacheRead``), and its usage
+# reaches us through the OpenInference ``llm.token_count.*`` attributes that
+# ``applyUsage`` also stamps — so it takes the instrumentor path, not this one.
 _MANUAL_USAGE_KEYS = (
     "input_tokens",
     "output_tokens",
@@ -209,17 +212,17 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
     """Parse the manual usage dict reported via the SDKs' update-span API.
 
     The ``traceroot.llm.usage`` attribute is untrusted wire input: a non-JSON
-    string, a non-dict payload, or a non-numeric/negative/non-finite/out-of-range
-    field must
-    never crash ingestion (``json.loads`` accepts literal ``Infinity``/``NaN``,
-    and ``int(inf)`` raises OverflowError). Unusable fields are dropped and
+    string, a non-dict payload, or a non-numeric, negative, non-finite or
+    out-of-range field must never crash ingestion (``json.loads`` accepts literal
+    ``Infinity``/``NaN``, and ``int(inf)`` raises OverflowError). Values are
+    truncated toward zero. Unusable fields are dropped and
     counts are clamped non-negative, so a partially-malformed dict degrades to
     its valid fields (and an entirely unusable one to the text-estimation
     fallback), never to an error.
 
     Args:
-        raw (Any): The raw attribute value (a JSON string from either SDK, or an
-            already-decoded dict).
+        raw (Any): The raw attribute value (a JSON string as the SDK writes it,
+            or an already-decoded dict).
 
     Returns:
         dict[str, int]: The recognized usage fields with non-negative int
@@ -721,6 +724,16 @@ def transform_otel_to_clickhouse(
                             api_cache_write_tokens = manual_usage.get("cache_write_tokens")
                             api_cache_write_1h_tokens = manual_usage.get("cache_write_1h_tokens")
                             api_reasoning_tokens = manual_usage.get("reasoning_tokens")
+                        elif manual_usage:
+                            # Recognized fields, but nothing to price against: a
+                            # cache or reasoning count alone does not describe a
+                            # call. Dropping it silently is the same data loss the
+                            # field-level warnings above exist to surface.
+                            logger.warning(
+                                "Manual usage reported only %s with no input_tokens or "
+                                "output_tokens; ignoring it",
+                                sorted(manual_usage),
+                            )
 
                     if not aggregate_wrapper and (
                         api_input_tokens is not None or api_output_tokens is not None

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -691,6 +691,12 @@ def transform_otel_to_clickhouse(
                     # conventions (gross vs net input) and double-price cache.
                     # When the manual dict is used, it replaces every field, so
                     # the span is priced under the reporter's one convention.
+                    # The aggregate check here is belt-and-braces, not load-bearing:
+                    # the adoption branch below is gated on it too, so a wrapper's
+                    # manual dict would be parsed and then discarded anyway. Keeping
+                    # it states the invariant where the dict is read — manual usage
+                    # must never resurrect counts on a span we suppressed — and skips
+                    # a needless parse.
                     if (
                         not aggregate_wrapper
                         and api_input_tokens is None

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -237,6 +237,17 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
         if raw is not None:
             logger.warning("Manual usage attribute is not an object; ignoring it")
         return {}
+    # Fields outside the recognized set are never examined below, so without this
+    # they vanish without any signal at all — a provider token type we don't model
+    # yet (audio, image, a new cache variant) reads as if it was never reported.
+    # Bounded because the payload is client-controlled.
+    unrecognized = sorted(k for k in raw if k not in _MANUAL_USAGE_KEYS)
+    if unrecognized:
+        logger.warning(
+            "Manual usage fields %s are not recognized and were ignored; recognized fields are %s",
+            unrecognized[:10],
+            list(_MANUAL_USAGE_KEYS),
+        )
     usage: dict[str, int] = {}
     for key in _MANUAL_USAGE_KEYS:
         value = raw.get(key)

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -231,19 +231,34 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
         # RecursionError: json.loads raises it on deeply-nested payloads, which
         # would otherwise fail the whole ingest task instead of this one attribute.
         except (TypeError, ValueError, RecursionError):
+            logger.warning("Manual usage attribute is not valid JSON; ignoring it")
             return {}
     if not isinstance(raw, dict):
+        if raw is not None:
+            logger.warning("Manual usage attribute is not an object; ignoring it")
         return {}
     usage: dict[str, int] = {}
     for key in _MANUAL_USAGE_KEYS:
         value = raw.get(key)
-        if value is None or isinstance(value, bool):
+        if value is None:
+            continue
+        # A dropped field is silent data loss from the user's point of view: they
+        # reported a count and it is priced as if absent. Warn as int_or_zero does
+        # for the same input class, so the discard is diagnosable from the logs.
+        if isinstance(value, bool):
+            logger.warning("Manual usage field %s is a bool (%r); ignoring it", key, value)
             continue
         try:
             parsed = max(int(value), 0)
         except (TypeError, ValueError, OverflowError):
+            logger.warning(
+                "Manual usage field %s is not a usable number (%r); ignoring it", key, value
+            )
             continue
         if parsed > _MANUAL_USAGE_MAX_TOKENS:
+            logger.warning(
+                "Manual usage field %s exceeds the sanity bound (%r); ignoring it", key, value
+            )
             continue
         usage[key] = parsed
     return usage

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -96,7 +96,6 @@ _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.type",
     "traceroot.span.metadata",
     "traceroot.span.tags",
-    "traceroot.llm.",
     "traceroot.trace.",
     "traceroot.environment",
     "traceroot.git.",
@@ -114,9 +113,25 @@ _KNOWN_ATTRIBUTE_PREFIXES = {
 }
 
 
+# Extracted attributes matched by EXACT name — a prefix entry would also swallow
+# siblings that are NOT extracted (e.g. "traceroot.llm.model" prefix-matches
+# traceroot.llm.model_parameters, which must flow to metadata instead).
+_KNOWN_ATTRIBUTE_EXACT = frozenset(
+    {
+        "traceroot.llm.model",  # -> model_name column + LLM span-kind detection
+        # -> token/cost pipeline (parse_manual_usage). Consumed only when a model
+        # name is present (the token block is model-gated), so usage reported
+        # without traceroot.llm.model is dropped entirely rather than priced.
+        "traceroot.llm.usage",
+    }
+)
+
+
 def _is_known_attribute(key: str) -> bool:
     """Check if an attribute key is already extracted into a dedicated field."""
-    return any(key == prefix or key.startswith(prefix) for prefix in _KNOWN_ATTRIBUTE_PREFIXES)
+    return key in _KNOWN_ATTRIBUTE_EXACT or any(
+        key == prefix or key.startswith(prefix) for prefix in _KNOWN_ATTRIBUTE_PREFIXES
+    )
 
 
 def first_present(attrs: dict[str, Any], keys: list[str]) -> Any:
@@ -167,6 +182,57 @@ def int_or_zero(value: Any) -> int:
     except (TypeError, ValueError):
         logger.warning("Non-numeric OTEL token attribute %r; treating as 0", value)
         return 0
+
+
+# Fields recognized in the SDKs' manual usage dict (Python
+# ``update_current_span(usage=...)`` / TS ``updateCurrentSpan({usage})``), which
+# both serialize as JSON into the ``traceroot.llm.usage`` span attribute.
+_MANUAL_USAGE_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "cache_write_1h_tokens",
+    "reasoning_tokens",
+)
+
+
+def parse_manual_usage(raw: Any) -> dict[str, int]:
+    """Parse the manual usage dict reported via the SDKs' update-span API.
+
+    The ``traceroot.llm.usage`` attribute is untrusted wire input: a non-JSON
+    string, a non-dict payload, or a non-numeric/negative/non-finite field must
+    never crash ingestion (``json.loads`` accepts literal ``Infinity``/``NaN``,
+    and ``int(inf)`` raises OverflowError). Unusable fields are dropped and
+    counts are clamped non-negative, so a partially-malformed dict degrades to
+    its valid fields (and an entirely unusable one to the text-estimation
+    fallback), never to an error.
+
+    Args:
+        raw (Any): The raw attribute value (a JSON string from either SDK, or an
+            already-decoded dict).
+
+    Returns:
+        dict[str, int]: The recognized usage fields with non-negative int
+            values; empty when the payload is missing or unusable.
+    """
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+    if not isinstance(raw, dict):
+        return {}
+    usage: dict[str, int] = {}
+    for key in _MANUAL_USAGE_KEYS:
+        value = raw.get(key)
+        if value is None or isinstance(value, bool):
+            continue
+        try:
+            usage[key] = max(int(value), 0)
+        except (TypeError, ValueError, OverflowError):
+            continue
+    return usage
 
 
 def decode_otel_id(b64_value: str | None) -> str | None:
@@ -586,6 +652,29 @@ def transform_otel_to_clickhouse(
                     aggregate_wrapper = _span_aggregates_child_usage(
                         scope_name, span_kind, span_attrs
                     )
+
+                    # Manual usage reported via the SDKs' update-span API
+                    # (traceroot.llm.usage) — the documented token source for
+                    # self-instrumented spans, where no instrumentor maps the
+                    # provider response (custom clients, gateways, proxies).
+                    # Instrumentor attributes win WHOLE-DICT, never per-field:
+                    # merging could pair counts measured under different
+                    # conventions (gross vs net input) and double-price cache.
+                    # When the manual dict is used, it replaces every field, so
+                    # the span is priced under the reporter's one convention.
+                    if (
+                        not aggregate_wrapper
+                        and api_input_tokens is None
+                        and api_output_tokens is None
+                    ):
+                        manual_usage = parse_manual_usage(span_attrs.get("traceroot.llm.usage"))
+                        if "input_tokens" in manual_usage or "output_tokens" in manual_usage:
+                            api_input_tokens = manual_usage.get("input_tokens")
+                            api_output_tokens = manual_usage.get("output_tokens")
+                            api_cache_read_tokens = manual_usage.get("cache_read_tokens")
+                            api_cache_write_tokens = manual_usage.get("cache_write_tokens")
+                            api_cache_write_1h_tokens = manual_usage.get("cache_write_1h_tokens")
+                            api_reasoning_tokens = manual_usage.get("reasoning_tokens")
 
                     if not aggregate_wrapper and (
                         api_input_tokens is not None or api_output_tokens is not None

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -196,12 +196,21 @@ _MANUAL_USAGE_KEYS = (
     "reasoning_tokens",
 )
 
+# Upper sanity bound per manual usage field. The token columns are Int64 and we
+# store SUMS of fields (total_tokens = uncached + cache buckets + output), so the
+# bound must sit far below Int64-max — capping at Int64-max itself would still
+# let two capped fields overflow the stored sum and reject the whole insert
+# batch. 10^15 tokens is orders of magnitude beyond any real span while keeping
+# any sum of the six fields comfortably inside Int64.
+_MANUAL_USAGE_MAX_TOKENS = 10**15
+
 
 def parse_manual_usage(raw: Any) -> dict[str, int]:
     """Parse the manual usage dict reported via the SDKs' update-span API.
 
     The ``traceroot.llm.usage`` attribute is untrusted wire input: a non-JSON
-    string, a non-dict payload, or a non-numeric/negative/non-finite field must
+    string, a non-dict payload, or a non-numeric/negative/non-finite/out-of-range
+    field must
     never crash ingestion (``json.loads`` accepts literal ``Infinity``/``NaN``,
     and ``int(inf)`` raises OverflowError). Unusable fields are dropped and
     counts are clamped non-negative, so a partially-malformed dict degrades to
@@ -219,7 +228,9 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
     if isinstance(raw, str):
         try:
             raw = json.loads(raw)
-        except (TypeError, ValueError):
+        # RecursionError: json.loads raises it on deeply-nested payloads, which
+        # would otherwise fail the whole ingest task instead of this one attribute.
+        except (TypeError, ValueError, RecursionError):
             return {}
     if not isinstance(raw, dict):
         return {}
@@ -229,9 +240,12 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
         if value is None or isinstance(value, bool):
             continue
         try:
-            usage[key] = max(int(value), 0)
+            parsed = max(int(value), 0)
         except (TypeError, ValueError, OverflowError):
             continue
+        if parsed > _MANUAL_USAGE_MAX_TOKENS:
+            continue
+        usage[key] = parsed
     return usage
 
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -1777,6 +1777,43 @@ class TestManualUsageAttribute:
             ],
         )
 
+    def test_manual_1h_cache_write_portion_is_priced_at_its_own_rate(self):
+        """The 1-hour portion is a sub-partition of the cache-write total, priced at
+        its own higher rate. Nothing else in this class reports it, so without this
+        the key could be dropped from the recognized set and only the cost would
+        move — silently, and in the direction that undercharges."""
+        from unittest.mock import patch
+
+        prices = {**MANUAL_USAGE_PRICES, "cacheWrite1h": 0.000006}
+        payload = make_otel_payload(
+            [
+                self._manual_span(
+                    {
+                        "input_tokens": 1000,
+                        "output_tokens": 10,
+                        "cache_write_tokens": 800,
+                        "cache_write_1h_tokens": 300,
+                    }
+                )
+            ],
+            scope_name="traceroot",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        span = spans[0]
+        assert span["usage_details"]["cache_write_1h_tokens"] == 300
+        assert span["usage_details"]["cache_write_tokens"] == 800
+        # 200 uncached (1000 gross - 800 written) + the write total split into its
+        # 1-hour portion and the remainder, each at its own rate.
+        expected = (
+            200 * prices["input"]
+            + 300 * prices["cacheWrite1h"]
+            + 500 * prices["cacheWrite"]
+            + 10 * prices["output"]
+        )
+        assert span["cost"] == pytest.approx(expected)
+
     def test_manual_usage_feeds_tokens_cache_and_cost(self):
         from unittest.mock import patch
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -1766,7 +1766,7 @@ class TestManualUsageAttribute:
         return make_span(
             "aa" * 16,
             "bb" * 8,
-            name="criteria_scorer_llm",
+            name="custom_llm_call",
             attributes=[
                 make_attr("traceroot.llm.model", "claude-3-5-sonnet"),
                 make_attr(
@@ -1997,6 +1997,26 @@ class TestManualUsageAttribute:
         with caplog.at_level(logging.WARNING):
             parse_manual_usage('{"input_tokens": 10, "output_tokens": 5}')
         assert not caplog.records
+
+    def test_usage_without_priceable_totals_is_reported(self, caplog):
+        """A dict of only cache or reasoning counts parses cleanly but cannot be
+        priced, so the adoption guard drops it. Say so, rather than repeating the
+        silent discard the field-level warnings exist to prevent."""
+        import logging
+        from unittest.mock import patch
+
+        payload = make_otel_payload(
+            [self._manual_span({"cache_read_tokens": 900, "reasoning_tokens": 10})],
+            scope_name="traceroot",
+        )
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("worker.tokens.pricing.get_model_price", return_value=MANUAL_USAGE_PRICES),
+        ):
+            transform_otel_to_clickhouse(payload, "proj-1")
+        logged = "\n".join(r.getMessage() for r in caplog.records)
+        assert "cache_read_tokens" in logged
+        assert "no input_tokens or output_tokens" in logged
 
     def test_model_parameters_and_prompt_flow_to_metadata(self):
         import json

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -1926,8 +1926,16 @@ class TestManualUsageAttribute:
         assert parse_manual_usage(
             '{"input_tokens": Infinity, "output_tokens": NaN, "cache_read_tokens": 5}'
         ) == {"cache_read_tokens": 5}
+        # The token columns are Int64 and sums of fields are stored, so absurd
+        # magnitudes must drop — an unbounded int would reject the insert batch.
+        assert parse_manual_usage(
+            '{"input_tokens": 99999999999999999999999999, "output_tokens": 7}'
+        ) == {"output_tokens": 7}
         assert parse_manual_usage(None) == {}
         assert parse_manual_usage("[1, 2]") == {}
+        # Deeply-nested JSON raises RecursionError inside json.loads; it must
+        # degrade to "no usage", not crash the ingest task.
+        assert parse_manual_usage("[" * 200_000 + "]" * 200_000) == {}
 
     def test_model_parameters_and_prompt_flow_to_metadata(self):
         import json

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -1742,3 +1742,211 @@ class TestCacheTokenMetadata:
         ud = spans[0]["usage_details"]
         assert "cache_write_1h_tokens" not in ud
         assert set(ud) == {"cache_read_tokens", "cache_write_tokens", "reasoning_tokens"}
+
+
+MANUAL_USAGE_PRICES = {
+    "input": 0.000003,
+    "output": 0.000015,
+    "cacheRead": 0.0000003,
+    "cacheWrite": 0.00000375,
+}
+
+
+class TestManualUsageAttribute:
+    """The SDKs' update-span API serializes usage as JSON into traceroot.llm.usage
+    — the documented token source for self-instrumented spans (custom clients,
+    gateways, proxies), where no instrumentor maps the provider response. These
+    tests pin that the dict feeds the same bucket/pricing pipeline as instrumentor
+    attributes, loses to them whole-dict, and degrades safely when malformed."""
+
+    @staticmethod
+    def _manual_span(usage, *extra):
+        import json
+
+        return make_span(
+            "aa" * 16,
+            "bb" * 8,
+            name="criteria_scorer_llm",
+            attributes=[
+                make_attr("traceroot.llm.model", "claude-3-5-sonnet"),
+                make_attr(
+                    "traceroot.llm.usage",
+                    json.dumps(usage) if not isinstance(usage, str) else usage,
+                ),
+                *extra,
+            ],
+        )
+
+    def test_manual_usage_feeds_tokens_cache_and_cost(self):
+        from unittest.mock import patch
+
+        # Gross input: 1000 = 50 uncached + 900 cache-read + 50 cache-write.
+        payload = make_otel_payload(
+            [
+                self._manual_span(
+                    {
+                        "input_tokens": 1000,
+                        "output_tokens": 200,
+                        "cache_read_tokens": 900,
+                        "cache_write_tokens": 50,
+                        "reasoning_tokens": 150,
+                    },
+                    # Input text present: if estimation ran instead of the manual
+                    # dict, the token counts would come from tiktoken, not 1000/200.
+                    make_attr("traceroot.span.input", "some prompt text " * 50),
+                )
+            ],
+            scope_name="traceroot",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=MANUAL_USAGE_PRICES):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        span = spans[0]
+        assert span["input_tokens"] == 1000
+        assert span["output_tokens"] == 200
+        assert span["usage_details"]["cache_read_tokens"] == 900
+        assert span["usage_details"]["cache_write_tokens"] == 50
+        assert span["usage_details"]["reasoning_tokens"] == 150
+        expected = (
+            50 * MANUAL_USAGE_PRICES["input"]
+            + 900 * MANUAL_USAGE_PRICES["cacheRead"]
+            + 50 * MANUAL_USAGE_PRICES["cacheWrite"]
+            + 200 * MANUAL_USAGE_PRICES["output"]
+        )
+        assert span["cost"] == pytest.approx(expected)
+
+    def test_manual_net_input_floors_uncached_and_prices_cache_in_full(self):
+        from unittest.mock import patch
+
+        # Anthropic-style NET report: input_tokens excludes cache. The uncached
+        # bucket floors to zero and the gross input reconstructs from the buckets.
+        payload = make_otel_payload(
+            [
+                self._manual_span(
+                    {
+                        "input_tokens": 2,
+                        "output_tokens": 204,
+                        "cache_read_tokens": 900,
+                        "cache_write_tokens": 50,
+                    }
+                )
+            ],
+            scope_name="traceroot",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=MANUAL_USAGE_PRICES):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        span = spans[0]
+        assert span["input_tokens"] == 950  # 0 uncached + 900 + 50
+        expected = (
+            900 * MANUAL_USAGE_PRICES["cacheRead"]
+            + 50 * MANUAL_USAGE_PRICES["cacheWrite"]
+            + 204 * MANUAL_USAGE_PRICES["output"]
+        )
+        assert span["cost"] == pytest.approx(expected)
+
+    def test_instrumentor_attributes_win_whole_dict(self):
+        from unittest.mock import patch
+
+        # A span carrying both instrumentor totals and a conflicting manual dict
+        # must be priced from the instrumentor values only — including the cache
+        # fields, which must NOT be merged in from the manual dict.
+        payload = make_otel_payload(
+            [
+                self._manual_span(
+                    {"input_tokens": 9999, "output_tokens": 9999, "cache_read_tokens": 9999},
+                    make_attr("gen_ai.usage.input_tokens", 100),
+                    make_attr("gen_ai.usage.output_tokens", 50),
+                )
+            ],
+            scope_name="traceroot",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=MANUAL_USAGE_PRICES):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        span = spans[0]
+        assert span["input_tokens"] == 100
+        assert span["output_tokens"] == 50
+        assert span["usage_details"]["cache_read_tokens"] == 0
+
+    def test_lone_instrumentor_total_also_suppresses_manual_dict(self):
+        from unittest.mock import patch
+
+        # Even a single instrumentor total (only output here) means the span IS
+        # instrumented, so the manual dict must be suppressed whole — not used
+        # to fill the missing input or merge in cache fields.
+        payload = make_otel_payload(
+            [
+                self._manual_span(
+                    {"input_tokens": 9999, "cache_read_tokens": 9999},
+                    make_attr("gen_ai.usage.output_tokens", 50),
+                )
+            ],
+            scope_name="traceroot",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=MANUAL_USAGE_PRICES):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        span = spans[0]
+        assert span["input_tokens"] == 0
+        assert span["output_tokens"] == 50
+        assert span["usage_details"]["cache_read_tokens"] == 0
+
+    def test_malformed_usage_falls_back_to_estimation(self):
+        from unittest.mock import patch
+
+        payload = make_otel_payload(
+            [
+                self._manual_span(
+                    "not valid json {",
+                    make_attr("traceroot.span.input", "some prompt text " * 50),
+                    make_attr("traceroot.span.output", "a response"),
+                )
+            ],
+            scope_name="traceroot",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=MANUAL_USAGE_PRICES):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        span = spans[0]
+        # Estimation ran (text-derived counts), and no usage_details map is set
+        # on the estimation path — identical to before this change.
+        assert span["input_tokens"] > 0
+        assert "usage_details" not in span
+
+    def test_invalid_fields_dropped_and_negatives_clamped(self):
+        from worker.otel_transform import parse_manual_usage
+
+        assert parse_manual_usage(
+            '{"input_tokens": "abc", "output_tokens": -5, "cache_read_tokens": 900, '
+            '"unknown_key": 7, "reasoning_tokens": true}'
+        ) == {"output_tokens": 0, "cache_read_tokens": 900}
+        # json.loads accepts literal Infinity/NaN; int(inf) raises OverflowError
+        # (not ValueError), so non-finite fields must drop rather than crash.
+        assert parse_manual_usage(
+            '{"input_tokens": Infinity, "output_tokens": NaN, "cache_read_tokens": 5}'
+        ) == {"cache_read_tokens": 5}
+        assert parse_manual_usage(None) == {}
+        assert parse_manual_usage("[1, 2]") == {}
+
+    def test_model_parameters_and_prompt_flow_to_metadata(self):
+        import json
+
+        payload = make_otel_payload(
+            [
+                self._manual_span(
+                    {"input_tokens": 10, "output_tokens": 5},
+                    make_attr("traceroot.llm.model_parameters", '{"temperature": 0.2}'),
+                    make_attr("traceroot.llm.prompt", '[{"role": "user"}]'),
+                )
+            ],
+            scope_name="traceroot",
+        )
+        _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        metadata = json.loads(spans[0]["metadata"])
+        assert metadata["traceroot.llm.model_parameters"] == '{"temperature": 0.2}'
+        assert metadata["traceroot.llm.prompt"] == '[{"role": "user"}]'
+        # Extracted keys stay out of metadata.
+        assert "traceroot.llm.model" not in metadata
+        assert "traceroot.llm.usage" not in metadata

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -1974,6 +1974,30 @@ class TestManualUsageAttribute:
         # degrade to "no usage", not crash the ingest task.
         assert parse_manual_usage("[" * 200_000 + "]" * 200_000) == {}
 
+    def test_unrecognized_usage_fields_are_reported(self, caplog):
+        """A provider token type we do not model yet (audio, image, a new cache
+        variant) is never examined by the parser, so without a warning it vanishes
+        with no signal anywhere. The recognized fields must still parse."""
+        import logging
+
+        from worker.otel_transform import parse_manual_usage
+
+        with caplog.at_level(logging.WARNING):
+            usage = parse_manual_usage('{"input_tokens": 10, "audio_tokens": 7, "image_tokens": 3}')
+        assert usage == {"input_tokens": 10}
+        warning = "\n".join(r.getMessage() for r in caplog.records)
+        assert "audio_tokens" in warning
+        assert "image_tokens" in warning
+
+    def test_fully_recognized_usage_logs_no_warning(self, caplog):
+        import logging
+
+        from worker.otel_transform import parse_manual_usage
+
+        with caplog.at_level(logging.WARNING):
+            parse_manual_usage('{"input_tokens": 10, "output_tokens": 5}')
+        assert not caplog.records
+
     def test_model_parameters_and_prompt_flow_to_metadata(self):
         import json
 

--- a/tests/worker/test_otel_transform_metadata.py
+++ b/tests/worker/test_otel_transform_metadata.py
@@ -323,7 +323,8 @@ def test_span_path_attributes_survive_into_metadata():
     This is what lets the client rebuild the tree of an in-flight trace: children
     are exported before their parents, so the missing ancestors are synthesized
     from these keys. They survive only because they are absent from
-    `_KNOWN_ATTRIBUTE_PREFIXES` and therefore fall into the leftover-attribute
+    `_KNOWN_ATTRIBUTE_PREFIXES` or `_KNOWN_ATTRIBUTE_EXACT`, and therefore fall
+    into the leftover-attribute
     bag that becomes `metadata` — an incidental mechanism. Adding them to that
     prefix set would silently disable live-tree repair with no other failure, so
     it is pinned here.


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked PR — 2 of 2.** Base is `fix/semconv-agent-usage-double-count` (#1612), **not `main`**.
> Merge order: **#1612 first, then this PR.** The two conflicted on the same guard in
> `otel_transform.py`; the resolution lives in this branch, so CI here tests the real combination.
> If #1612 is squash-merged, GitHub retargets this PR to `main` but does not rebase it — it will
> need one rebase at that point.

Closes #1600

## Problem

Both SDKs document a manual API for reporting LLM token usage on self-instrumented spans — the recommended path when no auto-instrumentor fits (custom clients, API-compatible gateways, routing proxies). Both serialize the dict as JSON into the `traceroot.llm.usage` span attribute.

Ingestion never read that attribute, and the blanket `traceroot.llm.` entry in the known-attribute strip-list also excluded it from the metadata passthrough — so reported usage was destroyed on ingest and the span silently fell back to tiktoken text estimation. Consequences (details in #1600): displayed tokens were estimates presented as truth, the cache read/write breakdown could never populate for these spans, net-style input reports undercounted to near-zero, and `traceroot.llm.model_parameters` / `traceroot.llm.prompt` were destroyed outright.

## Changes

- **`parse_manual_usage()`** — defensive parse of the untrusted JSON attribute: recognized keys only (`input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_write_tokens`, `cache_write_1h_tokens`, `reasoning_tokens`), non-numeric/bool fields dropped, negatives clamped, non-finite values (`json.loads` accepts literal `Infinity`/`NaN`; `int(inf)` raises `OverflowError`) dropped rather than crashing, malformed payloads degrade to the estimation fallback — never an exception.
- **Token pipeline injection** — when no instrumentor input/output token attribute matched, a manual dict containing `input_tokens` or `output_tokens` populates the API-token path and flows through the existing machinery unchanged: `normalize_token_usage` buckets, `cost_from_buckets` pricing, `usage_details` persistence. Estimation no longer overrides reported counts. Instrumentor attributes win **whole-dict**, never per-field — merging could pair counts measured under different gross/net conventions and double-price cache. Net-style input needs no new logic: the existing subtract-and-floor bucket rule prices both conventions correctly.
- **Strip-list narrowed** — the blanket `traceroot.llm.` prefix is replaced by an exact-match set for the two genuinely-extracted keys (`traceroot.llm.model`, `traceroot.llm.usage`), so `model_parameters` and `prompt` now flow into span metadata. Exact matching matters: a `traceroot.llm.model` prefix would also swallow `model_parameters`.

No schema migration — `usage_details` is already a generic Map, and metadata is an existing blob column.

## Not in this PR (tracked in #1600 follow-ups)

Instrumentation scope-name persistence (needs a ClickHouse migration), warning on impossible token shapes (output without input), and the SDK docstring/type updates for the key contract (separate repos).

## Verification

- 7 new tests in `TestManualUsageAttribute`: gross happy path with exact cost + cache + reasoning in `usage_details`; net input floors uncached and prices cache in full; whole-dict precedence with both instrumentor totals and with a lone one; malformed JSON falls back to estimation with no `usage_details`; parser hardening (non-numeric, negative, non-finite, non-dict); `model_parameters`/`prompt` metadata passthrough with extracted keys still stripped.
- Full `tests/worker/` suite: 372 passed. Ruff check and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ingests manually reported LLM token usage from `traceroot.llm.usage` into the token/cost pipeline when no instrumentor tokens are present. Fixes undercounting and missing cache breakdown for self-instrumented spans and restores `model_parameters`/`prompt` metadata passthrough (addresses #1600).

- **New Features**
  - Parse `traceroot.llm.usage` defensively: accept known keys only, drop invalid/non-finite values, clamp negatives, cap per-field counts, survive deeply nested JSON, and warn on discarded/unrecognized fields and on payloads that parse but cannot be priced — never throw; price `cache_write_1h_tokens` at its own rate.
  - Use the parsed dict to populate input/output/cache/reasoning tokens only when no instrumentor token attributes exist; instrumentor values win as a whole.

- **Bug Fixes**
  - Replace the `traceroot.llm.` strip-prefix with exact matches for `traceroot.llm.model` and `traceroot.llm.usage`, so `model_parameters` and `prompt` flow to metadata.
  - Stop text estimation from overriding reported counts, enabling accurate cost and `usage_details` (including cache read/write, 1-hour cache write, and reasoning tokens).

<sup>Written for commit 4f6533570fc062757482ee028d24f2c874981952. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

