### PR TITLE
feat(api): per-operation x-tool curation in the public OpenAPI schema

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1248,7 +1248,12 @@
         "summary": "List Detectors",
         "tags": [
           "Detectors (Public)"
-        ]
+        ],
+        "x-tool": {
+          "description": "List the project's detectors (id, name, template, enabled flag, creation time).",
+          "enabled": true,
+          "name": "list_detectors"
+        }
       }
     },
     "/api/v1/public/detectors/findings": {
@@ -1420,7 +1425,12 @@
         "summary": "List Findings",
         "tags": [
           "Detectors (Public)"
-        ]
+        ],
+        "x-tool": {
+          "description": "List detector findings for the project, optionally filtered by detector (id, name, or template), trace id, or time range.",
+          "enabled": true,
+          "name": "list_findings"
+        }
       }
     },
     "/api/v1/public/detectors/findings/{finding_id}": {
@@ -1528,7 +1538,12 @@
         "summary": "Get Finding",
         "tags": [
           "Detectors (Public)"
-        ]
+        ],
+        "x-tool": {
+          "description": "Fetch one detector finding by id, with its full analysis detail.",
+          "enabled": true,
+          "name": "get_finding"
+        }
       }
     },
     "/api/v1/public/detectors/traces/{trace_id}/finding": {
@@ -1636,7 +1651,12 @@
         "summary": "Get Finding By Trace",
         "tags": [
           "Detectors (Public)"
-        ]
+        ],
+        "x-tool": {
+          "description": "Fetch the detector finding attached to a specific trace, if any.",
+          "enabled": true,
+          "name": "get_finding_by_trace"
+        }
       }
     },
     "/api/v1/public/traces": {
@@ -1772,7 +1792,12 @@
         "summary": "List Traces",
         "tags": [
           "Traces (Public)"
-        ]
+        ],
+        "x-tool": {
+          "description": "List recent traces for the project (newest first), optionally bounded to a time range. Use this for discovery before fetching a specific trace.",
+          "enabled": true,
+          "name": "list_traces"
+        }
       },
       "post": {
         "description": "Ingest OTLP trace data.\n\nAccepts OTLP protobuf format only (optionally gzip compressed).\nProtobuf is converted to camelCase JSON before storage in S3.\n\nS3 path: events/otel/{project_id}/{yyyy}/{mm}/{dd}/{hh}/{uuid}.json\n\nHeaders:\n    Authorization: Bearer <api_key>\n    Content-Encoding: gzip (optional)\n    Content-Type: application/x-protobuf\n\nBody:\n    OTLP trace data in protobuf format",
@@ -1908,7 +1933,10 @@
         "summary": "Ingest Traces",
         "tags": [
           "Traces (Public)"
-        ]
+        ],
+        "x-tool": {
+          "enabled": false
+        }
       }
     },
     "/api/v1/public/traces/{trace_id}": {
@@ -2049,7 +2077,12 @@
         "summary": "Get Trace",
         "tags": [
           "Traces (Public)"
-        ]
+        ],
+        "x-tool": {
+          "description": "Fetch one trace with its span tree. Defaults to the lightweight skeleton projection; pass fields=full for per-span input/output/metadata.",
+          "enabled": true,
+          "name": "get_trace"
+        }
       }
     },
     "/api/v1/public/traces/{trace_id}/export": {
@@ -2190,7 +2223,12 @@
         "summary": "Export Trace",
         "tags": [
           "Traces (Public)"
-        ]
+        ],
+        "x-tool": {
+          "description": "Export the complete bundle (trace, spans, git context, manifest) for one trace.",
+          "enabled": true,
+          "name": "export_trace"
+        }
       }
     },
     "/api/v1/public/whoami": {
@@ -2257,7 +2295,12 @@
         "summary": "Whoami",
         "tags": [
           "Whoami (Public)"
-        ]
+        ],
+        "x-tool": {
+          "description": "Identify the project and workspace the current credential belongs to.",
+          "enabled": true,
+          "name": "whoami"
+        }
       }
     }
   }

--- a/backend/rest/openapi_public.py
+++ b/backend/rest/openapi_public.py
@@ -105,6 +105,105 @@ def _apply_public_contract(schema: dict[str, Any]) -> None:
             op["responses"].setdefault("500", _error_response("Failed to read finding"))
 
 
+# Agent/CLI-facing tool curation, keyed by operationId. Reviewed in the same PR
+# as any endpoint change so tool naming can't drift from the API. Every public
+# operation MUST have an entry: enabled tools carry the agent-facing
+# description; disabled ones are excluded from generated tool registries.
+# `name` equals the operationId today but stays an explicit field so a tool
+# could be renamed without an API change.
+_TOOL_CURATION: dict[str, dict[str, Any]] = {
+    "whoami": {
+        "name": "whoami",
+        "description": "Identify the project and workspace the current credential belongs to.",
+        "enabled": True,
+    },
+    "ingest_traces": {"enabled": False},
+    "list_traces": {
+        "name": "list_traces",
+        "description": (
+            "List recent traces for the project (newest first), optionally bounded to a "
+            "time range. Use this for discovery before fetching a specific trace."
+        ),
+        "enabled": True,
+    },
+    "get_trace": {
+        "name": "get_trace",
+        "description": (
+            "Fetch one trace with its span tree. Defaults to the lightweight skeleton "
+            "projection; pass fields=full for per-span input/output/metadata."
+        ),
+        "enabled": True,
+    },
+    "export_trace": {
+        "name": "export_trace",
+        "description": (
+            "Export the complete bundle (trace, spans, git context, manifest) for one trace."
+        ),
+        "enabled": True,
+    },
+    "list_detectors": {
+        "name": "list_detectors",
+        "description": (
+            "List the project's detectors (id, name, template, enabled flag, creation time)."
+        ),
+        "enabled": True,
+    },
+    "list_findings": {
+        "name": "list_findings",
+        "description": (
+            "List detector findings for the project, optionally filtered by detector "
+            "(id, name, or template), trace id, or time range."
+        ),
+        "enabled": True,
+    },
+    "get_finding": {
+        "name": "get_finding",
+        "description": "Fetch one detector finding by id, with its full analysis detail.",
+        "enabled": True,
+    },
+    "get_finding_by_trace": {
+        "name": "get_finding_by_trace",
+        "description": "Fetch the detector finding attached to a specific trace, if any.",
+        "enabled": True,
+    },
+}
+
+
+def _apply_tool_curation(schema: dict[str, Any]) -> None:
+    """Stamp the per-operation ``x-tool`` block from ``_TOOL_CURATION``.
+
+    Args:
+        schema (dict[str, Any]): The public-only OpenAPI document; mutated in
+            place.
+
+    Raises:
+        ValueError: If a public operation has no curation entry — forces every
+            new endpoint to make an explicit tool decision in the same PR — or
+            if a curation entry matches no public operation (stale after a
+            rename or removal).
+    """
+    consumed: set[str] = set()
+    for path, item in schema["paths"].items():
+        for method, op in item.items():
+            if method not in _HTTP_METHODS:
+                continue
+            op_id = op.get("operationId")
+            entry = _TOOL_CURATION.get(op_id or "")
+            if entry is None:
+                raise ValueError(
+                    f"public operation {method.upper()} {path} ({op_id}) has no "
+                    "_TOOL_CURATION entry — add one (enabled or disabled)"
+                )
+            consumed.add(op_id)
+            op["x-tool"] = copy.deepcopy(entry)
+    stale = set(_TOOL_CURATION) - consumed
+    if stale:
+        raise ValueError(
+            "stale _TOOL_CURATION entries with no matching public operation: "
+            + ", ".join(sorted(stale))
+        )
+
+
 def _collect_refs(node: Any, acc: set[str]) -> None:
     """Collect component schema names referenced by `$ref` anywhere under `node`."""
     if isinstance(node, dict):
@@ -162,6 +261,7 @@ def build_public_schema(app: Any) -> dict[str, Any]:
         "components": components,
     }
     _apply_public_contract(schema)
+    _apply_tool_curation(schema)
     return schema
 
 

--- a/tests/rest/test_public_openapi.py
+++ b/tests/rest/test_public_openapi.py
@@ -4,8 +4,10 @@ import json
 from copy import deepcopy
 from pathlib import Path
 
+import pytest
+
 from rest.main import app
-from rest.openapi_public import PUBLIC_PREFIX, build_public_schema, render
+from rest.openapi_public import PUBLIC_PREFIX, _apply_tool_curation, build_public_schema, render
 
 ARTIFACT = Path(__file__).resolve().parents[2] / "backend" / "rest" / "openapi" / "public.json"
 
@@ -183,3 +185,53 @@ def test_operation_ids_are_clean_tool_names():
         for path, item in schema["paths"].items()
     }
     assert actual == EXPECTED_OPERATION_IDS
+
+
+def test_every_public_op_has_x_tool():
+    schema = _schema()
+    for path, item in schema["paths"].items():
+        for method, op in item.items():
+            if method not in _METHODS:
+                continue
+            assert "x-tool" in op, f"{method.upper()} {path} missing x-tool"
+
+
+def test_x_tool_enabled_set_and_shape():
+    schema = _schema()
+    enabled, disabled = {}, set()
+    for item in schema["paths"].values():
+        for method, op in item.items():
+            if method not in _METHODS:
+                continue
+            tool = op["x-tool"]
+            if tool["enabled"]:
+                enabled[tool["name"]] = tool
+            else:
+                disabled.add(op["operationId"])
+    assert disabled == {"ingest_traces"}
+    assert set(enabled) == {
+        "whoami",
+        "list_traces",
+        "get_trace",
+        "export_trace",
+        "list_detectors",
+        "list_findings",
+        "get_finding",
+        "get_finding_by_trace",
+    }
+    for name, tool in enabled.items():
+        assert tool["description"], f"{name} needs an agent-facing description"
+
+
+def test_uncurated_public_op_fails_build():
+    fake = {"paths": {"/api/v1/public/new": {"get": {"operationId": "brand_new_op"}}}}
+    with pytest.raises(ValueError, match="brand_new_op"):
+        _apply_tool_curation(fake)
+
+
+def test_stale_curation_entry_fails_build():
+    # A curation entry whose operation was renamed/removed must fail the build,
+    # so the map stays exactly the public operation set.
+    fake = {"paths": {"/api/v1/public/whoami": {"get": {"operationId": "whoami"}}}}
+    with pytest.raises(ValueError, match=r"stale _TOOL_CURATION.*list_traces"):
+        _apply_tool_curation(fake)


### PR DESCRIPTION
## What

Adds a `_TOOL_CURATION` dict (keyed by operationId) and `_apply_tool_curation()` to `backend/rest/openapi_public.py`, called at the end of `build_public_schema` after `_apply_public_contract`. Every public operation gets an `x-tool` block stamped into the generated schema: enabled entries carry `{name, description, enabled: true}`, disabled ones are `{"enabled": false}`.

- All eight read operations are enabled with hand-written, agent-facing descriptions; `ingest_traces` stays disabled (SDK-only surface, not a tool).
- The check is fail-closed in **both** directions: a public operation with no curation entry raises `ValueError` (every new endpoint must make an explicit tool decision in the PR that adds it, or the schema build — and therefore CI — fails), and a stale curation entry whose operation was renamed or removed also raises, so the map stays exactly the operation set.
- Per the updated design decision, the v1 x-tool block carries **no scopes field** — the permission model is deferred to the auth phase, so curation is `{name, description, enabled}` only.

## Why

The public schema carried no tool metadata: the in-app assistant's tool definitions and the CLI's command definitions each hand-author their own names and descriptions for the same operations. This puts the decision "is this operation exposed as a tool, and how is it described to a model?" next to the API contract, reviewed in the same PR that changes an endpoint.

## Details

- Regenerated the committed `public.json` (sorted-key render lands the blocks deterministically; drift test passes).
- Tests: every operation carries `x-tool`; the enabled set is exactly the intended one; enabled entries have non-empty descriptions; an uncurated operation raises; a stale entry raises.
- Descriptions were verified against the actual route params and response models.

Stacked on #1742.

Closes #1731

🤖 Generated with [Claude Code](https://claude.com/claude-code)