### PR TITLE
docs: align remaining product descriptions with self-improving positioning

### DIFF
--- a/backend/rest/main.py
+++ b/backend/rest/main.py
@@ -34,7 +34,7 @@ from shared.config import settings
 
 app = FastAPI(
     title="TraceRoot API",
-    description="Observability platform for LLM applications",
+    description="Observability and self-improving layer for AI agents",
     version="0.1.0",
 )
 

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,7 +1,7 @@
 # deploy/helm/Chart.yaml
 apiVersion: v2
 name: traceroot
-description: AI agent observability platform
+description: Observability and self-improving layer for AI agents
 type: application
 version: 0.1.0
 appVersion: "0.1.0"

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -1,9 +1,9 @@
 ---
 title: Introduction
-description: "Open-source observability and self-healing layer for AI agents"
+description: "Open-source observability and self-improving layer for AI agents"
 ---
 
-TraceRoot is an [open-source](https://github.com/traceroot-ai/traceroot) observability and self-healing layer for AI agents. Instrument your code with a few lines, get full visibility into every LLM call, tool invocation, and agent decision. Run detectors to catch failures and hallucinations the moment they happen. Then let TraceRoot's AI agent analyze findings, debug failures and create fix PRs automatically.
+TraceRoot is an [open-source](https://github.com/traceroot-ai/traceroot) observability and self-improving layer for AI agents. Instrument your code with a few lines, get full visibility into every LLM call, tool invocation, and agent decision. Run detectors to catch failures and hallucinations the moment they happen. Then let TraceRoot's AI agent analyze findings, debug failures and create fix PRs automatically.
 
 ## Key Capabilities
 

--- a/docs/integrations/llamaindex.mdx
+++ b/docs/integrations/llamaindex.mdx
@@ -33,7 +33,7 @@ Settings.llm = OpenAI(model="gpt-4o-mini")
 Settings.embed_model = OpenAIEmbedding(model="text-embedding-3-small")
 
 documents = [
-    Document(text="TraceRoot is an open-source observability platform for AI agents."),
+    Document(text="TraceRoot is an open-source observability and self-improving layer for AI agents."),
     Document(text="TraceRoot supports OpenTelemetry-compatible tracing via a Python SDK."),
 ]
 

--- a/examples/python/llamaindex-rag/main.py
+++ b/examples/python/llamaindex-rag/main.py
@@ -41,7 +41,7 @@ Settings.llm = OpenAI(model="gpt-4o-mini")
 documents = [
     Document(
         text=(
-            "TraceRoot is an open-source observability platform for AI agents. "
+            "TraceRoot is an open-source observability and self-improving layer for AI agents. "
             "It captures traces, debugs with AI, and helps ship with confidence. "
             "The platform is built on OpenTelemetry and supports BYOK for any model provider."
         )

--- a/frontend/ui/src/app/layout.tsx
+++ b/frontend/ui/src/app/layout.tsx
@@ -12,7 +12,7 @@ const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "TraceRoot",
-  description: "AI Observability Platform",
+  description: "Observability and self-improving layer for AI agents",
   icons: {
     icon: "/images/favicon.ico",
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "traceroot-platform"
 version = "0.1.0"
-description = "TraceRoot - AI Observability Platform"
+description = "TraceRoot - open-source observability and self-improving layer for AI agents"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
## Summary

Sweep of stale one-liners left behind after the README pivot (#1738, #1739, #1740). All now read "observability and self-improving layer for AI agents", matching the repo About line:

- `docs/getting-started/introduction.mdx` — the docs landing page still said **self-healing** (frontmatter + intro paragraph)
- `frontend/ui/src/app/layout.tsx` — app `<meta>` description said "AI Observability Platform"
- `backend/rest/main.py` — FastAPI/OpenAPI description said "Observability platform for LLM applications"
- `pyproject.toml`, `deploy/helm/Chart.yaml` — same treatment
- `docs/integrations/llamaindex.mdx` + `examples/python/llamaindex-rag/main.py` — sample RAG documents describing TraceRoot updated to match

No functional changes — strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned remaining product descriptions to the new positioning: "observability and self-improving layer for AI agents."
Updates span docs intro, app metadata (frontend), FastAPI/OpenAPI, Helm chart, `pyproject.toml`, and LlamaIndex docs/examples; strings only, no functional changes.

<sup>Written for commit 2c5c6b4e15e2054e6f5f18e6189b502c40fa416c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

