### PR TITLE
fix(worker): stop one malformed span from discarding a whole ingest batch

### DIFF
--- a/backend/worker/ingest_tasks.py
+++ b/backend/worker/ingest_tasks.py
@@ -121,10 +121,16 @@ def process_s3_traces(self, s3_key: str, project_id: str) -> dict:
                 ]
                 if trace_records_missing_root:
                     ids = [t["trace_id"] for t in trace_records_missing_root]
+                    # project_id is the sort-key prefix, and trace_id carries no skip
+                    # index — so without this predicate the probe cannot prune and
+                    # becomes a FINAL scan of every project in the table to answer a
+                    # question about one. Still O(project), not O(batch): nothing
+                    # bounds trace_start_time here.
                     result = ch_client.query(
                         "SELECT DISTINCT trace_id FROM traces FINAL"
-                        " WHERE trace_id IN {ids:Array(String)}",
-                        parameters={"ids": ids},
+                        " WHERE project_id = {project_id:String}"
+                        " AND trace_id IN {ids:Array(String)}",
+                        parameters={"ids": ids, "project_id": project_id},
                     )
                     existing_ids = {row[0] for row in result.result_rows}
                     traces = [

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -150,24 +150,59 @@ def first_present(attrs: dict[str, Any], keys: list[str]) -> Any:
     return None
 
 
+# Upper sanity bound per token field, shared by the manual-usage and instrumentor
+# paths. Sized by the tightest downstream column, which is `cost`, not the token
+# columns: every accepted count is priced into Decimal64(9) — Decimal(18,9), nine
+# integer digits, so strictly under $10^9 (the same ceiling `filters/translate.py`
+# derives for that type). Pricing multiplies a count by a per-token rate, and the
+# catalog's most expensive model is under 1e-3/token summed across its input,
+# cache, and output rates, so a bound of 10^9 prices to under $10^6 — three orders
+# inside the column, which keeps the guard correct no matter what rate a future
+# catalog row carries rather than resting on today's most expensive model. Any sum
+# of the fields stays far inside the Int64 token columns. 10^9 tokens is orders of
+# magnitude beyond any shipped context window, so nothing legitimate is near it.
+_MAX_PLAUSIBLE_TOKENS = 10**9
+
+
+def _usable_token_value(value: Any) -> bool:
+    """Check whether a token attribute will survive ``int_or_zero`` intact.
+
+    Single source of truth for "usable count", so the candidate-list scan and the
+    coercion cannot disagree about which values are worth taking.
+
+    Args:
+        value (Any): Raw OTEL attribute value.
+
+    Returns:
+        bool: True when the value parses to a non-negative int within the
+            plausible bound -- i.e. ``int_or_zero`` will return it unchanged.
+    """
+    if value is None or value == "" or isinstance(value, bool):
+        return False
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return False
+    return 0 <= parsed <= _MAX_PLAUSIBLE_TOKENS
+
+
 def first_present_number(attrs: dict[str, Any], keys: list[str]) -> Any:
     """Like ``first_present`` but for numeric token attributes: skip keys whose
     value is missing or malformed (empty / non-numeric) so a malformed
     high-priority attribute cannot suppress a valid lower-priority fallback.
 
-    Validity mirrors ``int_or_zero`` (the value must coerce via ``int``); a present
-    but unusable value is skipped rather than short-circuiting the candidate list.
+    Validity is exactly what ``int_or_zero`` will accept, via the shared
+    ``_usable_token_value`` predicate. The two must not drift: a value this
+    function returns but ``int_or_zero`` then drops to 0 gets the worst of both
+    behaviours -- the malformed attribute short-circuits the candidate list AND
+    resolves to nothing, so a perfectly good lower-priority fallback is never
+    reached and the span is stored with no usage at all.
+
     Returns the first usable value, or None if none qualify.
     """
     for key in keys:
-        value = attrs.get(key)
-        if value is None or value == "":
-            continue
-        try:
-            int(value)
-        except (TypeError, ValueError):
-            continue
-        return value
+        if _usable_token_value(attrs.get(key)):
+            return attrs.get(key)
     return None
 
 
@@ -177,14 +212,97 @@ def int_or_zero(value: Any) -> int:
     ``first_present`` returns falsy-but-present values (e.g. an empty string for
     an attribute that exists with a non-numeric value), so guard the cast — a
     single malformed attribute must not crash ingestion of the whole batch.
+
+    Bounded by the same limit as the manual-usage path, and an over-bound value is
+    dropped to 0 rather than clamped (see below): these values are summed into
+    ``total_tokens`` (Int64) and priced into ``cost`` (Decimal(18,9)), so an
+    unbounded per-field value overflows the column and ClickHouse rejects the
+    whole insert — which on the public path discards every trace in the batch,
+    not just this span. Negative counts are floored at 0 for the same reason the
+    manual path floors them: they are meaningless as usage and would subtract
+    from dashboard sums.
     """
     if value is None or value == "":
         return 0
     try:
-        return int(value)
+        parsed = int(value)
     except (TypeError, ValueError):
         logger.warning("Non-numeric OTEL token attribute %r; treating as 0", value)
         return 0
+    if parsed < 0:
+        logger.warning("Negative OTEL token attribute %r; treating as 0", value)
+        return 0
+    if parsed > _MAX_PLAUSIBLE_TOKENS:
+        # Dropped, not clamped. Clamping substitutes an implausible count that is then
+        # priced and stored, so one malformed span lands a trillion-token, nine-figure
+        # row that dominates every cost and token aggregate it appears in. The
+        # manual-usage path discards an over-bound field for the same reason, and every
+        # other unusable value here already resolves to 0.
+        logger.warning(
+            "OTEL token attribute %r exceeds the plausible bound %d; treating as 0",
+            value,
+            _MAX_PLAUSIBLE_TOKENS,
+        )
+        return 0
+    return parsed
+
+
+def str_or_none(value: Any) -> str | None:
+    """Coerce a present OTEL attribute to str for a String column; None stays None.
+
+    Same hazard as ``str_attr``, one layer later: OTLP values are typed, so an
+    ordinary sender can put an int in ``user.id`` or a bool in ``session.id``. Those
+    reach ClickHouse columns typed ``Nullable(String)``, which rejects a non-string
+    and fails the INSERT — and the insert carries the whole batch, so on the public
+    path one such span discards every trace in the export after the route already
+    returned 200. Coerce rather than drop: the value is still the caller's identifier,
+    just wrongly typed on the wire.
+    """
+    if value is None or isinstance(value, str):
+        return value
+    return str(value)
+
+
+def int32_or_none(value: Any) -> int | None:
+    """Coerce a present OTEL attribute to an Int32-representable int; else None.
+
+    Mirror of ``str_or_none`` for the ``Nullable(Int32)`` columns. An SDK is free to
+    report a line number as a string, a float, or a value past the Int32 range, and
+    any of those fails the INSERT for the whole batch. Out-of-range and unparseable
+    values become None rather than being clamped: a wrong line number is worse than
+    an absent one, since it points a reader at unrelated source.
+    """
+    # isinstance(True, int) is True and int(True) is 1, so an unguarded bool would
+    # silently record line 1 -- the "points a reader at unrelated source" outcome
+    # this helper drops out-of-range values to avoid.
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        logger.warning("Non-numeric OTEL Int32 attribute %r; dropping", value)
+        return None
+    if not (-(2**31) <= parsed < 2**31):
+        logger.warning("OTEL Int32 attribute %r outside the column range; dropping", value)
+        return None
+    return parsed
+
+
+def str_attr(value: Any) -> str:
+    """Coerce a present OTEL attribute to str for case-folding; missing -> "".
+
+    OTLP attribute values are typed — a sender may legitimately supply an int,
+    bool, double or array for a key we expect to be a string. Guarding only for
+    None (``attrs.get(k) or ""``) leaves ``.upper()``/``.lower()`` to raise
+    AttributeError on those, which on the public path is fatal well past the
+    point of no return: the route has already 200'd, so the whole S3 batch —
+    every trace in that export, not just the offending span — is lost after the
+    task's retries. Coerce instead; a wrong-typed value simply fails to match
+    any known kind and falls through to the normal inference path.
+    """
+    if value is None:
+        return ""
+    return value if isinstance(value, str) else str(value)
 
 
 # Fields recognized in the Python SDK's manual usage dict
@@ -201,14 +319,6 @@ _MANUAL_USAGE_KEYS = (
     "cache_write_1h_tokens",
     "reasoning_tokens",
 )
-
-# Upper sanity bound per manual usage field. The token columns are Int64 and we
-# store SUMS of fields (total_tokens = uncached + cache buckets + output), so the
-# bound must sit far below Int64-max — capping at Int64-max itself would still
-# let two capped fields overflow the stored sum and reject the whole insert
-# batch. 10^15 tokens is orders of magnitude beyond any real span while keeping
-# any sum of the six fields comfortably inside Int64.
-_MANUAL_USAGE_MAX_TOKENS = 10**15
 
 
 def parse_manual_usage(raw: Any) -> dict[str, int]:
@@ -272,7 +382,7 @@ def parse_manual_usage(raw: Any) -> dict[str, int]:
                 "Manual usage field %s is not a usable number (%r); ignoring it", key, value
             )
             continue
-        if parsed > _MANUAL_USAGE_MAX_TOKENS:
+        if parsed > _MAX_PLAUSIBLE_TOKENS:
             logger.warning(
                 "Manual usage field %s exceeds the sanity bound (%r); ignoring it", key, value
             )
@@ -395,12 +505,12 @@ def get_span_kind(attrs: dict[str, Any], otel_kind: int | str | None) -> str:
         One of: "LLM", "SPAN", "AGENT", "TOOL"
     """
     # Check explicit type attribute (handle None values)
-    explicit_type = (attrs.get("traceroot.span.type") or "").upper()
+    explicit_type = str_attr(attrs.get("traceroot.span.type")).upper()
     if explicit_type in (SpanKind.LLM, SpanKind.SPAN, SpanKind.AGENT, SpanKind.TOOL):
         return explicit_type
 
     # Check OpenInference semantic conventions (handle None values)
-    openinference_type = (attrs.get("openinference.span.kind") or "").upper()
+    openinference_type = str_attr(attrs.get("openinference.span.kind")).upper()
     if openinference_type == SpanKind.LLM:
         return SpanKind.LLM
     elif openinference_type == SpanKind.AGENT:
@@ -411,7 +521,7 @@ def get_span_kind(attrs: dict[str, Any], otel_kind: int | str | None) -> str:
         return SpanKind.SPAN
 
     # GenAI semconv operation name (pydantic-ai, native OTel GenAI instrumentors)
-    operation_name = (attrs.get("gen_ai.operation.name") or "").lower()
+    operation_name = str_attr(attrs.get("gen_ai.operation.name")).lower()
     if operation_name in ("chat", "text_completion", "embeddings"):
         return SpanKind.LLM
     if operation_name == "execute_tool":
@@ -442,14 +552,14 @@ def get_span_kind(attrs: dict[str, Any], otel_kind: int | str | None) -> str:
 
 def _extract_user_id(attrs: dict[str, Any]) -> str | None:
     """Extract user_id from span attributes, checking multiple keys."""
-    return (
+    return str_or_none(
         attrs.get("traceroot.trace.user_id") or attrs.get("user.id") or attrs.get("session.user_id")
     )
 
 
 def _extract_session_id(attrs: dict[str, Any]) -> str | None:
     """Extract session_id from span attributes, checking multiple keys."""
-    return attrs.get("traceroot.trace.session_id") or attrs.get("session.id")
+    return str_or_none(attrs.get("traceroot.trace.session_id") or attrs.get("session.id"))
 
 
 def transform_otel_to_clickhouse(
@@ -538,7 +648,10 @@ def transform_otel_to_clickhouse(
                 if span_kind == SpanKind.TOOL:
                     tool_name = span_attrs.get("gen_ai.tool.name") or span_attrs.get("tool.name")
                     if tool_name:
-                        span_name = tool_name
+                        # `name` is a non-nullable String on both spans and traces, and
+                        # this is the one path that sources it from a caller attribute
+                        # rather than the proto's own string field.
+                        span_name = str_attr(tool_name)
 
                 # Build span record
                 environment = span_attrs.get("traceroot.environment")
@@ -557,9 +670,11 @@ def transform_otel_to_clickhouse(
                     span_record["environment"] = environment
 
                 # Extract git source fields for span
-                git_source_file = span_attrs.get("traceroot.git.source_file")
-                git_source_line = span_attrs.get("traceroot.git.source_line")
-                git_source_function = span_attrs.get("traceroot.git.source_function")
+                git_source_file = str_or_none(span_attrs.get("traceroot.git.source_file"))
+                # source_line lands in Nullable(Int32): parse it like any other numeric
+                # attribute rather than passing a non-numeric string straight through.
+                git_source_line = int32_or_none(span_attrs.get("traceroot.git.source_line"))
+                git_source_function = str_or_none(span_attrs.get("traceroot.git.source_function"))
                 if git_source_file is not None:
                     span_record["git_source_file"] = git_source_file
                 if git_source_line is not None:
@@ -610,7 +725,12 @@ def transform_otel_to_clickhouse(
                 # name is present, not just for LLM spans. Auto-instrumentors
                 # (OpenInference, GenAI) set model/token attrs on AGENT and CHAIN spans
                 # too. Text-based ESTIMATION, however, is LLM-spans-only (see below).
-                model_name = (
+                # Coerced before use, not just before storage: a non-string model
+                # reaches `get_model_price`, whose catalog lookup is a regex match and
+                # raises TypeError on a non-str — out of the per-span loop and out of
+                # the whole transform, so the batch is lost before it ever reaches an
+                # INSERT the column type could reject.
+                model_name = str_or_none(
                     span_attrs.get("traceroot.llm.model")
                     or span_attrs.get("gen_ai.request.model")
                     or span_attrs.get("llm.model_name")
@@ -905,8 +1025,8 @@ def transform_otel_to_clickhouse(
                 # Priority: root span values overwrite, child span values only set if empty
                 span_user_id = _extract_user_id(span_attrs)
                 span_session_id = _extract_session_id(span_attrs)
-                span_git_ref = span_attrs.get("traceroot.git.ref")
-                span_git_repo = span_attrs.get("traceroot.git.repo")
+                span_git_ref = str_or_none(span_attrs.get("traceroot.git.ref"))
+                span_git_repo = str_or_none(span_attrs.get("traceroot.git.repo"))
 
                 if trace_id not in trace_attrs:
                     trace_attrs[trace_id] = {"user_id": None, "session_id": None}
@@ -975,7 +1095,7 @@ def transform_otel_to_clickhouse(
                     span_path_c = span_attrs.get(SPAN_PATH)
                     ids_path_c = span_attrs.get(SPAN_IDS_PATH)
                     candidate_name = (
-                        span_path_c[0]
+                        str_attr(span_path_c[0])
                         if isinstance(span_path_c, (list, tuple)) and span_path_c
                         else span_name
                     )

--- a/tests/worker/test_ingest_tasks.py
+++ b/tests/worker/test_ingest_tasks.py
@@ -120,6 +120,20 @@ class TestProcessS3Traces:
         # Only the root-bearing trace is passed; the child-only late_trace is not.
         assert traces_with_root == {root_trace}
 
+    def test_missing_root_probe_is_scoped_to_the_project(self, mock_s3, mock_ch):
+        """The probe names project_id, the sort-key prefix it needs to prune on."""
+        late_trace = "cc" * 16
+        mock_s3.download_json.return_value = make_otel_payload(
+            [make_span(late_trace, "44" * 8, name="child", parent_span_id_hex="55" * 8)]
+        )
+        mock_ch.query.return_value = MagicMock(result_rows=[])
+
+        process_s3_traces(s3_key="test/key.json", project_id="proj-1")
+
+        args, kwargs = mock_ch.query.call_args
+        assert "project_id" in args[0]
+        assert kwargs["parameters"]["project_id"] == "proj-1"
+
     def test_detector_enqueue_not_called_for_empty_batch(
         self, mock_s3, mock_ch, mock_detector_enqueue
     ):

--- a/tests/worker/test_otel_transform_attr_hardening.py
+++ b/tests/worker/test_otel_transform_attr_hardening.py
@@ -1,0 +1,232 @@
+"""OTLP attribute values are typed, and a wrong type must not destroy an export.
+
+Every attribute here reaches a typed ClickHouse column. A value of the wrong type
+raises inside the transform or is rejected by the column, and on the public path
+that happens AFTER the route returned 200 — the celery task then retries and drops
+the whole S3 export, every trace in it, not just the offending span. These pin the
+coercions that keep one malformed span from doing that.
+"""
+
+import base64
+import json
+from pathlib import Path
+
+import pytest
+
+from worker.otel_transform import (
+    _MAX_PLAUSIBLE_TOKENS,
+    first_present_number,
+    get_span_kind,
+    int32_or_none,
+    int_or_zero,
+    str_or_none,
+    transform_otel_to_clickhouse,
+)
+
+# Seed for the `standard_model_prices` rows the pricing cache reads at runtime. The
+# runtime source is Postgres, so this is the closest checked-in stand-in — a price
+# added to the product arrives here first.
+_PRICE_CATALOG = "frontend/packages/core/src/standard-model-prices.json"
+
+
+@pytest.mark.parametrize("value", [7, True, ["chat"], 1.5, {"a": 1}])
+def test_wrong_typed_span_kind_attributes_do_not_raise(value):
+    """The three case-folded lookups previously raised AttributeError on non-str."""
+    for key in ("traceroot.span.type", "openinference.span.kind", "gen_ai.operation.name"):
+        assert get_span_kind({key: value}, None) == "SPAN"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("llm", "LLM"), ("LLM", "LLM"), ("Llm", "LLM"), ("agent", "AGENT"), ("", "SPAN")],
+)
+def test_string_classification_is_unchanged_by_coercion(value, expected):
+    """Coercion must not alter how real string values classify."""
+    assert get_span_kind({"traceroot.span.type": value}, None) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(12345, "12345"), (True, "True"), (["a"], "['a']"), ("kept", "kept"), (None, None)],
+)
+def test_string_column_attributes_are_coerced(value, expected):
+    """user.id / session.id / git.* land in Nullable(String); an int fails the insert."""
+    assert str_or_none(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (100, 100),
+        (-500, 0),  # negative usage would subtract from dashboard sums
+        (2**63 - 1, 0),  # Int64max: dropped, not clamped
+        (10**16, 0),
+        (_MAX_PLAUSIBLE_TOKENS, _MAX_PLAUSIBLE_TOKENS),  # the bound itself is kept
+        (_MAX_PLAUSIBLE_TOKENS + 1, 0),
+        ("abc", 0),
+        (None, 0),
+        ("", 0),
+    ],
+)
+def test_token_values_outside_the_plausible_range_resolve_to_zero(value, expected):
+    """Dropped rather than clamped: a clamped count is still priced and stored, so it
+    would land an implausible nine-figure row in the customer's cost aggregates."""
+    assert int_or_zero(value) == expected
+
+
+def test_the_bound_survives_pricing_into_the_cost_column():
+    """The bound is sized by `cost`, not by the Int64 token columns.
+
+    `cost` is Decimal64(9) — Decimal(18,9), nine integer digits — so it holds strictly
+    less than $10**9, the same ceiling `rest/services/filters/translate.py` derives for
+    that type. A count that prices past it fails the INSERT, and on the public path the
+    INSERT carries the whole batch. The worst-case rate is read from the seeded price
+    catalog rather than hardcoded, so adding an expensive model fails this test instead
+    of silently re-arming the overflow.
+    """
+    catalog = json.loads((Path(__file__).resolve().parents[2] / _PRICE_CATALOG).read_text())
+    # A single span is priced across disjoint buckets, so the worst case is one model's
+    # summed per-token rate, taking the dearer of the two mutually exclusive cache-write
+    # tiers — not any one rate, and not a rate multiplied by the field count.
+    # `or 0`, not a get() default: entries carry explicit nulls for tiers they lack.
+    worst_rate = max(
+        (p.get("input") or 0)
+        + (p.get("output") or 0)
+        + (p.get("cacheRead") or 0)
+        + max(p.get("cacheWrite") or 0, p.get("cacheWrite1h") or 0)
+        for p in (m["prices"] for m in catalog)
+    )
+    decimal64_9_ceiling = 10**9
+    assert _MAX_PLAUSIBLE_TOKENS * worst_rate < decimal64_9_ceiling
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (42, 42),
+        ("42", 42),
+        (12.7, 12),
+        ("not-a-line", None),
+        (2**31, None),
+        (-(2**31) - 1, None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_int32_column_attributes_are_coerced_or_dropped(value, expected):
+    """git.source_line lands in Nullable(Int32); a string or an out-of-range value
+    is rejected by the column and takes the batch with it."""
+    assert int32_or_none(value) == expected
+
+
+# =============================================================================
+# End-to-end: the coercion must be pinned AT ITS CALL SITES, not just as helpers.
+# Testing the helpers alone leaves every call site free to regress silently --
+# existing transform tests keep the lines covered, so the diff-coverage gate stays
+# green while the fix is gone. These drive real OTLP payloads through the whole
+# transform and assert the record field types the INSERT actually enforces.
+# =============================================================================
+
+
+def _payload(attrs: dict, *, span_name: str = "op", kind: str = "SPAN_KIND_INTERNAL") -> dict:
+    """One-span OTLP body with `attrs` applied, shaped as MessageToDict emits it."""
+    return {
+        "resourceSpans": [
+            {
+                "scopeSpans": [
+                    {
+                        "scope": {"name": "test"},
+                        "spans": [
+                            {
+                                "traceId": base64.b64encode(b"\xab" * 16).decode(),
+                                "spanId": base64.b64encode(b"\x01" * 8).decode(),
+                                "name": span_name,
+                                "kind": kind,
+                                "startTimeUnixNano": "1700000000000000000",
+                                "endTimeUnixNano": "1700000001000000000",
+                                "attributes": [{"key": k, "value": v} for k, v in attrs.items()],
+                                "status": {"code": "STATUS_CODE_OK"},
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+    }
+
+
+# (attribute, wrong-typed OTLP value, record it lands in, field, type the column takes)
+_TYPED_SITES = [
+    ("user.id", {"intValue": "42"}, "trace", "user_id", str),
+    ("session.id", {"boolValue": True}, "trace", "session_id", str),
+    ("traceroot.git.ref", {"intValue": "7"}, "trace", "git_ref", str),
+    ("traceroot.git.repo", {"intValue": "8"}, "trace", "git_repo", str),
+    ("traceroot.git.source_file", {"intValue": "3"}, "span", "git_source_file", str),
+    ("traceroot.git.source_function", {"intValue": "4"}, "span", "git_source_function", str),
+    ("gen_ai.request.model", {"intValue": "9"}, "span", "model_name", str),
+    (
+        "llm.model_name",
+        {"arrayValue": {"values": [{"stringValue": "m"}]}},
+        "span",
+        "model_name",
+        str,
+    ),
+    ("traceroot.git.source_line", {"stringValue": "not-a-line"}, "span", "git_source_line", int),
+]
+
+
+@pytest.mark.parametrize(("attr", "value", "record", "field", "column_type"), _TYPED_SITES)
+def test_wrongly_typed_attribute_lands_as_the_column_type(attr, value, record, field, column_type):
+    """Each typed column's extraction site must coerce; a raw value fails the INSERT."""
+    traces, spans = transform_otel_to_clickhouse(_payload({attr: value}), "p1")
+    rows = traces if record == "trace" else spans
+    assert rows, f"{attr} produced no {record} record"
+    got = rows[0].get(field)
+    assert got is None or isinstance(got, column_type), (
+        f"{attr} -> {field}={got!r} ({type(got).__name__}), column takes {column_type.__name__}"
+    )
+
+
+def test_tool_name_of_the_wrong_type_does_not_reach_the_name_column():
+    """`name` is non-nullable String, and TOOL spans source it from an attribute."""
+    body = _payload(
+        {"traceroot.span.type": {"stringValue": "tool"}, "gen_ai.tool.name": {"intValue": "9"}}
+    )
+    _, spans = transform_otel_to_clickhouse(body, "p1")
+    assert isinstance(spans[0]["name"], str)
+
+
+def test_span_path_of_the_wrong_type_does_not_reach_the_trace_name_column():
+    """The trace name candidate comes from traceroot.span.path[0], also an attribute."""
+    body = _payload({"traceroot.span.path": {"arrayValue": {"values": [{"intValue": "7"}]}}})
+    traces, _ = transform_otel_to_clickhouse(body, "p1")
+    assert isinstance(traces[0]["name"], str)
+
+
+def test_one_malformed_span_does_not_discard_its_batch_mates():
+    """The whole point: the transform raising loses every trace in the S3 export,
+    because the route already 200'd and the celery task retries then drops it."""
+    bad = _payload({"gen_ai.request.model": {"intValue": "7"}})
+    good_span = dict(bad["resourceSpans"][0]["scopeSpans"][0]["spans"][0])
+    good_span["traceId"] = base64.b64encode(b"\xcc" * 16).decode()
+    good_span["spanId"] = base64.b64encode(b"\x02" * 8).decode()
+    good_span["attributes"] = [{"key": "traceroot.span.type", "value": {"stringValue": "llm"}}]
+    bad["resourceSpans"][0]["scopeSpans"][0]["spans"].append(good_span)
+
+    _, spans = transform_otel_to_clickhouse(bad, "p1")
+    assert any(s["trace_id"] == "cc" * 16 for s in spans), "well-formed batch mate was lost"
+
+
+def test_the_bound_is_not_tightened_into_a_data_loss_bug():
+    """The bound has a floor as well as a ceiling: set too low it silently zeroes
+    legitimate long-context spans, which no other assertion here would catch."""
+    assert _MAX_PLAUSIBLE_TOKENS >= 10**8
+
+
+@pytest.mark.parametrize("value", [-5, 10**12, "abc", True])
+def test_a_malformed_high_priority_count_does_not_suppress_a_valid_fallback(value):
+    """first_present_number and int_or_zero must agree on 'usable', else the bad
+    attribute short-circuits the list AND resolves to 0, losing real usage."""
+    attrs = {"llm.token_count.prompt": value, "gen_ai.usage.input_tokens": 1200}
+    picked = first_present_number(attrs, ["llm.token_count.prompt", "gen_ai.usage.input_tokens"])
+    assert int_or_zero(picked) == 1200


### PR DESCRIPTION
Two independent defects on the S3 ingest path, both in `process_s3_traces`. They share a call path, so they land together.

## 1. A wrong-typed OTLP attribute destroys the whole export

OTLP attribute values are a typed union — int, bool, double, array and kvlist are all legal on the wire — and `/v1/traces` accepts any OTel client, so the TypeScript SDK's typing is no constraint on what actually arrives. Measured against the pre-change code, three attributes raised out of the transform entirely rather than failing on their own span:

| attribute | wrong type | result |
|---|---|---|
| `gen_ai.request.model` | int | `TypeError` — regex catalog lookup |
| `llm.model_name` | array | `TypeError` — same |
| `traceroot.span.type` | int | `AttributeError` — `.upper()` on a non-str |

Others (`user.id`, `session.id`, `git.*`, `tool.name`, `span.path`) survived the transform but reached `String` columns as non-strings, which clickhouse-connect rejects at write time.

Either way the failure lands **after the route has already returned 200**: the task raises, celery retries five times, and the entire S3 export is dropped — along with every well-formed trace batched beside the offending span. The sender sees success and the data is simply gone.

Adds `str_attr` (non-nullable), `str_or_none` (nullable) and `int32_or_none`, applied at every extraction site whose column is typed — including `model_name` *before* the pricing lookup that raises on it. `int32_or_none` rejects bools explicitly, since `isinstance(True, int)` holds and an unguarded bool would record line 1 rather than being dropped.

**Token bound.** Counts are bounded and an out-of-range value is *dropped*, not clamped — a clamped count is still priced and stored, so one malformed span would land a nine-figure row in the customer's cost aggregates. The bound comes from `cost` `Decimal64(9)`, whose ceiling is under `1e9`; the catalog's worst summed per-token rate is `7.5e-4`, so `10^9` tokens prices to $750k. The test reads that rate from the seeded catalog so an expensive new model fails the test rather than silently re-arming the overflow, and asserts a floor as well as a ceiling so the bound can't be tightened into a data-loss bug.

**`first_present_number` drift.** It now shares one usability predicate with `int_or_zero`. They had diverged: a negative or over-bound high-priority attribute was "usable" enough to short-circuit the candidate list, then got dropped to 0 — so a valid lower-priority fallback was never reached and the span stored no usage at all. Exactly the failure that function exists to prevent.

## 2. The missing-root existence probe could not use the sort key

```sql
SELECT DISTINCT trace_id FROM traces FINAL WHERE trace_id IN (...)
```

`traces` is `ORDER BY (project_id, toDate(trace_start_time), trace_id)` with no skip index on `trace_id`, so a predicate on a non-prefix key prunes nothing and `FINAL` forces merge-on-read over everything it touches. Measured on a 4M-row table with the same sort key, partitioning and engine, across 200 projects and 6 monthly partitions:

| | granules | rows read | elapsed |
|---|---|---|---|
| `trace_id` only | 499 / 499 | 5,768,547 | 764 ms |
| `+ project_id` | **24 / 499** | **196,608** | **25 ms** |

Naming `project_id` restores pruning. It's the project the batch is already being ingested under — the transform stamps it on every trace record it produces — so it cannot change which rows match. Still O(project) rather than O(batch): nothing bounds `trace_start_time` here, which is a separate change.

## Testing

1123 tests pass. The coercion tests drive **real OTLP payloads through `transform_otel_to_clickhouse`** and assert the resulting field types, rather than exercising the helpers in isolation — that distinction mattered:

- stripping the coercion from all call sites while leaving the helpers defined → **9 tests fail**
- with the earlier helper-only tests → **0 failed**, and the diff-coverage gate stayed green because existing transform tests execute those lines

Reverting the `project_id` predicate fails `test_missing_root_probe_is_scoped_to_the_project` and nothing else.

> The branch is named `fix/self-trace-ingest-scoping`, which no longer describes the change. Renaming a branch on GitHub closes the PR using it as head irreversibly, so it's left alone deliberately.