### PR TITLE
docs(readme): tighten hero one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
     <img src="frontend/ui/public/images/traceroot_logo.png" alt="TraceRoot Logo">
   </a>
 
-[TraceRoot](https://traceroot.ai/) is the open-source self-improving layer for AI agents — observability that detects failures in production, root-causes them against your source code and GitHub history, opens verified fix PRs, and closes the loop with golden datasets and evals — so your agent automatically grows more robust, accurate, and efficient with every release.
+[TraceRoot](https://traceroot.ai/) is the open-source self-improving layer for AI agents.
+
+Detects failures in production, root-causes them against your source code and GitHub history, opens verified fix PRs, and evals every fix — so your agent gets more robust, accurate, and efficient with every release.
 
   [![Y Combinator][y-combinator-image]][y-combinator-url]
   [![License][license-image]][license-url]

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
     <img src="frontend/ui/public/images/traceroot_logo.png" alt="TraceRoot Logo">
   </a>
 
-[TraceRoot](https://traceroot.ai/) is the open-source self-improving layer for AI agents.
-
-Detects failures in production, root-causes them against your source code and GitHub history, opens verified fix PRs, and evals every fix — so your agent gets more robust, accurate, and efficient with every release.
+[TraceRoot](https://traceroot.ai/) is the open-source self-improving layer for AI agents — observability that detects failures in production, root-causes them against your source code and GitHub history, opens verified fix PRs, and evals every fix — so your agent gets more robust, accurate, and efficient with every release.
 
   [![Y Combinator][y-combinator-image]][y-combinator-url]
   [![License][license-image]][license-url]


### PR DESCRIPTION
## Summary

Tightens the hero one-liner while keeping the single-paragraph format:

- Keeps **observability** as the searchable category anchor
- Trims the loop description ("closes the loop with golden datasets and evals" → "evals every fix") so the line renders shorter
- Golden datasets remain covered in the features table and the Why section

🤖 Generated with [Claude Code](https://claude.com/claude-code)