### PR TITLE
feat(api): stable snake_case operation ids on public operations

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1118,7 +1118,7 @@
     "/api/v1/public/detectors": {
       "get": {
         "description": "List the detectors in the API key's project (newest first).",
-        "operationId": "list_detectors_api_v1_public_detectors_get",
+        "operationId": "list_detectors",
         "parameters": [
           {
             "description": "Items per page",
@@ -1254,7 +1254,7 @@
     "/api/v1/public/detectors/findings": {
       "get": {
         "description": "List recent detector findings for the API key's project (newest first).",
-        "operationId": "list_findings_api_v1_public_detectors_findings_get",
+        "operationId": "list_findings",
         "parameters": [
           {
             "description": "Items per page",
@@ -1426,7 +1426,7 @@
     "/api/v1/public/detectors/findings/{finding_id}": {
       "get": {
         "description": "Get a single finding by id for the key's project.",
-        "operationId": "get_finding_api_v1_public_detectors_findings__finding_id__get",
+        "operationId": "get_finding",
         "parameters": [
           {
             "in": "path",
@@ -1534,7 +1534,7 @@
     "/api/v1/public/detectors/traces/{trace_id}/finding": {
       "get": {
         "description": "Get the finding for a single trace (findings are 1-per-trace).",
-        "operationId": "get_finding_by_trace_api_v1_public_detectors_traces__trace_id__finding_get",
+        "operationId": "get_finding_by_trace",
         "parameters": [
           {
             "in": "path",
@@ -1642,7 +1642,7 @@
     "/api/v1/public/traces": {
       "get": {
         "description": "List recent traces for the API key's project (newest first).",
-        "operationId": "list_traces_api_v1_public_traces_get",
+        "operationId": "list_traces",
         "parameters": [
           {
             "description": "Items per page",
@@ -1776,7 +1776,7 @@
       },
       "post": {
         "description": "Ingest OTLP trace data.\n\nAccepts OTLP protobuf format only (optionally gzip compressed).\nProtobuf is converted to camelCase JSON before storage in S3.\n\nS3 path: events/otel/{project_id}/{yyyy}/{mm}/{dd}/{hh}/{uuid}.json\n\nHeaders:\n    Authorization: Bearer <api_key>\n    Content-Encoding: gzip (optional)\n    Content-Type: application/x-protobuf\n\nBody:\n    OTLP trace data in protobuf format",
-        "operationId": "ingest_traces_api_v1_public_traces_post",
+        "operationId": "ingest_traces",
         "requestBody": {
           "content": {
             "application/x-protobuf": {
@@ -1914,7 +1914,7 @@
     "/api/v1/public/traces/{trace_id}": {
       "get": {
         "description": "Get a single trace for the key's project.\n\nDefaults to the lightweight `skeleton` projection (no per-span I/O); pass\n`fields=full` (or `fields=io,metadata`) for per-span input/output/metadata.\n\nArgs:\n    auth (StampedAuth): Resolved API-key context; scopes the read to its\n        project and stamps the rate-limit identity.\n    trace_id (str): Trace to fetch.\n    fields (str | None): Comma-separated projection groups (e.g. ``io``,\n        ``metadata``) or an alias (``skeleton``/``full``). ``None`` selects\n        the default `skeleton` projection.\n\nReturns:\n    PublicTraceDetailResponse: The trace with span skeletons, plus per-span\n        I/O when the projection requests it.\n\nRaises:\n    HTTPException: 400 if `fields` is invalid, 404 if the trace is missing\n        or outside the key's project, 500 on a reader failure.",
-        "operationId": "get_trace_api_v1_public_traces__trace_id__get",
+        "operationId": "get_trace",
         "parameters": [
           {
             "in": "path",
@@ -2055,7 +2055,7 @@
     "/api/v1/public/traces/{trace_id}/export": {
       "get": {
         "description": "Export the V1 bundle (trace + spans + git_context + manifest) for the key's project.\n\nDefaults to the `full` projection \u2014 an export is explicit intent to take the\ncomplete trace, so per-span input/output/metadata are included unless the\ncaller narrows `fields`. `bundle.trace` equals the `traces get` payload at the\nsame projection.\n\nRate limited on its own `export` bucket because it builds and serializes the\nfull bundle.\n\nArgs:\n    auth (StampedAuth): Resolved API-key context; scopes the read to its\n        project and stamps the rate-limit identity.\n    trace_id (str): Trace to export.\n    fields (str | None): Comma-separated projection groups or an alias\n        (``skeleton``/``full``). ``None`` selects the default `full`\n        projection.\n\nReturns:\n    PublicTraceExportResponse: The V1 export bundle (manifest, trace, spans,\n        git_context) at the requested projection.\n\nRaises:\n    HTTPException: 400 if `fields` is invalid, 404 if the trace is missing\n        or outside the key's project, 500 on a reader failure.",
-        "operationId": "export_trace_api_v1_public_traces__trace_id__export_get",
+        "operationId": "export_trace",
         "parameters": [
           {
             "in": "path",
@@ -2196,7 +2196,7 @@
     "/api/v1/public/whoami": {
       "get": {
         "description": "Return the identity the authenticated API key maps to.",
-        "operationId": "whoami_api_v1_public_whoami_get",
+        "operationId": "whoami",
         "responses": {
           "200": {
             "content": {

--- a/backend/rest/routers/public/detectors_read.py
+++ b/backend/rest/routers/public/detectors_read.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/public/detectors", tags=["Detectors (Public)"])
 
 
-@router.get("", response_model=PublicDetectorListResponse)
+@router.get("", response_model=PublicDetectorListResponse, operation_id="list_detectors")
 @limiter.shared_limit(
     resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
 )
@@ -70,7 +70,7 @@ async def list_detectors(
     )
 
 
-@router.get("/findings", response_model=PublicFindingListResponse)
+@router.get("/findings", response_model=PublicFindingListResponse, operation_id="list_findings")
 @limiter.shared_limit(
     resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
 )
@@ -112,7 +112,7 @@ async def list_findings(
     )
 
 
-@router.get("/findings/{finding_id}", response_model=FindingDetail)
+@router.get("/findings/{finding_id}", response_model=FindingDetail, operation_id="get_finding")
 @limiter.shared_limit(
     resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
 )
@@ -129,7 +129,9 @@ async def get_finding(
     )
 
 
-@router.get("/traces/{trace_id}/finding", response_model=FindingDetail)
+@router.get(
+    "/traces/{trace_id}/finding", response_model=FindingDetail, operation_id="get_finding_by_trace"
+)
 @limiter.shared_limit(
     resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
 )

--- a/backend/rest/routers/public/traces.py
+++ b/backend/rest/routers/public/traces.py
@@ -76,7 +76,7 @@ class IngestResponse(BaseModel):
     file_key: str
 
 
-@router.post("", response_model=IngestResponse)
+@router.post("", response_model=IngestResponse, operation_id="ingest_traces")
 @limiter.limit(resolve_limit, key_func=key_ingest)
 async def ingest_traces(
     request: Request,

--- a/backend/rest/routers/public/traces_read.py
+++ b/backend/rest/routers/public/traces_read.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/public/traces", tags=["Traces (Public)"])
 
 
-@router.get("", response_model=PublicTraceListResponse)
+@router.get("", response_model=PublicTraceListResponse, operation_id="list_traces")
 @limiter.shared_limit(
     resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
 )
@@ -87,7 +87,7 @@ async def list_traces(
     return result
 
 
-@router.get("/{trace_id}", response_model=PublicTraceDetailResponse)
+@router.get("/{trace_id}", response_model=PublicTraceDetailResponse, operation_id="get_trace")
 @limiter.shared_limit(
     resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
 )
@@ -124,7 +124,9 @@ async def get_trace(
     return public_trace_detail(trace, auth.project_id)
 
 
-@router.get("/{trace_id}/export", response_model=PublicTraceExportResponse)
+@router.get(
+    "/{trace_id}/export", response_model=PublicTraceExportResponse, operation_id="export_trace"
+)
 @limiter.limit(resolve_limit, key_func=key_export, exempt_when=is_request_rate_limit_exempt)
 async def export_trace(
     request: Request,

--- a/backend/rest/routers/public/whoami.py
+++ b/backend/rest/routers/public/whoami.py
@@ -21,7 +21,7 @@ from shared.config import settings
 router = APIRouter(prefix="/public/whoami", tags=["Whoami (Public)"])
 
 
-@router.get("", response_model=WhoamiResponse)
+@router.get("", response_model=WhoamiResponse, operation_id="whoami")
 @limiter.shared_limit(
     resolve_limit, scope=BUCKET_READ, key_func=key_read, exempt_when=is_request_rate_limit_exempt
 )

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -159,3 +159,27 @@ def test_detectors_list_route_documents_error_responses():
     assert "get" in paths["/api/v1/public/detectors"]
     responses = paths["/api/v1/public/detectors"]["get"]["responses"]
     assert set(responses) >= {"200", "401", "500"}
+
+
+_METHODS = {"get", "post", "put", "patch", "delete"}
+
+EXPECTED_OPERATION_IDS = {
+    "/api/v1/public/detectors": {"get": "list_detectors"},
+    "/api/v1/public/detectors/findings": {"get": "list_findings"},
+    "/api/v1/public/detectors/findings/{finding_id}": {"get": "get_finding"},
+    "/api/v1/public/detectors/traces/{trace_id}/finding": {"get": "get_finding_by_trace"},
+    "/api/v1/public/traces": {"get": "list_traces", "post": "ingest_traces"},
+    "/api/v1/public/traces/{trace_id}": {"get": "get_trace"},
+    "/api/v1/public/traces/{trace_id}/export": {"get": "export_trace"},
+    "/api/v1/public/whoami": {"get": "whoami"},
+}
+
+
+def test_operation_ids_are_clean_tool_names():
+    """Public operationIds are short snake_case names, not path-mangled defaults."""
+    schema = _schema()
+    actual = {
+        path: {m: op["operationId"] for m, op in item.items() if m in _METHODS}
+        for path, item in schema["paths"].items()
+    }
+    assert actual == EXPECTED_OPERATION_IDS


### PR DESCRIPTION
## What

Sets an explicit `operation_id=` on each of the nine public route decorators, replacing FastAPI's autogenerated `{function}_{path}_{method}` ids (e.g. `list_traces_api_v1_public_traces_get`) with stable, human-named ones: `whoami`, `ingest_traces`, `list_traces`, `get_trace`, `export_trace`, `list_detectors`, `list_findings`, `get_finding`, `get_finding_by_trace`.

## Why

Anything that generates tooling from the public schema (the upcoming shared tool registry, client codegen keyed by operation) needs stable ids; the mangled defaults also churn whenever a path changes.

Deliberately **not** a global `generate_unique_id_function` on `FastAPI()`: that derives ids from endpoint function names across all routers and would collide (the internal traces router and the public traces-read router both define a `list_traces` function), and it would churn ids on non-public routes for no benefit. Explicit per-route ids touch only the public surface.

## Details

- Regenerated the committed `backend/rest/openapi/public.json` (drift test passes).
- New test pins the full path→method→operationId mapping exactly, so an accidental rename or a new op with a default id fails CI.
- Downstream type codegen (openapi-typescript) keys on `paths`, not operationIds, so existing consumers are unaffected.

Closes #1730

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets stable snake_case operationIds on all public API routes to stop churn from path changes and enable reliable tooling/codegen. Previously operationIds were autogenerated from function, path, and method; now each public operation has an explicit short name.

- Adds explicit operation_id on public routes: whoami, ingest_traces, list_traces, get_trace, export_trace, list_detectors, list_findings, get_finding, get_finding_by_trace.
- Regenerates `backend/rest/openapi/public.json` and adds a test that asserts the exact path→method→operationId mapping for all public paths.

**Migration**
- Clients or codegen keyed by operationId must update to the new names above.
- No changes for `openapi-typescript` consumers keyed on `paths`.

<sup>Written for commit 96ed76303084fdba8b1b301a14c3cd97912aab62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

