### PR TITLE
fix(pricing): strip the Python inline flag so the TS regex fallback actually matches

### DIFF
--- a/frontend/packages/core/src/__tests__/model-pricing.test.ts
+++ b/frontend/packages/core/src/__tests__/model-pricing.test.ts
@@ -81,7 +81,9 @@ describe("getModelPricing + calculateCost (prisma-backed)", () => {
     (prisma.standardModel.findMany as ReturnType<typeof vi.fn>).mockResolvedValue([
       {
         modelName: "claude-opus-4-7",
-        matchPattern: "^claude-opus-4-7$",
+        // Real patterns are shared with the Python worker and start with the
+        // "(?i)" inline flag, which JS RegExp rejects — the case this guards.
+        matchPattern: "(?i)^(anthropic\\/)?claude-opus-4-7(-[\\d-]+)?$",
         prices: [
           { usageType: "input", price: 0.000005 },
           { usageType: "output", price: 0.000025 },
@@ -110,5 +112,20 @@ describe("getModelPricing + calculateCost (prisma-backed)", () => {
   it("returns 0 when the model is not in the pricing table", async () => {
     const cost = await calculateCost("totally-unknown-model-2099", 100, 50);
     expect(cost).toBe(0);
+  });
+
+  // Regression for the "(?i)" inline flag: a gateway-prefixed id is not an exact
+  // modelName match, so it must resolve through the regex fallback. Before the
+  // fix, `new RegExp("(?i)...")` threw and the fallback silently matched nothing.
+  it("matches a gateway-prefixed id via the regex fallback", async () => {
+    const pricing = await getModelPricing("anthropic/claude-opus-4-7");
+    expect(pricing).not.toBeNull();
+    expect(pricing!.input).toBe(0.000005);
+  });
+
+  it("matches a versioned id via the regex fallback", async () => {
+    const pricing = await getModelPricing("claude-opus-4-7-20260514");
+    expect(pricing).not.toBeNull();
+    expect(pricing!.output).toBe(0.000025);
   });
 });

--- a/frontend/packages/core/src/model-pricing/lookup.ts
+++ b/frontend/packages/core/src/model-pricing/lookup.ts
@@ -68,10 +68,14 @@ export async function getModelPricing(modelId: string): Promise<ModelPricing | n
   const exact = models.find((m) => m.modelName === modelId);
   if (exact) return exact.prices;
 
-  // Regex fallback
+  // Regex fallback. The patterns are authored for Python's re (shared with the
+  // worker) and begin with the inline flag `(?i)`, which JS RegExp does not
+  // support — `new RegExp("(?i)...")` throws `Invalid group`, so without
+  // stripping it every pattern hit the catch below and the regex path never
+  // matched. Drop the leading `(?i)` and pass the equivalent "i" flag instead.
   for (const m of models) {
     try {
-      const re = new RegExp(m.matchPattern, "i");
+      const re = new RegExp(m.matchPattern.replace(/^\(\?i\)/, ""), "i");
       if (re.test(modelId)) return m.prices;
     } catch {
       // Invalid regex — skip


### PR DESCRIPTION
## What

`lookup.ts`'s regex fallback strips the leading Python inline flag `(?i)` from `matchPattern` before compiling it with `new RegExp(..., "i")`.

## Why

Follow-up to the discussion on #1587 / #1593, as promised to @ka1kqi.

`matchPattern` values are authored for Python's `re` (shared with the worker) and begin with the inline flag `(?i)`. JavaScript's `RegExp` does not support inline flags — it throws:

```
$ node -e 'new RegExp("(?i)^abc$", "i")'
SyntaxError: Invalid regular expression: /(?i)^abc$/i: Invalid group
```

In [`lookup.ts`](https://github.com/traceroot-ai/traceroot/blob/main/frontend/packages/core/src/model-pricing/lookup.ts#L74) that `throw` is swallowed by the `catch { // Invalid regex — skip }` immediately below it. So **every** pattern threw, every pattern was skipped, and the regex fallback has silently never matched anything since it was written. Only exact `modelName` equality has ever resolved a price on the TS side.

Practical effect: any id that needs the fallback rather than an exact hit — gateway-prefixed (`anthropic/claude-opus-4-7`) or date-versioned (`claude-opus-4-7-20260514`) — resolves to `null` and is billed at `0`. The Python worker, which compiles the same patterns natively, prices them correctly. That divergence is the TS half of what #1597 describes.

This is latent rather than user-visible today, since the paths that currently reach `getModelPricing` tend to pass exact ids — but it means the fallback offers none of the protection it appears to, and the two implementations are not at parity.

## How

One line in the loop:

```ts
const re = new RegExp(m.matchPattern.replace(/^\(\?i\)/, ""), "i");
```

The `"i"` flag was already being passed, so stripping the prefix preserves the intended case-insensitive semantics exactly. Only a *leading* `(?i)` is removed; a genuinely malformed pattern still hits the existing `catch` and is skipped as before.

The existing test's fixture used a hand-simplified `^claude-opus-4-7$`, which is why this was never caught — it happens to be valid JS regex. It now uses a realistic pattern in the shipped `(?i)^(anthropic\/)?...` shape.

## Tests

Two regression tests in `model-pricing.test.ts`, both exercising the fallback rather than the exact-match path.

Verified they fail before the change and pass after:

```
# with lookup.ts reverted to main
× matches a gateway-prefixed id via the regex fallback  → expected null not to be null
× matches a versioned id via the regex fallback         → expected null not to be null
  Tests  2 failed | 11 passed (13)

# with the fix
  Tests  13 passed (13)
```

Related: #1597 (pricing resolution implemented twice with no shared contract).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the TS pricing regex fallback by stripping Python’s leading `(?i)` inline flag from `matchPattern` before compiling with the `"i"` flag. Gateway-prefixed and versioned model IDs now resolve pricing in TS, matching the Python worker.

<sup>Written for commit 2e4698cf68c5a0e4af48ce0addcae1bcc5d145d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

