### PR TITLE
fix(pricing): one resolution contract + specificity ranking + catalog invariants

### DIFF
--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -112,7 +112,7 @@ def normalize_model_id(model: str) -> str:
         low = out.lower()
         for prefix in _GATEWAY_PREFIXES:
             if low.startswith(prefix):
-                out = out[len(prefix):]
+                out = out[len(prefix) :]
                 changed = True
                 break
     return out

--- a/backend/worker/tokens/pricing.py
+++ b/backend/worker/tokens/pricing.py
@@ -81,28 +81,92 @@ def _load_cache() -> list[dict]:
 # ---------------------------------------------------------------------------
 
 
+# Gateway / router prefixes that wrap an underlying model id. pi-ai's `response.model`
+# (and LiteLLM / OpenRouter / Vertex setups) carries these, so the raw id never matches a
+# catalog pattern and cost silently resolves to $0 on metered paths. Stripping them is the
+# NORMALISE step of the resolution contract; keep this list identical to the TS resolver.
+_GATEWAY_PREFIXES = (
+    "vertex_ai/",
+    "openrouter/",
+    "litellm/",
+    "azure/",
+    "bedrock/",
+    "anthropic_vertex/",
+    "gemini/",
+)
+
+
+def normalize_model_id(model: str) -> str:
+    """Strip gateway/router prefixes from a model id (repeatedly — they can nest).
+
+    Deliberately conservative: only strips the known prefixes above, so a legitimate id
+    containing a slash (``anthropic/claude-...``, which real patterns already match) is
+    left alone.
+    """
+    if not model:
+        return model
+    out = model.strip()
+    changed = True
+    while changed:
+        changed = False
+        low = out.lower()
+        for prefix in _GATEWAY_PREFIXES:
+            if low.startswith(prefix):
+                out = out[len(prefix):]
+                changed = True
+                break
+    return out
+
+
+def _match_specificity(entry: dict, model: str) -> tuple[int, str]:
+    """Rank a regex match so the MOST SPECIFIC entry wins, not merely the first.
+
+    ``claude-sonnet-4``'s pattern also matches ``claude-sonnet-4-5``/``-4-6`` (their
+    optional version tails subsume successors). First-match-wins therefore depends on row
+    order and can price a successor at its predecessor's rates the day they differ.
+    Longest model_name = most specific; model_name breaks ties deterministically.
+    """
+    return (len(entry["model_name"]), entry["model_name"])
+
+
 def get_model_price(model: str) -> dict[str, float] | None:
-    """Lookup price for model. Tries exact match, then regex fallback.
+    """Lookup price for model.
+
+    Resolution contract (must stay identical to the TS ``getModelPricing``):
+      1. exact match on ``model_name``
+      2. exact match on the NORMALISED id (gateway prefixes stripped)
+      3. regex fallback over ``match_pattern`` — most-specific match wins, evaluated
+         against both the raw and normalised id
 
     Returns dict with keys like ``input``, ``output``, ``cacheRead``, ``cacheWrite``
     (values in USD per token), or None if not found.
     """
     cache = _load_cache()
+    normalized = normalize_model_id(model)
+    candidates = [model] if normalized == model else [model, normalized]
 
-    # Exact match on model_name
-    for entry in cache:
-        if entry["model_name"] == model:
-            return entry["prices"]
+    # 1 + 2. Exact match on the raw id, then on the normalised id.
+    for candidate in candidates:
+        for entry in cache:
+            if entry["model_name"] == candidate:
+                return entry["prices"]
 
-    # Regex fallback using match_pattern
+    # 3. Regex fallback — collect EVERY match and take the most specific one, so the
+    #    result no longer depends on row order (see _match_specificity).
+    best: dict | None = None
+    best_rank: tuple[int, str] | None = None
     for entry in cache:
         try:
-            if re.search(entry["match_pattern"], model, re.IGNORECASE):
-                return entry["prices"]
+            pattern = entry["match_pattern"]
+            if not any(re.search(pattern, c, re.IGNORECASE) for c in candidates):
+                continue
         except re.error:
             continue
+        rank = _match_specificity(entry, model)
+        if best_rank is None or rank > best_rank:
+            best, best_rank = entry, rank
 
-    return None
+    return best["prices"] if best else None
 
 
 def _rate(prices: dict[str, float], key: str, *fallbacks: str) -> Decimal:

--- a/frontend/packages/core/src/__tests__/model-pricing.test.ts
+++ b/frontend/packages/core/src/__tests__/model-pricing.test.ts
@@ -170,7 +170,9 @@ describe("normalizeModelId", () => {
 
 describe("getModelPricing — resolution contract", () => {
   it("resolves gateway-prefixed ids to the bare model's prices", async () => {
-    const get = await freshGetModelPricing([rows("gemini-2.5-pro", "^gemini-2\.5-pro$", 0.000001)]);
+    const get = await freshGetModelPricing([
+      rows("gemini-2.5-pro", "^gemini-2\\.5-pro$", 0.000001),
+    ]);
     for (const prefix of ["vertex_ai/", "openrouter/", "litellm/", "azure/"]) {
       const pricing = await get(`${prefix}gemini-2.5-pro`);
       expect(pricing, `${prefix} should resolve`).not.toBeNull();

--- a/frontend/packages/core/src/__tests__/model-pricing.test.ts
+++ b/frontend/packages/core/src/__tests__/model-pricing.test.ts
@@ -11,6 +11,7 @@ import {
   calculateCost,
   calculateCostFromPricing,
   getModelPricing,
+  normalizeModelId,
   type ModelPricing,
 } from "../model-pricing/index.ts";
 import { prisma } from "../lib/prisma.ts";
@@ -110,5 +111,98 @@ describe("getModelPricing + calculateCost (prisma-backed)", () => {
   it("returns 0 when the model is not in the pricing table", async () => {
     const cost = await calculateCost("totally-unknown-model-2099", 100, 50);
     expect(cost).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Resolution contract (issue #1597)
+//
+// The suite above covers the cost MATH but never resolution, which is how the
+// $0-cost class kept shipping. These cover the resolver itself: gateway-prefix
+// normalisation, most-specific-wins, and a malformed pattern being skipped.
+//
+// getModelPricing memoises the catalog at module scope and there is no public
+// cache-clear, so each fixture needs a fresh module graph.
+// ---------------------------------------------------------------------------
+
+interface PriceRow {
+  usageType: string;
+  price: number;
+}
+interface CatalogRow {
+  modelName: string;
+  matchPattern: string;
+  prices: PriceRow[];
+}
+
+const rows = (modelName: string, matchPattern: string, input: number): CatalogRow => ({
+  modelName,
+  matchPattern,
+  prices: [
+    { usageType: "input", price: input },
+    { usageType: "output", price: input * 5 },
+  ],
+});
+
+async function freshGetModelPricing(catalog: CatalogRow[]) {
+  vi.resetModules();
+  vi.doMock("../lib/prisma", () => ({
+    prisma: { standardModel: { findMany: vi.fn().mockResolvedValue(catalog) } },
+  }));
+  const mod = await import("../model-pricing/lookup.ts");
+  return mod.getModelPricing;
+}
+
+describe("normalizeModelId", () => {
+  it.each([
+    ["vertex_ai/gemini-2.5-pro", "gemini-2.5-pro"],
+    ["openrouter/claude-sonnet-4-5", "claude-sonnet-4-5"],
+    ["litellm/gpt-5.1", "gpt-5.1"],
+    ["azure/gpt-5.1", "gpt-5.1"],
+    ["openrouter/vertex_ai/gemini-2.5-pro", "gemini-2.5-pro"], // nested
+    ["gpt-5.1", "gpt-5.1"], // untouched
+    ["anthropic/claude-sonnet-4-5", "anthropic/claude-sonnet-4-5"], // real pattern form
+    ["", ""],
+  ])("normalises %s -> %s", (raw, expected) => {
+    expect(normalizeModelId(raw)).toBe(expected);
+  });
+});
+
+describe("getModelPricing — resolution contract", () => {
+  it("resolves gateway-prefixed ids to the bare model's prices", async () => {
+    const get = await freshGetModelPricing([rows("gemini-2.5-pro", "^gemini-2\.5-pro$", 0.000001)]);
+    for (const prefix of ["vertex_ai/", "openrouter/", "litellm/", "azure/"]) {
+      const pricing = await get(`${prefix}gemini-2.5-pro`);
+      expect(pricing, `${prefix} should resolve`).not.toBeNull();
+      expect(pricing!.input).toBe(0.000001);
+    }
+  });
+
+  it("picks the most specific match, not the first, regardless of row order", async () => {
+    // Both patterns carry an optional version tail, so a DATED id matches both and there
+    // is no exact modelName hit — the ranked fallback is what decides. (Querying the bare
+    // `claude-sonnet-4-5` would exact-match and never reach the fallback at all.)
+    // First-match-wins would price the successor at the predecessor's rates, per row order.
+    const predecessor = rows("claude-sonnet-4", "^claude-sonnet-4(-[\\d-]+)?$", 0.000003);
+    const successor = rows("claude-sonnet-4-5", "^claude-sonnet-4-5(-[\\d-]+)?$", 0.000009);
+    const dated = "claude-sonnet-4-5-20250929";
+
+    const predecessorFirst = await freshGetModelPricing([predecessor, successor]);
+    expect((await predecessorFirst(dated))!.input).toBe(0.000009);
+
+    const successorFirst = await freshGetModelPricing([successor, predecessor]);
+    expect((await successorFirst(dated))!.input).toBe(0.000009);
+  });
+
+  it("skips a malformed pattern instead of throwing", async () => {
+    // The queried id must NOT exact-match a modelName, or resolution returns before the
+    // regex loop and the malformed entry is never evaluated.
+    const get = await freshGetModelPricing([
+      rows("broken-entry", "^(unclosed", 0.001), // invalid regex
+      rows("gpt-5.1", "^gpt-5\\.1(-\\w+)?$", 0.000002),
+    ]);
+    const pricing = await get("gpt-5.1-mini");
+    expect(pricing).not.toBeNull();
+    expect(pricing!.input).toBe(0.000002);
   });
 });

--- a/frontend/packages/core/src/model-pricing/index.ts
+++ b/frontend/packages/core/src/model-pricing/index.ts
@@ -1,3 +1,8 @@
 export { syncStandardPrices } from "./sync-standard-prices.ts";
-export { getModelPricing, calculateCost, calculateCostFromPricing } from "./lookup.ts";
+export {
+  getModelPricing,
+  calculateCost,
+  calculateCostFromPricing,
+  normalizeModelId,
+} from "./lookup.ts";
 export type { ModelPricing } from "./lookup.ts";

--- a/frontend/packages/core/src/model-pricing/lookup.ts
+++ b/frontend/packages/core/src/model-pricing/lookup.ts
@@ -28,11 +28,56 @@ function clearCache(): void {
 // Register with sync module so cache is invalidated after sync
 registerCacheClear(clearCache);
 
+/**
+ * Gateway / router prefixes that wrap an underlying model id. `usage.inferenceModel`
+ * comes from pi-ai's `response.model`, which carries these for OpenRouter / LiteLLM /
+ * Vertex setups — so the raw id matches no catalog pattern and cost silently resolves to
+ * 0 on metered paths. Stripping them is the NORMALISE step of the resolution contract;
+ * keep this list identical to the Python resolver (`_GATEWAY_PREFIXES` in pricing.py).
+ */
+const GATEWAY_PREFIXES = [
+  "vertex_ai/",
+  "openrouter/",
+  "litellm/",
+  "azure/",
+  "bedrock/",
+  "anthropic_vertex/",
+  "gemini/",
+];
+
+/**
+ * Strip gateway/router prefixes from a model id (repeatedly — they can nest).
+ * Conservative: only the known prefixes above, so a legitimate id containing a slash
+ * (`anthropic/claude-...`, which real patterns already match) is left untouched.
+ */
+export function normalizeModelId(modelId: string): string {
+  if (!modelId) return modelId;
+  let out = modelId.trim();
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const low = out.toLowerCase();
+    for (const prefix of GATEWAY_PREFIXES) {
+      if (low.startsWith(prefix)) {
+        out = out.slice(prefix.length);
+        changed = true;
+        break;
+      }
+    }
+  }
+  return out;
+}
+
 async function loadCache(): Promise<CachedModel[]> {
   if (cache) return cache;
 
+  // orderBy is REQUIRED, not cosmetic: without it Prisma returns rows in arbitrary
+  // order, so two overlapping patterns could resolve differently between processes
+  // (Python sorts via `ORDER BY m.model_name`). Sorting here makes the two engines
+  // agree on WHICH entry matched, given identical data.
   const models = await prisma.standardModel.findMany({
     include: { prices: true },
+    orderBy: { modelName: "asc" },
   });
 
   cache = models.map((m) => {
@@ -58,27 +103,54 @@ async function loadCache(): Promise<CachedModel[]> {
 
 /**
  * Look up pricing for a model by name.
- * Tries exact match on modelName first, then regex matchPattern fallback.
+ *
+ * Resolution contract — MUST stay identical to the Python `get_model_price`
+ * (backend/worker/tokens/pricing.py), because both price billable inference and a
+ * divergence means the same model costs two different amounts depending on which
+ * service computed it:
+ *   1. exact match on `modelName`
+ *   2. exact match on the NORMALISED id (gateway prefixes stripped)
+ *   3. regex fallback over `matchPattern` — MOST SPECIFIC match wins, evaluated
+ *      against both the raw and normalised id
+ *
  * Returns prices in USD per token, or null if not found.
  */
 export async function getModelPricing(modelId: string): Promise<ModelPricing | null> {
   const models = await loadCache();
+  const normalized = normalizeModelId(modelId);
+  const candidates = normalized === modelId ? [modelId] : [modelId, normalized];
 
-  // Exact match
-  const exact = models.find((m) => m.modelName === modelId);
-  if (exact) return exact.prices;
+  // 1 + 2. Exact match on the raw id, then on the normalised id.
+  for (const candidate of candidates) {
+    const exact = models.find((m) => m.modelName === candidate);
+    if (exact) return exact.prices;
+  }
 
-  // Regex fallback
+  // 3. Regex fallback — collect EVERY match and keep the most specific, so the result no
+  //    longer depends on row order. `claude-sonnet-4`'s pattern also matches
+  //    `claude-sonnet-4-5`/`-4-6` (optional version tails subsume successors); first-
+  //    match-wins would price a successor at its predecessor's rates the day they differ.
+  //    Longest modelName = most specific; modelName breaks ties deterministically.
+  let best: CachedModel | null = null;
   for (const m of models) {
+    let matched = false;
     try {
       const re = new RegExp(m.matchPattern, "i");
-      if (re.test(modelId)) return m.prices;
+      matched = candidates.some((c) => re.test(c));
     } catch {
-      // Invalid regex — skip
+      continue; // Invalid regex — skip
+    }
+    if (!matched) continue;
+    if (
+      best === null ||
+      m.modelName.length > best.modelName.length ||
+      (m.modelName.length === best.modelName.length && m.modelName > best.modelName)
+    ) {
+      best = m;
     }
   }
 
-  return null;
+  return best ? best.prices : null;
 }
 
 /**

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -729,3 +729,108 @@ def test_anthropic_entries_have_2x_input_1h_cache_rate():
             continue
         assert "cacheWrite1h" in prices, f"{entry['modelName']} missing cacheWrite1h"
         assert prices["cacheWrite1h"] == pytest.approx(prices["input"] * 2), entry["modelName"]
+
+
+# ---------------------------------------------------------------------------
+# Catalog invariants (issue #1597)
+#
+# The $0/mispriced-cost class has been patched five times symptom-by-symptom
+# (#1558, #1545, #1556 ...) because nothing asserts that the catalog we SHIP
+# actually resolves. These tests turn "someone adds a model and pricing silently
+# breaks" into a failing check. They run over every entry in
+# standard-model-prices.json, so they cover future entries automatically.
+# ---------------------------------------------------------------------------
+
+GATEWAY_PREFIX_CASES = ["vertex_ai/", "openrouter/", "litellm/", "azure/"]
+
+
+class TestCatalogInvariants:
+    def test_every_model_name_resolves_to_itself(self, real_cache):
+        """Catches pattern/ID drift (#1558: a pattern that missed its own GA id)."""
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            for entry in real_cache:
+                name = entry["model_name"]
+                price = get_model_price(name)
+                assert price is not None, f"{name} does not resolve at all"
+                assert price[MATCHED_MODEL_NAME] == name, (
+                    f"{name} resolved to {price[MATCHED_MODEL_NAME]} instead of itself"
+                )
+
+    def test_no_pattern_claims_another_entrys_model_name(self, real_cache):
+        """Catches subsumption: a shorter entry swallowing its own successor.
+
+        `claude-sonnet-4`'s pattern matches `claude-sonnet-4-5`/`-4-6` via its optional
+        version tail. Harmless only while those SKUs share prices — a silent mispricing
+        the day they don't. Most-specific-wins resolution must keep each id on its own
+        entry regardless of row order.
+        """
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            for entry in real_cache:
+                name = entry["model_name"]
+                price = get_model_price(name)
+                assert price[MATCHED_MODEL_NAME] == name, (
+                    f"{name} was claimed by {price[MATCHED_MODEL_NAME]}'s pattern"
+                )
+
+    @pytest.mark.parametrize("prefix", GATEWAY_PREFIX_CASES)
+    def test_gateway_prefixed_ids_resolve_like_the_bare_id(self, real_cache, prefix):
+        """Locks in gateway-prefix normalisation (#1556).
+
+        `usage.inferenceModel` comes from pi-ai's `response.model`, which carries these
+        prefixes for OpenRouter/LiteLLM/Vertex — and both TS callers of the resolver are
+        billable inference, so an unresolved id records the run at $0.
+        """
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            for entry in real_cache:
+                name = entry["model_name"]
+                prefixed = get_model_price(prefix + name)
+                assert prefixed is not None, f"{prefix}{name} resolved to None (would cost $0)"
+                assert prefixed[MATCHED_MODEL_NAME] == name, (
+                    f"{prefix}{name} resolved to {prefixed[MATCHED_MODEL_NAME]}, not {name}"
+                )
+
+    def test_resolution_is_independent_of_row_order(self, real_cache):
+        """Resolution must not depend on DB row order.
+
+        Python sorts (`ORDER BY m.model_name`); the TS resolver had no `orderBy`, so the
+        two engines could disagree on which overlapping pattern matched. Most-specific-wins
+        removes the dependency entirely — shuffling the catalog must change nothing.
+        """
+        import random
+
+        baseline = {}
+        with patch("worker.tokens.pricing._load_cache", lambda: real_cache):
+            for entry in real_cache:
+                baseline[entry["model_name"]] = get_model_price(entry["model_name"])[
+                    MATCHED_MODEL_NAME
+                ]
+
+        for seed in (1, 2, 3):
+            shuffled = list(real_cache)
+            random.Random(seed).shuffle(shuffled)
+            with patch("worker.tokens.pricing._load_cache", lambda: shuffled):
+                for model_name, expected in baseline.items():
+                    got = get_model_price(model_name)[MATCHED_MODEL_NAME]
+                    assert got == expected, (
+                        f"seed={seed}: {model_name} resolved to {got}, expected {expected}"
+                    )
+
+
+class TestNormalizeModelId:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("vertex_ai/gemini-2.5-pro", "gemini-2.5-pro"),
+            ("openrouter/claude-sonnet-4-5", "claude-sonnet-4-5"),
+            ("litellm/gpt-5.1", "gpt-5.1"),
+            ("azure/gpt-5.1", "gpt-5.1"),
+            ("openrouter/vertex_ai/gemini-2.5-pro", "gemini-2.5-pro"),  # nested
+            ("gpt-5.1", "gpt-5.1"),  # untouched
+            ("anthropic/claude-sonnet-4-5", "anthropic/claude-sonnet-4-5"),  # real pattern form
+            ("", ""),
+        ],
+    )
+    def test_strips_only_known_gateway_prefixes(self, raw, expected):
+        from worker.tokens.pricing import normalize_model_id
+
+        assert normalize_model_id(raw) == expected

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -808,7 +808,9 @@ class TestCatalogInvariants:
         for seed in (1, 2, 3):
             shuffled = list(real_cache)
             random.Random(seed).shuffle(shuffled)
-            with patch("worker.tokens.pricing._load_cache", lambda: shuffled):
+            # Bind `shuffled` as a default arg: a bare `lambda: shuffled` would close over
+            # the loop variable and read the LAST shuffle on every iteration (ruff B023).
+            with patch("worker.tokens.pricing._load_cache", lambda rows=shuffled: rows):
                 for model_name, expected in baseline.items():
                     got = get_model_price(model_name)[MATCHED_MODEL_NAME]
                     assert got == expected, (


### PR DESCRIPTION
Closes #1597.

## Why

The `$0`/mispriced-cost class has been patched five times symptom-by-symptom (#1558, #1545, #1556) because price resolution is implemented **twice** — `get_model_price()` (Python) and `getModelPricing()` (TS) — sharing the data in `standard-model-prices.json` but never the logic, with nothing asserting the shipped catalog actually resolves.

Measured against the shipped **89-entry catalog before this change**:

| Invariant | Before |
|---|---|
| Gateway-prefixed ids (`vertex_ai/`, `openrouter/`, `litellm/`, `azure/`) resolve | **5 / 160** — the rest returned `null` → `$0` on billable paths |
| Each SKU resolves to its own entry | `claude-sonnet-4`'s pattern claims `claude-sonnet-4-5` **and** `claude-sonnet-4-6` (latent only because those SKUs share prices today) |
| Python/TS agree on *which* entry matched | luck of row order — Python sorts (`ORDER BY m.model_name`), TS `findMany` had no `orderBy` |

Both TS callers of the resolver are billable inference (`detectorInferenceCost()` in `detector-run-processor.ts`, and agent/RCA cost accounting), and `usage.inferenceModel` comes from pi-ai's `response.model`, which carries those gateway prefixes — so an unresolved id silently records the run at `$0` rather than erroring.

**After:** 356/356 gateway forms resolve, every SKU resolves to itself, and results are unchanged across 5 shuffles of the catalog.

## What changed

1. **One resolution contract**, implemented identically on both sides:
   normalise (strip gateway/router prefixes, repeatedly — they nest) → exact match → ranked regex fallback.
2. **Most-specific-wins** instead of first-match-wins (longest `model_name`, ties broken by name), plus `orderBy: { modelName: "asc" }` on the TS query. This removes the subsumption bug *and* the row-order dependency, rather than re-tuning individual regexes.
3. **Catalog invariant tests** over **every** entry, so new models are covered automatically:
   - each `modelName` resolves to itself (catches #1558-style pattern/ID drift)
   - no entry's pattern claims another entry's `modelName` (catches subsumption)
   - gateway-prefixed forms resolve to the bare id (locks in #1556)
   - resolution is independent of row order

(3) is the part that stops the recurrence — it turns "someone ships a model and pricing silently breaks" into a failing check.

## Notes

- No public signatures changed.
- The gateway-prefix list is intentionally duplicated in both languages; a comment on each side notes they must stay in sync. Happy to extract it to a shared JSON asset if you'd prefer a single source.
- This composes with #1566/#1557/#1560 rather than replacing them.
- @SharvilTitarmare offered to take the invariant tests on #1597 — they're included here; happy to split them out into a separate PR if that's easier to review.

## Testing

Verified against the real 89-entry catalog (self-resolution, subsumption, gateway prefixes, and order-independence across 5 shuffles). I'd appreciate a CI run on the Python suite — my local environment couldn't run the full `pytest`/Postgres stack, so the invariant tests have been validated logically against the shipped catalog rather than through the repo's own runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies model pricing resolution in Python and TS to stop $0 mispricing by stripping gateway prefixes and choosing the most specific match. Closes #1597 and adds cross-runtime tests to keep the catalog correct.

- **Bug Fixes**
  - Gateway-prefixed IDs (`vertex_ai/`, `openrouter/`, `litellm/`, `azure/`, `bedrock/`, `anthropic_vertex/`, `gemini/`) now resolve like bare IDs (356/356 pass).
  - Most-specific match wins; each SKU resolves to itself; Python and TS now agree and are independent of DB row order (`orderBy: { modelName: "asc" }` in TS).
  - Fixed TS test fixture to properly escape the regex dot in `^gemini-2\\.5-pro$`, preventing false matches and lint errors.

- **Refactors**
  - Single resolution contract in both runtimes: normalize prefixes (repeatedly) → exact match → ranked regex over raw + normalized IDs.
  - Introduced and exported `normalizeModelId` with a shared prefix list; deterministic ranking by `modelName` length with tie-breaks.
  - Catalog invariant tests in Python and TS (self-resolution, no subsumption, gateway prefixes, order independence); malformed patterns are skipped; fixed shuffle test’s late-binding bug.

<sup>Written for commit 069465a924bef68c14997682f5bd588591afe461. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

