### PR TITLE
docs: sync zh/ko READMEs with self-improving positioning

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -3,7 +3,7 @@
     <img src="frontend/ui/public/images/traceroot_logo.png" alt="TraceRoot Logo">
   </a>
 
-[TraceRoot]("https://traceroot.ai/")는 AI 에이전트를 위한 오픈소스 옵저버빌리티 플랫폼입니다 — 트레이스 수집, 프로덕션 이슈 모니터링, 그리고 소스 코드 및 GitHub 히스토리를 이해하는 AI 기반 디버깅 기능을 제공합니다.
+[TraceRoot](https://traceroot.ai/)는 AI 에이전트를 위한 오픈소스 self-improving 레이어입니다 — 프로덕션에서 장애를 탐지하고, 소스 코드와 GitHub 히스토리를 바탕으로 root cause를 규명하며, 검증된 수정 PR을 생성하고, 모든 수정에 대해 eval을 실행하는 옵저버빌리티입니다. 릴리스를 거듭할수록 에이전트는 더 견고하고, 정확하고, 효율적으로 발전합니다.
 
   [![Y Combinator][y-combinator-image]][y-combinator-url]
   [![License][license-image]][license-url]
@@ -33,6 +33,7 @@
 | ------- | ----------- |
 | Detectors | LLM-as-a-Judge evaluator가 hallucination, 툴/로직 실패, 안전성 위반, intent drift를 모니터링합니다. 이상 징후를 탐지하고 이메일 및 Slack 알림과 함께 root cause analysis를 자동 수행합니다. |
 | Agentic Debugging | 모든 트레이스를 이해하는 AI가 프로덕션 소스 코드가 연결된 샌드박스에서 정확한 실패 지점을 식별하고, GitHub 커밋·PR·이슈와 연관 분석합니다. 모든 모델 프로바이더에 대해 BYOK를 지원합니다. |
+| Datasets & Evals | 프로덕션에서 발견된 문제를 클릭 한 번으로 golden dataset으로 전환합니다. Claude Code, Codex, Cursor 같은 코딩 에이전트 안에서 TraceRoot CLI 또는 SDK로 오프라인 eval을 실행해 모든 수정을 검증하고, 에이전트의 견고함과 성능을 체계적으로 개선합니다. |
 | Tracing | OpenTelemetry 호환 SDK를 통해 LLM 호출, 에이전트 액션, 툴 사용 내역을 수집합니다. 노이즈는 제거하고 중요한 시그널 중심으로 트레이스를 제공합니다. |
 
 ## Why TraceRoot?
@@ -41,9 +42,13 @@
 
   AI 에이전트 시스템이 복잡해질수록 모든 트레이스를 사람이 직접 분석하는 방식은 한계가 있습니다. TraceRoot의 Detectors는 유입되는 트레이스를 선별적으로 분석해 hallucination, 툴 실패, 로직 오류, 안전성 이슈를 자동으로 탐지합니다. 문제를 찾는 데 시간을 쓰는 대신, 문제를 해결하는 데 집중할 수 있습니다.
 
-- **AI 에이전트 디버깅은 어렵습니다.**
+- **프로덕션에서 AI 에이전트 시스템을 디버깅하는 일은 고통스럽습니다.**
 
   Hallucination, 툴 호출 불안정성, 버전 변경 등 다양한 원인으로 발생하는 장애의 root cause를 추적하는 일은 쉽지 않습니다. TraceRoot의 AI는 프로덕션 소스 코드가 실행되는 샌드박스에 연결되어 정확한 실패 지점을 식별하고, GitHub 커밋·PR·오픈 이슈와 교차 분석해 수정용 PR까지 생성합니다.
+
+- **에이전트 개선은 임기응변이 아니라 체계적이어야 합니다.**
+
+  대부분의 팀은 프로덕션 이슈를 디버깅하고 그냥 넘어갑니다 — 그 과정에서 얻은 교훈은 사라집니다. TraceRoot는 온라인과 오프라인 평가를 하나의 루프로 연결합니다. Detectors가 라이브 트래픽을 평가하고, 확인된 실패는 golden dataset이 되며, 오프라인 eval이 모든 수정을 검증합니다. 릴리스를 거듭할수록 에이전트는 측정 가능한 수준으로 더 견고해지고 성능이 향상됩니다 — 개선이 일회성 대응이 아닌 반복 가능한 프로세스가 됩니다.
 
 - **완전한 오픈소스. 벤더 락인 없음.**
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -3,7 +3,7 @@
     <img src="frontend/ui/public/images/traceroot_logo.png" alt="TraceRoot Logo">
   </a>
 
-[TraceRoot]("https://traceroot.ai/") 是面向 AI Agent 的开源可观测性平台 —— 捕获调用链路，监控生产环境问题，并通过能够理解你的源码与 GitHub 上下文的 AI 快速定位并修复问题。
+[TraceRoot](https://traceroot.ai/) 是面向 AI Agent 的开源自我改进层（self-improving layer）—— 一套可观测性系统，它检测生产环境中的故障，结合你的源码与 GitHub 历史定位根因，创建经过验证的修复 PR，并对每次修复运行评测（eval）—— 让你的 Agent 随每个版本变得更健壮、更准确、更高效。
 
   [![Y Combinator][y-combinator-image]][y-combinator-url]
   [![License][license-image]][license-url]
@@ -33,6 +33,7 @@
 | ---- | ---- |
 | 检测器（Detectors） | 由 LLM 充当评审，监控进入的追踪是否存在幻觉、工具/逻辑错误、安全违规以及意图漂移 —— 自动呈现发现项，并触发根因分析与邮件、Slack 告警。 |
 | 智能调试（Agentic Debugging） | AI 可以看到你的所有追踪，连接到运行你生产源码的沙箱中，精确定位出错的代码行，并将故障与你的 GitHub commit、PR、issue 关联起来。支持 BYOK，可接入任意模型厂商。 |
+| 数据集与评测（Datasets & Evals） | 一键将生产环境中的发现转化为黄金数据集（golden dataset）。在 Claude Code、Codex、Cursor 等编程 Agent 中，通过 TraceRoot CLI 或 SDK 运行离线评测 —— 验证每一次修复，让 Agent 的健壮性与性能得到系统性的持续提升。 |
 | 追踪（Tracing） | 通过兼容 OpenTelemetry 的 SDK 采集 LLM 调用、Agent 行为以及工具使用情况。智能浮现真正值得关注的追踪 —— 过滤噪声，优先呈现信号。 |
 
 ## 为什么选择 TraceRoot？
@@ -41,9 +42,13 @@
 
   随着 AI Agent 系统越来越复杂，手动逐条翻看追踪已经不可持续。TraceRoot 的检测器会有选择地筛查进入的追踪 —— 自动标记幻觉、工具失败、逻辑错误以及安全问题，让你把时间花在解决问题上，而不是寻找问题上。
 
-- **调试 AI Agent 系统非常痛苦。**
+- **在生产环境中调试 AI Agent 系统非常痛苦。**
 
   Agent 幻觉、工具调用不稳定、版本变更带来的故障，根因定位都非常困难。TraceRoot 的 AI 会连接到运行你生产源码的沙箱，准确指出出错的代码行，交叉比对你的 GitHub 历史 —— commit、PR、开启中的 issue，并自动创建 PR 来修复问题。
+
+- **Agent 的改进应当是系统性的，而不是临时起意的。**
+
+  大多数团队排查完生产问题就翻篇了 —— 经验教训随之蒸发。TraceRoot 将在线与离线评测连成一个闭环：检测器持续评估线上流量，确认的故障沉淀为黄金数据集，离线评测再据此验证每一次修复。一个版本接一个版本，你的 Agent 变得可度量地更健壮、性能更好 —— 改进成为可重复的流程，而不是一次性的救火。
 
 - **完全开源，无厂商锁定。**
 

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -9,7 +9,7 @@
 
 ## 1. What Are We Building?
 
-TraceRoot is an open-source observability and self-healing platform for AI agents. It captures LLM traces, filters signal from noise, and enables AI-assisted root cause analysis by connecting to a sandbox with production source code and GitHub history.
+TraceRoot is an open-source observability and self-improving platform for AI agents. It captures LLM traces, filters signal from noise, and enables AI-assisted root cause analysis by connecting to a sandbox with production source code and GitHub history.
 
 ### System Components
 


### PR DESCRIPTION
## Summary

Ports the merged English README changes (#1738, #1739) to `README.zh.md` and `README.ko.md`:

- New hero one-liner (self-improving layer + observability anchor + the detect → root-cause → fix → eval loop)
- **Datasets & Evals** row in the features table (between Agentic Debugging and Tracing, so the table reads as the loop)
- "Debugging in production is painful" scoping on the second Why bullet
- New third Why bullet: agent improvement should be systematic, not ad hoc (online + offline evals as one loop)
- Fixes the broken markdown link (stray quotes in the URL) both files inherited from the old English hero

Also aligns `THREAT_MODEL.md`'s one-line product description with the current positioning ("self-healing" → "self-improving").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `README.zh.md` and `README.ko.md` with the latest English copy to reflect the self-improving positioning and closed-loop workflow. Adds the new hero line, a Datasets & Evals feature row, tighter “debugging in production” wording, and a “systematic improvement” bullet; fixes stray-quote markdown links and updates `THREAT_MODEL.md` from self-healing to self-improving.

<sup>Written for commit 787fecde514529181ac83b0c065feb8fb2aa741f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

