### PR TITLE
fix(pricing): TS model-price resolver never matched via regex (all patterns invalid in JS) + catalog invariants

### DIFF
--- a/frontend/packages/core/src/__tests__/model-pricing-catalog.test.ts
+++ b/frontend/packages/core/src/__tests__/model-pricing-catalog.test.ts
@@ -1,0 +1,163 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+
+// lookup.ts imports prisma at module load (registerCacheClear); mock it so these
+// pure-function tests run without a generated client or DB (mirrors
+// model-pricing.test.ts). resolveModelPricing/stripGatewayPrefix never touch it.
+vi.mock("../lib/prisma", () => ({
+  prisma: { standardModel: { findMany: vi.fn() } },
+}));
+
+import {
+  compileMatchPattern,
+  resolveModelPricing,
+  stripGatewayPrefix,
+} from "../model-pricing/lookup.ts";
+
+// The shipped catalog synced into the standard_models / standard_model_prices
+// tables. We resolve against it directly (pure, no Prisma) so these invariants
+// guard the DATA that both the TS and Python resolvers share — turning the
+// recurring "$0 / mispriced model" class (#1545, #1556, #1558, #1560) into a
+// failing CI check instead of a customer report. See #1597.
+interface CatalogEntry {
+  modelName: string;
+  matchPattern: string;
+  prices: Record<string, number>;
+}
+
+const CATALOG: CatalogEntry[] = JSON.parse(
+  readFileSync(new URL("../standard-model-prices.json", import.meta.url), "utf8"),
+);
+
+const GATEWAY_PREFIXES = ["openai", "openrouter", "litellm", "vertex_ai", "anthropic"];
+
+describe("standard-model-prices.json — catalog invariants (#1597)", () => {
+  it("is non-empty and well-formed", () => {
+    expect(CATALOG.length).toBeGreaterThan(0);
+    for (const e of CATALOG) {
+      expect(typeof e.modelName).toBe("string");
+      expect(e.modelName.length).toBeGreaterThan(0);
+      expect(typeof e.matchPattern).toBe("string");
+    }
+  });
+
+  it("every matchPattern compiles through the resolver's compiler", () => {
+    // The catalog authors patterns with a leading Python inline flag `(?i)`, which
+    // a raw JS `new RegExp` rejects ("Invalid group") — so the resolver must
+    // normalize them. Guarding this here means the TS regex fallback can never be
+    // silently dead again (#1597).
+    const bad: string[] = [];
+    for (const e of CATALOG) {
+      if (compileMatchPattern(e.matchPattern) === null) bad.push(e.modelName);
+    }
+    expect(bad, `patterns the resolver cannot compile: ${bad.join(", ")}`).toEqual([]);
+  });
+
+  it("documents that raw JS RegExp rejects these patterns (why compile is needed)", () => {
+    // Regression anchor: the whole catalog uses `(?i)`, which raw JS RegExp throws on.
+    // If this ever stops being true, the compiler's inline-flag handling can be revisited.
+    const rawRejected = CATALOG.filter((e) => {
+      try {
+        new RegExp(e.matchPattern, "i");
+        return false;
+      } catch {
+        return true;
+      }
+    });
+    expect(rawRejected.length).toBeGreaterThan(0);
+  });
+
+  it("every model resolves to ITS OWN prices (no pattern/id drift — catches #1558)", () => {
+    // A model whose own matchPattern does not match its own modelName is unpriced
+    // (returns $0), which is exactly how gemini-3-flash shipped broken in #1558.
+    const drifted: string[] = [];
+    for (const e of CATALOG) {
+      const resolved = resolveModelPricing(CATALOG, e.modelName);
+      if (resolved !== e.prices) drifted.push(e.modelName);
+    }
+    expect(drifted, `models that don't resolve to themselves: ${drifted.join(", ")}`).toEqual([]);
+  });
+
+  it("no model is silently mispriced by a different entry's pattern", () => {
+    // resolveModelPricing must never return a DIFFERENT entry's prices for a
+    // shipped model id. (Same-price overlaps are harmless and allowed.)
+    const mispriced: string[] = [];
+    for (const e of CATALOG) {
+      const resolved = resolveModelPricing(CATALOG, e.modelName);
+      if (resolved && resolved !== e.prices) mispriced.push(e.modelName);
+    }
+    expect(mispriced, `models resolving to another entry's price: ${mispriced.join(", ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("gateway/router-prefixed ids resolve to the same price as the bare id (#1556)", () => {
+    const broken: string[] = [];
+    for (const e of CATALOG) {
+      for (const prefix of GATEWAY_PREFIXES) {
+        const resolved = resolveModelPricing(CATALOG, `${prefix}/${e.modelName}`);
+        if (resolved !== e.prices) broken.push(`${prefix}/${e.modelName}`);
+      }
+    }
+    expect(broken, `prefixed ids that don't match the bare price: ${broken.join(", ")}`).toEqual(
+      [],
+    );
+  });
+
+  it("resolution is independent of catalog order (deterministic)", () => {
+    const reversed = [...CATALOG].reverse();
+    const sample = CATALOG.slice(0, 40).map((e) => e.modelName);
+    for (const name of sample) {
+      expect(resolveModelPricing(reversed, name)).toBe(resolveModelPricing(CATALOG, name));
+    }
+  });
+});
+
+describe("stripGatewayPrefix", () => {
+  it("leaves a bare model id unchanged", () => {
+    expect(stripGatewayPrefix("gpt-5")).toBe("gpt-5");
+    expect(stripGatewayPrefix("claude-opus-4-8")).toBe("claude-opus-4-8");
+  });
+
+  it("strips a single known prefix", () => {
+    expect(stripGatewayPrefix("openrouter/gpt-5")).toBe("gpt-5");
+    expect(stripGatewayPrefix("vertex_ai/gemini-2.5-pro")).toBe("gemini-2.5-pro");
+  });
+
+  it("strips chained prefixes", () => {
+    expect(stripGatewayPrefix("openrouter/anthropic/claude-opus-4-8")).toBe("claude-opus-4-8");
+    expect(stripGatewayPrefix("litellm/openai/gpt-5")).toBe("gpt-5");
+  });
+
+  it("stops at the first non-gateway segment (leaves org/name paths intact)", () => {
+    expect(stripGatewayPrefix("someorg/custom-model")).toBe("someorg/custom-model");
+    // Bedrock dot-format is not slash-prefixed, so it is untouched.
+    expect(stripGatewayPrefix("us.anthropic.claude-sonnet-4")).toBe("us.anthropic.claude-sonnet-4");
+  });
+});
+
+describe("resolveModelPricing — specificity & determinism", () => {
+  const P_GENERIC = { input: 1 };
+  const P_SPECIFIC = { input: 2 };
+
+  // A shorter entry whose pattern subsumes a longer sibling, ordered so the
+  // generic one comes first — the old first-match-wins loop returned it.
+  const OVERLAP = [
+    { modelName: "foo-4", matchPattern: "^foo-4(-.+)?$", prices: P_GENERIC },
+    { modelName: "foo-4-turbo", matchPattern: "^foo-4-turbo(-\\d+)?$", prices: P_SPECIFIC },
+  ];
+
+  it("returns the MOST specific match, not the first in order", () => {
+    // "foo-4-turbo-2099" is matched by BOTH patterns; the longer modelName must win.
+    expect(resolveModelPricing(OVERLAP, "foo-4-turbo-2099")).toBe(P_SPECIFIC);
+  });
+
+  it("exact match always wins over a broader pattern", () => {
+    expect(resolveModelPricing(OVERLAP, "foo-4-turbo")).toBe(P_SPECIFIC);
+    expect(resolveModelPricing(OVERLAP, "foo-4")).toBe(P_GENERIC);
+  });
+
+  it("returns null when nothing matches", () => {
+    expect(resolveModelPricing(OVERLAP, "totally-unknown-2099")).toBeNull();
+  });
+});

--- a/frontend/packages/core/src/model-pricing/index.ts
+++ b/frontend/packages/core/src/model-pricing/index.ts
@@ -1,3 +1,10 @@
 export { syncStandardPrices } from "./sync-standard-prices.ts";
-export { getModelPricing, calculateCost, calculateCostFromPricing } from "./lookup.ts";
+export {
+  getModelPricing,
+  calculateCost,
+  calculateCostFromPricing,
+  resolveModelPricing,
+  stripGatewayPrefix,
+  compileMatchPattern,
+} from "./lookup.ts";
 export type { ModelPricing } from "./lookup.ts";

--- a/frontend/packages/core/src/model-pricing/lookup.ts
+++ b/frontend/packages/core/src/model-pricing/lookup.ts
@@ -28,11 +28,135 @@ function clearCache(): void {
 // Register with sync module so cache is invalidated after sync
 registerCacheClear(clearCache);
 
+/**
+ * Gateway / router prefixes that SDKs prepend to the bare model id
+ * (LiteLLM, OpenRouter, Vercel AI Gateway, cloud provider SDKs), e.g.
+ * `openrouter/anthropic/claude-opus-4-8`, `vertex_ai/gemini-2.5-pro`,
+ * `litellm/openai/gpt-5`.
+ *
+ * Kept in sync with the Python worker's `_GATEWAY_PREFIXES`
+ * (`backend/worker/tokens/pricing.py`, added in #1566) so the two price
+ * resolvers agree on prefixed ids instead of one returning a price and the
+ * other `null` → `$0` (issue #1597).
+ */
+const GATEWAY_PREFIXES: ReadonlySet<string> = new Set([
+  "openai",
+  "azure",
+  "google",
+  "googleai",
+  "vertex_ai",
+  "anthropic",
+  "bedrock",
+  "openrouter",
+  "litellm",
+  "models",
+  "deepseek",
+  "xai",
+  "moonshot",
+  "zai",
+]);
+
+/**
+ * Strip one or more leading gateway/router prefixes separated by `/`.
+ *
+ * Iterates so chained prefixes (`openrouter/anthropic/claude-opus-4-8`) are
+ * fully reduced, and stops at the first segment that is not a recognised
+ * gateway name — so Bedrock dot-format (`us.anthropic.claude-...`) and Vertex
+ * `@date` variants are left untouched. Mirrors the worker's
+ * `_strip_gateway_prefix`.
+ */
+export function stripGatewayPrefix(modelId: string): string {
+  let id = modelId;
+  for (;;) {
+    const slash = id.indexOf("/");
+    if (slash === -1) break;
+    if (!GATEWAY_PREFIXES.has(id.slice(0, slash).toLowerCase())) break;
+    id = id.slice(slash + 1);
+  }
+  return id;
+}
+
+/**
+ * Compile a stored `matchPattern` into a JavaScript `RegExp`.
+ *
+ * The catalog patterns are authored with a leading Python-style inline flag
+ * `(?i)` (see standard-model-prices.json). JavaScript's `RegExp` does NOT support
+ * inline flags and throws "Invalid group" on them — so a raw
+ * `new RegExp(matchPattern, "i")` fails for EVERY catalog entry. The previous
+ * resolver swallowed that in a `try/catch`, which meant its regex fallback never
+ * fired at all: only exact `modelName` matches resolved, and any non-exact id
+ * (dated snapshot, gateway-prefixed, version variant) fell through to `null` →
+ * `$0`. The Python worker's `re` accepts `(?i)`, so it matched these fine — this
+ * is a concrete driver of the Python/TS divergence in #1597.
+ *
+ * Strip a leading inline-flag group and apply the native `i` flag (the catalog
+ * only uses `(?i)`; case-insensitive is the intent everywhere). Returns `null`
+ * for a pattern that still won't compile, so a single bad entry can't throw.
+ */
+export function compileMatchPattern(matchPattern: string): RegExp | null {
+  const body = matchPattern.replace(/^\(\?[a-z]+\)/, "");
+  try {
+    return new RegExp(body, "i");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pure price resolution over an in-memory catalog — no DB, so it is unit-testable
+ * against the shipped `standard-model-prices.json` directly (mirrors how
+ * `calculateCostFromPricing` is pure).
+ *
+ * Resolution order:
+ *   1. gateway-prefix normalisation, then exact match (raw id first, then stripped),
+ *   2. regex fallback that returns the MOST SPECIFIC match — the entry with the
+ *      longest `modelName` — with an alphabetical tiebreak.
+ *
+ * The specificity ranking (vs. the previous first-match-wins) fixes two things at
+ * once (issue #1597): a shorter entry whose pattern subsumes a longer sibling
+ * (e.g. `claude-sonnet-4` matching `claude-sonnet-4-5`) no longer wins, and the
+ * result no longer depends on catalog row order — the old loop returned whatever
+ * `findMany` happened to yield first.
+ */
+export function resolveModelPricing<P>(
+  models: ReadonlyArray<{ modelName: string; matchPattern: string; prices: P }>,
+  modelId: string,
+): P | null {
+  const stripped = stripGatewayPrefix(modelId);
+
+  // Exact match — raw id first, then the prefix-stripped form.
+  for (const candidate of stripped === modelId ? [modelId] : [modelId, stripped]) {
+    const exact = models.find((m) => m.modelName === candidate);
+    if (exact) return exact.prices;
+  }
+
+  // Most-specific regex match. Longest modelName wins; alphabetical tiebreak keeps
+  // it deterministic regardless of the catalog's iteration order.
+  let best: { modelName: string; prices: P } | null = null;
+  for (const m of models) {
+    const re = compileMatchPattern(m.matchPattern);
+    if (re === null) continue; // uncompilable pattern — skip
+    if (!re.test(modelId) && !re.test(stripped)) continue;
+    if (
+      best === null ||
+      m.modelName.length > best.modelName.length ||
+      (m.modelName.length === best.modelName.length && m.modelName < best.modelName)
+    ) {
+      best = m;
+    }
+  }
+  return best ? best.prices : null;
+}
+
 async function loadCache(): Promise<CachedModel[]> {
   if (cache) return cache;
 
   const models = await prisma.standardModel.findMany({
     include: { prices: true },
+    // Deterministic order so results never depend on DB row order. The
+    // specificity ranking in resolveModelPricing makes this redundant for
+    // correctness, but a stable order keeps the cache reproducible.
+    orderBy: { modelName: "asc" },
   });
 
   cache = models.map((m) => {
@@ -63,22 +187,7 @@ async function loadCache(): Promise<CachedModel[]> {
  */
 export async function getModelPricing(modelId: string): Promise<ModelPricing | null> {
   const models = await loadCache();
-
-  // Exact match
-  const exact = models.find((m) => m.modelName === modelId);
-  if (exact) return exact.prices;
-
-  // Regex fallback
-  for (const m of models) {
-    try {
-      const re = new RegExp(m.matchPattern, "i");
-      if (re.test(modelId)) return m.prices;
-    } catch {
-      // Invalid regex — skip
-    }
-  }
-
-  return null;
+  return resolveModelPricing(models, modelId);
 }
 
 /**


### PR DESCRIPTION
## What & why

While building the fix for #1597 (duplicated Python/TS price resolvers with no shared contract), the new catalog invariant test surfaced a live bug: **the TypeScript price resolver's regex fallback never fired.**

`getModelPricing` tried each entry's `matchPattern` via `new RegExp(pattern, "i")` inside a `try/catch`. Every pattern in `standard-model-prices.json` is authored with a leading Python inline flag `(?i)`, which JavaScript's `RegExp` rejects with `Invalid group`. The `catch` swallowed all 90 patterns, so only **exact** `modelName` matches ever resolved — any non-exact id (dated snapshot, gateway/router prefix like `vertex_ai/…` or `openrouter/…`, version variant) fell through to `null`.

Both TS callers are billable, and both take the local-pricing fallback when the provider doesn't report a cost:
- `frontend/worker/src/processors/detector-run-processor.ts` — `detectorInferenceCost`
- `frontend/packages/agent/src/index.ts` — agent/RCA cost

So those paths silently recorded **$0** for any non-exact model id. The Python worker's `re` accepts `(?i)`, so it matched fine — this is the concrete mechanism behind the Python/TS divergence described in #1597.

## Changes (TypeScript only)

Scoped to `frontend/packages/core/src/model-pricing` so it does **not** overlap #1566 (which adds gateway-prefix stripping to the Python worker):

- **`compileMatchPattern()`** — strips a leading inline-flag group and applies the native `i` flag, so catalog patterns actually compile.
- **`stripGatewayPrefix()`** — normalizes gateway/router prefixes before lookup, mirroring the worker's `_strip_gateway_prefix` (#1566) so the two resolvers agree on prefixed ids.
- **`resolveModelPricing()`** — pure, catalog-testable resolution: normalize → exact → **most-specific** regex match (longest `modelName`), replacing the order-dependent first-match-wins. Deterministic regardless of DB row order; `findMany` also gets a stable `orderBy`.
- **`getModelPricing()`** delegates to the pure resolver.
- **Catalog invariant tests** over the shipped JSON: every pattern compiles, every model resolves to itself (catches the #1558 GA/preview drift), none is mispriced by another entry's pattern, gateway-prefixed ids match the bare price (#1556), and resolution is order-independent. This turns the recurring `$0`/mispricing class (#1545 / #1556 / #1558 / #1560) into a failing CI check.

## Testing

- `frontend/packages/core`: **86/86 tests pass** (14 new), including the existing pricing suite — no regressions.
- `tsc --noEmit`, `eslint`, and `prettier --check` all clean on the changed files.

## Notes

- Complements #1566 / #1557 / #1560 rather than duplicating them — they fix the current symptoms on the Python/data side; this fixes the TS resolver and adds the cross-cutting guard.
- A follow-up worth considering: a Python↔TS parity test over a shared fixture list, once #1566 lands.

Refs #1597


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TypeScript model pricing resolver so catalog regex patterns actually match and prevents $0 costs for non‑exact model IDs. Aligns with the Python resolver and makes matching deterministic and most‑specific.

- **Bug Fixes**
  - Compile Python‑style `(?i)` patterns with `compileMatchPattern` and apply JS `i` flag so catalog regexes work.
  - Normalize gateway/router prefixes with `stripGatewayPrefix` (e.g., `openrouter/...`, `vertex_ai/...`) to match bare IDs; parity with the Python worker in #1566.
  - Add `resolveModelPricing`: normalize → exact → most‑specific regex (longest `modelName`), with stable results; `getModelPricing` now delegates.
  - Catalog invariant tests over `standard-model-prices.json` ensure patterns compile, self‑resolution, prefix parity, and order‑independence, preventing regressions tied to #1597.

<sup>Written for commit 9ed2f629182161c0c0a60beac659d7d27959188d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

