### PR TITLE
example(pi-agent-sdk): migrate to pi 0.80.x ModelRuntime API

### DIFF
--- a/examples/typescript/pi-agent-sdk/agent.ts
+++ b/examples/typescript/pi-agent-sdk/agent.ts
@@ -45,12 +45,16 @@ import { fileURLToPath } from 'node:url';
 import 'dotenv/config';
 import * as pi from '@earendil-works/pi-coding-agent';
 import {
-  AuthStorage,
   createAgentSession,
   ModelRegistry,
+  ModelRuntime,
   type AgentSession,
 } from '@earendil-works/pi-coding-agent';
 import { TraceRoot, observe, usingAttributes } from '@traceroot-ai/traceroot';
+
+// pi doesn't re-export the pi-ai `Model` type from its entrypoint, so derive it
+// from ModelRegistry.find()'s return type instead of importing it directly.
+type PiModel = NonNullable<ReturnType<ModelRegistry['find']>>;
 
 // One call wires the pi instrumentation (via instrumentModules.piCodingAgent)
 // and registers the OpenTelemetry pipeline. It must run BEFORE
@@ -152,19 +156,30 @@ console.log('pricing tests passed');
 `,
 );
 
-const authStorage = AuthStorage.create();
-const modelRegistry = ModelRegistry.create(authStorage);
-const model = modelRegistry.find('openai', 'gpt-4o-mini');
-if (!model) {
-  // find() only checks pi's static built-in model list, not auth — gpt-4o-mini is
-  // always in that list, so this would only fire if pi renames/drops the model id.
-  throw new Error('gpt-4o-mini is not a known model id in this version of pi-coding-agent.');
-}
-if (!modelRegistry.hasConfiguredAuth(model)) {
-  throw new Error(
-    'No OpenAI credentials found. Set OPENAI_API_KEY in your environment (pi falls back to it ' +
-      "when there's no `pi auth login` credential on disk).",
-  );
+/**
+ * Resolve the pi model + its model/auth runtime. `ModelRuntime` is pi 0.80's
+ * canonical model+credential surface: created async (it reads the on-disk models
+ * catalog), then handed to `createAgentSession`. We inject OPENAI_API_KEY as a
+ * runtime credential so the demo authenticates from env alone, no `pi auth login`.
+ */
+async function resolveModel(): Promise<{ modelRuntime: ModelRuntime; model: PiModel }> {
+  const modelRuntime = await ModelRuntime.create();
+  if (process.env.OPENAI_API_KEY) {
+    await modelRuntime.setRuntimeApiKey('openai', process.env.OPENAI_API_KEY);
+  }
+  const modelRegistry = new ModelRegistry(modelRuntime);
+  const model = modelRegistry.find('openai', 'gpt-4o-mini');
+  if (!model) {
+    // find() only checks pi's static built-in model list, not auth — gpt-4o-mini is
+    // always in that list, so this would only fire if pi renames/drops the model id.
+    throw new Error('gpt-4o-mini is not a known model id in this version of pi-coding-agent.');
+  }
+  if (!modelRegistry.hasConfiguredAuth(model)) {
+    throw new Error(
+      'No OpenAI credentials found. Set OPENAI_API_KEY in your environment (or run `pi auth login`).',
+    );
+  }
+  return { modelRuntime, model };
 }
 
 /** subscribe() surfaces tool calls and assistant messages as they happen — useful
@@ -249,11 +264,11 @@ async function report(session: AgentSession, prompt: string): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  const { modelRuntime, model } = await resolveModel();
   const { session } = await createAgentSession({
     cwd: workspace,
     model,
-    authStorage,
-    modelRegistry,
+    modelRuntime,
     // Deliberately NO `tools` option here. Passing one would permanently cap
     // the tool REGISTRY (not just the active set) to that allowlist, and
     // setActiveToolsByName() could then never widen past it later. Creating


### PR DESCRIPTION
## Problem

The Pi coding-agent SDK example fails to run against a current `@earendil-works/pi-coding-agent` release. The example pins `^0.80.0`, which now resolves to a 0.80.x that **removed** the `AuthStorage` export (and `ModelRegistry.create(authStorage)` / the `createAgentSession` `authStorage` option) in favor of a single async `ModelRuntime`. As shipped, the example throws at import:

```
SyntaxError: The requested module '@earendil-works/pi-coding-agent'
does not provide an export named 'AuthStorage'
```

## Fix

Migrate the example's model/auth bootstrap to the current API:

- `const modelRuntime = await ModelRuntime.create()`
- `await modelRuntime.setRuntimeApiKey('openai', process.env.OPENAI_API_KEY)` (authenticate from env, no `pi auth login` needed)
- `new ModelRegistry(modelRuntime)` → `find(...)` / `hasConfiguredAuth(...)`
- pass `modelRuntime` to `createAgentSession(...)`

`Model` isn't re-exported from pi's entrypoint, so its type is derived from `ModelRegistry.find()`. Only the example changes — the SDK's pi instrumentation is unaffected.

## Verification

- `tsc --noEmit` passes against `@traceroot-ai/traceroot@0.1.8` + `@earendil-works/pi-coding-agent@0.80.10`.
- `pnpm demo` runs the incident walkthrough end-to-end and exports a clean 27-span trace (agent → recon/remediate/report → per-turn LLM + tool spans, including the two genuine error spans).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the Pi coding-agent TypeScript example to the `ModelRuntime` API in `@earendil-works/pi-coding-agent@0.80.x`. Fixes the broken `AuthStorage` import and enables env-based OpenAI auth via `OPENAI_API_KEY`.

- **Migration**
  - Replace `AuthStorage` with `await ModelRuntime.create()` and `setRuntimeApiKey('openai', process.env.OPENAI_API_KEY)`.
  - Build `new ModelRegistry(modelRuntime)`, use `find(...)`/`hasConfiguredAuth(...)`.
  - Pass `modelRuntime` to `createAgentSession(...)`.
  - Derive the model type from `ModelRegistry.find()` since `Model` isn’t re-exported.

<sup>Written for commit 25bf9c470966a2a455793eb5a9c393c895202a7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

