### PR TITLE
fix(worker): Avoid Vercel v7 operation usage double count

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -53,6 +53,14 @@ def _scope_skips_text_token_estimation(scope_name: str | None) -> bool:
     return scope_name in _SKIP_TEXT_TOKEN_ESTIMATION_SCOPES
 
 
+def _scope_skips_token_usage(scope_name: str | None, span_kind: str, attrs: dict[str, Any]) -> bool:
+    """Reject aggregate usage copied onto Vercel v7 operation wrappers."""
+    if scope_name != "gen_ai":
+        return False
+    operation_name = attrs.get("gen_ai.operation.name")
+    return operation_name == "invoke_agent" or span_kind != SpanKind.LLM
+
+
 # Attributes that are already extracted into dedicated fields
 _KNOWN_ATTRIBUTE_PREFIXES = {
     "traceroot.span.input",
@@ -474,8 +482,19 @@ def transform_otel_to_clickhouse(
                         # real usage still lands on an LLM .doGenerate child.
                         input_token_keys += ["ai.usage.inputTokens", "ai.usage.promptTokens"]
                         output_token_keys += ["ai.usage.outputTokens", "ai.usage.completionTokens"]
-                    api_input_tokens = first_present_number(span_attrs, input_token_keys)
-                    api_output_tokens = first_present_number(span_attrs, output_token_keys)
+                    accept_token_usage = not _scope_skips_token_usage(
+                        scope_name, span_kind, span_attrs
+                    )
+                    api_input_tokens = (
+                        first_present_number(span_attrs, input_token_keys)
+                        if accept_token_usage
+                        else None
+                    )
+                    api_output_tokens = (
+                        first_present_number(span_attrs, output_token_keys)
+                        if accept_token_usage
+                        else None
+                    )
                     # Cache buckets. The OpenInference keys (prompt_details.*) are the
                     # verified path for Anthropic/OpenAI and MUST be listed first —
                     # they are the same family as llm.token_count.prompt (read above).
@@ -598,8 +617,10 @@ def transform_otel_to_clickhouse(
                         cost = cost_from_buckets(get_model_price(model_name), buckets)
                         if cost is not None:
                             span_record["cost"] = cost
-                    elif span_kind == SpanKind.LLM and not _scope_skips_text_token_estimation(
-                        scope_name
+                    elif (
+                        accept_token_usage
+                        and span_kind == SpanKind.LLM
+                        and not _scope_skips_text_token_estimation(scope_name)
                     ):
                         # Fall back to text-based estimation — only for LLM (completion)
                         # spans. Wrapper AGENT/CHAIN spans restate text their LLM children

--- a/backend/worker/tokens/buckets.py
+++ b/backend/worker/tokens/buckets.py
@@ -74,6 +74,7 @@ _KNOWN_SCOPE_PREFIXES: tuple[str, ...] = (
 _KNOWN_SCOPE_EXACT: frozenset[str] = frozenset(
     {
         "ai",  # Vercel AI SDK tracer; GROSS input with cache detail under ai.usage.*
+        "gen_ai",  # Vercel AI SDK v7 semconv tracer; GROSS gen_ai.usage.* totals
     }
 )
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -755,6 +755,103 @@ class TestTransformOtelToClickhouse:
         assert sum((s.get("output_tokens") or 0) for s in spans) == 178
         assert by_id  # spans were keyed by id without collision
 
+    @pytest.mark.parametrize("openinference_kind", [None, "AGENT"])
+    def test_vercel_gen_ai_operation_root_usage_not_double_counted(self, openinference_kind):
+        """The v7 gen_ai operation root restates the usage of its chat child.
+
+        TraceRoot's OpenInference processor marks the root as AGENT, but raw
+        @ai-sdk/otel exports are currently inferred as LLM from their model attr.
+        The emitter operation must identify the aggregate wrapper in both paths.
+        """
+        from unittest.mock import patch
+
+        prices = {
+            "input": 0.000003,
+            "output": 0.000015,
+            "cacheRead": 0.0,
+            "cacheWrite": 0.0,
+        }
+        root_attrs = [
+            make_attr("gen_ai.operation.name", "invoke_agent"),
+            make_attr("gen_ai.request.model", "claude-haiku-4-5"),
+            make_attr("gen_ai.usage.input_tokens", 10),
+            make_attr("gen_ai.usage.output_tokens", 16),
+            make_attr("gen_ai.input.messages", '[{"role":"user","content":"hello"}]'),
+            make_attr("gen_ai.output.messages", '[{"role":"assistant","content":"hi"}]'),
+        ]
+        if openinference_kind is not None:
+            root_attrs.append(make_attr("openinference.span.kind", openinference_kind))
+
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    name="committee.chair",
+                    attributes=root_attrs,
+                ),
+                make_span(
+                    "aa" * 16,
+                    "cc" * 8,
+                    name="chat claude-haiku-4-5",
+                    parent_span_id_hex="bb" * 8,
+                    attributes=[
+                        make_attr("gen_ai.operation.name", "chat"),
+                        make_attr("gen_ai.request.model", "claude-haiku-4-5"),
+                        make_attr("gen_ai.usage.input_tokens", 10),
+                        make_attr("gen_ai.usage.output_tokens", 16),
+                    ],
+                ),
+            ],
+            scope_name="gen_ai",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        root = next(span for span in spans if span["name"] == "committee.chair")
+        child = next(span for span in spans if span["name"].startswith("chat "))
+
+        assert root["model_name"] == "claude-haiku-4-5"
+        assert root["input"] == '[{"role":"user","content":"hello"}]'
+        assert root["output"] == '[{"role":"assistant","content":"hi"}]'
+        assert "usage_details" not in root
+        assert "total_tokens" not in root
+        assert (root.get("input_tokens") or 0) == 0
+        assert (root.get("output_tokens") or 0) == 0
+        assert (root.get("cost") or 0) == 0
+        assert child["input_tokens"] == 10
+        assert child["output_tokens"] == 16
+        assert sum((span.get("input_tokens") or 0) for span in spans) == 10
+        assert sum((span.get("output_tokens") or 0) for span in spans) == 16
+
+    def test_other_scope_non_llm_usage_remains_authoritative(self):
+        """Other emitters may report their only authoritative usage on AGENT spans."""
+        from unittest.mock import patch
+
+        prices = {"input": 0.000003, "output": 0.000015}
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=[
+                        make_attr("openinference.span.kind", "AGENT"),
+                        make_attr("gen_ai.operation.name", "invoke_agent"),
+                        make_attr("gen_ai.request.model", "gpt-4o-mini"),
+                        make_attr("gen_ai.usage.input_tokens", 11),
+                        make_attr("gen_ai.usage.output_tokens", 7),
+                    ],
+                )
+            ],
+            scope_name="custom-agent-instrumentor",
+        )
+        with patch("worker.tokens.pricing.get_model_price", return_value=prices):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert spans[0]["input_tokens"] == 11
+        assert spans[0]["output_tokens"] == 7
+        assert spans[0]["cost"] == pytest.approx(11 * prices["input"] + 7 * prices["output"])
+
     def test_vercel_do_generate_raw_totals_used_when_normalized_absent(self):
         """On an LLM doGenerate span that exposes ONLY the raw ai.usage.* totals
         (no normalized llm.*/gen_ai.* keys), those totals are still adopted —

--- a/tests/worker/tokens/test_buckets.py
+++ b/tests/worker/tokens/test_buckets.py
@@ -164,6 +164,19 @@ def test_vercel_ai_scope_is_known_inclusive_no_warning(caplog):
     assert not any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
 
 
+def test_vercel_gen_ai_scope_is_known_inclusive_no_warning(caplog):
+    with caplog.at_level(logging.WARNING):
+        b = normalize_token_usage(
+            "gen_ai",
+            input_tokens=26,
+            output_tokens=16,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+        )
+    assert b == TokenBuckets(input_uncached=26, output=16, cache_read=0, cache_write=0)
+    assert not any("unknown instrumentation scope" in r.message.lower() for r in caplog.records)
+
+
 def test_ai_prefixed_scope_still_warns(caplog):
     # "ai" is matched exactly, not as a prefix — an unrelated ai*-named scope
     # must still surface the unknown-emitter warning.


### PR DESCRIPTION
Fixes #1610

## Summary

- Ignore aggregate `gen_ai.usage.*` values on Vercel AI SDK v7 `invoke_agent` roots and non-LLM wrappers.
- Preserve the root's model, input, and output while keeping exact `chat` child usage and other instrumentation scopes unchanged.
- Register the exact `gen_ai` tracer scope so valid inference spans no longer emit an unknown-scope warning.

## Details

The v7 emitter uses the exact `gen_ai` scope. Its `invoke_agent` operation root repeats the sum of the `chat` inference children, so ingest previously stored and priced both copies. The emitter-specific gate now suppresses both API-provided and text-estimated usage on the aggregate wrapper.

This does not change span classification, token bucket math, storage schemas, or non-Vercel emitters. It affects newly ingested rows only; existing rows are not backfilled.

## Validation

- Added regression coverage for raw exports and roots marked as AGENT by OpenInference.
- Added a control proving another emitter's authoritative AGENT usage remains priced.
- `uv run coverage run -m pytest tests/`: 890 passed, 1 skipped.
- `uv run ruff check .`
- `uv run ruff format --check .`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent double-counted usage and cost from Vercel AI SDK v7 by ignoring aggregate `gen_ai.usage.*` on `invoke_agent` roots and using child `chat` LLM spans instead. Root still records model, input, and output; only new ingests change.

- **Bug Fixes**
  - Ignore usage on `gen_ai` operation wrappers and non-LLM spans; rely on child `chat` spans for tokens and cost.
  - Recognize the `gen_ai` tracer scope to remove unknown-scope warnings.
  - No changes to pricing math, schemas, or non-Vercel emitters.
  - Added tests for raw exports and AGENT roots; other emitters’ AGENT usage remains authoritative.

<sup>Written for commit 73a968e6ca1d6ca4bc9fe225a88b0a852e41a8d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

