### PR TITLE
fix(billing): hide dead upgrade path and unenforced caps on self-host

### DIFF
--- a/frontend/ui/src/app/api/billing/change-plan/route.test.ts
+++ b/frontend/ui/src/app/api/billing/change-plan/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const mockIsBillingEnabled = vi.fn();
+const mockGetSession = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: (...a: unknown[]) => mockGetSession(...a) } },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers(),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: { workspace: { findFirst: vi.fn(), update: vi.fn() } },
+  getStripeOrThrow: vi.fn(),
+  getPlanConfig: vi.fn(),
+  isUpgrade: vi.fn(),
+  isBillingEnabled: () => mockIsBillingEnabled(),
+  PlanType: { FREE: "free", STARTER: "starter", PRO: "pro", ENTERPRISE: "enterprise" },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/billing/change-plan", () => {
+  it("returns 400 without hitting auth when billing is disabled (self-host)", async () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ workspaceId: "ws1", newPlan: "pro" }),
+      }) as any,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Billing is disabled on this deployment");
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it("proceeds past the billing gate when billing is enabled", async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockGetSession.mockResolvedValue(null);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ workspaceId: "ws1", newPlan: "pro" }),
+      }) as any,
+    );
+
+    // Reaches the auth check (not the billing gate) — proves the gate didn't
+    // short-circuit when billing is enabled.
+    expect(res.status).toBe(401);
+  });
+});

--- a/frontend/ui/src/app/api/billing/change-plan/route.ts
+++ b/frontend/ui/src/app/api/billing/change-plan/route.ts
@@ -1,10 +1,24 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
-import { prisma, getStripeOrThrow, getPlanConfig, isUpgrade, PlanType } from "@traceroot/core";
+import {
+  prisma,
+  getStripeOrThrow,
+  getPlanConfig,
+  isUpgrade,
+  isBillingEnabled,
+  PlanType,
+} from "@traceroot/core";
 
 export async function POST(req: NextRequest) {
   try {
+    if (!isBillingEnabled()) {
+      return NextResponse.json(
+        { error: "Billing is disabled on this deployment" },
+        { status: 400 },
+      );
+    }
+
     const session = await auth.api.getSession({ headers: await headers() });
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/frontend/ui/src/app/api/billing/checkout/route.test.ts
+++ b/frontend/ui/src/app/api/billing/checkout/route.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const mockIsBillingEnabled = vi.fn();
+const mockGetSession = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: (...a: unknown[]) => mockGetSession(...a) } },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers(),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: { workspace: { findFirst: vi.fn(), update: vi.fn() } },
+  getStripeOrThrow: vi.fn(),
+  getPlanConfig: vi.fn(),
+  isBillingEnabled: () => mockIsBillingEnabled(),
+  PlanType: { FREE: "free", STARTER: "starter", PRO: "pro", ENTERPRISE: "enterprise" },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/billing/checkout", () => {
+  it("returns 400 without hitting auth/Stripe when billing is disabled (self-host)", async () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ workspaceId: "ws1", plan: "starter" }),
+      }) as any,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Billing is disabled on this deployment");
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it("proceeds past the billing gate when billing is enabled", async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockGetSession.mockResolvedValue({ user: { id: "u1" } });
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ workspaceId: "ws1", plan: "invalid-plan" }),
+      }) as any,
+    );
+
+    // Reaches the plan-validation step (not the billing gate) — proves the
+    // gate didn't short-circuit when billing is enabled.
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Invalid plan");
+  });
+});

--- a/frontend/ui/src/app/api/billing/checkout/route.ts
+++ b/frontend/ui/src/app/api/billing/checkout/route.ts
@@ -1,10 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
-import { prisma, getStripeOrThrow, getPlanConfig, PlanType } from "@traceroot/core";
+import {
+  prisma,
+  getStripeOrThrow,
+  getPlanConfig,
+  isBillingEnabled,
+  PlanType,
+} from "@traceroot/core";
 
 export async function POST(req: NextRequest) {
   try {
+    if (!isBillingEnabled()) {
+      return NextResponse.json(
+        { error: "Billing is disabled on this deployment" },
+        { status: 400 },
+      );
+    }
+
     const session = await auth.api.getSession({ headers: await headers() });
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/frontend/ui/src/app/api/billing/portal/route.test.ts
+++ b/frontend/ui/src/app/api/billing/portal/route.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const mockIsBillingEnabled = vi.fn();
+const mockGetSession = vi.fn();
+
+vi.mock("@/lib/auth", () => ({
+  auth: { api: { getSession: (...a: unknown[]) => mockGetSession(...a) } },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers(),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: { workspace: { findFirst: vi.fn() } },
+  getStripeOrThrow: vi.fn(),
+  isBillingEnabled: () => mockIsBillingEnabled(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("POST /api/billing/portal", () => {
+  it("returns 400 without hitting auth when billing is disabled (self-host)", async () => {
+    mockIsBillingEnabled.mockReturnValue(false);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ workspaceId: "ws1" }),
+      }) as any,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Billing is disabled on this deployment");
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it("proceeds past the billing gate when billing is enabled", async () => {
+    mockIsBillingEnabled.mockReturnValue(true);
+    mockGetSession.mockResolvedValue(null);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      new Request("http://localhost/", {
+        method: "POST",
+        body: JSON.stringify({ workspaceId: "ws1" }),
+      }) as any,
+    );
+
+    // Reaches the auth check (not the billing gate) — proves the gate didn't
+    // short-circuit when billing is enabled.
+    expect(res.status).toBe(401);
+  });
+});

--- a/frontend/ui/src/app/api/billing/portal/route.ts
+++ b/frontend/ui/src/app/api/billing/portal/route.ts
@@ -1,10 +1,17 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
-import { prisma, getStripeOrThrow } from "@traceroot/core";
+import { prisma, getStripeOrThrow, isBillingEnabled } from "@traceroot/core";
 
 export async function POST(req: NextRequest) {
   try {
+    if (!isBillingEnabled()) {
+      return NextResponse.json(
+        { error: "Billing is disabled on this deployment" },
+        { status: 400 },
+      );
+    }
+
     const session = await auth.api.getSession({ headers: await headers() });
     if (!session?.user?.id) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/route.test.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/route.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+const mockRequireAuth = vi.fn();
+const mockRequireWorkspaceMembership = vi.fn();
+const mockFindUnique = vi.fn();
+const mockIsBillingEnabled = vi.fn();
+
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...a: unknown[]) => mockRequireAuth(...a),
+  requireWorkspaceMembership: (...a: unknown[]) => mockRequireWorkspaceMembership(...a),
+  errorResponse: (msg: string, s: number) =>
+    new Response(JSON.stringify({ error: msg }), { status: s }),
+  successResponse: (d: unknown) => new Response(JSON.stringify(d), { status: 200 }),
+}));
+
+vi.mock("@traceroot/core", () => ({
+  prisma: { workspace: { findUnique: (...a: unknown[]) => mockFindUnique(...a) } },
+  Role: { ADMIN: "ADMIN", MEMBER: "MEMBER" },
+  isBillingEnabled: () => mockIsBillingEnabled(),
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+const baseWorkspace = {
+  id: "ws1",
+  name: "Acme",
+  projects: [],
+  _count: { members: 1 },
+  createTime: new Date("2026-01-01"),
+  billingPlan: "free",
+  billingCustomerId: null,
+  billingSubscriptionId: null,
+  billingStatus: null,
+  currentUsage: null,
+};
+
+describe("GET /api/workspaces/[workspaceId]", () => {
+  it("reports billingEnabled: true on a cloud deployment", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" }, error: null });
+    mockRequireWorkspaceMembership.mockResolvedValue({
+      membership: { role: "ADMIN" },
+      error: null,
+    });
+    mockFindUnique.mockResolvedValue(baseWorkspace);
+    mockIsBillingEnabled.mockReturnValue(true);
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://localhost/"), {
+      params: Promise.resolve({ workspaceId: "ws1" }),
+    } as any);
+    const body = await res.json();
+
+    expect(body.billingEnabled).toBe(true);
+  });
+
+  it("reports billingEnabled: false on a self-host deployment (ENABLE_BILLING=false)", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "u1" }, error: null });
+    mockRequireWorkspaceMembership.mockResolvedValue({
+      membership: { role: "ADMIN" },
+      error: null,
+    });
+    mockFindUnique.mockResolvedValue(baseWorkspace);
+    mockIsBillingEnabled.mockReturnValue(false);
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://localhost/"), {
+      params: Promise.resolve({ workspaceId: "ws1" }),
+    } as any);
+    const body = await res.json();
+
+    expect(body.billingEnabled).toBe(false);
+  });
+});

--- a/frontend/ui/src/app/api/workspaces/[workspaceId]/route.ts
+++ b/frontend/ui/src/app/api/workspaces/[workspaceId]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { prisma, Role } from "@traceroot/core";
+import { prisma, Role, isBillingEnabled } from "@traceroot/core";
 import {
   requireAuth,
   requireWorkspaceMembership,
@@ -65,6 +65,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     billingSubscriptionId: workspace.billingSubscriptionId,
     billingStatus: workspace.billingStatus,
     currentUsage: workspace.currentUsage,
+    billingEnabled: isBillingEnabled(),
   });
 }
 

--- a/frontend/ui/src/app/workspaces/[workspaceId]/settings/billing/page.tsx
+++ b/frontend/ui/src/app/workspaces/[workspaceId]/settings/billing/page.tsx
@@ -34,6 +34,7 @@ export default function WorkspaceSettingsBillingPage() {
             currentPlan={(workspace?.billingPlan as PlanType) || PlanType.FREE}
             hasSubscription={!!workspace?.billingSubscriptionId}
             currentUsage={workspace?.currentUsage}
+            billingEnabled={workspace?.billingEnabled ?? true}
           />
         )}
       </SettingsLayout>

--- a/frontend/ui/src/components/layout/SidebarUpgradeButton.test.tsx
+++ b/frontend/ui/src/components/layout/SidebarUpgradeButton.test.tsx
@@ -136,6 +136,24 @@ describe("SidebarUpgradeButton", () => {
     expect(dialog.getAttribute("data-open")).toBe("true");
   });
 
+  it("should render nothing when billing is disabled (self-host)", () => {
+    mockUseProject.mockReturnValue({ data: undefined });
+    mockUseWorkspace.mockReturnValue({
+      data: {
+        id: "w1",
+        billingPlan: PlanType.FREE,
+        billingEnabled: false,
+      },
+    });
+
+    const { container } = renderWithProvider(
+      <SidebarUpgradeButton workspaceId="w1" collapsed={false} />,
+    );
+
+    expect(container.textContent).toBe("");
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
   it("should handle propWorkspaceId prioritisation over project workspace_id", () => {
     mockUseProject.mockReturnValue({ data: { workspace_id: "w-project" } });
     mockUseWorkspace.mockReturnValue({

--- a/frontend/ui/src/components/layout/SidebarUpgradeButton.tsx
+++ b/frontend/ui/src/components/layout/SidebarUpgradeButton.tsx
@@ -27,6 +27,13 @@ export function SidebarUpgradeButton({
   const workspaceId = propWorkspaceId || project?.workspace_id || "";
   const { data: workspace } = useWorkspace(workspaceId);
 
+  // Self-host (ENABLE_BILLING=false) is intentionally unlimited — there's no
+  // higher tier to upgrade to, so don't show a CTA that leads to a dead
+  // checkout flow.
+  if (workspace?.billingEnabled === false) {
+    return null;
+  }
+
   return (
     <>
       <Tooltip>

--- a/frontend/ui/src/ee/features/billing/BillingTab.test.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.test.tsx
@@ -10,7 +10,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("./api", () => ({
   getPortalUrl: vi.fn(),
-  getSubscriptionInfo: vi.fn(),
+  getSubscriptionInfo: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("./PricingDialog", () => ({
@@ -94,5 +94,117 @@ describe("BillingTab", () => {
 
     expect(screen.queryByText("unknown")).toBeNull();
     expect(screen.getByText("claude-opus-4-8")).toBeTruthy();
+  });
+});
+
+describe("BillingTab - self-host (ENABLE_BILLING=false)", () => {
+  it("hides Change plan / Manage billing and shows the unlimited self-host message", () => {
+    render(
+      <BillingTab
+        workspaceId="ws_1"
+        currentPlan={PlanType.FREE}
+        hasSubscription={false}
+        billingEnabled={false}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Change plan" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Manage billing/ })).toBeNull();
+    expect(
+      screen.getByText(
+        "This is a self-hosted deployment — every plan limit is unlimited, so there's no higher tier to move to.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText(/currently on the/)).toBeNull();
+  });
+
+  it("does not advertise the Free plan's hard caps on self-host", () => {
+    render(
+      <BillingTab
+        workspaceId="ws_1"
+        currentPlan={PlanType.FREE}
+        hasSubscription={false}
+        billingEnabled={false}
+        currentUsage={{
+          traces: 60_000,
+          spans: 0,
+          tokens: 0,
+          updatedAt: "2026-07-01T00:00:00.000Z",
+        }}
+      />,
+    );
+
+    expect(screen.queryByText(/hard cap/)).toBeNull();
+    expect(
+      screen.getByText(
+        "Events ingested this period. Self-hosted deployments have no event limits.",
+      ),
+    ).toBeTruthy();
+    // 60,000 traces exceeds the Free plan's 50,000 cap — the "Total events"
+    // row must render as unlimited (no "/ 50,000" suffix), matching the
+    // enforcement layer which never blocks ingestion when billing is disabled.
+    const totalEventsLabel = screen.getByText("Total events");
+    const totalEventsRow = totalEventsLabel.closest("div");
+    expect(totalEventsRow?.textContent).toBe("Total events60,000");
+  });
+
+  it("shows chat/RCA runs as Unlimited and drops the billing-mechanics copy", () => {
+    render(
+      <BillingTab
+        workspaceId="ws_1"
+        currentPlan={PlanType.FREE}
+        hasSubscription={false}
+        billingEnabled={false}
+        currentUsage={{
+          traces: 0,
+          spans: 0,
+          tokens: 0,
+          updatedAt: "2026-07-01T00:00:00.000Z",
+          ai: {
+            runsUsed: 45,
+            systemUsage: { messages: 0, cost: 0, inputTokens: 0, outputTokens: 0 },
+            byokUsage: { messages: 0, cost: 0, inputTokens: 0, outputTokens: 0 },
+            byModel: [],
+          },
+        }}
+      />,
+    );
+
+    // 45 exceeds Free's 30-run cap — must show Unlimited, not "45 / 30".
+    expect(screen.getByText("45 (Unlimited)")).toBeTruthy();
+    expect(screen.getAllByText("No billing on self-hosted deployments.").length).toBeGreaterThan(0);
+    expect(screen.queryByText(/we pay/)).toBeNull();
+    expect(screen.queryByText(/markup/)).toBeNull();
+  });
+
+  it("still shows a Change plan button and cloud caps when billing is enabled", () => {
+    render(<BillingTab workspaceId="ws_1" currentPlan={PlanType.FREE} billingEnabled={true} />);
+
+    expect(screen.getByRole("button", { name: "Change plan" })).toBeTruthy();
+    expect(screen.getByText(/currently on the/)).toBeTruthy();
+    expect(screen.getByText(/hard cap/)).toBeTruthy();
+  });
+
+  it("still shows Manage billing for a subscribed cloud workspace", () => {
+    render(
+      <BillingTab
+        workspaceId="ws_1"
+        currentPlan={PlanType.PRO}
+        hasSubscription={true}
+        billingEnabled={true}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Manage billing/ })).toBeTruthy();
+  });
+
+  it("shows unlimited events copy for a paid plan with no included cap", () => {
+    render(
+      <BillingTab workspaceId="ws_1" currentPlan={PlanType.ENTERPRISE} billingEnabled={true} />,
+    );
+
+    expect(
+      screen.getByText("Events used this billing period. Unlimited events included."),
+    ).toBeTruthy();
   });
 });

--- a/frontend/ui/src/ee/features/billing/BillingTab.tsx
+++ b/frontend/ui/src/ee/features/billing/BillingTab.tsx
@@ -116,6 +116,11 @@ interface BillingTabProps {
   currentPlan?: PlanType;
   hasSubscription?: boolean; // true if workspace has billingSubscriptionId
   currentUsage?: UsageStats | null;
+  // False on self-host deployments (ENABLE_BILLING=false). The entitlement
+  // layer already treats these workspaces as unlimited, so this UI must not
+  // show a "Change plan" affordance that leads to a dead Stripe checkout, or
+  // advertise plan caps that aren't actually enforced.
+  billingEnabled?: boolean;
 }
 
 export function BillingTab({
@@ -123,10 +128,13 @@ export function BillingTab({
   currentPlan = PlanType.FREE,
   hasSubscription = false,
   currentUsage,
+  billingEnabled = true,
 }: BillingTabProps) {
   const searchParams = useSearchParams();
   const upgradeIntent = searchParams.get("upgrade");
-  const [showPricingDialog, setShowPricingDialog] = useState(Boolean(upgradeIntent));
+  const [showPricingDialog, setShowPricingDialog] = useState(
+    billingEnabled && Boolean(upgradeIntent),
+  );
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [subscriptionInfo, setSubscriptionInfo] = useState<SubscriptionInfo | null>(null);
@@ -135,21 +143,26 @@ export function BillingTab({
   const aiUsage = currentUsage?.ai;
   const rcaUsage = currentUsage?.rca;
   const detectorUsage = currentUsage?.detector;
-  const eventQuota = EVENT_QUOTAS[currentPlan];
-  const aiRunQuota = AI_RUN_QUOTAS[currentPlan];
-  const rcaRunQuota = RCA_RUN_QUOTAS[currentPlan];
-  const detectorRunQuota = DETECTOR_RUN_QUOTAS[currentPlan];
+  // Self-host has no plan tier to enforce — read quotas from Enterprise's
+  // Infinity shape so this UI matches the entitlement layer (which already
+  // short-circuits every quota check to "allow" when billing is disabled)
+  // instead of showing the nominal Free-plan caps the workspace row defaults to.
+  const quotaPlan = billingEnabled ? currentPlan : PlanType.ENTERPRISE;
+  const eventQuota = EVENT_QUOTAS[quotaPlan];
+  const aiRunQuota = AI_RUN_QUOTAS[quotaPlan];
+  const rcaRunQuota = RCA_RUN_QUOTAS[quotaPlan];
+  const detectorRunQuota = DETECTOR_RUN_QUOTAS[quotaPlan];
 
   // Fetch live subscription info from Stripe
   useEffect(() => {
-    if (!hasSubscription) return;
+    if (!billingEnabled || !hasSubscription) return;
 
     getSubscriptionInfo(workspaceId)
       .then(setSubscriptionInfo)
       .catch((err) => {
         console.error("Failed to fetch subscription info:", err);
       });
-  }, [workspaceId, hasSubscription]);
+  }, [workspaceId, hasSubscription, billingEnabled]);
 
   async function handleOpenPortal() {
     setIsLoading(true);
@@ -187,8 +200,14 @@ export function BillingTab({
         </div>
         <div className="px-4 py-3">
           <p className="text-sm text-muted-foreground">
-            You are currently on the{" "}
-            <span className="font-medium text-foreground">{currentPlanConfig.name}</span> plan.
+            {billingEnabled ? (
+              <>
+                You are currently on the{" "}
+                <span className="font-medium text-foreground">{currentPlanConfig.name}</span> plan.
+              </>
+            ) : (
+              "This is a self-hosted deployment — every plan limit is unlimited, so there's no higher tier to move to."
+            )}
           </p>
 
           {/* Cancellation Notice */}
@@ -237,16 +256,18 @@ export function BillingTab({
             </p>
           )}
 
-          <div className="mt-3 flex gap-2">
-            <Button variant="outline" size="sm" onClick={() => setShowPricingDialog(true)}>
-              Change plan
-            </Button>
-            {hasSubscription && (
-              <Button variant="ghost" size="sm" onClick={handleOpenPortal} disabled={isLoading}>
-                Manage billing <ExternalLink className="ml-1 h-3 w-3" />
+          {billingEnabled && (
+            <div className="mt-3 flex gap-2">
+              <Button variant="outline" size="sm" onClick={() => setShowPricingDialog(true)}>
+                Change plan
               </Button>
-            )}
-          </div>
+              {hasSubscription && (
+                <Button variant="ghost" size="sm" onClick={handleOpenPortal} disabled={isLoading}>
+                  Manage billing <ExternalLink className="ml-1 h-3 w-3" />
+                </Button>
+              )}
+            </div>
+          )}
         </div>
       </div>
 
@@ -257,11 +278,13 @@ export function BillingTab({
         </div>
         <div className="px-4 py-3">
           <p className="text-sm text-muted-foreground">
-            {currentPlan === PlanType.FREE
-              ? `Events used this period. Free plan includes ${eventQuota.included.toLocaleString()} events (hard cap).`
-              : eventQuota.included === Infinity
-                ? "Events used this billing period. Unlimited events included."
-                : `Events used this billing period. ${eventQuota.included.toLocaleString()} included, then ${eventQuota.overageLabel}.`}
+            {!billingEnabled
+              ? "Events ingested this period. Self-hosted deployments have no event limits."
+              : currentPlan === PlanType.FREE
+                ? `Events used this period. Free plan includes ${eventQuota.included.toLocaleString()} events (hard cap).`
+                : eventQuota.included === Infinity
+                  ? "Events used this billing period. Unlimited events included."
+                  : `Events used this billing period. ${eventQuota.included.toLocaleString()} included, then ${eventQuota.overageLabel}.`}
           </p>
           <div className="mt-3 space-y-2 text-sm">
             <div className="flex justify-between">
@@ -300,15 +323,17 @@ export function BillingTab({
         }
         runsHelper={
           "Each chat request." +
-          (currentPlan !== PlanType.FREE && currentPlan !== PlanType.ENTERPRISE
+          (billingEnabled && currentPlan !== PlanType.FREE && currentPlan !== PlanType.ENTERPRISE
             ? ` Overage: ${aiRunQuota.overageLabel}.`
             : "")
         }
         systemCost={aiUsage?.systemUsage.cost ?? 0}
         systemHelper={
-          currentPlan === PlanType.FREE
-            ? "Included in your plan (we pay)."
-            : "Included with runs; 1.05x markup on overage token cost."
+          !billingEnabled
+            ? "No billing on self-hosted deployments."
+            : currentPlan === PlanType.FREE
+              ? "Included in your plan (we pay)."
+              : "Included with runs; 1.05x markup on overage token cost."
         }
         systemInputTokens={aiUsage?.systemUsage.inputTokens ?? 0}
         systemOutputTokens={aiUsage?.systemUsage.outputTokens ?? 0}
@@ -337,15 +362,17 @@ export function BillingTab({
         runsValue={formatRcaQuotaLabel(rcaRunQuota, rcaUsage?.runsUsed ?? 0)}
         runsHelper={
           "Triggered by detector findings." +
-          (currentPlan !== PlanType.FREE && currentPlan !== PlanType.ENTERPRISE
+          (billingEnabled && currentPlan !== PlanType.FREE && currentPlan !== PlanType.ENTERPRISE
             ? ` Overage: ${rcaRunQuota.overageLabel}.`
             : "")
         }
         systemCost={rcaUsage?.systemTokenCost ?? 0}
         systemHelper={
-          currentPlan === PlanType.FREE
-            ? "Included in your plan (we pay)."
-            : "Included with runs; 1.05x markup on overage token cost."
+          !billingEnabled
+            ? "No billing on self-hosted deployments."
+            : currentPlan === PlanType.FREE
+              ? "Included in your plan (we pay)."
+              : "Included with runs; 1.05x markup on overage token cost."
         }
         systemInputTokens={rcaUsage?.systemInputTokens ?? 0}
         systemOutputTokens={rcaUsage?.systemOutputTokens ?? 0}
@@ -353,13 +380,15 @@ export function BillingTab({
       />
 
       {/* Pricing Dialog */}
-      <PricingDialog
-        open={showPricingDialog}
-        onOpenChange={setShowPricingDialog}
-        workspaceId={workspaceId}
-        currentPlan={currentPlan}
-        hasSubscription={hasSubscription}
-      />
+      {billingEnabled && (
+        <PricingDialog
+          open={showPricingDialog}
+          onOpenChange={setShowPricingDialog}
+          workspaceId={workspaceId}
+          currentPlan={currentPlan}
+          hasSubscription={hasSubscription}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/ui/src/types/api.ts
+++ b/frontend/ui/src/types/api.ts
@@ -32,6 +32,9 @@ export interface Workspace {
   billingSubscriptionId?: string | null;
   billingStatus?: string | null;
   currentUsage?: UsageStats | null;
+  // False on self-host deployments (ENABLE_BILLING=false) — the plan/upgrade
+  // UI should show an unlimited state instead of the cloud plan surface.
+  billingEnabled?: boolean;
 }
 
 export interface WorkspaceWithProjects extends Workspace {


### PR DESCRIPTION
## Summary

Fixes #1586.

On self-host (`ENABLE_BILLING=false`), the entitlement layer already treats every workspace as unlimited — `isBillingEnabled()` short-circuits every quota/seat/feature check to "allow". But the billing UI never matched that: the Billing tab, "Change plan" button, and PricingDialog rendered unconditionally, so clicking Upgrade hit a Stripe checkout that always 500s. Usage sections also advertised Free-plan hard caps ("50,000 events (hard cap)", "30 chat runs/month") that aren't actually enforced on self-host.

## Changes

- `GET /api/workspaces/[workspaceId]` now returns `billingEnabled: isBillingEnabled()`, threaded through the `Workspace` type.
- `BillingTab`: when billing is disabled, replaces "You are currently on the Free plan" + Change plan/Manage billing with an explicit "self-hosted — every plan limit is unlimited" state, and reads quotas as Enterprise-shaped (`Infinity`) instead of the nominal Free-plan caps, so displayed numbers match what's actually enforced. Cloud behavior (billing enabled) is unchanged.
- `SidebarUpgradeButton`: hides entirely on self-host — there's no higher tier to upgrade to.
- `checkout` / `change-plan` / `portal` routes: added an explicit `isBillingEnabled()` guard returning a clear 400 ("Billing is disabled on this deployment") instead of accidentally 500ing via `getStripeOrThrow()` if one of these is somehow still hit.

## Test plan

- [x] `tsc --noEmit` clean on all touched files (pre-existing unrelated errors elsewhere untouched by this PR)
- [x] `eslint` clean on all touched files (only pre-existing warnings, no errors)
- [x] New/updated unit tests: workspace route (`billingEnabled` field), all 3 billing route guards, `SidebarUpgradeButton` (hidden when disabled), `BillingTab` (6 new self-host cases + 2 cloud-path regression cases covering Manage billing and unlimited-plan copy)
- [x] Full frontend suite passes (pre-existing, unrelated environment flakes aside — locale-dependent formatting, timing-sensitive tests)
- [x] Local diff-cover: 95% on this PR's diff

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns self-host deployments with the entitlement layer: when `ENABLE_BILLING=false`, hide upgrade/billing UI, show unlimited quotas, and block Stripe flows with a clear 400. Exposes `billingEnabled` on the workspace API so the UI can switch modes.

- **Bug Fixes**
  - `GET /api/workspaces/[workspaceId]` now includes `billingEnabled`, threaded through the `Workspace` type; `BillingTab` uses it to show a self-host “unlimited” state and read Enterprise-shaped quotas (`Infinity`) instead of Free caps.
  - Hide `SidebarUpgradeButton` when `billingEnabled` is false.
  - Guard `POST /api/billing/checkout`, `change-plan`, and `portal` with `isBillingEnabled()`, returning 400 ("Billing is disabled on this deployment") instead of 500s.
  - Only render the Pricing dialog and “Change plan/Manage billing” controls when billing is enabled; cloud behavior is unchanged.

<sup>Written for commit 4c967472c9a29e1b2660a45dcc2733db9dbf1181. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

