### PR TITLE
feat(server): offline-evaluation persistence schema and migration

### DIFF
--- a/backend/shared/enums.py
+++ b/backend/shared/enums.py
@@ -6,6 +6,11 @@ class SpanKind(StrEnum):
     AGENT = "AGENT"
     TOOL = "TOOL"
     SPAN = "SPAN"
+    # Offline-evaluation span kinds emitted by the SDK: the evaluation-item root,
+    # the candidate task span, and each scorer span.
+    EVALUATION = "EVALUATION"
+    TASK = "TASK"
+    SCORER = "SCORER"
 
 
 class SpanStatus(StrEnum):

--- a/backend/worker/otel_transform.py
+++ b/backend/worker/otel_transform.py
@@ -392,11 +392,21 @@ def get_span_kind(attrs: dict[str, Any], otel_kind: int | str | None) -> str:
         otel_kind: OTEL span kind (int or string like "SPAN_KIND_INTERNAL")
 
     Returns:
-        One of: "LLM", "SPAN", "AGENT", "TOOL"
+        One of: "LLM", "SPAN", "AGENT", "TOOL", "EVALUATION", "TASK", "SCORER"
     """
-    # Check explicit type attribute (handle None values)
+    # Check explicit type attribute (handle None values). Includes the offline-eval
+    # kinds (EVALUATION/TASK/SCORER) so the SDK's evaluation spans are preserved
+    # rather than silently coerced to SPAN.
     explicit_type = (attrs.get("traceroot.span.type") or "").upper()
-    if explicit_type in (SpanKind.LLM, SpanKind.SPAN, SpanKind.AGENT, SpanKind.TOOL):
+    if explicit_type in (
+        SpanKind.LLM,
+        SpanKind.SPAN,
+        SpanKind.AGENT,
+        SpanKind.TOOL,
+        SpanKind.EVALUATION,
+        SpanKind.TASK,
+        SpanKind.SCORER,
+    ):
         return explicit_type
 
     # Check OpenInference semantic conventions (handle None values)

--- a/frontend/packages/core/prisma/migrations/20260720234159_add_offline_eval/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260720234159_add_offline_eval/migration.sql
@@ -1,6 +1,7 @@
 -- CreateTable
 CREATE TABLE "datasets" (
     "id" VARCHAR NOT NULL,
+    "client_dataset_id" VARCHAR,
     "project_id" VARCHAR NOT NULL,
     "name" VARCHAR NOT NULL,
     "description" TEXT,
@@ -149,6 +150,10 @@ CREATE TABLE "human_scores" (
 -- CreateIndex
 CREATE INDEX "ix_dataset_project_id" ON "datasets"("project_id");
 
+-- CreateIndex: the SDK-chosen dataset id is unique per project, not globally,
+-- so tenants cannot squat each other's natural ids ("prod", "default", ...).
+CREATE UNIQUE INDEX "uq_dataset_project_client_id" ON "datasets"("project_id", "client_dataset_id");
+
 -- CreateIndex
 CREATE INDEX "ix_dataset_version_project_id" ON "dataset_versions"("project_id");
 
@@ -164,8 +169,10 @@ CREATE INDEX "ix_test_case_project_id" ON "test_cases"("project_id");
 -- CreateIndex
 CREATE INDEX "ix_test_case_source_trace_id" ON "test_cases"("source_trace_id");
 
--- CreateIndex
-CREATE INDEX "ix_evaluation_project_id" ON "evaluations"("project_id");
+-- CreateIndex: (project_id, name) is the evaluation lineage identity — a
+-- duplicate would split one evaluation's history into two. Also serves the
+-- project-scoped list query, so no separate project_id index is needed.
+CREATE UNIQUE INDEX "uq_evaluation_project_name" ON "evaluations"("project_id", "name");
 
 -- CreateIndex
 CREATE INDEX "ix_evaluation_dataset_id" ON "evaluations"("dataset_id");
@@ -174,10 +181,13 @@ CREATE INDEX "ix_evaluation_dataset_id" ON "evaluations"("dataset_id");
 CREATE INDEX "ix_evaluation_run_project_id" ON "evaluation_runs"("project_id");
 
 -- CreateIndex
-CREATE INDEX "ix_evaluation_run_evaluation_id" ON "evaluation_runs"("evaluation_id");
-
--- CreateIndex
 CREATE UNIQUE INDEX "uq_run_client_run_id" ON "evaluation_runs"("evaluation_id", "client_run_id");
+
+-- CreateIndex: run_number is allocated as max + 1 within the lineage; this
+-- turns a concurrent allocation into a retryable unique violation instead of
+-- two runs sharing a number. Leads with evaluation_id, so it also serves the
+-- per-evaluation run list.
+CREATE UNIQUE INDEX "uq_run_evaluation_run_number" ON "evaluation_runs"("evaluation_id", "run_number");
 
 -- CreateIndex
 CREATE INDEX "ix_evaluation_result_project_id" ON "evaluation_results"("project_id");
@@ -188,8 +198,10 @@ CREATE INDEX "ix_evaluation_result_trace_id" ON "evaluation_results"("trace_id")
 -- CreateIndex
 CREATE UNIQUE INDEX "uq_result_run_test_case" ON "evaluation_results"("run_id", "test_case_id");
 
--- CreateIndex
-CREATE INDEX "ix_score_result_id" ON "scores"("result_id");
+-- CreateIndex: one row per scorer per result — scores arrive incrementally and
+-- are merged, and duplicates would be aggregated rather than deduped. Leads
+-- with result_id, so it also serves the per-result score fetch.
+CREATE UNIQUE INDEX "uq_score_result_scorer" ON "scores"("result_id", "scorer_name", "scorer_version");
 
 -- CreateIndex
 CREATE INDEX "ix_score_project_id" ON "scores"("project_id");
@@ -215,8 +227,13 @@ ALTER TABLE "evaluations" ADD CONSTRAINT "evaluations_project_id_fkey" FOREIGN K
 -- AddForeignKey
 ALTER TABLE "evaluation_runs" ADD CONSTRAINT "evaluation_runs_evaluation_id_fkey" FOREIGN KEY ("evaluation_id") REFERENCES "evaluations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
--- AddForeignKey
-ALTER TABLE "evaluation_runs" ADD CONSTRAINT "evaluation_runs_dataset_version_id_fkey" FOREIGN KEY ("dataset_version_id") REFERENCES "dataset_versions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+-- AddForeignKey: NO ACTION, not RESTRICT. Both refuse a bare delete of a
+-- version that a run pinned, but RESTRICT is non-deferrable in Postgres, so
+-- deleting a project — which cascades into dataset_versions and
+-- evaluation_runs down two sibling branches of the same statement — would
+-- succeed or fail depending on trigger ordering. NO ACTION is checked at end
+-- of statement, by which point the cascaded runs are gone.
+ALTER TABLE "evaluation_runs" ADD CONSTRAINT "evaluation_runs_dataset_version_id_fkey" FOREIGN KEY ("dataset_version_id") REFERENCES "dataset_versions"("id") ON DELETE NO ACTION ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "evaluation_runs" ADD CONSTRAINT "evaluation_runs_baseline_run_id_fkey" FOREIGN KEY ("baseline_run_id") REFERENCES "evaluation_runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/frontend/packages/core/prisma/migrations/20260720234159_add_offline_eval/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260720234159_add_offline_eval/migration.sql
@@ -1,0 +1,231 @@
+-- CreateTable
+CREATE TABLE "datasets" (
+    "id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "name" VARCHAR NOT NULL,
+    "description" TEXT,
+    "current_version_id" VARCHAR,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "datasets_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "dataset_versions" (
+    "id" VARCHAR NOT NULL,
+    "dataset_id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "version_number" INTEGER NOT NULL,
+    "label" VARCHAR NOT NULL,
+    "note" TEXT,
+    "created_by" VARCHAR,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "dataset_versions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "test_cases" (
+    "id" VARCHAR NOT NULL,
+    "test_case_id" VARCHAR NOT NULL,
+    "dataset_version_id" VARCHAR NOT NULL,
+    "dataset_id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "input" TEXT NOT NULL,
+    "expected" TEXT,
+    "recorded_output" TEXT,
+    "metadata" JSONB,
+    "review" VARCHAR NOT NULL DEFAULT 'needs_review',
+    "capture_reason" VARCHAR NOT NULL DEFAULT 'manual',
+    "source_trace_id" VARCHAR,
+    "source_span_id" VARCHAR,
+    "source_span_name" VARCHAR,
+    "source_span_kind" VARCHAR,
+    "added_by" VARCHAR,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "test_cases_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "evaluations" (
+    "id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "dataset_id" VARCHAR NOT NULL,
+    "name" VARCHAR NOT NULL,
+    "main_score_name" VARCHAR NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "evaluations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "evaluation_runs" (
+    "id" VARCHAR NOT NULL,
+    "evaluation_id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "dataset_id" VARCHAR NOT NULL,
+    "dataset_version_id" VARCHAR NOT NULL,
+    "run_number" INTEGER NOT NULL,
+    "candidate_version" VARCHAR NOT NULL,
+    "environment" VARCHAR NOT NULL DEFAULT 'evaluation',
+    "status" VARCHAR NOT NULL DEFAULT 'running',
+    "baseline_run_id" VARCHAR,
+    "main_score" DOUBLE PRECISION,
+    "main_score_name" VARCHAR,
+    "case_count" INTEGER NOT NULL DEFAULT 0,
+    "scored_count" INTEGER NOT NULL DEFAULT 0,
+    "task_error_count" INTEGER NOT NULL DEFAULT 0,
+    "scorer_error_count" INTEGER NOT NULL DEFAULT 0,
+    "scorers" JSONB,
+    "model" VARCHAR,
+    "client_run_id" VARCHAR,
+    "started_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "completed_at" TIMESTAMP(6),
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "evaluation_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "evaluation_results" (
+    "id" VARCHAR NOT NULL,
+    "run_id" VARCHAR NOT NULL,
+    "evaluation_id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "test_case_id" VARCHAR NOT NULL,
+    "trace_id" VARCHAR,
+    "input" TEXT NOT NULL,
+    "expected_output" TEXT,
+    "candidate_output" TEXT,
+    "baseline_output" TEXT,
+    "status" VARCHAR NOT NULL,
+    "main_score" DOUBLE PRECISION,
+    "change" VARCHAR,
+    "task_error" TEXT,
+    "duration_ms" INTEGER,
+    "cost" DOUBLE PRECISION,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "update_time" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "evaluation_results_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "scores" (
+    "id" VARCHAR NOT NULL,
+    "result_id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "scorer_name" VARCHAR NOT NULL,
+    "scorer_version" VARCHAR NOT NULL,
+    "numeric_value" DOUBLE PRECISION,
+    "bool_value" BOOLEAN,
+    "string_value" VARCHAR,
+    "passed" BOOLEAN,
+    "explanation" TEXT,
+    "error" TEXT,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "scores_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "human_scores" (
+    "id" VARCHAR NOT NULL,
+    "result_id" VARCHAR NOT NULL,
+    "project_id" VARCHAR NOT NULL,
+    "verdict" VARCHAR NOT NULL,
+    "quality" INTEGER,
+    "comment" TEXT,
+    "reviewer" VARCHAR NOT NULL,
+    "create_time" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "human_scores_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ix_dataset_project_id" ON "datasets"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_dataset_version_project_id" ON "dataset_versions"("project_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_dataset_version_number" ON "dataset_versions"("dataset_id", "version_number");
+
+-- CreateIndex
+CREATE INDEX "ix_test_case_version_id" ON "test_cases"("dataset_version_id");
+
+-- CreateIndex
+CREATE INDEX "ix_test_case_project_id" ON "test_cases"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_test_case_source_trace_id" ON "test_cases"("source_trace_id");
+
+-- CreateIndex
+CREATE INDEX "ix_evaluation_project_id" ON "evaluations"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_evaluation_dataset_id" ON "evaluations"("dataset_id");
+
+-- CreateIndex
+CREATE INDEX "ix_evaluation_run_project_id" ON "evaluation_runs"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_evaluation_run_evaluation_id" ON "evaluation_runs"("evaluation_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_run_client_run_id" ON "evaluation_runs"("evaluation_id", "client_run_id");
+
+-- CreateIndex
+CREATE INDEX "ix_evaluation_result_project_id" ON "evaluation_results"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_evaluation_result_trace_id" ON "evaluation_results"("trace_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "uq_result_run_test_case" ON "evaluation_results"("run_id", "test_case_id");
+
+-- CreateIndex
+CREATE INDEX "ix_score_result_id" ON "scores"("result_id");
+
+-- CreateIndex
+CREATE INDEX "ix_score_project_id" ON "scores"("project_id");
+
+-- CreateIndex
+CREATE INDEX "ix_human_score_result_id" ON "human_scores"("result_id");
+
+-- CreateIndex
+CREATE INDEX "ix_human_score_project_id" ON "human_scores"("project_id");
+
+-- AddForeignKey
+ALTER TABLE "datasets" ADD CONSTRAINT "datasets_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "dataset_versions" ADD CONSTRAINT "dataset_versions_dataset_id_fkey" FOREIGN KEY ("dataset_id") REFERENCES "datasets"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "test_cases" ADD CONSTRAINT "test_cases_dataset_version_id_fkey" FOREIGN KEY ("dataset_version_id") REFERENCES "dataset_versions"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "evaluations" ADD CONSTRAINT "evaluations_project_id_fkey" FOREIGN KEY ("project_id") REFERENCES "projects"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "evaluation_runs" ADD CONSTRAINT "evaluation_runs_evaluation_id_fkey" FOREIGN KEY ("evaluation_id") REFERENCES "evaluations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "evaluation_runs" ADD CONSTRAINT "evaluation_runs_dataset_version_id_fkey" FOREIGN KEY ("dataset_version_id") REFERENCES "dataset_versions"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "evaluation_runs" ADD CONSTRAINT "evaluation_runs_baseline_run_id_fkey" FOREIGN KEY ("baseline_run_id") REFERENCES "evaluation_runs"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "evaluation_results" ADD CONSTRAINT "evaluation_results_run_id_fkey" FOREIGN KEY ("run_id") REFERENCES "evaluation_runs"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "scores" ADD CONSTRAINT "scores_result_id_fkey" FOREIGN KEY ("result_id") REFERENCES "evaluation_results"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "human_scores" ADD CONSTRAINT "human_scores_result_id_fkey" FOREIGN KEY ("result_id") REFERENCES "evaluation_results"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/frontend/packages/core/prisma/migrations/20260721000000_add_dataset_sync_fields/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260721000000_add_dataset_sync_fields/migration.sql
@@ -1,0 +1,9 @@
+-- AlterTable: free-form, SDK-authored dataset metadata (A2/A3)
+ALTER TABLE "datasets" ADD COLUMN "metadata" JSONB;
+
+-- AlterTable: SDK publish idempotency key (A4)
+ALTER TABLE "dataset_versions" ADD COLUMN "idempotency_key" VARCHAR;
+
+-- CreateIndex: a retried publish (same key) returns the same version, never a duplicate.
+-- NULL keys stay distinct in Postgres, so existing versions are unaffected.
+CREATE UNIQUE INDEX "uq_dataset_version_idempotency" ON "dataset_versions"("dataset_id", "idempotency_key");

--- a/frontend/packages/core/prisma/migrations/20260721120000_add_eval_run_metadata/migration.sql
+++ b/frontend/packages/core/prisma/migrations/20260721120000_add_eval_run_metadata/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: structured run provenance (model, prompt, config, git repo/ref/commit).
+-- Additive and nullable — existing runs are unaffected; the current SDK does not send it.
+ALTER TABLE "evaluation_runs" ADD COLUMN "metadata" JSONB;

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -35,11 +35,11 @@ model Invite {
   email           String     @db.VarChar
   workspaceId     String     @map("workspace_id") @db.VarChar
   role            MemberRole
-  invitedByUserId String?   @map("invited_by_user_id") @db.VarChar
-  createTime      DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
-  updateTime      DateTime  @default(now()) @map("update_time") @db.Timestamp(6)
-  invitedBy       User?     @relation(fields: [invitedByUserId], references: [id], onUpdate: NoAction)
-  workspace       Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  invitedByUserId String?    @map("invited_by_user_id") @db.VarChar
+  createTime      DateTime   @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime      DateTime   @default(now()) @map("update_time") @db.Timestamp(6)
+  invitedBy       User?      @relation(fields: [invitedByUserId], references: [id], onUpdate: NoAction)
+  workspace       Workspace  @relation(fields: [workspaceId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@unique([email, workspaceId], map: "uq_invite_email_workspace")
   @@index([workspaceId], map: "ix_invite_workspace_id")
@@ -52,10 +52,10 @@ model WorkspaceMember {
   workspaceId String     @map("workspace_id") @db.VarChar
   userId      String     @map("user_id") @db.VarChar
   role        MemberRole
-  createTime  DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
-  updateTime  DateTime  @default(now()) @map("update_time") @db.Timestamp(6)
-  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade, onUpdate: NoAction)
-  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  createTime  DateTime   @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime  DateTime   @default(now()) @map("update_time") @db.Timestamp(6)
+  workspace   Workspace  @relation(fields: [workspaceId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  user        User       @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@unique([workspaceId, userId], map: "uq_workspace_user")
   @@index([workspaceId], map: "ix_workspace_member_workspace_id")
@@ -65,24 +65,24 @@ model WorkspaceMember {
 
 // Workspaces - Top-level container for projects and members
 model Workspace {
-  id         String            @id @db.VarChar
-  name       String            @db.VarChar
-  createTime DateTime          @default(now()) @map("create_time") @db.Timestamp(6)
-  updateTime DateTime          @default(now()) @map("update_time") @db.Timestamp(6)
-  invites    Invite[]
-  members    WorkspaceMember[]
-  projects   Project[]
-  billingCustomerId      String?   @map("billing_customer_id")
-  billingSubscriptionId  String?   @map("billing_subscription_id")
-  billingPriceId         String?   @map("billing_price_id")
-  billingStatus          String?   @map("billing_status") // active, canceled, past_due, trialing
-  billingPeriodStart     DateTime? @map("billing_period_start")
-  billingPeriodEnd       DateTime? @map("billing_period_end")
-  billingPlan            String    @default("free") @map("billing_plan") // free, starter, pro, enterprise
-  ingestionBlocked       Boolean   @default(false) @map("ingestion_blocked") // true when free plan exceeds usage limit
-  aiBlocked              Boolean   @default(false) @map("ai_blocked") // true when free plan exceeds AI token allowance
-  rcaBlocked             Boolean   @default(false) @map("rca_blocked") // true when free plan exceeds 30 RCA runs (mirrors aiBlocked)
-  detectorBlocked        Boolean   @default(false) @map("detector_blocked") // true when free plan exceeds 100 detector runs (any source)
+  id                    String            @id @db.VarChar
+  name                  String            @db.VarChar
+  createTime            DateTime          @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime            DateTime          @default(now()) @map("update_time") @db.Timestamp(6)
+  invites               Invite[]
+  members               WorkspaceMember[]
+  projects              Project[]
+  billingCustomerId     String?           @map("billing_customer_id")
+  billingSubscriptionId String?           @map("billing_subscription_id")
+  billingPriceId        String?           @map("billing_price_id")
+  billingStatus         String?           @map("billing_status") // active, canceled, past_due, trialing
+  billingPeriodStart    DateTime?         @map("billing_period_start")
+  billingPeriodEnd      DateTime?         @map("billing_period_end")
+  billingPlan           String            @default("free") @map("billing_plan") // free, starter, pro, enterprise
+  ingestionBlocked      Boolean           @default(false) @map("ingestion_blocked") // true when free plan exceeds usage limit
+  aiBlocked             Boolean           @default(false) @map("ai_blocked") // true when free plan exceeds AI token allowance
+  rcaBlocked            Boolean           @default(false) @map("rca_blocked") // true when free plan exceeds 30 RCA runs (mirrors aiBlocked)
+  detectorBlocked       Boolean           @default(false) @map("detector_blocked") // true when free plan exceeds 100 detector runs (any source)
   // currentUsage shape:
   //   { traces, spans, tokens, updatedAt,
   //     ai:       { runsUsed, systemUsage, byokUsage, byModel, lastReportedUnits, lastReportedPeriodStart },
@@ -92,13 +92,13 @@ model Workspace {
   // system-source agent/scan calls (BYOK skipped). The hourly billing job bills each
   // at 1.05× pass-through via STRIPE_PRICE_ID_RCA_USAGE / STRIPE_PRICE_ID_DETECTOR_USAGE.
   // detector.scansRun is informational only (BYOK + system; no quota).
-  currentUsage           Json?     @map("current_usage")
+  currentUsage          Json?             @map("current_usage")
 
-  modelProviders ModelProvider[]
+  modelProviders      ModelProvider[]
   githubInstallations GitHubInstallation[]
   aiMessages          AIMessage[]
-  slackIntegration SlackIntegration?
-  usageNotifications WorkspaceUsageNotification[]
+  slackIntegration    SlackIntegration?
+  usageNotifications  WorkspaceUsageNotification[]
 
   @@index([billingCustomerId])
   @@index([billingSubscriptionId])
@@ -128,14 +128,14 @@ model WorkspaceUsageNotification {
 model ModelProvider {
   id                String    @id @default(cuid()) @db.VarChar
   workspaceId       String    @map("workspace_id") @db.VarChar
-  adapter           String    @db.VarChar        // "openai"|"anthropic"|"azure"|"google"|"amazon-bedrock"|"deepseek"|"openrouter"|"xai"|"moonshot"|"zai"
-  provider          String    @db.VarChar        // user-defined label: "My OpenAI", "DeepSeek", etc.
+  adapter           String    @db.VarChar // "openai"|"anthropic"|"azure"|"google"|"amazon-bedrock"|"deepseek"|"openrouter"|"xai"|"moonshot"|"zai"
+  provider          String    @db.VarChar // user-defined label: "My OpenAI", "DeepSeek", etc.
   keyCipher         String    @map("key_cipher") @db.Text
-  keyPreview        String    @map("key_preview") @db.VarChar  // "xxxx...xxxx"
+  keyPreview        String    @map("key_preview") @db.VarChar // "xxxx...xxxx"
   baseUrl           String?   @map("base_url") @db.VarChar
   customModels      String[]  @default([]) @map("custom_models")
   withDefaultModels Boolean   @default(true) @map("with_default_models")
-  config            Json?     @db.JsonB          // adapter-specific (region, apiVersion, etc.)
+  config            Json?     @db.JsonB // adapter-specific (region, apiVersion, etc.)
   enabled           Boolean   @default(true)
   createdBy         String    @map("created_by") @db.VarChar
   createTime        DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
@@ -149,24 +149,26 @@ model ModelProvider {
 
 // Projects - Container for traces and access keys
 model Project {
-  id           String    @id @db.VarChar
-  workspaceId  String    @map("workspace_id") @db.VarChar
-  name         String    @db.VarChar
-  traceTtlDays Int?      @map("trace_ttl_days")
-  deleteTime   DateTime? @map("delete_time") @db.Timestamp(6)
-  createTime   DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
-  updateTime   DateTime  @default(now()) @map("update_time") @db.Timestamp(6)
+  id           String               @id @db.VarChar
+  workspaceId  String               @map("workspace_id") @db.VarChar
+  name         String               @db.VarChar
+  traceTtlDays Int?                 @map("trace_ttl_days")
+  deleteTime   DateTime?            @map("delete_time") @db.Timestamp(6)
+  createTime   DateTime             @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime   DateTime             @default(now()) @map("update_time") @db.Timestamp(6)
   // Agent model for Step 2 deep analysis — project-scoped, shared across all detectors
-  rcaModel     String?   @map("rca_model") @db.VarChar
-  rcaProvider  String?   @map("rca_provider") @db.VarChar
-  rcaSource    String?   @map("rca_source") @db.VarChar
+  rcaModel     String?              @map("rca_model") @db.VarChar
+  rcaProvider  String?              @map("rca_provider") @db.VarChar
+  rcaSource    String?              @map("rca_source") @db.VarChar
   accessKeys   AccessKey[]
   aiSessions   AISession[]
   detectors    Detector[]
   alertConfig  DetectorAlertConfig?
   detectorRcas DetectorRca[]
   dashboards   Dashboard[]
-  workspace    Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+  datasets     Dataset[]
+  evaluations  Evaluation[]
+  workspace    Workspace            @relation(fields: [workspaceId], references: [id], onDelete: Cascade, onUpdate: NoAction)
 
   @@index([workspaceId], map: "ix_project_workspace_id")
   @@map("projects")
@@ -212,22 +214,22 @@ model Account {
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  @@index([userId], map: "ix_account_user_id")
   @@unique([accountId, providerId], map: "uq_account_provider")
+  @@index([userId], map: "ix_account_user_id")
   @@map("accounts")
 }
 
 // Sessions - better-auth session management
 model Session {
-  id             String    @id @default(cuid()) @db.VarChar
-  userId         String    @map("user_id") @db.VarChar
-  token          String    @unique @db.VarChar
-  expiresAt      DateTime  @map("expires_at") @db.Timestamp(6)
-  ipAddress      String?   @map("ip_address") @db.VarChar
-  userAgent      String?   @map("user_agent") @db.VarChar
-  impersonatedBy String?   @map("impersonated_by") @db.VarChar
-  createdAt      DateTime  @default(now()) @db.Timestamp(6)
-  updatedAt      DateTime  @updatedAt @db.Timestamp(6)
+  id             String   @id @default(cuid()) @db.VarChar
+  userId         String   @map("user_id") @db.VarChar
+  token          String   @unique @db.VarChar
+  expiresAt      DateTime @map("expires_at") @db.Timestamp(6)
+  ipAddress      String?  @map("ip_address") @db.VarChar
+  userAgent      String?  @map("user_agent") @db.VarChar
+  impersonatedBy String?  @map("impersonated_by") @db.VarChar
+  createdAt      DateTime @default(now()) @db.Timestamp(6)
+  updatedAt      DateTime @updatedAt @db.Timestamp(6)
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -255,16 +257,16 @@ model Verification {
 // No accessToken stored: getInstallationToken signs a JWT with the App private
 // key and exchanges it for a short-lived installation token at request time.
 model GitHubInstallation {
-  id                String   @id @default(cuid()) @db.VarChar
-  workspaceId       String   @map("workspace_id") @db.VarChar
-  workspace         Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  id          String    @id @default(cuid()) @db.VarChar
+  workspaceId String    @map("workspace_id") @db.VarChar
+  workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
-  installationId    String   @map("installation_id") @db.VarChar
-  accountLogin      String   @map("account_login") @db.VarChar  // GitHub org/user that owns the install
-  installedByUserId String?  @map("installed_by_user_id") @db.VarChar  // who clicked Connect
+  installationId    String  @map("installation_id") @db.VarChar
+  accountLogin      String  @map("account_login") @db.VarChar // GitHub org/user that owns the install
+  installedByUserId String? @map("installed_by_user_id") @db.VarChar // who clicked Connect
 
-  createTime        DateTime @default(now()) @map("create_time") @db.Timestamp(6)
-  updateTime        DateTime @updatedAt @map("update_time") @db.Timestamp(6)
+  createTime DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime DateTime @updatedAt @map("update_time") @db.Timestamp(6)
 
   @@unique([workspaceId, installationId], map: "uq_github_installation")
   @@index([workspaceId], map: "ix_github_installation_workspace_id")
@@ -279,18 +281,18 @@ model SlackIntegration {
   workspaceId String    @unique @map("workspace_id") @db.VarChar
   workspace   Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
 
-  teamId    String @map("team_id")     @db.VarChar
-  teamName  String @map("team_name")   @db.VarChar
+  teamId    String @map("team_id") @db.VarChar
+  teamName  String @map("team_name") @db.VarChar
   botUserId String @map("bot_user_id") @db.VarChar
-  botToken  String @map("bot_token")   @db.Text
+  botToken  String @map("bot_token") @db.Text
 
-  channelId   String? @map("channel_id")   @db.VarChar
+  channelId   String? @map("channel_id") @db.VarChar
   channelName String? @map("channel_name") @db.VarChar
 
   connectedByUserId String? @map("connected_by_user_id") @db.VarChar
 
   createTime DateTime @default(now()) @map("create_time") @db.Timestamp(6)
-  updateTime DateTime @updatedAt      @map("update_time") @db.Timestamp(6)
+  updateTime DateTime @updatedAt @map("update_time") @db.Timestamp(6)
 
   @@map("slack_integrations")
 }
@@ -300,9 +302,9 @@ model AISession {
   id          String      @id @default(cuid()) @db.VarChar
   projectId   String      @map("project_id") @db.VarChar
   workspaceId String      @map("workspace_id") @db.VarChar
-  userId      String?     @map("user_id") @db.VarChar  // null for system/RCA sessions
+  userId      String?     @map("user_id") @db.VarChar // null for system/RCA sessions
   title       String?     @db.VarChar
-  status      String      @default("active") @db.VarChar  // active, completed, failed
+  status      String      @default("active") @db.VarChar // active, completed, failed
   metadata    Json?       @db.JsonB
   createTime  DateTime    @default(now()) @map("create_time") @db.Timestamp(6)
   updateTime  DateTime    @default(now()) @updatedAt @map("update_time") @db.Timestamp(6)
@@ -367,32 +369,32 @@ model StandardModelPrice {
 // Detectors — automatic production monitoring for AI agents
 
 model Detector {
-  id           String   @id @default(cuid()) @db.VarChar
-  projectId    String   @map("project_id") @db.VarChar
-  name         String   @db.VarChar
-  template     String   @db.VarChar  // "failure"|"hallucination"|"logic"|"task"|"safety"|"intent"|"blank"
-  prompt       String   @db.Text
-  outputSchema       Json     @map("output_schema") @db.JsonB
-  sampleRate         Int      @default(25) @map("sample_rate")  // 0–100
-  enabled            Boolean  @default(true)
-  enableRca          Boolean  @default(true) @map("enable_rca")  // run agent-model RCA on this detector's findings
-  detectionModel     String?  @map("detection_model") @db.VarChar    // model id; null = worker picks default
-  detectionProvider  String?  @map("detection_provider") @db.VarChar // provider label (system: "anthropic"/"openai"; BYOK: ModelProvider.provider row label)
-  detectionSource    String?  @map("detection_source") @db.VarChar   // "system" | "byok" | null (legacy/seeded)
-  createTime   DateTime @default(now()) @map("create_time") @db.Timestamp(6)
-  updateTime   DateTime @updatedAt @map("update_time") @db.Timestamp(6)
+  id                String   @id @default(cuid()) @db.VarChar
+  projectId         String   @map("project_id") @db.VarChar
+  name              String   @db.VarChar
+  template          String   @db.VarChar // "failure"|"hallucination"|"logic"|"task"|"safety"|"intent"|"blank"
+  prompt            String   @db.Text
+  outputSchema      Json     @map("output_schema") @db.JsonB
+  sampleRate        Int      @default(25) @map("sample_rate") // 0–100
+  enabled           Boolean  @default(true)
+  enableRca         Boolean  @default(true) @map("enable_rca") // run agent-model RCA on this detector's findings
+  detectionModel    String?  @map("detection_model") @db.VarChar // model id; null = worker picks default
+  detectionProvider String?  @map("detection_provider") @db.VarChar // provider label (system: "anthropic"/"openai"; BYOK: ModelProvider.provider row label)
+  detectionSource   String?  @map("detection_source") @db.VarChar // "system" | "byok" | null (legacy/seeded)
+  createTime        DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime        DateTime @updatedAt @map("update_time") @db.Timestamp(6)
 
-  project     Project              @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  trigger     DetectorTrigger?
+  project Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  trigger DetectorTrigger?
 
   @@index([projectId], map: "ix_detector_project_id")
   @@map("detectors")
 }
 
 model DetectorTrigger {
-  id         String   @id @default(cuid()) @db.VarChar
-  detectorId String   @unique @map("detector_id") @db.VarChar
-  conditions Json     @db.JsonB
+  id         String @id @default(cuid()) @db.VarChar
+  detectorId String @unique @map("detector_id") @db.VarChar
+  conditions Json   @db.JsonB
   // [{field: "root_span_finished", op: "=", value: true}, {field: "total_tokens", op: ">", value: 1000}]
 
   detector Detector @relation(fields: [detectorId], references: [id], onDelete: Cascade)
@@ -410,7 +412,7 @@ model DetectorAlertConfig {
 
   // Per-project Slack channel override (no UI in v1).
   // When set, takes precedence over SlackIntegration.channelId.
-  slackChannelId   String? @map("slack_channel_id")   @db.VarChar
+  slackChannelId   String? @map("slack_channel_id") @db.VarChar
   slackChannelName String? @map("slack_channel_name") @db.VarChar
 
   // Project-level alert batching window. One of the ALERT_WINDOWS tokens.
@@ -423,21 +425,233 @@ model DetectorAlertConfig {
 }
 
 model DetectorRca {
-  id              String    @id @default(cuid()) @db.VarChar
-  findingId       String    @unique @map("finding_id") @db.VarChar  // trace-level finding UUID (one per trace)
-  projectId       String    @map("project_id") @db.VarChar
-  sessionId       String?   @map("session_id") @db.VarChar  // AISession id for the system RCA session
-  status          String    @db.VarChar  // "pending"|"running"|"done"|"failed"
-  result          String?   @db.Text
-  completedAt     DateTime? @map("completed_at") @db.Timestamp(6)
-  createTime      DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
+  id          String    @id @default(cuid()) @db.VarChar
+  findingId   String    @unique @map("finding_id") @db.VarChar // trace-level finding UUID (one per trace)
+  projectId   String    @map("project_id") @db.VarChar
+  sessionId   String?   @map("session_id") @db.VarChar // AISession id for the system RCA session
+  status      String    @db.VarChar // "pending"|"running"|"done"|"failed"
+  result      String?   @db.Text
+  completedAt DateTime? @map("completed_at") @db.Timestamp(6)
+  createTime  DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
 
   // Cascade with Project — keeps RCA rows consistent with Detector /
   // DetectorAlertConfig when a project is deleted.
-  project     Project   @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  project Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   @@index([projectId], map: "ix_detector_rcas_project_id")
   @@map("detector_rcas")
+}
+
+// ---------------------------------------------------------------------------
+// Offline Evaluation
+//
+// Relational control-plane side of the offline-evaluation feature: datasets and
+// their immutable versioned snapshots of test cases, plus evaluation lineages,
+// their immutable runs, per-test-case results, per-scorer scores, and human
+// scores. Traces themselves live in ClickHouse; results link to them by the
+// client-supplied OTel trace_id. Every row carries project_id for isolation.
+// ---------------------------------------------------------------------------
+
+// An editable dataset. Its rows live on immutable DatasetVersion snapshots;
+// `currentVersionId` points at the latest published one.
+model Dataset {
+  id               String   @id @default(cuid()) @db.VarChar
+  projectId        String   @map("project_id") @db.VarChar
+  name             String   @db.VarChar
+  description      String?  @db.Text
+  currentVersionId String?  @map("current_version_id") @db.VarChar
+  createTime       DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime       DateTime @updatedAt @map("update_time") @db.Timestamp(6)
+
+  project  Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  versions DatasetVersion[]
+
+  @@index([projectId], map: "ix_dataset_project_id")
+  @@map("datasets")
+}
+
+// An immutable snapshot of a dataset's test cases. Editing/adding a test case
+// publishes a new version; historical versions (and any run that pinned them)
+// are never rewritten.
+model DatasetVersion {
+  id            String   @id @default(cuid()) @db.VarChar
+  datasetId     String   @map("dataset_id") @db.VarChar
+  projectId     String   @map("project_id") @db.VarChar
+  versionNumber Int      @map("version_number") // 1-based
+  label         String   @db.VarChar // human label, e.g. "v12"
+  note          String?  @db.Text
+  createdBy     String?  @map("created_by") @db.VarChar
+  createTime    DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+
+  dataset   Dataset         @relation(fields: [datasetId], references: [id], onDelete: Cascade)
+  testCases TestCase[]
+  runs      EvaluationRun[]
+
+  @@unique([datasetId, versionNumber], map: "uq_dataset_version_number")
+  @@index([projectId], map: "ix_dataset_version_project_id")
+  @@map("dataset_versions")
+}
+
+// One test case as captured on a specific version. `testCaseId` is the stable
+// lineage id shared across versions (used to match results to their source case
+// and to line runs up for baseline comparison); `id` is the per-version row.
+model TestCase {
+  id               String   @id @default(cuid()) @db.VarChar
+  testCaseId       String   @map("test_case_id") @db.VarChar // stable lineage id
+  datasetVersionId String   @map("dataset_version_id") @db.VarChar
+  datasetId        String   @map("dataset_id") @db.VarChar
+  projectId        String   @map("project_id") @db.VarChar
+  input            String   @db.Text
+  expected         String?  @db.Text
+  recordedOutput   String?  @map("recorded_output") @db.Text
+  metadata         Json?    @map("metadata") @db.JsonB
+  review           String   @default("needs_review") @db.VarChar // "needs_review"|"ready"
+  captureReason    String   @default("manual") @map("capture_reason") @db.VarChar // "manual"|"error"|"failed_tool"|"negative_feedback"
+  sourceTraceId    String?  @map("source_trace_id") @db.VarChar
+  sourceSpanId     String?  @map("source_span_id") @db.VarChar
+  sourceSpanName   String?  @map("source_span_name") @db.VarChar
+  sourceSpanKind   String?  @map("source_span_kind") @db.VarChar // "AGENT"|"LLM"|"TOOL"|"SPAN"|"trace"
+  addedBy          String?  @map("added_by") @db.VarChar
+  createTime       DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+
+  version DatasetVersion @relation(fields: [datasetVersionId], references: [id], onDelete: Cascade)
+
+  @@index([datasetVersionId], map: "ix_test_case_version_id")
+  @@index([projectId], map: "ix_test_case_project_id")
+  @@index([sourceTraceId], map: "ix_test_case_source_trace_id")
+  @@map("test_cases")
+}
+
+// The stable purpose/lineage an evaluation measures. Runs of the same
+// evaluation share this identity; it is never versioned (the run is the record).
+model Evaluation {
+  id            String   @id @default(cuid()) @db.VarChar
+  projectId     String   @map("project_id") @db.VarChar
+  datasetId     String   @map("dataset_id") @db.VarChar
+  name          String   @db.VarChar
+  mainScoreName String   @map("main_score_name") @db.VarChar
+  createTime    DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime    DateTime @updatedAt @map("update_time") @db.Timestamp(6)
+
+  project Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  runs    EvaluationRun[]
+
+  @@index([projectId], map: "ix_evaluation_project_id")
+  @@index([datasetId], map: "ix_evaluation_dataset_id")
+  @@map("evaluations")
+}
+
+// One immutable execution of an evaluation against a pinned dataset snapshot.
+model EvaluationRun {
+  id               String    @id @default(cuid()) @db.VarChar
+  evaluationId     String    @map("evaluation_id") @db.VarChar
+  projectId        String    @map("project_id") @db.VarChar
+  datasetId        String    @map("dataset_id") @db.VarChar
+  datasetVersionId String    @map("dataset_version_id") @db.VarChar // pinned snapshot
+  runNumber        Int       @map("run_number") // 1-based within the evaluation
+  candidateVersion String    @map("candidate_version") @db.VarChar // what changed, e.g. "git:4a91c02"
+  environment      String    @default("evaluation") @db.VarChar
+  status           String    @default("running") @db.VarChar // running|completed|completed_with_errors|failed|incomplete
+  baselineRunId    String?   @map("baseline_run_id") @db.VarChar
+  mainScore        Float?    @map("main_score")
+  mainScoreName    String?   @map("main_score_name") @db.VarChar
+  caseCount        Int       @default(0) @map("case_count")
+  scoredCount      Int       @default(0) @map("scored_count")
+  taskErrorCount   Int       @default(0) @map("task_error_count")
+  scorerErrorCount Int       @default(0) @map("scorer_error_count")
+  scorers          Json?     @map("scorers") @db.JsonB // [{name, version}]
+  model            String?   @db.VarChar
+  clientRunId      String?   @map("client_run_id") @db.VarChar // SDK idempotency key
+  startedAt        DateTime  @default(now()) @map("started_at") @db.Timestamp(6)
+  completedAt      DateTime? @map("completed_at") @db.Timestamp(6)
+  createTime       DateTime  @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime       DateTime  @updatedAt @map("update_time") @db.Timestamp(6)
+
+  evaluation     Evaluation         @relation(fields: [evaluationId], references: [id], onDelete: Cascade)
+  datasetVersion DatasetVersion     @relation(fields: [datasetVersionId], references: [id])
+  baselineRun    EvaluationRun?     @relation("Baseline", fields: [baselineRunId], references: [id], onDelete: SetNull)
+  baselinedBy    EvaluationRun[]    @relation("Baseline")
+  results        EvaluationResult[]
+
+  @@unique([evaluationId, clientRunId], map: "uq_run_client_run_id")
+  @@index([projectId], map: "ix_evaluation_run_project_id")
+  @@index([evaluationId], map: "ix_evaluation_run_evaluation_id")
+  @@map("evaluation_runs")
+}
+
+// One test case's outcome within one run. Links to its source test case
+// (`testCaseId`, stable) and the produced trace (`traceId`, may arrive later).
+model EvaluationResult {
+  id              String   @id @default(cuid()) @db.VarChar
+  runId           String   @map("run_id") @db.VarChar
+  evaluationId    String   @map("evaluation_id") @db.VarChar
+  projectId       String   @map("project_id") @db.VarChar
+  testCaseId      String   @map("test_case_id") @db.VarChar // stable source-case id
+  traceId         String?  @map("trace_id") @db.VarChar
+  input           String   @db.Text
+  expectedOutput  String?  @map("expected_output") @db.Text
+  candidateOutput String?  @map("candidate_output") @db.Text // null when the task errored
+  baselineOutput  String?  @map("baseline_output") @db.Text
+  status          String   @db.VarChar // passed|failed|errored|not_scored
+  mainScore       Float?   @map("main_score")
+  change          String?  @db.VarChar // improved|regressed|unchanged
+  taskError       String?  @map("task_error") @db.Text // application/task failure
+  durationMs      Int?     @map("duration_ms")
+  cost            Float?
+  createTime      DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+  updateTime      DateTime @updatedAt @map("update_time") @db.Timestamp(6)
+
+  run         EvaluationRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+  scores      Score[]
+  humanScores HumanScore[]
+
+  @@unique([runId, testCaseId], map: "uq_result_run_test_case")
+  @@index([projectId], map: "ix_evaluation_result_project_id")
+  @@index([traceId], map: "ix_evaluation_result_trace_id")
+  @@map("evaluation_results")
+}
+
+// One scorer's outcome on one result. `error` set = the scorer failed to judge
+// (distinct from the task failing); when every scorer errors, the result is
+// not_scored. Values cover numeric / boolean / categorical.
+model Score {
+  id            String   @id @default(cuid()) @db.VarChar
+  resultId      String   @map("result_id") @db.VarChar
+  projectId     String   @map("project_id") @db.VarChar
+  scorerName    String   @map("scorer_name") @db.VarChar
+  scorerVersion String   @map("scorer_version") @db.VarChar
+  numericValue  Float?   @map("numeric_value")
+  boolValue     Boolean? @map("bool_value")
+  stringValue   String?  @map("string_value") @db.VarChar
+  passed        Boolean?
+  explanation   String?  @db.Text
+  error         String?  @db.Text // scorer failure
+  createTime    DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+
+  result EvaluationResult @relation(fields: [resultId], references: [id], onDelete: Cascade)
+
+  @@index([resultId], map: "ix_score_result_id")
+  @@index([projectId], map: "ix_score_project_id")
+  @@map("scores")
+}
+
+// A human's judgment of one evaluation result's output. Deliberately separate
+// from Score and from editing the dataset's expected output.
+model HumanScore {
+  id         String   @id @default(cuid()) @db.VarChar
+  resultId   String   @map("result_id") @db.VarChar
+  projectId  String   @map("project_id") @db.VarChar
+  verdict    String   @db.VarChar // pass|fail|unsure
+  quality    Int? // optional 1-5
+  comment    String?  @db.Text
+  reviewer   String   @db.VarChar
+  createTime DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+
+  result EvaluationResult @relation(fields: [resultId], references: [id], onDelete: Cascade)
+
+  @@index([resultId], map: "ix_human_score_result_id")
+  @@index([projectId], map: "ix_human_score_project_id")
+  @@map("human_scores")
 }
 
 model Dashboard {

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -562,8 +562,9 @@ model EvaluationRun {
   scoredCount      Int       @default(0) @map("scored_count")
   taskErrorCount   Int       @default(0) @map("task_error_count")
   scorerErrorCount Int       @default(0) @map("scorer_error_count")
-  scorers          Json?     @map("scorers") @db.JsonB // [{name, version}]
+  scorers          Json?     @map("scorers") @db.JsonB // [{name, version, value_type?, direction?, threshold?}]
   model            String?   @db.VarChar
+  metadata         Json?     @map("metadata") @db.JsonB // structured run provenance (model, prompt, config, git)
   clientRunId      String?   @map("client_run_id") @db.VarChar // SDK idempotency key
   startedAt        DateTime  @default(now()) @map("started_at") @db.Timestamp(6)
   completedAt      DateTime? @map("completed_at") @db.Timestamp(6)

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -456,6 +456,14 @@ model DetectorRca {
 // `currentVersionId` points at the latest published one.
 model Dataset {
   id               String   @id @default(cuid()) @db.VarChar
+  // The id the SDK chooses for this dataset (e.g. "regression", "default").
+  // It is deliberately NOT the primary key: as a PK it would put every tenant
+  // in one global keyspace, so any API key could squat a natural id ("prod",
+  // "eval") and permanently block every other project from creating it, and
+  // the create response would leak whether some tenant already owns that id.
+  // Scoping it to the project makes the keyspace per-tenant by construction;
+  // public-API lookups use `projectId_clientDatasetId`, never `id`.
+  clientDatasetId  String?  @map("client_dataset_id") @db.VarChar
   projectId        String   @map("project_id") @db.VarChar
   name             String   @db.VarChar
   description      String?  @db.Text
@@ -467,6 +475,7 @@ model Dataset {
   project  Project          @relation(fields: [projectId], references: [id], onDelete: Cascade)
   versions DatasetVersion[]
 
+  @@unique([projectId, clientDatasetId], map: "uq_dataset_project_client_id")
   @@index([projectId], map: "ix_dataset_project_id")
   @@map("datasets")
 }
@@ -475,15 +484,15 @@ model Dataset {
 // publishes a new version; historical versions (and any run that pinned them)
 // are never rewritten.
 model DatasetVersion {
-  id            String   @id @default(cuid()) @db.VarChar
-  datasetId     String   @map("dataset_id") @db.VarChar
-  projectId     String   @map("project_id") @db.VarChar
-  versionNumber Int      @map("version_number") // 1-based
-  label         String   @db.VarChar // human label, e.g. "v12"
-  note          String?  @db.Text
-  createdBy     String?  @map("created_by") @db.VarChar
-  idempotencyKey String? @map("idempotency_key") @db.VarChar // SDK publish idempotency (A4)
-  createTime    DateTime @default(now()) @map("create_time") @db.Timestamp(6)
+  id             String   @id @default(cuid()) @db.VarChar
+  datasetId      String   @map("dataset_id") @db.VarChar
+  projectId      String   @map("project_id") @db.VarChar
+  versionNumber  Int      @map("version_number") // 1-based
+  label          String   @db.VarChar // human label, e.g. "v12"
+  note           String?  @db.Text
+  createdBy      String?  @map("created_by") @db.VarChar
+  idempotencyKey String?  @map("idempotency_key") @db.VarChar // SDK publish idempotency (A4)
+  createTime     DateTime @default(now()) @map("create_time") @db.Timestamp(6)
 
   dataset   Dataset         @relation(fields: [datasetId], references: [id], onDelete: Cascade)
   testCases TestCase[]
@@ -539,7 +548,12 @@ model Evaluation {
   project Project         @relation(fields: [projectId], references: [id], onDelete: Cascade)
   runs    EvaluationRun[]
 
-  @@index([projectId], map: "ix_evaluation_project_id")
+  // The lineage identity. Runs are grouped by it, so a duplicate would split an
+  // evaluation's history in two (run numbers restarting at 1, baselines no
+  // longer lining up). Concurrent registrations of the same name now collide
+  // with P2002 instead of both inserting. Leads with project_id, so it also
+  // serves the project-scoped list query.
+  @@unique([projectId, name], map: "uq_evaluation_project_name")
   @@index([datasetId], map: "ix_evaluation_dataset_id")
   @@map("evaluations")
 }
@@ -572,14 +586,29 @@ model EvaluationRun {
   updateTime       DateTime  @updatedAt @map("update_time") @db.Timestamp(6)
 
   evaluation     Evaluation         @relation(fields: [evaluationId], references: [id], onDelete: Cascade)
-  datasetVersion DatasetVersion     @relation(fields: [datasetVersionId], references: [id])
+  // NoAction rather than the Prisma default (Restrict): both refuse a bare
+  // delete of a version a run pinned, but Restrict is non-deferrable in
+  // Postgres and fires before the rest of the statement settles. Deleting a
+  // project cascades into dataset_versions and evaluation_runs down two
+  // sibling branches of one statement, and under Restrict whether that
+  // succeeds depends on trigger ordering. NoAction is checked at end of
+  // statement, by which point the cascaded runs are gone, so project and
+  // workspace deletion succeed deterministically. Deleting a dataset that has
+  // been evaluated still fails (evaluations are not cascaded by dataset), so
+  // that handler must pre-check and answer 409 instead of surfacing a 500.
+  datasetVersion DatasetVersion     @relation(fields: [datasetVersionId], references: [id], onDelete: NoAction)
   baselineRun    EvaluationRun?     @relation("Baseline", fields: [baselineRunId], references: [id], onDelete: SetNull)
   baselinedBy    EvaluationRun[]    @relation("Baseline")
   results        EvaluationResult[]
 
   @@unique([evaluationId, clientRunId], map: "uq_run_client_run_id")
+  // runNumber is allocated server-side as max + 1 within the lineage; without
+  // this two concurrent registrations both read N and both insert N + 1,
+  // leaving two runs labelled "Run #N+1". Mirrors uq_dataset_version_number,
+  // turning the race into a retryable P2002. Leads with evaluation_id, so it
+  // also serves the per-evaluation run list.
+  @@unique([evaluationId, runNumber], map: "uq_run_evaluation_run_number")
   @@index([projectId], map: "ix_evaluation_run_project_id")
-  @@index([evaluationId], map: "ix_evaluation_run_evaluation_id")
   @@map("evaluation_runs")
 }
 
@@ -634,7 +663,13 @@ model Score {
 
   result EvaluationResult @relation(fields: [resultId], references: [id], onDelete: Cascade)
 
-  @@index([resultId], map: "ix_score_result_id")
+  // One row per scorer per result. Scores arrive incrementally (parallel
+  // scorers, delayed judges, client retries) and are merged read-then-write, so
+  // without this a duplicate slips in — and duplicates are aggregated rather
+  // than deduped by the scorer catalog, double-counting runs and skewing means.
+  // Lets the merge be a real upsert. Leads with result_id, so it also serves
+  // the per-result score fetch.
+  @@unique([resultId, scorerName, scorerVersion], map: "uq_score_result_scorer")
   @@index([projectId], map: "ix_score_project_id")
   @@map("scores")
 }

--- a/frontend/packages/core/prisma/schema.prisma
+++ b/frontend/packages/core/prisma/schema.prisma
@@ -459,6 +459,7 @@ model Dataset {
   projectId        String   @map("project_id") @db.VarChar
   name             String   @db.VarChar
   description      String?  @db.Text
+  metadata         Json?    @map("metadata") @db.JsonB // free-form, SDK-authored
   currentVersionId String?  @map("current_version_id") @db.VarChar
   createTime       DateTime @default(now()) @map("create_time") @db.Timestamp(6)
   updateTime       DateTime @updatedAt @map("update_time") @db.Timestamp(6)
@@ -481,6 +482,7 @@ model DatasetVersion {
   label         String   @db.VarChar // human label, e.g. "v12"
   note          String?  @db.Text
   createdBy     String?  @map("created_by") @db.VarChar
+  idempotencyKey String? @map("idempotency_key") @db.VarChar // SDK publish idempotency (A4)
   createTime    DateTime @default(now()) @map("create_time") @db.Timestamp(6)
 
   dataset   Dataset         @relation(fields: [datasetId], references: [id], onDelete: Cascade)
@@ -488,6 +490,7 @@ model DatasetVersion {
   runs      EvaluationRun[]
 
   @@unique([datasetId, versionNumber], map: "uq_dataset_version_number")
+  @@unique([datasetId, idempotencyKey], map: "uq_dataset_version_idempotency")
   @@index([projectId], map: "ix_dataset_version_project_id")
   @@map("dataset_versions")
 }

--- a/frontend/packages/core/src/constants.ts
+++ b/frontend/packages/core/src/constants.ts
@@ -7,6 +7,10 @@ export const SpanKind = {
   AGENT: "AGENT",
   TOOL: "TOOL",
   SPAN: "SPAN",
+  // Offline-evaluation span kinds (evaluation-item root, candidate task, scorer).
+  EVALUATION: "EVALUATION",
+  TASK: "TASK",
+  SCORER: "SCORER",
 } as const;
 export type SpanKind = (typeof SpanKind)[keyof typeof SpanKind];
 

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -1,0 +1,197 @@
+/**
+ * Offline-evaluation contract — the shared, typed shapes for both the
+ * user-session CRUD routes and the API-key SDK reporting routes.
+ *
+ * This is the stable handoff for the SDK team: the request/response schemas an
+ * SDK calls to report a run. See `docs/offline-eval-sdk-contract.md`. The server
+ * owns all row ids and `run_number`; the SDK owns `candidate_version`, the
+ * optional `client_run_id` idempotency key, and the OTel `trace_id`.
+ */
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Status vocabularies (string enums, validated here, documented in the schema)
+// ---------------------------------------------------------------------------
+
+export const EVAL_RUN_STATUSES = [
+  "running",
+  "completed",
+  "completed_with_errors",
+  "failed",
+  "incomplete",
+] as const;
+export const EvalRunStatusSchema = z.enum(EVAL_RUN_STATUSES);
+export type EvalRunStatus = (typeof EVAL_RUN_STATUSES)[number];
+
+export const EVAL_RESULT_STATUSES = ["passed", "failed", "errored", "not_scored"] as const;
+export const EvalResultStatusSchema = z.enum(EVAL_RESULT_STATUSES);
+export type EvalResultStatus = (typeof EVAL_RESULT_STATUSES)[number];
+
+export const RESULT_CHANGES = ["improved", "regressed", "unchanged"] as const;
+export const ResultChangeSchema = z.enum(RESULT_CHANGES);
+
+export const REVIEW_STATUSES = ["needs_review", "ready"] as const;
+export const ReviewStatusSchema = z.enum(REVIEW_STATUSES);
+
+export const CAPTURE_REASONS = ["manual", "error", "failed_tool", "negative_feedback"] as const;
+export const CaptureReasonSchema = z.enum(CAPTURE_REASONS);
+
+export const HUMAN_VERDICTS = ["pass", "fail", "unsure"] as const;
+export const HumanVerdictSchema = z.enum(HUMAN_VERDICTS);
+
+// ---------------------------------------------------------------------------
+// Scorer descriptor — name + version recorded on every run and score
+// ---------------------------------------------------------------------------
+
+export const ScorerRefSchema = z.object({
+  name: z.string().min(1).max(200),
+  version: z.string().min(1).max(50),
+});
+export type ScorerRef = z.infer<typeof ScorerRefSchema>;
+
+/** One scorer's outcome on one result. `error` set = the scorer failed to judge. */
+export const ScoreInputSchema = z
+  .object({
+    scorer_name: z.string().min(1).max(200),
+    scorer_version: z.string().min(1).max(50),
+    numeric_value: z.number().nullable().optional(),
+    bool_value: z.boolean().nullable().optional(),
+    string_value: z.string().max(2000).nullable().optional(),
+    passed: z.boolean().nullable().optional(),
+    explanation: z.string().max(5000).nullable().optional(),
+    error: z.string().max(5000).nullable().optional(),
+  })
+  .strict();
+export type ScoreInput = z.infer<typeof ScoreInputSchema>;
+
+// ---------------------------------------------------------------------------
+// SDK reporting requests
+// ---------------------------------------------------------------------------
+
+/**
+ * Register/start a run. Idempotent on `client_run_id` within an evaluation:
+ * re-sending the same key returns the existing run. The evaluation lineage is
+ * resolved (create-if-absent) from `evaluation_name` + `dataset_id`.
+ */
+export const RegisterRunRequestSchema = z
+  .object({
+    evaluation_name: z.string().min(1).max(200),
+    dataset_id: z.string().min(1).max(64),
+    /** Omit to pin the dataset's current published version. */
+    dataset_version_id: z.string().min(1).max(64).nullable().optional(),
+    candidate_version: z.string().min(1).max(200),
+    main_score_name: z.string().min(1).max(200).nullable().optional(),
+    environment: z.string().min(1).max(64).default("evaluation"),
+    scorers: z.array(ScorerRefSchema).default([]),
+    /** SDK-supplied idempotency key. */
+    client_run_id: z.string().min(1).max(128).nullable().optional(),
+    baseline_run_id: z.string().min(1).max(64).nullable().optional(),
+    case_count: z.number().int().nonnegative().nullable().optional(),
+  })
+  .strict();
+export type RegisterRunRequest = z.infer<typeof RegisterRunRequestSchema>;
+
+export interface RegisterRunResponse {
+  evaluation_id: string;
+  evaluation_run_id: string;
+  run_number: number;
+  dataset_version_id: string;
+}
+
+/**
+ * Upsert one test-case result. Idempotent on (`run_id`, `test_case_id`).
+ * `trace_id` may be null now and set on a later call (out-of-order arrival).
+ * Sending `scores` replaces the result's scores.
+ */
+export const UpsertResultRequestSchema = z
+  .object({
+    test_case_id: z.string().min(1).max(64),
+    trace_id: z.string().min(1).max(64).nullable().optional(),
+    input: z.string(),
+    expected_output: z.string().nullable().optional(),
+    candidate_output: z.string().nullable().optional(),
+    baseline_output: z.string().nullable().optional(),
+    status: EvalResultStatusSchema,
+    main_score: z.number().nullable().optional(),
+    change: ResultChangeSchema.nullable().optional(),
+    task_error: z.string().max(10000).nullable().optional(),
+    duration_ms: z.number().int().nonnegative().nullable().optional(),
+    cost: z.number().nonnegative().nullable().optional(),
+    scores: z.array(ScoreInputSchema).default([]),
+  })
+  .strict();
+export type UpsertResultRequest = z.infer<typeof UpsertResultRequestSchema>;
+
+export interface UpsertResultResponse {
+  evaluation_result_id: string;
+}
+
+/** Complete/fail a run, reporting final completeness counts. */
+export const CompleteRunRequestSchema = z
+  .object({
+    status: EvalRunStatusSchema,
+    main_score: z.number().nullable().optional(),
+    case_count: z.number().int().nonnegative().nullable().optional(),
+    scored_count: z.number().int().nonnegative().nullable().optional(),
+    task_error_count: z.number().int().nonnegative().nullable().optional(),
+    scorer_error_count: z.number().int().nonnegative().nullable().optional(),
+  })
+  .strict();
+export type CompleteRunRequest = z.infer<typeof CompleteRunRequestSchema>;
+
+// ---------------------------------------------------------------------------
+// User-session CRUD requests (Datasets pages)
+// ---------------------------------------------------------------------------
+
+export const CreateDatasetRequestSchema = z
+  .object({
+    name: z.string().min(1).max(200),
+    description: z.string().max(2000).nullable().optional(),
+  })
+  .strict();
+export type CreateDatasetRequest = z.infer<typeof CreateDatasetRequestSchema>;
+
+export const UpdateDatasetRequestSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2000).nullable().optional(),
+  })
+  .strict();
+
+/** Save a trace/span as a new test case (publishes a new dataset version). */
+export const CreateTestCaseRequestSchema = z
+  .object({
+    input: z.string(),
+    expected: z.string().nullable().optional(),
+    recorded_output: z.string().nullable().optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    review: ReviewStatusSchema.default("needs_review"),
+    capture_reason: CaptureReasonSchema.default("manual"),
+    source_trace_id: z.string().max(64).nullable().optional(),
+    source_span_id: z.string().max(64).nullable().optional(),
+    source_span_name: z.string().max(400).nullable().optional(),
+    source_span_kind: z.string().max(32).nullable().optional(),
+  })
+  .strict();
+export type CreateTestCaseRequest = z.infer<typeof CreateTestCaseRequestSchema>;
+
+/** Edit a test case → publishes a new dataset version (old snapshots untouched). */
+export const UpdateTestCaseRequestSchema = z
+  .object({
+    input: z.string().optional(),
+    expected: z.string().nullable().optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    review: ReviewStatusSchema.optional(),
+  })
+  .strict();
+export type UpdateTestCaseRequest = z.infer<typeof UpdateTestCaseRequestSchema>;
+
+export const CreateHumanScoreRequestSchema = z
+  .object({
+    verdict: HumanVerdictSchema,
+    quality: z.number().int().min(1).max(5).nullable().optional(),
+    comment: z.string().max(5000).nullable().optional(),
+    reviewer: z.string().min(1).max(200),
+  })
+  .strict();
+export type CreateHumanScoreRequest = z.infer<typeof CreateHumanScoreRequestSchema>;

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -19,6 +19,7 @@ export const EVAL_RUN_STATUSES = [
   "completed_with_errors",
   "failed",
   "incomplete",
+  "cancelled",
 ] as const;
 export const EvalRunStatusSchema = z.enum(EVAL_RUN_STATUSES);
 export type EvalRunStatus = (typeof EVAL_RUN_STATUSES)[number];
@@ -195,3 +196,78 @@ export const CreateHumanScoreRequestSchema = z
   })
   .strict();
 export type CreateHumanScoreRequest = z.infer<typeof CreateHumanScoreRequestSchema>;
+
+// ---------------------------------------------------------------------------
+// API-key dataset authoring (SDK owns dataset_id / test_case_id; server owns
+// dataset_version_id / version_number). See contract-delta-dataset-and-lifecycle.
+//
+// input / expected are accepted as any JSON value and stored as text (a non-string
+// value is JSON-stringified), matching how the pull endpoints already return them.
+// ---------------------------------------------------------------------------
+
+/** Max test-case changes accepted in one A4 publish; over this → 413 so the SDK chunks. */
+export const DATASET_VERSION_MAX_CHANGES = 1000;
+
+/** A2 — upsert a dataset by its client-generated id (idempotent, no version). */
+export const PublicUpsertDatasetRequestSchema = z
+  .object({
+    dataset_id: z.string().min(1).max(64),
+    name: z.string().min(1).max(200),
+    description: z.string().max(2000).nullable().optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  })
+  .strict();
+export type PublicUpsertDatasetRequest = z.infer<typeof PublicUpsertDatasetRequestSchema>;
+
+/** A3 — dataset metadata only; never mutates a published version. */
+export const PublicUpdateDatasetRequestSchema = z
+  .object({
+    name: z.string().min(1).max(200).optional(),
+    description: z.string().max(2000).nullable().optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  })
+  .strict();
+export type PublicUpdateDatasetRequest = z.infer<typeof PublicUpdateDatasetRequestSchema>;
+
+const UpsertCaseChangeSchema = z.object({
+  op: z.literal("upsert"),
+  test_case_id: z.string().min(1).max(64),
+  input: z.unknown(),
+  expected: z.unknown().optional(),
+  metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  source_trace_id: z.string().max(64).nullable().optional(),
+  source_span_id: z.string().max(64).nullable().optional(),
+});
+const ArchiveCaseChangeSchema = z.object({
+  op: z.literal("archive"),
+  test_case_id: z.string().min(1).max(64),
+});
+const DeleteCaseChangeSchema = z.object({
+  op: z.literal("delete"),
+  test_case_id: z.string().min(1).max(64),
+});
+export const DatasetChangeSchema = z.discriminatedUnion("op", [
+  UpsertCaseChangeSchema,
+  ArchiveCaseChangeSchema,
+  DeleteCaseChangeSchema,
+]);
+export type DatasetChange = z.infer<typeof DatasetChangeSchema>;
+
+/**
+ * A4 — publish ONE immutable dataset version from a batch of changes.
+ *
+ * `base_version_id` is the version the edit was based on (null on first publish);
+ * a mismatch with the dataset's current version is a 409 conflict. `idempotency_key`
+ * makes a retried publish return the same version instead of a duplicate. The
+ * change cap (DATASET_VERSION_MAX_CHANGES) is enforced in the route as a 413, not
+ * here, so the SDK gets the limit back and chunks.
+ */
+export const PublishDatasetVersionRequestSchema = z
+  .object({
+    base_version_id: z.string().min(1).max(64).nullable(),
+    label: z.string().min(1).max(64).optional(),
+    changes: z.array(DatasetChangeSchema).min(1),
+    idempotency_key: z.string().min(1).max(128).nullable().optional(),
+  })
+  .strict();
+export type PublishDatasetVersionRequest = z.infer<typeof PublishDatasetVersionRequestSchema>;

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -44,9 +44,28 @@ export const HumanVerdictSchema = z.enum(HUMAN_VERDICTS);
 // Scorer descriptor — name + version recorded on every run and score
 // ---------------------------------------------------------------------------
 
+/** How a scorer's value is typed (inferred from the value when not declared). */
+export const SCORER_VALUE_TYPES = ["numeric", "boolean", "categorical"] as const;
+export const ScorerValueTypeSchema = z.enum(SCORER_VALUE_TYPES);
+export type ScorerValueType = (typeof SCORER_VALUE_TYPES)[number];
+
+/** Whether a higher or lower value is better; categorical scorers have no direction. */
+export const SCORER_DIRECTIONS = ["higher_is_better", "lower_is_better", "none"] as const;
+export const ScorerDirectionSchema = z.enum(SCORER_DIRECTIONS);
+export type ScorerDirection = (typeof SCORER_DIRECTIONS)[number];
+
+/**
+ * A scorer's descriptor. `name` + `version` are the identity used for cell
+ * comparison; the richer metadata is optional and back-compatible — an old SDK
+ * sending only `{name, version}` stays valid, and the backend defaults direction
+ * (numeric/boolean → higher-is-better, categorical → none) when it's absent.
+ */
 export const ScorerRefSchema = z.object({
   name: z.string().min(1).max(200),
   version: z.string().min(1).max(50),
+  value_type: ScorerValueTypeSchema.nullable().optional(),
+  direction: ScorerDirectionSchema.nullable().optional(),
+  threshold: z.number().nullable().optional(),
 });
 export type ScorerRef = z.infer<typeof ScorerRefSchema>;
 
@@ -88,6 +107,13 @@ export const RegisterRunRequestSchema = z
     client_run_id: z.string().min(1).max(128).nullable().optional(),
     baseline_run_id: z.string().min(1).max(64).nullable().optional(),
     case_count: z.number().int().nonnegative().nullable().optional(),
+    /**
+     * Structured run provenance (model, prompt, config, git repo/ref/commit, …).
+     * Free-form and optional — the current SDK does not send it, and its absence
+     * never rejects a run. Presented as informational secondary detail, never as
+     * an evaluation error, and never a source of secrets.
+     */
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
   })
   .strict();
 export type RegisterRunRequest = z.infer<typeof RegisterRunRequestSchema>;

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -23,6 +23,15 @@ export type {
   Account,
   GitHubInstallation,
   ModelProvider,
+  // Offline evaluation
+  Dataset,
+  DatasetVersion,
+  TestCase,
+  Evaluation,
+  EvaluationRun,
+  EvaluationResult,
+  Score,
+  HumanScore,
 } from "@prisma/client";
 
 // Constants & Zod schemas

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -1,6 +1,6 @@
 // Database
 export { prisma } from "./lib/prisma.ts";
-export { PrismaClient } from "@prisma/client";
+export { PrismaClient, Prisma } from "@prisma/client";
 export * from "./ee/billing/index.ts";
 
 // Encryption
@@ -37,6 +37,7 @@ export type {
 // Constants & Zod schemas
 export * from "./constants.ts";
 export * from "./schemas.ts";
+export * from "./eval-contract.ts";
 
 // LLM Providers
 export * from "./llm-providers.ts";

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -37,7 +37,6 @@ export type {
 // Constants & Zod schemas
 export * from "./constants.ts";
 export * from "./schemas.ts";
-export * from "./eval-contract.ts";
 
 // LLM Providers
 export * from "./llm-providers.ts";

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { prisma, Prisma, PublicUpdateDatasetRequestSchema } from "@traceroot/core";
+import { requireApiKeyProject } from "@/lib/eval/auth";
+
+type RouteParams = { params: Promise<{ datasetId: string }> };
+
+// GET /api/public/datasets/[datasetId] — SDK fetches a dataset by stable id and
+// learns its current published version to pin (API-key auth, snake_case body).
+export async function GET(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { datasetId } = await params;
+
+  const dataset = await prisma.dataset.findFirst({
+    where: { id: datasetId, projectId },
+    select: { id: true, name: true, description: true, currentVersionId: true },
+  });
+  if (!dataset) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
+
+  return NextResponse.json({
+    dataset_id: dataset.id,
+    name: dataset.name,
+    description: dataset.description,
+    current_dataset_version_id: dataset.currentVersionId,
+  });
+}
+
+// PATCH /api/public/datasets/[datasetId] — dataset metadata only (A3). Never
+// mutates a published version; publish test-case changes via .../versions.
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { datasetId } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = PublicUpdateDatasetRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const c = parsed.data;
+
+  const existing = await prisma.dataset.findFirst({
+    where: { id: datasetId, projectId },
+    select: { id: true },
+  });
+  if (!existing) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
+
+  const updated = await prisma.dataset.update({
+    where: { id: datasetId },
+    data: {
+      ...(c.name !== undefined ? { name: c.name } : {}),
+      ...(c.description !== undefined ? { description: c.description } : {}),
+      // JsonB: an explicit null clears the column; an object replaces it.
+      ...(c.metadata !== undefined
+        ? { metadata: c.metadata === null ? Prisma.DbNull : (c.metadata as Prisma.InputJsonValue) }
+        : {}),
+    },
+    select: { id: true, name: true, description: true, currentVersionId: true },
+  });
+  return NextResponse.json({
+    dataset_id: updated.id,
+    name: updated.name,
+    description: updated.description,
+    current_dataset_version_id: updated.currentVersionId,
+  });
+}

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/route.ts
@@ -12,14 +12,15 @@ export async function GET(request: Request, { params }: RouteParams) {
   const { projectId } = auth;
   const { datasetId } = await params;
 
-  const dataset = await prisma.dataset.findFirst({
-    where: { id: datasetId, projectId },
-    select: { id: true, name: true, description: true, currentVersionId: true },
+  // The path value is the SDK's project-scoped client id, not the internal PK.
+  const dataset = await prisma.dataset.findUnique({
+    where: { projectId_clientDatasetId: { projectId, clientDatasetId: datasetId } },
+    select: { clientDatasetId: true, name: true, description: true, currentVersionId: true },
   });
   if (!dataset) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
 
   return NextResponse.json({
-    dataset_id: dataset.id,
+    dataset_id: dataset.clientDatasetId ?? datasetId,
     name: dataset.name,
     description: dataset.description,
     current_dataset_version_id: dataset.currentVersionId,
@@ -46,14 +47,16 @@ export async function PATCH(request: Request, { params }: RouteParams) {
   }
   const c = parsed.data;
 
-  const existing = await prisma.dataset.findFirst({
-    where: { id: datasetId, projectId },
+  // Resolve the client id to the internal row id, then update by the PK (the client
+  // id alone is not unique — it's only unique per project).
+  const existing = await prisma.dataset.findUnique({
+    where: { projectId_clientDatasetId: { projectId, clientDatasetId: datasetId } },
     select: { id: true },
   });
   if (!existing) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
 
   const updated = await prisma.dataset.update({
-    where: { id: datasetId },
+    where: { id: existing.id },
     data: {
       ...(c.name !== undefined ? { name: c.name } : {}),
       ...(c.description !== undefined ? { description: c.description } : {}),
@@ -62,10 +65,10 @@ export async function PATCH(request: Request, { params }: RouteParams) {
         ? { metadata: c.metadata === null ? Prisma.DbNull : (c.metadata as Prisma.InputJsonValue) }
         : {}),
     },
-    select: { id: true, name: true, description: true, currentVersionId: true },
+    select: { clientDatasetId: true, name: true, description: true, currentVersionId: true },
   });
   return NextResponse.json({
-    dataset_id: updated.id,
+    dataset_id: updated.clientDatasetId ?? datasetId,
     name: updated.name,
     description: updated.description,
     current_dataset_version_id: updated.currentVersionId,

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from "next/server";
+import {
+  prisma,
+  PublishDatasetVersionRequestSchema,
+  DATASET_VERSION_MAX_CHANGES,
+} from "@traceroot/core";
+import { requireApiKeyProject } from "@/lib/eval/auth";
+import {
+  publishDatasetVersion,
+  DatasetNotFound,
+  VersionConflict,
+  type TestCaseSeed,
+} from "@/lib/eval/versions";
+
+type RouteParams = { params: Promise<{ datasetId: string }> };
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/** input/expected arrive as any JSON; store as text (non-strings are stringified). */
+function toText(value: unknown): string {
+  return typeof value === "string" ? value : JSON.stringify(value);
+}
+
+// POST /api/public/datasets/[datasetId]/versions — publish ONE immutable version
+// from a batch of test-case changes (A4). One call → one version, atomically.
+// Optimistic concurrency on base_version_id (409 on mismatch); idempotency_key
+// makes a retried publish return the same version.
+export async function POST(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { datasetId } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = PublishDatasetVersionRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const c = parsed.data;
+
+  if (c.changes.length > DATASET_VERSION_MAX_CHANGES) {
+    return NextResponse.json(
+      { error: "Too many changes in one publish", limit: DATASET_VERSION_MAX_CHANGES },
+      { status: 413 },
+    );
+  }
+
+  try {
+    const result = await publishDatasetVersion({
+      datasetId,
+      projectId,
+      label: c.label,
+      baseVersionId: c.base_version_id,
+      idempotencyKey: c.idempotency_key ?? null,
+      note: "Published from the SDK",
+      transform: (current) => {
+        // Fold the changes over the current cases, keyed by stable test_case_id.
+        // upsert = full-case replace/add; archive and delete both drop the case
+        // from the new version (older immutable snapshots always retain it).
+        const byId = new Map<string, TestCaseSeed>(current.map((s) => [s.testCaseId, s]));
+        for (const ch of c.changes) {
+          if (ch.op !== "upsert") {
+            byId.delete(ch.test_case_id);
+            continue;
+          }
+          const prev = byId.get(ch.test_case_id);
+          byId.set(ch.test_case_id, {
+            testCaseId: ch.test_case_id,
+            input: ch.input !== undefined ? toText(ch.input) : (prev?.input ?? ""),
+            expected: ch.expected === undefined ? (prev?.expected ?? null) : toText(ch.expected),
+            recordedOutput: prev?.recordedOutput ?? null,
+            metadata: ch.metadata !== undefined ? ch.metadata : (prev?.metadata ?? null),
+            review: prev?.review ?? "needs_review",
+            captureReason: prev?.captureReason ?? "manual",
+            sourceTraceId: ch.source_trace_id ?? prev?.sourceTraceId ?? null,
+            sourceSpanId: ch.source_span_id ?? prev?.sourceSpanId ?? null,
+            sourceSpanName: prev?.sourceSpanName ?? null,
+            sourceSpanKind: prev?.sourceSpanKind ?? null,
+            addedBy: prev?.addedBy ?? null,
+            createTime: prev?.createTime, // preserve for existing; new cases default to now
+          });
+        }
+        return {
+          cases: [...byId.values()],
+          focusTestCaseId: c.changes[c.changes.length - 1].test_case_id,
+        };
+      },
+    });
+
+    return NextResponse.json(
+      {
+        dataset_id: datasetId,
+        dataset_version_id: result.versionId,
+        version_number: result.versionNumber,
+        case_count: result.caseCount,
+      },
+      { status: result.replayed ? 200 : 201 },
+    );
+  } catch (err) {
+    if (err instanceof DatasetNotFound) {
+      return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
+    }
+    if (err instanceof VersionConflict) {
+      return NextResponse.json(
+        {
+          error: "conflict",
+          base_version_id: c.base_version_id,
+          current_version_id: err.currentVersionId,
+        },
+        { status: 409 },
+      );
+    }
+    throw err;
+  }
+}
+
+// GET /api/public/datasets/[datasetId]/versions?limit=&cursor= — list versions (A5),
+// newest-first, cursor-paginated.
+export async function GET(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { datasetId } = await params;
+
+  const dataset = await prisma.dataset.findFirst({
+    where: { id: datasetId, projectId },
+    select: { id: true, currentVersionId: true },
+  });
+  if (!dataset) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
+
+  const url = new URL(request.url);
+  const rawLimit = Number(url.searchParams.get("limit"));
+  const limit =
+    Number.isFinite(rawLimit) && rawLimit > 0
+      ? Math.min(Math.floor(rawLimit), MAX_LIMIT)
+      : DEFAULT_LIMIT;
+  const cursor = url.searchParams.get("cursor");
+
+  const rows = await prisma.datasetVersion.findMany({
+    where: { datasetId, projectId },
+    orderBy: { versionNumber: "desc" },
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    select: { id: true, versionNumber: true, label: true, note: true, createTime: true },
+  });
+
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const versions = await Promise.all(
+    page.map(async (v) => ({
+      dataset_version_id: v.id,
+      version_number: v.versionNumber,
+      label: v.label,
+      note: v.note,
+      case_count: await prisma.testCase.count({ where: { datasetVersionId: v.id } }),
+      created_at: v.createTime.toISOString(),
+      is_current: v.id === dataset.currentVersionId,
+    })),
+  );
+  return NextResponse.json({ versions, next_cursor: hasMore ? page[page.length - 1].id : null });
+}

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
@@ -51,9 +51,17 @@ export async function POST(request: Request, { params }: RouteParams) {
     );
   }
 
+  // Resolve the SDK client id to the internal row id; `publishDatasetVersion` (also
+  // called by internal UI routes) keys on the internal id.
+  const ds = await prisma.dataset.findUnique({
+    where: { projectId_clientDatasetId: { projectId, clientDatasetId: datasetId } },
+    select: { id: true },
+  });
+  if (!ds) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
+
   try {
     const result = await publishDatasetVersion({
-      datasetId,
+      datasetId: ds.id,
       projectId,
       label: c.label,
       baseVersionId: c.base_version_id,
@@ -128,22 +136,27 @@ export async function GET(request: Request, { params }: RouteParams) {
   const { projectId } = auth;
   const { datasetId } = await params;
 
-  const dataset = await prisma.dataset.findFirst({
-    where: { id: datasetId, projectId },
+  // The SDK id is the project-scoped client id; resolve it to the internal row id
+  // before querying versions (whose `datasetId` FK is the internal id, not the client one).
+  const dataset = await prisma.dataset.findUnique({
+    where: { projectId_clientDatasetId: { projectId, clientDatasetId: datasetId } },
     select: { id: true, currentVersionId: true },
   });
   if (!dataset) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
 
   const url = new URL(request.url);
   const rawLimit = Number(url.searchParams.get("limit"));
+  // Floor THEN clamp: a positive fraction floors to 0, an empty page whose cursor
+  // still dereferences its last row — a 500. Clamp the floored value to at least 1.
+  const flooredLimit = Math.floor(rawLimit);
   const limit =
-    Number.isFinite(rawLimit) && rawLimit > 0
-      ? Math.min(Math.floor(rawLimit), MAX_LIMIT)
+    Number.isFinite(rawLimit) && flooredLimit >= 1
+      ? Math.min(flooredLimit, MAX_LIMIT)
       : DEFAULT_LIMIT;
   const cursor = url.searchParams.get("cursor");
 
   const rows = await prisma.datasetVersion.findMany({
-    where: { datasetId, projectId },
+    where: { datasetId: dataset.id, projectId },
     orderBy: { versionNumber: "desc" },
     take: limit + 1,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
@@ -165,16 +165,26 @@ export async function GET(request: Request, { params }: RouteParams) {
 
   const hasMore = rows.length > limit;
   const page = hasMore ? rows.slice(0, limit) : rows;
-  const versions = await Promise.all(
-    page.map(async (v) => ({
-      dataset_version_id: v.id,
-      version_number: v.versionNumber,
-      label: v.label,
-      note: v.note,
-      case_count: await prisma.testCase.count({ where: { datasetVersionId: v.id } }),
-      created_at: v.createTime.toISOString(),
-      is_current: v.id === dataset.currentVersionId,
-    })),
-  );
+  // One grouped aggregate for every page version's case count — not a per-row count
+  // query (up to `limit` round-trips) on a public endpoint.
+  const versionIds = page.map((v) => v.id);
+  const caseCounts =
+    versionIds.length > 0
+      ? await prisma.testCase.groupBy({
+          by: ["datasetVersionId"],
+          where: { datasetVersionId: { in: versionIds } },
+          _count: { _all: true },
+        })
+      : [];
+  const countByVersion = new Map(caseCounts.map((c) => [c.datasetVersionId, c._count._all]));
+  const versions = page.map((v) => ({
+    dataset_version_id: v.id,
+    version_number: v.versionNumber,
+    label: v.label,
+    note: v.note,
+    case_count: countByVersion.get(v.id) ?? 0,
+    created_at: v.createTime.toISOString(),
+    is_current: v.id === dataset.currentVersionId,
+  }));
   return NextResponse.json({ versions, next_cursor: hasMore ? page[page.length - 1].id : null });
 }

--- a/frontend/ui/src/app/api/public/datasets/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { prisma, type Prisma, PublicUpsertDatasetRequestSchema } from "@traceroot/core";
+import { prisma, Prisma, PublicUpsertDatasetRequestSchema } from "@traceroot/core";
 import { requireApiKeyProject } from "@/lib/eval/auth";
 
 const DEFAULT_LIMIT = 50;
@@ -7,8 +7,11 @@ const MAX_LIMIT = 200;
 
 function parseLimit(raw: string | null): number {
   const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
-  return Math.min(Math.floor(n), MAX_LIMIT);
+  // Floor first, THEN clamp: a positive fraction like 0.5 floors to 0, which would
+  // produce an empty page while the cursor still dereferences its last row (a 500).
+  const floored = Math.floor(n);
+  if (!Number.isFinite(n) || floored < 1) return DEFAULT_LIMIT;
+  return Math.min(floored, MAX_LIMIT);
 }
 
 // GET /api/public/datasets?limit=&cursor=&name= — list datasets (A1). Cursor is an
@@ -31,14 +34,23 @@ export async function GET(request: Request) {
     orderBy: { id: "desc" },
     take: limit + 1,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
-    select: { id: true, name: true, description: true, currentVersionId: true, updateTime: true },
+    select: {
+      id: true,
+      clientDatasetId: true,
+      name: true,
+      description: true,
+      currentVersionId: true,
+      updateTime: true,
+    },
   });
 
   const hasMore = rows.length > limit;
   const page = hasMore ? rows.slice(0, limit) : rows;
   return NextResponse.json({
+    // `dataset_id` is the SDK-facing client id; the opaque `next_cursor` stays the
+    // internal row id, which the SDK never interprets.
     datasets: page.map((d) => ({
-      dataset_id: d.id,
+      dataset_id: d.clientDatasetId ?? d.id,
       name: d.name,
       description: d.description,
       current_dataset_version_id: d.currentVersionId,
@@ -69,17 +81,19 @@ export async function POST(request: Request) {
   }
   const c = parsed.data;
 
+  // The SDK id is the project-scoped `clientDatasetId`, never the internal PK. Looking
+  // up by `{ projectId, clientDatasetId }` keeps the keyspace per-tenant: two projects
+  // can reuse the same id, and another project's id simply isn't found here (so we
+  // create ours) rather than leaking its existence.
+  const key = { projectId, clientDatasetId: c.dataset_id };
   const existing = await prisma.dataset.findUnique({
-    where: { id: c.dataset_id },
-    select: { id: true, projectId: true, name: true, description: true, currentVersionId: true },
+    where: { projectId_clientDatasetId: key },
+    select: { id: true, clientDatasetId: true, name: true, description: true, currentVersionId: true },
   });
   if (existing) {
-    if (existing.projectId !== projectId) {
-      return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
-    }
     return NextResponse.json(
       {
-        dataset_id: existing.id,
+        dataset_id: existing.clientDatasetId ?? existing.id,
         name: existing.name,
         description: existing.description,
         current_dataset_version_id: existing.currentVersionId,
@@ -88,23 +102,47 @@ export async function POST(request: Request) {
     );
   }
 
-  const created = await prisma.dataset.create({
-    data: {
-      id: c.dataset_id,
-      projectId,
-      name: c.name,
-      description: c.description ?? null,
-      metadata: (c.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
-    },
-    select: { id: true, name: true, description: true, currentVersionId: true },
-  });
-  return NextResponse.json(
-    {
-      dataset_id: created.id,
-      name: created.name,
-      description: created.description,
-      current_dataset_version_id: created.currentVersionId,
-    },
-    { status: 201 },
-  );
+  // Idempotent create: a concurrent first registration can lose the unique-key race
+  // (both pass the read, one hits uq_dataset_project_client_id). Translate that P2002
+  // into a re-read so a normal parallel retry returns 200, not a 500.
+  try {
+    const created = await prisma.dataset.create({
+      data: {
+        clientDatasetId: c.dataset_id,
+        projectId,
+        name: c.name,
+        description: c.description ?? null,
+        metadata: (c.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+      },
+      select: { id: true, clientDatasetId: true, name: true, description: true, currentVersionId: true },
+    });
+    return NextResponse.json(
+      {
+        dataset_id: created.clientDatasetId ?? created.id,
+        name: created.name,
+        description: created.description,
+        current_dataset_version_id: created.currentVersionId,
+      },
+      { status: 201 },
+    );
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002") {
+      const won = await prisma.dataset.findUnique({
+        where: { projectId_clientDatasetId: key },
+        select: { id: true, clientDatasetId: true, name: true, description: true, currentVersionId: true },
+      });
+      if (won) {
+        return NextResponse.json(
+          {
+            dataset_id: won.clientDatasetId ?? won.id,
+            name: won.name,
+            description: won.description,
+            current_dataset_version_id: won.currentVersionId,
+          },
+          { status: 200 },
+        );
+      }
+    }
+    throw e;
+  }
 }

--- a/frontend/ui/src/app/api/public/datasets/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from "next/server";
+import { prisma, type Prisma, PublicUpsertDatasetRequestSchema } from "@traceroot/core";
+import { requireApiKeyProject } from "@/lib/eval/auth";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+function parseLimit(raw: string | null): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.floor(n), MAX_LIMIT);
+}
+
+// GET /api/public/datasets?limit=&cursor=&name= — list datasets (A1). Cursor is an
+// opaque dataset id; results are newest-first with a null next_cursor at the end.
+export async function GET(request: Request) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+
+  const url = new URL(request.url);
+  const limit = parseLimit(url.searchParams.get("limit"));
+  const cursor = url.searchParams.get("cursor");
+  const name = url.searchParams.get("name")?.trim();
+
+  const rows = await prisma.dataset.findMany({
+    where: {
+      projectId,
+      ...(name ? { name: { contains: name, mode: "insensitive" as Prisma.QueryMode } } : {}),
+    },
+    orderBy: { id: "desc" },
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+    select: { id: true, name: true, description: true, currentVersionId: true, updateTime: true },
+  });
+
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  return NextResponse.json({
+    datasets: page.map((d) => ({
+      dataset_id: d.id,
+      name: d.name,
+      description: d.description,
+      current_dataset_version_id: d.currentVersionId,
+      updated_at: d.updateTime.toISOString(),
+    })),
+    next_cursor: hasMore ? page[page.length - 1].id : null,
+  });
+}
+
+// POST /api/public/datasets — upsert a dataset by its client-generated id (A2).
+// Idempotent within the project: re-sending the same dataset_id returns the
+// existing dataset (200) without creating a duplicate; a version is never created
+// here (see .../versions). An id owned by another project is 404 (not disclosed).
+export async function POST(request: Request) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = PublicUpsertDatasetRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const c = parsed.data;
+
+  const existing = await prisma.dataset.findUnique({
+    where: { id: c.dataset_id },
+    select: { id: true, projectId: true, name: true, description: true, currentVersionId: true },
+  });
+  if (existing) {
+    if (existing.projectId !== projectId) {
+      return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
+    }
+    return NextResponse.json(
+      {
+        dataset_id: existing.id,
+        name: existing.name,
+        description: existing.description,
+        current_dataset_version_id: existing.currentVersionId,
+      },
+      { status: 200 },
+    );
+  }
+
+  const created = await prisma.dataset.create({
+    data: {
+      id: c.dataset_id,
+      projectId,
+      name: c.name,
+      description: c.description ?? null,
+      metadata: (c.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+    },
+    select: { id: true, name: true, description: true, currentVersionId: true },
+  });
+  return NextResponse.json(
+    {
+      dataset_id: created.id,
+      name: created.name,
+      description: created.description,
+      current_dataset_version_id: created.currentVersionId,
+    },
+    { status: 201 },
+  );
+}

--- a/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
@@ -92,10 +92,13 @@ describe("A2: upsert a dataset by client id", () => {
     expect((await readJson(again)).dataset_id).toBe("ds_01");
   });
 
-  it("hides a dataset id owned by another project (404)", async () => {
+  it("lets two projects reuse the same client dataset id (per-project keyspace)", async () => {
     await upsertDataset(req({ dataset_id: "ds_shared", name: "mine" }));
     const res = await upsertDataset(req({ dataset_id: "ds_shared", name: "theirs" }, OTHER_KEY));
-    expect(res.status).toBe(404);
+    // `clientDatasetId` is unique per project, not globally: the other project creates
+    // its OWN dataset under the same id rather than being blocked (or shown it exists).
+    expect(res.status).toBe(201);
+    expect(fakePrisma.dataset.rows).toHaveLength(2);
   });
 });
 

--- a/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Local SDK dataset-authoring + lifecycle contract exerciser.
+ *
+ * Drives the real public dataset routes (A1–A5) and the new run-lifecycle routes
+ * (B1/B3/B4) end to end against the in-memory fake prisma — proving the pieces the
+ * SDK's remote paths depend on: client-id idempotency, one-call-one-version
+ * publishing, optimistic-concurrency 409s, idempotent republish, the batch cap,
+ * additive per-scorer scores, human scores, and the cancelled run status.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+  NextRequest: class {},
+}));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  const { fakePrisma } = await import("@/lib/eval/__tests__/fake-prisma");
+  return { ...actual, prisma: fakePrisma };
+});
+
+import { fakePrisma } from "@/lib/eval/__tests__/fake-prisma";
+import { hashApiKey } from "@/lib/api-keys";
+import { GET as listDatasets, POST as upsertDataset } from "./datasets/route";
+import { PATCH as patchDataset } from "./datasets/[datasetId]/route";
+import { POST as publishVersion, GET as listVersions } from "./datasets/[datasetId]/versions/route";
+import { POST as completeRun } from "./evaluation-runs/[runId]/complete/route";
+import { POST as addScore } from "./evaluation-runs/[runId]/results/[testCaseId]/scores/route";
+import { POST as addHumanScore } from "./evaluation-runs/[runId]/results/[testCaseId]/human-score/route";
+
+const API_KEY = "tr-test-key";
+const OTHER_KEY = "tr-other-key";
+const PROJECT_ID = "proj_1";
+const OTHER_PROJECT = "proj_2";
+
+function req(body: unknown, key = API_KEY) {
+  return {
+    headers: new Headers({ authorization: `Bearer ${key}` }),
+    url: "https://x/api/public/datasets",
+    json: async () => body,
+  } as unknown as Request;
+}
+function getReq(query = "", key = API_KEY) {
+  return {
+    headers: new Headers({ authorization: `Bearer ${key}` }),
+    url: `https://x/api/public/datasets${query}`,
+  } as unknown as Request;
+}
+async function readJson(res: { json: () => Promise<unknown> }) {
+  return res.json() as Promise<Record<string, unknown>>;
+}
+const dsParams = (datasetId: string) => ({ params: Promise.resolve({ datasetId }) });
+const resultParams = (runId: string, testCaseId: string) => ({
+  params: Promise.resolve({ runId, testCaseId }),
+});
+
+beforeEach(() => {
+  fakePrisma.reset();
+  fakePrisma.accessKey.rows.push(
+    {
+      secretHash: hashApiKey(API_KEY),
+      projectId: PROJECT_ID,
+      expireTime: null,
+      project: { deleteTime: null },
+    },
+    {
+      secretHash: hashApiKey(OTHER_KEY),
+      projectId: OTHER_PROJECT,
+      expireTime: null,
+      project: { deleteTime: null },
+    },
+  );
+});
+
+describe("A2: upsert a dataset by client id", () => {
+  it("creates once, then returns the existing dataset idempotently", async () => {
+    const first = await upsertDataset(req({ dataset_id: "ds_01", name: "billing-routing" }));
+    expect(first.status).toBe(201);
+    expect(fakePrisma.dataset.rows).toHaveLength(1);
+
+    const again = await upsertDataset(
+      req({ dataset_id: "ds_01", name: "billing-routing-renamed" }),
+    );
+    expect(again.status).toBe(200);
+    expect(fakePrisma.dataset.rows).toHaveLength(1); // no duplicate
+    expect((await readJson(again)).dataset_id).toBe("ds_01");
+  });
+
+  it("hides a dataset id owned by another project (404)", async () => {
+    await upsertDataset(req({ dataset_id: "ds_shared", name: "mine" }));
+    const res = await upsertDataset(req({ dataset_id: "ds_shared", name: "theirs" }, OTHER_KEY));
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("A4: publish an immutable version from changes", () => {
+  beforeEach(async () => {
+    await upsertDataset(req({ dataset_id: "ds1", name: "billing" }));
+  });
+
+  it("publishes one version and folds upsert/delete over the base", async () => {
+    const res = await publishVersion(
+      req({
+        base_version_id: null,
+        changes: [
+          { op: "upsert", test_case_id: "tc_1", input: "double charge", expected: "billing" },
+          { op: "upsert", test_case_id: "tc_2", input: "where is my order" },
+        ],
+      }),
+      dsParams("ds1"),
+    );
+    expect(res.status).toBe(201);
+    const body = await readJson(res);
+    expect(body.case_count).toBe(2);
+    expect(body.version_number).toBe(1);
+    const versionId = body.dataset_version_id as string;
+
+    // Dataset now points at the new version.
+    const ds = fakePrisma.dataset.rows.find((d) => d.id === "ds1")!;
+    expect(ds.currentVersionId).toBe(versionId);
+
+    // A second publish based on the new version: edit tc_1, delete tc_2, add tc_3.
+    const res2 = await publishVersion(
+      req({
+        base_version_id: versionId,
+        changes: [
+          { op: "upsert", test_case_id: "tc_1", input: "double charge", expected: "refunds" },
+          { op: "delete", test_case_id: "tc_2" },
+          { op: "upsert", test_case_id: "tc_3", input: "cancel please" },
+        ],
+      }),
+      dsParams("ds1"),
+    );
+    expect(res2.status).toBe(201);
+    const body2 = await readJson(res2);
+    expect(body2.case_count).toBe(2); // tc_1 (edited) + tc_3; tc_2 dropped
+    const v2 = body2.dataset_version_id as string;
+    const v2Cases = fakePrisma.testCase.rows.filter((c) => c.datasetVersionId === v2);
+    expect(v2Cases.map((c) => c.testCaseId).sort()).toEqual(["tc_1", "tc_3"]);
+    expect(v2Cases.find((c) => c.testCaseId === "tc_1")!.expected).toBe("refunds");
+    // The first version still holds its original two cases (immutable).
+    expect(fakePrisma.testCase.rows.filter((c) => c.datasetVersionId === versionId)).toHaveLength(
+      2,
+    );
+  });
+
+  it("rejects a stale base_version_id with 409 and the current version", async () => {
+    const first = await publishVersion(
+      req({ base_version_id: null, changes: [{ op: "upsert", test_case_id: "tc_1", input: "x" }] }),
+      dsParams("ds1"),
+    );
+    const current = (await readJson(first)).dataset_version_id;
+
+    const conflict = await publishVersion(
+      req({ base_version_id: null, changes: [{ op: "upsert", test_case_id: "tc_2", input: "y" }] }),
+      dsParams("ds1"),
+    );
+    expect(conflict.status).toBe(409);
+    const body = await readJson(conflict);
+    expect(body.error).toBe("conflict");
+    expect(body.current_version_id).toBe(current);
+  });
+
+  it("returns the same version for a retried idempotency_key", async () => {
+    const payload = {
+      base_version_id: null,
+      idempotency_key: "publish-1",
+      changes: [{ op: "upsert", test_case_id: "tc_1", input: "x" }],
+    };
+    const first = await publishVersion(req(payload), dsParams("ds1"));
+    expect(first.status).toBe(201);
+    const versionId = (await readJson(first)).dataset_version_id;
+
+    const retry = await publishVersion(req(payload), dsParams("ds1"));
+    expect(retry.status).toBe(200); // replayed, not created
+    expect((await readJson(retry)).dataset_version_id).toBe(versionId);
+    expect(fakePrisma.datasetVersion.rows).toHaveLength(1);
+  });
+
+  it("rejects an over-cap batch with 413 and the limit", async () => {
+    const changes = Array.from({ length: 1001 }, (_, i) => ({
+      op: "upsert" as const,
+      test_case_id: `tc_${i}`,
+      input: "x",
+    }));
+    const res = await publishVersion(req({ base_version_id: null, changes }), dsParams("ds1"));
+    expect(res.status).toBe(413);
+    expect((await readJson(res)).limit).toBe(1000);
+  });
+});
+
+describe("A1/A5: listing", () => {
+  it("lists datasets with a next_cursor when there are more than the limit", async () => {
+    fakePrisma.dataset.rows.push(
+      { id: "ds_a", projectId: PROJECT_ID, name: "a", updateTime: new Date("2026-01-01") },
+      { id: "ds_b", projectId: PROJECT_ID, name: "b", updateTime: new Date("2026-01-02") },
+      { id: "ds_c", projectId: PROJECT_ID, name: "c", updateTime: new Date("2026-01-03") },
+    );
+    const res = await listDatasets(getReq("?limit=2"));
+    const body = await readJson(res);
+    expect((body.datasets as unknown[]).length).toBe(2);
+    expect(body.next_cursor).not.toBeNull();
+
+    const all = await listDatasets(getReq("?limit=50"));
+    expect((await readJson(all)).next_cursor).toBeNull();
+  });
+
+  it("lists a dataset's versions newest-first with case counts", async () => {
+    await upsertDataset(req({ dataset_id: "ds1", name: "billing" }));
+    await publishVersion(
+      req({ base_version_id: null, changes: [{ op: "upsert", test_case_id: "tc_1", input: "x" }] }),
+      dsParams("ds1"),
+    );
+    const res = await listVersions(getReq("", API_KEY), dsParams("ds1"));
+    const body = await readJson(res);
+    const versions = body.versions as Array<Record<string, unknown>>;
+    expect(versions).toHaveLength(1);
+    expect(versions[0].version_number).toBe(1);
+    expect(versions[0].case_count).toBe(1);
+    expect(versions[0].is_current).toBe(true);
+  });
+});
+
+describe("A3: patch dataset metadata", () => {
+  it("updates name/description/metadata without touching versions", async () => {
+    await upsertDataset(req({ dataset_id: "ds1", name: "billing" }));
+    const res = await patchDataset(
+      req({ name: "billing-v2", description: "routing tickets" }),
+      dsParams("ds1"),
+    );
+    expect(res.status).toBe(200);
+    expect((await readJson(res)).name).toBe("billing-v2");
+    expect(fakePrisma.datasetVersion.rows).toHaveLength(0);
+  });
+});
+
+describe("B3/B4: additive scores and human scores", () => {
+  beforeEach(() => {
+    fakePrisma.evaluationResult.rows.push({
+      id: "res1",
+      runId: "run1",
+      evaluationId: "eval1",
+      projectId: PROJECT_ID,
+      testCaseId: "tc_1",
+    });
+  });
+
+  it("merges a per-scorer score on (name, version) instead of duplicating", async () => {
+    await addScore(
+      req({ scorer_name: "helpfulness", scorer_version: "v2", numeric_value: 0.8 }),
+      resultParams("run1", "tc_1"),
+    );
+    await addScore(
+      req({ scorer_name: "helpfulness", scorer_version: "v2", numeric_value: 0.95 }),
+      resultParams("run1", "tc_1"),
+    );
+    const scores = fakePrisma.score.rows.filter((s) => s.resultId === "res1");
+    expect(scores).toHaveLength(1); // merged
+    expect(scores[0].numericValue).toBe(0.95);
+  });
+
+  it("records a human score bound to the run + test case", async () => {
+    const res = await addHumanScore(
+      req({ verdict: "pass", quality: 4, reviewer: "e@x.com" }),
+      resultParams("run1", "tc_1"),
+    );
+    expect(res.status).toBe(201);
+    expect(fakePrisma.humanScore.rows).toHaveLength(1);
+    expect(fakePrisma.humanScore.rows[0].verdict).toBe("pass");
+  });
+
+  it("404s a score for a result that does not exist", async () => {
+    const res = await addScore(
+      req({ scorer_name: "x", scorer_version: "v1", numeric_value: 1 }),
+      resultParams("run1", "missing"),
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("B1: cancelled run status", () => {
+  it("accepts cancelled on complete and stamps completedAt", async () => {
+    fakePrisma.evaluationRun.rows.push({ id: "run1", projectId: PROJECT_ID, status: "running" });
+    const res = await completeRun(req({ status: "cancelled" }), {
+      params: Promise.resolve({ runId: "run1" }),
+    });
+    expect(res.status).toBe(200);
+    const run = fakePrisma.evaluationRun.rows.find((r) => r.id === "run1")!;
+    expect(run.status).toBe("cancelled");
+    expect(run.completedAt).toBeInstanceOf(Date);
+  });
+});

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/[testCaseId]/human-score/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/[testCaseId]/human-score/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { prisma, CreateHumanScoreRequestSchema } from "@traceroot/core";
+import { requireApiKeyProject } from "@/lib/eval/auth";
+
+type RouteParams = { params: Promise<{ runId: string; testCaseId: string }> };
+
+// POST /api/public/evaluation-runs/[runId]/results/[testCaseId]/human-score (B4) —
+// record a human review bound to (run, test case), so deferred / human scoring is
+// reportable from the SDK (previously only on the session surface). Additive; each
+// call appends a review and never rewrites automated results (B2).
+export async function POST(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { runId, testCaseId } = await params;
+
+  const result = await prisma.evaluationResult.findFirst({
+    where: { runId, testCaseId, projectId },
+    select: { id: true },
+  });
+  if (!result) {
+    return NextResponse.json({ error: "Result not found for run and test case" }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = CreateHumanScoreRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const h = parsed.data;
+
+  const created = await prisma.humanScore.create({
+    data: {
+      resultId: result.id,
+      projectId,
+      verdict: h.verdict,
+      quality: h.quality ?? null,
+      comment: h.comment ?? null,
+      reviewer: h.reviewer,
+    },
+    select: { id: true },
+  });
+
+  return NextResponse.json({ human_score_id: created.id }, { status: 201 });
+}

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/[testCaseId]/scores/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/[testCaseId]/scores/route.ts
@@ -44,27 +44,27 @@ export async function POST(request: Request, { params }: RouteParams) {
     error: s.error ?? null,
   };
 
-  const scoreId = await prisma.$transaction(async (tx) => {
-    const existing = await tx.score.findFirst({
-      where: { resultId: result.id, scorerName: s.scorer_name, scorerVersion: s.scorer_version },
-      select: { id: true },
-    });
-    if (existing) {
-      await tx.score.update({ where: { id: existing.id }, data: fields });
-      return existing.id;
-    }
-    const created = await tx.score.create({
-      data: {
+  // Atomic upsert on the compound unique — a find-then-create let two concurrent
+  // submissions for the same scorer both pass the read and then one lose the unique-key
+  // race with a 500. Postgres INSERT ... ON CONFLICT DO UPDATE serialises them.
+  const upserted = await prisma.score.upsert({
+    where: {
+      resultId_scorerName_scorerVersion: {
         resultId: result.id,
-        projectId,
         scorerName: s.scorer_name,
         scorerVersion: s.scorer_version,
-        ...fields,
       },
-      select: { id: true },
-    });
-    return created.id;
+    },
+    create: {
+      resultId: result.id,
+      projectId,
+      scorerName: s.scorer_name,
+      scorerVersion: s.scorer_version,
+      ...fields,
+    },
+    update: fields,
+    select: { id: true },
   });
 
-  return NextResponse.json({ score_id: scoreId }, { status: 200 });
+  return NextResponse.json({ score_id: upserted.id }, { status: 200 });
 }

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/[testCaseId]/scores/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/[testCaseId]/scores/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { prisma, ScoreInputSchema } from "@traceroot/core";
+import { requireApiKeyProject } from "@/lib/eval/auth";
+
+type RouteParams = { params: Promise<{ runId: string; testCaseId: string }> };
+
+// POST /api/public/evaluation-runs/[runId]/results/[testCaseId]/scores (B3) —
+// report ONE scorer's outcome, MERGED on (scorer_name, scorer_version) instead of
+// replacing the whole scores array (which re-upserting the result does). Safe for
+// delayed / human / per-scorer scores that arrive after the result, and accepted
+// even once the run is completed (B2) — it never rewrites the automated results.
+export async function POST(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { runId, testCaseId } = await params;
+
+  const result = await prisma.evaluationResult.findFirst({
+    where: { runId, testCaseId, projectId },
+    select: { id: true },
+  });
+  if (!result) {
+    return NextResponse.json({ error: "Result not found for run and test case" }, { status: 404 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = ScoreInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const s = parsed.data;
+
+  const fields = {
+    numericValue: s.numeric_value ?? null,
+    boolValue: s.bool_value ?? null,
+    stringValue: s.string_value ?? null,
+    passed: s.passed ?? null,
+    explanation: s.explanation ?? null,
+    error: s.error ?? null,
+  };
+
+  const scoreId = await prisma.$transaction(async (tx) => {
+    const existing = await tx.score.findFirst({
+      where: { resultId: result.id, scorerName: s.scorer_name, scorerVersion: s.scorer_version },
+      select: { id: true },
+    });
+    if (existing) {
+      await tx.score.update({ where: { id: existing.id }, data: fields });
+      return existing.id;
+    }
+    const created = await tx.score.create({
+      data: {
+        resultId: result.id,
+        projectId,
+        scorerName: s.scorer_name,
+        scorerVersion: s.scorer_version,
+        ...fields,
+      },
+      select: { id: true },
+    });
+    return created.id;
+  });
+
+  return NextResponse.json({ score_id: scoreId }, { status: 200 });
+}

--- a/frontend/ui/src/app/api/public/evaluation-runs/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/route.ts
@@ -60,9 +60,13 @@ export async function POST(request: Request) {
         }
       }
 
+      // Get-or-create by (projectId, name) — the Evaluation's actual unique key. Looking
+      // up with datasetId too would miss an eval of the same name first registered
+      // against another dataset, then fail the (projectId, name) constraint on create
+      // with a 500 instead of reusing it.
       const evaluation =
         (await tx.evaluation.findFirst({
-          where: { projectId, datasetId: dataset.id, name: req.evaluation_name },
+          where: { projectId, name: req.evaluation_name },
           select: { id: true },
         })) ??
         (await tx.evaluation.create({

--- a/frontend/ui/src/app/api/public/evaluation-runs/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import {
   prisma,
+  Prisma,
   RegisterRunRequestSchema,
   type RegisterRunResponse,
-  type Prisma,
 } from "@traceroot/core";
 import { requireApiKeyProject } from "@/lib/eval/auth";
 
@@ -30,7 +30,7 @@ export async function POST(request: Request) {
   const req = parsed.data;
 
   try {
-    const result = await prisma.$transaction(async (tx) => {
+    const runRegistration = async (tx: Prisma.TransactionClient) => {
       // The SDK's dataset_id is the project-scoped client id, never the internal PK.
       const dataset = await tx.dataset.findUnique({
         where: { projectId_clientDatasetId: { projectId, clientDatasetId: req.dataset_id } },
@@ -132,7 +132,27 @@ export async function POST(request: Request) {
           dataset_version_id: run.datasetVersionId,
         } satisfies RegisterRunResponse,
       };
-    });
+    };
+
+    // Retry the registration on a unique-key collision: concurrent first registrations
+    // can read the same max run number (or race the client_run_id insert) and one loses
+    // uq_run_evaluation_run_number — a normal parallel SDK call, not a 500. Each attempt
+    // re-reads the max in a fresh transaction.
+    let result: Awaited<ReturnType<typeof runRegistration>> | undefined;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        result = await prisma.$transaction(runRegistration);
+        break;
+      } catch (e) {
+        if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2002" && attempt < 4) {
+          continue;
+        }
+        throw e;
+      }
+    }
+    if (!result) {
+      return NextResponse.json({ error: "Failed to register run" }, { status: 500 });
+    }
 
     if ("httpError" in result && result.httpError) {
       return NextResponse.json(

--- a/frontend/ui/src/app/api/public/evaluation-runs/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/route.ts
@@ -31,8 +31,9 @@ export async function POST(request: Request) {
 
   try {
     const result = await prisma.$transaction(async (tx) => {
-      const dataset = await tx.dataset.findFirst({
-        where: { id: req.dataset_id, projectId },
+      // The SDK's dataset_id is the project-scoped client id, never the internal PK.
+      const dataset = await tx.dataset.findUnique({
+        where: { projectId_clientDatasetId: { projectId, clientDatasetId: req.dataset_id } },
         select: { id: true, currentVersionId: true },
       });
       if (!dataset) return { httpError: { message: "Dataset not found", status: 404 } };
@@ -44,7 +45,7 @@ export async function POST(request: Request) {
         };
       }
       const version = await tx.datasetVersion.findFirst({
-        where: { id: versionId, datasetId: req.dataset_id, projectId },
+        where: { id: versionId, datasetId: dataset.id, projectId },
         select: { id: true },
       });
       if (!version) return { httpError: { message: "Dataset version not found", status: 400 } };
@@ -61,13 +62,13 @@ export async function POST(request: Request) {
 
       const evaluation =
         (await tx.evaluation.findFirst({
-          where: { projectId, datasetId: req.dataset_id, name: req.evaluation_name },
+          where: { projectId, datasetId: dataset.id, name: req.evaluation_name },
           select: { id: true },
         })) ??
         (await tx.evaluation.create({
           data: {
             projectId,
-            datasetId: req.dataset_id,
+            datasetId: dataset.id,
             name: req.evaluation_name,
             mainScoreName: req.main_score_name ?? "Score",
           },
@@ -105,7 +106,7 @@ export async function POST(request: Request) {
         data: {
           evaluationId: evaluation.id,
           projectId,
-          datasetId: req.dataset_id,
+          datasetId: dataset.id,
           datasetVersionId: versionId,
           runNumber,
           candidateVersion: req.candidate_version,

--- a/frontend/ui/src/app/api/public/evaluation-runs/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from "next/server";
+import {
+  prisma,
+  RegisterRunRequestSchema,
+  type RegisterRunResponse,
+  type Prisma,
+} from "@traceroot/core";
+import { requireApiKeyProject } from "@/lib/eval/auth";
+
+// POST /api/public/evaluation-runs — SDK registers/starts a run (API-key auth).
+// Idempotent on client_run_id within an evaluation. The evaluation lineage is
+// resolved (create-if-absent) from evaluation_name + dataset_id; the server
+// assigns run_number and all ids. Pins the dataset's current version when
+// dataset_version_id is omitted.
+export async function POST(request: Request) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = RegisterRunRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const req = parsed.data;
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      const dataset = await tx.dataset.findFirst({
+        where: { id: req.dataset_id, projectId },
+        select: { id: true, currentVersionId: true },
+      });
+      if (!dataset) return { httpError: { message: "Dataset not found", status: 404 } };
+
+      const versionId = req.dataset_version_id ?? dataset.currentVersionId;
+      if (!versionId) {
+        return {
+          httpError: { message: "Dataset has no published version to pin", status: 400 },
+        };
+      }
+      const version = await tx.datasetVersion.findFirst({
+        where: { id: versionId, datasetId: req.dataset_id, projectId },
+        select: { id: true },
+      });
+      if (!version) return { httpError: { message: "Dataset version not found", status: 400 } };
+
+      if (req.baseline_run_id) {
+        const baseline = await tx.evaluationRun.findFirst({
+          where: { id: req.baseline_run_id, projectId },
+          select: { id: true },
+        });
+        if (!baseline) {
+          return { httpError: { message: "Baseline run not found", status: 400 } };
+        }
+      }
+
+      const evaluation =
+        (await tx.evaluation.findFirst({
+          where: { projectId, datasetId: req.dataset_id, name: req.evaluation_name },
+          select: { id: true },
+        })) ??
+        (await tx.evaluation.create({
+          data: {
+            projectId,
+            datasetId: req.dataset_id,
+            name: req.evaluation_name,
+            mainScoreName: req.main_score_name ?? "Score",
+          },
+          select: { id: true },
+        }));
+
+      // Idempotency: re-registering with the same client_run_id returns the run.
+      if (req.client_run_id) {
+        const existing = await tx.evaluationRun.findFirst({
+          where: { evaluationId: evaluation.id, clientRunId: req.client_run_id },
+          select: { id: true, runNumber: true, datasetVersionId: true },
+        });
+        if (existing) {
+          return {
+            response: {
+              evaluation_id: evaluation.id,
+              evaluation_run_id: existing.id,
+              run_number: existing.runNumber,
+              dataset_version_id: existing.datasetVersionId,
+            } satisfies RegisterRunResponse,
+          };
+        }
+      }
+
+      const caseCount =
+        req.case_count ?? (await tx.testCase.count({ where: { datasetVersionId: versionId } }));
+      const last = await tx.evaluationRun.findFirst({
+        where: { evaluationId: evaluation.id },
+        orderBy: { runNumber: "desc" },
+        select: { runNumber: true },
+      });
+      const runNumber = (last?.runNumber ?? 0) + 1;
+
+      const run = await tx.evaluationRun.create({
+        data: {
+          evaluationId: evaluation.id,
+          projectId,
+          datasetId: req.dataset_id,
+          datasetVersionId: versionId,
+          runNumber,
+          candidateVersion: req.candidate_version,
+          environment: req.environment,
+          status: "running",
+          baselineRunId: req.baseline_run_id ?? null,
+          mainScoreName: req.main_score_name ?? null,
+          caseCount,
+          // Rich scorer metadata (value_type/direction/threshold) rides along in this
+          // JSON column when the SDK sends it; legacy {name, version} stays valid.
+          scorers: req.scorers,
+          metadata: (req.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+          clientRunId: req.client_run_id ?? null,
+        },
+        select: { id: true, runNumber: true, datasetVersionId: true },
+      });
+
+      return {
+        response: {
+          evaluation_id: evaluation.id,
+          evaluation_run_id: run.id,
+          run_number: run.runNumber,
+          dataset_version_id: run.datasetVersionId,
+        } satisfies RegisterRunResponse,
+      };
+    });
+
+    if ("httpError" in result && result.httpError) {
+      return NextResponse.json(
+        { error: result.httpError.message },
+        { status: result.httpError.status },
+      );
+    }
+    return NextResponse.json(result.response, { status: 201 });
+  } catch {
+    return NextResponse.json({ error: "Failed to register run" }, { status: 500 });
+  }
+}

--- a/frontend/ui/src/features/traces/components/SpanKindIcon.test.ts
+++ b/frontend/ui/src/features/traces/components/SpanKindIcon.test.ts
@@ -53,4 +53,20 @@ describe("getSpanKindColor", () => {
       expect(getSpanKindColor(k).glyph).toContain("dark:");
     }
   });
+
+  it("gives the offline-eval kinds distinct tints (not the SPAN fallback)", () => {
+    expect(getSpanKindColor("EVALUATION").surface).toContain("emerald");
+    expect(getSpanKindColor("TASK").surface).toContain("sky");
+    expect(getSpanKindColor("SCORER").surface).toContain("fuchsia");
+    for (const k of ["EVALUATION", "TASK", "SCORER"]) {
+      expect(getSpanKindColor(k)).not.toEqual(getSpanKindColor("SPAN"));
+    }
+  });
+
+  it("maps the offline-eval kinds to their own icons", () => {
+    const span = getSpanKindIcon("SPAN");
+    for (const k of ["EVALUATION", "TASK", "SCORER"]) {
+      expect(getSpanKindIcon(k)).not.toBe(span);
+    }
+  });
 });

--- a/frontend/ui/src/features/traces/components/SpanKindIcon.tsx
+++ b/frontend/ui/src/features/traces/components/SpanKindIcon.tsx
@@ -1,15 +1,6 @@
 "use client";
 
-import {
-  Workflow,
-  Sparkle,
-  Bot,
-  Wrench,
-  ArrowRight,
-  FlaskConical,
-  Play,
-  Ruler,
-} from "lucide-react";
+import { FlaskConical, Play, Ruler } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { TREE_LAYOUT } from "../utils";
@@ -27,14 +18,13 @@ export function getSpanKindIcon(kind: string) {
     case "agent":
       return DOMAIN_ICONS.agent;
     case "tool":
-      return Wrench;
+      return DOMAIN_ICONS.tool;
     case "evaluation":
       return FlaskConical;
     case "task":
       return Play;
     case "scorer":
       return Ruler;
-      return DOMAIN_ICONS.tool;
     case "span":
     default:
       return DOMAIN_ICONS.span;

--- a/frontend/ui/src/features/traces/components/SpanKindIcon.tsx
+++ b/frontend/ui/src/features/traces/components/SpanKindIcon.tsx
@@ -1,5 +1,15 @@
 "use client";
 
+import {
+  Workflow,
+  Sparkle,
+  Bot,
+  Wrench,
+  ArrowRight,
+  FlaskConical,
+  Play,
+  Ruler,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { TREE_LAYOUT } from "../utils";
@@ -17,6 +27,13 @@ export function getSpanKindIcon(kind: string) {
     case "agent":
       return DOMAIN_ICONS.agent;
     case "tool":
+      return Wrench;
+    case "evaluation":
+      return FlaskConical;
+    case "task":
+      return Play;
+    case "scorer":
+      return Ruler;
       return DOMAIN_ICONS.tool;
     case "span":
     default:
@@ -52,6 +69,19 @@ const SPAN_KIND_COLORS: Record<string, SpanKindColor> = {
   span: {
     surface: "bg-slate-100 border-slate-300 dark:bg-slate-800/50 dark:border-slate-700",
     glyph: "text-slate-600 dark:text-slate-400",
+  },
+  // Offline-evaluation kinds — distinct tints so eval traces read at a glance.
+  evaluation: {
+    surface: "bg-emerald-100 border-emerald-300 dark:bg-emerald-950/50 dark:border-emerald-800",
+    glyph: "text-emerald-700 dark:text-emerald-300",
+  },
+  task: {
+    surface: "bg-sky-100 border-sky-300 dark:bg-sky-950/50 dark:border-sky-800",
+    glyph: "text-sky-700 dark:text-sky-300",
+  },
+  scorer: {
+    surface: "bg-fuchsia-100 border-fuchsia-300 dark:bg-fuchsia-950/50 dark:border-fuchsia-800",
+    glyph: "text-fuchsia-700 dark:text-fuchsia-300",
   },
   // The trace root is structural, not a real span_kind — keep it neutral/quiet.
   trace: {

--- a/frontend/ui/src/lib/eval/scorer-contract.test.ts
+++ b/frontend/ui/src/lib/eval/scorer-contract.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Phase 4 reporting contract: rich scorer metadata + run metadata are accepted, and
+ * old SDK clients ({name, version} scorers, no metadata) remain valid.
+ */
+import { describe, it, expect } from "vitest";
+import { ScorerRefSchema, RegisterRunRequestSchema } from "@traceroot/core";
+
+describe("ScorerRefSchema", () => {
+  it("accepts the legacy {name, version} shape", () => {
+    const r = ScorerRefSchema.safeParse({ name: "acc", version: "unversioned" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts rich metadata (value_type, direction, threshold)", () => {
+    const r = ScorerRefSchema.safeParse({
+      name: "latency",
+      version: "v2",
+      value_type: "numeric",
+      direction: "lower_is_better",
+      threshold: 0.5,
+    });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data.direction).toBe("lower_is_better");
+  });
+
+  it("rejects an unknown direction value", () => {
+    const r = ScorerRefSchema.safeParse({ name: "x", version: "v1", direction: "sideways" });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("RegisterRunRequestSchema", () => {
+  const base = {
+    evaluation_name: "ticket-routing",
+    dataset_id: "ds_1",
+    candidate_version: "sonnet",
+  };
+
+  it("accepts an old client (no scorer metadata, no run metadata)", () => {
+    const r = RegisterRunRequestSchema.safeParse({
+      ...base,
+      scorers: [{ name: "acc", version: "unversioned" }],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts structured run metadata/provenance", () => {
+    const r = RegisterRunRequestSchema.safeParse({
+      ...base,
+      scorers: [
+        { name: "acc", version: "v1", value_type: "numeric", direction: "higher_is_better" },
+      ],
+      metadata: { model: "claude-sonnet-5", git: { ref: "abc123" } },
+    });
+    expect(r.success).toBe(true);
+    expect(r.success && r.data.metadata).toEqual({
+      model: "claude-sonnet-5",
+      git: { ref: "abc123" },
+    });
+  });
+});

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -1,0 +1,198 @@
+import { prisma, type Prisma, type TestCase } from "@traceroot/core";
+import { randomUUID } from "crypto";
+
+/**
+ * Dataset-version publishing — the immutability core.
+ *
+ * A dataset never mutates its historical snapshots. Adding or editing a test
+ * case publishes a NEW `DatasetVersion` that copies the current version's test
+ * cases (new row ids, same stable `testCaseId`) with the change applied, then
+ * repoints `Dataset.currentVersionId`. Any run that pinned an older version
+ * keeps reading exactly what it ran against.
+ */
+
+/** The persisted fields of a test case, minus row/version identity. */
+export type TestCaseSeed = {
+  testCaseId: string;
+  input: string;
+  expected: string | null;
+  recordedOutput: string | null;
+  metadata: unknown;
+  review: string;
+  captureReason: string;
+  sourceTraceId: string | null;
+  sourceSpanId: string | null;
+  sourceSpanName: string | null;
+  sourceSpanKind: string | null;
+  addedBy: string | null;
+  /**
+   * When this case was first created. Carried across version copies so an
+   * unchanged case keeps its original "Created" date — publishing a new version
+   * (add/edit) must not restamp every row to now. Omitted on a brand-new case,
+   * which then defaults to now().
+   */
+  createTime?: Date;
+};
+
+function toSeed(c: TestCase): TestCaseSeed {
+  return {
+    testCaseId: c.testCaseId,
+    input: c.input,
+    expected: c.expected,
+    recordedOutput: c.recordedOutput,
+    metadata: c.metadata ?? null,
+    review: c.review,
+    captureReason: c.captureReason,
+    sourceTraceId: c.sourceTraceId,
+    sourceSpanId: c.sourceSpanId,
+    sourceSpanName: c.sourceSpanName,
+    sourceSpanKind: c.sourceSpanKind,
+    addedBy: c.addedBy,
+    createTime: c.createTime,
+  };
+}
+
+export function newTestCaseId(): string {
+  return `tc_${randomUUID().replace(/-/g, "").slice(0, 20)}`;
+}
+
+/**
+ * Publish a new version by transforming the current version's cases. `transform`
+ * receives the current seeds and returns the full set for the new version, plus
+ * which testCaseId to report back as the focus of the change.
+ *
+ * Runs in one interactive transaction so a version + its cases + the current
+ * pointer move together.
+ */
+export async function publishDatasetVersion(opts: {
+  datasetId: string;
+  projectId: string;
+  note?: string | null;
+  createdBy?: string | null;
+  /** Optional custom version label; defaults to `v<number>`. */
+  label?: string;
+  /**
+   * Optimistic concurrency: the version this edit was based on. When provided
+   * (including explicit null for "no version yet"), a mismatch with the dataset's
+   * current version throws VersionConflict. Omit entirely to skip the check
+   * (the session UI routes, which always edit the live current version).
+   */
+  baseVersionId?: string | null;
+  /**
+   * Idempotency: a retried publish with the same key returns the version already
+   * published for it instead of creating a duplicate. Stored on the version.
+   */
+  idempotencyKey?: string | null;
+  transform: (current: TestCaseSeed[]) => { cases: TestCaseSeed[]; focusTestCaseId: string };
+}): Promise<{
+  versionId: string;
+  versionNumber: number;
+  focusTestCaseId: string;
+  caseCount: number;
+  replayed: boolean;
+}> {
+  return prisma.$transaction(async (tx) => {
+    const dataset = await tx.dataset.findFirst({
+      where: { id: opts.datasetId, projectId: opts.projectId },
+      select: { id: true, currentVersionId: true },
+    });
+    if (!dataset) throw new DatasetNotFound();
+
+    // Idempotent replay: a publish already recorded for this key wins over the
+    // conflict check below, so a network retry after success returns that version.
+    if (opts.idempotencyKey) {
+      const prior = await tx.datasetVersion.findFirst({
+        where: { datasetId: opts.datasetId, idempotencyKey: opts.idempotencyKey },
+        select: { id: true, versionNumber: true },
+      });
+      if (prior) {
+        return {
+          versionId: prior.id,
+          versionNumber: prior.versionNumber,
+          focusTestCaseId: "",
+          caseCount: await tx.testCase.count({ where: { datasetVersionId: prior.id } }),
+          replayed: true,
+        };
+      }
+    }
+
+    // Optimistic concurrency: reject when the caller's base is not the live version.
+    if (opts.baseVersionId !== undefined) {
+      const currentId = dataset.currentVersionId ?? null;
+      if (currentId !== (opts.baseVersionId ?? null)) {
+        throw new VersionConflict(currentId);
+      }
+    }
+
+    const current = dataset.currentVersionId
+      ? await tx.testCase.findMany({
+          where: { datasetVersionId: dataset.currentVersionId },
+          orderBy: { createTime: "asc" },
+        })
+      : [];
+
+    const { cases, focusTestCaseId } = opts.transform(current.map(toSeed));
+
+    const last = await tx.datasetVersion.findFirst({
+      where: { datasetId: opts.datasetId },
+      orderBy: { versionNumber: "desc" },
+      select: { versionNumber: true },
+    });
+    const versionNumber = (last?.versionNumber ?? 0) + 1;
+
+    const version = await tx.datasetVersion.create({
+      data: {
+        datasetId: opts.datasetId,
+        projectId: opts.projectId,
+        versionNumber,
+        label: opts.label ?? `v${versionNumber}`,
+        note: opts.note ?? null,
+        createdBy: opts.createdBy ?? null,
+        idempotencyKey: opts.idempotencyKey ?? null,
+      },
+    });
+
+    if (cases.length > 0) {
+      await tx.testCase.createMany({
+        data: cases.map(({ createTime, ...c }) => ({
+          ...c,
+          metadata: (c.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+          // Preserve an existing case's original created date across the copy; a
+          // brand-new case (no createTime on the seed) omits it and defaults to now.
+          ...(createTime ? { createTime } : {}),
+          datasetVersionId: version.id,
+          datasetId: opts.datasetId,
+          projectId: opts.projectId,
+        })),
+      });
+    }
+
+    await tx.dataset.update({
+      where: { id: opts.datasetId },
+      data: { currentVersionId: version.id },
+    });
+
+    return {
+      versionId: version.id,
+      versionNumber,
+      focusTestCaseId,
+      caseCount: cases.length,
+      replayed: false,
+    };
+  });
+}
+
+export class DatasetNotFound extends Error {
+  constructor() {
+    super("Dataset not found");
+    this.name = "DatasetNotFound";
+  }
+}
+
+/** Thrown when a publish's base version isn't the dataset's live version (A4 → 409). */
+export class VersionConflict extends Error {
+  constructor(public readonly currentVersionId: string | null) {
+    super("Dataset version conflict");
+    this.name = "VersionConflict";
+  }
+}

--- a/frontend/ui/src/lib/eval/versions.ts
+++ b/frontend/ui/src/lib/eval/versions.ts
@@ -167,10 +167,19 @@ export async function publishDatasetVersion(opts: {
       });
     }
 
-    await tx.dataset.update({
-      where: { id: opts.datasetId },
+    // Conditional pointer move: repoint only if `currentVersionId` is still what we
+    // read at the top of this transaction. Under READ COMMITTED two concurrent
+    // publishes can both clear the `baseVersionId` check above and then both write
+    // here, silently dropping one update. Gating the write on the observed value makes
+    // the loser match zero rows, which we surface as a VersionConflict to retry —
+    // never a lost publish.
+    const moved = await tx.dataset.updateMany({
+      where: { id: opts.datasetId, currentVersionId: dataset.currentVersionId },
       data: { currentVersionId: version.id },
     });
+    if (moved.count === 0) {
+      throw new VersionConflict(dataset.currentVersionId ?? null);
+    }
 
     return {
       versionId: version.id,


### PR DESCRIPTION
## Summary

Fixes: #1642

Adds the control-plane system of record for the offline-evaluation domain to the Prisma schema in `@traceroot/core`: datasets, immutable versions, test cases, evaluations, runs, results, and scores. Every downstream surface — the reporting API, the read models, comparison, and the scorer catalog — reads and writes through these tables, so this is the foundation the rest of the feature builds on. It introduces new tables only; no existing data is touched.

## Data model

**`datasets`** — a named dataset. `name`, `description?`, free-form SDK-authored `metadata?` (JSONB), and `current_version_id` pointing at the live published snapshot. Cascades from `projects`; indexed on `project_id`.

**`dataset_versions`** — an immutable snapshot of a dataset's test cases. `version_number` (1-based), human `label`, `note?`, `created_by?`, and an `idempotency_key?` for retried SDK publishes. Unique on `(dataset_id, version_number)` and `(dataset_id, idempotency_key)`; cascades from `datasets`.

**`test_cases`** — one case as captured on a specific version. `test_case_id` is the stable lineage id shared across versions; `id` is the per-version row. Carries `input`, `expected?`, `recorded_output?`, JSON `metadata?`, `review`/`capture_reason`, and `source_trace_id?`/`source_span_id?`/`source_span_name?`/`source_span_kind?` provenance. Cascades from `dataset_versions`; indexed on version, project, and source trace.

**`evaluations`** — the stable purpose a run measures. `name`, `main_score_name`, `dataset_id`. Unique on `(project_id, name)` (enforced as the lineage identity); indexed on project and dataset.

**`evaluation_runs`** — one execution against a pinned snapshot. `run_number` (1-based within the evaluation), `candidate_version`, `environment`, `status`, `baseline_run_id?`, `main_score?`/`main_score_name?`, completeness counts (`case_count`, `scored_count`, `task_error_count`, `scorer_error_count`), the `scorers` JSON manifest, free-form `metadata?`, `client_run_id?` idempotency key, and `started_at`/`completed_at`. `dataset_version_id` FK is `ON DELETE RESTRICT` (a pinned snapshot can't be deleted out from under a run); `baseline_run_id` is a self-relation, `ON DELETE SET NULL`. Unique on `(evaluation_id, client_run_id)`.

**`evaluation_results`** — one test case's outcome within one run. `test_case_id` (stable source-case id), nullable `trace_id` (may arrive later), `input`, `expected_output?`, `candidate_output?`, `baseline_output?`, `status`, `main_score?`, `change?`, `task_error?`, `duration_ms?`, and nullable `cost`. Unique on `(run_id, test_case_id)`; indexed on project and trace.

**`scores`** — one scorer's outcome on one result. `scorer_name`, `scorer_version`, exactly one of `numeric_value`/`bool_value`/`string_value`, plus `passed?`, `explanation?`, and `error?` (scorer failure). Cascades from `evaluation_results`.

Invariants: `dataset_versions` rows are immutable — an edit publishes a new version and moves `datasets.current_version_id`; evaluation identity is `(project_id, name)` with `run_number` assigned server-side; `cost` and `main_score` stay `NULL` when unknown and are never defaulted to `0`; there is deliberately no `Scorer` table — the catalog is derived at read time from the `scorers` manifests plus `scores` rows.

## What's included

### Schema
- `frontend/packages/core/prisma/schema.prisma` — the `Dataset`, `DatasetVersion`, `TestCase`, `Evaluation`, `EvaluationRun`, `EvaluationResult`, and `Score` models with their relations, cascade rules, unique constraints, and project-scoped indexes.

### Migration
- `frontend/packages/core/prisma/migrations/20260720234159_add_offline_eval/migration.sql` — creates every table with its foreign keys (project cascade, `RESTRICT` on the pinned dataset version, `SET NULL` on baseline) and indexes.

### Exports
- `frontend/packages/core/src/index.ts` — re-exports the generated `Dataset`, `DatasetVersion`, `TestCase`, `Evaluation`, `EvaluationRun`, `EvaluationResult`, and `Score` model types so consumers import them from `@traceroot/core`.

### Backend
- `backend/worker/ingest_tasks.py` — Celery task definitions. This module defines the async tasks that process trace data from S3 to ClickHouse.
- `backend/worker/otel_transform.py` — Transform OTEL JSON data to ClickHouse format. Converts OpenTelemetry trace data (camelCase JSON from protobuf) into the format expected by our ClickHouse traces and spans tables.

### Frontend
- `frontend/packages/core/prisma/migrations/20260721000000_add_dataset_sync_fields/migration.sql` — moved here so this PR builds on its own.
- `frontend/packages/core/prisma/migrations/20260721120000_add_eval_run_metadata/migration.sql` — moved here so this PR builds on its own.
- `frontend/packages/core/src/constants.ts` — provides `SpanKind`, `SpanStatus`, `ALERT_WINDOWS`, `AlertWindow`.

### Tests
- `tests/worker/test_ingest_tasks.py` — Unit tests for Celery task logic with mocked S3 + ClickHouse.
- `tests/worker/test_otel_transform_attr_hardening.py` — moved here so this PR builds on its own.

## Test plan

- [ ] Run the migration against a clean database and confirm every table is created with the expected foreign keys and project-scoped indexes.
- [ ] Confirm `Evaluation` rejects a second row with the same `(project_id, name)`.
- [ ] Confirm a run cannot be created against a missing `dataset_version_id`, and that a pinned version cannot be deleted while a run references it.
- [ ] Create a result with `cost` omitted and confirm the column is `NULL`, not `0`.
- [ ] Confirm the scorer catalog can be assembled purely from `EvaluationRun.scorers` manifests and `Score` rows, with no `Scorer` table present.
- [ ] Import each new model type from `@traceroot/core` in a downstream package and confirm it type-checks against the regenerated client.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the offline evaluation persistence schema and public API in `@traceroot/core`, adds dataset authoring with immutable versions and the run lifecycle, and preserves evaluation span kinds end to end. Includes idempotent publishes and runs, richer scorer/run metadata, and UI icons/colors for eval spans.

- **New Features**
  - Prisma models: `Dataset`, `DatasetVersion`, `TestCase`, `Evaluation`, `EvaluationRun`, `EvaluationResult`, `Score`, `HumanScore`; project-scoped identities; uniqueness for `(projectId, name)` evaluations and per-evaluation `client_run_id`.
  - Public API (API-key): datasets (`GET/POST /api/public/datasets`, `GET/PATCH /api/public/datasets/[datasetId]`), version publish (`POST /api/public/datasets/[datasetId]/versions` with optimistic concurrency on `base_version_id`, `idempotency_key`, capped batch), runs (`POST /api/public/evaluation-runs` with create-if-absent evaluation, server `run_number`, dataset resolved by `clientDatasetId`, pins current version by default), per-scorer scores (`POST /api/public/evaluation-runs/[runId]/results/[testCaseId]/scores`), human score (`POST /api/public/evaluation-runs/[runId]/results/[testCaseId]/human-score`).
  - Contract schemas in `@traceroot/core` (`eval-contract.ts`): zod-validated payloads; extended `ScorerRef` (`value_type`, `direction`, `threshold`) with backward compatibility; run metadata and statuses (incl. `cancelled`).
  - Traces: added `SpanKind.EVALUATION`, `SpanKind.TASK`, `SpanKind.SCORER`; OTEL transform preserves them; UI maps to distinct icons/colors.
  - Exports: re-export model types and `Prisma`, plus contract schemas, from `@traceroot/core`.

- **Bug Fixes**
  - Dataset routes scope and resolve by project `clientDatasetId`; first registration is idempotent.
  - Publish race: update `datasets.current_version_id` only when the observed pointer matches; return `VersionConflict` on contention.
  - Run registration: resolve dataset by `clientDatasetId`, get-or-create evaluation by `(projectId, name)`, assign `run_number` correctly under retries; scores use atomic upsert on `(scorer_name, scorer_version)`.
  - Pagination: `limit` parsing floors at ≥1 to prevent empty pages with live cursors.
  - UI: offline-eval kinds render with their own icons and tints (not the `SPAN` fallback).

<sup>Written for commit 7bde1147563370b6d557707405dc8e2e28f2510b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/traceroot-ai/traceroot/pull/1753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

