### PR TITLE
test: add live tracing coverage for worker, router, and trace tree

### DIFF
--- a/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanTreeView.test.ts
@@ -4,6 +4,7 @@ import type { Span } from "@/types/api";
 import type { SpanTreeRow } from "../types";
 import { buildSpanTree } from "../utils";
 import { flattenTreeWithMetrics } from "../utils/timeline";
+import { mergeSpans } from "../hooks/use-trace-stream";
 import { getVisibleSpanRows, buildTreeRows } from "./SpanTreeView";
 
 // Minimal span factory — only fields relevant to the tree row model.
@@ -192,42 +193,59 @@ describe("buildTreeRows ↔ flattenTreeWithMetrics ordering parity", () => {
     expect(timelineIds).toEqual(treeIds);
   });
 
-  it("stabilizes sibling order when several spans are all in-progress", () => {
-    // Same start time and no end time on every child: the end-time comparison
-    // is Infinity vs Infinity, so ordering must come from the span_id
-    // tie-break regardless of arrival order.
-    const spans = [
-      makeSpan({ span_id: "root" }),
-      makeSpan({
-        span_id: "c-live",
-        parent_span_id: "root",
-        span_start_time: "2024-01-01T00:00:00.100Z",
-        span_end_time: null,
-      }),
-      makeSpan({
-        span_id: "a-live",
-        parent_span_id: "root",
-        span_start_time: "2024-01-01T00:00:00.100Z",
-        span_end_time: null,
-      }),
-      makeSpan({
-        span_id: "b-live",
-        parent_span_id: "root",
-        span_start_time: "2024-01-01T00:00:00.100Z",
-        span_end_time: null,
-      }),
+  it("keeps same-millisecond siblings deterministic across SSE arrival and final refetch order", () => {
+    const root = makeSpan({ span_id: "root" });
+    const aLive = makeSpan({
+      span_id: "a-live",
+      parent_span_id: "root",
+      span_start_time: "2024-01-01T00:00:00.100Z",
+      span_end_time: null,
+    });
+    const bLive = makeSpan({
+      span_id: "b-live",
+      parent_span_id: "root",
+      span_start_time: "2024-01-01T00:00:00.100Z",
+      span_end_time: null,
+    });
+    const cLive = makeSpan({
+      span_id: "c-live",
+      parent_span_id: "root",
+      span_start_time: "2024-01-01T00:00:00.100Z",
+      span_end_time: null,
+    });
+
+    function displayedOrders(spans: Span[]) {
+      const spanById = new Map(spans.map((span) => [span.span_id, span]));
+      const treeIds = buildTreeRows(buildSpanTree(spans), spanById, new Set()).flatMap((row) =>
+        row.type === "span" ? [row.row.span.span_id] : [],
+      );
+      const timelineIds = flattenTreeWithMetrics(spans, new Set(), 1000, 800).map(
+        (item) => item.span.span_id,
+      );
+      return { treeIds, timelineIds };
+    }
+
+    const finalRefetchOrder = displayedOrders([root, aLive, bLive, cLive]);
+
+    expect(finalRefetchOrder.treeIds).toEqual(["root", "a-live", "b-live", "c-live"]);
+    expect(finalRefetchOrder.timelineIds).toEqual(finalRefetchOrder.treeIds);
+
+    const sseArrivalOrders = [
+      [cLive, aLive, bLive],
+      [bLive, cLive, aLive],
+      [aLive, bLive, cLive],
     ];
 
-    const spanById = new Map(spans.map((s) => [s.span_id, s]));
-    const rows = buildSpanTree(spans);
-    const treeIds = buildTreeRows(rows, spanById, new Set()).flatMap((r) =>
-      r.type === "span" ? [r.row.span.span_id] : [],
-    );
-    const timelineIds = flattenTreeWithMetrics(spans, new Set(), 1000, 800).map(
-      (item) => item.span.span_id,
-    );
+    for (const arrivalOrder of sseArrivalOrders) {
+      const liveSpans = arrivalOrder.reduce<Span[]>(
+        (cachedSpans, arrivingSpan) => mergeSpans(cachedSpans, [arrivingSpan]),
+        [root],
+      );
+      const liveOrder = displayedOrders(liveSpans);
 
-    expect(treeIds).toEqual(["root", "a-live", "b-live", "c-live"]);
-    expect(timelineIds).toEqual(treeIds);
+      expect(liveOrder.timelineIds).toEqual(liveOrder.treeIds);
+      expect(liveOrder.treeIds).toEqual(finalRefetchOrder.treeIds);
+      expect(liveOrder.timelineIds).toEqual(finalRefetchOrder.timelineIds);
+    }
   });
 });

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
@@ -1,47 +1,43 @@
 // @vitest-environment jsdom
-
 /**
- * The stream writes into the trace-detail cache with an exact-hash
- * setQueryData, so the tests use the same source-aware key as the panel.
+ * The stream writes into the trace-detail cache with an exact-hash setQueryData, so the
+ * only thing worth asserting is that spans land at the key the panel actually reads —
+ * a key that is right in shape but wrong in `source` drops every span event silently.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook } from "@testing-library/react";
-import type { ReactNode } from "react";
 
 import type { Span, TraceDetail } from "@/types/api";
 import { traceQueryKey } from "./index";
 import { useTraceStream } from "./use-trace-stream";
 
-function emit(es: FakeEventSource, type: string, data: unknown): void {
-  // EventSource callbacks update React state, so the test must deliver them
-  // inside act() just as React would process a browser event.
+/**
+ * Deliver an SSE event the way the browser would: the handler calls setIsStreaming, so
+ * without act() the hook's returned state lags the cache write we just made.
+ */
+function emit(es: FakeEventSource, type: string, data: unknown) {
   act(() => es.emit(type, data));
 }
 
-/** jsdom and Node 20 do not provide EventSource, so tests control this fake. */
+/** Minimal EventSource stand-in: jsdom has none, and we need to fire events by hand. */
 class FakeEventSource {
   static instances: FakeEventSource[] = [];
-  listeners = new Map<string, (event: MessageEvent) => void>();
+  listeners = new Map<string, (e: MessageEvent) => void>();
   closed = false;
   onerror: (() => void) | null = null;
 
   constructor(public url: string) {
     FakeEventSource.instances.push(this);
   }
-
-  addEventListener(type: string, listener: (event: MessageEvent) => void): void {
-    this.listeners.set(type, listener);
+  addEventListener(type: string, fn: (e: MessageEvent) => void) {
+    this.listeners.set(type, fn);
   }
-
-  close(): void {
+  close() {
     this.closed = true;
   }
-
-  emit(type: string, data: unknown): void {
-    this.listeners.get(type)?.({
-      data: JSON.stringify(data),
-    } as MessageEvent);
+  emit(type: string, data: unknown) {
+    this.listeners.get(type)?.({ data: JSON.stringify(data) } as MessageEvent);
   }
 }
 
@@ -59,31 +55,24 @@ function span(id: string, extra: Partial<Span> = {}): Span {
 }
 
 function traceDetail(spans: Span[]): TraceDetail {
-  return {
-    trace_id: "t1",
-    project_id: "p1",
-    spans,
-  } as TraceDetail;
+  return { trace_id: "t1", project_id: "p1", spans } as TraceDetail;
 }
 
 let client: QueryClient;
 
-function wrapper({ children }: { children: ReactNode }) {
+function wrapper({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 }
 
 beforeEach(() => {
   FakeEventSource.instances = [];
-  client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   vi.stubGlobal("EventSource", FakeEventSource);
 });
 
 afterEach(() => {
   cleanup();
   vi.unstubAllGlobals();
-  vi.restoreAllMocks();
 });
 
 describe("useTraceStream", () => {
@@ -92,15 +81,9 @@ describe("useTraceStream", () => {
     client.setQueryData<TraceDetail>(key, traceDetail([span("a")]));
 
     const { result } = renderHook(() => useTraceStream("p1", "t1", true, "detector"), { wrapper });
+    emit(FakeEventSource.instances[0], "spans", { spans: [span("b")] });
 
-    emit(FakeEventSource.instances[0], "spans", {
-      spans: [span("b")],
-    });
-
-    expect(client.getQueryData<TraceDetail>(key)?.spans.map((item) => item.span_id)).toEqual([
-      "a",
-      "b",
-    ]);
+    expect(client.getQueryData<TraceDetail>(key)?.spans.map((s) => s.span_id)).toEqual(["a", "b"]);
     expect(result.current.isStreaming).toBe(true);
   });
 
@@ -109,113 +92,62 @@ describe("useTraceStream", () => {
     client.setQueryData<TraceDetail>(traceQueryKey("p1", "t1"), traceDetail([]));
 
     renderHook(() => useTraceStream("p1", "t1", true, "detector"), { wrapper });
-    emit(FakeEventSource.instances[0], "spans", {
-      spans: [span("b")],
-    });
+    emit(FakeEventSource.instances[0], "spans", { spans: [span("b")] });
 
     expect(client.getQueryData<TraceDetail>(traceQueryKey("p1", "t1"))?.spans).toEqual([]);
   });
 
-  it("re-subscribes when source changes on a fixed trace id", () => {
+  it("re-subscribes when source changes on a fixed trace id, so writes follow the key", () => {
+    // Reachable because a customer-supplied trace_id can equal a run's dashless run_id:
+    // traceId stays put while source flips, and a stale subscription would keep writing
+    // the old key. `source` must therefore be in the effect's dependency array.
     type Props = { source: "detector" | "user" };
-
     const { rerender } = renderHook(
       ({ source }: Props) => useTraceStream("p1", "t1", true, source),
-      {
-        wrapper,
-        initialProps: {
-          source: "detector",
-        } as Props,
-      },
+      { wrapper, initialProps: { source: "detector" } as Props },
     );
-
     expect(FakeEventSource.instances).toHaveLength(1);
 
     rerender({ source: "user" });
-
     expect(FakeEventSource.instances).toHaveLength(2);
     expect(FakeEventSource.instances[0].closed).toBe(true);
 
     const userKey = traceQueryKey("p1", "t1", "user");
     client.setQueryData<TraceDetail>(userKey, traceDetail([span("a")]));
-
-    emit(FakeEventSource.instances[1], "spans", {
-      spans: [span("b")],
-    });
-
-    expect(client.getQueryData<TraceDetail>(userKey)?.spans.map((item) => item.span_id)).toEqual([
+    emit(FakeEventSource.instances[1], "spans", { spans: [span("b")] });
+    expect(client.getQueryData<TraceDetail>(userKey)?.spans.map((s) => s.span_id)).toEqual([
       "a",
       "b",
     ]);
   });
 
-  it("invalidates by the same key and closes on trace_complete", () => {
+  it("invalidates by the same key and closes the stream on trace_complete", () => {
     const invalidate = vi.spyOn(client, "invalidateQueries");
-
     const { result } = renderHook(() => useTraceStream("p1", "t1", true, "detector"), { wrapper });
 
     emit(FakeEventSource.instances[0], "trace_complete", {});
 
-    expect(invalidate).toHaveBeenCalledWith({
-      queryKey: traceQueryKey("p1", "t1", "detector"),
-    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: traceQueryKey("p1", "t1", "detector") });
     expect(FakeEventSource.instances[0].closed).toBe(true);
     expect(result.current.isStreaming).toBe(false);
   });
 
-  it("clears streaming state when EventSource reports an error", () => {
-    const { result } = renderHook(() => useTraceStream("p1", "t1", true, "detector"), { wrapper });
-    const eventSource = FakeEventSource.instances[0];
-
-    emit(eventSource, "spans", {
-      spans: [span("live")],
-    });
-    expect(result.current.isStreaming).toBe(true);
-
-    act(() => {
-      // This invokes the hook's real current onerror behavior.
-      eventSource.onerror?.();
-    });
-
-    expect(result.current.isStreaming).toBe(false);
-    // Current behavior leaves the EventSource open for browser retry.
-    expect(eventSource.closed).toBe(false);
-  });
-
-  it("closes the EventSource when the hook unmounts", () => {
-    const { unmount } = renderHook(() => useTraceStream("p1", "t1", true, "detector"), { wrapper });
-    const eventSource = FakeEventSource.instances[0];
-
-    expect(eventSource.closed).toBe(false);
-
-    act(() => {
-      unmount();
-    });
-
-    expect(eventSource.closed).toBe(true);
-  });
-
   it("does not subscribe when disabled", () => {
     renderHook(() => useTraceStream("p1", "t1", false, "detector"), { wrapper });
-
     expect(FakeEventSource.instances).toHaveLength(0);
   });
 
-  it("ignores malformed events and empty span batches", () => {
+  it("ignores a malformed event and an empty span batch", () => {
     const key = traceQueryKey("p1", "t1", "detector");
     client.setQueryData<TraceDetail>(key, traceDetail([span("a")]));
-
     const { result } = renderHook(() => useTraceStream("p1", "t1", true, "detector"), { wrapper });
-    const eventSource = FakeEventSource.instances[0];
 
-    act(() => {
-      eventSource.listeners.get("spans")?.({
-        data: "not json",
-      } as MessageEvent);
-    });
-    emit(eventSource, "spans", { spans: [] });
+    act(() =>
+      FakeEventSource.instances[0].listeners.get("spans")?.({ data: "not json" } as MessageEvent),
+    );
+    emit(FakeEventSource.instances[0], "spans", { spans: [] });
 
-    expect(client.getQueryData<TraceDetail>(key)?.spans.map((item) => item.span_id)).toEqual(["a"]);
+    expect(client.getQueryData<TraceDetail>(key)?.spans.map((s) => s.span_id)).toEqual(["a"]);
     expect(result.current.isStreaming).toBe(false);
   });
 });

--- a/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
+++ b/frontend/ui/src/features/traces/hooks/use-trace-stream.test.tsx
@@ -1,0 +1,230 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SpanKind, SpanStatus } from "@traceroot/core";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Span, TraceDetail } from "@/types/api";
+import { useTraceStream } from "./use-trace-stream";
+
+const TRACE_KEY = ["trace", "project-1", "trace-1"] as const;
+
+type EventSourceListener = (event: MessageEvent<string>) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  readonly url: string;
+  onerror: ((event: Event) => void) | null = null;
+  private listeners = new Map<string, EventSourceListener[]>();
+  close = vi.fn();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: EventSourceListener): void {
+    const listeners = this.listeners.get(type) ?? [];
+    this.listeners.set(type, [...listeners, listener]);
+  }
+
+  emit(type: string, data: unknown = {}): void {
+    const event = new MessageEvent<string>(type, {
+      data: JSON.stringify(data),
+    });
+
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  fail(): void {
+    this.onerror?.(new Event("error"));
+  }
+}
+
+function makeSpan(overrides: Partial<Span> & { span_id: string }): Span {
+  return {
+    span_id: overrides.span_id,
+    trace_id: "trace-1",
+    parent_span_id: null,
+    name: overrides.span_id,
+    span_kind: SpanKind.SPAN,
+    span_start_time: "2026-07-29T10:00:00.000Z",
+    span_end_time: "2026-07-29T10:00:01.000Z",
+    status: SpanStatus.OK,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    input: null,
+    output: null,
+    metadata: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...overrides,
+  };
+}
+
+function makeTrace(spans: Span[]): TraceDetail {
+  return {
+    trace_id: "trace-1",
+    project_id: "project-1",
+    name: "test trace",
+    trace_start_time: "2026-07-29T10:00:00.000Z",
+    user_id: null,
+    session_id: null,
+    git_ref: null,
+    git_repo: null,
+    environment: "test",
+    release: null,
+    input: null,
+    output: null,
+    metadata: null,
+    spans,
+  };
+}
+
+function createHarness() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+
+  return {
+    queryClient,
+    wrapper: Wrapper,
+  };
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.stubGlobal("EventSource", MockEventSource);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useTraceStream", () => {
+  it("merges span events into the trace cache", () => {
+    const { queryClient, wrapper } = createHarness();
+
+    queryClient.setQueryData(
+      TRACE_KEY,
+      makeTrace([
+        makeSpan({
+          span_id: "existing",
+          input: undefined,
+          output: undefined,
+          metadata: undefined,
+        }),
+      ]),
+    );
+
+    const { result } = renderHook(() => useTraceStream("project-1", "trace-1", true), { wrapper });
+    const eventSource = MockEventSource.instances[0];
+
+    expect(eventSource.url).toBe("/api/projects/project-1/traces/trace-1/live");
+
+    act(() => {
+      eventSource.emit("spans", {
+        spans: [
+          makeSpan({
+            span_id: "existing",
+            input: "complete input",
+          }),
+          makeSpan({
+            span_id: "new-span",
+          }),
+        ],
+      });
+    });
+
+    const cachedTrace = queryClient.getQueryData<TraceDetail>(TRACE_KEY);
+
+    expect(cachedTrace?.spans.filter((span) => span.span_id === "existing")).toHaveLength(1);
+    expect(cachedTrace?.spans.find((span) => span.span_id === "existing")?.input).toBe(
+      "complete input",
+    );
+    expect(cachedTrace?.spans.some((span) => span.span_id === "new-span")).toBe(true);
+    expect(result.current.isStreaming).toBe(true);
+  });
+
+  it("closes and invalidates the trace query when trace_complete arrives", () => {
+    const { queryClient, wrapper } = createHarness();
+    queryClient.setQueryData(TRACE_KEY, makeTrace([]));
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+
+    const { result } = renderHook(() => useTraceStream("project-1", "trace-1", true), { wrapper });
+    const eventSource = MockEventSource.instances[0];
+
+    act(() => {
+      eventSource.emit("spans", {
+        spans: [makeSpan({ span_id: "live-span" })],
+      });
+    });
+    expect(result.current.isStreaming).toBe(true);
+
+    act(() => {
+      eventSource.emit("trace_complete");
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(eventSource.close).toHaveBeenCalledOnce();
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["trace", "project-1", "trace-1"],
+    });
+  });
+
+  it("clears streaming state when EventSource reports an error", () => {
+    const { queryClient, wrapper } = createHarness();
+    queryClient.setQueryData(TRACE_KEY, makeTrace([]));
+
+    const { result } = renderHook(() => useTraceStream("project-1", "trace-1", true), { wrapper });
+    const eventSource = MockEventSource.instances[0];
+
+    act(() => {
+      eventSource.emit("spans", {
+        spans: [makeSpan({ span_id: "live-span" })],
+      });
+    });
+    expect(result.current.isStreaming).toBe(true);
+
+    act(() => {
+      eventSource.fail();
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(eventSource.close).not.toHaveBeenCalled();
+  });
+
+  it("closes the EventSource when the hook unmounts", () => {
+    const { wrapper } = createHarness();
+
+    const { unmount } = renderHook(() => useTraceStream("project-1", "trace-1", true), { wrapper });
+    const eventSource = MockEventSource.instances[0];
+
+    expect(eventSource.close).not.toHaveBeenCalled();
+
+    act(() => {
+      unmount();
+    });
+
+    expect(eventSource.close).toHaveBeenCalledOnce();
+  });
+});

--- a/frontend/ui/src/features/traces/utils/index.test.ts
+++ b/frontend/ui/src/features/traces/utils/index.test.ts
@@ -536,10 +536,10 @@ describe("base-fetched skeleton spans build a connected tree", () => {
   // connected. The backend half is guarded in tests/rest/test_trace_reader.py
   // (the SELECT extracts the attrs) and tests/rest/test_traces_router.py (the
   // dashboard route does not drop them).
-  it("nests a skeleton child under a synthesized ancestor instead of orphaning it", () => {
+  it("builds one connected tree from a base skeleton with pending ancestors", () => {
     // Only the leaf has been exported so far: its parent chain is still running.
     const skeletonSpans = [
-      makeSpan({
+      makeSkeletonSpan({
         span_id: "leaf",
         parent_span_id: "agent",
         name: "tool_call",
@@ -547,19 +547,19 @@ describe("base-fetched skeleton spans build a connected tree", () => {
       }),
     ];
 
-    const rows = buildSpanTree(enrichSpansWithPending(skeletonSpans));
+    const repairedSpans = enrichSpansWithPending(skeletonSpans);
+    const rows = buildSpanTree(repairedSpans);
+    const visibleHierarchy = rows.map((row) => [row.span.span_id, row.level]);
 
-    expect(rows.map((r) => [r.span.span_id, r.level])).toEqual([
+    expect(visibleHierarchy).toEqual([
       ["root", 0],
       ["agent", 1],
       ["leaf", 2],
     ]);
-    // The ancestors are placeholders, and the real leaf is not one.
-    expect(rows[0].span.pending).toBe(true);
-    expect(rows[1].span.pending).toBe(true);
-    expect(rows[2].span.pending).toBeUndefined();
-    // Exactly one top-level row: nothing is orphaned up to the root.
-    expect(rows.filter((r) => r.level === 0)).toHaveLength(1);
+
+    const topLevelRows = rows.filter((row) => row.level === 0);
+    expect(topLevelRows).toHaveLength(1);
+    expect(topLevelRows[0].span.span_id).toBe("root");
   });
 
   it("orphans the child when the skeleton carries no path metadata", () => {

--- a/tests/rest/test_live_router.py
+++ b/tests/rest/test_live_router.py
@@ -60,6 +60,14 @@ def redis_message(payload: dict) -> dict:
 
 
 @pytest.fixture()
+def mock_ch(monkeypatch):
+    """Mock ClickHouse client."""
+    mock = MagicMock()
+    monkeypatch.setattr("db.clickhouse.client.get_clickhouse_client", lambda: mock)
+    return mock
+
+
+@pytest.fixture()
 def client():
     async def mock_access(project_id: str, x_user_id=None):
         return ProjectAccessInfo(project_id=project_id, user_id="u1", role="ADMIN")
@@ -85,19 +93,59 @@ class ConnectedRequest:
         return False
 
 
+class TestCompletionStateInClickHouse:
+    def test_queries_latest_span_versions_and_returns_timestamps(self, mock_ch):
+        """The helper pins the dedup query and returns ClickHouse timestamps."""
+        root_end_time = datetime(2026, 7, 28, 10, 0, 0)
+        last_ingest_time = datetime(2026, 7, 28, 10, 0, 5)
+        mock_ch.query.return_value = MagicMock(result_rows=[(root_end_time, last_ingest_time)])
+
+        result = live_router._completion_state_in_clickhouse(PROJECT_ID, TRACE_ID)
+
+        assert result == (root_end_time, last_ingest_time)
+        mock_ch.query.assert_called_once()
+
+        query_call = mock_ch.query.call_args
+        sql = " ".join(query_call.args[0].split())
+
+        assert "maxIf(span_end_time, isNull(parent_span_id))" in sql
+        assert "max(ch_update_time)" in sql
+        assert "ORDER BY ch_update_time DESC" in sql
+        assert "LIMIT 1 BY span_id" in sql
+        assert query_call.kwargs["parameters"] == {
+            "project_id": PROJECT_ID,
+            "trace_id": TRACE_ID,
+        }
+
+    def test_returns_open_root_state(self, mock_ch):
+        """A null root end time means the root span is still open."""
+        last_ingest_time = datetime(2026, 7, 28, 10, 0, 5)
+        mock_ch.query.return_value = MagicMock(result_rows=[(None, last_ingest_time)])
+
+        result = live_router._completion_state_in_clickhouse(PROJECT_ID, TRACE_ID)
+
+        assert result == (None, last_ingest_time)
+
+    def test_returns_empty_state_when_clickhouse_has_no_rows(self, mock_ch):
+        """No ClickHouse rows means no known completion or activity."""
+        mock_ch.query.return_value = MagicMock(result_rows=[])
+
+        result = live_router._completion_state_in_clickhouse(PROJECT_ID, TRACE_ID)
+
+        assert result == (None, None)
+
+
 class TestAlreadyCompleteTrace:
-    def test_emits_trace_complete_after_quiet_window(self, client):
+    def test_emits_trace_complete_after_quiet_window(self, client, mock_ch):
         """A root span with end_time starts the quiet window, then emits completion."""
         pubsub = MockPubSub([])
         mock_redis = MagicMock()
         mock_redis.pubsub.return_value = pubsub
+        completed_at = _utcnow_naive()
+        mock_ch.query.return_value = MagicMock(result_rows=[(completed_at, completed_at)])
 
         with (
             patch("rest.routers.live.TRACE_COMPLETE_QUIET_SECONDS", 0.1),
-            patch(
-                "rest.routers.live._completion_state_in_clickhouse",
-                return_value=(_utcnow_naive(), _utcnow_naive()),
-            ),
             patch("shared.redis.get_async_redis_client", return_value=mock_redis),
         ):
             resp = client.get(ENDPOINT)
@@ -105,6 +153,7 @@ class TestAlreadyCompleteTrace:
         assert resp.status_code == 200
         events = parse_sse_events(resp.text)
         assert events == ["event: trace_complete"]
+        mock_ch.query.assert_called_once()
 
     def test_expired_quiet_window_closes_without_redis_poll(self, client):
         """If the quiet deadline has already elapsed, completion is emitted directly."""
@@ -404,19 +453,20 @@ class TestHardDeadline:
         events = parse_sse_events(resp.text)
         assert events == ["event: trace_complete"]
 
-    def test_hard_deadline_without_completed_root_emits_stream_timeout(self, client):
+    def test_hard_deadline_without_completed_root_emits_stream_timeout(self, client, mock_ch):
         """A trace whose root never completed hits the ceiling as a timeout,
         not a completion — the trace is not done."""
         pubsub = MockPubSub([])
         mock_redis = MagicMock()
         mock_redis.pubsub.return_value = pubsub
+        mock_ch.query.return_value = MagicMock(result_rows=[(None, None)])
 
         with (
             patch("rest.routers.live.MAX_STREAM_SECONDS", -1),
-            patch("rest.routers.live._completion_state_in_clickhouse", return_value=(None, None)),
             patch("shared.redis.get_async_redis_client", return_value=mock_redis),
         ):
             resp = client.get(ENDPOINT)
 
         events = parse_sse_events(resp.text)
         assert events == ["event: stream_timeout"]
+        mock_ch.query.assert_called_once()

--- a/tests/worker/test_ingest_tasks.py
+++ b/tests/worker/test_ingest_tasks.py
@@ -1,14 +1,23 @@
 """Unit tests for Celery task logic with mocked S3 + ClickHouse."""
 
+import json
 from unittest.mock import MagicMock
 
 import pytest
 
 from tests.fixtures.otel_payloads import make_otel_payload, make_span
-from worker.ingest_tasks import process_s3_traces
+from worker.ingest_tasks import _publish_live_spans, process_s3_traces
 
 TRACE_HEX = "aa" * 16
 SPAN_HEX = "bb" * 8
+
+
+@pytest.fixture()
+def mock_redis(monkeypatch):
+    """Mock Redis Client."""
+    mock = MagicMock()
+    monkeypatch.setattr("redis.from_url", lambda url, decode_responses=True: mock)
+    return mock
 
 
 @pytest.fixture()
@@ -35,8 +44,87 @@ def mock_detector_enqueue(monkeypatch):
     return mock
 
 
+class TestPublishLiveSpans:
+    def test_groups_spans_by_trace(self, mock_redis):
+        """Each trace receives one spans event on its own Redis channel."""
+        trace_a_spans = [
+            {
+                "trace_id": "trace-a",
+                "span_id": "a-root",
+                "parent_span_id": "existing-parent",
+                "span_end_time": None,
+            },
+            {
+                "trace_id": "trace-a",
+                "span_id": "a-child",
+                "parent_span_id": "a-root",
+                "span_end_time": None,
+            },
+        ]
+        trace_b_spans = [
+            {
+                "trace_id": "trace-b",
+                "span_id": "b-child",
+                "parent_span_id": "b-root",
+                "span_end_time": None,
+            },
+        ]
+
+        _publish_live_spans(
+            [trace_a_spans[0], trace_b_spans[0], trace_a_spans[1]],
+            project_id="proj-1",
+        )
+
+        published_span_events = {}
+        for publish_call in mock_redis.publish.call_args_list:
+            channel, encoded_payload = publish_call.args
+            payload = json.loads(encoded_payload)
+            if payload["type"] == "spans":
+                published_span_events[channel] = payload["spans"]
+
+        assert published_span_events == {
+            "trace:live:proj-1:trace-a": trace_a_spans,
+            "trace:live:proj-1:trace-b": trace_b_spans,
+        }
+        mock_redis.close.assert_called_once_with()
+
+    def test_publishes_completion_only_for_completed_root(self, mock_redis):
+        """A completed child or an open root must not complete a trace."""
+        spans = [
+            {
+                "trace_id": "completed-trace",
+                "span_id": "completed-root",
+                "parent_span_id": None,
+                "span_end_time": "2026-07-28T10:00:00",
+            },
+            {
+                "trace_id": "open-trace",
+                "span_id": "open-root",
+                "parent_span_id": None,
+                "span_end_time": None,
+            },
+            {
+                "trace_id": "child-only-trace",
+                "span_id": "completed-child",
+                "parent_span_id": "missing-root",
+                "span_end_time": "2026-07-28T10:00:00",
+            },
+        ]
+
+        _publish_live_spans(spans, project_id="proj-1")
+
+        completion_channels = []
+        for publish_call in mock_redis.publish.call_args_list:
+            channel, encoded_payload = publish_call.args
+            payload = json.loads(encoded_payload)
+            if payload["type"] == "trace_complete":
+                completion_channels.append(channel)
+
+        assert completion_channels == ["trace:live:proj-1:completed-trace"]
+
+
 class TestProcessS3Traces:
-    def test_happy_path(self, mock_s3, mock_ch):
+    def test_happy_path(self, mock_s3, mock_ch, mock_redis):
         """Downloads from S3, transforms, inserts traces + spans."""
         payload = make_otel_payload([make_span(TRACE_HEX, SPAN_HEX, name="test")])
         mock_s3.download_json.return_value = payload
@@ -48,8 +136,25 @@ class TestProcessS3Traces:
         assert result["spans"] == 1
         mock_ch.insert_traces_batch.assert_called_once()
         mock_ch.insert_spans_batch.assert_called_once()
+        mock_redis.publish.assert_called()
 
-    def test_empty_payload(self, mock_s3, mock_ch):
+    def test_redis_publish_failure_does_not_break_ingestion(
+        self, mock_s3, mock_ch, mock_redis, caplog
+    ):
+        """Redis failure is logged, but ClickHouse ingestion still succeeds."""
+        payload = make_otel_payload([make_span(TRACE_HEX, SPAN_HEX, name="test")])
+        mock_s3.download_json.return_value = payload
+        mock_redis.publish.side_effect = ConnectionError("Redis unavailable")
+
+        result = process_s3_traces(s3_key="test/key.json", project_id="proj-1")
+
+        assert result["traces"] == 1
+        assert result["spans"] == 1
+        mock_ch.insert_traces_batch.assert_called_once()
+        mock_ch.insert_spans_batch.assert_called_once()
+        assert "Failed to publish live spans to Redis" in caplog.text
+
+    def test_empty_payload(self, mock_s3, mock_ch, mock_redis):
         """Empty OTEL data -> no inserts, returns zeros."""
         mock_s3.download_json.return_value = {"resourceSpans": []}
 
@@ -59,8 +164,9 @@ class TestProcessS3Traces:
         assert result["spans"] == 0
         mock_ch.insert_traces_batch.assert_not_called()
         mock_ch.insert_spans_batch.assert_not_called()
+        mock_redis.publish.assert_not_called()
 
-    def test_s3_download_fails(self, mock_s3, mock_ch):
+    def test_s3_download_fails(self, mock_s3, mock_ch, mock_redis):
         """S3 error -> exception raised (Celery will retry)."""
         mock_s3.download_json.side_effect = Exception("S3 error")
 
@@ -68,8 +174,9 @@ class TestProcessS3Traces:
             process_s3_traces(s3_key="test/key.json", project_id="proj-1")
 
         mock_ch.insert_traces_batch.assert_not_called()
+        mock_redis.publish.assert_not_called()
 
-    def test_clickhouse_insert_fails(self, mock_s3, mock_ch):
+    def test_clickhouse_insert_fails(self, mock_s3, mock_ch, mock_redis):
         """CH insert error -> exception raised."""
         payload = make_otel_payload([make_span(TRACE_HEX, SPAN_HEX)])
         mock_s3.download_json.return_value = payload
@@ -78,7 +185,9 @@ class TestProcessS3Traces:
         with pytest.raises(Exception, match="CH connection error"):
             process_s3_traces(s3_key="test/key.json", project_id="proj-1")
 
-    def test_multiple_traces_and_spans(self, mock_s3, mock_ch):
+        mock_redis.publish.assert_not_called()
+
+    def test_multiple_traces_and_spans(self, mock_s3, mock_ch, mock_redis):
         """Payload with multiple traces processes correctly."""
         trace1 = "aa" * 16
         trace2 = "bb" * 16
@@ -95,9 +204,10 @@ class TestProcessS3Traces:
 
         assert result["traces"] == 2
         assert result["spans"] == 3
+        mock_redis.publish.assert_called()
 
     def test_detector_enqueue_gets_only_root_bearing_traces(
-        self, mock_s3, mock_ch, mock_detector_enqueue
+        self, mock_s3, mock_ch, mock_redis, mock_detector_enqueue
     ):
         """Enqueue receives only the traces whose root span arrived in this batch."""
         root_trace = "aa" * 16
@@ -119,6 +229,7 @@ class TestProcessS3Traces:
         assert project_id == "proj-1"
         # Only the root-bearing trace is passed; the child-only late_trace is not.
         assert traces_with_root == {root_trace}
+        mock_redis.publish.assert_called()
 
     def test_detector_enqueue_not_called_for_empty_batch(
         self, mock_s3, mock_ch, mock_detector_enqueue


### PR DESCRIPTION
Fixes #1490 

## Summary

Adds regression tests for the live tracing paths.

- The tests cover:
- Redis publishing from the worker
- Completion-state inference from ClickHouse
- Router completion and timeout behavior
- Deterministic sibling ordering during live updates
- Pending-ancestor repair in the trace tree

All backend tests use fake Redis and ClickHouse clients, so they do not require external services.

Tests

`tests/worker/test_ingest_tasks.py` — verifies live spans are grouped by trace and published to the correct Redis channels, `trace_complete` is emitted only for completed root spans, Redis failures are logged without breaking ClickHouse ingestion, and empty or failed ingestion batches do not publish.

`tests/rest/test_live_router.py` — exercises the real `_completion_state_in_clickhouse` helper with a fake ClickHouse client, verifies the deduplicating query shape and completion results, and covers router completion, Redis draining, and hard stream-timeout behavior without connecting to real Redis or ClickHouse.

`frontend/ui/src/features/traces/components/SpanTreeView.test.ts` — verifies same-millisecond sibling spans remain in a deterministic order across different SSE arrival orders, and that tree order, timeline order, and final refetch order stay consistent.

`frontend/ui/src/features/traces/utils/index.test.ts` — verifies a base-fetched skeleton containing a leaf span is repaired with pending ancestors and produces one connected `root → agent → leaf` tree, while spans without path metadata remain orphaned.

## Type of Change

- [ ] feat - A new feature
- [ ] fix - A bug fix
- [ ] docs - Documentation only changes
- [ ] style - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
- [ ] refactor - A code change that neither fixes a bug nor adds a feature
- [ ] perf - A code change that improves performance
- [x] test - Adding missing tests or correcting existing tests
- [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
- [ ] ci - Changes to our Cl configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
- [ ] chore - Other changes that don't modify sc or test files
- [ ] revert - Reverts a previous commit
- [ ] security - A security fix or improvement
- [ ] github - Changes to our GitHub configuration files and scripts
- [ ] other (please describe):

## Details

## Screenshots / Recordings (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added/updated tests where applicable
- [ ] I have added screenshots or recordings for UI changes (if applicable)
- [ ] I have updated documentation where necessary


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests for live tracing across the worker, live router, and UI trace tree to ensure correct publishing, completion inference, deterministic ordering, and ancestor repair without external services.

- **Backend Tests**
  - Worker: groups span publish by trace and emits `trace_complete` only for completed roots; logs Redis failures; skips publish on empty batches.
  - Router: exercises `_completion_state_in_clickhouse` with a mock client, pins the dedup query shape, and covers quiet-window completion vs hard stream timeout.

- **Frontend Tests**
  - Span tree: keeps same-millisecond siblings deterministic across SSE arrival and final refetch via `mergeSpans`, with parity between tree and timeline.
  - Utils: repairs a skeleton leaf with pending ancestors into one connected `root → agent → leaf` tree; orphans spans without path metadata.

<sup>Written for commit b7c449579b567a194a457970721a202080b26089. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

