### PR TITLE
fix(api): exclude detector self-traces from dashboard widget reads

### DIFF
--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -38,6 +38,35 @@ DISTINCT_VALUES_CACHE_MAX = 256
 # open-ended custom ranges. Matches the UI's own default preset ("Last 24 hours").
 DEFAULT_SPAN_SCAN_LOOKBACK_HOURS = 24
 
+# Markers stored in spans.source / traces.source. Customer traffic carries 'user' (the
+# column's DEFAULT); internal telemetry carries a marker of its own.
+USER_SOURCE = "user"
+DETECTOR_SOURCE = "detector"
+
+
+def customer_traffic_only(alias: str = "") -> str:
+    """WHERE condition restricting a spans/traces scan to customer traffic.
+
+    Single definition of the rule: every customer-facing read that scans spans or traces
+    calls this rather than spelling the comparison out, so a new surface can't quietly
+    ship without it.
+
+    Asserts ``source = 'user'`` rather than ``!= 'detector'`` deliberately. The
+    inequality is fail-open — a second internal marker (an RCA or assistant self-trace,
+    say) would pass it and leak into customer lists, dropdowns and billing until every
+    call site was revisited. Naming the one value that IS customer traffic excludes any
+    future internal marker the day it is introduced.
+
+    Args:
+        alias (str): Table alias qualifying the column (e.g. ``"t"``), or ``""`` when the
+            scan is unaliased.
+
+    Returns:
+        str: A WHERE-clause condition.
+    """
+    column = f"{alias}.source" if alias else "source"
+    return f"{column} = '{USER_SOURCE}'"
+
 
 def _floor_minute(dt: datetime | None) -> datetime | None:
     """Truncate a datetime to the whole minute (for the distinct-values cache key)."""

--- a/backend/rest/services/trace_reader.py
+++ b/backend/rest/services/trace_reader.py
@@ -53,7 +53,7 @@ def customer_traffic_only(alias: str = "") -> str:
 
     Asserts ``source = 'user'`` rather than ``!= 'detector'`` deliberately. The
     inequality is fail-open — a second internal marker (an RCA or assistant self-trace,
-    say) would pass it and leak into customer lists, dropdowns and billing until every
+    say) would pass it and leak into customer lists, sessions and dropdowns until every
     call site was revisited. Naming the one value that IS customer traffic excludes any
     future internal marker the day it is introduced.
 
@@ -279,7 +279,9 @@ class TraceReaderService:
             return cached[1]
 
         params: dict = {"project_id": project_id}
-        inner_conditions = ["project_id = {project_id:String}"]
+        # Detector self-traces carry their own model/environment/name values; excluding
+        # them keeps internal telemetry out of the customer's filter dropdown options.
+        inner_conditions = ["project_id = {project_id:String}", customer_traffic_only()]
         if normalized_start is not None:
             # Exact bound, no lookback back-off: this is a self-contained window scan with
             # no trace-level semi-join, so the boundary-drift false-negative reasoning that

--- a/backend/rest/services/widget_registry.py
+++ b/backend/rest/services/widget_registry.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
+from rest.services.trace_reader import customer_traffic_only
+
 FILTER_OPS_STRING = ("=", "contains")
 FILTER_OPS_NUMBER = (">", ">=", "<", "<=", "=")
 AGGS_NUMBER = ("sum", "avg", "min", "max", "p50", "p95", "p99")
@@ -59,6 +61,7 @@ _SPANS_BASE = f"""
             span_start_time, span_end_time, cost, input_tokens, output_tokens, total_tokens, usage_details
         FROM spans
         WHERE project_id = {{project_id:String}}
+          AND {customer_traffic_only()}
           AND span_start_time >= {{start_time:DateTime64(3)}}
           AND span_start_time < {{end_time:DateTime64(3)}}
         ORDER BY ch_update_time DESC
@@ -94,6 +97,7 @@ _TRACES_BASE = f"""
             trace_id, name, user_id, session_id, environment, trace_start_time
         FROM traces
         WHERE project_id = {{project_id:String}}
+          AND {customer_traffic_only()}
           AND trace_start_time >= {{start_time:DateTime64(3)}}
           AND trace_start_time < {{end_time:DateTime64(3)}}
         ORDER BY ch_update_time DESC
@@ -122,6 +126,7 @@ _TRACES_BASE = f"""
                 {_CACHE_WRITE_TOKENS_EXPR} AS cache_write_tokens
             FROM spans
             WHERE project_id = {{project_id:String}}
+              AND {customer_traffic_only()}
               AND span_start_time >= {{start_time:DateTime64(3)}}
               AND span_start_time < {{end_time:DateTime64(3)}}
             ORDER BY ch_update_time DESC

--- a/tests/rest/test_trace_filter_meta.py
+++ b/tests/rest/test_trace_filter_meta.py
@@ -151,6 +151,20 @@ class TestGetDistinctSpanValues:
         params = kwargs["parameters"]
         assert params["project_id"] == "p1"
 
+    def test_excludes_detector_self_traces(self, monkeypatch):
+        # A self-trace carries its own name, environment and model, so an unguarded
+        # scan offers them as options in the customer's own dropdown. Asserted via the
+        # helper, not a literal: changing the predicate shouldn't look like a lost guard.
+        from rest.services.trace_reader import customer_traffic_only
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_span_values(project_id="p1", column="model_name")
+
+        assert customer_traffic_only() in mock_client.query.call_args[0][0]
+
     def test_no_window_defaults_a_lookback_bound_never_unbounded(self, monkeypatch):
         """A direct caller passing no window must not trigger an all-time span scan:
         a default lower bound is injected (symmetric with the filtered trace list)."""
@@ -297,6 +311,19 @@ class TestGetDistinctTraceValues:
         # Deduped to the latest ReplacingMergeTree version per trace before counting.
         assert "LIMIT 1 BY project_id, trace_id" in query_text
         assert kwargs["parameters"]["project_id"] == "p1"
+
+    def test_excludes_detector_self_traces(self, monkeypatch):
+        # Same shared helper as the spans wrapper, asserted separately: both wrappers
+        # feed customer-facing dropdowns, so a guard lost on either one leaks.
+        from rest.services.trace_reader import customer_traffic_only
+
+        mock_client = MagicMock()
+        mock_client.query.return_value.result_rows = []
+        svc = self._service(monkeypatch, mock_client)
+
+        svc.get_distinct_trace_values(project_id="p1", column="name")
+
+        assert customer_traffic_only() in mock_client.query.call_args[0][0]
 
     def test_no_window_defaults_a_lookback_bound_never_unbounded(self, monkeypatch):
         """Same never-scan-all-time rule as the span variant, on trace_start_time."""

--- a/tests/rest/test_widget_registry.py
+++ b/tests/rest/test_widget_registry.py
@@ -7,6 +7,7 @@ not the internal shape of individual fields.
 import json
 import re
 
+from rest.services.trace_reader import customer_traffic_only
 from rest.services.widget_registry import REGISTRY, registry_schema
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -121,3 +122,19 @@ def test_token_measures_list_components_before_total():
             "cache_write_tokens",
             "total_tokens",
         ], f"{view}: token measures out of order: {token_order}"
+
+
+def test_every_base_relation_excludes_detector_self_traces():
+    """No widget view may count detector self-traces as customer data.
+
+    Dashboard measures (count, cost, tokens, latency, error_count) are billed
+    and charted as customer activity, so a base relation that scans spans or
+    traces without the source predicate silently inflates them. Asserted per
+    scan site rather than per view: `traces` reads both tables.
+    """
+    for view_name, view in REGISTRY.items():
+        scans = view.base_sql.count("FROM spans") + view.base_sql.count("FROM traces")
+        # Count via the helper, not a literal: hardcoding the spelling would make a
+        # change to the predicate look like a missing guard.
+        guards = view.base_sql.count(customer_traffic_only())
+        assert guards == scans, f"{view_name}: {scans} table scan(s) but {guards} detector guard(s)"

--- a/tests/rest/test_widget_registry.py
+++ b/tests/rest/test_widget_registry.py
@@ -127,14 +127,29 @@ def test_token_measures_list_components_before_total():
 def test_every_base_relation_excludes_detector_self_traces():
     """No widget view may count detector self-traces as customer data.
 
-    Dashboard measures (count, cost, tokens, latency, error_count) are billed
-    and charted as customer activity, so a base relation that scans spans or
-    traces without the source predicate silently inflates them. Asserted per
-    scan site rather than per view: `traces` reads both tables.
+    Dashboard measures (count, cost, tokens, latency, error_count) are charted as
+    customer activity, so a base relation that scans spans or traces without the
+    source predicate silently inflates them.
+
+    Asserted per scan site, not as a per-view total: `traces` reads both tables, and
+    comparing counts would accept two guards on one subquery and none on the other —
+    which still lets detector rows through the unguarded one.
     """
+    guard = customer_traffic_only()
     for view_name, view in REGISTRY.items():
-        scans = view.base_sql.count("FROM spans") + view.base_sql.count("FROM traces")
-        # Count via the helper, not a literal: hardcoding the spelling would make a
-        # change to the predicate look like a missing guard.
-        guards = view.base_sql.count(customer_traffic_only())
-        assert guards == scans, f"{view_name}: {scans} table scan(s) but {guards} detector guard(s)"
+        sql = view.base_sql
+        # \b so a future `FROM traces_something` CTE can't be mistaken for the table.
+        scans = list(re.finditer(r"FROM\s+(spans|traces)\b", sql))
+        assert scans, f"{view_name}: no table scan found — has the base relation moved?"
+        for scan in scans:
+            # A derived table's own WHERE runs from its FROM up to its dedup; a guard
+            # past that boundary belongs to a different subquery and doesn't protect
+            # this one. Matched via the helper, not a literal, so changing the
+            # predicate's spelling doesn't read as a missing guard.
+            after = sql[scan.end() :]
+            cutoff = after.find("ORDER BY")
+            where_clause = after[:cutoff] if cutoff != -1 else after
+            assert guard in where_clause, (
+                f"{view_name}: the scan of `{scan.group(1)}` at offset {scan.start()} "
+                f"has no detector guard in its own WHERE"
+            )


### PR DESCRIPTION
> [!CAUTION]
> **Draft: must not merge before the self-tracing stack.** This reads a `source` column that does not exist on `main`; migration `006` adds it and ships with #1599. Merged early — or deployed to an environment where that migration has not run — every dashboard widget query **and** every trace-list filter dropdown fails with an unknown-identifier error. That is an outage, not a degradation, because the guard sits in the base relation wrapping every widget query path. Undraft once #1599 has merged and `006` has run everywhere.

Detector self-traces are internal telemetry written into the customer's own project, marked by `spans.source` / `traces.source`. The widget engine's base relations scan `spans` and `traces` directly, so those rows would be counted as customer activity in **every** widget measure — count, cost, tokens, latency, error_count — inflating the customer's own charts with our telemetry.

This does **not** affect billing: every stored row is metered regardless of source, self-traces included. The guard is about what the customer is *shown*.

Guards all three scan sites: the spans base relation, the traces base relation, and the span aggregation the traces view joins for its measures. The registry test asserts a guard per *scan site* rather than per view — a per-view count would accept two guards on one subquery and none on another, which still lets detector rows through the unguarded one.

The predicate asserts `source = 'user'` rather than `!= 'detector'`. The inequality is fail-open: a second internal marker — an RCA or assistant self-trace — would pass it and leak into widget measures until someone revisited the comparison. The helper is byte-identical to the copy on the self-tracing branch (same name, constants, body and comment wording), so the eventual merge resolves to a single copy rather than a conflict.

### Rebased onto current `main`

This branch was based on an older `main` and had rewritten the widget base-relation SQL from f-strings into string concatenation. `main` has since added the cache-token measures inside those same blocks, which conflicted. Resolved by discarding the concatenation rewrite entirely and taking `main`'s f-string version verbatim, injecting the guard as an interpolated `{customer_traffic_only()}`. Net effect: `widget_registry.py` is **+5 lines** rather than a 72-line rewrite, every cache-token measure is preserved, and there are no conflicts against either `main` or the self-tracing branch.

## ⚠️ Accepted tradeoff: this disqualifies the spans projection

**Reviewers should know this and decide whether it is acceptable.**

Migration 005 added `spans_no_io_by_start_time`, a projection sorted `(project_id, span_start_time, trace_id, span_id)` that makes time-windowed span scans cheap — the dashboard is its primary consumer. Its column list was written a month before `source` existed and cannot supply it, and `ADD COLUMN` does not extend an existing projection.

ClickHouse only elects a projection that supplies every column a query touches. So the two spans scans in these base relations fall back to the base table, which is sorted `trace_id`-first and can therefore prune a 24-hour window only by monthly partition — no granule skipping.

Two things to be clear about:

- **Results are unchanged.** This is a query-plan regression, not a correctness one.
- **It takes effect on deploy, not when the first detector row arrives.** The plan changes because the *query* mentions `source`, regardless of what the column contains. Any wording suggesting this is inert until self-tracing ships is wrong.

**Impact is unmeasured.** On a project holding a week of data, "reads the whole month" and "reads one day" may be indistinguishable; on a large project it may not be. The measurement is one `EXPLAIN indexes=1` against a widget query on a realistic project.

If it turns out to matter, the fix is to rebuild the projection with `source` included. That is a `DROP` / `ADD` / `MATERIALIZE PROJECTION` backfill and belongs in its own migration (**008** — 006 and 007 are taken). `traces` has no projection, so only the spans scans are affected.

The same tradeoff already exists on the self-tracing stack for `get_distinct_span_values`, so a measurement settles both.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents detector self-traces from inflating dashboard metrics by filtering widget reads to customer traffic only. Applies `source = 'user'` to all spans/traces scans; results are unchanged, but this bypasses the `spans_no_io_by_start_time` projection and may slow some queries.

- **Bug Fixes**
  - Guarded the spans base relation, the traces base relation, and the spans aggregation joined by the traces view using `customer_traffic_only()` (`source = 'user'`).
  - Centralized the predicate in `customer_traffic_only()` to match usage metering and avoid fail-open comparisons.
  - Added a registry test that enforces one guard per table scan via the helper’s output.

<sup>Written for commit 900617218e2c6f62ef1a7255b015bcbae5beece1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
