### PR TITLE
fix(traces): keep detector results live on a freshly opened trace

### DIFF
--- a/backend/rest/routers/internal.py
+++ b/backend/rest/routers/internal.py
@@ -4,6 +4,7 @@ These endpoints are protected by X-Internal-Secret header and not exposed public
 """
 
 import hmac
+import json
 import logging
 from datetime import datetime
 from typing import Annotated, Any
@@ -18,6 +19,7 @@ from rest.schemas.detectors import (
 )
 from rest.sql_utils import escape_ilike, to_utc_naive
 from shared.config import settings
+from shared.detector_keys import detection_claim_key
 
 logger = logging.getLogger(__name__)
 
@@ -662,6 +664,74 @@ async def list_trace_detector_runs(trace_id: str, project_id: str):
             row_dict["timestamp"] = row_dict["timestamp"].isoformat()
         runs.append(row_dict)
     return {"runs": runs}
+
+
+_DETECTION_STATES = frozenset({"deciding", "sampled_out", "pending"})
+
+
+class TraceDetectionStateResponse(BaseModel):
+    """Per-trace detection state.
+
+    ``state`` is the worker's enqueue-claim state, or ``None`` when no claim record
+    is readable (never detected, expired, or Redis down). ``None`` means "no
+    signal", not "nothing is coming".
+    """
+
+    state: str | None = None
+    detector_ids: list[str] = Field(default_factory=list)
+
+
+@router.get(
+    "/traces/{trace_id}/detection-state",
+    response_model=TraceDetectionStateResponse,
+    dependencies=[Depends(verify_internal_secret)],
+)
+async def get_trace_detection_state(trace_id: str, project_id: str):
+    """Report whether detection is queued for a trace, and which detectors ran.
+
+    Detection is debounced (the evaluator waits for the trace to go quiet), so a
+    fresh trace has no findings or runs for roughly a minute. The worker already
+    records its enqueue decision per trace; exposing it lets a client show
+    "detection in progress" right away and know which runs to expect, instead of
+    guessing with a timer. ``sampled_out`` sticks: every detector was rejected, so
+    no run or finding will ever appear.
+
+    Fails soft by contract — an unreadable claim record returns an empty state
+    rather than an error, since this is only a hint and the client has a fallback.
+
+    Args:
+        trace_id (str): Trace whose detection state to report.
+        project_id (str): Project that owns the trace; scopes the claim key.
+
+    Returns:
+        TraceDetectionStateResponse: ``state`` one of ``deciding``,
+            ``pending``, ``sampled_out`` or ``None``, plus ``detector_ids``
+            (the detectors enqueued for this trace; empty unless ``pending``).
+    """
+    from shared.redis import get_async_redis_client
+
+    key = detection_claim_key(project_id, trace_id)
+    try:
+        raw = await get_async_redis_client().get(key)
+        payload = json.loads(raw) if raw else None
+    except Exception:
+        # Redis down or a payload we cannot decode — both are "no signal".
+        logger.warning("detection-state: unreadable claim for trace %s", trace_id, exc_info=True)
+        return TraceDetectionStateResponse()
+
+    if not isinstance(payload, dict):
+        return TraceDetectionStateResponse()
+
+    # Drop an unrecognized future state rather than leaking it to clients that
+    # branch on the known vocabulary.
+    state = payload.get("state")
+    raw_ids = payload.get("detector_ids")
+    return TraceDetectionStateResponse(
+        state=state if state in _DETECTION_STATES else None,
+        detector_ids=[d for d in raw_ids if isinstance(d, str)]
+        if isinstance(raw_ids, list)
+        else [],
+    )
 
 
 def _fetch_sample_summaries(

--- a/backend/shared/detector_keys.py
+++ b/backend/shared/detector_keys.py
@@ -1,0 +1,23 @@
+"""Redis key formats for detector state, shared by the worker and the REST API.
+
+Both processes address the same records, so the formats live here: importing
+across ``worker`` and ``rest`` would drag one's dependencies into the other.
+"""
+
+
+def detection_claim_key(project_id: str, trace_id: str) -> str:
+    """Build the Redis key for a trace's detector-enqueue claim.
+
+    The key — not its value — is the exactly-once guard: a single ``SET NX`` on it
+    decides which ingest batch may enqueue detection for the trace. The value
+    records the outcome (``deciding``, ``pending`` or ``sampled_out``), which the
+    REST API reports so clients know whether results are coming.
+
+    Args:
+        project_id (str): Project that owns the trace.
+        trace_id (str): Trace being claimed for enqueue.
+
+    Returns:
+        str: The namespaced Redis key for this ``(project, trace)`` claim.
+    """
+    return f"detector-enq:{project_id}:{trace_id}"

--- a/backend/worker/detector_tasks.py
+++ b/backend/worker/detector_tasks.py
@@ -17,6 +17,8 @@ import json
 import logging
 import uuid
 
+from shared.detector_keys import detection_claim_key
+
 logger = logging.getLogger(__name__)
 
 # BullMQ queue name — must match TypeScript DETECTOR_RUN_QUEUE constant
@@ -52,19 +54,12 @@ def _get_redis():
 
 
 def _lock_key(project_id: str, trace_id: str) -> str:
-    """Build the Redis key for the per-trace enqueue claim (the NX dedup marker).
+    """Redis key for the per-trace enqueue claim (the NX dedup marker).
 
-    The key — not its value — is the exactly-once guard: a single ``SET NX`` on
-    it decides which batch is allowed to enqueue detection for the trace.
-
-    Args:
-        project_id (str): Project that owns the trace.
-        trace_id (str): Trace being claimed for enqueue.
-
-    Returns:
-        str: The namespaced Redis key for this ``(project, trace)`` claim.
+    The format lives in ``shared.detector_keys`` because the REST API reads these
+    records too; see :func:`shared.detector_keys.detection_claim_key`.
     """
-    return f"detector-enq:{project_id}:{trace_id}"
+    return detection_claim_key(project_id, trace_id)
 
 
 def _release_lock_if_value(redis_client, key: str, expected: str) -> None:

--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/detection-state/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/detection-state/route.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextRequest: class {},
+  NextResponse: { json: (body: unknown, init?: { status?: number }) => Response.json(body, init) },
+}));
+
+vi.mock("@/env", () => ({ env: { INTERNAL_API_SECRET: "test-secret" } }));
+
+const requireAuthMock = vi.fn();
+const requireProjectAccessMock = vi.fn();
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: (...args: unknown[]) => requireAuthMock(...args),
+  requireProjectAccess: (...args: unknown[]) => requireProjectAccessMock(...args),
+  successResponse: (data: unknown, status = 200) => Response.json(data, { status }),
+}));
+
+import { GET } from "./route";
+
+const backendFetchMock = vi.fn();
+vi.stubGlobal("fetch", backendFetchMock);
+
+const EMPTY = { state: null, detector_ids: [] };
+
+function makeParams() {
+  return { params: Promise.resolve({ projectId: "proj-1", traceId: "trace-1" }) };
+}
+
+function backendResponse(body: unknown, status = 200) {
+  return { ok: status >= 200 && status < 300, status, json: async () => body };
+}
+
+beforeEach(() => {
+  requireAuthMock.mockReset();
+  requireProjectAccessMock.mockReset();
+  backendFetchMock.mockReset();
+  requireAuthMock.mockResolvedValue({ user: { id: "user-1" } });
+  requireProjectAccessMock.mockResolvedValue({ project: { workspaceId: "ws-1" } });
+});
+
+describe("GET .../traces/[traceId]/detection-state", () => {
+  it("returns the auth error when unauthenticated", async () => {
+    requireAuthMock.mockResolvedValue({
+      error: { status: 401, json: async () => ({ error: "Unauthorized" }) },
+    });
+    const res = await GET({} as Parameters<typeof GET>[0], makeParams());
+    expect(res.status).toBe(401);
+    expect(backendFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the access error when the user lacks project access", async () => {
+    requireProjectAccessMock.mockResolvedValue({
+      error: { status: 403, json: async () => ({ error: "Forbidden" }) },
+    });
+    const res = await GET({} as Parameters<typeof GET>[0], makeParams());
+    expect(res.status).toBe(403);
+    expect(backendFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("passes the backend state through, with the internal secret", async () => {
+    const state = { state: "pending", detector_ids: ["d1", "d2"] };
+    backendFetchMock.mockResolvedValue(backendResponse(state));
+
+    const res = await GET({} as Parameters<typeof GET>[0], makeParams());
+    expect(await res.json()).toEqual(state);
+
+    const [url, init] = backendFetchMock.mock.calls[0];
+    expect(url).toContain("/traces/trace-1/detection-state");
+    expect(url).toContain("project_id=proj-1");
+    expect(init.headers["X-Internal-Secret"]).toBe("test-secret");
+  });
+
+  it("reports an empty state when the backend errors", async () => {
+    // Fail soft: the trace page treats this as "no signal" and falls back to its
+    // own wait, rather than surfacing an error for what is only a hint.
+    backendFetchMock.mockResolvedValue(backendResponse({ detail: "boom" }, 500));
+    const res = await GET({} as Parameters<typeof GET>[0], makeParams());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(EMPTY);
+  });
+
+  it("reports an empty state when the backend is unreachable", async () => {
+    backendFetchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+    const res = await GET({} as Parameters<typeof GET>[0], makeParams());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(EMPTY);
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/detection-state/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/detection-state/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from "next/server";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+import { env } from "@/env";
+
+const BACKEND_URL = process.env.BACKEND_INTERNAL_URL || "http://localhost:8000";
+const INTERNAL_API_SECRET = env.INTERNAL_API_SECRET || "";
+
+type RouteParams = { params: Promise<{ projectId: string; traceId: string }> };
+
+/**
+ * Whether detection is queued for a trace, and which detectors to expect. Lets the
+ * trace page show "detection in progress" during the ~1min debounce and stop
+ * polling once nothing is coming (`sampled_out`) or every run has landed.
+ *
+ * Returns an empty state on any backend failure: it is a hint, not page data.
+ */
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, traceId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const empty = { state: null, detector_ids: [] };
+  try {
+    const res = await fetch(
+      `${BACKEND_URL}/api/v1/internal/traces/${encodeURIComponent(traceId)}/detection-state?project_id=${encodeURIComponent(projectId)}`,
+      { headers: { "X-Internal-Secret": INTERNAL_API_SECRET } },
+    );
+    if (!res.ok) return successResponse(empty);
+    return successResponse(await res.json());
+  } catch (err) {
+    console.error("[trace-detection-state proxy] fetch error:", err);
+    return successResponse(empty);
+  }
+}

--- a/frontend/ui/src/features/detectors/hooks/use-findings.polling.test.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-findings.polling.test.ts
@@ -8,19 +8,27 @@ import {
   findingsPollInterval,
   detectorRunsPollInterval,
   rcaPollInterval,
+  detectionStatePollInterval,
+  detectionInFlight,
+  detectionRuledOut,
   TRACE_POLL_INTERVAL_MS,
   TRACE_POLL_WINDOW_MS,
   TRACE_POLL_GRACE_MS,
+  type TraceDetectionState,
 } from "./use-findings";
 
 // Findings and runs arrive a while after ingestion (evaluation is debounced
-// ~1min), so a trace opened live has to poll for them — and has to stop. These
-// cases pin down each stop condition.
+// ~1min), so a trace opened live has to poll for them — and has to stop, driven by
+// the detection state rather than a timer. These cases pin down each condition.
+
+const PENDING = (ids: string[]): TraceDetectionState => ({ state: "pending", detectorIds: ids });
+const SAMPLED_OUT: TraceDetectionState = { state: "sampled_out", detectorIds: [] };
+const NO_SIGNAL: TraceDetectionState = { state: null, detectorIds: [] };
 
 describe("findingsPollInterval — trace-page findings poll cadence", () => {
-  it("polls at the interval while no finding exists and the window is open", () => {
+  it("polls at the interval while no finding exists and the wait is open", () => {
     expect(findingsPollInterval(0, 0)).toBe(TRACE_POLL_INTERVAL_MS);
-    expect(findingsPollInterval(0, TRACE_POLL_WINDOW_MS - 1)).toBe(TRACE_POLL_INTERVAL_MS);
+    expect(findingsPollInterval(0, TRACE_POLL_GRACE_MS - 1)).toBe(TRACE_POLL_INTERVAL_MS);
   });
 
   it("stops immediately once a finding exists (Alert button + useRca take over)", () => {
@@ -29,24 +37,107 @@ describe("findingsPollInterval — trace-page findings poll cadence", () => {
     expect(findingsPollInterval(3, 5000)).toBe(false);
   });
 
-  it("stops once the window elapses so an unflagged trace doesn't poll forever", () => {
-    expect(findingsPollInterval(0, TRACE_POLL_WINDOW_MS)).toBe(false);
+  it("does not poll at all when detection is authoritatively ruled out", () => {
+    // sampled_out sticks: no finding will ever appear, so waiting is waste.
+    expect(findingsPollInterval(0, 0, SAMPLED_OUT)).toBe(false);
+  });
+
+  it("keeps polling through the debounce while detection is pending", () => {
+    // The ~60s debounce must not be read as "nothing coming".
+    expect(findingsPollInterval(0, 65_000, PENDING(["d1"]))).toBe(TRACE_POLL_INTERVAL_MS);
+  });
+
+  it("gives an unsignalled trace only the grace period, not the full window", () => {
+    // No record usually means an older trace whose claim expired — polling it for
+    // minutes would cost every historical trace view a standing poll.
+    expect(findingsPollInterval(0, 0, NO_SIGNAL)).toBe(TRACE_POLL_INTERVAL_MS);
+    expect(findingsPollInterval(0, TRACE_POLL_GRACE_MS, NO_SIGNAL)).toBe(false);
+  });
+
+  it("keeps the long window while detection is pending", () => {
+    // Results are genuinely on the way here, so the wait outlasts the debounce.
+    expect(findingsPollInterval(0, TRACE_POLL_GRACE_MS, PENDING(["d1"]))).toBe(
+      TRACE_POLL_INTERVAL_MS,
+    );
+    expect(findingsPollInterval(0, TRACE_POLL_WINDOW_MS, PENDING(["d1"]))).toBe(false);
+  });
+
+  it("stops once the wait elapses so an unflagged trace doesn't poll forever", () => {
+    expect(findingsPollInterval(0, TRACE_POLL_GRACE_MS)).toBe(false);
     expect(findingsPollInterval(0, TRACE_POLL_WINDOW_MS + 10_000)).toBe(false);
   });
 });
 
 describe("detectorRunsPollInterval — trace-page detector-runs poll cadence", () => {
-  it("polls while the window is open so runs appear as they complete", () => {
-    expect(detectorRunsPollInterval(0)).toBe(TRACE_POLL_INTERVAL_MS);
-    expect(detectorRunsPollInterval(TRACE_POLL_WINDOW_MS - 1)).toBe(TRACE_POLL_INTERVAL_MS);
+  it("polls while the wait is open so runs appear as they complete", () => {
+    expect(detectorRunsPollInterval(0, 0)).toBe(TRACE_POLL_INTERVAL_MS);
+    expect(detectorRunsPollInterval(0, TRACE_POLL_GRACE_MS - 1)).toBe(TRACE_POLL_INTERVAL_MS);
+    // A queued detection earns the longer wait.
+    expect(detectorRunsPollInterval(0, TRACE_POLL_WINDOW_MS - 1, PENDING(["a"]))).toBe(
+      TRACE_POLL_INTERVAL_MS,
+    );
   });
 
-  it("keeps polling through the debounce, which must not be read as 'nothing coming'", () => {
-    expect(detectorRunsPollInterval(65_000)).toBe(TRACE_POLL_INTERVAL_MS);
+  it("stops as soon as every enqueued detector has a run (precise completion)", () => {
+    // 3 expected, 3 present → done, regardless of how much window remains.
+    expect(detectorRunsPollInterval(3, 0, PENDING(["a", "b", "c"]))).toBe(false);
   });
 
-  it("stops once the window elapses", () => {
-    expect(detectorRunsPollInterval(TRACE_POLL_WINDOW_MS)).toBe(false);
+  it("keeps polling while runs are still missing, even past the window", () => {
+    // The expected count outranks the clock: 1 of 3 landed.
+    expect(detectorRunsPollInterval(1, 65_000, PENDING(["a", "b", "c"]))).toBe(
+      TRACE_POLL_INTERVAL_MS,
+    );
+  });
+
+  it("does not poll at all when detection is ruled out", () => {
+    expect(detectorRunsPollInterval(0, 0, SAMPLED_OUT)).toBe(false);
+  });
+
+  it("stops at the window when an expected run never materializes", () => {
+    // Safety net: a dead job must not leave the page polling forever.
+    expect(detectorRunsPollInterval(1, TRACE_POLL_GRACE_MS, PENDING(["a", "b"]))).toBe(
+      TRACE_POLL_INTERVAL_MS,
+    );
+    expect(detectorRunsPollInterval(1, TRACE_POLL_WINDOW_MS, PENDING(["a", "b"]))).toBe(false);
+  });
+
+  it("stops at the grace period when nothing signals that runs are coming", () => {
+    expect(detectorRunsPollInterval(0, TRACE_POLL_GRACE_MS)).toBe(false);
+  });
+});
+
+describe("detectionStatePollInterval — re-reading the claim record", () => {
+  it("re-reads only the transient deciding state", () => {
+    expect(detectionStatePollInterval("deciding")).toBe(TRACE_POLL_INTERVAL_MS);
+  });
+
+  it("stops on sticky states — there is nothing further to learn", () => {
+    expect(detectionStatePollInterval("pending")).toBe(false);
+    expect(detectionStatePollInterval("sampled_out")).toBe(false);
+  });
+
+  it("does not poll a missing record (would add a standing poll to old traces)", () => {
+    expect(detectionStatePollInterval(null)).toBe(false);
+  });
+});
+
+describe("detection state predicates", () => {
+  it("treats pending and deciding as in flight — the early working signal", () => {
+    expect(detectionInFlight(PENDING(["d1"]))).toBe(true);
+    expect(detectionInFlight({ state: "deciding", detectorIds: [] })).toBe(true);
+  });
+
+  it("is not in flight for sampled_out, missing signal, or undefined", () => {
+    expect(detectionInFlight(SAMPLED_OUT)).toBe(false);
+    expect(detectionInFlight(NO_SIGNAL)).toBe(false);
+    expect(detectionInFlight(undefined)).toBe(false);
+  });
+
+  it("rules out only sampled_out — an absent signal is not a promise of nothing", () => {
+    expect(detectionRuledOut(SAMPLED_OUT)).toBe(true);
+    expect(detectionRuledOut(NO_SIGNAL)).toBe(false);
+    expect(detectionRuledOut(undefined)).toBe(false);
   });
 });
 
@@ -77,12 +168,21 @@ describe("rcaPollInterval — RCA poll cadence through the finding→row gap", (
   });
 });
 
-/** Renders useTraceFindings with a stubbed backend; `calls` counts the fetches. */
-function renderTraceFindings(findingsOnCall: (call: number) => unknown[]) {
+/**
+ * Renders useTraceFindings with a stubbed backend; `calls` counts the findings
+ * fetches. Routed by URL because the hook also reads the detection state.
+ */
+function renderTraceFindings(
+  detectionState: { state: string; detector_ids: string[] },
+  findingsOnCall: (call: number) => unknown[],
+) {
   const calls = { findings: 0 };
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () => {
+    vi.fn(async (url: string) => {
+      if (url.includes("/detection-state")) {
+        return { ok: true, json: async () => detectionState };
+      }
       const call = ++calls.findings;
       return { ok: true, json: async () => ({ findings: findingsOnCall(call) }) };
     }),
@@ -103,8 +203,8 @@ describe("useTraceFindings — polling is wired to the interval", () => {
 
   it("keeps fetching while findings are empty, then stops once one arrives", async () => {
     vi.useFakeTimers();
-    // Empty for the first two polls (the worker hasn't flagged yet), then flagged.
-    const calls = renderTraceFindings((call) =>
+    // One detector queued, so the gate stays open. Empty for two polls, then flagged.
+    const calls = renderTraceFindings({ state: "pending", detector_ids: ["d1"] }, (call) =>
       call > 2 ? [{ finding_id: "f1", trace_id: "t1" }] : [],
     );
 
@@ -122,13 +222,12 @@ describe("useTraceFindings — polling is wired to the interval", () => {
     expect(calls.findings).toBe(3);
   });
 
-  it("stops polling once the window has elapsed", async () => {
+  it("never polls when detection is sampled out (no detector will ever run)", async () => {
     vi.useFakeTimers();
-    const calls = renderTraceFindings(() => []);
+    const calls = renderTraceFindings({ state: "sampled_out", detector_ids: [] }, () => []);
 
-    await vi.advanceTimersByTimeAsync(TRACE_POLL_WINDOW_MS + TRACE_POLL_INTERVAL_MS * 2);
-    const atWindow = calls.findings;
+    // One initial read, then nothing.
     await vi.advanceTimersByTimeAsync(TRACE_POLL_INTERVAL_MS * 5);
-    expect(calls.findings).toBe(atWindow);
+    expect(calls.findings).toBe(1);
   });
 });

--- a/frontend/ui/src/features/detectors/hooks/use-findings.polling.test.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-findings.polling.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import {
+  useTraceFindings,
+  findingsPollInterval,
+  detectorRunsPollInterval,
+  rcaPollInterval,
+  TRACE_POLL_INTERVAL_MS,
+  TRACE_POLL_WINDOW_MS,
+  TRACE_POLL_GRACE_MS,
+} from "./use-findings";
+
+// Findings and runs arrive a while after ingestion (evaluation is debounced
+// ~1min), so a trace opened live has to poll for them — and has to stop. These
+// cases pin down each stop condition.
+
+describe("findingsPollInterval — trace-page findings poll cadence", () => {
+  it("polls at the interval while no finding exists and the window is open", () => {
+    expect(findingsPollInterval(0, 0)).toBe(TRACE_POLL_INTERVAL_MS);
+    expect(findingsPollInterval(0, TRACE_POLL_WINDOW_MS - 1)).toBe(TRACE_POLL_INTERVAL_MS);
+  });
+
+  it("stops immediately once a finding exists (Alert button + useRca take over)", () => {
+    // Even at t=0 with the window wide open, a finding ends polling.
+    expect(findingsPollInterval(1, 0)).toBe(false);
+    expect(findingsPollInterval(3, 5000)).toBe(false);
+  });
+
+  it("stops once the window elapses so an unflagged trace doesn't poll forever", () => {
+    expect(findingsPollInterval(0, TRACE_POLL_WINDOW_MS)).toBe(false);
+    expect(findingsPollInterval(0, TRACE_POLL_WINDOW_MS + 10_000)).toBe(false);
+  });
+});
+
+describe("detectorRunsPollInterval — trace-page detector-runs poll cadence", () => {
+  it("polls while the window is open so runs appear as they complete", () => {
+    expect(detectorRunsPollInterval(0)).toBe(TRACE_POLL_INTERVAL_MS);
+    expect(detectorRunsPollInterval(TRACE_POLL_WINDOW_MS - 1)).toBe(TRACE_POLL_INTERVAL_MS);
+  });
+
+  it("keeps polling through the debounce, which must not be read as 'nothing coming'", () => {
+    expect(detectorRunsPollInterval(65_000)).toBe(TRACE_POLL_INTERVAL_MS);
+  });
+
+  it("stops once the window elapses", () => {
+    expect(detectorRunsPollInterval(TRACE_POLL_WINDOW_MS)).toBe(false);
+  });
+});
+
+describe("rcaPollInterval — RCA poll cadence through the finding→row gap", () => {
+  it("polls while the run is in flight (pending/running), regardless of elapsed time", () => {
+    expect(rcaPollInterval("pending", 0)).toBe(TRACE_POLL_INTERVAL_MS);
+    // Still polling even past the window — an in-flight run isn't abandoned.
+    expect(rcaPollInterval("running", TRACE_POLL_WINDOW_MS + 60_000)).toBe(TRACE_POLL_INTERVAL_MS);
+  });
+
+  it("keeps polling for a missing row through the grace period", () => {
+    // The finding is written before the RCA row, so a fresh finding has no row
+    // yet (status undefined) and must still be waited on.
+    expect(rcaPollInterval(undefined, 0)).toBe(TRACE_POLL_INTERVAL_MS);
+    expect(rcaPollInterval(undefined, TRACE_POLL_GRACE_MS - 1)).toBe(TRACE_POLL_INTERVAL_MS);
+  });
+
+  it("gives a missing row only the grace period, not the full window", () => {
+    // An RCA-disabled detector never writes a row, so waiting minutes for one
+    // would poll every such finding for the whole window.
+    expect(rcaPollInterval(undefined, TRACE_POLL_GRACE_MS)).toBe(false);
+    expect(TRACE_POLL_GRACE_MS).toBeLessThan(TRACE_POLL_WINDOW_MS);
+  });
+
+  it("stops on a terminal status", () => {
+    expect(rcaPollInterval("done", 0)).toBe(false);
+    expect(rcaPollInterval("failed", 0)).toBe(false);
+  });
+});
+
+/** Renders useTraceFindings with a stubbed backend; `calls` counts the fetches. */
+function renderTraceFindings(findingsOnCall: (call: number) => unknown[]) {
+  const calls = { findings: 0 };
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => {
+      const call = ++calls.findings;
+      return { ok: true, json: async () => ({ findings: findingsOnCall(call) }) };
+    }),
+  );
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  renderHook(() => useTraceFindings("p1", "t1"), {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client }, children),
+  });
+  return calls;
+}
+
+describe("useTraceFindings — polling is wired to the interval", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps fetching while findings are empty, then stops once one arrives", async () => {
+    vi.useFakeTimers();
+    // Empty for the first two polls (the worker hasn't flagged yet), then flagged.
+    const calls = renderTraceFindings((call) =>
+      call > 2 ? [{ finding_id: "f1", trace_id: "t1" }] : [],
+    );
+
+    // Initial fetch.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls.findings).toBe(1);
+
+    // Two poll ticks: empty, empty → keeps polling.
+    await vi.advanceTimersByTimeAsync(TRACE_POLL_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(TRACE_POLL_INTERVAL_MS);
+    expect(calls.findings).toBe(3);
+
+    // The third response carried a finding → polling stops; further time is inert.
+    await vi.advanceTimersByTimeAsync(TRACE_POLL_INTERVAL_MS * 4);
+    expect(calls.findings).toBe(3);
+  });
+
+  it("stops polling once the window has elapsed", async () => {
+    vi.useFakeTimers();
+    const calls = renderTraceFindings(() => []);
+
+    await vi.advanceTimersByTimeAsync(TRACE_POLL_WINDOW_MS + TRACE_POLL_INTERVAL_MS * 2);
+    const atWindow = calls.findings;
+    await vi.advanceTimersByTimeAsync(TRACE_POLL_INTERVAL_MS * 5);
+    expect(calls.findings).toBe(atWindow);
+  });
+});

--- a/frontend/ui/src/features/detectors/hooks/use-findings.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-findings.ts
@@ -92,6 +92,11 @@ function fetchRca(projectId: string, findingId: string) {
 // The worker writes findings, runs and RCA after a trace is ingested, so a trace
 // opened live starts with none of them. These queries poll until they arrive, so
 // the Alert button, Detectors tab and RCA answer show up without a refresh.
+//
+// The detection state (useTraceDetectionState) says when to stop: "sampled_out"
+// means nothing will ever appear, "pending" names the runs to expect. Only a
+// queued detection earns the long window; without that signal — an expired record
+// on an older trace — we wait out the write race and give up.
 export const TRACE_POLL_INTERVAL_MS = 3000;
 // Waiting for results the pipeline still owes us. Must outlast it: evaluation
 // waits for the trace to go quiet (EVALUATOR_DELAY, ~60s) and jobs have no cap.
@@ -101,23 +106,77 @@ export const TRACE_POLL_WINDOW_MS = 300000;
 // coming at all.
 export const TRACE_POLL_GRACE_MS = 30000;
 
+/** Worker enqueue-claim state for a trace; `null` means "no signal". */
+export type DetectionStateValue = "deciding" | "pending" | "sampled_out" | null;
+
+export interface TraceDetectionState {
+  state: DetectionStateValue;
+  /** Detectors enqueued for this trace. Populated only when state is "pending". */
+  detectorIds: string[];
+}
+
+/** Nothing will ever appear for this trace, so don't poll and don't promise results. */
+export function detectionRuledOut(detection: TraceDetectionState | undefined): boolean {
+  return detection?.state === "sampled_out";
+}
+
+/** Detection is queued or being decided — the working signal, before any result exists. */
+export function detectionInFlight(detection: TraceDetectionState | undefined): boolean {
+  return detection?.state === "pending" || detection?.state === "deciding";
+}
+
 /** Poll until `settled`, giving up at `windowMs`. */
 function pollUntilSettled(settled: boolean, elapsedMs: number, windowMs: number): number | false {
   if (settled) return false;
   return elapsedMs < windowMs ? TRACE_POLL_INTERVAL_MS : false;
 }
 
-/** Settled once a finding exists: the Alert button and useRca take over. */
-export function findingsPollInterval(findingCount: number, elapsedMs: number): number | false {
-  return pollUntilSettled(findingCount > 0, elapsedMs, TRACE_POLL_WINDOW_MS);
+/**
+ * How long to keep waiting: the long window only when detection says results are
+ * still coming. Absent that, a trace whose claim record has expired would poll for
+ * minutes with nothing on the way.
+ */
+function windowFor(detection?: TraceDetectionState): number {
+  return detectionInFlight(detection) ? TRACE_POLL_WINDOW_MS : TRACE_POLL_GRACE_MS;
+}
+
+/** Settled once a finding exists (Alert button and useRca take over) or is ruled out. */
+export function findingsPollInterval(
+  findingCount: number,
+  elapsedMs: number,
+  detection?: TraceDetectionState,
+): number | false {
+  return pollUntilSettled(
+    findingCount > 0 || detectionRuledOut(detection),
+    elapsedMs,
+    windowFor(detection),
+  );
 }
 
 /**
- * A run row appears only once its detector finishes, so there is no way to tell
- * "all runs are in" from "one is still coming". Poll for the whole window.
+ * A run row appears only once its detector finishes, so completion means every
+ * enqueued detector has one. Also settled when detection is ruled out.
  */
-export function detectorRunsPollInterval(elapsedMs: number): number | false {
-  return elapsedMs < TRACE_POLL_WINDOW_MS ? TRACE_POLL_INTERVAL_MS : false;
+export function detectorRunsPollInterval(
+  runCount: number,
+  elapsedMs: number,
+  detection?: TraceDetectionState,
+): number | false {
+  const expected = detection?.state === "pending" ? detection.detectorIds.length : 0;
+  return pollUntilSettled(
+    detectionRuledOut(detection) || (expected > 0 && runCount >= expected),
+    elapsedMs,
+    windowFor(detection),
+  );
+}
+
+/**
+ * Only "deciding" is worth re-reading. "pending" and "sampled_out" stay put for
+ * the record's TTL, and re-reading a missing record would put a standing poll on
+ * every historical trace view.
+ */
+export function detectionStatePollInterval(state: DetectionStateValue): number | false {
+  return state === "deciding" ? TRACE_POLL_INTERVAL_MS : false;
 }
 
 /**
@@ -226,14 +285,51 @@ export function useRuns(projectId: string, detectorId: string, query: RunsQuery 
   });
 }
 
+const EMPTY_DETECTION: TraceDetectionState = { state: null, detectorIds: [] };
+
+/**
+ * Reads the trace's detection state. Fails soft to an empty state — it only gates
+ * polling, so an outage should fall back to the window, not error the page.
+ */
+async function fetchTraceDetectionState(
+  projectId: string,
+  traceId: string,
+): Promise<TraceDetectionState> {
+  const res = await fetch(`/api/projects/${projectId}/traces/${traceId}/detection-state`);
+  if (!res.ok) return EMPTY_DETECTION;
+  const data = (await res.json()) as { state?: string | null; detector_ids?: unknown };
+  return {
+    state: (data.state ?? null) as DetectionStateValue,
+    detectorIds: Array.isArray(data.detector_ids)
+      ? data.detector_ids.filter((d): d is string => typeof d === "string")
+      : [],
+  };
+}
+
+/**
+ * Whether detection will produce anything for this trace, and what to expect. Lets
+ * the page show a working state right away and stop polling exactly when it should.
+ */
+export function useTraceDetectionState(projectId: string, traceId: string) {
+  return useQuery({
+    queryKey: ["trace-detection-state", projectId, traceId],
+    queryFn: () => fetchTraceDetectionState(projectId, traceId),
+    enabled: !!projectId && !!traceId,
+    refetchInterval: (query) => detectionStatePollInterval(query.state.data?.state ?? null),
+  });
+}
+
 export function useTraceFindings(projectId: string, traceId: string) {
   const elapsed = useElapsedSince(traceId);
+  // Read here rather than passed in, so call sites need no plumbing. React Query
+  // dedupes it against the panel's own subscription to the same key.
+  const { data: detection } = useTraceDetectionState(projectId, traceId);
   return useQuery({
     queryKey: ["trace-findings", projectId, traceId],
     queryFn: () => fetchTraceFindings(projectId, traceId),
     enabled: !!projectId && !!traceId,
     refetchInterval: (query) =>
-      findingsPollInterval(query.state.data?.findings?.length ?? 0, elapsed()),
+      findingsPollInterval(query.state.data?.findings?.length ?? 0, elapsed(), detection),
   });
 }
 
@@ -246,10 +342,12 @@ function fetchTraceDetectorRuns(projectId: string, traceId: string) {
 
 export function useTraceDetectorRuns(projectId: string, traceId: string) {
   const elapsed = useElapsedSince(traceId);
+  const { data: detection } = useTraceDetectionState(projectId, traceId);
   return useQuery({
     queryKey: ["trace-detector-runs", projectId, traceId],
     queryFn: () => fetchTraceDetectorRuns(projectId, traceId),
     enabled: !!projectId && !!traceId,
-    refetchInterval: () => detectorRunsPollInterval(elapsed()),
+    refetchInterval: (query) =>
+      detectorRunsPollInterval(query.state.data?.runs?.length ?? 0, elapsed(), detection),
   });
 }

--- a/frontend/ui/src/features/detectors/hooks/use-findings.ts
+++ b/frontend/ui/src/features/detectors/hooks/use-findings.ts
@@ -1,3 +1,4 @@
+import { useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { ApiError } from "@/lib/api/client";
 
@@ -50,19 +51,25 @@ export interface PaginationMeta {
   total: number;
 }
 
-async function fetchTraceFindings(
-  projectId: string,
-  traceId: string,
-): Promise<{ findings: BackendFinding[] }> {
-  const url = `/api/projects/${projectId}/traces/${traceId}/findings`;
+/**
+ * GET a detector endpoint. Failures become an ApiError carrying the backend's
+ * `detail`, which callers branch on (e.g. retention gating).
+ */
+async function getJson<T>(url: string, what: string): Promise<T> {
   const res = await fetch(url);
   if (!res.ok) {
-    const body = await res
-      .json()
-      .catch(() => ({ detail: `Failed to fetch trace findings: ${res.status}` }));
-    throw new ApiError(res.status, body.detail ?? `Failed to fetch trace findings: ${res.status}`);
+    const fallback = `Failed to fetch ${what}: ${res.status}`;
+    const body = await res.json().catch(() => ({ detail: fallback }));
+    throw new ApiError(res.status, body.detail ?? fallback);
   }
-  return res.json() as Promise<{ findings: BackendFinding[] }>;
+  return res.json() as Promise<T>;
+}
+
+function fetchTraceFindings(projectId: string, traceId: string) {
+  return getJson<{ findings: BackendFinding[] }>(
+    `/api/projects/${projectId}/traces/${traceId}/findings`,
+    "trace findings",
+  );
 }
 
 export interface DetectorRca {
@@ -75,29 +82,74 @@ export interface DetectorRca {
   createTime: string;
 }
 
-async function fetchRca(
-  projectId: string,
-  findingId: string,
-): Promise<{ rca: DetectorRca | null }> {
-  const url = `/api/projects/${projectId}/findings/${findingId}/rca`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({ detail: `Failed to fetch RCA: ${res.status}` }));
-    throw new ApiError(res.status, body.detail ?? `Failed to fetch RCA: ${res.status}`);
-  }
-  return res.json() as Promise<{ rca: DetectorRca | null }>;
+function fetchRca(projectId: string, findingId: string) {
+  return getJson<{ rca: DetectorRca | null }>(
+    `/api/projects/${projectId}/findings/${findingId}/rca`,
+    "RCA",
+  );
+}
+
+// The worker writes findings, runs and RCA after a trace is ingested, so a trace
+// opened live starts with none of them. These queries poll until they arrive, so
+// the Alert button, Detectors tab and RCA answer show up without a refresh.
+export const TRACE_POLL_INTERVAL_MS = 3000;
+// Waiting for results the pipeline still owes us. Must outlast it: evaluation
+// waits for the trace to go quiet (EVALUATOR_DELAY, ~60s) and jobs have no cap.
+export const TRACE_POLL_WINDOW_MS = 300000;
+// Waiting out a write race, where the record should already be there. Short,
+// because the alternative is polling for minutes on a trace that has nothing
+// coming at all.
+export const TRACE_POLL_GRACE_MS = 30000;
+
+/** Poll until `settled`, giving up at `windowMs`. */
+function pollUntilSettled(settled: boolean, elapsedMs: number, windowMs: number): number | false {
+  if (settled) return false;
+  return elapsedMs < windowMs ? TRACE_POLL_INTERVAL_MS : false;
+}
+
+/** Settled once a finding exists: the Alert button and useRca take over. */
+export function findingsPollInterval(findingCount: number, elapsedMs: number): number | false {
+  return pollUntilSettled(findingCount > 0, elapsedMs, TRACE_POLL_WINDOW_MS);
+}
+
+/**
+ * A run row appears only once its detector finishes, so there is no way to tell
+ * "all runs are in" from "one is still coming". Poll for the whole window.
+ */
+export function detectorRunsPollInterval(elapsedMs: number): number | false {
+  return elapsedMs < TRACE_POLL_WINDOW_MS ? TRACE_POLL_INTERVAL_MS : false;
+}
+
+/**
+ * Polls while the run is in flight. A missing row only gets the grace period: the
+ * worker writes the finding before the row, so a fresh finding briefly has none —
+ * but an RCA-disabled detector never writes one at all.
+ */
+export function rcaPollInterval(
+  status: DetectorRca["status"] | undefined,
+  elapsedMs: number,
+): number | false {
+  if (status === "pending" || status === "running") return TRACE_POLL_INTERVAL_MS;
+  return pollUntilSettled(status !== undefined, elapsedMs, TRACE_POLL_GRACE_MS); // done|failed => settled
+}
+
+/**
+ * Milliseconds since `key` last changed. Switching trace or finding restarts the
+ * window, so each freshly-opened one gets the full wait.
+ */
+function useElapsedSince(key: string): () => number {
+  const ref = useRef<{ key: string; at: number }>({ key, at: Date.now() });
+  if (ref.current.key !== key) ref.current = { key, at: Date.now() };
+  return () => Date.now() - ref.current.at;
 }
 
 export function useRca(projectId: string, findingId: string) {
+  const elapsed = useElapsedSince(findingId);
   return useQuery({
     queryKey: ["detector-rca", projectId, findingId],
     queryFn: () => fetchRca(projectId, findingId),
     enabled: !!projectId && !!findingId,
-    refetchInterval: (query) => {
-      const status = query.state.data?.rca?.status;
-      // Poll while running/pending, stop once done or failed
-      return status === "running" || status === "pending" ? 3000 : false;
-    },
+    refetchInterval: (query) => rcaPollInterval(query.state.data?.rca?.status, elapsed()),
   });
 }
 
@@ -140,11 +192,7 @@ export interface RunsResponse {
   meta: PaginationMeta;
 }
 
-async function fetchRuns(
-  projectId: string,
-  detectorId: string,
-  query: RunsQuery = {},
-): Promise<RunsResponse> {
+function fetchRuns(projectId: string, detectorId: string, query: RunsQuery = {}) {
   const params = new URLSearchParams();
   if (query.page !== undefined) params.set("page", String(query.page));
   if (query.limit !== undefined) params.set("limit", String(query.limit));
@@ -154,13 +202,10 @@ async function fetchRuns(
   if (query.identified) params.set("identified", "true");
 
   const qs = params.toString();
-  const url = `/api/projects/${projectId}/detectors/${detectorId}/runs${qs ? `?${qs}` : ""}`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    const body = await res.json().catch(() => ({ detail: `Failed to fetch runs: ${res.status}` }));
-    throw new ApiError(res.status, body.detail ?? `Failed to fetch runs: ${res.status}`);
-  }
-  return res.json() as Promise<RunsResponse>;
+  return getJson<RunsResponse>(
+    `/api/projects/${projectId}/detectors/${detectorId}/runs${qs ? `?${qs}` : ""}`,
+    "runs",
+  );
 }
 
 export function useRuns(projectId: string, detectorId: string, query: RunsQuery = {}) {
@@ -182,35 +227,29 @@ export function useRuns(projectId: string, detectorId: string, query: RunsQuery 
 }
 
 export function useTraceFindings(projectId: string, traceId: string) {
+  const elapsed = useElapsedSince(traceId);
   return useQuery({
     queryKey: ["trace-findings", projectId, traceId],
     queryFn: () => fetchTraceFindings(projectId, traceId),
     enabled: !!projectId && !!traceId,
+    refetchInterval: (query) =>
+      findingsPollInterval(query.state.data?.findings?.length ?? 0, elapsed()),
   });
 }
 
-async function fetchTraceDetectorRuns(
-  projectId: string,
-  traceId: string,
-): Promise<{ runs: BackendRun[] }> {
-  const url = `/api/projects/${projectId}/traces/${traceId}/detector-runs`;
-  const res = await fetch(url);
-  if (!res.ok) {
-    const body = await res
-      .json()
-      .catch(() => ({ detail: `Failed to fetch trace detector runs: ${res.status}` }));
-    throw new ApiError(
-      res.status,
-      body.detail ?? `Failed to fetch trace detector runs: ${res.status}`,
-    );
-  }
-  return res.json() as Promise<{ runs: BackendRun[] }>;
+function fetchTraceDetectorRuns(projectId: string, traceId: string) {
+  return getJson<{ runs: BackendRun[] }>(
+    `/api/projects/${projectId}/traces/${traceId}/detector-runs`,
+    "trace detector runs",
+  );
 }
 
 export function useTraceDetectorRuns(projectId: string, traceId: string) {
+  const elapsed = useElapsedSince(traceId);
   return useQuery({
     queryKey: ["trace-detector-runs", projectId, traceId],
     queryFn: () => fetchTraceDetectorRuns(projectId, traceId),
     enabled: !!projectId && !!traceId,
+    refetchInterval: () => detectorRunsPollInterval(elapsed()),
   });
 }

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -193,6 +193,32 @@ describe("TraceViewerPanel detectors view", () => {
   });
 });
 
+describe("TraceViewerPanel detection indicator", () => {
+  it("shows a Detecting chip while detection is queued", () => {
+    // Evaluation is debounced ~1min, so without this the header sits empty for
+    // that whole time and the page looks idle.
+    mocks.detection = { state: "pending", detectorIds: ["d1"] };
+    renderPanel();
+    expect(screen.getByText("Detecting…")).toBeTruthy();
+  });
+
+  it("hides the chip once the analysis is available", () => {
+    // hasRca means results have landed; the Alert badge speaks for them.
+    mocks.detection = { state: "pending", detectorIds: ["d1"] };
+    mocks.finding = { finding_id: "f1" };
+    mocks.rca = { rca: { sessionId: "s1", status: "done" } };
+    renderPanel();
+    expect(screen.queryByText("Detecting…")).toBeNull();
+    expect(screen.getByRole("button", { name: "Alert" })).toBeTruthy();
+  });
+
+  it("shows no chip when detection is ruled out or unknown", () => {
+    mocks.detection = { state: "sampled_out", detectorIds: [] };
+    renderPanel();
+    expect(screen.queryByText("Detecting…")).toBeNull();
+  });
+});
+
 describe("TraceViewerPanel content states", () => {
   it("renders the span detail panel in tree mode", () => {
     renderPanel();
@@ -234,32 +260,6 @@ describe("TraceViewerPanel content states", () => {
     mocks.aiPanelOpen = true;
     renderPanel();
     expect(screen.getByTestId("ai-panel")).toBeTruthy();
-  });
-});
-
-describe("TraceViewerPanel detection indicator", () => {
-  it("shows a Detecting chip while detection is queued", () => {
-    // Evaluation is debounced ~1min, so without this the header sits empty for
-    // that whole time and the page looks idle.
-    mocks.detection = { state: "pending", detectorIds: ["d1"] };
-    renderPanel();
-    expect(screen.getByText("Detecting…")).toBeTruthy();
-  });
-
-  it("hides the chip once the analysis is available", () => {
-    // hasRca means results have landed; the Alert badge speaks for them.
-    mocks.detection = { state: "pending", detectorIds: ["d1"] };
-    mocks.finding = { finding_id: "f1" };
-    mocks.rca = { rca: { sessionId: "s1", status: "done" } };
-    renderPanel();
-    expect(screen.queryByText("Detecting…")).toBeNull();
-    expect(screen.getByRole("button", { name: "Alert" })).toBeTruthy();
-  });
-
-  it("shows no chip when detection is ruled out or unknown", () => {
-    mocks.detection = { state: "sampled_out", detectorIds: [] };
-    renderPanel();
-    expect(screen.queryByText("Detecting…")).toBeNull();
   });
 });
 

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -260,6 +260,9 @@ describe("TraceViewerPanel detection indicator", () => {
     mocks.detection = { state: "sampled_out", detectorIds: [] };
     renderPanel();
     expect(screen.queryByText("Detecting…")).toBeNull();
+  });
+});
+
 describe("source-scoped fetch", () => {
   it("threads source into the queryKey and the getTrace call", async () => {
     renderPanel({ source: "detector" });

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.test.tsx
@@ -8,6 +8,9 @@ const mocks = vi.hoisted(() => ({
   traceError: null as unknown,
   traceLoading: false,
   aiPanelOpen: false,
+  detection: undefined as unknown,
+  finding: undefined as unknown,
+  rca: undefined as unknown,
 }));
 
 // Layout context drives the fullscreen width math (sidebar width).
@@ -29,9 +32,13 @@ vi.mock("@tanstack/react-query", () => ({
 vi.mock("@/lib/api", () => ({ getTrace: vi.fn() }));
 vi.mock("../hooks/use-trace-stream", () => ({ useTraceStream: vi.fn() }));
 vi.mock("@/features/detectors/hooks/use-findings", () => ({
-  useTraceFindings: () => ({ data: undefined }),
-  useRca: () => ({ data: undefined }),
+  useTraceFindings: () => ({ data: mocks.finding ? { findings: [mocks.finding] } : undefined }),
+  useRca: () => ({ data: mocks.rca }),
   useTraceDetectorRuns: () => ({ data: undefined, isLoading: false, error: null }),
+  useTraceDetectionState: () => ({ data: mocks.detection }),
+  // Real predicate, so the test exercises the component's own gating.
+  detectionInFlight: (d: { state?: string } | undefined) =>
+    d?.state === "pending" || d?.state === "deciding",
 }));
 
 // Heavy children + resizable layout — replace with passthroughs so only the
@@ -80,6 +87,9 @@ afterEach(() => {
   mocks.traceError = null;
   mocks.traceLoading = false;
   mocks.aiPanelOpen = false;
+  mocks.detection = undefined;
+  mocks.finding = undefined;
+  mocks.rca = undefined;
 });
 
 describe("TraceViewerPanel layout", () => {
@@ -208,5 +218,31 @@ describe("TraceViewerPanel content states", () => {
     mocks.aiPanelOpen = true;
     renderPanel();
     expect(screen.getByTestId("ai-panel")).toBeTruthy();
+  });
+});
+
+describe("TraceViewerPanel detection indicator", () => {
+  it("shows a Detecting chip while detection is queued", () => {
+    // Evaluation is debounced ~1min, so without this the header sits empty for
+    // that whole time and the page looks idle.
+    mocks.detection = { state: "pending", detectorIds: ["d1"] };
+    renderPanel();
+    expect(screen.getByText("Detecting…")).toBeTruthy();
+  });
+
+  it("hides the chip once the analysis is available", () => {
+    // hasRca means results have landed; the Alert badge speaks for them.
+    mocks.detection = { state: "pending", detectorIds: ["d1"] };
+    mocks.finding = { finding_id: "f1" };
+    mocks.rca = { rca: { sessionId: "s1", status: "done" } };
+    renderPanel();
+    expect(screen.queryByText("Detecting…")).toBeNull();
+    expect(screen.getByRole("button", { name: "Alert" })).toBeTruthy();
+  });
+
+  it("shows no chip when detection is ruled out or unknown", () => {
+    mocks.detection = { state: "sampled_out", detectorIds: [] };
+    renderPanel();
+    expect(screen.queryByText("Detecting…")).toBeNull();
   });
 });

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -11,6 +11,7 @@ import {
   Expand,
   Shrink,
   SquareArrowOutUpRight,
+  Loader2,
 } from "lucide-react";
 import { cn, buildUrlWithFilters } from "@/lib/utils";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
@@ -26,7 +27,12 @@ import { AiAssistantPanel } from "@/features/ai-assistant/components/ai-assistan
 import { useTraceStream } from "../hooks/use-trace-stream";
 import { SpanTimelineView } from "./SpanTimelineView";
 import { TREE_LAYOUT } from "../utils";
-import { useTraceFindings, useRca } from "@/features/detectors/hooks/use-findings";
+import {
+  useTraceFindings,
+  useRca,
+  useTraceDetectionState,
+  detectionInFlight,
+} from "@/features/detectors/hooks/use-findings";
 import { TraceDetectorsTab } from "./TraceDetectorsTab";
 import { isRetentionError, getRetentionDetail } from "@/lib/api/retention";
 import { RetentionGateBanner } from "@/components/RetentionGateBanner";
@@ -129,6 +135,10 @@ export function TraceViewerPanel({
   const { data: rcaData } = useRca(projectId, traceFinding?.finding_id ?? "");
   const hasRca = !!traceFinding && !!rcaData?.rca;
   const rcaSessionId = rcaData?.rca?.sessionId ?? undefined;
+  // Detection is queued but has nothing to show yet. Evaluation is debounced by
+  // ~a minute, so without this the header sits empty for that whole time.
+  const { data: detection } = useTraceDetectionState(projectId, traceId);
+  const detecting = !hasRca && detectionInFlight(detection);
 
   // Auto-open chat with RCA session loaded when arriving from /detectors.
   // Waits for rcaSessionId so the chat opens already pointing at the session,
@@ -246,6 +256,15 @@ export function TraceViewerPanel({
             <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
           </div>
           <div className="flex items-center gap-1">
+            {detecting && (
+              <span
+                className="flex items-center gap-1 rounded-md border border-border bg-muted/50 px-2 py-1 text-[11px] font-medium text-muted-foreground"
+                title="Detectors are evaluating this trace — results appear here automatically"
+              >
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Detecting…
+              </span>
+            )}
             {hasRca && (
               <button
                 type="button"

--- a/tests/rest/test_internal_trace_detection_state.py
+++ b/tests/rest/test_internal_trace_detection_state.py
@@ -1,0 +1,99 @@
+"""Unit tests for the internal trace detection-state endpoint.
+
+The trace page uses this to know whether detector results are coming, and which
+runs to expect, instead of guessing with a timer. It reads the worker's per-trace
+enqueue-claim record and is deliberately fail-soft: a hint, not page data.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from rest.main import app
+from shared.config import settings
+
+
+@pytest.fixture()
+def secret(monkeypatch):
+    """Configure a known internal-secret so the auth dep accepts our header."""
+    monkeypatch.setattr(settings, "internal_api_secret", "test-secret")
+    return "test-secret"
+
+
+@pytest.fixture()
+def mock_redis(monkeypatch):
+    """Mock the async Redis client the endpoint reads the claim record from."""
+    mock = MagicMock()
+    mock.get = AsyncMock(return_value=None)
+    monkeypatch.setattr("shared.redis.get_async_redis_client", lambda: mock)
+    return mock
+
+
+@pytest.fixture()
+def client(secret, mock_redis):
+    return TestClient(app)
+
+
+class TestTraceDetectionState:
+    URL = "/api/v1/internal/traces/trace-abc/detection-state"
+
+    def _get(self, client, secret):
+        return client.get(
+            self.URL, params={"project_id": "p1"}, headers={"X-Internal-Secret": secret}
+        )
+
+    def test_reports_pending_with_expected_detectors(self, client, mock_redis, secret):
+        # The detector ids are what let the client stop polling exactly when
+        # every enqueued run has landed.
+        mock_redis.get.return_value = json.dumps(
+            {"state": "pending", "detector_ids": ["d1", "d2"], "token": "t"}
+        )
+        resp = self._get(client, secret)
+        assert resp.status_code == 200
+        assert resp.json() == {"state": "pending", "detector_ids": ["d1", "d2"]}
+
+    def test_reports_sampled_out(self, client, mock_redis, secret):
+        # A sticky "nothing will ever appear": the client must not poll at all.
+        mock_redis.get.return_value = json.dumps({"state": "sampled_out", "token": "t"})
+        resp = self._get(client, secret)
+        assert resp.json() == {"state": "sampled_out", "detector_ids": []}
+
+    def test_reads_the_worker_claim_key(self, client, mock_redis, secret):
+        self._get(client, secret)
+        # Same key the worker claims under (shared.detector_keys).
+        mock_redis.get.assert_awaited_once_with("detector-enq:p1:trace-abc")
+
+    def test_missing_record_is_no_signal(self, client, mock_redis, secret):
+        # Expired or never detected. Absence is not a promise of nothing, so the
+        # client falls back to its own window rather than giving up.
+        mock_redis.get.return_value = None
+        resp = self._get(client, secret)
+        assert resp.json() == {"state": None, "detector_ids": []}
+
+    def test_unrecognized_future_state_is_not_leaked(self, client, mock_redis, secret):
+        mock_redis.get.return_value = json.dumps({"state": "quarantined"})
+        resp = self._get(client, secret)
+        assert resp.json() == {"state": None, "detector_ids": []}
+
+    def test_undecodable_payload_fails_soft(self, client, mock_redis, secret):
+        mock_redis.get.return_value = "not-json"
+        resp = self._get(client, secret)
+        assert resp.status_code == 200
+        assert resp.json() == {"state": None, "detector_ids": []}
+
+    def test_non_string_detector_ids_are_dropped(self, client, mock_redis, secret):
+        mock_redis.get.return_value = json.dumps({"state": "pending", "detector_ids": ["d1", 7]})
+        assert self._get(client, secret).json()["detector_ids"] == ["d1"]
+
+    def test_redis_outage_fails_soft(self, client, mock_redis, secret):
+        # A hint must never become a 500 on the trace page.
+        mock_redis.get.side_effect = RuntimeError("connection refused")
+        resp = self._get(client, secret)
+        assert resp.status_code == 200
+        assert resp.json() == {"state": None, "detector_ids": []}
+
+    def test_requires_internal_secret(self, client, mock_redis):
+        resp = client.get(self.URL, params={"project_id": "p1"})
+        assert resp.status_code == 403


### PR DESCRIPTION
Fixes #1637
## Summary

A trace opened while detection is still running shows no Alert badge and an empty Detectors tab until the user refreshes: findings, runs and the RCA row are written by the worker after ingestion, but the page read each of them once, on open.

Those queries now poll until the results land, and the worker's per-trace enqueue decision — already in Redis, now exposed over the internal API — says when to stop.

## Type of Change

- [x] fix - A bug fix

## Details

**1. Poll for worker-written results.** Findings, runs and RCA poll at 3s, time-boxed per trace so a stale tab doesn't poll forever. The window is 5min to outlast the ~60s evaluator debounce. `rcaPollInterval` also polls while the RCA row is still *missing* — the worker writes the finding first, so a fresh finding briefly has none and the query would otherwise stop on that empty fetch. Cadence decisions are pure functions, unit-tested without real timers.

**2. Gate that polling on the detection state.** A timer can't tell "queued and late" from "no detector will ever run". The new endpoint reports the worker's claim: `sampled_out` stops polling immediately, `pending` names the runs to expect so polling stops once they land, and both `pending`/`deciding` drive a "Detecting…" chip. A missing record means "no signal", not "nothing coming" — it fails soft and callers fall back to the window, so a Redis outage costs precision, not correctness.

Tests: 24 cases on the cadence functions and predicates (plus two fake-timer integration cases), 9 on the endpoint covering fail-soft, the exact claim key, and auth.

Related to #935 — same root cause on the AI-assistant surface, fixed separately.

## Screenshots / Recordings (if applicable)
<img width="1550" height="752" alt="Screenshot 2026-07-29 at 2 00 24 PM" src="https://github.com/user-attachments/assets/aa403da0-3f2c-4efa-8955-d0b772d43e5d" />

<!--
Open a trace right after ingesting it and let it sit: the Detectors tab fills in
and the Alert badge appears with no refresh. On `main` it stays empty.

To capture the chip on demand:
  redis-cli SET "detector-enq:<PROJECT_ID>:<TRACE_ID>" \
    '{"state":"pending","detector_ids":["d1","d2"]}' EX 300
-->

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1637. The trace page now polls findings, detector runs, and RCA based on the worker’s detection state, so fresh traces populate without refresh, and polling stops when nothing will ever run.

- New Features
  - Added `GET /api/v1/internal/traces/{trace_id}/detection-state` and Next proxy at `/api/projects/{projectId}/traces/{traceId}/detection-state`; fail-softs to an empty state.
  - Findings and runs poll every 3s with a 5m window when detection is in flight, 30s grace without signal; `sampled_out` stops immediately; runs stop when all expected `detectorIds` land.
  - RCA polls while `pending`/`running` and through the brief finding→row gap; detection-state re-reads only while `deciding`.
  - The trace header shows a “Detecting…” chip while `deciding`/`pending`.

- Refactors
  - Centralized Redis key format in `backend/shared/detector_keys.py` and reused in the worker.
  - Consolidated fetch error handling into `getJson`; added pure polling-cadence helpers and tests for the endpoint, Next proxy, chip visibility (including `sampled_out`), and UI hooks.

<sup>Written for commit 2c95c863e798816047b8de6d48495b30bdc21561. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

