### PR TITLE
guard model attributes before pricing

### DIFF
--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -47,6 +47,11 @@ logger = logging.getLogger(__name__)
 # deliberately-empty spans get fabricated counts. Python only — the TypeScript scope
 # ("@traceroot-ai/claude-agent-sdk") reports real per-turn usage and is excluded.
 _SKIP_TEXT_TOKEN_ESTIMATION_SCOPES = frozenset({"traceroot.claude-agent-sdk"})
+_MODEL_NAME_ATTRIBUTE_KEYS = (
+    "traceroot.llm.model",
+    "gen_ai.request.model",
+    "llm.model_name",
+)
 
 
 def _scope_skips_text_token_estimation(scope_name: str | None) -> bool:
@@ -234,6 +239,15 @@ def attributes_to_dict(attributes: list[dict]) -> dict[str, Any]:
     return result
 
 
+def _extract_model_name(attrs: dict[str, Any]) -> str | None:
+    """Return the first non-empty string model attribute, ignoring malformed values."""
+    for key in _MODEL_NAME_ATTRIBUTE_KEYS:
+        value = attrs.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
 def get_span_kind(attrs: dict[str, Any], otel_kind: int | str | None) -> str:
     """Determine the span kind from span attributes.
 
@@ -270,12 +284,7 @@ def get_span_kind(attrs: dict[str, Any], otel_kind: int | str | None) -> str:
         return SpanKind.TOOL
 
     # Infer from LLM-related attributes
-    if (
-        attrs.get("gen_ai.system")
-        or attrs.get("gen_ai.request.model")
-        or attrs.get("llm.model_name")
-        or attrs.get("traceroot.llm.model")
-    ):
+    if attrs.get("gen_ai.system") or _extract_model_name(attrs):
         return SpanKind.LLM
 
     # Use `is not None` (not truthiness) so an empty-string value still classifies as TOOL
@@ -442,11 +451,7 @@ def transform_otel_to_clickhouse(
                 # name is present, not just for LLM spans. Auto-instrumentors
                 # (OpenInference, GenAI) set model/token attrs on AGENT and CHAIN spans
                 # too. Text-based ESTIMATION, however, is LLM-spans-only (see below).
-                model_name = (
-                    span_attrs.get("traceroot.llm.model")
-                    or span_attrs.get("gen_ai.request.model")
-                    or span_attrs.get("llm.model_name")
-                )
+                model_name = _extract_model_name(span_attrs)
                 if model_name:
                     span_record["model_name"] = model_name
 

--- a/tests/worker/test_otel_transform.py
+++ b/tests/worker/test_otel_transform.py
@@ -1491,3 +1491,88 @@ class TestCacheTokenMetadata:
         ud = spans[0]["usage_details"]
         assert "cache_write_1h_tokens" not in ud
         assert set(ud) == {"cache_read_tokens", "cache_write_tokens", "reasoning_tokens"}
+
+
+class TestModelNameAttributeTypeGuard:
+    def test_non_string_model_does_not_drop_valid_spans_from_same_batch(self):
+        """A mis-typed model attribute degrades to unset instead of poisoning the batch."""
+        from unittest.mock import patch
+
+        trace_hex = "aa" * 16
+        payload = make_otel_payload(
+            [
+                make_span(
+                    trace_hex,
+                    "11" * 8,
+                    name="valid-root",
+                    attributes=[
+                        make_attr("gen_ai.request.model", "gpt-4o"),
+                        make_attr("gen_ai.usage.input_tokens", 10),
+                        make_attr("gen_ai.usage.output_tokens", 5),
+                    ],
+                ),
+                make_span(
+                    trace_hex,
+                    "22" * 8,
+                    name="bad-model-child",
+                    parent_span_id_hex="11" * 8,
+                    attributes=[
+                        make_attr("gen_ai.request.model", 12345),
+                        make_attr("gen_ai.usage.input_tokens", 7),
+                        make_attr("gen_ai.usage.output_tokens", 3),
+                    ],
+                ),
+            ]
+        )
+        cache = [
+            {
+                "model_name": "gpt-4o",
+                "match_pattern": r"^gpt-4o(?:-|$)",
+                "prices": {"input": 0.0000025, "output": 0.00001},
+            }
+        ]
+
+        with patch("worker.tokens.pricing._load_cache", return_value=cache):
+            _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert [span["name"] for span in spans] == ["valid-root", "bad-model-child"]
+        assert spans[0]["model_name"] == "gpt-4o"
+        assert "model_name" not in spans[1]
+
+    @pytest.mark.parametrize(
+        "model_key",
+        ["traceroot.llm.model", "gen_ai.request.model", "llm.model_name"],
+    )
+    def test_each_non_string_model_alias_degrades_to_unset(self, model_key):
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=[make_attr(model_key, 12345)],
+                )
+            ]
+        )
+
+        _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert "model_name" not in spans[0]
+
+    def test_invalid_high_priority_model_falls_through_to_valid_alias(self):
+        payload = make_otel_payload(
+            [
+                make_span(
+                    "aa" * 16,
+                    "bb" * 8,
+                    attributes=[
+                        make_attr("traceroot.llm.model", 12345),
+                        make_attr("gen_ai.request.model", "gpt-4o"),
+                    ],
+                )
+            ],
+            scope_name="traceroot.claude-agent-sdk",
+        )
+
+        _, spans = transform_otel_to_clickhouse(payload, "proj-1")
+
+        assert spans[0]["model_name"] == "gpt-4o"


### PR DESCRIPTION
## Why

OTLP `AnyValue` permits integers, but model-name attributes are expected to be strings. A non-string model currently reaches the pricing regex and raises `TypeError`, so one malformed span can make the worker retry its whole S3 batch and block valid sibling spans.

## What changed

- Select the first non-empty string from the supported model attribute aliases
- Reuse that selection for span-kind inference and pricing
- Keep malformed spans with model and cost unset, while allowing a valid lower-priority alias to be used

## Test plan

- `pytest -q tests/worker/test_otel_transform.py` (110 passed)
- `pytest -q tests` (891 passed, 1 skipped)
- Ruff check and format check on the changed files

## Notes

The malformed-input frequency is unknown and likely low. The guard is at the public OTLP ingestion boundary because the failure otherwise affects unrelated spans in the same batch.

This overlaps a small section of `otel_transform.py` and its test file with #1601, but addresses a separate failure mode. If #1601 merges first, this branch can be rebased without changing the behavior under test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard model-name attributes at OTLP ingestion to prevent pricing regex crashes and whole-batch retries. Malformed model values are ignored so valid spans in the same batch continue.

- **Bug Fixes**
  - Select the first non-empty string from model aliases: traceroot.llm.model, gen_ai.request.model, llm.model_name.
  - Reuse the selected model for span-kind inference and pricing.
  - Ignore non-string/empty values; leave model_name and cost unset, and fall back to a valid lower-priority alias when available.

<sup>Written for commit 7cceb8fe16c69dd502ff9a3b2a62b9bfd2d07ce2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

