### PR TITLE
fix(ai-assistant): show activity for an RCA answer written out-of-band

### DIFF
--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -25,8 +25,8 @@ interface LayoutContextType {
   // an existing session; clear when opening a fresh chat.
   aiInitialSessionId: string | undefined;
   setAiInitialSessionId: (sessionId: string | undefined) => void;
-  // Set by the host that owns the opened session while a worker is still writing
-  // its answer; see UseAiChatOptions.initialSessionPending.
+  // True while a worker is still writing the opened session's answer. Set by
+  // the host that owns the session.
   aiInitialSessionPending: boolean;
   setAiInitialSessionPending: (pending: boolean) => void;
   hideAiButton: boolean;

--- a/frontend/ui/src/components/layout/app-layout.tsx
+++ b/frontend/ui/src/components/layout/app-layout.tsx
@@ -25,6 +25,10 @@ interface LayoutContextType {
   // an existing session; clear when opening a fresh chat.
   aiInitialSessionId: string | undefined;
   setAiInitialSessionId: (sessionId: string | undefined) => void;
+  // Set by the host that owns the opened session while a worker is still writing
+  // its answer; see UseAiChatOptions.initialSessionPending.
+  aiInitialSessionPending: boolean;
+  setAiInitialSessionPending: (pending: boolean) => void;
   hideAiButton: boolean;
   setHideAiButton: (hide: boolean) => void;
   // Hosts (TraceViewerPanel / SessionDetailPanel) claim ownership of the AI
@@ -46,6 +50,8 @@ const LayoutContext = createContext<LayoutContextType>({
   setAiContext: () => {},
   aiInitialSessionId: undefined,
   setAiInitialSessionId: () => {},
+  aiInitialSessionPending: false,
+  setAiInitialSessionPending: () => {},
   hideAiButton: false,
   setHideAiButton: () => {},
   viewerOwnsAiSlot: false,
@@ -62,6 +68,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
   const [aiPanelOpen, setAiPanelOpen] = useState(false);
   const [aiContext, setAiContext] = useState<AiTraceContext | null>(null);
   const [aiInitialSessionId, setAiInitialSessionId] = useState<string | undefined>(undefined);
+  const [aiInitialSessionPending, setAiInitialSessionPending] = useState(false);
   const [hideAiButton, setHideAiButton] = useState(true);
   const [aiHostRefCount, setAiHostRefCount] = useState(0);
   const pathname = usePathname();
@@ -72,6 +79,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
     setAiPanelOpen(false);
     setAiContext(null);
     setAiInitialSessionId(undefined);
+    setAiInitialSessionPending(false);
   }, [pathname]);
 
   const registerAiHost = useCallback(() => {
@@ -110,6 +118,8 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         setAiContext,
         aiInitialSessionId,
         setAiInitialSessionId,
+        aiInitialSessionPending,
+        setAiInitialSessionPending,
         hideAiButton,
         setHideAiButton,
         viewerOwnsAiSlot,
@@ -120,6 +130,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
         projectId={projectId}
         initialContext={aiContext}
         initialSessionId={aiInitialSessionId}
+        initialSessionPending={aiInitialSessionPending}
       >
         <div className="flex h-screen overflow-hidden">
           <Sidebar collapsed={sidebarCollapsed} />

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -67,6 +67,7 @@ export function AiAssistantPanel({ projectId, onClose, compact = false }: AiAssi
   const {
     messages,
     isStreaming,
+    isLoadingSession,
     sessions,
     historyOpen,
     currentSessionId,
@@ -177,7 +178,13 @@ export function AiAssistantPanel({ projectId, onClose, compact = false }: AiAssi
           </div>
         </div>
       ) : (
-        <MessageList messages={messages} sessionStreaming={isStreaming} />
+        <MessageList
+          messages={messages}
+          sessionStreaming={isStreaming || isLoadingSession}
+          // Only the out-of-band wait gets a label: a live stream shows its own
+          // text arriving, and the run being waited on here is the RCA agent's.
+          waitingLabel={isLoadingSession ? "Analyzing the trace…" : undefined}
+        />
       )}
 
       {/* Input */}

--- a/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-assistant-panel.tsx
@@ -181,8 +181,7 @@ export function AiAssistantPanel({ projectId, onClose, compact = false }: AiAssi
         <MessageList
           messages={messages}
           sessionStreaming={isStreaming || isLoadingSession}
-          // Only the out-of-band wait gets a label: a live stream shows its own
-          // text arriving, and the run being waited on here is the RCA agent's.
+          // Only this wait gets a label; a live stream is its own feedback.
           waitingLabel={isLoadingSession ? "Analyzing the trace…" : undefined}
         />
       )}

--- a/frontend/ui/src/features/ai-assistant/components/ai-chat-context.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-chat-context.tsx
@@ -22,8 +22,7 @@ interface AiChatProviderProps {
   // continues attribution there. Clearing it lets the chat fall back to lazy
   // session creation on the next user message.
   initialSessionId?: string;
-  // True while the pre-loaded session's answer is still being written by a
-  // worker; see UseAiChatOptions.initialSessionPending.
+  // True while a worker is still writing the pre-loaded session's answer.
   initialSessionPending?: boolean;
   children: ReactNode;
 }

--- a/frontend/ui/src/features/ai-assistant/components/ai-chat-context.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/ai-chat-context.tsx
@@ -22,6 +22,9 @@ interface AiChatProviderProps {
   // continues attribution there. Clearing it lets the chat fall back to lazy
   // session creation on the next user message.
   initialSessionId?: string;
+  // True while the pre-loaded session's answer is still being written by a
+  // worker; see UseAiChatOptions.initialSessionPending.
+  initialSessionPending?: boolean;
   children: ReactNode;
 }
 
@@ -29,6 +32,7 @@ export function AiChatProvider({
   projectId,
   initialContext,
   initialSessionId,
+  initialSessionPending,
   children,
 }: AiChatProviderProps) {
   const chat = useAiChat({
@@ -36,6 +40,7 @@ export function AiChatProvider({
     traceId: initialContext?.traceId,
     traceSessionId: initialContext?.traceSessionId,
     initialSessionId,
+    initialSessionPending,
   });
   return <AiChatContext.Provider value={chat}>{children}</AiChatContext.Provider>;
 }

--- a/frontend/ui/src/features/ai-assistant/components/message-list.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-list.test.tsx
@@ -2,7 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, screen } from "@testing-library/react";
 
-// Markdown rendering is irrelevant here and pulls in a heavy parser chain.
+// Stub out the markdown parser; rendering it isn't what's under test.
 vi.mock("react-markdown", () => ({
   default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
 }));
@@ -20,17 +20,15 @@ const PROMPT: AIMessage = {
 
 afterEach(cleanup);
 
-// The waiting indicator carries a label only for a wait the user has no other
-// feedback on — a worker writing an answer out-of-band, which can run for tens
-// of seconds with nothing else moving on screen. A live stream shows its own
-// text arriving, so labelling it would flash between tokens and tool steps.
+// The label is for waits with no other feedback on screen. A live stream shows
+// its own text arriving, so labelling it would flash between tokens.
 describe("MessageList waiting indicator", () => {
   it("names what is being waited on when given a label", () => {
     render(
       <MessageList messages={[PROMPT]} sessionStreaming waitingLabel="Analyzing the trace…" />,
     );
-    // role=status (via LoadingState) is what makes the wait audible to a screen
-    // reader; the bare spinner announces nothing.
+    // LoadingState's role=status is what a screen reader announces; the bare
+    // spinner announces nothing.
     expect(screen.getByRole("status").textContent).toContain("Analyzing the trace…");
   });
 

--- a/frontend/ui/src/features/ai-assistant/components/message-list.test.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-list.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+
+// Markdown rendering is irrelevant here and pulls in a heavy parser chain.
+vi.mock("react-markdown", () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("remark-gfm", () => ({ default: () => {} }));
+
+import { MessageList } from "./message-list";
+import type { AIMessage } from "../types";
+
+const PROMPT: AIMessage = {
+  id: "u-1",
+  role: "user",
+  content: "Analyze this trace",
+  timestamp: "2026-01-01T00:00:00Z",
+};
+
+afterEach(cleanup);
+
+// The waiting indicator carries a label only for a wait the user has no other
+// feedback on — a worker writing an answer out-of-band, which can run for tens
+// of seconds with nothing else moving on screen. A live stream shows its own
+// text arriving, so labelling it would flash between tokens and tool steps.
+describe("MessageList waiting indicator", () => {
+  it("names what is being waited on when given a label", () => {
+    render(
+      <MessageList messages={[PROMPT]} sessionStreaming waitingLabel="Analyzing the trace…" />,
+    );
+    // role=status (via LoadingState) is what makes the wait audible to a screen
+    // reader; the bare spinner announces nothing.
+    expect(screen.getByRole("status").textContent).toContain("Analyzing the trace…");
+  });
+
+  it("stays unlabelled for a live stream", () => {
+    render(<MessageList messages={[PROMPT]} sessionStreaming />);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("shows no indicator at all once the session is idle", () => {
+    render(<MessageList messages={[PROMPT]} waitingLabel="Analyzing the trace…" />);
+    expect(screen.queryByRole("status")).toBeNull();
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/components/message-list.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-list.tsx
@@ -471,12 +471,8 @@ function UsageFooter({ msg }: { msg: AIMessage }) {
 interface MessageListProps {
   messages: AIMessage[];
   sessionStreaming?: boolean;
-  /**
-   * Names what is being waited on, for a wait the user has no other feedback on
-   * — nothing streams in and it can run for tens of seconds. Omit for a live
-   * stream, where text arriving is the feedback and a label would just flash
-   * between tokens and tool steps.
-   */
+  // Names what is being waited on when nothing is streaming in. Omit for a live
+  // stream, where the text arriving is the feedback.
   waitingLabel?: string;
 }
 

--- a/frontend/ui/src/features/ai-assistant/components/message-list.tsx
+++ b/frontend/ui/src/features/ai-assistant/components/message-list.tsx
@@ -16,6 +16,7 @@ import type { Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { ChevronRight, Loader2, CheckCircle2, XCircle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { LoadingState } from "@/components/ui/loading-state";
 import type { AIMessage, ToolCallStep } from "../types";
 import { PANEL_MAX_WIDTH } from "../constants";
 
@@ -470,9 +471,20 @@ function UsageFooter({ msg }: { msg: AIMessage }) {
 interface MessageListProps {
   messages: AIMessage[];
   sessionStreaming?: boolean;
+  /**
+   * Names what is being waited on, for a wait the user has no other feedback on
+   * — nothing streams in and it can run for tens of seconds. Omit for a live
+   * stream, where text arriving is the feedback and a label would just flash
+   * between tokens and tool steps.
+   */
+  waitingLabel?: string;
 }
 
-export function MessageList({ messages, sessionStreaming = false }: MessageListProps) {
+export function MessageList({
+  messages,
+  sessionStreaming = false,
+  waitingLabel,
+}: MessageListProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
   const userScrolledRef = useRef(false);
@@ -570,7 +582,11 @@ export function MessageList({ messages, sessionStreaming = false }: MessageListP
         })}
         {isWaiting && (
           <div className="px-1 pb-2">
-            <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground/40" />
+            {waitingLabel ? (
+              <LoadingState label={waitingLabel} className="text-[12px]" />
+            ) : (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground/40" />
+            )}
           </div>
         )}
       </div>

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.ts
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useState } from "react";
+
+// The real stream is a live SSE connection. Fake it so a test can hold a stream
+// open, which is what makes the message list unsafe to replace.
+const stream = vi.hoisted(() => ({ active: false }));
+vi.mock("./use-ai-stream", () => ({
+  useAIStream: () => {
+    const [messages, setMessages] = useState<unknown[]>([]);
+    return {
+      messages,
+      isStreaming: stream.active,
+      sendMessage: vi.fn(),
+      abort: vi.fn(),
+      setMessages,
+    };
+  },
+}));
+
+import { useAiChat } from "./use-ai-chat";
+
+// Opening a detector-flagged trace pre-loads an RCA session that a worker
+// populates out-of-band, so the answer can arrive after the chat is already on
+// screen. The chat must show a working indicator while the run is still
+// generating (its owner reports that status via `initialSessionPending`) and
+// re-read the session when the run finishes, with no manual page refresh.
+
+type Raw = { id: string; role: "user" | "assistant"; content: string; createTime: string };
+
+function msg(role: "user" | "assistant", content: string, id = `${role}-1`): Raw {
+  return { id, role, content, createTime: "2026-01-01T00:00:00Z" };
+}
+
+function ok(messages: Raw[]) {
+  return { ok: true, json: async () => ({ messages }) };
+}
+
+const PROMPT = msg("user", "Analyze this trace");
+const ANSWER = msg("assistant", "Root cause: the worker dropped the span.", "a-1");
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  stream.active = false;
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useAiChat — pre-loaded RCA session working indicator", () => {
+  it("keeps the indicator up while the RCA run is pending, then reloads the answer when it completes", async () => {
+    fetchMock
+      .mockResolvedValueOnce(ok([PROMPT])) // opened while still generating
+      .mockResolvedValueOnce(ok([PROMPT, ANSWER])); // reload once the run finishes
+
+    const { result, rerender } = renderHook(
+      ({ pending }) =>
+        useAiChat({
+          projectId: "p1",
+          traceId: "t1",
+          initialSessionId: "s1",
+          initialSessionPending: pending,
+        }),
+      { initialProps: { pending: true } },
+    );
+
+    // Indicator shows immediately — driven by the authoritative running status.
+    expect(result.current.isLoadingSession).toBe(true);
+    await waitFor(() => expect(result.current.messages.map((m) => m.role)).toEqual(["user"]));
+    expect(result.current.isLoadingSession).toBe(true);
+
+    // Run finishes → status flips → the answer is reloaded and the indicator clears.
+    rerender({ pending: false });
+    expect(result.current.isLoadingSession).toBe(false);
+    await waitFor(() =>
+      expect(result.current.messages.map((m) => m.role)).toEqual(["user", "assistant"]),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("holds the completion reload until the user's own stream has finished", async () => {
+    // A reload replaces the whole list, so landing one mid-stream would orphan
+    // the message the stream is writing into and the answer would stop
+    // mid-sentence. The read is owed, not dropped: it happens once the turn ends.
+    fetchMock.mockResolvedValue(ok([PROMPT, ANSWER]));
+
+    const { result, rerender } = renderHook(
+      ({ pending }) =>
+        useAiChat({
+          projectId: "p1",
+          traceId: "t1",
+          initialSessionId: "s1",
+          initialSessionPending: pending,
+        }),
+      { initialProps: { pending: true } },
+    );
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // The user asks a follow-up while the run is still generating.
+    stream.active = true;
+    rerender({ pending: true });
+    expect(result.current.isStreaming).toBe(true);
+
+    // Run finishes mid-stream — no reload yet.
+    rerender({ pending: false });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Their turn ends → the owed reload lands.
+    stream.active = false;
+    rerender({ pending: false });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("shows no indicator and loads once when the RCA answer is already complete on open", async () => {
+    fetchMock.mockResolvedValue(ok([PROMPT, ANSWER]));
+
+    const { result } = renderHook(() =>
+      useAiChat({
+        projectId: "p1",
+        traceId: "t1",
+        initialSessionId: "s1",
+        initialSessionPending: false,
+      }),
+    );
+
+    expect(result.current.isLoadingSession).toBe(false);
+    await waitFor(() => expect(result.current.messages).toHaveLength(2));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.test.ts
@@ -3,8 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import { useState } from "react";
 
-// The real stream is a live SSE connection. Fake it so a test can hold a stream
-// open, which is what makes the message list unsafe to replace.
+// Fake the SSE stream so a test can hold one open mid-turn.
 const stream = vi.hoisted(() => ({ active: false }));
 vi.mock("./use-ai-stream", () => ({
   useAIStream: () => {
@@ -21,11 +20,9 @@ vi.mock("./use-ai-stream", () => ({
 
 import { useAiChat } from "./use-ai-chat";
 
-// Opening a detector-flagged trace pre-loads an RCA session that a worker
-// populates out-of-band, so the answer can arrive after the chat is already on
-// screen. The chat must show a working indicator while the run is still
-// generating (its owner reports that status via `initialSessionPending`) and
-// re-read the session when the run finishes, with no manual page refresh.
+// Opening a detector-flagged trace pre-loads an RCA session that a worker fills
+// in, so the answer can arrive after the chat is already on screen. Until then
+// the chat shows a working indicator, driven by `initialSessionPending`.
 
 type Raw = { id: string; role: "user" | "assistant"; content: string; createTime: string };
 
@@ -69,7 +66,7 @@ describe("useAiChat — pre-loaded RCA session working indicator", () => {
       { initialProps: { pending: true } },
     );
 
-    // Indicator shows immediately — driven by the authoritative running status.
+    // Indicator shows immediately, before any messages have loaded.
     expect(result.current.isLoadingSession).toBe(true);
     await waitFor(() => expect(result.current.messages.map((m) => m.role)).toEqual(["user"]));
     expect(result.current.isLoadingSession).toBe(true);
@@ -85,8 +82,7 @@ describe("useAiChat — pre-loaded RCA session working indicator", () => {
 
   it("holds the completion reload until the user's own stream has finished", async () => {
     // A reload replaces the whole list, so landing one mid-stream would orphan
-    // the message the stream is writing into and the answer would stop
-    // mid-sentence. The read is owed, not dropped: it happens once the turn ends.
+    // the message the stream is writing into. It is owed, not dropped.
     fetchMock.mockResolvedValue(ok([PROMPT, ANSWER]));
 
     const { result, rerender } = renderHook(

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -24,11 +24,9 @@ function mapSessionMessages(data: { messages?: RawSessionMessage[] } | null): AI
 interface UseAiChatOptions extends AiTraceContext {
   projectId: string | undefined;
   initialSessionId?: string; // pre-load an existing session (e.g. RCA session from Step 2)
-  // True while a worker is still writing that session's answer (an RCA run in
-  // pending/running). Drives the working indicator, and its flip to false
-  // reloads the session so the finished answer appears without a manual
-  // refresh. The owner of this flag already tracks the status, so the chat
-  // never polls for it itself.
+  // True while a worker is still writing that session's answer. Shows the
+  // working indicator; flipping to false reloads the session so the finished
+  // answer appears. Reported by the caller, so the chat never polls for it.
   initialSessionPending?: boolean;
 }
 
@@ -50,17 +48,14 @@ export function useAiChat({
   // (session creation + first network round-trip). Without this, React 19 can batch
   // setIsStreaming(true) and setIsStreaming(false) into a single frame, hiding the button.
   const [isSending, setIsSending] = useState(false);
-  // Working indicator for a pre-loaded session whose answer is still being
-  // written elsewhere; see initialSessionPending.
+  // Working indicator for a pre-loaded session; see initialSessionPending.
   const [isLoadingSession, setIsLoadingSession] = useState(false);
-  // The session id we last cleared messages for, so a status-driven reload of
-  // the same session doesn't flash the list empty.
+  // Last session we cleared messages for, so a reload of the same session
+  // doesn't flash the list empty.
   const loadedInitialSessionRef = useRef<string | null>(null);
-  // Session whose reload is owed once the user's own turn finishes; see the
-  // deferred-reload effect below.
+  // Session whose reload is owed until the user's own turn finishes.
   const deferredReloadRef = useRef<string | null>(null);
-  // A stream is writing into `messages` right now. Read from an effect that must
-  // not itself re-run when this flips, so it lives in a ref.
+  // A ref because the effect below reads it but must not re-run when it flips.
   const streamActive = isSending || isStreaming || messages.some((m) => m.isStreaming);
   const streamActiveRef = useRef(streamActive);
   streamActiveRef.current = streamActive;
@@ -96,11 +91,10 @@ export function useAiChat({
     setMessages([]);
   }, [projectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Load a pre-loaded session's messages on open, and load them again when
-  // initialSessionPending flips false — that is the one signal that a
-  // worker-written answer has landed, so re-reading then is what makes it appear
-  // without a manual refresh. AbortController guards against a stale fetch
-  // overwriting a newer session's messages.
+  // Load a pre-loaded session's messages on open, and again when
+  // initialSessionPending flips false — the signal that the worker's answer has
+  // landed. AbortController guards against a stale fetch overwriting a newer
+  // session's messages.
   useEffect(() => {
     if (!initialSessionId || !projectId) return;
     sessionIdRef.current = initialSessionId;
@@ -111,10 +105,8 @@ export function useAiChat({
       setMessages([]);
       loadedInitialSessionRef.current = initialSessionId;
     } else if (streamActiveRef.current) {
-      // Reloading replaces the list wholesale, which would orphan the message
-      // the user's own stream is writing into (useAIStream applies deltas by
-      // message id, so they would land nowhere and the answer would stop
-      // mid-sentence). Owe the reload instead and settle it below.
+      // A reload replaces the whole list, orphaning the message the user's
+      // stream is writing into. Owe it until the stream ends instead.
       deferredReloadRef.current = initialSessionId;
       return;
     }
@@ -124,9 +116,8 @@ export function useAiChat({
     return () => ac.abort();
   }, [initialSessionId, initialSessionPending, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Settle a reload that was owed while the user was mid-turn. Runs once the
-  // stream ends, so the list picks up both the worker's answer and the user's
-  // completed exchange in one read.
+  // Run a reload that was owed while the user was mid-turn. One read now picks
+  // up both the worker's answer and the user's finished exchange.
   useEffect(() => {
     if (streamActive) return;
     const sessionId = deferredReloadRef.current;
@@ -257,8 +248,8 @@ export function useAiChat({
     // State
     messages,
     isStreaming: streamActive,
-    // Kept separate from isStreaming so the Stop button (which aborts a live
-    // stream) stays hidden while an RCA session is merely still generating.
+    // Separate from isStreaming so the Stop button, which aborts a live stream,
+    // stays hidden while a worker is writing the answer.
     isLoadingSession,
     sessions,
     historyOpen,

--- a/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
+++ b/frontend/ui/src/features/ai-assistant/hooks/use-ai-chat.ts
@@ -5,9 +5,31 @@ import { useAIStream } from "./use-ai-stream";
 import type { AISession, AIMessage, AiTraceContext } from "../types";
 import type { ModelSelection } from "../components/model-selector";
 
+interface RawSessionMessage {
+  id: string;
+  role: string;
+  content: string;
+  createTime: string;
+}
+
+function mapSessionMessages(data: { messages?: RawSessionMessage[] } | null): AIMessage[] {
+  return (data?.messages ?? []).map((m) => ({
+    id: m.id,
+    role: m.role as "user" | "assistant",
+    content: m.content,
+    timestamp: m.createTime,
+  }));
+}
+
 interface UseAiChatOptions extends AiTraceContext {
   projectId: string | undefined;
   initialSessionId?: string; // pre-load an existing session (e.g. RCA session from Step 2)
+  // True while a worker is still writing that session's answer (an RCA run in
+  // pending/running). Drives the working indicator, and its flip to false
+  // reloads the session so the finished answer appears without a manual
+  // refresh. The owner of this flag already tracks the status, so the chat
+  // never polls for it itself.
+  initialSessionPending?: boolean;
 }
 
 export function useAiChat({
@@ -15,6 +37,7 @@ export function useAiChat({
   traceId,
   traceSessionId,
   initialSessionId,
+  initialSessionPending,
 }: UseAiChatOptions) {
   const { messages, isStreaming, sendMessage, abort, setMessages } = useAIStream();
   const sessionIdRef = useRef<string | null>(null);
@@ -27,6 +50,36 @@ export function useAiChat({
   // (session creation + first network round-trip). Without this, React 19 can batch
   // setIsStreaming(true) and setIsStreaming(false) into a single frame, hiding the button.
   const [isSending, setIsSending] = useState(false);
+  // Working indicator for a pre-loaded session whose answer is still being
+  // written elsewhere; see initialSessionPending.
+  const [isLoadingSession, setIsLoadingSession] = useState(false);
+  // The session id we last cleared messages for, so a status-driven reload of
+  // the same session doesn't flash the list empty.
+  const loadedInitialSessionRef = useRef<string | null>(null);
+  // Session whose reload is owed once the user's own turn finishes; see the
+  // deferred-reload effect below.
+  const deferredReloadRef = useRef<string | null>(null);
+  // A stream is writing into `messages` right now. Read from an effect that must
+  // not itself re-run when this flips, so it lives in a ref.
+  const streamActive = isSending || isStreaming || messages.some((m) => m.isStreaming);
+  const streamActiveRef = useRef(streamActive);
+  streamActiveRef.current = streamActive;
+
+  // Replaces the message list with the session's persisted messages.
+  const loadSessionMessages = useCallback(
+    (sessionId: string, signal: AbortSignal) =>
+      fetch(`/api/projects/${projectId}/ai/sessions/${sessionId}/messages`, { signal })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (signal.aborted || !data) return;
+          setMessages(mapSessionMessages(data));
+        })
+        .catch((err) => {
+          if (err?.name !== "AbortError")
+            console.error("[AI Chat] Failed to load initial session:", err);
+        }),
+    [projectId], // eslint-disable-line react-hooks/exhaustive-deps
+  );
 
   // Reset session + messages when the user navigates to a different project so
   // a session ID from project A can never be replayed against project B's chat
@@ -43,38 +96,47 @@ export function useAiChat({
     setMessages([]);
   }, [projectId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // When initialSessionId is provided, load that session's messages on mount / change.
-  // AbortController guards against stale fetches: if the user switches between
-  // RCA sessions quickly, an older fetch resolving after a newer one would
-  // otherwise overwrite the current session's messages.
+  // Load a pre-loaded session's messages on open, and load them again when
+  // initialSessionPending flips false — that is the one signal that a
+  // worker-written answer has landed, so re-reading then is what makes it appear
+  // without a manual refresh. AbortController guards against a stale fetch
+  // overwriting a newer session's messages.
   useEffect(() => {
     if (!initialSessionId || !projectId) return;
     sessionIdRef.current = initialSessionId;
-    setMessages([]);
+    setIsLoadingSession(!!initialSessionPending);
+    // Clear only when switching sessions, not on a same-session status reload.
+    const isNewSession = loadedInitialSessionRef.current !== initialSessionId;
+    if (isNewSession) {
+      setMessages([]);
+      loadedInitialSessionRef.current = initialSessionId;
+    } else if (streamActiveRef.current) {
+      // Reloading replaces the list wholesale, which would orphan the message
+      // the user's own stream is writing into (useAIStream applies deltas by
+      // message id, so they would land nowhere and the answer would stop
+      // mid-sentence). Owe the reload instead and settle it below.
+      deferredReloadRef.current = initialSessionId;
+      return;
+    }
 
     const ac = new AbortController();
-    fetch(`/api/projects/${projectId}/ai/sessions/${initialSessionId}/messages`, {
-      signal: ac.signal,
-    })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (ac.signal.aborted || !data) return;
-        const all = (data.messages || []).map(
-          (m: { id: string; role: string; content: string; createTime: string }) => ({
-            id: m.id,
-            role: m.role as "user" | "assistant",
-            content: m.content,
-            timestamp: m.createTime,
-          }),
-        );
-        setMessages(all);
-      })
-      .catch((err) => {
-        if (err?.name !== "AbortError")
-          console.error("[AI Chat] Failed to load initial session:", err);
-      });
+    loadSessionMessages(initialSessionId, ac.signal);
     return () => ac.abort();
-  }, [initialSessionId, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initialSessionId, initialSessionPending, projectId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Settle a reload that was owed while the user was mid-turn. Runs once the
+  // stream ends, so the list picks up both the worker's answer and the user's
+  // completed exchange in one read.
+  useEffect(() => {
+    if (streamActive) return;
+    const sessionId = deferredReloadRef.current;
+    deferredReloadRef.current = null;
+    if (!sessionId || !projectId || sessionId !== sessionIdRef.current) return;
+
+    const ac = new AbortController();
+    loadSessionMessages(sessionId, ac.signal);
+    return () => ac.abort();
+  }, [streamActive, projectId, loadSessionMessages]);
 
   // Lazy session creation — only when first message is sent. The fetch is
   // cancellable so handleClose can prevent a pending response from resurrecting
@@ -171,14 +233,7 @@ export function useAiChat({
       try {
         const res = await fetch(`/api/projects/${projectId}/ai/sessions/${session.id}/messages`);
         if (res.ok) {
-          const data = await res.json();
-          const loaded = (data.messages || []).map((m: any) => ({
-            id: m.id,
-            role: m.role as "user" | "assistant",
-            content: m.content,
-            timestamp: m.createTime,
-          }));
-          setMessages(loaded);
+          setMessages(mapSessionMessages(await res.json()));
         }
       } catch (err) {
         console.error("[AI Chat] Failed to load session messages:", err);
@@ -201,7 +256,10 @@ export function useAiChat({
   return {
     // State
     messages,
-    isStreaming: isSending || isStreaming || messages.some((m) => m.isStreaming),
+    isStreaming: streamActive,
+    // Kept separate from isStreaming so the Stop button (which aborts a live
+    // stream) stays hidden while an RCA session is merely still generating.
+    isLoadingSession,
     sessions,
     historyOpen,
     currentSessionId: sessionIdRef.current,

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -8,6 +8,9 @@ const mocks = vi.hoisted(() => ({
   traceError: null as unknown,
   traceLoading: false,
   aiPanelOpen: false,
+  rca: undefined as unknown,
+  setAiInitialSessionId: vi.fn(),
+  setAiInitialSessionPending: vi.fn(),
 }));
 
 // Layout context drives the fullscreen width math (sidebar width).
@@ -16,7 +19,8 @@ vi.mock("@/components/layout/app-layout", () => ({
     aiPanelOpen: mocks.aiPanelOpen,
     setAiPanelOpen: vi.fn(),
     setAiContext: vi.fn(),
-    setAiInitialSessionId: vi.fn(),
+    setAiInitialSessionId: mocks.setAiInitialSessionId,
+    setAiInitialSessionPending: mocks.setAiInitialSessionPending,
     registerAiHost: () => () => {},
     sidebarCollapsed: mocks.sidebarCollapsed,
   }),
@@ -30,7 +34,7 @@ vi.mock("@/lib/api", () => ({ getTrace: vi.fn() }));
 vi.mock("../hooks/use-trace-stream", () => ({ useTraceStream: vi.fn() }));
 vi.mock("@/features/detectors/hooks/use-findings", () => ({
   useTraceFindings: () => ({ data: undefined }),
-  useRca: () => ({ data: undefined }),
+  useRca: () => ({ data: mocks.rca }),
   useTraceDetectorRuns: () => ({ data: undefined, isLoading: false, error: null }),
 }));
 
@@ -57,7 +61,7 @@ vi.mock("@/components/ui/resizable", () => ({
 import { ApiError } from "@/lib/api/client";
 import { TraceViewerPanel } from "./TraceViewerPanel";
 
-function renderPanel(props: { initialFullscreen?: boolean } = {}) {
+function renderPanel(props: { initialFullscreen?: boolean; autoOpenRca?: boolean } = {}) {
   const { container } = render(
     <TraceViewerPanel
       projectId="proj-1"
@@ -80,6 +84,9 @@ afterEach(() => {
   mocks.traceError = null;
   mocks.traceLoading = false;
   mocks.aiPanelOpen = false;
+  mocks.rca = undefined;
+  mocks.setAiInitialSessionId.mockClear();
+  mocks.setAiInitialSessionPending.mockClear();
 });
 
 describe("TraceViewerPanel layout", () => {
@@ -100,6 +107,25 @@ describe("TraceViewerPanel layout", () => {
     const panel = renderPanel({ initialFullscreen: false });
     expect(panel.className).toContain("w-[70%]");
     expect(panel.className).toContain("top-0");
+  });
+});
+
+describe("TraceViewerPanel RCA session hand-off", () => {
+  it("reports a still-generating run in the same update that opens its session", () => {
+    // The chat re-reads the session on every change of the pending flag, so the
+    // status has to travel with the session id. Reporting it a render later
+    // would cost a second fetch of the message list on every open.
+    mocks.rca = { rca: { sessionId: "sess-1", status: "running" } };
+    renderPanel({ autoOpenRca: true });
+    expect(mocks.setAiInitialSessionId).toHaveBeenCalledWith("sess-1");
+    expect(mocks.setAiInitialSessionPending).toHaveBeenCalledWith(true);
+  });
+
+  it("opens a finished run's session with no pending claim", () => {
+    mocks.rca = { rca: { sessionId: "sess-1", status: "done" } };
+    renderPanel({ autoOpenRca: true });
+    expect(mocks.setAiInitialSessionId).toHaveBeenCalledWith("sess-1");
+    expect(mocks.setAiInitialSessionPending).not.toHaveBeenCalledWith(true);
   });
 });
 

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -112,9 +112,8 @@ describe("TraceViewerPanel layout", () => {
 
 describe("TraceViewerPanel RCA session hand-off", () => {
   it("reports a still-generating run in the same update that opens its session", () => {
-    // The chat re-reads the session on every change of the pending flag, so the
-    // status has to travel with the session id. Reporting it a render later
-    // would cost a second fetch of the message list on every open.
+    // The chat re-reads the session on every change of the pending flag, so
+    // reporting the status a render later costs a second fetch on every open.
     mocks.rca = { rca: { sessionId: "sess-1", status: "running" } };
     renderPanel({ autoOpenRca: true });
     expect(mocks.setAiInitialSessionId).toHaveBeenCalledWith("sess-1");

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -76,7 +76,7 @@ function renderPanel(
     initialFullscreen?: boolean;
     source?: "detector" | "user";
     runTimestamp?: string;
-    autoOpenRca?: boolean
+    autoOpenRca?: boolean;
   } = {},
 ) {
   const { container } = render(

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -93,7 +93,9 @@ export function TraceViewerPanel({
     aiPanelOpen,
     setAiPanelOpen,
     setAiContext,
+    aiInitialSessionId,
     setAiInitialSessionId,
+    setAiInitialSessionPending,
     registerAiHost,
     sidebarCollapsed,
   } = useLayout();
@@ -129,6 +131,16 @@ export function TraceViewerPanel({
   const { data: rcaData } = useRca(projectId, traceFinding?.finding_id ?? "");
   const hasRca = !!traceFinding && !!rcaData?.rca;
   const rcaSessionId = rcaData?.rca?.sessionId ?? undefined;
+  // A worker is still writing this session's answer.
+  const rcaStatus = rcaData?.rca?.status;
+  const rcaPending = rcaStatus === "pending" || rcaStatus === "running";
+  // Latest-value ref so opening the chat can report the run's status in the same
+  // state update as the session id — the chat re-reads the session whenever that
+  // flag changes, so reporting it a render later costs an extra fetch on every
+  // open. A ref rather than a dependency: re-running the open effect on a status
+  // change would re-open a panel the user had closed.
+  const rcaPendingRef = useRef(rcaPending);
+  rcaPendingRef.current = rcaPending;
 
   // Auto-open chat with RCA session loaded when arriving from /detectors.
   // Waits for rcaSessionId so the chat opens already pointing at the session,
@@ -137,8 +149,26 @@ export function TraceViewerPanel({
     if (!autoOpenRca || !rcaSessionId) return;
     setAiContext({ traceId });
     setAiInitialSessionId(rcaSessionId);
+    setAiInitialSessionPending(rcaPendingRef.current);
     setAiPanelOpen(true);
-  }, [autoOpenRca, rcaSessionId, traceId, setAiContext, setAiInitialSessionId, setAiPanelOpen]);
+  }, [
+    autoOpenRca,
+    rcaSessionId,
+    traceId,
+    setAiContext,
+    setAiInitialSessionId,
+    setAiInitialSessionPending,
+    setAiPanelOpen,
+  ]);
+
+  // Keep the chat's view of the run's status current for as long as this trace's
+  // RCA session is the one open: the assistant shows a working indicator until
+  // the worker finishes writing the answer, then reloads it. useRca already polls
+  // this status, so nothing new polls here. Setting an unchanged value is a
+  // no-op, so this costs nothing when the session was opened with it already set.
+  useEffect(() => {
+    setAiInitialSessionPending(!!rcaSessionId && aiInitialSessionId === rcaSessionId && rcaPending);
+  }, [aiInitialSessionId, rcaSessionId, rcaPending, setAiInitialSessionPending]);
 
   const {
     data: trace,
@@ -252,6 +282,8 @@ export function TraceViewerPanel({
                 onClick={() => {
                   setAiContext({ traceId });
                   setAiInitialSessionId(rcaSessionId);
+                  // Same update as the session id — see rcaPendingRef above.
+                  setAiInitialSessionPending(rcaPending);
                   setAiPanelOpen(true);
                 }}
                 className="rounded-md border border-red-300 bg-red-50 px-2 py-1 text-[11px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-800 dark:bg-red-950/40 dark:text-red-400 dark:hover:bg-red-950/60"

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -134,11 +134,9 @@ export function TraceViewerPanel({
   // A worker is still writing this session's answer.
   const rcaStatus = rcaData?.rca?.status;
   const rcaPending = rcaStatus === "pending" || rcaStatus === "running";
-  // Latest-value ref so opening the chat can report the run's status in the same
-  // state update as the session id — the chat re-reads the session whenever that
-  // flag changes, so reporting it a render later costs an extra fetch on every
-  // open. A ref rather than a dependency: re-running the open effect on a status
-  // change would re-open a panel the user had closed.
+  // A ref so the open effect can report the status alongside the session id
+  // without depending on it: the chat re-reads the session on every change of
+  // the flag, and re-running the effect would re-open a closed panel.
   const rcaPendingRef = useRef(rcaPending);
   rcaPendingRef.current = rcaPending;
 
@@ -161,11 +159,9 @@ export function TraceViewerPanel({
     setAiPanelOpen,
   ]);
 
-  // Keep the chat's view of the run's status current for as long as this trace's
-  // RCA session is the one open: the assistant shows a working indicator until
-  // the worker finishes writing the answer, then reloads it. useRca already polls
-  // this status, so nothing new polls here. Setting an unchanged value is a
-  // no-op, so this costs nothing when the session was opened with it already set.
+  // Keep the flag current while this trace's RCA session is the open one, so the
+  // chat clears its indicator and reloads the answer when the run finishes.
+  // useRca already polls the status, and setting an unchanged value is a no-op.
   useEffect(() => {
     setAiInitialSessionPending(!!rcaSessionId && aiInitialSessionId === rcaSessionId && rcaPending);
   }, [aiInitialSessionId, rcaSessionId, rcaPending, setAiInitialSessionPending]);


### PR DESCRIPTION
Fixes #935 

## Summary

Opening a detector-flagged trace pre-loads the RCA session, but the answer is written by a worker *after* the chat is already on screen. The chat showed the prompt with no sign of activity and never picked the answer up, so the panel looked idle until the user refreshed the page.

The host that opens the session (`TraceViewerPanel`) already polls the run's authoritative status via `useRca`, so it now reports that to the chat as `initialSessionPending`. True drives a working indicator; the flip to false re-reads the session so the finished answer appears on its own.

## Type of Change

- [x] fix - A bug fix

## Details

**Why nothing showed.** Normal chat streams to the browser, so `isStreaming` covers it. An RCA answer is generated out-of-band by `detector-rca-processor`, and the assistant message isn't persisted until the stream completes — so mid-run the session genuinely contains only the user prompt, and the chat's one-shot `GET .../messages` had no reason to look again.

**What changed.**

- `useAiChat` gains `initialSessionPending` and exposes `isLoadingSession`. The session-load effect now also runs when that flag changes, which is what makes a worker-written answer appear without a refresh. It clears messages only when the session id itself changes, so a status-driven reload doesn't blank the list.
- `AiAssistantPanel` passes `sessionStreaming={isStreaming || isLoadingSession}` — a widening OR, so the existing streaming path is untouched.
- `TraceViewerPanel` mirrors `rcaData.rca.status` into the flag while its RCA session is the one open, and reports it in the **same state update** as the session id. Reporting it a render later costs a second fetch of the message list on every open.
- The flag is deliberately separate from `isStreaming` so the **Stop** button — which aborts a live stream that doesn't exist here — stays hidden.

**Nothing new polls.** `useRca` already polled this status on `main`; this only consumes it.

**Scope.** This covers a trace whose finding and RCA row already exist. A trace opened *before* detection has run is a separate gap (no finding yet, so no session to indicate on) — addressed in the follow-up PRs.

## Screenshots / Recordings (if applicable)

### Before the Fix
No indication of the running state even force a `finding_id` status to be `running`

https://github.com/user-attachments/assets/0202384c-6e42-4889-875d-67b3dfbd70c0

Indicating "Analyzing the trace" when a `finding_id` is `running

https://github.com/user-attachments/assets/54185c82-3fbf-43c8-9056-5d6ecbec823a


## Testing

Automated:

- `use-ai-chat.test.ts` — the indicator holds while the run is pending, then the answer is reloaded on completion; and a session that is already complete on open loads exactly once.
- `TraceViewerPanel.test.tsx` — the open path reports a still-generating run in the same update as the session id (verified to fail when that line is removed).

Manual. The in-flight window is short — the run finishes in tens of seconds — so the
practical way to see it (and to record it) is to drive the status directly. **Local dev
database only**, and note the row's original status so you can put it back:

1. `UPDATE detector_rcas SET status='running' WHERE finding_id='<id>';`
2. Load the trace and open the session via the Alert badge → faint spinner at the bottom of the message list, no Stop button.
3. `UPDATE detector_rcas SET status='done' WHERE finding_id='<id>';` → within ~3s the spinner clears and the analysis appears.

In DevTools, requests to `/ai/sessions/<id>/messages`: **one** on load, **one** after the flip. On `main` there is exactly one, ever, and the flip changes nothing.

Set the status *before* the page loads — `done` is terminal, so `useRca` has stopped polling and a live page cannot observe a backwards transition.

Note what this does and doesn't prove. Forcing `running` on a row that already has a
`result` is a state the pipeline never produces, so the analysis text is already in the
message list: you're verifying the indicator and the reload, not the answer materializing.
Only a genuinely in-flight run shows that, which is what the recording below captures.

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a working indicator and auto-loads the RCA answer when it’s generated out-of-band, labeled “Analyzing the trace…” so detector-flagged traces no longer look idle or need a refresh. Fixes #965.

- **Bug Fixes**
  - `TraceViewerPanel` sets `initialSessionPending` in the same update as the RCA `sessionId` (auto-open and badge click), and keeps it synced while the session is open by mirroring `useRca` status (no new polling).
  - `AppLayout` adds `aiInitialSessionPending` to layout context, resets it on navigation, and passes it to the chat; `ai-chat-context` forwards `initialSessionPending` to `useAiChat`.
  - `useAiChat` adds `initialSessionPending` → `isLoadingSession`; reloads messages when pending flips to false, avoids clearing on same-session reloads, and defers the reload until any active user stream finishes; separates loading from `isStreaming` so Stop stays hidden for non-stream runs.
  - `AiAssistantPanel` widens activity to `isStreaming || isLoadingSession`; `MessageList` shows a labeled wait (“Analyzing the trace…”) for out-of-band runs and an unlabeled spinner for live streams, using `LoadingState` for accessible status.
  - Tests cover pending→done reload, deferring reload until a stream ends, already-complete sessions, the same-update pending hand-off, and the labeled waiting indicator.

<sup>Written for commit 034b6a80a2f38626f03b2e50c9ff3631417596bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





