### PR TITLE
docs(readme): reposition as self-improving layer with Datasets & Evals loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
   As AI agent systems grow more complex, manually sifting through every trace is unsustainable. TraceRoot's Detectors selectively screen incoming traces — flagging hallucinations, tool failures, logic errors, and safety issues automatically, so you spend time fixing problems, not hunting for them.
 
-- **Debugging AI agent systems is painful.**
+- **Debugging AI agent systems in production is painful.**
 
   Root-causing failures across agent hallucinations, tool call instabilities, and version changes is hard. TraceRoot's AI connects to a sandbox running your production source code, identifies the exact failing line, cross-references your GitHub history — commits, PRs, open issues — and opens a PR to fix it.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img src="frontend/ui/public/images/traceroot_logo.png" alt="TraceRoot Logo">
   </a>
 
-[TraceRoot]("https://traceroot.ai/") is an open-source observability platform for AI agents — Capture traces, monitors production issues, and debug with AI that sees your source code and Github history.
+[TraceRoot](https://traceroot.ai/) is the open-source self-improving layer for AI agents — observability that detects failures in production, root-causes them against your source code and GitHub history, opens verified fix PRs, and closes the loop with golden datasets and evals — so your agent automatically grows more robust, accurate, and efficient with every release.
 
   [![Y Combinator][y-combinator-image]][y-combinator-url]
   [![License][license-image]][license-url]
@@ -31,8 +31,9 @@
 
 | Feature | Description |
 | ------- | ----------- |
-| Detectors | LLM-as-judge evaluator monitors incoming trace for hallucinations, tool/logic failures, safety violations, and intent drift — surfaces findings and auto-triggers root cause analysis with email and slack alerts. |
+| Detectors | LLM-as-judge evaluator monitors incoming traces for hallucinations, tool/logic failures, safety violations, and intent drift — surfaces findings and auto-triggers root cause analysis with email and Slack alerts. |
 | Agentic Debugging | AI that sees all your traces, connects to a sandbox with your production source code, identifies the exact failing line, and correlates the failure with your GitHub commits, PRs, and issues. BYOK support for any model provider. |
+| Datasets & Evals | Turn production findings into golden datasets with one click. Run offline evals from the TraceRoot CLI or SDK inside coding agents like Claude Code, Codex, and Cursor — verifying every fix and systematically improving your agent's robustness and performance over time. |
 | Tracing | Capture LLM calls, agent actions, and tool usage via OpenTelemetry-compatible SDK. Intelligently surfaces the traces that matter — noise filtered, signal prioritized. |
 
 ## Why TraceRoot?
@@ -43,7 +44,11 @@
 
 - **Debugging AI agent systems is painful.**
 
-  Root-causing failures across agent hallucinations, tool call instabilities, and version changes is hard. TraceRoot's AI connects to a sandbox running your production source code, identifies the exact failing line, and cross-references your GitHub history — commits, PRs, open issues and creates PR to fix it.
+  Root-causing failures across agent hallucinations, tool call instabilities, and version changes is hard. TraceRoot's AI connects to a sandbox running your production source code, identifies the exact failing line, cross-references your GitHub history — commits, PRs, open issues — and opens a PR to fix it.
+
+- **Agent improvement should be systematic, not ad hoc.**
+
+  Most teams debug production issues and move on — the learning evaporates. TraceRoot connects online and offline evaluation in a single loop: Detectors evaluate live traffic, confirmed failures become golden datasets, and offline evals verify every fix against them. Release over release, your agent gets measurably more robust and performant — improvement becomes a repeatable process, not a one-off firefight.
 
 - **Fully open source, no vendor lock-in.**
 


### PR DESCRIPTION
## Summary

Repositions the README around the self-improving loop: detect failures in production → root-cause against source code and GitHub history → open verified fix PRs → turn findings into golden datasets and offline evals.

- **One-liner** rewritten around the loop; also fixes the broken markdown link (stray quotes in the URL) and grammar on line 6
- **Features table**: new **Datasets & Evals** row — golden datasets from production findings, offline evals via the TraceRoot CLI/SDK inside coding agents (Claude Code, Codex, Cursor); table now reads top-to-bottom as the loop (Detectors → Agentic Debugging → Datasets & Evals → Tracing)
- **Why TraceRoot**: new bullet "Agent improvement should be systematic, not ad hoc" framing online (Detectors) + offline evals as a single improvement loop
- Minor grammar fixes in the existing Detectors and Agentic Debugging copy

## Notes

- Datasets & Evals lands in the next few days; this README update is timed with it
- Follow-up: sync `README.zh.md` and `README.ko.md` to the new English copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repositions the README around a self‑improving loop (detect → root‑cause → fix → eval) and adds a Datasets & Evals pillar to close the loop. Also fixes the traceroot.ai link and tightens copy for clarity.

- **Refactors**
  - Rewrites the one‑liner to describe the loop and outcomes.
  - Reorders the features table to follow the loop and adds a Datasets & Evals row (golden datasets, offline evals via CLI/SDK).
  - Updates Why TraceRoot: adds “systematic, not ad hoc” point linking online detectors and offline evals, and scopes the debugging pain point to production.

- **Bug Fixes**
  - Fixes a broken markdown link to https://traceroot.ai/.
  - Minor grammar and casing fixes (e.g., traces, Slack, “opens a PR”).

<sup>Written for commit 254de7cb7de885d7ff34b397cdfee2b43a1eca29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

