### PR TITLE
feat(pricing): add Claude Opus 5

### DIFF
--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -28,7 +28,7 @@
   {
     "id": "tr-claude-opus-5",
     "modelName": "claude-opus-5",
-    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-5(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-5-opus(@[\\d-]+)?)$",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-5(\\[1m\\])?(-[\\d-]+)?(@[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-5-opus(@[\\d-]+)?)$",
     "provider": "anthropic",
     "prices": {
       "input": 0.000005,

--- a/frontend/packages/core/src/standard-model-prices.json
+++ b/frontend/packages/core/src/standard-model-prices.json
@@ -13,6 +13,32 @@
     }
   },
   {
+    "id": "tr-claude-opus-5-fast",
+    "modelName": "claude-opus-5-fast",
+    "matchPattern": "(?i)^(anthropic\\/)?claude-opus-5-fast$",
+    "provider": "anthropic",
+    "prices": {
+      "input": 0.00001,
+      "output": 0.00005,
+      "cacheRead": 0.000001,
+      "cacheWrite": 0.0000125,
+      "cacheWrite1h": 0.00002
+    }
+  },
+  {
+    "id": "tr-claude-opus-5",
+    "modelName": "claude-opus-5",
+    "matchPattern": "(?i)^(anthropic\\/)?(claude-opus-5(\\[1m\\])?(-[\\d-]+)?|(eu\\.|us\\.|apac\\.|global\\.)?anthropic\\.claude-opus-5(-[\\d-]+)?(-v\\d+:\\d+)?|claude-5-opus(@[\\d-]+)?)$",
+    "provider": "anthropic",
+    "prices": {
+      "input": 0.000005,
+      "output": 0.000025,
+      "cacheRead": 0.0000005,
+      "cacheWrite": 0.00000625,
+      "cacheWrite1h": 0.00001
+    }
+  },
+  {
     "id": "tr-claude-opus-4-8-fast",
     "modelName": "claude-opus-4-8-fast",
     "matchPattern": "(?i)^(anthropic\\/)?claude-opus-4[.-]8-fast$",

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -344,6 +344,13 @@ CLAUDE_BEDROCK_VERTEX_CASES = [
     ("claude-fable-5[1m]", "claude-fable-5"),
     ("anthropic/claude-fable-5", "claude-fable-5"),
     ("us.anthropic.claude-fable-5-20260701-v1:0", "claude-fable-5"),
+    # Pus 5 — plain, [1m] variant, anthropic/ prefix, Bedrock, Vertex
+    ("claude-opus-5", "claude-opus-5"),
+    ("claude-opus-5[1m]", "claude-opus-5"),
+    ("anthropic/claude-opus-5", "claude-opus-5"),
+    ("us.anthropic.claude-opus-5-20260728-v1:0", "claude-opus-5"),
+    ("eu.anthropic.claude-opus-5-20260728-v1:0", "claude-opus-5"),
+    ("claude-5-opus@20260728", "claude-opus-5"),
     # Opus 4.8 — plain, [1m] variant, Bedrock, Vertex
     ("claude-opus-4-8", "claude-opus-4-8"),
     ("claude-opus-4-8[1m]", "claude-opus-4-8"),
@@ -425,6 +432,8 @@ class TestClaudeBedrockAndVertexIds:
 
 CLAUDE_FAST_AND_DOT_CASES = [
     # Fast mode — gateway slug, bare dot form, dashed canonical form
+    ("anthropic/claude-opus-5-fast", "claude-opus-5-fast"),
+    ("claude-opus-5-fast", "claude-opus-5-fast"),
     ("anthropic/claude-opus-4.8-fast", "claude-opus-4-8-fast"),
     ("claude-opus-4.8-fast", "claude-opus-4-8-fast"),
     ("claude-opus-4-8-fast", "claude-opus-4-8-fast"),

--- a/tests/worker/tokens/test_pricing.py
+++ b/tests/worker/tokens/test_pricing.py
@@ -344,12 +344,13 @@ CLAUDE_BEDROCK_VERTEX_CASES = [
     ("claude-fable-5[1m]", "claude-fable-5"),
     ("anthropic/claude-fable-5", "claude-fable-5"),
     ("us.anthropic.claude-fable-5-20260701-v1:0", "claude-fable-5"),
-    # Pus 5 — plain, [1m] variant, anthropic/ prefix, Bedrock, Vertex
+    # Opus 5 — plain, [1m] variant, anthropic/ prefix, Bedrock, Vertex
     ("claude-opus-5", "claude-opus-5"),
     ("claude-opus-5[1m]", "claude-opus-5"),
     ("anthropic/claude-opus-5", "claude-opus-5"),
     ("us.anthropic.claude-opus-5-20260728-v1:0", "claude-opus-5"),
     ("eu.anthropic.claude-opus-5-20260728-v1:0", "claude-opus-5"),
+    ("claude-opus-5@20260728", "claude-opus-5"),
     ("claude-5-opus@20260728", "claude-opus-5"),
     # Opus 4.8 — plain, [1m] variant, Bedrock, Vertex
     ("claude-opus-4-8", "claude-opus-4-8"),


### PR DESCRIPTION
Fixes #1624

## Summary
This PR implements the core data-layer addition for **Claude Opus 5** (`claude-opus-5`) and its companion **Fast-Mode variant** (`claude-opus-5-fast`) by appending their rate configurations to `standard-model-prices.json`. 

This provides pricing support for incoming tracking spans, enabling the system to map tokens to non-zero costs before the catalog rollout in #1618 sets this model as the workspace default.


## Type of Change

- [x] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

### New Pricing Rate Card Implementation
The pricing layout has been integrated according to Anthropic's published data tier, applying a 2x premium across the entire rate card for Fast Mode to match pre-existing model architectures: (price stays same as opus4-8)
* **Standard Rate Card ID (`tr-claude-opus-5`)**:
  * Base Input Tokens: `$5.00` / MTok (`0.000005`)
  * Output Tokens: `$25.00` / MTok (`0.000025`)
  * 5m Cache Writes: `$6.25` / MTok (`0.00000625`)
  * 1h Cache Writes: `$10.00` / MTok (`0.000010`)
  * Cache Hits & Refreshes: `$0.50` / MTok (`0.0000005`)
* **Fast-Mode Rate Card ID (`tr-claude-opus-5-fast`)**:
  * Base Input Tokens: `$10.00` / MTok (`0.000010`) *(2x Doubled)*
  * Output Tokens: `$50.00` / MTok (`0.000050`) *(2x Doubled)*
  * 5m Cache Writes: `$12.50` / MTok (`0.0000125`) *(2x Doubled)*
  * 1h Cache Writes: `$20.00` / MTok (`0.000020`) *(2x Doubled)*
  * Cache Hits & Refreshes: `$1.00` / MTok (`0.0000010`) *(2x Doubled)*

### Matching Pattern Specifications (stays same as 4-8 except dots)
A new `matchPattern` regex was designed to successfully isolate incoming raw payloads from multiple upstream providers:
* Handles direct identifiers (`claude-opus-5`) and standard provider prefixes (`anthropic/claude-opus-5`).
* Captures the dedicated **1M context frame marker** (`claude-opus-5[1m]`).
* Supports AWS Bedrock regional CRIS formats across `us.`, `eu.`, `apac.`, and `global.` routers as well as standalone `anthropic.` strings.
* Identifies Google Vertex AI reversed snapshots (`claude-5-opus@YYYYMMDD`).
* Employs an isolated expression `(?i)^(anthropic\/)?claude-opus-5-fast$` to track the fast variant independently.

### Testing Suite Changes
* Added official test cases to `CLAUDE_BEDROCK_VERTEX_CASES` inside `tests/worker/tokens/test_pricing.py` covering standard, 1M, prefixed, Bedrock regional, and Vertex snapshot names.
* Integrated fast-variant check cases alongside existing tracking rows.
* Confirmed that the real-cache parser test passes cleanly, validating that the setup maps the updated file data structures into runtime memory with zero regressions.
* Cost has been tested and confirmed by test span with claude-opus-5 as its model and synthetic token usages.


## Screenshots / Recordings
* All 277 test casses passed 
<img width="1908" height="368" alt="277_passed" src="https://github.com/user-attachments/assets/284cd8d6-c01e-4ae8-9661-bf447e4cbb76" />

* Specific opus-5 test cases results passed
<img width="1920" height="846" alt="newly_opus_5_specific" src="https://github.com/user-attachments/assets/cd13facb-57df-431c-bda5-7df8521c60fc" />

* Cost verified though token usage and opus-5 model
<img width="893" height="432" alt="Screenshot from 2026-07-28 03-46-43" src="https://github.com/user-attachments/assets/24e93f23-3857-4841-9a98-6ae10c719c0f" />
<img width="1105" height="897" alt="Screenshot from 2026-07-28 03-46-35" src="https://github.com/user-attachments/assets/82a7b9a1-a9bd-44f2-9bd0-271f7f06bc1b" />
* Verified prices from: https://platform.claude.com/docs/en/about-claude/pricing
<img width="1121" height="728" alt="image" src="https://github.com/user-attachments/assets/bdf20b91-6e66-4bbb-94bb-b38600fe3301" />

* Opus-5 fast 2x prices verified : https://platform.claude.com/docs/en/build-with-claude/fast-mode
<img width="1120" height="388" alt="image" src="https://github.com/user-attachments/assets/d5291fa7-be81-4cc4-8c55-1f2fcf0f122c" />

## Checklist


- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [x] I have added screenshots or recordings for UI changes 
- [ ] I have updated documentation where necessary (need to add opus-5 in docs/integrations after this merged)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pricing support for Claude Opus 5 (`claude-opus-5`) and Fast (`claude-opus-5-fast`) so spans calculate costs correctly. Fixes #1624.

- **New Features**
  - Added `tr-claude-opus-5` and `tr-claude-opus-5-fast` to `standard-model-prices.json` with input/output and cache read/write (5m, 1h) rates; Fast is 2x Standard.
  - `matchPattern` recognizes Anthropic IDs, `[1m]` context, Bedrock regional forms, and Vertex snapshots/aliases (`claude-opus-5@YYYYMMDD`, `claude-5-opus@YYYYMMDD`).
  - Extended tests to cover both variants and provider formats, verifying price loading and cost calculation.

- **Bug Fixes**
  - Corrected snapshot regex and tests for `@YYYYMMDD` forms (e.g., `claude-opus-5@20260728`) to avoid missed matches.

<sup>Written for commit e6d310e913c364166e39b709fed8d03224a09f72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



