### PR TITLE
retry detector dispatch after ingest

### DIFF
--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -1,8 +1,9 @@
 """
 Detector trigger evaluation and BullMQ enqueue.
 
-Called from process_s3_traces after ClickHouse insert.
-Non-blocking: exceptions are caught and logged, never re-raised.
+Scheduled by process_s3_traces after ClickHouse insert.
+Runs in its own retryable Celery task so dependency failures do not mark trace
+ingestion as failed and do not silently drop detector work.
 
 Exactly-once triggering: the ingest batch carrying a trace's root span claims
 the trace via a Redis lock, evaluates trigger conditions plus deterministic
@@ -22,14 +23,22 @@ logger = logging.getLogger(__name__)
 # BullMQ queue name — must match TypeScript DETECTOR_RUN_QUEUE constant
 DETECTOR_RUN_QUEUE = "detector-run"
 
-# Lock TTL for the per-trace enqueue claim. Detection only ever fires from the
-# root-bearing batch; the NX lock makes that enqueue exactly-once.
+# TTL for completed enqueue decisions. Detection only ever fires from the
+# root-bearing batch; the key makes that decision sticky across duplicate delivery.
 _LOCK_TTL_SECONDS = 3600
+# A dispatch task retry keeps the same owner id and may reclaim after a failed
+# attempt leaves its transient "deciding" claim behind.
+_DECIDING_TTL_SECONDS = 60
 
 # Initial delay on the enqueued job; the worker then waits until the trace has
 # been quiet this long (no new span) before evaluating. Must match the
 # TypeScript EVALUATOR_DELAY constant.
 EVALUATOR_DELAY = 60_000  # ms
+
+
+class DetectorDispatchError(RuntimeError):
+    """Transient dependency failure that should retry the detector dispatch task."""
+
 
 # Token-checked release: delete the lock only when it still holds the exact
 # value this attempt wrote, so a failing attempt can never delete state
@@ -283,6 +292,7 @@ def _claim_and_enqueue(
     trace_id: str,
     detectors: list[dict],
     summary: dict,
+    dispatch_id: str | None,
 ) -> None:
     """Root-bearing batch: claim the trace and enqueue at most one detection job.
 
@@ -301,24 +311,51 @@ def _claim_and_enqueue(
             ``sample_rate`` and ``conditions``.
         summary (dict): Trace summary fields used for trigger evaluation (e.g.
             ``environment``).
+        dispatch_id (str | None): Stable owner id retained across Celery retries.
 
     Returns:
         None: On an enqueue failure the lock value this attempt wrote is
             released (so a later batch can re-claim) and the error is re-raised
-            to the caller, which logs it per-trace without breaking ingestion.
+            to the dispatch task so Celery retries it.
     """
     # The lock's JSON payload (state/token/detector_ids) is diagnostic only —
     # nothing reads it back now that re-eval is gone; the key is purely an NX
     # dedup marker preventing a second enqueue for the same trace.
     key = _lock_key(project_id, trace_id)
     token = uuid.uuid4().hex
-    last_written = json.dumps({"state": "deciding", "token": token})
+    last_written = json.dumps({"state": "deciding", "token": token, "owner": dispatch_id})
 
     # NX claim: loses against ingest-task retry replay, duplicate root
     # delivery, or a concurrent batch — exactly-once holds either way.
-    if not redis_client.set(key, last_written, nx=True, ex=_LOCK_TTL_SECONDS):
-        logger.debug(f"Detector enqueue already claimed for trace {trace_id}; skipping")
-        return
+    try:
+        claimed = redis_client.set(key, last_written, nx=True, ex=_DECIDING_TTL_SECONDS)
+    except Exception as exc:
+        raise DetectorDispatchError(
+            f"Failed to claim detector enqueue for trace {trace_id}: {exc}"
+        ) from exc
+    if not claimed:
+        try:
+            existing_raw = redis_client.get(key)
+            existing_text = (
+                existing_raw.decode() if isinstance(existing_raw, bytes) else existing_raw
+            )
+            existing = json.loads(existing_text) if existing_text is not None else {}
+        except Exception as exc:
+            raise DetectorDispatchError(
+                f"Failed to inspect detector enqueue claim for trace {trace_id}: {exc}"
+            ) from exc
+        if (
+            dispatch_id is not None
+            and existing.get("state") == "deciding"
+            and existing.get("owner") == dispatch_id
+        ):
+            # The prior attempt failed before it could release its claim. Celery
+            # retries use the same task id, so resume that claim instead of
+            # reporting false success or waiting out its TTL.
+            last_written = existing_text
+        else:
+            logger.debug(f"Detector enqueue already claimed for trace {trace_id}; skipping")
+            return
 
     try:
         triggered_ids = [
@@ -330,35 +367,60 @@ def _claim_and_enqueue(
 
         if not triggered_ids:
             # Sticky no: a replay must not re-roll conditions or sampling.
-            redis_client.set(
-                key,
-                json.dumps({"state": "sampled_out", "token": token}),
-                ex=_LOCK_TTL_SECONDS,
-            )
+            try:
+                redis_client.set(
+                    key,
+                    json.dumps({"state": "sampled_out", "token": token}),
+                    ex=_LOCK_TTL_SECONDS,
+                )
+            except Exception as exc:
+                raise DetectorDispatchError(
+                    f"Failed to record detector decision for trace {trace_id}: {exc}"
+                ) from exc
             return
 
-        _add_bullmq_job(
-            f"{project_id}--{trace_id}",
-            {
-                "traceId": trace_id,
-                "detectorIds": triggered_ids,
-                "projectId": project_id,
-            },
-        )
-        redis_client.set(
-            key,
-            json.dumps({"state": "pending", "detector_ids": triggered_ids, "token": token}),
-            ex=_LOCK_TTL_SECONDS,
-        )
+        try:
+            _add_bullmq_job(
+                f"{project_id}--{trace_id}",
+                {
+                    "traceId": trace_id,
+                    "detectorIds": triggered_ids,
+                    "projectId": project_id,
+                },
+            )
+        except Exception as exc:
+            raise DetectorDispatchError(
+                f"Failed to enqueue detector job for trace {trace_id}: {exc}"
+            ) from exc
+        try:
+            redis_client.set(
+                key,
+                json.dumps({"state": "pending", "detector_ids": triggered_ids, "token": token}),
+                ex=_LOCK_TTL_SECONDS,
+            )
+        except Exception as exc:
+            raise DetectorDispatchError(
+                f"Failed to record pending detector job for trace {trace_id}: {exc}"
+            ) from exc
         logger.debug(f"Enqueued detector run: trace={trace_id} detectors={triggered_ids}")
     except Exception:
         # Release only the value this attempt wrote so a later batch or retry
         # can re-claim; a BullMQ job that was already added dedups by jobId.
-        _release_lock_if_value(redis_client, key, last_written)
+        try:
+            _release_lock_if_value(redis_client, key, last_written)
+        except Exception as release_exc:
+            raise DetectorDispatchError(
+                f"Failed to release detector enqueue claim for trace {trace_id}: {release_exc}"
+            ) from release_exc
         raise
 
 
-def enqueue_detector_runs(project_id: str, traces_with_root: set[str]) -> None:
+def enqueue_detector_runs(
+    project_id: str,
+    traces_with_root: set[str],
+    *,
+    dispatch_id: str | None = None,
+) -> None:
     """Claim and (conditions + sampling permitting) enqueue detection for traces
     whose root span arrived in this ingest batch.
 
@@ -366,44 +428,49 @@ def enqueue_detector_runs(project_id: str, traces_with_root: set[str]) -> None:
     batches without a trace's root span enqueue nothing for it (the worker waits
     out the quiescence window before evaluating, so late spans need no enqueue).
 
-    This function is intentionally non-raising — detector failures must not
-    break trace ingestion.
+    Dependency failures are raised after all traces in this dispatch have been
+    attempted. The dedicated Celery task retries them without re-running trace
+    ingestion. Invalid per-trace detector conditions are logged and skipped.
 
     Args:
         project_id (str): Project that owns the traces.
         traces_with_root (set[str]): Trace IDs whose root span arrived in this
             batch; each is claimed once and enqueued if it triggers.
+        dispatch_id (str | None): Stable owner id retained across retries.
     """
     if not traces_with_root:
         return
 
-    try:
-        root_traces = list(traces_with_root)
-        redis_client = _get_redis()
-        detectors = _get_active_detectors(project_id)
-        summaries = _get_trace_summaries(project_id, root_traces) if detectors else {}
-        for trace_id in root_traces:
-            # Per-trace try/except so a malformed condition (e.g. non-numeric
-            # `value` for a `>` op causing float() to ValueError, or a None
-            # sample_rate) only drops the offending trace — remaining traces
-            # in the batch still get enqueued.
-            try:
-                _claim_and_enqueue(
-                    redis_client,
-                    project_id,
-                    trace_id,
-                    detectors,
-                    summaries.get(trace_id, {}),
-                )
-            except Exception as trace_err:
-                logger.error(
-                    f"Failed to enqueue detector run for trace {trace_id}: {trace_err}",
-                    exc_info=True,
-                )
+    root_traces = sorted(traces_with_root)
+    redis_client = _get_redis()
+    detectors = _get_active_detectors(project_id)
+    summaries = _get_trace_summaries(project_id, root_traces) if detectors else {}
+    failures: list[Exception] = []
+    for trace_id in root_traces:
+        # Per-trace try/except so a malformed condition (e.g. non-numeric
+        # `value` for a `>` op causing float() to ValueError, or a None
+        # sample_rate) only drops the offending trace — remaining traces
+        # in the batch still get enqueued.
+        try:
+            _claim_and_enqueue(
+                redis_client,
+                project_id,
+                trace_id,
+                detectors,
+                summaries.get(trace_id, {}),
+                dispatch_id,
+            )
+        except DetectorDispatchError as trace_err:
+            logger.error(
+                f"Failed to enqueue detector run for trace {trace_id}: {trace_err}",
+                exc_info=True,
+            )
+            failures.append(trace_err)
+        except Exception as trace_err:
+            logger.error(
+                f"Invalid detector decision for trace {trace_id}: {trace_err}",
+                exc_info=True,
+            )
 
-    except Exception as e:
-        # Non-blocking: log and return, never raise
-        logger.error(
-            f"Failed to enqueue detector runs for project {project_id}: {e}",
-            exc_info=True,
-        )
+    if failures:
+        raise failures[0]

--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -13,6 +13,23 @@ from worker.celery_app import app
 logger = logging.getLogger(__name__)
 
 
+@app.task(
+    bind=True,
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_backoff_max=600,
+    max_retries=5,
+)
+def dispatch_detector_runs(self, project_id: str, trace_ids: list[str]) -> dict:
+    """Dispatch detector jobs after ingest, retrying transient dependency failures."""
+    from worker.detector_tasks import enqueue_detector_runs
+
+    unique_trace_ids = set(trace_ids)
+    dispatch_id = self.request.id or f"direct:{project_id}:{','.join(sorted(unique_trace_ids))}"
+    enqueue_detector_runs(project_id, unique_trace_ids, dispatch_id=dispatch_id)
+    return {"project_id": project_id, "traces": len(unique_trace_ids)}
+
+
 def _json_serializer(obj: object) -> str:
     """JSON serializer for datetime objects in span dicts."""
     if isinstance(obj, datetime):
@@ -142,19 +159,18 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
                 ch_client.insert_spans_batch(spans)
                 logger.info(f"Inserted {len(spans)} spans into ClickHouse")
 
-        # Trigger detector runs (fire-and-forget, non-blocking). The batch that
-        # carries a trace's root span triggers detection exactly once — a Redis
-        # lock keyed on (project, trace) dedups against ingest-task retries and
-        # duplicate root delivery. Batches without the root span are ignored
-        # here; the worker waits out the quiescence window before evaluating,
-        # so late spans need no enqueue.
+        # Hand detector work to its own retryable task. A Redis claim keyed on
+        # (project, trace) suppresses retries and duplicate root delivery while
+        # BullMQ's deterministic job id deduplicates repeated queue publication.
+        # Batches without the root span are ignored here; the detector worker
+        # waits out the quiescence window before evaluating, so late spans need
+        # no enqueue. A broker publication failure raises and retries this ingest
+        # task; failures after publication retry only the detector dispatch.
         if root_bearing_trace_ids:
-            try:
-                from worker.detector_tasks import enqueue_detector_runs
-
-                enqueue_detector_runs(project_id, root_bearing_trace_ids)
-            except Exception as e:
-                logger.error(f"Failed to call detector tasks: {e}", exc_info=True)
+            dispatch_detector_runs.delay(
+                project_id=project_id,
+                trace_ids=sorted(root_bearing_trace_ids),
+            )
 
         # 4. Publish to Redis for live trace streaming
         if spans:

--- a/tests/worker/test_detector_tasks.py
+++ b/tests/worker/test_detector_tasks.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import worker.detector_tasks as dt
+from worker.ingest_tasks import dispatch_detector_runs
 
 PROJECT = "proj-1"
 TRACE = "aa" * 16
@@ -204,7 +205,8 @@ class TestFailureRelease:
         _patch_summaries(monkeypatch, {})
 
         mock_add_job.side_effect = RuntimeError("redis down")
-        dt.enqueue_detector_runs(PROJECT, {TRACE})
+        with pytest.raises(dt.DetectorDispatchError, match="redis down"):
+            dt.enqueue_detector_runs(PROJECT, {TRACE})
         assert dt._lock_key(PROJECT, TRACE) not in fake_redis.store
 
         mock_add_job.side_effect = None
@@ -225,7 +227,8 @@ class TestFailureRelease:
             raise RuntimeError("boom")
 
         monkeypatch.setattr(dt, "_add_bullmq_job", hijack_then_fail)
-        dt.enqueue_detector_runs(PROJECT, {TRACE})
+        with pytest.raises(dt.DetectorDispatchError, match="boom"):
+            dt.enqueue_detector_runs(PROJECT, {TRACE})
 
         assert fake_redis.store[key] == foreign.encode()
 
@@ -321,6 +324,117 @@ class TestTopLevelGuard:
         )
         dt.enqueue_detector_runs(PROJECT, set())
 
-    def test_never_raises(self, monkeypatch):
+    def test_dependency_failure_raises_for_task_retry(self, monkeypatch):
         monkeypatch.setattr(dt, "_get_redis", MagicMock(side_effect=RuntimeError("redis down")))
-        dt.enqueue_detector_runs(PROJECT, {TRACE})
+        with pytest.raises(RuntimeError, match="redis down"):
+            dt.enqueue_detector_runs(PROJECT, {TRACE})
+
+
+class TestRetryableDispatchTask:
+    def test_redis_failure_surfaces_to_celery(self, monkeypatch):
+        """The dedicated dispatch task must fail so Celery can retry it."""
+        monkeypatch.setattr(dt, "_get_redis", MagicMock(side_effect=RuntimeError("redis down")))
+
+        with pytest.raises(RuntimeError, match="redis down"):
+            dispatch_detector_runs(project_id=PROJECT, trace_ids=[TRACE])
+
+    def test_postgres_failure_surfaces_to_celery(self, fake_redis, monkeypatch):
+        monkeypatch.setattr(
+            dt,
+            "_get_active_detectors",
+            MagicMock(side_effect=RuntimeError("postgres down")),
+        )
+
+        with pytest.raises(RuntimeError, match="postgres down"):
+            dispatch_detector_runs(project_id=PROJECT, trace_ids=[TRACE])
+
+    def test_bullmq_failure_surfaces_to_celery_and_releases_claim(self, monkeypatch):
+        """A failed Queue.add leaves the trace retryable and fails the dispatch task."""
+        redis = FakeRedis()
+        monkeypatch.setattr(dt, "_get_redis", lambda: redis)
+        _patch_detectors(monkeypatch, [_detector("d1")])
+        _patch_summaries(monkeypatch, {TRACE: {}})
+        monkeypatch.setattr(
+            dt,
+            "_add_bullmq_job",
+            MagicMock(side_effect=RuntimeError("bullmq down")),
+        )
+
+        with pytest.raises(RuntimeError, match="bullmq down"):
+            dispatch_detector_runs(project_id=PROJECT, trace_ids=[TRACE])
+
+        assert dt._lock_key(PROJECT, TRACE) not in redis.store
+
+    def test_retry_after_bullmq_recovery_enqueues_once(self, monkeypatch):
+        redis = FakeRedis()
+        add_job = MagicMock(side_effect=[RuntimeError("bullmq down"), None])
+        monkeypatch.setattr(dt, "_get_redis", lambda: redis)
+        _patch_detectors(monkeypatch, [_detector("d1")])
+        _patch_summaries(monkeypatch, {TRACE: {}})
+        monkeypatch.setattr(dt, "_add_bullmq_job", add_job)
+
+        result = dispatch_detector_runs.apply(
+            kwargs={"project_id": PROJECT, "trace_ids": [TRACE]},
+            throw=False,
+        )
+
+        assert result.successful()
+        assert result.result == {"project_id": PROJECT, "traces": 1}
+        assert add_job.call_count == 2
+        assert _lock_state(redis)["state"] == "pending"
+        assert dispatch_detector_runs.max_retries == 5
+
+    def test_retry_resumes_its_own_deciding_claim_after_release_failure(self, monkeypatch):
+        class ReleaseFailRedis(FakeRedis):
+            release_attempts = 0
+
+            def eval(self, script, numkeys, key, arg):
+                self.release_attempts += 1
+                raise RuntimeError("redis still down")
+
+        redis = ReleaseFailRedis()
+        add_job = MagicMock(side_effect=[RuntimeError("bullmq down"), None])
+        monkeypatch.setattr(dt, "_get_redis", lambda: redis)
+        _patch_detectors(monkeypatch, [_detector("d1")])
+        _patch_summaries(monkeypatch, {TRACE: {}})
+        monkeypatch.setattr(dt, "_add_bullmq_job", add_job)
+
+        result = dispatch_detector_runs.apply(
+            kwargs={"project_id": PROJECT, "trace_ids": [TRACE]},
+            throw=False,
+        )
+
+        assert result.successful()
+        assert result.result == {"project_id": PROJECT, "traces": 1}
+        assert add_job.call_count == 2
+        assert redis.release_attempts == 1
+        assert _lock_state(redis)["state"] == "pending"
+
+    def test_partial_batch_retry_skips_successes_and_recovers_failed_trace(self, monkeypatch):
+        other = "bb" * 16
+        redis = FakeRedis()
+        failed_once = False
+        added: list[str] = []
+
+        def add_with_one_transient_failure(job_id, data):
+            nonlocal failed_once
+            added.append(job_id)
+            if job_id == f"{PROJECT}--{TRACE}" and not failed_once:
+                failed_once = True
+                raise RuntimeError("bullmq down")
+
+        monkeypatch.setattr(dt, "_get_redis", lambda: redis)
+        _patch_detectors(monkeypatch, [_detector("d1")])
+        _patch_summaries(monkeypatch, {TRACE: {}, other: {}})
+        monkeypatch.setattr(dt, "_add_bullmq_job", add_with_one_transient_failure)
+
+        with pytest.raises(dt.DetectorDispatchError, match="bullmq down"):
+            dispatch_detector_runs(project_id=PROJECT, trace_ids=[TRACE, other])
+
+        result = dispatch_detector_runs(project_id=PROJECT, trace_ids=[TRACE, other])
+
+        assert result == {"project_id": PROJECT, "traces": 2}
+        assert added.count(f"{PROJECT}--{TRACE}") == 2
+        assert added.count(f"{PROJECT}--{other}") == 1
+        assert _lock_state(redis, trace_id=TRACE)["state"] == "pending"
+        assert _lock_state(redis, trace_id=other)["state"] == "pending"

--- a/tests/worker/test_ingest_tasks.py
+++ b/tests/worker/test_ingest_tasks.py
@@ -28,10 +28,10 @@ def mock_ch(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
-def mock_detector_enqueue(monkeypatch):
-    """Mock the detector enqueue so tests never touch Postgres/Redis/BullMQ."""
+def mock_detector_dispatch(monkeypatch):
+    """Mock detector task publication so tests never touch the Celery broker."""
     mock = MagicMock()
-    monkeypatch.setattr("worker.detector_tasks.enqueue_detector_runs", mock)
+    monkeypatch.setattr("worker.ingest_tasks.dispatch_detector_runs.delay", mock)
     return mock
 
 
@@ -97,9 +97,9 @@ class TestProcessS3Traces:
         assert result["spans"] == 3
 
     def test_detector_enqueue_gets_only_root_bearing_traces(
-        self, mock_s3, mock_ch, mock_detector_enqueue
+        self, mock_s3, mock_ch, mock_detector_dispatch
     ):
-        """Enqueue receives only the traces whose root span arrived in this batch."""
+        """The retryable dispatch receives only traces whose root arrived in this batch."""
         root_trace = "aa" * 16
         late_trace = "bb" * 16
         payload = make_otel_payload(
@@ -114,17 +114,31 @@ class TestProcessS3Traces:
 
         process_s3_traces(s3_key="test/key.json", project_id="proj-1")
 
-        mock_detector_enqueue.assert_called_once()
-        project_id, traces_with_root = mock_detector_enqueue.call_args[0]
-        assert project_id == "proj-1"
-        # Only the root-bearing trace is passed; the child-only late_trace is not.
-        assert traces_with_root == {root_trace}
+        mock_detector_dispatch.assert_called_once_with(
+            project_id="proj-1",
+            trace_ids=[root_trace],
+        )
 
     def test_detector_enqueue_not_called_for_empty_batch(
-        self, mock_s3, mock_ch, mock_detector_enqueue
+        self, mock_s3, mock_ch, mock_detector_dispatch
     ):
         mock_s3.download_json.return_value = {"resourceSpans": []}
 
         process_s3_traces(s3_key="test/key.json", project_id="proj-1")
 
-        mock_detector_enqueue.assert_not_called()
+        mock_detector_dispatch.assert_not_called()
+
+    def test_detector_task_publish_failure_retries_ingest(
+        self, mock_s3, mock_ch, mock_detector_dispatch
+    ):
+        """If the broker cannot accept the follow-up task, ingest must not report success."""
+        mock_s3.download_json.return_value = make_otel_payload(
+            [make_span(TRACE_HEX, SPAN_HEX, name="root")]
+        )
+        mock_detector_dispatch.side_effect = RuntimeError("broker down")
+
+        with pytest.raises(RuntimeError, match="broker down"):
+            process_s3_traces(s3_key="test/key.json", project_id="proj-1")
+
+        mock_ch.insert_traces_batch.assert_called_once()
+        mock_ch.insert_spans_batch.assert_called_once()


### PR DESCRIPTION
## Why

Trace ingestion writes to ClickHouse before scheduling detector work. Redis, Postgres, or BullMQ failures in that handoff were caught and logged, so Celery acknowledged the ingest task even though no detector job was queued. Later non-root batches do not schedule detection again, leaving a silent monitoring gap.

## What changed

- Move detector dispatch into a dedicated Celery task with bounded backoff retries
- Propagate dependency failures while continuing to skip invalid detector conditions
- Retain a stable dispatch owner across retries and use the existing Redis claim plus deterministic BullMQ job ID to suppress duplicate work
- Retry failed traces in a partial batch without republishing successful traces

## Test plan

- `pytest -q tests/worker/test_detector_tasks.py tests/worker/test_ingest_tasks.py` (32 passed)
- `pytest -q tests` (893 passed, 1 skipped)
- Ruff check and format check on the changed files

## Notes

This is a draft so maintainers can confirm the retry and dedup contract. It does not claim distributed exactly-once delivery.

A Celery broker publication failure still retries the ingest task; existing ClickHouse `ReplacingMergeTree` keys collapse replayed rows. The separate S3-to-Celery handoff gap in the public ingest route is not changed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run detector dispatch as a dedicated, retryable `Celery` task to prevent detector jobs from being silently dropped after ingest. Adds idempotent dedup so retries and duplicate root deliveries don’t enqueue extra work.

- **Bug Fixes**
  - Added `dispatch_detector_runs` with backoff (max 5); ingest publishes it and raises if the broker fails to ensure retry.
  - Propagate dependency failures (`Redis`, Postgres, `BullMQ`) to trigger task retry; skip invalid per-trace detector conditions.
  - Keep a stable dispatch owner across retries and reclaim the “deciding” claim; use a Redis claim plus deterministic `BullMQ` job ID to deduplicate.
  - Retry only failed traces in a partial batch; successful traces are not republished.

<sup>Written for commit 73b7cd450b1d15930a59abdc9083e9e0869547a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

