### PR TITLE
fix(ui): stop sidebar label tooltips flashing open on collapse (#1503)

### DIFF
--- a/frontend/ui/src/components/layout/sidebar.test.tsx
+++ b/frontend/ui/src/components/layout/sidebar.test.tsx
@@ -100,4 +100,43 @@ describe("Sidebar", () => {
     render();
     expect(container.innerHTML).toBe("");
   });
+
+  // Regression guard for #1503: collapsing the sidebar must not let a label
+  // tooltip open without a fresh hover. The fix suspends the zero-delay tooltip
+  // opening for one width-transition after every collapse toggle, surfaced as the
+  // `data-collapse-settling` flag on the sidebar frame. jsdom can't exercise
+  // Radix's real pointer-hover timing, so we assert the guard window instead.
+  describe("collapse tooltip guard (#1503)", () => {
+    function frame() {
+      return container.querySelector("div.flex.h-screen");
+    }
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    });
+
+    it("opens the settling window on collapse and clears it after the transition", () => {
+      render({ collapsed: false });
+      // Let the initial mount's settling window elapse first.
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(frame()?.getAttribute("data-collapse-settling")).toBeNull();
+
+      // Toggling to collapsed re-opens the settling window.
+      render({ collapsed: true });
+      expect(frame()?.getAttribute("data-collapse-settling")).toBe("true");
+
+      // After the width transition settles, the guard clears so fresh hovers work.
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+      expect(frame()?.getAttribute("data-collapse-settling")).toBeNull();
+    });
+  });
 });

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
@@ -26,6 +27,22 @@ import { GitHubStarWidget } from "@/components/layout/GitHubStarWidget";
 import { SidebarUpgradeButton } from "@/components/layout/SidebarUpgradeButton";
 import { clientEnv } from "@/env.client";
 
+// When collapsed, nav labels live in Radix tooltips opened with zero delay
+// (delayDuration={0}). Radix tracks pointer-hover on a trigger continuously, so
+// collapsing the sidebar can pop a label open with no fresh hover — either the
+// trigger the cursor already sat on carries its hover across the toggle, or the
+// width animation sweeps a trigger under a stationary cursor (issue #1503). Both
+// are guarded by a short "settling" window opened on every collapse toggle, during
+// which the zero delay is suspended.
+//
+// Kept a touch longer than the frame's width transition (duration-200 → 200ms) so
+// the sweep is fully covered before zero-delay hovers are re-enabled.
+const COLLAPSE_SETTLE_MS = 250;
+// A delay no real hover waits out — effectively disables tooltip opening while
+// expanded and during the settling window, without unmounting the always-on
+// triggers or the collapse animation.
+const TOOLTIP_OPEN_DISABLED_MS = 100_000;
+
 function getInitials(name?: string | null, email?: string | null): string {
   if (name) {
     const parts = name.trim().split(/\s+/);
@@ -51,6 +68,17 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   const { theme, setTheme } = useTheme();
   const params = useParams<{ projectId?: string; workspaceId?: string }>();
 
+  // Guard label tooltips from flashing open when the sidebar collapses (#1503).
+  // `isSettling` is true for one width-transition after every collapse toggle;
+  // while set, the zero-delay tooltip opening is suspended (see delayDuration
+  // below) so no label appears without a fresh, post-collapse hover.
+  const [isSettling, setIsSettling] = useState(false);
+  useEffect(() => {
+    setIsSettling(true);
+    const timer = setTimeout(() => setIsSettling(false), COLLAPSE_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [collapsed]);
+
   // Don't show sidebar on auth pages
   if (pathname.startsWith("/auth/")) {
     return null;
@@ -73,8 +101,13 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
       : null;
 
   return (
-    <TooltipProvider delayDuration={0}>
+    // Instant (zero-delay) tooltips only once the sidebar is collapsed AND the
+    // collapse animation has settled. While expanded, or during the settling
+    // window, opening is effectively disabled so a stationary cursor can't reveal
+    // a label without a fresh hover (#1503).
+    <TooltipProvider delayDuration={collapsed && !isSettling ? 0 : TOOLTIP_OPEN_DISABLED_MS}>
       <div
+        data-collapse-settling={isSettling ? "true" : undefined}
         className={cn(
           "flex h-screen shrink-0 flex-col border-r bg-background transition-all duration-200",
           collapsed ? "w-14" : "w-48",


### PR DESCRIPTION
## What & why

Fixes #1503.

When the sidebar is collapsed, each nav item's label is shown as a hover tooltip. The `TooltipProvider` used `delayDuration={0}`, so a tooltip opened the instant the pointer touched any trigger. Because the collapse toggle sits in the top header, collapsing the sidebar drags the cursor upward across every item above the starting one — and each brushed-past icon popped its label open on its own, with no intentional hover. The number of labels that flashed open equalled the starting item's position (Tracing → 1, Detectors → 2, Dashboard → 3).

## Fix

Suspend the zero-delay opening during a short "settling" window opened on every collapse toggle:

- `delayDuration` is `0` only while `collapsed && !isSettling`; otherwise it's a very large value that no real hover waits out (tooltips effectively can't auto-open).
- `isSettling` is `true` for 250ms after each collapse toggle (kept just longer than the 200ms width transition), so the collapse gesture itself can never trigger a label.

After the window settles, behavior is exactly as expected: hover a collapsed icon → its label shows; don't hover → nothing shows. No triggers are unmounted, so the collapse animation is unchanged.


## Testing

- Added a regression test in `sidebar.test.tsx` asserting the settling state is set on collapse and clears after the window.
- `pnpm test:coverage` passes for the ui package.

## Before / after
https://github.com/user-attachments/assets/53c4a01d-7205-474a-8d2c-d64b4a8f8384


https://github.com/user-attachments/assets/b8aaf9ff-6d4e-4c81-bd2c-a0fdf1e3b619



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sidebar label tooltips from flashing open during collapse by suspending zero‑delay tooltips for a short settling window. Fixes #1503; normal hover behavior after collapse is unchanged.

- **Bug Fixes**
  - Suspend zero-delay tooltips for 250ms after each collapse; `delayDuration` is 0 only when `collapsed && !isSettling`, otherwise set to a large value to block accidental opens.
  - Add a regression test to verify the settling window toggles and clears; collapse animation and UI mounting remain unchanged.

<sup>Written for commit 2e5098aa89a537cb24f446c3dfba9691c1ba7d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

