### PR TITLE
fix(ui): rebuild account menu on the shared dropdown-menu primitive

### DIFF
--- a/frontend/ui/src/components/layout/sidebar.test.tsx
+++ b/frontend/ui/src/components/layout/sidebar.test.tsx
@@ -135,9 +135,34 @@ describe("Sidebar", () => {
       await screen.findByRole("menu");
     }
 
+    async function openThemeSubmenu() {
+      fireEvent.click(screen.getByRole("menuitem", { name: /^Theme/ }));
+      await screen.findAllByRole("menuitemradio");
+    }
+
+    it("keeps the theme picker behind its own submenu, closed by default", async () => {
+      render();
+      await openAccountMenu();
+
+      const trigger = screen.getByRole("menuitem", { name: /^Theme/ });
+      expect(trigger.getAttribute("aria-haspopup")).toBe("menu");
+      expect(trigger.getAttribute("aria-expanded")).toBe("false");
+      expect(screen.queryByRole("menuitemradio")).toBeNull();
+    });
+
+    it("shows the active theme's icon on the submenu trigger without opening it", async () => {
+      mocks.theme = "dark";
+      render();
+      await openAccountMenu();
+
+      const trigger = screen.getByRole("menuitem", { name: /^Theme/ });
+      expect(trigger.querySelector("svg.lucide-moon")).toBeTruthy();
+    });
+
     it("shows left-aligned Light/Dark/System items with the active theme checked", async () => {
       render();
       await openAccountMenu();
+      await openThemeSubmenu();
 
       const items = screen.getAllByRole("menuitemradio");
       expect(items.map((el) => el.textContent)).toEqual(["Light", "Dark", "System"]);
@@ -151,17 +176,20 @@ describe("Sidebar", () => {
     it("calls setTheme when picking a different theme, without closing the menu", async () => {
       render();
       await openAccountMenu();
+      await openThemeSubmenu();
 
       fireEvent.click(screen.getByRole("menuitemradio", { name: "Dark" }));
 
       expect(mocks.setTheme).toHaveBeenCalledWith("dark");
-      expect(screen.getByRole("menu")).toBeTruthy();
+      // Both the root menu and the theme submenu should still be open.
+      expect(screen.getAllByRole("menu")).toHaveLength(2);
     });
 
     it("defaults to System checked when no theme is set yet", async () => {
       mocks.theme = undefined;
       render();
       await openAccountMenu();
+      await openThemeSubmenu();
 
       expect(
         screen.getByRole("menuitemradio", { name: "System" }).getAttribute("aria-checked"),

--- a/frontend/ui/src/components/layout/sidebar.test.tsx
+++ b/frontend/ui/src/components/layout/sidebar.test.tsx
@@ -2,8 +2,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Radix DropdownMenu opens on pointerdown and relies on pointer-capture APIs
+// jsdom doesn't implement.
+window.HTMLElement.prototype.hasPointerCapture = vi.fn();
+window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+window.HTMLElement.prototype.scrollIntoView = vi.fn();
 
 const navigation = { pathname: "/workspaces", params: {} as Record<string, string> };
 
@@ -12,15 +19,22 @@ vi.mock("next/navigation", () => ({
   useParams: () => navigation.params,
 }));
 
+const mocks = vi.hoisted(() => ({
+  theme: "light" as string | undefined,
+  setTheme: vi.fn(),
+  signOut: vi.fn(),
+}));
+
 vi.mock("@/lib/auth-client", () => ({
   authClient: {
     useSession: () => ({ data: null }),
     admin: { stopImpersonating: vi.fn() },
+    signOut: (...args: unknown[]) => mocks.signOut(...args),
   },
 }));
 
 vi.mock("next-themes", () => ({
-  useTheme: () => ({ theme: "light", setTheme: vi.fn() }),
+  useTheme: () => ({ theme: mocks.theme, setTheme: mocks.setTheme }),
 }));
 
 // Children with their own data needs; covered by their own tests
@@ -99,5 +113,76 @@ describe("Sidebar", () => {
     navigation.pathname = "/auth/sign-in";
     render();
     expect(container.innerHTML).toBe("");
+  });
+
+  describe("account menu", () => {
+    beforeEach(() => {
+      mocks.theme = "light";
+      mocks.setTheme.mockClear();
+      mocks.signOut.mockClear();
+      Object.defineProperty(window, "location", {
+        writable: true,
+        configurable: true,
+        value: { href: "" },
+      });
+    });
+
+    async function openAccountMenu() {
+      fireEvent.pointerDown(screen.getByRole("button", { name: "Account menu" }), {
+        button: 0,
+        pointerType: "mouse",
+      });
+      await screen.findByRole("menu");
+    }
+
+    it("shows left-aligned Light/Dark/System items with the active theme checked", async () => {
+      render();
+      await openAccountMenu();
+
+      const items = screen.getAllByRole("menuitemradio");
+      expect(items.map((el) => el.textContent)).toEqual(["Light", "Dark", "System"]);
+      items.forEach((el) => expect(el.className).not.toContain("justify-center"));
+
+      expect(items[0].getAttribute("aria-checked")).toBe("true");
+      expect(items[1].getAttribute("aria-checked")).toBe("false");
+      expect(items[2].getAttribute("aria-checked")).toBe("false");
+    });
+
+    it("calls setTheme when picking a different theme, without closing the menu", async () => {
+      render();
+      await openAccountMenu();
+
+      fireEvent.click(screen.getByRole("menuitemradio", { name: "Dark" }));
+
+      expect(mocks.setTheme).toHaveBeenCalledWith("dark");
+      expect(screen.getByRole("menu")).toBeTruthy();
+    });
+
+    it("defaults to System checked when no theme is set yet", async () => {
+      mocks.theme = undefined;
+      render();
+      await openAccountMenu();
+
+      expect(
+        screen.getByRole("menuitemradio", { name: "System" }).getAttribute("aria-checked"),
+      ).toBe("true");
+    });
+
+    it("shows Log Out with an icon, separated by a divider, styled as destructive, and signs out on click", async () => {
+      render();
+      await openAccountMenu();
+
+      expect(screen.getByRole("separator")).toBeTruthy();
+
+      const logOut = screen.getByRole("menuitem", { name: /Log Out/i });
+      expect(logOut.className).not.toContain("justify-center");
+      expect(logOut.className).toContain("text-red-600");
+      expect(logOut.querySelector("svg")).toBeTruthy();
+
+      fireEvent.click(logOut);
+
+      expect(mocks.signOut).toHaveBeenCalled();
+      await waitFor(() => expect(window.location.href).toBe("/auth/sign-in"));
+    });
   });
 });

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -4,7 +4,15 @@ import Link from "next/link";
 import { useParams, usePathname } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 import { useTheme } from "next-themes";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   LifeBuoy,
   ChevronRight,
@@ -14,6 +22,7 @@ import {
   Monitor,
   Settings,
   UserRoundSearch,
+  LogOut,
 } from "lucide-react";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -311,9 +320,10 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
           </Tooltip>
 
           {/* User menu */}
-          <Popover>
-            <PopoverTrigger asChild>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <button
+                aria-label="Account menu"
                 className={cn(
                   "flex w-full items-center gap-2 py-2 transition-colors hover:bg-muted/50",
                   collapsed ? "justify-center px-2" : "px-3",
@@ -331,8 +341,8 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
                   </>
                 )}
               </button>
-            </PopoverTrigger>
-            <PopoverContent
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
               side="right"
               align="end"
               className="w-48 p-0"
@@ -352,62 +362,38 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
 
               <div className="h-px bg-border" />
 
-              {/* Theme selector with submenu */}
               <div className="p-1">
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <button className="flex w-full items-center justify-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent">
-                      <span>Theme</span>
-                      <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                    </button>
-                  </PopoverTrigger>
-                  <PopoverContent side="right" align="start" className="w-28 p-1" sideOffset={4}>
-                    <button
-                      className={cn(
-                        "flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm transition-colors",
-                        theme === "light" ? "bg-accent" : "hover:bg-accent",
-                      )}
-                      onClick={() => setTheme("light")}
-                    >
-                      <span>Light</span>
-                      <Sun className="h-4 w-4" />
-                    </button>
-                    <button
-                      className={cn(
-                        "flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm transition-colors",
-                        theme === "dark" ? "bg-accent" : "hover:bg-accent",
-                      )}
-                      onClick={() => setTheme("dark")}
-                    >
-                      <span>Dark</span>
-                      <Moon className="h-4 w-4" />
-                    </button>
-                    <button
-                      className={cn(
-                        "flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm transition-colors",
-                        theme === "system" || !theme ? "bg-accent" : "hover:bg-accent",
-                      )}
-                      onClick={() => setTheme("system")}
-                    >
-                      <span>System</span>
-                      <Monitor className="h-4 w-4" />
-                    </button>
-                  </PopoverContent>
-                </Popover>
+                {/* Theme selector — inline, keyboard-navigable radio items */}
+                <DropdownMenuRadioGroup value={theme ?? "system"} onValueChange={setTheme}>
+                  <DropdownMenuRadioItem value="light" onSelect={(e) => e.preventDefault()}>
+                    <Sun className="h-4 w-4 text-muted-foreground" />
+                    Light
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="dark" onSelect={(e) => e.preventDefault()}>
+                    <Moon className="h-4 w-4 text-muted-foreground" />
+                    Dark
+                  </DropdownMenuRadioItem>
+                  <DropdownMenuRadioItem value="system" onSelect={(e) => e.preventDefault()}>
+                    <Monitor className="h-4 w-4 text-muted-foreground" />
+                    System
+                  </DropdownMenuRadioItem>
+                </DropdownMenuRadioGroup>
 
-                {/* Sign out */}
-                <button
-                  className="flex w-full items-center justify-center rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-accent"
-                  onClick={async () => {
+                <DropdownMenuSeparator />
+
+                <DropdownMenuItem
+                  className="text-red-600 focus:text-red-600"
+                  onSelect={async () => {
                     await authClient.signOut();
                     window.location.href = "/auth/sign-in";
                   }}
                 >
+                  <LogOut className="h-4 w-4" />
                   Log Out
-                </button>
+                </DropdownMenuItem>
               </div>
-            </PopoverContent>
-          </Popover>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
     </TooltipProvider>

--- a/frontend/ui/src/components/layout/sidebar.tsx
+++ b/frontend/ui/src/components/layout/sidebar.tsx
@@ -11,6 +11,9 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -55,6 +58,8 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   const { data: sessionData } = authClient.useSession();
   const isImpersonating = !!sessionData?.session?.impersonatedBy;
   const { theme, setTheme } = useTheme();
+  // Shown on the submenu trigger so the active theme stays glanceable without opening it.
+  const ThemeIcon = theme === "light" ? Sun : theme === "dark" ? Moon : Monitor;
   const params = useParams<{ projectId?: string; workspaceId?: string }>();
 
   // Don't show sidebar on auth pages
@@ -363,21 +368,30 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
               <div className="h-px bg-border" />
 
               <div className="p-1">
-                {/* Theme selector — inline, keyboard-navigable radio items */}
-                <DropdownMenuRadioGroup value={theme ?? "system"} onValueChange={setTheme}>
-                  <DropdownMenuRadioItem value="light" onSelect={(e) => e.preventDefault()}>
-                    <Sun className="h-4 w-4 text-muted-foreground" />
-                    Light
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem value="dark" onSelect={(e) => e.preventDefault()}>
-                    <Moon className="h-4 w-4 text-muted-foreground" />
-                    Dark
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem value="system" onSelect={(e) => e.preventDefault()}>
-                    <Monitor className="h-4 w-4 text-muted-foreground" />
-                    System
-                  </DropdownMenuRadioItem>
-                </DropdownMenuRadioGroup>
+                {/* Theme selector — own submenu; trigger shows the active theme's icon
+                    so it stays glanceable without opening it. */}
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>
+                    <ThemeIcon className="h-4 w-4 text-muted-foreground" />
+                    Theme
+                  </DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent className="w-32">
+                    <DropdownMenuRadioGroup value={theme ?? "system"} onValueChange={setTheme}>
+                      <DropdownMenuRadioItem value="light" onSelect={(e) => e.preventDefault()}>
+                        <Sun className="h-4 w-4 text-muted-foreground" />
+                        Light
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="dark" onSelect={(e) => e.preventDefault()}>
+                        <Moon className="h-4 w-4 text-muted-foreground" />
+                        Dark
+                      </DropdownMenuRadioItem>
+                      <DropdownMenuRadioItem value="system" onSelect={(e) => e.preventDefault()}>
+                        <Monitor className="h-4 w-4 text-muted-foreground" />
+                        System
+                      </DropdownMenuRadioItem>
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
 
                 <DropdownMenuSeparator />
 

--- a/frontend/ui/src/components/ui/dropdown-menu.tsx
+++ b/frontend/ui/src/components/ui/dropdown-menu.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
@@ -53,6 +54,30 @@ const DropdownMenuLabel = React.forwardRef<
 ));
 DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
 const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
@@ -71,5 +96,7 @@ export {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
 };

--- a/frontend/ui/src/components/ui/dropdown-menu.tsx
+++ b/frontend/ui/src/components/ui/dropdown-menu.tsx
@@ -2,12 +2,49 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { Check } from "lucide-react";
+import { Check, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const DropdownMenu = DropdownMenuPrimitive.Root;
 
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[state=open]:bg-accent data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.SubContent
+      ref={ref}
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
@@ -99,4 +136,7 @@ export {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 };


### PR DESCRIPTION
## Summary

Fixes #1699.

The account popover at the bottom of the sidebar (user info, Theme, Log Out) was a stack of hand-built `<button>`s inside nested `Popover`s instead of the app's shared dropdown-menu primitive: items were center-aligned, the theme picker was a fragile side-opening nested `Popover`, Log Out had no icon or visual separation from Theme, and none of it carried real menu semantics.

## Changes

- Added `DropdownMenuRadioGroup`/`DropdownMenuRadioItem` to the shared `frontend/ui/src/components/ui/dropdown-menu.tsx` primitive (standard Radix `role="menuitemradio"` + built-in check indicator + keyboard-navigable) — a reusable addition for any future mutually-exclusive menu choice, not just this one.
- Rebuilt the account menu in `sidebar.tsx` on `DropdownMenu`:
  - All items are left-aligned (no more `justify-center`).
  - The theme picker is now three inline radio items (Sun/Moon/Monitor) instead of a second nested `Popover` that opened to the side and could overflow.
  - Theme selection keeps the menu open (`onSelect` calls `preventDefault()`) so switching between themes doesn't require reopening the menu — matches the prior UX.
  - The active theme is indicated with a checkmark (via the new `DropdownMenuRadioItem`'s built-in indicator) instead of only a background tint.
  - Log Out gets a `LogOut` icon, a separator above it, and destructive text styling (`text-red-600`) — the same convention `WidgetCard`'s Delete item already uses elsewhere in the app.
- Removed the now-unused `Popover`/`PopoverContent`/`PopoverTrigger` imports.
<img width="558" height="400" alt="image" src="https://github.com/user-attachments/assets/a19cefff-42b9-4fcf-b1b2-37324be3eeb4" />



## Test plan

- [x] `tsc --noEmit` clean on all touched files
- [x] `eslint` clean on all touched files
- [x] New tests: left-aligned items + active-theme check state, `setTheme` called on pick without closing the menu, System defaults to checked when no theme is set, Log Out has an icon/divider/destructive styling and calls sign-out
- [x] Mutation-tested the "left-aligned" assertion by temporarily reintroducing `justify-center` — confirmed the test fails, proving it actually catches the regression
- [x] Full frontend suite passes (one pre-existing, unrelated locale-formatting flake aside)
- [x] Ran the existing `WidgetCard`/`WidgetBuilderPage`/`breadcrumb` suites (other consumers of the shared `dropdown-menu.tsx` primitive) to confirm the additive change doesn't break them
- [x] Local diff-cover: 100% on this PR's diff


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt the sidebar account menu on the shared dropdown-menu primitive for proper menu semantics, better keyboard access, and a cleaner UI. Moves the theme picker into its own submenu with radio items and improves the Log Out action. Fixes #1699.

- **New Features**
  - Added `DropdownMenuSub`, `DropdownMenuSubTrigger`, and `DropdownMenuSubContent` to the shared `dropdown-menu.tsx` primitive.
  - Added `DropdownMenuRadioGroup` and `DropdownMenuRadioItem` with built-in check indicator and `menuitemradio` semantics.

- **Refactors**
  - Replaced nested `Popover`s with `DropdownMenu`.
  - Theme picker is now a submenu with Light/Dark/System radio items; the trigger shows the active theme icon and selection keeps the menu open.
  - Items are left-aligned; active theme shows a checkmark.
  - Log Out has an icon, a separator, destructive styling, and signs out via `authClient.signOut()` with redirect to `/auth/sign-in`.

<sup>Written for commit 25709479e6c53ad603610526affc39fb22184ce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



