### PR TITLE
fix(worker): stop double-counting usage from semconv agent wrapper spans

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -268,6 +268,10 @@ def get_span_kind(attrs: dict[str, Any], otel_kind: int | str | None) -> str:
         return SpanKind.LLM
     if operation_name == "execute_tool":
         return SpanKind.TOOL
+    # Agent-invocation roots carry gen_ai.request.model too; decide AGENT here
+    # so the model fallback below cannot flip them to LLM.
+    if operation_name == "invoke_agent":
+        return SpanKind.AGENT
 
     # Infer from LLM-related attributes
     if (
@@ -538,7 +542,23 @@ def transform_otel_to_clickhouse(
                         ],
                     )
 
-                    if api_input_tokens is not None or api_output_tokens is not None:
+                    # The Vercel AI SDK's semconv emitter (tracer scope exactly
+                    # "gen_ai") stamps aggregate gen_ai.usage.* totals on the
+                    # operation root span, restating the SUM of its LLM children
+                    # — the same wrapper pattern as the raw ai.usage.* keys
+                    # gated above, moved into the normalized namespace. Trust
+                    # usage on that scope only on the LLM span itself; other
+                    # scopes are untouched (some instrumentors legitimately
+                    # report usage only on AGENT/CHAIN spans).
+                    vercel_semconv_wrapper = (
+                        isinstance(scope_name, str)
+                        and scope_name.lower() == "gen_ai"
+                        and span_kind != SpanKind.LLM
+                    )
+
+                    if not vercel_semconv_wrapper and (
+                        api_input_tokens is not None or api_output_tokens is not None
+                    ):
                         # Use API-provided counts (accurate).
                         input_tokens = int_or_zero(api_input_tokens)
                         output_tokens = int_or_zero(api_output_tokens)

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -53,6 +53,42 @@ def _scope_skips_text_token_estimation(scope_name: str | None) -> bool:
     return scope_name in _SKIP_TEXT_TOKEN_ESTIMATION_SCOPES
 
 
+# GenAI semconv operation names whose spans AGGREGATE the usage of their model-call
+# descendants: an agent invocation, and one step within it. Emitters restate the
+# children's totals on these spans, so adopting them prices the same tokens twice.
+# Keyed on the operation name rather than the tracer scope: the scope is chosen by
+# the emitting application (a private tracer provider can name it anything), so a
+# scope-keyed check silently misses those traces. "invoke_agent" is a GenAI semconv
+# operation name; "agent_step" is an emitter extension, not in the spec enum.
+_AGGREGATE_USAGE_OPERATIONS = frozenset({"invoke_agent", "agent_step"})
+
+
+def _span_aggregates_child_usage(
+    scope_name: str | None, span_kind: str, attrs: dict[str, Any]
+) -> bool:
+    """Check whether a span restates the token usage of its model-call children.
+
+    Args:
+        scope_name (str | None): Instrumentation scope of the emitting tracer.
+        span_kind (str): Span kind already resolved for this span.
+        attrs (dict[str, Any]): Span attributes.
+
+    Returns:
+        bool: True when the span's token counts duplicate its children's and must
+            neither be adopted nor re-derived from its text.
+    """
+    operation_name = attrs.get("gen_ai.operation.name")
+    if isinstance(operation_name, str) and operation_name.lower() in _AGGREGATE_USAGE_OPERATIONS:
+        return True
+    # Fallback for a wrapper that reaches us without an operation name — an emitter
+    # version that stops setting one would otherwise silently resume double-pricing,
+    # which nothing else in the pipeline would surface. Narrow on purpose: it costs
+    # nothing when the operation name is present, which is the shape observed today.
+    return (
+        isinstance(scope_name, str) and scope_name.lower() == "gen_ai" and span_kind != SpanKind.LLM
+    )
+
+
 # Attributes that are already extracted into dedicated fields
 _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.input",
@@ -542,21 +578,16 @@ def transform_otel_to_clickhouse(
                         ],
                     )
 
-                    # The Vercel AI SDK's semconv emitter (tracer scope exactly
-                    # "gen_ai") stamps aggregate gen_ai.usage.* totals on the
-                    # operation root span, restating the SUM of its LLM children
-                    # — the same wrapper pattern as the raw ai.usage.* keys
-                    # gated above, moved into the normalized namespace. Trust
-                    # usage on that scope only on the LLM span itself; other
-                    # scopes are untouched (some instrumentors legitimately
-                    # report usage only on AGENT/CHAIN spans).
-                    vercel_semconv_wrapper = (
-                        isinstance(scope_name, str)
-                        and scope_name.lower() == "gen_ai"
-                        and span_kind != SpanKind.LLM
+                    # Agent-invocation and step spans stamp aggregate
+                    # gen_ai.usage.* totals restating the SUM of their LLM
+                    # children — the same wrapper pattern as the raw ai.usage.*
+                    # keys gated above, moved into the normalized namespace.
+                    # Adopting them prices every token twice.
+                    aggregate_wrapper = _span_aggregates_child_usage(
+                        scope_name, span_kind, span_attrs
                     )
 
-                    if not vercel_semconv_wrapper and (
+                    if not aggregate_wrapper and (
                         api_input_tokens is not None or api_output_tokens is not None
                     ):
                         # Use API-provided counts (accurate).
@@ -618,14 +649,20 @@ def transform_otel_to_clickhouse(
                         cost = cost_from_buckets(get_model_price(model_name), buckets)
                         if cost is not None:
                             span_record["cost"] = cost
-                    elif span_kind == SpanKind.LLM and not _scope_skips_text_token_estimation(
-                        scope_name
+                    elif (
+                        not aggregate_wrapper
+                        and span_kind == SpanKind.LLM
+                        and not _scope_skips_text_token_estimation(scope_name)
                     ):
                         # Fall back to text-based estimation — only for LLM (completion)
                         # spans. Wrapper AGENT/CHAIN spans restate text their LLM children
                         # already account for (e.g. the Vercel AI SDK's ai.generateText
                         # wrapper carries a model name and the conversation text but no
                         # token counts), so estimating them double-counts the trace.
+                        # Aggregate spans are excluded for the same reason and must be
+                        # named explicitly: unlike AGENT/CHAIN wrappers they can be
+                        # LLM-kind, so the kind check alone would let their conversation
+                        # text be estimated into fabricated counts.
                         # Scopes in _SKIP_TEXT_TOKEN_ESTIMATION_SCOPES leave even their
                         # LLM spans deliberately unset and are skipped as well.
                         from worker.tokens import calculate_cost

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -73,7 +73,10 @@ _KNOWN_SCOPE_PREFIXES: tuple[str, ...] = (
 # "ai" prefix would also swallow unrelated ai*-named scopes).
 _KNOWN_SCOPE_EXACT: frozenset[str] = frozenset(
     {
-        "ai",  # Vercel AI SDK tracer; GROSS input with cache detail under ai.usage.*
+        "ai",  # Vercel AI SDK legacy tracer; GROSS input with cache detail under ai.usage.*
+        # Vercel AI SDK semconv tracer; same GROSS usage source as "ai", emitted
+        # under gen_ai.usage.* instead.
+        "gen_ai",
     }
 )
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -2,6 +2,7 @@
 
 import base64
 from datetime import datetime
+from typing import ClassVar
 
 import pytest
 
@@ -1094,6 +1095,163 @@ class TestGetSpanKindGenAI:
             )
             == "SPAN"
         )
+
+    def test_gen_ai_operation_name_invoke_agent_is_agent(self):
+        assert get_span_kind({"gen_ai.operation.name": "invoke_agent"}, None) == "AGENT"
+
+    def test_invoke_agent_wins_over_model_presence(self):
+        # Semconv agent-invocation roots carry gen_ai.request.model too; the
+        # operation name must decide the kind before the model fallback flips
+        # the span to LLM (which would let its aggregate usage be priced).
+        assert (
+            get_span_kind(
+                {
+                    "gen_ai.operation.name": "invoke_agent",
+                    "gen_ai.request.model": "claude-haiku-4-5-20251001",
+                },
+                None,
+            )
+            == "AGENT"
+        )
+
+
+# ── Vercel AI SDK semconv emitter (tracer scope "gen_ai") ──────────────
+
+
+def _semconv_agent_trace_spans(*, with_openinference_kinds: bool):
+    """Span shapes taken verbatim from a live ai@7 semconv-telemetry trace.
+
+    The operation root restates its LLM child's usage as an aggregate; the
+    step span carries no usage or model at all.
+
+    Args:
+        with_openinference_kinds (bool): Include openinference.span.kind attrs
+            (present when the openinference-vercel processor ran); omit them to
+            model a raw @ai-sdk/otel export.
+
+    Returns:
+        list: OTLP span dicts for make_otel_payload.
+    """
+    model = "claude-haiku-4-5-20251001"
+
+    def oi(kind):
+        return [make_attr("openinference.span.kind", kind)] if with_openinference_kinds else []
+
+    root = make_span(
+        "aa" * 16,
+        "bb" * 8,
+        name="committee.chair",
+        attributes=oi("AGENT")
+        + [
+            make_attr("gen_ai.operation.name", "invoke_agent"),
+            make_attr("gen_ai.agent.name", "committee.chair"),
+            make_attr("gen_ai.request.model", model),
+            make_attr("gen_ai.usage.input_tokens", 10),
+            make_attr("gen_ai.usage.output_tokens", 16),
+            make_attr("ai.usage.inputTokenDetails.noCacheTokens", 10),
+        ],
+    )
+    step = make_span(
+        "aa" * 16,
+        "cc" * 8,
+        name="step 1",
+        parent_span_id_hex="bb" * 8,
+        attributes=oi("LLM") + [make_attr("gen_ai.operation.name", "agent_step")],
+    )
+    chat = make_span(
+        "aa" * 16,
+        "dd" * 8,
+        name=f"chat {model}",
+        parent_span_id_hex="cc" * 8,
+        attributes=oi("LLM")
+        + [
+            make_attr("gen_ai.operation.name", "chat"),
+            make_attr("gen_ai.request.model", model),
+            make_attr("gen_ai.usage.input_tokens", 10),
+            make_attr("gen_ai.usage.output_tokens", 16),
+            make_attr("ai.usage.inputTokenDetails.noCacheTokens", 10),
+        ],
+    )
+    return [root, step, chat]
+
+
+class TestVercelSemconvScope:
+    """The ai@7 semconv emitter (tracer scope exactly "gen_ai") stamps aggregate
+    gen_ai.usage.* totals on the operation root span, restating the SUM of its
+    LLM children. Usage on that scope is trusted only on LLM spans, or the
+    trace is charged twice."""
+
+    PRICES: ClassVar[dict[str, float]] = {
+        "input": 0.000003,
+        "output": 0.000015,
+        "cacheRead": 0.0,
+        "cacheWrite": 0.0,
+    }
+
+    def _transform(self, spans, scope_name="gen_ai"):
+        from unittest.mock import patch
+
+        payload = make_otel_payload(spans, scope_name=scope_name)
+        with patch("worker.tokens.pricing.get_model_price", return_value=self.PRICES):
+            return transform_otel_to_clickhouse(payload, "proj-1")
+
+    def _assert_only_chat_priced(self, spans):
+        by_name = {s["name"]: s for s in spans}
+        root = by_name["committee.chair"]
+        chat = by_name["chat claude-haiku-4-5-20251001"]
+        step = by_name["step 1"]
+
+        # Root contributes nothing — its aggregate restates the chat span.
+        assert (root.get("input_tokens") or 0) == 0
+        assert (root.get("output_tokens") or 0) == 0
+        assert (root.get("cost") or 0) == 0
+        # The model name itself is still kept for display.
+        assert root["model_name"] == "claude-haiku-4-5-20251001"
+
+        # The chat span is priced from its own counts.
+        assert chat["input_tokens"] == 10
+        assert chat["output_tokens"] == 16
+        assert chat["total_tokens"] == 26
+        assert chat["cost"] == pytest.approx(10 * 0.000003 + 16 * 0.000015)
+
+        # The step span has no model and stores nothing.
+        assert (step.get("input_tokens") or 0) == 0
+
+        # Trace-wide sums equal the single real call, not 2x.
+        assert sum((s.get("input_tokens") or 0) for s in spans) == 10
+        assert sum((s.get("output_tokens") or 0) for s in spans) == 16
+
+    def test_semconv_agent_root_aggregate_not_double_counted(self):
+        _, spans = self._transform(_semconv_agent_trace_spans(with_openinference_kinds=True))
+        self._assert_only_chat_priced(spans)
+
+    def test_semconv_shape_without_openinference_kinds(self):
+        """A raw @ai-sdk/otel export has no openinference.span.kind attrs; the
+        root must classify AGENT via gen_ai.operation.name=invoke_agent so the
+        scope gate still applies."""
+        _, spans = self._transform(_semconv_agent_trace_spans(with_openinference_kinds=False))
+        by_name = {s["name"]: s for s in spans}
+        assert by_name["committee.chair"]["span_kind"] == "AGENT"
+        self._assert_only_chat_priced(spans)
+
+    def test_other_scopes_still_price_agent_spans(self):
+        """The gate is fenced to the "gen_ai" scope: instrumentors that report
+        usage only on AGENT spans must keep being priced from them."""
+        span = make_span(
+            "aa" * 16,
+            "bb" * 8,
+            name="agent run",
+            attributes=[
+                make_attr("openinference.span.kind", "AGENT"),
+                make_attr("gen_ai.request.model", "gpt-4o-mini"),
+                make_attr("gen_ai.usage.input_tokens", 100),
+                make_attr("gen_ai.usage.output_tokens", 50),
+            ],
+        )
+        _, spans = self._transform([span], scope_name="openinference.instrumentation.openai_agents")
+        assert spans[0]["input_tokens"] == 100
+        assert spans[0]["output_tokens"] == 50
+        assert spans[0]["cost"] == pytest.approx(100 * 0.000003 + 50 * 0.000015)
 
 
 # ── GenAI semconv input/output fallback ────────────────────────────────

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -1102,7 +1102,8 @@ class TestGetSpanKindGenAI:
     def test_invoke_agent_wins_over_model_presence(self):
         # Semconv agent-invocation roots carry gen_ai.request.model too; the
         # operation name must decide the kind before the model fallback flips
-        # the span to LLM (which would let its aggregate usage be priced).
+        # the span to LLM. Pricing no longer depends on this (the usage gate
+        # keys on the operation name), but the stored kind does.
         assert (
             get_span_kind(
                 {
@@ -1119,7 +1120,7 @@ class TestGetSpanKindGenAI:
 
 
 def _semconv_agent_trace_spans(*, with_openinference_kinds: bool):
-    """Span shapes taken verbatim from a live ai@7 semconv-telemetry trace.
+    """Span shapes modeled on an ai@7 semconv-telemetry trace.
 
     The operation root restates its LLM child's usage as an aggregate; the
     step span carries no usage or model at all.
@@ -1140,11 +1141,11 @@ def _semconv_agent_trace_spans(*, with_openinference_kinds: bool):
     root = make_span(
         "aa" * 16,
         "bb" * 8,
-        name="committee.chair",
+        name="example-agent.root",
         attributes=oi("AGENT")
         + [
             make_attr("gen_ai.operation.name", "invoke_agent"),
-            make_attr("gen_ai.agent.name", "committee.chair"),
+            make_attr("gen_ai.agent.name", "example-agent.root"),
             make_attr("gen_ai.request.model", model),
             make_attr("gen_ai.usage.input_tokens", 10),
             make_attr("gen_ai.usage.output_tokens", 16),
@@ -1175,11 +1176,12 @@ def _semconv_agent_trace_spans(*, with_openinference_kinds: bool):
     return [root, step, chat]
 
 
-class TestVercelSemconvScope:
-    """The ai@7 semconv emitter (tracer scope exactly "gen_ai") stamps aggregate
-    gen_ai.usage.* totals on the operation root span, restating the SUM of its
-    LLM children. Usage on that scope is trusted only on LLM spans, or the
-    trace is charged twice."""
+class TestAggregateUsageSpans:
+    """Agent-invocation and step spans stamp aggregate gen_ai.usage.* totals
+    restating the SUM of their model-call descendants. They are identified by
+    their semconv operation name — not by tracer scope, which the emitting
+    application chooses, nor by span kind, which they do not consistently
+    carry — and neither their reported counts nor their text may be priced."""
 
     PRICES: ClassVar[dict[str, float]] = {
         "input": 0.000003,
@@ -1197,7 +1199,7 @@ class TestVercelSemconvScope:
 
     def _assert_only_chat_priced(self, spans):
         by_name = {s["name"]: s for s in spans}
-        root = by_name["committee.chair"]
+        root = by_name["example-agent.root"]
         chat = by_name["chat claude-haiku-4-5-20251001"]
         step = by_name["step 1"]
 
@@ -1226,17 +1228,19 @@ class TestVercelSemconvScope:
         self._assert_only_chat_priced(spans)
 
     def test_semconv_shape_without_openinference_kinds(self):
-        """A raw @ai-sdk/otel export has no openinference.span.kind attrs; the
-        root must classify AGENT via gen_ai.operation.name=invoke_agent so the
-        scope gate still applies."""
+        """A raw @ai-sdk/otel export has no openinference.span.kind attrs, so the
+        root would otherwise infer LLM from its model attribute. Its usage is
+        skipped on the operation name either way; this pins the classification,
+        which the trace tree and span-kind filters also depend on."""
         _, spans = self._transform(_semconv_agent_trace_spans(with_openinference_kinds=False))
         by_name = {s["name"]: s for s in spans}
-        assert by_name["committee.chair"]["span_kind"] == "AGENT"
+        assert by_name["example-agent.root"]["span_kind"] == "AGENT"
         self._assert_only_chat_priced(spans)
 
     def test_other_scopes_still_price_agent_spans(self):
-        """The gate is fenced to the "gen_ai" scope: instrumentors that report
-        usage only on AGENT spans must keep being priced from them."""
+        """Only aggregate operations are skipped. An AGENT span carrying no
+        aggregate operation name is an emitter reporting usage at the wrapper
+        level, which stays authoritative and priced."""
         span = make_span(
             "aa" * 16,
             "bb" * 8,
@@ -1252,6 +1256,95 @@ class TestVercelSemconvScope:
         assert spans[0]["input_tokens"] == 100
         assert spans[0]["output_tokens"] == 50
         assert spans[0]["cost"] == pytest.approx(100 * 0.000003 + 50 * 0.000015)
+
+    def test_agent_step_aggregate_is_not_priced(self):
+        """A step span aggregates the model calls made inside it, and the
+        emitter marks it LLM — so the span-kind half of the check cannot catch
+        it. The semconv operation name is what identifies the aggregate."""
+        span = make_span(
+            "aa" * 16,
+            "bb" * 8,
+            name="step 1",
+            attributes=[
+                make_attr("openinference.span.kind", "LLM"),
+                make_attr("gen_ai.operation.name", "agent_step"),
+                make_attr("gen_ai.request.model", "claude-haiku-4-5-20251001"),
+                make_attr("gen_ai.usage.input_tokens", 10),
+                make_attr("gen_ai.usage.output_tokens", 16),
+            ],
+        )
+        _, spans = self._transform([span])
+        assert spans[0]["span_kind"] == "LLM"
+        assert (spans[0].get("input_tokens") or 0) == 0
+        assert (spans[0].get("cost") or 0) == 0
+        # The model name is still kept for display, as on the operation root.
+        assert spans[0]["model_name"] == "claude-haiku-4-5-20251001"
+
+    def test_aggregate_span_text_is_not_estimated_into_tokens(self):
+        """Refusing the aggregate's reported counts must not hand the span to the
+        estimation fallback instead. These spans are LLM-kind and carry the whole
+        conversation, so estimating them invents counts that are wrong twice over:
+        fabricated, and duplicating the children whose text they restate."""
+        span = make_span(
+            "aa" * 16,
+            "bb" * 8,
+            name="step 1",
+            attributes=[
+                make_attr("openinference.span.kind", "LLM"),
+                make_attr("gen_ai.operation.name", "agent_step"),
+                make_attr("gen_ai.request.model", "claude-haiku-4-5-20251001"),
+                make_attr("gen_ai.usage.input_tokens", 10),
+                make_attr("gen_ai.usage.output_tokens", 16),
+                make_attr("gen_ai.input.messages", "some prompt text " * 40),
+                make_attr("gen_ai.output.messages", "a fairly long response " * 20),
+            ],
+        )
+        _, spans = self._transform([span])
+        assert spans[0].get("input_tokens") is None
+        assert spans[0].get("output_tokens") is None
+        assert spans[0].get("total_tokens") is None
+        assert spans[0].get("cost") is None
+
+    def test_invoke_agent_aggregate_skipped_even_when_labelled_llm(self):
+        """Pricing must not hinge on classification winning the race: an
+        operation root that a processor labelled LLM, under a scope other than
+        "gen_ai", still restates its children and must not be adopted."""
+        span = make_span(
+            "aa" * 16,
+            "bb" * 8,
+            name="agent run",
+            attributes=[
+                make_attr("openinference.span.kind", "LLM"),
+                make_attr("gen_ai.operation.name", "invoke_agent"),
+                make_attr("gen_ai.request.model", "gpt-4o-mini"),
+                make_attr("gen_ai.usage.input_tokens", 100),
+                make_attr("gen_ai.usage.output_tokens", 50),
+            ],
+        )
+        _, spans = self._transform([span], scope_name="some-other-emitter")
+        assert (spans[0].get("input_tokens") or 0) == 0
+        assert (spans[0].get("cost") or 0) == 0
+
+    def test_semconv_wrapper_without_an_operation_name_is_still_skipped(self):
+        """Fallback for an emitter version that stops setting the operation name.
+        A non-LLM span on the semconv scope carrying a model and aggregate counts
+        is a wrapper whatever it calls itself, and resuming double-pricing here
+        would be silent — nothing downstream reconciles a trace against its spans."""
+        span = make_span(
+            "aa" * 16,
+            "bb" * 8,
+            name="some wrapper",
+            attributes=[
+                make_attr("openinference.span.kind", "AGENT"),
+                make_attr("gen_ai.request.model", "claude-haiku-4-5-20251001"),
+                make_attr("gen_ai.usage.input_tokens", 10),
+                make_attr("gen_ai.usage.output_tokens", 16),
+            ],
+        )
+        _, spans = self._transform([span])
+        assert spans[0].get("input_tokens") is None
+        assert spans[0].get("cost") is None
+        assert spans[0]["model_name"] == "claude-haiku-4-5-20251001"
 
 
 # ── GenAI semconv input/output fallback ────────────────────────────────

--- a/tests/worker/test_otel_transform_estimation_gate.py
+++ b/tests/worker/test_otel_transform_estimation_gate.py
@@ -8,8 +8,10 @@ Estimating tokens from a wrapper's text fabricates a duplicate of usage its LLM
 children already report, silently doubling per-trace token totals and cost.
 
 The estimation fallback must therefore fire only for spans classified as LLM.
-API-provided token counts are unaffected: they are trusted on any span kind, because
-some instrumentors legitimately report usage at the wrapper level.
+API-provided token counts are trusted on any span kind — some instrumentors
+legitimately report usage at the wrapper level — except on spans whose semconv
+operation name marks them as aggregates of their descendants, which are excluded
+from both estimation and adoption (see TestAggregateUsageSpans).
 
 Estimation tests use Claude model names: their token estimate is a deterministic,
 offline `len(text) // 4`, so the tests never depend on tiktoken downloads or pricing DB.

--- a/tests/worker/tokens/test_buckets.py
+++ b/tests/worker/tokens/test_buckets.py
@@ -164,6 +164,22 @@ def test_vercel_ai_scope_is_known_inclusive_no_warning(caplog):
     assert not any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
 
 
+def test_vercel_gen_ai_scope_is_known_inclusive_no_warning(caplog):
+    # The Vercel AI SDK's semconv emitter uses tracer scope exactly "gen_ai".
+    # Its gen_ai.usage.input_tokens comes from the same GROSS usage source as
+    # the legacy "ai" scope, so the standard subtraction applies silently.
+    with caplog.at_level(logging.WARNING):
+        b = normalize_token_usage(
+            "gen_ai",
+            input_tokens=28466,
+            output_tokens=120,
+            cache_read_tokens=22041,
+            cache_write_tokens=6422,
+        )
+    assert b == TokenBuckets(input_uncached=3, output=120, cache_read=22041, cache_write=6422)
+    assert not any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
+
+
 def test_ai_prefixed_scope_still_warns(caplog):
     # "ai" is matched exactly, not as a prefix — an unrelated ai*-named scope
     # must still surface the unknown-emitter warning.


### PR DESCRIPTION
## Summary

Traces from the Vercel AI SDK's semconv OTel emitter (`@ai-sdk/otel`, tracer scope exactly `"gen_ai"`) were stored with token usage **and cost on both the operation root span and its LLM child**, so every trace-level aggregate (trace list, trace-tree root chip, dashboards, digests) showed double the real usage — worse than 2x for multi-step agent runs, since the root restates the **sum** of all its children. Verified on a live staging trace: a single 10→16-token call displayed as 20→32 (52) at double the cost.

**Root cause:** the semconv emitter stamps aggregate `gen_ai.usage.*` totals on the operation root (`onGenerateEnd` in `@ai-sdk/otel`), restating its `chat <model>` children. The ingest transform trusts `gen_ai.usage.*` on any span kind with a model attribute (deliberate — some instrumentors report usage only on AGENT/CHAIN spans). The existing wrapper guard from #1187 only gates the **raw** `ai.usage.*` spellings; the semconv emitter moved the duplicates into the normalized namespace under a new tracer scope, bypassing it. The duplication is invisible in the UI because token chips render only on LLM-kind spans.

## Changes

- **`backend/worker/otel_transform.py`**
  - Gate API-provided token adoption: on tracer scope exactly `"gen_ai"`, usage is trusted only on LLM-kind spans. Skipping the branch also skips `usage_details` buckets and cost (all derived inside it). Model-name extraction is kept for display. No behavior change for any other scope.
  - `get_span_kind`: map `gen_ai.operation.name: "invoke_agent"` → AGENT, decided before the has-model→LLM fallback. Semconv operation roots carry `gen_ai.request.model`, so without this a raw `@ai-sdk/otel` export (no openinference kind attrs) would classify the root as LLM and dodge the gate. Also the semantically correct kind for these spans.
- **`backend/worker/tokens/buckets.py`** — register `"gen_ai"` as a known gross scope (exact match, mirroring `"ai"`); it previously fired the unknown-scope warning.

## Tests

- Semconv trace shape taken verbatim from the staging trace (AGENT root with aggregate usage + `step N` + `chat <model>` leaf): root stores no tokens/cost, leaf stores 10/16/26 with cost, trace-wide sums equal the single real call.
- Same shape **without** `openinference.span.kind` attrs — covers raw `@ai-sdk/otel` exports; passes via the `invoke_agent` → AGENT mapping.
- Control: an identical usage-bearing AGENT span under a different scope is still priced — the gate is fenced to `"gen_ai"`.
- `get_span_kind` units (`invoke_agent` → AGENT, including with a model attr present) and a buckets known-scope test.
- Full backend suite: 892 passed, 1 skipped (pre-existing).

## Known limitations (see issue)

- Ingest-time fix only — already-stored rows remain doubled unless re-ingested; no backfill.
- Embeddings/rerank operations have the same root+leaf duplicate pattern but both spans classify as LLM, so they keep today's (doubled) behavior — separate follow-up.

Closes #1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-counted token usage and cost for Vercel AI SDK semconv traces. Totals in trace lists, trees, dashboards, and digests now match the real LLM calls.

- **Bug Fixes**
  - Detect aggregate agent wrappers by `gen_ai.operation.name` (`invoke_agent`, `agent_step`) and ignore their `gen_ai.usage.*`; also skip text-based estimation for them. Model names are still extracted.
  - Fallback when no operation name: treat non-LLM spans on scope `gen_ai` as aggregates so wrapper usage is still ignored.
  - Classify `gen_ai.operation.name: invoke_agent` as AGENT in `get_span_kind`, so agent roots don’t appear as LLM spans.
  - Register `gen_ai` as a known gross scope in token buckets to apply standard cache subtraction and avoid warnings.

<sup>Written for commit 95c16b749634d154e30b9b5b4623104022cd1a60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

