### PR TITLE
fix(trace-view): stop rendering tool/shell output as audio (false media detection)

### DIFF
--- a/frontend/ui/src/features/traces/components/inline-media.test.ts
+++ b/frontend/ui/src/features/traces/components/inline-media.test.ts
@@ -45,7 +45,7 @@ describe("mediaSrc — data URIs", () => {
   });
 });
 
-describe("mediaSrc — bare base64 (magic-byte sniffing)", () => {
+describe("mediaSrc — bare base64 (encoding-prefix matching)", () => {
   it("detects PNG", () => {
     expect(mediaSrc(bare(PNG))?.kind).toBe("image");
     expect(mediaSrc(bare(PNG))?.src).toMatch(/^data:image\/png;base64,/);
@@ -65,8 +65,12 @@ describe("mediaSrc — bare base64 (magic-byte sniffing)", () => {
     expect(mediaSrc(bare("ID3"))?.src).toMatch(/^data:audio\/mpeg;base64,/);
   });
 
-  it("detects MP3 via frame sync", () => {
-    expect(mediaSrc(bare(MP3_FRAME))?.kind).toBe("audio");
+  // Bare MP3 frame sync (0xFF 0xEx) is deliberately NOT detected: it is only 11
+  // bits and collides with ordinary text — e.g. any string starting with "//"
+  // base64-decodes to 0xFF 0xF…. Detecting it mislabels source code as audio
+  // (see the "non-media" regression cases below). ID3-tagged MP3 is still caught.
+  it("does NOT detect bare MP3 frame sync (too ambiguous)", () => {
+    expect(mediaSrc(bare(MP3_FRAME))).toBeNull();
   });
 
   it("detects OGG", () => {
@@ -99,5 +103,35 @@ describe("mediaSrc — non-media", () => {
 
   it("returns null for long non-media base64", () => {
     expect(mediaSrc(bare("hello world this is not media"))).toBeNull();
+  });
+
+  // Regression: real pi/coding-agent bash tool output was mis-detected as audio.
+  // These are actual `sandbox_shell` results from prod trace
+  // c474ea5cc57670f835bdc46992eb7ec4. A leading "//" JS comment base64-decodes to
+  // an MP3 frame sync, so the old byte-sniffer rendered an <audio> player over the
+  // source code. Plain text is not contiguous base64 (spaces/newlines/'.'), so it
+  // must never be treated as media.
+  it("returns null for a JS source dump starting with // (was mis-detected as audio)", () => {
+    const jsFile =
+      "// Minimal user lookup used by the API layer.\n" +
+      'const { runQuery } = require("./client");\n\n' +
+      "// Fetch a user by id from the request. The id comes straight from the\n" +
+      "// untrusted query string.\n" +
+      "function getUser(req) {\n" +
+      "  const id = req.query.id;\n" +
+      '  const sql = "SELECT * FROM users WHERE id = \'" + id + "\'";\n' +
+      "  return runQuery(sql);\n" +
+      "}\n\nmodule.exports = { getUser };";
+    expect(jsFile.length).toBeGreaterThan(100); // clears the length threshold
+    expect(mediaSrc(jsFile)).toBeNull();
+  });
+
+  it("returns null for `ls -la` command output", () => {
+    const lsOut =
+      "total 8\n" +
+      "drwxr-xr-x 4 repair repair 120 Jul 20 05:37 .\n" +
+      "drwxr-xr-x 3 repair repair  96 Jul 20 05:37 ..\n" +
+      "drwxr-xr-x 2 repair repair  64 Jul 20 05:37 src";
+    expect(mediaSrc(lsOut)).toBeNull();
   });
 });

--- a/frontend/ui/src/features/traces/components/inline-media.tsx
+++ b/frontend/ui/src/features/traces/components/inline-media.tsx
@@ -7,42 +7,70 @@ export type Media = { src: string; kind: "image" | "audio" };
 const MEDIA_DATA_URI =
   /^data:(image\/(?:png|jpe?g|gif|webp)|audio\/(?:mpeg|mp3|wav|x-wav|ogg|webm));base64,[A-Za-z0-9+/=]+$/i;
 
-// Sniff real magic bytes from a decoded base64 prefix. This correctly
-// disambiguates RIFF containers (WEBP image vs WAVE audio), which share the
-// same base64 prefix and cannot be told apart by string matching alone.
-function sniffBase64(b64: string): Media | null {
-  let bytes: Uint8Array;
+// A bare base64 blob is a single CONTIGUOUS run of the base64 alphabet with valid
+// padding and a length that is a multiple of 4. Prose, code, and shell output
+// never satisfy this — they contain spaces, newlines, and characters like '.',
+// '-', ':' that are not in the alphabet — so they are never treated as candidate
+// media. This anchored, whole-string check (not a decode-and-sniff of the first
+// few bytes) is what keeps a "// comment" file dump from being mistaken for an
+// MP3: such text is not contiguous base64, so it is rejected before any matching.
+const BARE_BASE64 = /^[A-Za-z0-9+/]+={0,2}$/;
+
+// Known media identified by their base64 *encoding* prefix. Matching the encoded
+// prefix (rather than decoding bytes and comparing a 2-byte magic number) keeps
+// the check specific: these prefixes are 4–11 base64 chars, so a short ambiguous
+// string cannot collide with them. Notably there is no bare MP3 frame-sync check
+// (0xFF 0xEx) — it is only 11 bits and any "//"-prefixed text decodes to it, which
+// is exactly how source code got mislabeled as audio. ID3-tagged MP3 (SUQz) still
+// matches.
+const IMAGE_PREFIXES: ReadonlyArray<readonly [string, string]> = [
+  ["iVBORw0KGgo", "image/png"],
+  ["/9j/", "image/jpeg"],
+  ["R0lGOD", "image/gif"], // GIF87a / GIF89a
+];
+const AUDIO_PREFIXES: ReadonlyArray<readonly [string, string]> = [
+  ["SUQz", "audio/mpeg"], // ID3 tag
+  ["T2dnUw", "audio/ogg"], // "OggS"
+];
+
+const dataUri = (mime: string, b64: string): string => `data:${mime};base64,${b64}`;
+
+// RIFF containers (base64 prefix "UklGR") cover both WAVE (audio) and WEBP (image)
+// and can only be told apart by the 4-byte form tag at byte offset 8. The value is
+// already validated as contiguous base64, so a narrow decode of just the header is
+// safe and unambiguous here.
+function riffMedia(b64: string): Media | null {
+  let form: string;
   try {
-    const bin = atob(b64.slice(0, 24)); // ~18 bytes — enough for the RIFF format tag at offset 8
-    bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+    const bin = atob(b64.slice(0, 16)); // 16 base64 chars → 12 bytes: reaches the form tag at offset 8
+    form = bin.slice(8, 12);
   } catch {
     return null;
   }
-  const tag = (i: number, n: number) => String.fromCharCode(...bytes.slice(i, i + n));
-  const image = (mime: string): Media => ({ src: `data:${mime};base64,${b64}`, kind: "image" });
-  const audio = (mime: string): Media => ({ src: `data:${mime};base64,${b64}`, kind: "audio" });
-
-  if (bytes[0] === 0x89 && tag(1, 3) === "PNG") return image("image/png");
-  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return image("image/jpeg");
-  if (tag(0, 4) === "GIF8") return image("image/gif");
-  if (tag(0, 4) === "RIFF") {
-    const form = tag(8, 4);
-    if (form === "WEBP") return image("image/webp");
-    if (form === "WAVE") return audio("audio/wav");
-    return null; // other RIFF (e.g. AVI) — not handled
-  }
-  if (tag(0, 3) === "ID3" || (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0))
-    return audio("audio/mpeg");
-  if (tag(0, 4) === "OggS") return audio("audio/ogg");
-  return null;
+  if (form === "WEBP") return { src: dataUri("image/webp", b64), kind: "image" };
+  if (form === "WAVE") return { src: dataUri("audio/wav", b64), kind: "audio" };
+  return null; // other RIFF (e.g. AVI) — not handled
 }
 
 // Returns renderable media for inline base64 (data URIs and bare base64), or null.
 export function mediaSrc(value: string): Media | null {
-  const m = value.match(MEDIA_DATA_URI);
-  if (m) return { src: value, kind: m[1].toLowerCase().startsWith("image/") ? "image" : "audio" };
-  if (value.length < 100) return null;
-  return sniffBase64(value);
+  const uri = value.match(MEDIA_DATA_URI);
+  if (uri) {
+    return { src: value, kind: uri[1].toLowerCase().startsWith("image/") ? "image" : "audio" };
+  }
+
+  // Only a fully-contiguous base64 blob past the length threshold is a candidate.
+  // Anything with whitespace, prose, or punctuation is rejected outright.
+  if (value.length < 100 || value.length % 4 !== 0 || !BARE_BASE64.test(value)) return null;
+
+  for (const [prefix, mime] of IMAGE_PREFIXES) {
+    if (value.startsWith(prefix)) return { src: dataUri(mime, value), kind: "image" };
+  }
+  for (const [prefix, mime] of AUDIO_PREFIXES) {
+    if (value.startsWith(prefix)) return { src: dataUri(mime, value), kind: "audio" };
+  }
+  if (value.startsWith("UklGR")) return riffMedia(value);
+  return null;
 }
 
 export function InlineMedia({ src, kind }: Media) {


### PR DESCRIPTION
## Problem

In the trace detail view, some tool/shell (`sandbox_shell`, bash) outputs render as an inline **`<audio>` player** instead of text. Any output starting with `//` (a JS/C comment, protocol-relative URL, path) is affected.

Root cause: `inline-media.tsx` `mediaSrc()` ran binary magic-byte sniffing on **any** string ≥100 chars — `atob`-decoding the first 24 chars and matching a 2-byte magic number. The MP3 branch keyed on an 11-bit frame sync, and `"//"` base64-decodes to `0xFF 0xF…`, which satisfies it. `atob` strips whitespace first, so ordinary `// comment` source passes and is labeled `audio/mpeg` (over a `src` that isn't even valid base64 — a silent player over the user's code).

Fixes #1606.

## Change

- Only treat a value as bare-base64 media when the **entire** value is a single contiguous base64 run (`^[A-Za-z0-9+/]+={0,2}$`, length % 4 == 0). Prose / code / `ls` output fails this immediately.
- Identify the format by its base64 **encoding prefix** (png/jpeg/gif, `UklGR` + RIFF form tag for wav/webp, ID3, Ogg) instead of decoding and matching 2 bytes.
- **Drop the bare MP3 frame-sync branch** — 11 bits, indistinguishable from text.
- The explicit `data:` URI branch is unchanged.

Net: strictly more conservative and less code.

## Verification

- Unit tests (`inline-media.test.ts`): every existing format (PNG/JPEG/GIF/ID3/OGG/WAV/WEBP, data URIs) still detected; frame-sync case flipped to `null`; added regressions using the real production strings (a `// …` JS dump and `ls -la` output → `null`).
- Data-driven, full production spans table (1.08M outputs; 8,332 base64-candidate outputs), old vs. new logic:
  - Old flagged exactly **3** outputs as media in all of prod — all three are these bash false positives.
  - New: all three render as text; **0** false positives remain; **0** regressions (no output that was text becomes media); **0** genuine media lost.

## Follow-up (not in this PR)

Fully robust direction: stop sniffing at render time entirely and carry an explicit typed media reference from ingestion (and offload large blobs to storage, which also helps trace-detail payload size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false media detection in the trace view so tool/shell output renders as text instead of an audio player.

- **Bug Fixes**
  - Tightened `mediaSrc()` to only treat values as bare base64 when the entire string is contiguous base64 with valid padding and length is a multiple of 4.
  - Switched to base64 encoding-prefix checks (plus RIFF form tag for WAV/WEBP); removed the ambiguous MP3 frame-sync path; `data:` URI handling unchanged.
  - Added tests for supported formats and regressions; verified no false positives remain and no valid media regressions.

<sup>Written for commit 509da5431e3807051bbb78156463ce61b4423575. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

