### PR TITLE
feat(dashboards): expose cache read/write token measures in the widget builder

### DIFF
--- a/backend/rest/services/widget_registry.py
+++ b/backend/rest/services/widget_registry.py
@@ -38,20 +38,29 @@ class ViewDef:
     fields: dict[str, FieldDef] = field(default_factory=dict)
 
 
-_SPANS_BASE = """
+# Preserve NULL when cache token data was never reported.
+_CACHE_READ_TOKENS_EXPR = (
+    "if(mapContains(usage_details, 'cache_read_tokens'), usage_details['cache_read_tokens'], NULL)"
+)
+_CACHE_WRITE_TOKENS_EXPR = "if(mapContains(usage_details, 'cache_write_tokens'), usage_details['cache_write_tokens'], NULL)"
+
+
+_SPANS_BASE = f"""
     SELECT
         name, span_kind, status, model_name, environment,
         span_start_time AS event_time,
         dateDiff('millisecond', span_start_time, span_end_time) AS duration_ms,
-        cost, input_tokens, output_tokens, total_tokens
+        cost, input_tokens, output_tokens, total_tokens,
+        {_CACHE_READ_TOKENS_EXPR} AS cache_read_tokens,
+        {_CACHE_WRITE_TOKENS_EXPR} AS cache_write_tokens
     FROM (
         SELECT
             span_id, trace_id, name, span_kind, status, model_name, environment,
-            span_start_time, span_end_time, cost, input_tokens, output_tokens, total_tokens
+            span_start_time, span_end_time, cost, input_tokens, output_tokens, total_tokens, usage_details
         FROM spans
-        WHERE project_id = {project_id:String}
-          AND span_start_time >= {start_time:DateTime64(3)}
-          AND span_start_time < {end_time:DateTime64(3)}
+        WHERE project_id = {{project_id:String}}
+          AND span_start_time >= {{start_time:DateTime64(3)}}
+          AND span_start_time < {{end_time:DateTime64(3)}}
         ORDER BY ch_update_time DESC
         LIMIT 1 BY project_id, trace_id, span_id
     )
@@ -64,7 +73,7 @@ _SPANS_BASE = """
 # cost, and token counts here may differ from the per-trace detail page (which
 # joins all spans for a trace). The tradeoff is a bounded, fast scan for
 # dashboards vs. exact per-trace metrics in the trace list.
-_TRACES_BASE = """
+_TRACES_BASE = f"""
     SELECT
         t.name AS name, t.user_id AS user_id,
         t.session_id AS session_id, t.environment AS environment,
@@ -77,14 +86,16 @@ _TRACES_BASE = """
         if(sa.trace_id = '', NULL, sa.total_cost) AS cost,
         if(sa.trace_id = '', NULL, sa.input_tokens) AS input_tokens,
         if(sa.trace_id = '', NULL, sa.output_tokens) AS output_tokens,
-        if(sa.trace_id = '', NULL, sa.total_tokens) AS total_tokens
+        if(sa.trace_id = '', NULL, sa.total_tokens) AS total_tokens,
+        if(sa.trace_id = '', NULL, sa.cache_read_tokens) AS cache_read_tokens,
+        if(sa.trace_id = '', NULL, sa.cache_write_tokens) AS cache_write_tokens
     FROM (
         SELECT
             trace_id, name, user_id, session_id, environment, trace_start_time
         FROM traces
-        WHERE project_id = {project_id:String}
-          AND trace_start_time >= {start_time:DateTime64(3)}
-          AND trace_start_time < {end_time:DateTime64(3)}
+        WHERE project_id = {{project_id:String}}
+          AND trace_start_time >= {{start_time:DateTime64(3)}}
+          AND trace_start_time < {{end_time:DateTime64(3)}}
         ORDER BY ch_update_time DESC
         LIMIT 1 BY project_id, trace_id
     ) AS t
@@ -100,15 +111,19 @@ _TRACES_BASE = """
             sum(cost) AS total_cost,
             sum(input_tokens) AS input_tokens,
             sum(output_tokens) AS output_tokens,
-            sum(total_tokens) AS total_tokens
+            sum(total_tokens) AS total_tokens,
+            sum(cache_read_tokens) AS cache_read_tokens,
+            sum(cache_write_tokens) AS cache_write_tokens
         FROM (
             SELECT
                 trace_id, span_id, status, span_start_time, span_end_time, cost,
-                input_tokens, output_tokens, total_tokens
+                input_tokens, output_tokens, total_tokens,
+                {_CACHE_READ_TOKENS_EXPR} AS cache_read_tokens,
+                {_CACHE_WRITE_TOKENS_EXPR} AS cache_write_tokens
             FROM spans
-            WHERE project_id = {project_id:String}
-              AND span_start_time >= {start_time:DateTime64(3)}
-              AND span_start_time < {end_time:DateTime64(3)}
+            WHERE project_id = {{project_id:String}}
+              AND span_start_time >= {{start_time:DateTime64(3)}}
+              AND span_start_time < {{end_time:DateTime64(3)}}
             ORDER BY ch_update_time DESC
             LIMIT 1 BY project_id, trace_id, span_id
         )
@@ -158,6 +173,8 @@ REGISTRY: dict[str, ViewDef] = {
             "input_tokens": _number_measure("input_tokens", "Input tokens"),
             "output_tokens": _number_measure("output_tokens", "Output tokens"),
             "total_tokens": _number_measure("total_tokens", "Total tokens"),
+            "cache_read_tokens": _number_measure("cache_read_tokens", "Cache read tokens"),
+            "cache_write_tokens": _number_measure("cache_write_tokens", "Cache write tokens"),
             # expr="*" is a sentinel: the compiler translates it to count(*).
             "count": FieldDef(expr="*", type="number", label="Count", aggs=("count",)),
         },
@@ -177,6 +194,8 @@ REGISTRY: dict[str, ViewDef] = {
             "input_tokens": _number_measure("input_tokens", "Input tokens"),
             "output_tokens": _number_measure("output_tokens", "Output tokens"),
             "total_tokens": _number_measure("total_tokens", "Tokens"),
+            "cache_read_tokens": _number_measure("cache_read_tokens", "Cache read tokens"),
+            "cache_write_tokens": _number_measure("cache_write_tokens", "Cache write tokens"),
             # expr="*" is a sentinel: the compiler translates it to count(*).
             "count": FieldDef(expr="*", type="number", label="Count", aggs=("count",)),
             # Last, so the list reads as the spans measures plus one trailing

--- a/backend/rest/services/widget_registry.py
+++ b/backend/rest/services/widget_registry.py
@@ -172,9 +172,12 @@ REGISTRY: dict[str, ViewDef] = {
             "cost": _number_measure("cost", "Cost"),
             "input_tokens": _number_measure("input_tokens", "Input tokens"),
             "output_tokens": _number_measure("output_tokens", "Output tokens"),
-            "total_tokens": _number_measure("total_tokens", "Total tokens"),
             "cache_read_tokens": _number_measure("cache_read_tokens", "Cache read tokens"),
             "cache_write_tokens": _number_measure("cache_write_tokens", "Cache write tokens"),
+            # Total last: input + output. Cache read/write are a breakdown of
+            # the input above, not additional addends — summing all four
+            # double-counts the cache tokens.
+            "total_tokens": _number_measure("total_tokens", "Total tokens"),
             # expr="*" is a sentinel: the compiler translates it to count(*).
             "count": FieldDef(expr="*", type="number", label="Count", aggs=("count",)),
         },
@@ -193,9 +196,12 @@ REGISTRY: dict[str, ViewDef] = {
             "cost": _number_measure("cost", "Cost"),
             "input_tokens": _number_measure("input_tokens", "Input tokens"),
             "output_tokens": _number_measure("output_tokens", "Output tokens"),
-            "total_tokens": _number_measure("total_tokens", "Tokens"),
             "cache_read_tokens": _number_measure("cache_read_tokens", "Cache read tokens"),
             "cache_write_tokens": _number_measure("cache_write_tokens", "Cache write tokens"),
+            # Total last: input + output. Cache read/write are a breakdown of
+            # the input above, not additional addends — summing all four
+            # double-counts the cache tokens.
+            "total_tokens": _number_measure("total_tokens", "Tokens"),
             # expr="*" is a sentinel: the compiler translates it to count(*).
             "count": FieldDef(expr="*", type="number", label="Count", aggs=("count",)),
             # Last, so the list reads as the spans measures plus one trailing

--- a/frontend/ui/src/features/dashboards/components/field-icons.ts
+++ b/frontend/ui/src/features/dashboards/components/field-icons.ts
@@ -13,6 +13,8 @@ const WIDGET_FIELD_ICONS: Record<string, LucideIcon> = {
   error_count: DOMAIN_ICONS.error,
   input_tokens: DOMAIN_ICONS.tokens,
   output_tokens: DOMAIN_ICONS.tokens,
+  cache_read_tokens: DOMAIN_ICONS.tokens,
+  cache_write_tokens: DOMAIN_ICONS.tokens,
   count: DOMAIN_ICONS.count,
   user_id: DOMAIN_ICONS.user,
   session_id: DOMAIN_ICONS.session,

--- a/tests/rest/test_widget_query.py
+++ b/tests/rest/test_widget_query.py
@@ -433,6 +433,38 @@ def test_number_display_rejects_breakdown():
     assert exc.value.step == "breakdown"
 
 
+def test_compile_cache_tokens_spans():
+    """cache_read_tokens and cache_write_tokens compile correctly for spans."""
+    spec = make_spec(view="spans", display={"type": "number"}, breakdown=None)
+
+    spec["metric"] = {"measure": "cache_read_tokens", "agg": "sum"}
+    sql, _ = compile_(spec)
+    assert "sum(cache_read_tokens)" in sql
+    assert "mapContains(usage_details, 'cache_read_tokens')" in sql
+
+    spec["metric"] = {"measure": "cache_write_tokens", "agg": "sum"}
+    sql, _ = compile_(spec)
+    assert "sum(cache_write_tokens)" in sql
+    assert "mapContains(usage_details, 'cache_write_tokens')" in sql
+
+
+def test_compile_cache_tokens_traces():
+    """cache_read_tokens and cache_write_tokens compile correctly for traces."""
+    spec = make_spec(view="traces", display={"type": "number"}, breakdown=None, filters=[])
+
+    spec["metric"] = {"measure": "cache_read_tokens", "agg": "sum"}
+    sql, _ = compile_(spec)
+    assert "sum(cache_read_tokens)" in sql
+    assert "mapContains(usage_details, 'cache_read_tokens')" in sql
+    assert "if(sa.trace_id = '', NULL, sa.cache_read_tokens)" in sql
+
+    spec["metric"] = {"measure": "cache_write_tokens", "agg": "sum"}
+    sql, _ = compile_(spec)
+    assert "sum(cache_write_tokens)" in sql
+    assert "mapContains(usage_details, 'cache_write_tokens')" in sql
+    assert "if(sa.trace_id = '', NULL, sa.cache_write_tokens)" in sql
+
+
 def test_run_widget_query_sets_execution_guards(monkeypatch):
     """Every widget query runs read-only, time-capped, and with a GROUP BY
     memory ceiling that spills to disk instead of OOMing the server."""

--- a/tests/rest/test_widget_registry.py
+++ b/tests/rest/test_widget_registry.py
@@ -93,3 +93,12 @@ def test_schema_histogrammable_mirrors_compiler_rule():
     # The concrete case that motivated the flag: count is not histogrammable.
     assert schema["spans"]["fields"]["count"]["histogrammable"] is False
     assert schema["spans"]["fields"]["cost"]["histogrammable"] is True
+
+
+def test_registry_schema_exposes_cache_tokens():
+    """cache_read_tokens and cache_write_tokens must be exposed on both views."""
+    schema = registry_schema()
+    for view in ["spans", "traces"]:
+        fields = schema[view]["fields"]
+        assert "cache_read_tokens" in fields, f"{view}: missing cache_read_tokens"
+        assert "cache_write_tokens" in fields, f"{view}: missing cache_write_tokens"

--- a/tests/rest/test_widget_registry.py
+++ b/tests/rest/test_widget_registry.py
@@ -102,3 +102,22 @@ def test_registry_schema_exposes_cache_tokens():
         fields = schema[view]["fields"]
         assert "cache_read_tokens" in fields, f"{view}: missing cache_read_tokens"
         assert "cache_write_tokens" in fields, f"{view}: missing cache_write_tokens"
+
+
+def test_token_measures_list_components_before_total():
+    """The token measures must end with the total, not wedge it in the middle.
+
+    The builder renders fields in schema order, so the group should read as the
+    component measures (input, output, cache read, cache write) followed by the
+    total. Cache read/write decompose the gross input rather than adding to it,
+    so the total is input + output — listed last as the umbrella figure."""
+    for view in ["spans", "traces"]:
+        names = list(registry_schema()[view]["fields"])
+        token_order = [n for n in names if n.endswith("_tokens")]
+        assert token_order == [
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "total_tokens",
+        ], f"{view}: token measures out of order: {token_order}"


### PR DESCRIPTION
…t builder\n\nFixes #1608

Fixes <issue-id>

## Summary

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [ ] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes cache read/write token measures in the dashboards widget builder so you can chart cache usage on spans and traces. Orders token measures so Total tokens appears last. Fixes #1608.

- **New Features**
  - Adds `cache_read_tokens` and `cache_write_tokens` to `spans` and `traces`.
  - Reads from `usage_details[...]`, aggregates at trace level, and preserves NULLs when not reported.
  - Orders token measures as input, output, cache read, cache write, then total; updates schema/icons and adds tests.

<sup>Written for commit 74049fbfde76fda82886bd4ecdb2a3486d117807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

