### PR TITLE
chore(examples): nicer trace name for pi-agent-sdk demo

### DIFF
--- a/examples/typescript/pi-agent-sdk/agent.ts
+++ b/examples/typescript/pi-agent-sdk/agent.ts
@@ -14,7 +14,7 @@
  * README for why that's possible, and why the session must be created
  * without a `tools` allowlist for it to work):
  *
- *   incident_inv_2041                        (observe: agent)
+ *   pi-session                               (observe: agent)
  *   ├─ recon                                 (observe: span) — read-only tools
  *   │   ├─ AGENT  prompt 1: map the repo
  *   │   │   └─ TOOL  ls, find
@@ -289,7 +289,7 @@ async function main(): Promise<void> {
       { userId: 'example-user', sessionId: 'pi-agent-sdk-incident-session' },
       () =>
         observe(
-          { name: 'incident_inv_2041', type: 'agent' },
+          { name: 'pi-session', type: 'agent' },
           async (summary: string) => {
             console.log(`\n--- ${summary} ---`);
             await recon(session, RECON_PROMPTS);


### PR DESCRIPTION
## What

Renames the root agent span in the pi-agent-sdk TypeScript example from `incident_inv_2041` to `pi-session`.

## Why

The root span name doubles as the **trace title** and root tree-node label in the UI. `incident_inv_2041` reads like an internal ID rather than a title. `pi-session` is short (doesn't crowd the metrics beside the tree node), reads as a human-friendly name, and matches the existing `sessionId: 'pi-agent-sdk-incident-session'` style. The incident context isn't lost — the `recon → remediate → report` child spans and the "Incident INV-2041…" input text still tell that story.

## Changes

- `examples/typescript/pi-agent-sdk/agent.ts`: root `observe({ name: ... })` span name, plus the ASCII trace-tree doc comment updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the root agent span in the `pi-agent-sdk` TypeScript example from `incident_inv_2041` to `pi-session` to make the UI trace title human-friendly. Updated the ASCII trace-tree comment to match.

<sup>Written for commit 51b3b8f9b4fd550dd94c7c4504523b0d9d0aa4d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

