### PR TITLE
fix(detectors): stop the screening-model picker from silently pinning an auto-picked model

### DIFF
--- a/frontend/packages/core/src/__tests__/model-resolver.test.ts
+++ b/frontend/packages/core/src/__tests__/model-resolver.test.ts
@@ -16,11 +16,13 @@ vi.mock("../lib/encryption", () => ({
 
 import {
   resolvePiModel,
+  isSystemModelId,
   fetchProviderConfig,
   findByokKeyForPiProvider,
   invalidateProviderConfigCache,
   type ProviderModelConfig,
 } from "../model-resolver.ts";
+import { SYSTEM_MODELS, DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "../llm-providers.ts";
 import { prisma } from "../lib/prisma.ts";
 
 describe("resolvePiModel", () => {
@@ -204,5 +206,26 @@ describe("findByokKeyForPiProvider", () => {
     );
     const key = await findByokKeyForPiProvider("ws-5", "anthropic");
     expect(key).toBeNull();
+  });
+});
+
+describe("isSystemModelId", () => {
+  it("accepts every id the catalog offers", () => {
+    const ids = SYSTEM_MODELS.flatMap((s) => s.models.map((m) => m.id));
+    expect(ids.length).toBeGreaterThan(0);
+    for (const id of ids) {
+      expect(isSystemModelId(id)).toBe(true);
+    }
+  });
+
+  // Callers reject ids this returns false for, so a default that fell out of
+  // the catalog would fail every unpinned detector rather than degrade.
+  it("accepts the detector screening default", () => {
+    expect(isSystemModelId(DETECTOR_SYSTEM_DEFAULT_MODEL_ID)).toBe(true);
+  });
+
+  it("rejects a retired or invented id", () => {
+    expect(isSystemModelId("claude-retired-1")).toBe(false);
+    expect(isSystemModelId("")).toBe(false);
   });
 });

--- a/frontend/packages/core/src/model-resolver.ts
+++ b/frontend/packages/core/src/model-resolver.ts
@@ -48,6 +48,15 @@ for (const sys of SYSTEM_MODELS) {
 }
 
 /**
+ * Whether `modelId` is one of the compiled-in system models. Lets callers
+ * holding a *stored* id reject one that has left the catalog, which
+ * `resolvePiModel` would otherwise answer with a substitute model.
+ */
+export function isSystemModelId(modelId: string): boolean {
+  return systemModelLookup.has(modelId);
+}
+
+/**
  * Build a pi-ai Model object with the correct `api` protocol while preserving
  * pi-ai registry data (pricing, context window) when available.
  * Falls back to a manual object for models not in the registry.

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -6,6 +6,7 @@ import { getTemplate } from "@/features/detectors/templates";
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   mutateAsync: vi.fn().mockResolvedValue({ id: "det-1" }),
+  selectorProps: null as Record<string, unknown> | null,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -22,7 +23,10 @@ vi.mock("@/features/projects/components", () => ({
   ProjectBreadcrumb: () => null,
 }));
 vi.mock("@/features/ai-assistant/components/model-selector", () => ({
-  ModelSelector: () => null,
+  ModelSelector: (props: Record<string, unknown>) => {
+    mocks.selectorProps = props;
+    return null;
+  },
 }));
 vi.mock("@/features/detectors/components/trigger-editor", () => ({
   TriggerEditor: () => null,
@@ -40,6 +44,7 @@ afterEach(() => {
   cleanup();
   mocks.mutateAsync.mockClear();
   mocks.push.mockClear();
+  mocks.selectorProps = null;
 });
 
 describe("NewDetectorPage", () => {
@@ -81,5 +86,10 @@ describe("NewDetectorPage", () => {
       prompt: "my prompt",
       template: "failure",
     });
+  });
+
+  it("renders the screening-model picker with a system-default placeholder (no auto-pick)", () => {
+    render(<NewDetectorPage />);
+    expect(mocks.selectorProps?.placeholder).toBe("System default (claude-haiku-4-5)");
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -89,8 +89,8 @@ describe("NewDetectorPage", () => {
     });
   });
 
-  it("renders the screening-model picker with a system-default placeholder (no auto-pick)", () => {
+  it("renders the screening-model picker with a system-default model id (no auto-pick)", () => {
     render(<NewDetectorPage />);
-    expect(mocks.selectorProps?.placeholder).toBe(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
+    expect(mocks.selectorProps?.defaultModelId).toBe(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import { getTemplate } from "@/features/detectors/templates";
 
 const mocks = vi.hoisted(() => ({
@@ -90,6 +91,6 @@ describe("NewDetectorPage", () => {
 
   it("renders the screening-model picker with a system-default placeholder (no auto-pick)", () => {
     render(<NewDetectorPage />);
-    expect(mocks.selectorProps?.placeholder).toBe("System default (claude-haiku-4-5)");
+    expect(mocks.selectorProps?.placeholder).toBe(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
 });

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/features/ai-assistant/components/model-selector";
 import {
   DEFAULT_DETECTOR_SAMPLE_RATE,
+  DETECTOR_MODEL_PLACEHOLDER,
   DETECTOR_TEMPLATES,
   buildTemplateDetectorInput,
 } from "@/features/detectors/templates";
@@ -155,6 +156,7 @@ export default function NewDetectorPage() {
                     value={modelSelection}
                     onChange={setModelSelection}
                     workspaceId={project?.workspace_id}
+                    placeholder={DETECTOR_MODEL_PLACEHOLDER}
                   />
                   <p className="mt-1 text-[11px] text-muted-foreground">
                     Used to evaluate each trace for this detector.

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -156,7 +156,7 @@ export default function NewDetectorPage() {
                     value={modelSelection}
                     onChange={setModelSelection}
                     workspaceId={project?.workspace_id}
-                    placeholder={DETECTOR_SYSTEM_DEFAULT_MODEL_ID}
+                    defaultModelId={DETECTOR_SYSTEM_DEFAULT_MODEL_ID}
                   />
                   <p className="mt-1 text-[11px] text-muted-foreground">
                     Used to evaluate each trace for this detector.

--- a/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/new/page.tsx
@@ -8,9 +8,9 @@ import {
   ModelSelector,
   type ModelSelection,
 } from "@/features/ai-assistant/components/model-selector";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import {
   DEFAULT_DETECTOR_SAMPLE_RATE,
-  DETECTOR_MODEL_PLACEHOLDER,
   DETECTOR_TEMPLATES,
   buildTemplateDetectorInput,
 } from "@/features/detectors/templates";
@@ -156,7 +156,7 @@ export default function NewDetectorPage() {
                     value={modelSelection}
                     onChange={setModelSelection}
                     workspaceId={project?.workspace_id}
-                    placeholder={DETECTOR_MODEL_PLACEHOLDER}
+                    placeholder={DETECTOR_SYSTEM_DEFAULT_MODEL_ID}
                   />
                   <p className="mt-1 text-[11px] text-muted-foreground">
                     Used to evaluate each trace for this detector.

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
@@ -109,24 +109,23 @@ afterEach(() => {
 });
 
 describe("DetectorsPage", () => {
-  it("shows the resolved detector default model with a default marker", () => {
+  it("shows the resolved detector default model, unadorned", () => {
     render(<DetectorsPage />);
 
     const defaultRow = screen.getByText("My Detector").closest("tr");
     expect(defaultRow).not.toBeNull();
     expect(defaultRow?.textContent).toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
     expect(defaultRow?.textContent).not.toContain("System default:");
-    expect(defaultRow?.textContent).toContain("(default)");
+    expect(defaultRow?.textContent).not.toContain("(default)");
   });
 
-  it("does not label BYOK detectors without a model as a default", () => {
+  it("shows the provider name for BYOK detectors without a model", () => {
     render(<DetectorsPage />);
 
     const byokRow = screen.getByText("BYOK Detector").closest("tr");
     expect(byokRow).not.toBeNull();
     expect(byokRow?.textContent).toContain("Anthropic BYOK");
     expect(byokRow?.textContent).not.toContain("BYOK provider:");
-    expect(byokRow?.textContent).not.toContain("(default)");
     expect(byokRow?.textContent).not.toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
 
@@ -136,11 +135,10 @@ describe("DetectorsPage", () => {
     const legacyRow = screen.getByText("Legacy Detector").closest("tr");
     expect(legacyRow).not.toBeNull();
     expect(legacyRow?.textContent).toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
-    expect(legacyRow?.textContent).toContain("(default)");
     expect(legacyRow?.textContent).not.toContain("Auto-selected");
   });
 
-  it("shows pinned detector models without the default marker", () => {
+  it("shows pinned detector models with no source prefix", () => {
     render(<DetectorsPage />);
 
     const pinnedRow = screen.getByText("Pinned Detector").closest("tr");
@@ -148,7 +146,6 @@ describe("DetectorsPage", () => {
     expect(pinnedRow?.textContent).toContain("gpt-5.4");
     expect(pinnedRow?.textContent).not.toContain("System pinned:");
     expect(pinnedRow?.textContent).not.toContain("System default:");
-    expect(pinnedRow?.textContent).not.toContain("(default)");
   });
 
   it("shows pinned BYOK detector models without source prefixes", () => {
@@ -158,7 +155,6 @@ describe("DetectorsPage", () => {
     expect(pinnedByokRow).not.toBeNull();
     expect(pinnedByokRow?.textContent).toContain("gpt-5.4");
     expect(pinnedByokRow?.textContent).not.toContain("BYOK (OpenAI BYOK):");
-    expect(pinnedByokRow?.textContent).not.toContain("(default)");
   });
 
   it("carries the selected time range into the detector detail URL on row click", () => {

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
@@ -115,7 +115,6 @@ describe("DetectorsPage", () => {
     const defaultRow = screen.getByText("My Detector").closest("tr");
     expect(defaultRow).not.toBeNull();
     expect(defaultRow?.textContent).toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
-    expect(defaultRow?.textContent).not.toContain("System default:");
     expect(defaultRow?.textContent).not.toContain("(default)");
   });
 
@@ -125,7 +124,6 @@ describe("DetectorsPage", () => {
     const byokRow = screen.getByText("BYOK Detector").closest("tr");
     expect(byokRow).not.toBeNull();
     expect(byokRow?.textContent).toContain("Anthropic BYOK");
-    expect(byokRow?.textContent).not.toContain("BYOK provider:");
     expect(byokRow?.textContent).not.toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
 
@@ -138,23 +136,21 @@ describe("DetectorsPage", () => {
     expect(legacyRow?.textContent).not.toContain("Auto-selected");
   });
 
-  it("shows pinned detector models with no source prefix", () => {
+  it("shows a pinned model id verbatim", () => {
     render(<DetectorsPage />);
 
     const pinnedRow = screen.getByText("Pinned Detector").closest("tr");
     expect(pinnedRow).not.toBeNull();
     expect(pinnedRow?.textContent).toContain("gpt-5.4");
-    expect(pinnedRow?.textContent).not.toContain("System pinned:");
-    expect(pinnedRow?.textContent).not.toContain("System default:");
   });
 
-  it("shows pinned BYOK detector models without source prefixes", () => {
+  it("prefers a BYOK detector's pinned model over its provider name", () => {
     render(<DetectorsPage />);
 
     const pinnedByokRow = screen.getByText("Pinned BYOK Detector").closest("tr");
     expect(pinnedByokRow).not.toBeNull();
     expect(pinnedByokRow?.textContent).toContain("gpt-5.4");
-    expect(pinnedByokRow?.textContent).not.toContain("BYOK (OpenAI BYOK):");
+    expect(pinnedByokRow?.textContent).not.toContain("OpenAI BYOK");
   });
 
   it("carries the selected time range into the detector detail URL on row click", () => {

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.test.tsx
@@ -130,15 +130,14 @@ describe("DetectorsPage", () => {
     expect(byokRow?.textContent).not.toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
 
-  it("keeps legacy null-source detector labels availability-aware", () => {
+  it("labels legacy null-source detectors with the screening default the worker uses", () => {
     render(<DetectorsPage />);
 
     const legacyRow = screen.getByText("Legacy Detector").closest("tr");
     expect(legacyRow).not.toBeNull();
-    expect(legacyRow?.textContent).toContain("Auto-selected");
-    expect(legacyRow?.textContent).not.toContain("Auto-selected default");
+    expect(legacyRow?.textContent).toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
     expect(legacyRow?.textContent).toContain("(default)");
-    expect(legacyRow?.textContent).not.toContain(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
+    expect(legacyRow?.textContent).not.toContain("Auto-selected");
   });
 
   it("shows pinned detector models without the default marker", () => {

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -29,16 +29,16 @@ function formatDetectorModel(detector: {
   detectionSource: "system" | "byok" | null;
 }) {
   if (detector.detectionModel) {
-    return { label: detector.detectionModel, isDefault: false };
+    return detector.detectionModel;
   }
 
   if (detector.detectionSource === "byok") {
-    return { label: detector.detectionProvider ?? "configured provider", isDefault: false };
+    return detector.detectionProvider ?? "configured provider";
   }
 
   // Both "system" and a never-set null source resolve to the screening
   // default at eval time, so an unpinned detector reads the same either way.
-  return { label: DETECTOR_SYSTEM_DEFAULT_MODEL_ID, isDefault: true };
+  return DETECTOR_SYSTEM_DEFAULT_MODEL_ID;
 }
 
 export default function DetectorsPage() {
@@ -243,12 +243,7 @@ export default function DetectorsPage() {
                         {template?.label ?? detector.template}
                       </td>
                       <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
-                        {detectorModel.label}
-                        {detectorModel.isDefault && (
-                          <span className="ml-1 text-[11px] text-muted-foreground/70">
-                            (default)
-                          </span>
-                        )}
+                        {detectorModel}
                       </td>
                       <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                         {detector.sampleRate}%

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -36,11 +36,9 @@ function formatDetectorModel(detector: {
     return { label: detector.detectionProvider ?? "configured provider", isDefault: false };
   }
 
-  if (detector.detectionSource === "system") {
-    return { label: DETECTOR_SYSTEM_DEFAULT_MODEL_ID, isDefault: true };
-  }
-
-  return { label: "Auto-selected", isDefault: true };
+  // Both "system" and a never-set null source resolve to the screening
+  // default at eval time, so an unpinned detector reads the same either way.
+  return { label: DETECTOR_SYSTEM_DEFAULT_MODEL_ID, isDefault: true };
 }
 
 export default function DetectorsPage() {

--- a/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/detectors/page.tsx
@@ -219,7 +219,7 @@ export default function DetectorsPage() {
               <tbody>
                 {detectors.map((detector) => {
                   const template = getTemplate(detector.template);
-                  const detectorModel = formatDetectorModel(detector);
+                  const modelLabel = formatDetectorModel(detector);
                   const c = counts?.[detector.id];
                   const findingCount = c?.finding_count ?? 0;
                   const runCount = c?.run_count ?? 0;
@@ -243,7 +243,7 @@ export default function DetectorsPage() {
                         {template?.label ?? detector.template}
                       </td>
                       <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
-                        {detectorModel}
+                        {modelLabel}
                       </td>
                       <td className="border-r border-border/50 px-3 py-1.5 text-[12px] text-muted-foreground">
                         {detector.sampleRate}%

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -92,4 +92,60 @@ describe("ModelSelector", () => {
       adapter: "anthropic",
     });
   });
+
+  it("does not auto-pick when a placeholder marks empty as a valid state", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        placeholder="System default (claude-haiku-4-5)"
+      />,
+    );
+
+    expect(mocks.onChange).not.toHaveBeenCalled();
+    expect(screen.getByRole("button").textContent).toContain("System default (claude-haiku-4-5)");
+  });
+
+  it("still backfills a legacy model-only selection when a placeholder is set", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "claude-4", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        placeholder="System default (claude-haiku-4-5)"
+      />,
+    );
+
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: "claude-4",
+      provider: "anthropic",
+      source: "system",
+      adapter: "anthropic",
+    });
+  });
 });

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -153,6 +153,94 @@ describe("ModelSelector", () => {
     expect(other?.textContent).not.toContain("✓");
   });
 
+  it("picking the tracked default keeps the selection empty rather than pinning it", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [
+            { id: "claude-4", label: "Claude 4" },
+            { id: "claude-5", label: "Claude 5" },
+          ],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        defaultModelId="claude-4"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+
+    const rows = screen.getAllByRole("button").filter((b) => !b.hasAttribute("aria-haspopup"));
+    fireEvent.click(rows.find((b) => b.textContent?.includes("Claude 4"))!);
+    expect(mocks.onChange).not.toHaveBeenCalled();
+
+    // Any other row is a real pick and still writes a selection.
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(
+      screen
+        .getAllByRole("button")
+        .filter((b) => !b.hasAttribute("aria-haspopup"))
+        .find((b) => b.textContent?.includes("Claude 5"))!,
+    );
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: "claude-5",
+      provider: "anthropic",
+      source: "system",
+      adapter: "anthropic",
+    });
+  });
+
+  // The suppression above applies only while the selection is empty, so a
+  // parent that moved off the default can always move back to it.
+  it("selects the default model normally once something else is pinned", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [
+            { id: "claude-4", label: "Claude 4" },
+            { id: "claude-5", label: "Claude 5" },
+          ],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "claude-5", provider: "anthropic", source: "system", adapter: "anthropic" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        defaultModelId="claude-4"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    fireEvent.click(
+      screen
+        .getAllByRole("button")
+        .filter((b) => !b.hasAttribute("aria-haspopup"))
+        .find((b) => b.textContent?.includes("Claude 4"))!,
+    );
+
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: "claude-4",
+      provider: "anthropic",
+      source: "system",
+      adapter: "anthropic",
+    });
+  });
+
   // A BYOK provider may expose the same model id as the system default; that
   // is a separate row and picking it stores a different selection, so only
   // the system row is the tracked default.

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -111,12 +111,12 @@ describe("ModelSelector", () => {
         value={{ model: "", provider: "", source: "system", adapter: "" }}
         onChange={mocks.onChange}
         workspaceId="workspace-1"
-        placeholder="claude-haiku-4-5"
+        placeholder="Default model"
       />,
     );
 
     expect(mocks.onChange).not.toHaveBeenCalled();
-    expect(screen.getByRole("button").textContent).toContain("claude-haiku-4-5");
+    expect(screen.getByRole("button").textContent).toContain("Default model");
   });
 
   it("still backfills a legacy model-only selection when a placeholder is set", () => {
@@ -137,7 +137,7 @@ describe("ModelSelector", () => {
         value={{ model: "claude-4", provider: "", source: "system", adapter: "" }}
         onChange={mocks.onChange}
         workspaceId="workspace-1"
-        placeholder="claude-haiku-4-5"
+        placeholder="Default model"
       />,
     );
 

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, cleanup, screen } from "@testing-library/react";
+import { render, cleanup, screen, fireEvent } from "@testing-library/react";
 
 const mocks = vi.hoisted(() => ({
   models: undefined as
@@ -93,7 +93,7 @@ describe("ModelSelector", () => {
     });
   });
 
-  it("does not auto-pick when a placeholder marks empty as a valid state", () => {
+  it("does not auto-pick when a defaultModelId marks empty as a valid state", () => {
     mocks.models = {
       byokProviders: [],
       systemModels: [
@@ -111,15 +111,90 @@ describe("ModelSelector", () => {
         value={{ model: "", provider: "", source: "system", adapter: "" }}
         onChange={mocks.onChange}
         workspaceId="workspace-1"
-        placeholder="Default model"
+        defaultModelId="claude-4"
       />,
     );
 
     expect(mocks.onChange).not.toHaveBeenCalled();
-    expect(screen.getByRole("button").textContent).toContain("Default model");
+    expect(screen.getByRole("button").textContent).toContain("Claude 4");
   });
 
-  it("still backfills a legacy model-only selection when a placeholder is set", () => {
+  it("ticks the tracked default so an empty selection reads as a real pick", () => {
+    mocks.models = {
+      byokProviders: [],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [
+            { id: "claude-4", label: "Claude 4" },
+            { id: "claude-5", label: "Claude 5" },
+          ],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        defaultModelId="claude-4"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+
+    // The popover trigger repeats the selected label, so exclude it.
+    const rows = screen.getAllByRole("button").filter((b) => !b.hasAttribute("aria-haspopup"));
+    const tracked = rows.find((b) => b.textContent?.includes("Claude 4"));
+    const other = rows.find((b) => b.textContent?.includes("Claude 5"));
+    expect(tracked?.textContent).toContain("✓");
+    expect(other?.textContent).not.toContain("✓");
+  });
+
+  // A BYOK provider may expose the same model id as the system default; that
+  // is a separate row and picking it stores a different selection, so only
+  // the system row is the tracked default.
+  it("ticks only the system row when a BYOK provider exposes the same id", () => {
+    mocks.models = {
+      byokProviders: [
+        {
+          provider: "My Anthropic",
+          adapter: "anthropic",
+          source: "byok",
+          models: [{ id: "claude-4", label: "Claude 4", supported: true }],
+        },
+      ],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        defaultModelId="claude-4"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button"));
+
+    const ticked = screen
+      .getAllByRole("button")
+      .filter((b) => b.textContent?.includes("✓") && b.textContent?.includes("Claude 4"));
+    expect(ticked).toHaveLength(1);
+    // The BYOK row is the one carrying the provider tag.
+    expect(ticked[0].textContent).not.toContain("My Anthropic");
+  });
+
+  it("still backfills a legacy model-only selection when a defaultModelId is set", () => {
     mocks.models = {
       byokProviders: [],
       systemModels: [
@@ -137,7 +212,7 @@ describe("ModelSelector", () => {
         value={{ model: "claude-4", provider: "", source: "system", adapter: "" }}
         onChange={mocks.onChange}
         workspaceId="workspace-1"
-        placeholder="Default model"
+        defaultModelId="claude-4"
       />,
     );
 

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -241,6 +241,122 @@ describe("ModelSelector", () => {
     });
   });
 
+  // A BYOK detector with no model runs that provider's own model, so showing
+  // it the system default would name a model that will not run.
+  it("does not present the default to a BYOK selection with no model", () => {
+    mocks.models = {
+      byokProviders: [
+        {
+          provider: "My OpenAI",
+          adapter: "openai",
+          source: "byok",
+          models: [{ id: "gpt-5", label: "GPT-5", supported: true }],
+        },
+      ],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "My OpenAI", source: "byok", adapter: "openai" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        defaultModelId="claude-4"
+      />,
+    );
+
+    expect(screen.getByRole("button").textContent).toContain("Select model");
+    expect(screen.getByRole("button").textContent).not.toContain("Claude 4");
+
+    fireEvent.click(screen.getByRole("button"));
+    const ticked = screen.getAllByRole("button").filter((b) => b.textContent?.includes("✓"));
+    expect(ticked).toHaveLength(0);
+  });
+
+  // The catalog lists BYOK first and is not deduplicated, so an id-only match
+  // must not bind a system selection to a BYOK provider's credentials.
+  it("backfills a model-only selection from its own source, not the first row", () => {
+    mocks.models = {
+      byokProviders: [
+        {
+          provider: "My Anthropic",
+          adapter: "anthropic",
+          source: "byok",
+          models: [{ id: "claude-4", label: "Claude 4", supported: true }],
+        },
+      ],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "claude-4", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: "claude-4",
+      provider: "anthropic",
+      source: "system",
+      adapter: "anthropic",
+    });
+  });
+
+  // The source-preferring match must still fall back: a legacy hydrated
+  // selection (model id only, no provider) may name a model that exists only
+  // under BYOK, and dropping the fallback would stop backfilling it.
+  it("falls back across sources when the id exists under no other", () => {
+    mocks.models = {
+      byokProviders: [
+        {
+          provider: "My LLM",
+          adapter: "openai",
+          source: "byok",
+          models: [{ id: "custom-llm", label: "Custom LLM", supported: true }],
+        },
+      ],
+      systemModels: [
+        {
+          provider: "anthropic",
+          adapter: "anthropic",
+          source: "system",
+          models: [{ id: "claude-4", label: "Claude 4" }],
+        },
+      ],
+    };
+
+    render(
+      <ModelSelector
+        value={{ model: "custom-llm", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+      />,
+    );
+
+    expect(mocks.onChange).toHaveBeenCalledWith({
+      model: "custom-llm",
+      provider: "My LLM",
+      source: "byok",
+      adapter: "openai",
+    });
+  });
+
   // A BYOK provider may expose the same model id as the system default; that
   // is a separate row and picking it stores a different selection, so only
   // the system row is the tracked default.

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -111,12 +111,12 @@ describe("ModelSelector", () => {
         value={{ model: "", provider: "", source: "system", adapter: "" }}
         onChange={mocks.onChange}
         workspaceId="workspace-1"
-        placeholder="System default (claude-haiku-4-5)"
+        placeholder="claude-haiku-4-5"
       />,
     );
 
     expect(mocks.onChange).not.toHaveBeenCalled();
-    expect(screen.getByRole("button").textContent).toContain("System default (claude-haiku-4-5)");
+    expect(screen.getByRole("button").textContent).toContain("claude-haiku-4-5");
   });
 
   it("still backfills a legacy model-only selection when a placeholder is set", () => {
@@ -137,7 +137,7 @@ describe("ModelSelector", () => {
         value={{ model: "claude-4", provider: "", source: "system", adapter: "" }}
         onChange={mocks.onChange}
         workspaceId="workspace-1"
-        placeholder="System default (claude-haiku-4-5)"
+        placeholder="claude-haiku-4-5"
       />,
     );
 

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.test.tsx
@@ -333,6 +333,30 @@ describe("ModelSelector", () => {
     });
   });
 
+  // Only reachable since the pending gate landed: a settled empty catalog with
+  // a default still names the model that will be attempted, while the list says
+  // there is nothing configured. Naming it matches the worker, which fails the
+  // run rather than substituting.
+  it("still names the default when the settled catalog is empty", () => {
+    mocks.models = { byokProviders: [], systemModels: [] };
+
+    render(
+      <ModelSelector
+        value={{ model: "", provider: "", source: "system", adapter: "" }}
+        onChange={mocks.onChange}
+        workspaceId="workspace-1"
+        defaultModelId="claude-4"
+      />,
+    );
+
+    expect(screen.getByRole("button").textContent).toContain("claude-4");
+    expect(mocks.onChange).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button"));
+    expect(screen.getByText(/No models available/)).toBeDefined();
+    expect(screen.getByRole("link", { name: "configure one" })).toBeDefined();
+  });
+
   // A BYOK detector with no model runs that provider's own model, so showing
   // it the system default would name a model that will not run.
   it("does not present the default to a BYOK selection with no model", () => {

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -20,13 +20,20 @@ interface ModelSelectorProps {
   value: ModelSelection;
   onChange: (selection: ModelSelection) => void;
   workspaceId?: string;
+  /**
+   * When set, an empty selection is a valid persistent state ("use the
+   * system default"): the trigger shows this label and the selector never
+   * writes an auto-picked default into the parent's state. Surfaces that
+   * require a concrete selection leave this unset and get the auto-pick.
+   */
+  placeholder?: string;
 }
 
 function modelKey(m: { id?: string; model?: string; source: string; provider: string }) {
   return `${m.source}:${m.provider}:${m.id ?? m.model}`;
 }
 
-export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorProps) {
+export function ModelSelector({ value, onChange, workspaceId, placeholder }: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
 
   const { data } = useQuery({
@@ -43,7 +50,8 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
   //   2. model-id-only match (legacy/hydrated state where the parent only has
   //      `model` saved, e.g. `project.rca_model: string`) → backfill the rest
   //   3. no match → preserve the current selection if the user already picked
-  //      one, and only auto-pick a default when the model is still empty.
+  //      one, and only auto-pick a default when the model is still empty and
+  //      no placeholder marks "empty" as a valid persistent state.
   // Without case 2 the selector would silently auto-pick a default when a
   // partially-hydrated saved selection arrives, clobbering the user's choice.
   useEffect(() => {
@@ -57,7 +65,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
     const match = exact ?? modelOnly;
 
     if (!match) {
-      if (!value.model) {
+      if (!value.model && !placeholder) {
         const pick = pickDefaultModel(models);
         if (pick) {
           onChange({
@@ -87,7 +95,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
         adapter: match.adapter,
       });
     }
-  }, [models, value, onChange]);
+  }, [models, value, onChange, placeholder]);
 
   const selectedKey = modelKey({ id: value.model, source: value.source, provider: value.provider });
   const selectedModel = models.find((m) => modelKey(m) === selectedKey);
@@ -101,7 +109,7 @@ export function ModelSelector({ value, onChange, workspaceId }: ModelSelectorPro
             size="sm"
             className="h-7 gap-1 rounded-sm px-2 text-[11px] text-muted-foreground hover:text-foreground"
           >
-            {selectedModel?.label || value.model || "Select model"}
+            {selectedModel?.label || value.model || placeholder || "Select model"}
             <ChevronDown className="h-3 w-3" />
           </Button>
         </PopoverTrigger>

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -22,12 +22,10 @@ interface ModelSelectorProps {
   workspaceId?: string;
   /**
    * System model id the parent falls back to when the selection is empty.
-   * Setting it makes an empty selection a valid persistent state ("track
-   * this model"): the selector never writes an auto-picked default into the
-   * parent's state, and it presents that model exactly as an explicit pick
-   * would — same trigger label, same checkmark — so the user sees what will
-   * run without the parent having to store it. Surfaces that require a
-   * concrete stored selection leave this unset and get the auto-pick.
+   * Setting it makes an empty selection a valid persistent state: the selector
+   * never auto-picks into the parent's state, and presents that model as an
+   * explicit pick of it would. Surfaces needing a concrete stored selection
+   * leave this unset and get the auto-pick.
    */
   defaultModelId?: string;
 }
@@ -68,8 +66,14 @@ export function ModelSelector({
     const exact = models.find(
       (m) => m.id === value.model && m.provider === value.provider && m.source === value.source,
     );
+    // Prefer the selection's own source: the list is BYOK-first and not
+    // deduplicated, so a bare id could bind a system selection to a BYOK
+    // provider sharing that id — same name, different credentials at run time.
     const modelOnly =
-      !exact && value.model && !value.provider ? models.find((m) => m.id === value.model) : null;
+      !exact && value.model && !value.provider
+        ? (models.find((m) => m.id === value.model && m.source === value.source) ??
+          models.find((m) => m.id === value.model))
+        : null;
     const match = exact ?? modelOnly;
 
     if (!match) {
@@ -105,17 +109,16 @@ export function ModelSelector({
     }
   }, [models, value, onChange, defaultModelId]);
 
-  // With nothing explicitly picked, present the tracked default as if it were
-  // the selection, so an unpinned parent looks exactly like one that stored
-  // this model. Scoped to a system row: a BYOK provider exposing the same id
-  // is a different row and must not also be ticked.
-  const trackedDefault =
-    !value.model && defaultModelId
-      ? models.find((m) => m.id === defaultModelId && m.source === "system")
-      : undefined;
+  // Present the tracked default as the selection so an unpinned parent reads
+  // like one that stored this model. A BYOK selection with no model runs its
+  // provider's model, not this one, so it tracks nothing here.
+  const showsDefault = !value.model && value.source !== "byok" && !!defaultModelId;
+  const defaultRow = showsDefault
+    ? models.find((m) => m.id === defaultModelId && m.source === "system")
+    : undefined;
 
-  const selectedKey = trackedDefault
-    ? modelKey(trackedDefault)
+  const selectedKey = defaultRow
+    ? modelKey(defaultRow)
     : modelKey({ id: value.model, source: value.source, provider: value.provider });
   const selectedModel = models.find((m) => modelKey(m) === selectedKey);
 
@@ -128,7 +131,10 @@ export function ModelSelector({
             size="sm"
             className="h-7 gap-1 rounded-sm px-2 text-[11px] text-muted-foreground hover:text-foreground"
           >
-            {selectedModel?.label || value.model || defaultModelId || "Select model"}
+            {selectedModel?.label ||
+              value.model ||
+              (showsDefault ? defaultModelId : "") ||
+              "Select model"}
             <ChevronDown className="h-3 w-3" />
           </Button>
         </PopoverTrigger>
@@ -151,11 +157,10 @@ export function ModelSelector({
                   isSelected && "font-medium text-foreground",
                 )}
                 onClick={() => {
-                  // Picking the row that is already the tracked default looks
-                  // like a no-op but would write a selection, pinning the
-                  // parent to this model and quietly opting it out of any
-                  // later change to the default. Leave the empty selection be.
-                  if (!(trackedDefault && isSelected)) {
+                  // Picking the already-shown default would look like a no-op
+                  // while pinning the parent to it, opting it out of any later
+                  // change to the default.
+                  if (!(defaultRow && isSelected)) {
                     onChange({
                       model: m.id,
                       provider: m.provider,

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -21,19 +21,27 @@ interface ModelSelectorProps {
   onChange: (selection: ModelSelection) => void;
   workspaceId?: string;
   /**
-   * When set, an empty selection is a valid persistent state ("use the
-   * system default"): the trigger shows this label and the selector never
-   * writes an auto-picked default into the parent's state. Surfaces that
-   * require a concrete selection leave this unset and get the auto-pick.
+   * System model id the parent falls back to when the selection is empty.
+   * Setting it makes an empty selection a valid persistent state ("track
+   * this model"): the selector never writes an auto-picked default into the
+   * parent's state, and it presents that model exactly as an explicit pick
+   * would — same trigger label, same checkmark — so the user sees what will
+   * run without the parent having to store it. Surfaces that require a
+   * concrete stored selection leave this unset and get the auto-pick.
    */
-  placeholder?: string;
+  defaultModelId?: string;
 }
 
 function modelKey(m: { id?: string; model?: string; source: string; provider: string }) {
   return `${m.source}:${m.provider}:${m.id ?? m.model}`;
 }
 
-export function ModelSelector({ value, onChange, workspaceId, placeholder }: ModelSelectorProps) {
+export function ModelSelector({
+  value,
+  onChange,
+  workspaceId,
+  defaultModelId,
+}: ModelSelectorProps) {
   const [open, setOpen] = useState(false);
 
   const { data } = useQuery({
@@ -51,7 +59,7 @@ export function ModelSelector({ value, onChange, workspaceId, placeholder }: Mod
   //      `model` saved, e.g. `project.rca_model: string`) → backfill the rest
   //   3. no match → preserve the current selection if the user already picked
   //      one, and only auto-pick a default when the model is still empty and
-  //      no placeholder marks "empty" as a valid persistent state.
+  //      no `defaultModelId` marks "empty" as a valid persistent state.
   // Without case 2 the selector would silently auto-pick a default when a
   // partially-hydrated saved selection arrives, clobbering the user's choice.
   useEffect(() => {
@@ -65,7 +73,7 @@ export function ModelSelector({ value, onChange, workspaceId, placeholder }: Mod
     const match = exact ?? modelOnly;
 
     if (!match) {
-      if (!value.model && !placeholder) {
+      if (!value.model && !defaultModelId) {
         const pick = pickDefaultModel(models);
         if (pick) {
           onChange({
@@ -95,9 +103,20 @@ export function ModelSelector({ value, onChange, workspaceId, placeholder }: Mod
         adapter: match.adapter,
       });
     }
-  }, [models, value, onChange, placeholder]);
+  }, [models, value, onChange, defaultModelId]);
 
-  const selectedKey = modelKey({ id: value.model, source: value.source, provider: value.provider });
+  // With nothing explicitly picked, present the tracked default as if it were
+  // the selection, so an unpinned parent looks exactly like one that stored
+  // this model. Scoped to a system row: a BYOK provider exposing the same id
+  // is a different row and must not also be ticked.
+  const trackedDefault =
+    !value.model && defaultModelId
+      ? models.find((m) => m.id === defaultModelId && m.source === "system")
+      : undefined;
+
+  const selectedKey = trackedDefault
+    ? modelKey(trackedDefault)
+    : modelKey({ id: value.model, source: value.source, provider: value.provider });
   const selectedModel = models.find((m) => modelKey(m) === selectedKey);
 
   return (
@@ -109,7 +128,7 @@ export function ModelSelector({ value, onChange, workspaceId, placeholder }: Mod
             size="sm"
             className="h-7 gap-1 rounded-sm px-2 text-[11px] text-muted-foreground hover:text-foreground"
           >
-            {selectedModel?.label || value.model || placeholder || "Select model"}
+            {selectedModel?.label || value.model || defaultModelId || "Select model"}
             <ChevronDown className="h-3 w-3" />
           </Button>
         </PopoverTrigger>

--- a/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/model-selector.tsx
@@ -151,12 +151,18 @@ export function ModelSelector({
                   isSelected && "font-medium text-foreground",
                 )}
                 onClick={() => {
-                  onChange({
-                    model: m.id,
-                    provider: m.provider,
-                    source: m.source,
-                    adapter: m.adapter,
-                  });
+                  // Picking the row that is already the tracked default looks
+                  // like a no-op but would write a selection, pinning the
+                  // parent to this model and quietly opting it out of any
+                  // later change to the default. Leave the empty selection be.
+                  if (!(trackedDefault && isSelected)) {
+                    onChange({
+                      model: m.id,
+                      provider: m.provider,
+                      source: m.source,
+                      adapter: m.adapter,
+                    });
+                  }
                   setOpen(false);
                 }}
               >

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -6,6 +6,7 @@ import type { Detector } from "../hooks/use-detectors";
 const mocks = vi.hoisted(() => ({
   detector: undefined as Detector | undefined,
   mutate: vi.fn(),
+  selectorProps: null as Record<string, unknown> | null,
 }));
 
 vi.mock("../hooks/use-detectors", () => ({
@@ -22,7 +23,10 @@ vi.mock("./agent-model-link", () => ({
   AgentModelLink: () => null,
 }));
 vi.mock("@/features/ai-assistant/components/model-selector", () => ({
-  ModelSelector: () => null,
+  ModelSelector: (props: Record<string, unknown>) => {
+    mocks.selectorProps = props;
+    return null;
+  },
 }));
 vi.mock("./rca-toggle", () => ({
   RcaToggle: ({
@@ -81,6 +85,7 @@ afterEach(() => {
   cleanup();
   mocks.detector = undefined;
   mocks.mutate.mockReset();
+  mocks.selectorProps = null;
 });
 
 describe("DetectorPanel", () => {
@@ -124,6 +129,12 @@ describe("DetectorPanel", () => {
     fireEvent.click(saveButton());
     expect(mocks.mutate).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders the screening-model picker with a system-default placeholder (no auto-pick)", () => {
+    mocks.detector = { ...baseDetector, detectionModel: null, detectionProvider: null };
+    renderPanel();
+    expect(mocks.selectorProps?.placeholder).toBe("System default (claude-haiku-4-5)");
   });
 
   it("clears the form and disables Save while the loaded detector does not match the id", () => {

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, screen, fireEvent } from "@testing-library/react";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import type { Detector } from "../hooks/use-detectors";
 
 const mocks = vi.hoisted(() => ({
@@ -134,7 +135,7 @@ describe("DetectorPanel", () => {
   it("renders the screening-model picker with a system-default placeholder (no auto-pick)", () => {
     mocks.detector = { ...baseDetector, detectionModel: null, detectionProvider: null };
     renderPanel();
-    expect(mocks.selectorProps?.placeholder).toBe("System default (claude-haiku-4-5)");
+    expect(mocks.selectorProps?.placeholder).toBe(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
 
   it("clears the form and disables Save while the loaded detector does not match the id", () => {

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -132,8 +132,14 @@ describe("DetectorPanel", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it("renders the screening-model picker with a system-default placeholder (no auto-pick)", () => {
-    mocks.detector = { ...baseDetector, detectionModel: null, detectionProvider: null };
+  // Passed unconditionally: the placeholder is what an empty selection reads
+  // as, so a pinned detector gets it too — the pin just wins over it. Both
+  // fixtures are listed so the unpinned case the prop exists for is covered.
+  it.each([
+    ["unpinned", { ...baseDetector, detectionModel: null }],
+    ["pinned", baseDetector],
+  ])("hands the screening-model picker the system-default placeholder (%s)", (_label, detector) => {
+    mocks.detector = detector;
     renderPanel();
     expect(mocks.selectorProps?.placeholder).toBe(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });

--- a/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.test.tsx
@@ -132,16 +132,16 @@ describe("DetectorPanel", () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  // Passed unconditionally: the placeholder is what an empty selection reads
-  // as, so a pinned detector gets it too — the pin just wins over it. Both
+  // Passed unconditionally: it names the model an empty selection falls back
+  // to, so a pinned detector gets it too — the pin just wins over it. Both
   // fixtures are listed so the unpinned case the prop exists for is covered.
   it.each([
     ["unpinned", { ...baseDetector, detectionModel: null }],
     ["pinned", baseDetector],
-  ])("hands the screening-model picker the system-default placeholder (%s)", (_label, detector) => {
+  ])("hands the screening-model picker the system-default model id (%s)", (_label, detector) => {
     mocks.detector = detector;
     renderPanel();
-    expect(mocks.selectorProps?.placeholder).toBe(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
+    expect(mocks.selectorProps?.defaultModelId).toBe(DETECTOR_SYSTEM_DEFAULT_MODEL_ID);
   });
 
   it("clears the form and disables Save while the loaded detector does not match the id", () => {

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Eye, X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
 import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
-import { DEFAULT_DETECTOR_SAMPLE_RATE } from "../templates";
+import { DEFAULT_DETECTOR_SAMPLE_RATE, DETECTOR_MODEL_PLACEHOLDER } from "../templates";
 import { useProject } from "@/features/projects/hooks";
 import { TriggerEditor } from "./trigger-editor";
 import type { TriggerCondition } from "./trigger-editor";
@@ -237,6 +237,7 @@ export function DetectorPanel({
                 value={editModelSelection}
                 onChange={setEditModelSelection}
                 workspaceId={workspaceId}
+                placeholder={DETECTOR_MODEL_PLACEHOLDER}
               />
               <p className="mt-1 text-[11px] text-muted-foreground">
                 Used to evaluate each trace for this detector.

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { Eye, X, Copy, Check, ArrowUp, ArrowDown } from "lucide-react";
 import { useDetector, useUpdateDetector } from "../hooks/use-detectors";
-import { DEFAULT_DETECTOR_SAMPLE_RATE, DETECTOR_MODEL_PLACEHOLDER } from "../templates";
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
+import { DEFAULT_DETECTOR_SAMPLE_RATE } from "../templates";
 import { useProject } from "@/features/projects/hooks";
 import { TriggerEditor } from "./trigger-editor";
 import type { TriggerCondition } from "./trigger-editor";
@@ -237,7 +238,7 @@ export function DetectorPanel({
                 value={editModelSelection}
                 onChange={setEditModelSelection}
                 workspaceId={workspaceId}
-                placeholder={DETECTOR_MODEL_PLACEHOLDER}
+                placeholder={DETECTOR_SYSTEM_DEFAULT_MODEL_ID}
               />
               <p className="mt-1 text-[11px] text-muted-foreground">
                 Used to evaluate each trace for this detector.

--- a/frontend/ui/src/features/detectors/components/detector-panel.tsx
+++ b/frontend/ui/src/features/detectors/components/detector-panel.tsx
@@ -238,7 +238,7 @@ export function DetectorPanel({
                 value={editModelSelection}
                 onChange={setEditModelSelection}
                 workspaceId={workspaceId}
-                placeholder={DETECTOR_SYSTEM_DEFAULT_MODEL_ID}
+                defaultModelId={DETECTOR_SYSTEM_DEFAULT_MODEL_ID}
               />
               <p className="mt-1 text-[11px] text-muted-foreground">
                 Used to evaluate each trace for this detector.

--- a/frontend/ui/src/features/detectors/templates.ts
+++ b/frontend/ui/src/features/detectors/templates.ts
@@ -1,3 +1,4 @@
+import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import type { CreateDetectorInput } from "@/features/detectors/hooks/use-detectors";
 
 export interface DetectorTemplate {
@@ -117,6 +118,12 @@ export const DETECTOR_QUICK_ADD_TEMPLATES = DETECTOR_TEMPLATES.filter((t) => t.i
 // schema files only take literals — so a drift-guard test in templates.test.ts
 // asserts the two stay equal.
 export const DEFAULT_DETECTOR_SAMPLE_RATE = 25;
+
+// Placeholder for the screening-model picker on the create form and edit
+// panel. An untouched picker persists detectionModel: null, so the detector
+// tracks the system screening default instead of being pinned to whatever
+// the picker would auto-select.
+export const DETECTOR_MODEL_PLACEHOLDER = `System default (${DETECTOR_SYSTEM_DEFAULT_MODEL_ID})`;
 
 // Default create payload for a template — shared by the new-detector form and the
 // project-creation quick-add step so the two creation paths cannot drift.

--- a/frontend/ui/src/features/detectors/templates.ts
+++ b/frontend/ui/src/features/detectors/templates.ts
@@ -1,4 +1,3 @@
-import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
 import type { CreateDetectorInput } from "@/features/detectors/hooks/use-detectors";
 
 export interface DetectorTemplate {
@@ -118,12 +117,6 @@ export const DETECTOR_QUICK_ADD_TEMPLATES = DETECTOR_TEMPLATES.filter((t) => t.i
 // schema files only take literals — so a drift-guard test in templates.test.ts
 // asserts the two stay equal.
 export const DEFAULT_DETECTOR_SAMPLE_RATE = 25;
-
-// Placeholder for the screening-model picker on the create form and edit
-// panel. An untouched picker persists detectionModel: null, so the detector
-// tracks the system screening default instead of being pinned to whatever
-// the picker would auto-select.
-export const DETECTOR_MODEL_PLACEHOLDER = `System default (${DETECTOR_SYSTEM_DEFAULT_MODEL_ID})`;
 
 // Default create payload for a template — shared by the new-detector form and the
 // project-creation quick-add step so the two creation paths cannot drift.

--- a/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
+++ b/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockComplete, mockResolvePiModel, mockFetchProviderConfig, mockFindByokKey } = vi.hoisted(
-  () => ({
-    mockComplete: vi.fn(),
-    mockResolvePiModel: vi.fn(),
-    mockFetchProviderConfig: vi.fn(),
-    mockFindByokKey: vi.fn().mockResolvedValue(null),
-  }),
-);
+const {
+  mockComplete,
+  mockResolvePiModel,
+  mockFetchProviderConfig,
+  mockFindByokKey,
+  mockIsSystemModelId,
+} = vi.hoisted(() => ({
+  mockComplete: vi.fn(),
+  mockResolvePiModel: vi.fn(),
+  mockFetchProviderConfig: vi.fn(),
+  mockFindByokKey: vi.fn().mockResolvedValue(null),
+  mockIsSystemModelId: vi.fn(),
+}));
 
 // Forward unmocked exports (Type, getModel, etc.) so submit-result-tool.ts's
 // TypeBox imports still work; only `complete` is replaced with the mock.
@@ -23,6 +28,7 @@ vi.mock("@traceroot/core/model-resolver", () => ({
   resolvePiModel: mockResolvePiModel,
   fetchProviderConfig: mockFetchProviderConfig,
   findByokKeyForPiProvider: mockFindByokKey,
+  isSystemModelId: mockIsSystemModelId,
 }));
 
 import {
@@ -79,6 +85,8 @@ describe("runDetectionForTrace", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockResolvePiModel.mockReturnValue(ANTHROPIC_MODEL);
+    // Default: the id is in the catalog. The retired-model test overrides this.
+    mockIsSystemModelId.mockReturnValue(true);
     // Default: workspace BYOK scan returns a key. Individual tests can override
     // by chaining mockResolvedValueOnce(null) before the call to simulate "no key".
     mockFindByokKey.mockResolvedValue("test-api-key");
@@ -159,6 +167,57 @@ describe("runDetectionForTrace", () => {
     });
 
     expect(mockResolvePiModel).toHaveBeenCalledWith(DETECTOR_SYSTEM_DEFAULT_MODEL_ID, null);
+  });
+
+  // A retired model id, or one an API client invented, would otherwise resolve
+  // to an unrelated fallback and screen on it while the UI shows the pinned id.
+  it("refuses a pinned system model that has left the catalog", async () => {
+    mockIsSystemModelId.mockReturnValue(false);
+
+    const result = await runDetectionForTrace({
+      traceId: "trace-abc",
+      spansJsonl: "{}",
+      detector: { ...DETECTOR, detectionSource: "system", detectionModel: "claude-retired-1" },
+      workspaceId: "ws-1",
+    });
+
+    expect(result.error).toContain("claude-retired-1");
+    expect(result.inferenceSource).toBe("system");
+    expect(mockResolvePiModel).not.toHaveBeenCalled();
+    expect(mockComplete).not.toHaveBeenCalled();
+  });
+
+  // BYOK rows resolve against their own provider catalog, so the system-model
+  // check must not reject them.
+  it("does not apply the system-catalog check to BYOK detectors", async () => {
+    mockIsSystemModelId.mockReturnValue(false);
+    mockFetchProviderConfig.mockResolvedValueOnce(BYOK_PROVIDER_CONFIG);
+    mockComplete.mockResolvedValueOnce({
+      content: [
+        {
+          type: "toolCall",
+          name: "submit_result",
+          arguments: { identified: false, summary: "Clean trace", data: {} },
+        },
+      ],
+      usage: ZERO_USAGE,
+      stopReason: "toolUse",
+    });
+
+    const result = await runDetectionForTrace({
+      traceId: "trace-abc",
+      spansJsonl: "{}",
+      detector: {
+        ...DETECTOR,
+        detectionSource: "byok",
+        detectionProvider: "My Anthropic",
+        detectionModel: "custom-model-1",
+      },
+      workspaceId: "ws-1",
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(mockResolvePiModel).toHaveBeenCalledWith("custom-model-1", BYOK_PROVIDER_CONFIG);
   });
 
   it("passes pinned system detector models through to the resolver", async () => {

--- a/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
+++ b/frontend/worker/src/detection/__tests__/sandbox-eval.test.ts
@@ -138,7 +138,7 @@ describe("runDetectionForTrace", () => {
     expect(mockResolvePiModel).toHaveBeenCalledWith(DETECTOR_SYSTEM_DEFAULT_MODEL_ID, null);
   });
 
-  it("keeps legacy null-source detectors on the availability-aware resolver default", async () => {
+  it("screens legacy null-source detectors on the system default, as the UI labels them", async () => {
     mockComplete.mockResolvedValueOnce({
       content: [
         {
@@ -158,7 +158,7 @@ describe("runDetectionForTrace", () => {
       workspaceId: "ws-1",
     });
 
-    expect(mockResolvePiModel).toHaveBeenCalledWith(undefined, null);
+    expect(mockResolvePiModel).toHaveBeenCalledWith(DETECTOR_SYSTEM_DEFAULT_MODEL_ID, null);
   });
 
   it("passes pinned system detector models through to the resolver", async () => {
@@ -557,7 +557,10 @@ describe("runDetectionForTrace", () => {
       expect(result.inferenceSource).toBe("system");
     });
 
-    it("treats null source as null on the EvalResult (processor normalizes)", async () => {
+    // Attribution follows the model that actually ran: a null-source detector
+    // screens on the system default with a system key, so the run is system.
+    // Billing is unaffected either way — the processor only asks `=== "byok"`.
+    it("attributes a null-source run to system on the EvalResult", async () => {
       mockComplete.mockResolvedValueOnce({
         content: [
           {
@@ -570,15 +573,14 @@ describe("runDetectionForTrace", () => {
         stopReason: "toolUse",
       });
 
-      const detectorWithoutSource = { ...DETECTOR };
       const result = await runDetectionForTrace({
         traceId: "t",
         spansJsonl: "{}",
-        detector: detectorWithoutSource,
+        detector: { ...DETECTOR, detectionSource: null },
         workspaceId: "ws-1",
       });
 
-      expect(result.inferenceSource).toBeNull();
+      expect(result.inferenceSource).toBe("system");
       expect(result.inferenceCost).toBeCloseTo(0.002, 6);
     });
   });

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -136,7 +136,17 @@ export async function runDetectionForTrace(params: {
   workspaceId: string;
 }): Promise<EvalResult> {
   const { traceId, spansJsonl, detector, workspaceId } = params;
-  const source = detector.detectionSource ?? null;
+  // A null source means "never set" — legacy rows, and any API client that
+  // omitted the field. Every UI path writes "system" explicitly and the UI
+  // reads null back as "system", so treat it as system here too.
+  //
+  // Note the reach: with the pickers persisting an empty selection, every
+  // unpinned detector — newly created ones included, not just legacy rows —
+  // screens on the fixed default instead of an availability-aware provider
+  // pick. A deployment holding no key for that model's provider, in env or
+  // in a workspace BYOK row, fails those evals rather than quietly screening
+  // on whichever provider happens to be configured.
+  const source = detector.detectionSource ?? "system";
 
   // 1. BYOK config
   let providerConfig: ProviderModelConfig | null = null;

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -4,6 +4,7 @@ import {
   findByokKeyForPiProvider,
   fetchProviderConfig,
   resolvePiModel,
+  isSystemModelId,
   type ProviderModelConfig,
 } from "@traceroot/core/model-resolver";
 import { DETECTOR_SYSTEM_DEFAULT_MODEL_ID } from "@traceroot/core/llm-providers";
@@ -136,16 +137,11 @@ export async function runDetectionForTrace(params: {
   workspaceId: string;
 }): Promise<EvalResult> {
   const { traceId, spansJsonl, detector, workspaceId } = params;
-  // A null source means "never set" — legacy rows, and any API client that
-  // omitted the field. Every UI path writes "system" explicitly and the UI
-  // reads null back as "system", so treat it as system here too.
-  //
-  // Note the reach: with the pickers persisting an empty selection, every
-  // unpinned detector — newly created ones included, not just legacy rows —
-  // screens on the fixed default instead of an availability-aware provider
-  // pick. A deployment holding no key for that model's provider, in env or
-  // in a workspace BYOK row, fails those evals rather than quietly screening
-  // on whichever provider happens to be configured.
+  // A null source means "never set" — legacy rows, and API clients that
+  // omitted the field. Every UI path writes "system" and reads null back as
+  // "system", so treat it as system here too. Unpinned detectors therefore
+  // screen on the fixed default, not an availability-aware pick: a deployment
+  // with no key for that provider fails them rather than substituting.
   const source = detector.detectionSource ?? "system";
 
   // 1. BYOK config
@@ -166,6 +162,14 @@ export async function runDetectionForTrace(params: {
   // 2. Resolve model
   const modelId =
     detector.detectionModel ?? (source === "system" ? DETECTOR_SYSTEM_DEFAULT_MODEL_ID : undefined);
+
+  // A retired or invented id resolves to an unrelated fallback rather than
+  // failing, which would screen on a model nobody chose while every surface
+  // shows the pinned one. A failed run is visible; a substitution is not.
+  if (!providerConfig && modelId && !isSystemModelId(modelId)) {
+    return errorResult(`Detection model "${modelId}" is not a known system model`, source);
+  }
+
   const model = resolvePiModel(modelId, providerConfig);
 
   // 3. Resolve API key (BYOK row → env var → workspace BYOK scan)

--- a/frontend/worker/src/detection/sandbox-eval.ts
+++ b/frontend/worker/src/detection/sandbox-eval.ts
@@ -31,7 +31,7 @@ export interface EvalResult {
   /** Sum of `response.usage.output` tokens across attempts. */
   inferenceOutputTokens: number;
   /** Source attribution for billing — preserved on error paths so failures still attribute. */
-  inferenceSource: "system" | "byok" | null;
+  inferenceSource: "system" | "byok";
   /** Model id reported by pi-ai (e.g. "claude-haiku-4-5"); null on early-exit error paths. */
   inferenceModel: string | null;
   /** Provider key reported by pi-ai (e.g. "anthropic"); null on early-exit error paths. */
@@ -83,7 +83,7 @@ const TOOL_CHOICE = "auto";
 
 function errorResult(
   message: string,
-  source: "system" | "byok" | null,
+  source: "system" | "byok",
   inferenceCost = 0,
   inferenceInputTokens = 0,
   inferenceOutputTokens = 0,

--- a/frontend/worker/src/processors/detector-run-processor.ts
+++ b/frontend/worker/src/processors/detector-run-processor.ts
@@ -130,7 +130,7 @@ export interface ScanUsage {
   inferenceCost: number;
   inferenceInputTokens: number;
   inferenceOutputTokens: number;
-  inferenceSource: "system" | "byok" | null;
+  inferenceSource: "system" | "byok";
   inferenceModel: string | null;
   inferenceProvider: string | null;
 }


### PR DESCRIPTION
## Summary

The detector create form and edit panel reuse the AI-assistant `ModelSelector`, whose auto-pick effect wrote the first-priority model (`claude-opus-4-8`) into form state whenever the incoming selection was empty. Submitting the create form, or saving **any** field in the edit panel of an unpinned detector, then persisted that as a pinned `detectionModel` — silently moving detection screening (one LLM eval per sampled trace at ingestion, the highest-volume LLM workload) off the cheap default (`claude-haiku-4-5`) onto the most expensive model, which is also marked up on paid plans.

This adds an opt-out `defaultModelId` prop to `ModelSelector`: when set, an empty selection is a valid persistent state — the picker presents that model as if it were the selection instead of writing one into form state, and only an explicit pick of a *different* model pins anything. Both detector screening surfaces pass it.

It also closes the other half of the same inconsistency in the worker: a detector whose `detectionSource` was never set (`null`) was excluded from the screening default and fell through to the provider-priority model, even though every UI surface labelled it as tracking the default.

## Changes

- `ModelSelector` gains an optional `defaultModelId` prop. When set, the reconcile effect no longer auto-picks for an empty selection, and that model is presented as the selection — same trigger label, same checkmark — so an unpinned parent is indistinguishable from one that stored it. Clicking that row is suppressed, since it would look like a no-op while pinning the model and opting the parent out of later changes to the default. The adapter/legacy backfill branches and every consumer that omits the prop (assistant chat, the Agent Model pickers) are unchanged.
- The create form and edit panel pass `DETECTOR_SYSTEM_DEFAULT_MODEL_ID`, so an unpinned detector shows the bare model id.
- The detectors list model column drops its `(default)` marker and shows the model name alone, matching the picker. That was the only consumer of the helper's `isDefault` flag, so it returns a plain label string now.
- An untouched create form now persists `detectionModel: null`; the edit panel no longer converts an unpinned detector to a pin on an unrelated save.
- The worker resolves a null `detectionSource` as `"system"`, so legacy and API-created rows screen on the same default as everything else. That makes the list page's separate `"Auto-selected"` branch unreachable, so it is removed.

## Behavior

- Created or edited without touching the picker → detector tracks the system default, shown as `claude-haiku-4-5` in both the picker and the list.
- Pick a model explicitly → that model is pinned and shown.
- An unpinned detector and one explicitly pinned to the same model now read identically everywhere. The distinction survives in the data — `detectionModel: null` follows the default if it ever changes, a pin does not — but is deliberately not surfaced.
- Legacy `detectionSource: null` rows now screen on the system default instead of the provider-priority model, which is what the UI already claimed they did.
- No data migration: rows already silently pinned are indistinguishable from deliberate picks, so this only stops new pins. Existing pinned rows keep their model.

## Deployment invariant this establishes

Unpinned detectors now resolve to a **fixed** default model rather than an availability-aware provider pick. The previous auto-pick was availability-aware by construction, because the system-model catalog endpoint filters `SYSTEM_MODELS` by env-var presence — so a deployment with only `OPENAI_API_KEY` used to pin a working OpenAI model.

After this change, a deployment that holds no key for the default model's provider (neither in env nor as a workspace BYOK row) will fail those evals with `No API key configured` rather than quietly screening on whatever else is configured. This is accepted deliberately: it is the same tradeoff every explicitly-`"system"` detector already made, and it keeps the highest-volume LLM workload on a known cheap model instead of silently drifting to whatever a deployment happens to have. Deployments are expected to configure a key for the provider of `DETECTOR_SYSTEM_DEFAULT_MODEL_ID`.

## Tests

- `ModelSelector`: the default suppresses the auto-pick, is ticked, is not written when picked, is still selectable once another model is pinned, is withheld from a BYOK selection, and is not ticked twice when a BYOK provider shares the id; the legacy model-only backfill still works across sources. Existing auto-pick tests unchanged, proving the other surfaces are unaffected.
- Create form and edit panel: assert the picker receives the system-default model id.
- `packages/core`: `isSystemModelId` accepts every catalog id and the screening default, and rejects retired ids.
- Worker: null-source detectors resolve to the screening default, and attribute the run as `system` — billing is unaffected, since the only consumer asks whether the source is `byok`.
- List page: null-source rows render the default label rather than the removed `"Auto-selected"` string, and no row renders a `(default)` marker.

## Displayed model vs. model that runs

Three ways those could differ are closed here:

- A pinned model id that has left the catalog resolved to an unrelated fallback rather than failing, so retiring a model would silently move every detector pinned to it onto that fallback while the UI kept showing the retired id. The worker now rejects the id. The detector stops producing findings instead of producing them off the wrong model; the run row has no error column, so the reason reaches the worker log only.
- A BYOK detector with no pinned model was shown the system default, which is not what it runs.
- An id-only backfill could bind a system selection to a BYOK provider exposing the same id — same model name on screen, different credentials at run time.

## Known gaps, deliberately not addressed here

- Un-pinning is not reachable from the UI: the popover lists only concrete models, and the patch builder omits an empty model, so a user who pins a model cannot return the detector to default-tracking. Pre-existing, but this change makes "empty" a first-class state and so raises the question.
- A `detectionSource: "byok"` row with no model now reads "Select model" rather than naming the wrong one, but still does not name the model that runs (the adapter's first curated one). That needs the deferred write-time validation.
- The project RCA/agent model has the same displayed-vs-run gap on a different surface: an unknown stored `rca_model` falls back to a hardcoded model while the settings picker keeps showing the stored id. Out of scope here; tracked separately.
- Detector write failures are still invisible to the user; tracked separately.

## Screenshots

The earlier screenshots showed the interim `System default (claude-haiku-4-5)` wording and have been removed — the picker now renders the bare model id.
