### PR TITLE
feat(evaluations): reporting contract for the public eval API

### DIFF
--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1131,9 +1131,42 @@
         "title": "ScoreInput",
         "type": "object"
       },
-      "ScorerRef": {
-        "description": "A scorer's descriptor. ``name`` + ``version`` are the comparison identity;\nthe richer metadata is optional and back-compatible (an old SDK sending only\n``{name, version}`` stays valid). Mirrors the non-strict ``ScorerRefSchema``,\nso unknown keys are ignored rather than rejected.",
+      "ScorerMessage": {
+        "description": "One prompt message of an LLM-judge scorer's definition.",
         "properties": {
+          "content": {
+            "title": "Content",
+            "type": "string"
+          },
+          "role": {
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Role",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role",
+          "content"
+        ],
+        "title": "ScorerMessage",
+        "type": "object"
+      },
+      "ScorerRef": {
+        "description": "A scorer's descriptor. ``name`` + ``version`` are the comparison identity;\nthe richer metadata is optional and back-compatible (an old SDK sending only\n``{name, version}`` stays valid). Mirrors the non-strict ``ScorerRefSchema``,\nso unknown keys are ignored rather than rejected.\n\nThe DEFINITION fields (``scorer_type``, prompt/source, config) let the read-only\nScorer detail render an LLM judge's model + messages or a code scorer's snippet.",
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
           "direction": {
             "anyOf": [
               {
@@ -1150,11 +1183,102 @@
             ],
             "title": "Direction"
           },
+          "language": {
+            "anyOf": [
+              {
+                "enum": [
+                  "python",
+                  "typescript"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language"
+          },
+          "messages": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ScorerMessage"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Messages"
+          },
+          "metadata": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
           "name": {
             "maxLength": 200,
             "minLength": 1,
             "title": "Name",
             "type": "string"
+          },
+          "output_type": {
+            "anyOf": [
+              {
+                "enum": [
+                  "score",
+                  "classification"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Type"
+          },
+          "scorer_type": {
+            "anyOf": [
+              {
+                "enum": [
+                  "llm_judge",
+                  "code"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scorer Type"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
           },
           "threshold": {
             "anyOf": [

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1021,6 +1021,10 @@
           "run_path": {
             "title": "Run Path",
             "type": "string"
+          },
+          "run_url": {
+            "title": "Run Url",
+            "type": "string"
           }
         },
         "required": [
@@ -1028,7 +1032,8 @@
           "evaluation_run_id",
           "run_number",
           "dataset_version_id",
-          "run_path"
+          "run_path",
+          "run_url"
         ],
         "title": "RegisterRunResponse",
         "type": "object"

--- a/backend/rest/openapi/public.json
+++ b/backend/rest/openapi/public.json
@@ -1,6 +1,114 @@
 {
   "components": {
     "schemas": {
+      "CompleteRunRequest": {
+        "additionalProperties": false,
+        "description": "Complete/fail a run, reporting final completeness counts.",
+        "properties": {
+          "case_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Case Count"
+          },
+          "main_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Score"
+          },
+          "scored_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scored Count"
+          },
+          "scorer_error_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scorer Error Count"
+          },
+          "status": {
+            "enum": [
+              "running",
+              "completed",
+              "completed_with_errors",
+              "failed",
+              "incomplete",
+              "cancelled"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "task_error_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Error Count"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "CompleteRunRequest",
+        "type": "object"
+      },
+      "CompleteRunResponse": {
+        "properties": {
+          "evaluation_run_id": {
+            "title": "Evaluation Run Id",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "running",
+              "completed",
+              "completed_with_errors",
+              "failed",
+              "incomplete",
+              "cancelled"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "evaluation_run_id",
+          "status"
+        ],
+        "title": "CompleteRunResponse",
+        "type": "object"
+      },
       "DetectorItem": {
         "description": "A detector from the project's catalog (Postgres ``detectors``).\n\n``detector_id`` is the value to pass to ``findings list --detector`` to filter\nfindings to this detector.",
         "properties": {
@@ -85,6 +193,20 @@
           "data"
         ],
         "title": "DetectorResultItem",
+        "type": "object"
+      },
+      "ErrorResponse": {
+        "description": "The canonical public error envelope (matches the gateway's normalized shape).",
+        "properties": {
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          }
+        },
+        "required": [
+          "detail"
+        ],
+        "title": "ErrorResponse",
         "type": "object"
       },
       "ExportManifest": {
@@ -757,6 +879,319 @@
         "title": "RCAResult",
         "type": "object"
       },
+      "RegisterRunRequest": {
+        "additionalProperties": false,
+        "description": "Register/start a run. Idempotent on ``client_run_id`` within an evaluation.",
+        "properties": {
+          "baseline_run_id": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Baseline Run Id"
+          },
+          "candidate_version": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Candidate Version",
+            "type": "string"
+          },
+          "case_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Case Count"
+          },
+          "client_run_id": {
+            "anyOf": [
+              {
+                "maxLength": 128,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Run Id"
+          },
+          "dataset_id": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Dataset Id",
+            "type": "string"
+          },
+          "dataset_version_id": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dataset Version Id"
+          },
+          "environment": {
+            "default": "evaluation",
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Environment",
+            "type": "string"
+          },
+          "evaluation_name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Evaluation Name",
+            "type": "string"
+          },
+          "main_score_name": {
+            "anyOf": [
+              {
+                "maxLength": 200,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Score Name"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "scorers": {
+            "items": {
+              "$ref": "#/components/schemas/ScorerRef"
+            },
+            "title": "Scorers",
+            "type": "array"
+          }
+        },
+        "required": [
+          "evaluation_name",
+          "dataset_id",
+          "candidate_version"
+        ],
+        "title": "RegisterRunRequest",
+        "type": "object"
+      },
+      "RegisterRunResponse": {
+        "properties": {
+          "dataset_version_id": {
+            "title": "Dataset Version Id",
+            "type": "string"
+          },
+          "evaluation_id": {
+            "title": "Evaluation Id",
+            "type": "string"
+          },
+          "evaluation_run_id": {
+            "title": "Evaluation Run Id",
+            "type": "string"
+          },
+          "run_number": {
+            "title": "Run Number",
+            "type": "integer"
+          },
+          "run_path": {
+            "title": "Run Path",
+            "type": "string"
+          }
+        },
+        "required": [
+          "evaluation_id",
+          "evaluation_run_id",
+          "run_number",
+          "dataset_version_id",
+          "run_path"
+        ],
+        "title": "RegisterRunResponse",
+        "type": "object"
+      },
+      "ScoreInput": {
+        "additionalProperties": false,
+        "description": "One scorer's outcome on one result. ``error`` set = the scorer failed to judge.",
+        "properties": {
+          "bool_value": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bool Value"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "maxLength": 5000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "explanation": {
+            "anyOf": [
+              {
+                "maxLength": 5000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Explanation"
+          },
+          "numeric_value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Numeric Value"
+          },
+          "passed": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Passed"
+          },
+          "scorer_name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Scorer Name",
+            "type": "string"
+          },
+          "scorer_version": {
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Scorer Version",
+            "type": "string"
+          },
+          "string_value": {
+            "anyOf": [
+              {
+                "maxLength": 2000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "String Value"
+          }
+        },
+        "required": [
+          "scorer_name",
+          "scorer_version"
+        ],
+        "title": "ScoreInput",
+        "type": "object"
+      },
+      "ScorerRef": {
+        "description": "A scorer's descriptor. ``name`` + ``version`` are the comparison identity;\nthe richer metadata is optional and back-compatible (an old SDK sending only\n``{name, version}`` stays valid). Mirrors the non-strict ``ScorerRefSchema``,\nso unknown keys are ignored rather than rejected.",
+        "properties": {
+          "direction": {
+            "anyOf": [
+              {
+                "enum": [
+                  "higher_is_better",
+                  "lower_is_better",
+                  "none"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Direction"
+          },
+          "name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "threshold": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Threshold"
+          },
+          "value_type": {
+            "anyOf": [
+              {
+                "enum": [
+                  "numeric",
+                  "boolean",
+                  "categorical"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Type"
+          },
+          "version": {
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "version"
+        ],
+        "title": "ScorerRef",
+        "type": "object"
+      },
       "SpanResponse": {
         "description": "A span skeleton plus its per-span I/O blobs (``input``/``output``/``metadata``).\n\nThe projection-capable superset returned by the trace get/export endpoints.\nThe blobs default to ``None`` and are populated only when the caller requests\nthe matching field group (``io``/``metadata``; see\n``rest.projection``). The default ``skeleton`` projection leaves them ``None``\nand never runs the bulk span-I/O query, so there is no payload or query-cost\nregression for the dashboard. Keeping the fields present (as ``null``) rather\nthan omitting them is additive: a few bytes per span, and it matches the\nfields the shipped CLI's generated types already declare.\n\nOne internal-only exception: the dashboard's trace-detail read leaves a small\nSDK span-path subset in ``metadata`` on the skeleton, which it needs to\nrebuild the tree of an in-flight trace. The public routes drop it (see\n``rest.projection.drop_span_tree_metadata``), so for API clients the contract\nabove holds exactly: ``metadata`` is ``null`` unless requested.",
         "properties": {
@@ -974,6 +1409,168 @@
           "total_tokens"
         ],
         "title": "SpanResponse",
+        "type": "object"
+      },
+      "UpsertResultRequest": {
+        "additionalProperties": false,
+        "description": "Upsert one test-case result. Idempotent on (``run_id``, ``test_case_id``).\n``trace_id`` may be null now and set on a later call (out-of-order arrival).\nSending ``scores`` replaces the result's scores.",
+        "properties": {
+          "baseline_output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Baseline Output"
+          },
+          "candidate_output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Candidate Output"
+          },
+          "change": {
+            "anyOf": [
+              {
+                "enum": [
+                  "improved",
+                  "regressed",
+                  "unchanged"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Change"
+          },
+          "cost": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms"
+          },
+          "expected_output": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Output"
+          },
+          "input": {
+            "title": "Input",
+            "type": "string"
+          },
+          "main_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Main Score"
+          },
+          "scores": {
+            "items": {
+              "$ref": "#/components/schemas/ScoreInput"
+            },
+            "title": "Scores",
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "passed",
+              "failed",
+              "errored",
+              "not_scored"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "task_error": {
+            "anyOf": [
+              {
+                "maxLength": 10000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Task Error"
+          },
+          "test_case_id": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Test Case Id",
+            "type": "string"
+          },
+          "trace_id": {
+            "anyOf": [
+              {
+                "maxLength": 64,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trace Id"
+          }
+        },
+        "required": [
+          "test_case_id",
+          "input",
+          "status"
+        ],
+        "title": "UpsertResultRequest",
+        "type": "object"
+      },
+      "UpsertResultResponse": {
+        "properties": {
+          "evaluation_result_id": {
+            "title": "Evaluation Result Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "evaluation_result_id"
+        ],
+        "title": "UpsertResultResponse",
         "type": "object"
       },
       "ValidationError": {
@@ -1631,9 +2228,322 @@
         ]
       }
     },
+    "/api/v1/public/evaluation-runs": {
+      "post": {
+        "description": "Register/start a run. Idempotent on ``client_run_id`` within an evaluation.",
+        "operationId": "register_run_api_v1_public_evaluation_runs_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisterRunResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Register an evaluation run",
+        "tags": [
+          "Offline Eval (Public)"
+        ]
+      }
+    },
+    "/api/v1/public/evaluation-runs/{run_id}/complete": {
+      "post": {
+        "description": "Complete/fail a run, reporting final completeness counts.",
+        "operationId": "complete_run_api_v1_public_evaluation_runs__run_id__complete_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CompleteRunResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Complete/finalize an evaluation run",
+        "tags": [
+          "Offline Eval (Public)"
+        ]
+      }
+    },
+    "/api/v1/public/evaluation-runs/{run_id}/results": {
+      "post": {
+        "description": "Upsert one test-case result (and its scores). Idempotent on (run, test case).",
+        "operationId": "upsert_result_api_v1_public_evaluation_runs__run_id__results_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "run_id",
+            "required": true,
+            "schema": {
+              "title": "Run Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpsertResultRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UpsertResultResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Invalid request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            },
+            "description": "Not found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "detail": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Authentication service unavailable"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Upsert one test-case result with scores",
+        "tags": [
+          "Offline Eval (Public)"
+        ]
+      }
+    },
     "/api/v1/public/traces": {
       "get": {
-        "description": "List recent traces for the API key's project (newest first).",
+        "description": "List recent traces for the API key's project (newest first).\n\nOffline-evaluation traces are excluded by default; pass\n``include_evaluations=true`` to include them.",
         "operationId": "list_traces_api_v1_public_traces_get",
         "parameters": [
           {
@@ -1686,6 +2596,18 @@
               ],
               "description": "Only traces that started before this time (exclusive, ISO 8601)",
               "title": "End Before"
+            }
+          },
+          {
+            "description": "Include offline-evaluation traces (environment=evaluation). Excluded by default so evaluation runs do not appear in the production trace list.",
+            "in": "query",
+            "name": "include_evaluations",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Include offline-evaluation traces (environment=evaluation). Excluded by default so evaluation runs do not appear in the production trace list.",
+              "title": "Include Evaluations",
+              "type": "boolean"
             }
           }
         ],

--- a/backend/rest/routers/public/eval.py
+++ b/backend/rest/routers/public/eval.py
@@ -1,0 +1,190 @@
+"""Public offline-evaluation API gateway.
+
+Datasets, dataset versions, and evaluation runs live in the Postgres control
+plane, which is owned by the Next.js app (Prisma). This router is a thin
+authenticated reverse proxy: it forwards the SDK's
+
+    /api/v1/public/{datasets,dataset-versions,evaluation-runs}/*
+
+requests to the Next.js ``/api/public/*`` route handlers that implement them, so
+the SDK reaches dataset authoring + run reporting through the SAME ``host_url``
+it already uses for trace ingestion — no separate eval URL. This is the
+"two-hop" production path the SDK contract anticipated: SDK → this gateway →
+Next.js control plane.
+
+Auth is enforced here (``authenticate_api_key``, same as every public route) and
+the Bearer key is forwarded so the Next.js handler re-validates authoritatively
+against Postgres.
+"""
+
+import logging
+from typing import Annotated, Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi.responses import JSONResponse
+
+from rest.routers.public.deps import AuthResult, authenticate_api_key
+from rest.schemas.eval import (
+    CompleteRunRequest,
+    CompleteRunResponse,
+    ErrorResponse,
+    RegisterRunRequest,
+    RegisterRunResponse,
+    UpsertResultRequest,
+    UpsertResultResponse,
+)
+from shared.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/public", tags=["Offline Eval (Public)"])
+
+Auth = Annotated[AuthResult, Depends(authenticate_api_key)]
+
+# Forward everything except hop-by-hop / host-specific headers.
+_SKIP_REQUEST_HEADERS = {"host", "content-length", "connection", "accept-encoding"}
+
+# Shown when an upstream failure carries no usable message (non-JSON body, HTML
+# error page, unexpected structure). Deliberately generic so nothing internal leaks.
+_GENERIC_UPSTREAM_ERROR = "Evaluation request failed"
+
+
+def _normalized_error(upstream: httpx.Response) -> JSONResponse:
+    """Re-serialize an upstream non-2xx into the canonical ``{"detail": ...}`` shape.
+
+    The Next.js control plane returns ``{"error": ...}`` (and occasionally
+    ``{"detail": ...}``); the public API contract is uniformly ``{"detail": ...}``.
+    We surface only a safe human-readable *string* message and never the raw
+    upstream body — which could be an HTML error page, a stack trace, or unexpected
+    structure — falling back to a generic message otherwise. The upstream HTTP
+    status is preserved.
+    """
+    detail = _GENERIC_UPSTREAM_ERROR
+    try:
+        data = upstream.json()
+    except ValueError:
+        data = None
+    if isinstance(data, dict):
+        # Prefer an already-canonical `detail`, else accept Next.js's `error`.
+        message = data.get("detail")
+        if not (isinstance(message, str) and message.strip()):
+            message = data.get("error")
+        if isinstance(message, str) and message.strip():
+            detail = message.strip()
+    return JSONResponse(status_code=upstream.status_code, content={"detail": detail})
+
+
+async def _forward(request: Request, subpath: str) -> Response:
+    """Proxy the current request to the Next.js ``/api/public/<subpath>`` route.
+
+    Successful (2xx/3xx) responses pass through verbatim. Upstream failures are
+    normalized to ``{"detail": ...}`` (see ``_normalized_error``); a transport
+    failure reaching the control plane is a native 503 in the same shape.
+    """
+    url = f"{settings.traceroot_ui_url.rstrip('/')}/api/public/{subpath}"
+    body = await request.body()
+    headers = {k: v for k, v in request.headers.items() if k.lower() not in _SKIP_REQUEST_HEADERS}
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            upstream = await client.request(
+                request.method,
+                url,
+                params=dict(request.query_params),
+                content=body,
+                headers=headers,
+            )
+    except httpx.RequestError as e:
+        logger.error("Eval gateway forward to %s failed: %s", url, e)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Evaluation service unavailable",
+        ) from e
+
+    if upstream.status_code >= 400:
+        return _normalized_error(upstream)
+
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        media_type=upstream.headers.get("content-type", "application/json"),
+    )
+
+
+# --- Datasets (A1/A2 list+upsert, A3 patch, A4/A5 versions) -----------------
+@router.api_route("/datasets", methods=["GET", "POST"], include_in_schema=False)
+async def datasets_root(request: Request, auth: Auth) -> Response:
+    return await _forward(request, "datasets")
+
+
+@router.api_route(
+    "/datasets/{subpath:path}", methods=["GET", "POST", "PATCH"], include_in_schema=False
+)
+async def datasets_sub(subpath: str, request: Request, auth: Auth) -> Response:
+    return await _forward(request, f"datasets/{subpath}")
+
+
+# --- Dataset versions (pull an immutable snapshot) --------------------------
+@router.api_route("/dataset-versions/{subpath:path}", methods=["GET"], include_in_schema=False)
+async def dataset_versions(subpath: str, request: Request, auth: Auth) -> Response:
+    return await _forward(request, f"dataset-versions/{subpath}")
+
+
+# --- Evaluation runs (Phase-4 write path) -----------------------------------
+# The three reporting endpoints are explicit, typed, and published to OpenAPI so
+# the CLI can codegen a real client. They still forward the (now request-validated)
+# body to the Prisma-owned Next.js handlers — no persistence is duplicated here.
+# The response_model documents the success shape; the actual body is the upstream
+# response passed through by ``_forward``. These are registered before the catch-all
+# below so they win for their exact paths.
+
+_EVAL_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    400: {"model": ErrorResponse, "description": "Invalid request"},
+    404: {"model": ErrorResponse, "description": "Not found"},
+}
+
+
+@router.post(
+    "/evaluation-runs",
+    response_model=RegisterRunResponse,
+    status_code=status.HTTP_201_CREATED,
+    responses=_EVAL_ERROR_RESPONSES,
+    summary="Register an evaluation run",
+)
+async def register_run(payload: RegisterRunRequest, request: Request, auth: Auth) -> Response:
+    """Register/start a run. Idempotent on ``client_run_id`` within an evaluation."""
+    return await _forward(request, "evaluation-runs")
+
+
+@router.post(
+    "/evaluation-runs/{run_id}/results",
+    response_model=UpsertResultResponse,
+    responses=_EVAL_ERROR_RESPONSES,
+    summary="Upsert one test-case result with scores",
+)
+async def upsert_result(
+    run_id: str, payload: UpsertResultRequest, request: Request, auth: Auth
+) -> Response:
+    """Upsert one test-case result (and its scores). Idempotent on (run, test case)."""
+    return await _forward(request, f"evaluation-runs/{run_id}/results")
+
+
+@router.post(
+    "/evaluation-runs/{run_id}/complete",
+    response_model=CompleteRunResponse,
+    responses=_EVAL_ERROR_RESPONSES,
+    summary="Complete/finalize an evaluation run",
+)
+async def complete_run(
+    run_id: str, payload: CompleteRunRequest, request: Request, auth: Auth
+) -> Response:
+    """Complete/fail a run, reporting final completeness counts."""
+    return await _forward(request, f"evaluation-runs/{run_id}/complete")
+
+
+# Remaining untyped run subpaths (additive per-scorer scores, human review) stay a
+# hidden catch-all until they're typed in a later phase. Registered last so it does
+# not shadow the explicit routes above.
+@router.api_route("/evaluation-runs/{subpath:path}", methods=["POST"], include_in_schema=False)
+async def evaluation_runs_sub(subpath: str, request: Request, auth: Auth) -> Response:
+    return await _forward(request, f"evaluation-runs/{subpath}")

--- a/backend/rest/schemas/eval.py
+++ b/backend/rest/schemas/eval.py
@@ -13,15 +13,47 @@ Parity rules with the Zod source:
 - ``z.string().min(1).max(n)`` → ``Field(min_length=1, max_length=n)``.
 - ``z.number().int().nonnegative()`` → ``int`` with ``ge=0``; ``z.number()`` → ``float``.
 - ``.nullable().optional()`` → ``T | None = None``; ``.default(x)`` → default ``x``.
+- ``z.array(X).max(n)`` → ``list[X]`` with ``max_length=n``.
+- A display-only enum with ``.catch(null)`` → ``Literal[...] | None`` plus a
+  ``mode="before"`` validator that degrades an unrecognised value to ``None``.
 
 A cross-language drift test (``tests/rest/test_eval_contract_parity.py`` +
 ``eval-contract-parity.drift.test.ts``) feeds the same representative payloads to
 both layers and asserts identical accept/reject verdicts.
 """
 
-from typing import Any, Literal
+import json
+from typing import Any, Literal, get_args
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
+
+# --- Payload caps (mirror the shared caps at the top of the Zod contract) ----
+
+#: Max characters of a stored text payload (``input``, ``*_output``).
+EVAL_PAYLOAD_TEXT_MAX = 1_000_000
+#: Max characters of a free-form ``metadata`` object once serialized to JSON.
+EVAL_METADATA_MAX = 64_000
+#: Max scorers declared on one run, and max scores sent with one result.
+EVAL_SCORER_LIST_MAX = 200
+#: Max prompt messages, and max characters of each, on an llm_judge descriptor.
+SCORER_MESSAGES_MAX = 50
+SCORER_MESSAGE_CONTENT_MAX = 20_000
+#: Max characters of a code scorer's ``source`` snippet.
+SCORER_SOURCE_MAX = 50_000
+
+
+def _check_json_size(value: Any, max_chars: int, field: str) -> Any:
+    """Mirror of the Zod ``withinJsonSize`` refinement on free-form JSON fields."""
+    if value is None:
+        return value
+    try:
+        serialized = json.dumps(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be JSON-serializable") from exc
+    if len(serialized) > max_chars:
+        raise ValueError(f"{field} must serialize to at most {max_chars} characters")
+    return value
+
 
 # --- Status vocabularies (mirror the z.enum unions) -------------------------
 
@@ -50,7 +82,15 @@ class ScorerMessage(BaseModel):
     """One prompt message of an LLM-judge scorer's definition."""
 
     role: str = Field(min_length=1, max_length=50)
-    content: str
+    content: str = Field(max_length=SCORER_MESSAGE_CONTENT_MAX)
+
+
+#: The display-only vocabularies that degrade instead of rejecting (see ScorerRef).
+_DISPLAY_ONLY_VARIANTS: dict[str, frozenset[str]] = {
+    "scorer_type": frozenset(get_args(ScorerType)),
+    "output_type": frozenset(get_args(ScorerOutputType)),
+    "language": frozenset(get_args(ScorerLanguage)),
+}
 
 
 class ScorerRef(BaseModel):
@@ -61,6 +101,12 @@ class ScorerRef(BaseModel):
 
     The DEFINITION fields (``scorer_type``, prompt/source, config) let the read-only
     Scorer detail render an LLM judge's model + messages or a code scorer's snippet.
+
+    ``scorer_type`` / ``output_type`` / ``language`` are display-only, so an
+    unrecognised value from a newer SDK degrades to ``None`` rather than failing
+    run registration (which would lose the run's every result and score) —
+    matching ``.catch(null)`` on the Zod side. The vocabularies that drive
+    persistence and aggregation still reject.
     """
 
     name: str = Field(min_length=1, max_length=200)
@@ -68,17 +114,28 @@ class ScorerRef(BaseModel):
     value_type: ScorerValueType | None = None
     direction: ScorerDirection | None = None
     threshold: float | None = None
-    # SDK-reported definition (all optional; absent → "—" in the detail).
+    # SDK-reported definition (all optional; absent or unrecognised → "—" in the detail).
     scorer_type: ScorerType | None = None
     output_type: ScorerOutputType | None = None
     description: str | None = Field(default=None, max_length=2000)
     metadata: Any | None = None
     # llm_judge
     model: str | None = Field(default=None, max_length=200)
-    messages: list[ScorerMessage] | None = None
+    messages: list[ScorerMessage] | None = Field(default=None, max_length=SCORER_MESSAGES_MAX)
     # code
     language: ScorerLanguage | None = None
-    source: str | None = None
+    source: str | None = Field(default=None, max_length=SCORER_SOURCE_MAX)
+
+    @field_validator("scorer_type", "output_type", "language", mode="before")
+    @classmethod
+    def _degrade_unknown_variant(cls, v: Any, info: ValidationInfo) -> Any:
+        allowed = _DISPLAY_ONLY_VARIANTS[str(info.field_name)]
+        return v if isinstance(v, str) and v in allowed else None
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _check_metadata_size(cls, v: Any) -> Any:
+        return _check_json_size(v, EVAL_METADATA_MAX, "metadata")
 
 
 class ScoreInput(BaseModel):
@@ -111,13 +168,18 @@ class RegisterRunRequest(BaseModel):
     candidate_version: str = Field(min_length=1, max_length=200)
     main_score_name: str | None = Field(default=None, min_length=1, max_length=200)
     environment: str = Field(default="evaluation", min_length=1, max_length=64)
-    scorers: list[ScorerRef] = Field(default_factory=list)
+    scorers: list[ScorerRef] = Field(default_factory=list, max_length=EVAL_SCORER_LIST_MAX)
     # SDK-supplied idempotency key.
     client_run_id: str | None = Field(default=None, min_length=1, max_length=128)
     baseline_run_id: str | None = Field(default=None, min_length=1, max_length=64)
     case_count: int | None = Field(default=None, ge=0)
     # Free-form run provenance (model, prompt, config, git repo/ref/commit, …).
     metadata: dict[str, Any] | None = None
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _check_metadata_size(cls, v: Any) -> Any:
+        return _check_json_size(v, EVAL_METADATA_MAX, "metadata")
 
 
 class RegisterRunResponse(BaseModel):
@@ -141,24 +203,29 @@ class RegisterRunResponse(BaseModel):
 class UpsertResultRequest(BaseModel):
     """Upsert one test-case result. Idempotent on (``run_id``, ``test_case_id``).
     ``trace_id`` may be null now and set on a later call (out-of-order arrival).
-    Sending ``scores`` replaces the result's scores.
+
+    ``scores`` is genuinely optional and carries three distinct meanings, so the
+    out-of-order flow (POST the result with its scores, then re-POST later just to
+    attach the OTel ``trace_id``) cannot destroy them: absent → leave the existing
+    scores untouched, ``[]`` → clear them, non-empty → replace them. Do not give
+    this a ``default_factory=list``, which would collapse the first two cases.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     test_case_id: str = Field(min_length=1, max_length=64)
     trace_id: str | None = Field(default=None, min_length=1, max_length=64)
-    input: str
-    expected_output: str | None = None
-    candidate_output: str | None = None
-    baseline_output: str | None = None
+    input: str = Field(max_length=EVAL_PAYLOAD_TEXT_MAX)
+    expected_output: str | None = Field(default=None, max_length=EVAL_PAYLOAD_TEXT_MAX)
+    candidate_output: str | None = Field(default=None, max_length=EVAL_PAYLOAD_TEXT_MAX)
+    baseline_output: str | None = Field(default=None, max_length=EVAL_PAYLOAD_TEXT_MAX)
     status: EvalResultStatus
     main_score: float | None = None
     change: ResultChange | None = None
     task_error: str | None = Field(default=None, max_length=10000)
     duration_ms: int | None = Field(default=None, ge=0)
     cost: float | None = Field(default=None, ge=0)
-    scores: list[ScoreInput] = Field(default_factory=list)
+    scores: list[ScoreInput] | None = Field(default=None, max_length=EVAL_SCORER_LIST_MAX)
 
 
 class UpsertResultResponse(BaseModel):

--- a/backend/rest/schemas/eval.py
+++ b/backend/rest/schemas/eval.py
@@ -32,6 +32,9 @@ EvalResultStatus = Literal["passed", "failed", "errored", "not_scored"]
 ResultChange = Literal["improved", "regressed", "unchanged"]
 ScorerValueType = Literal["numeric", "boolean", "categorical"]
 ScorerDirection = Literal["higher_is_better", "lower_is_better", "none"]
+ScorerType = Literal["llm_judge", "code"]
+ScorerOutputType = Literal["score", "classification"]
+ScorerLanguage = Literal["python", "typescript"]
 
 
 class ErrorResponse(BaseModel):
@@ -43,11 +46,21 @@ class ErrorResponse(BaseModel):
 # --- Scorer + score descriptors ---------------------------------------------
 
 
+class ScorerMessage(BaseModel):
+    """One prompt message of an LLM-judge scorer's definition."""
+
+    role: str = Field(min_length=1, max_length=50)
+    content: str
+
+
 class ScorerRef(BaseModel):
     """A scorer's descriptor. ``name`` + ``version`` are the comparison identity;
     the richer metadata is optional and back-compatible (an old SDK sending only
     ``{name, version}`` stays valid). Mirrors the non-strict ``ScorerRefSchema``,
     so unknown keys are ignored rather than rejected.
+
+    The DEFINITION fields (``scorer_type``, prompt/source, config) let the read-only
+    Scorer detail render an LLM judge's model + messages or a code scorer's snippet.
     """
 
     name: str = Field(min_length=1, max_length=200)
@@ -55,6 +68,17 @@ class ScorerRef(BaseModel):
     value_type: ScorerValueType | None = None
     direction: ScorerDirection | None = None
     threshold: float | None = None
+    # SDK-reported definition (all optional; absent → "—" in the detail).
+    scorer_type: ScorerType | None = None
+    output_type: ScorerOutputType | None = None
+    description: str | None = Field(default=None, max_length=2000)
+    metadata: Any | None = None
+    # llm_judge
+    model: str | None = Field(default=None, max_length=200)
+    messages: list[ScorerMessage] | None = None
+    # code
+    language: ScorerLanguage | None = None
+    source: str | None = None
 
 
 class ScoreInput(BaseModel):

--- a/backend/rest/schemas/eval.py
+++ b/backend/rest/schemas/eval.py
@@ -1,0 +1,155 @@
+"""Typed request/response models for the public offline-evaluation reporting API.
+
+These mirror the finalized Next.js/Zod contract in
+``frontend/packages/core/src/eval-contract.ts`` field-for-field, so the gateway
+can (a) validate SDK payloads before forwarding and (b) publish a useful,
+codegen-friendly OpenAPI schema. Persistence stays in the Prisma-owned Next.js
+handlers — the gateway forwards the (validated) body on and never duplicates it.
+
+Parity rules with the Zod source:
+- Zod ``.strict()`` objects reject unknown keys → ``ConfigDict(extra="forbid")``.
+- ``ScorerRefSchema`` is a plain (non-strict) ``z.object`` that strips unknown
+  keys → default ``extra="ignore"`` (no forbid) on ``ScorerRef``.
+- ``z.string().min(1).max(n)`` → ``Field(min_length=1, max_length=n)``.
+- ``z.number().int().nonnegative()`` → ``int`` with ``ge=0``; ``z.number()`` → ``float``.
+- ``.nullable().optional()`` → ``T | None = None``; ``.default(x)`` → default ``x``.
+
+A cross-language drift test (``tests/rest/test_eval_contract_parity.py`` +
+``eval-contract-parity.drift.test.ts``) feeds the same representative payloads to
+both layers and asserts identical accept/reject verdicts.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# --- Status vocabularies (mirror the z.enum unions) -------------------------
+
+EvalRunStatus = Literal[
+    "running", "completed", "completed_with_errors", "failed", "incomplete", "cancelled"
+]
+EvalResultStatus = Literal["passed", "failed", "errored", "not_scored"]
+ResultChange = Literal["improved", "regressed", "unchanged"]
+ScorerValueType = Literal["numeric", "boolean", "categorical"]
+ScorerDirection = Literal["higher_is_better", "lower_is_better", "none"]
+
+
+class ErrorResponse(BaseModel):
+    """The canonical public error envelope (matches the gateway's normalized shape)."""
+
+    detail: str
+
+
+# --- Scorer + score descriptors ---------------------------------------------
+
+
+class ScorerRef(BaseModel):
+    """A scorer's descriptor. ``name`` + ``version`` are the comparison identity;
+    the richer metadata is optional and back-compatible (an old SDK sending only
+    ``{name, version}`` stays valid). Mirrors the non-strict ``ScorerRefSchema``,
+    so unknown keys are ignored rather than rejected.
+    """
+
+    name: str = Field(min_length=1, max_length=200)
+    version: str = Field(min_length=1, max_length=50)
+    value_type: ScorerValueType | None = None
+    direction: ScorerDirection | None = None
+    threshold: float | None = None
+
+
+class ScoreInput(BaseModel):
+    """One scorer's outcome on one result. ``error`` set = the scorer failed to judge."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    scorer_name: str = Field(min_length=1, max_length=200)
+    scorer_version: str = Field(min_length=1, max_length=50)
+    numeric_value: float | None = None
+    bool_value: bool | None = None
+    string_value: str | None = Field(default=None, max_length=2000)
+    passed: bool | None = None
+    explanation: str | None = Field(default=None, max_length=5000)
+    error: str | None = Field(default=None, max_length=5000)
+
+
+# --- (a) Register / start a run ---------------------------------------------
+
+
+class RegisterRunRequest(BaseModel):
+    """Register/start a run. Idempotent on ``client_run_id`` within an evaluation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    evaluation_name: str = Field(min_length=1, max_length=200)
+    dataset_id: str = Field(min_length=1, max_length=64)
+    # Omit to pin the dataset's current published version.
+    dataset_version_id: str | None = Field(default=None, min_length=1, max_length=64)
+    candidate_version: str = Field(min_length=1, max_length=200)
+    main_score_name: str | None = Field(default=None, min_length=1, max_length=200)
+    environment: str = Field(default="evaluation", min_length=1, max_length=64)
+    scorers: list[ScorerRef] = Field(default_factory=list)
+    # SDK-supplied idempotency key.
+    client_run_id: str | None = Field(default=None, min_length=1, max_length=128)
+    baseline_run_id: str | None = Field(default=None, min_length=1, max_length=64)
+    case_count: int | None = Field(default=None, ge=0)
+    # Free-form run provenance (model, prompt, config, git repo/ref/commit, …).
+    metadata: dict[str, Any] | None = None
+
+
+class RegisterRunResponse(BaseModel):
+    evaluation_id: str
+    evaluation_run_id: str
+    run_number: int
+    dataset_version_id: str
+
+
+# --- (b) Upsert one test-case result with scores ----------------------------
+
+
+class UpsertResultRequest(BaseModel):
+    """Upsert one test-case result. Idempotent on (``run_id``, ``test_case_id``).
+    ``trace_id`` may be null now and set on a later call (out-of-order arrival).
+    Sending ``scores`` replaces the result's scores.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    test_case_id: str = Field(min_length=1, max_length=64)
+    trace_id: str | None = Field(default=None, min_length=1, max_length=64)
+    input: str
+    expected_output: str | None = None
+    candidate_output: str | None = None
+    baseline_output: str | None = None
+    status: EvalResultStatus
+    main_score: float | None = None
+    change: ResultChange | None = None
+    task_error: str | None = Field(default=None, max_length=10000)
+    duration_ms: int | None = Field(default=None, ge=0)
+    cost: float | None = Field(default=None, ge=0)
+    scores: list[ScoreInput] = Field(default_factory=list)
+
+
+class UpsertResultResponse(BaseModel):
+    evaluation_result_id: str
+
+
+# --- (c) Complete / finalize a run ------------------------------------------
+
+
+class CompleteRunRequest(BaseModel):
+    """Complete/fail a run, reporting final completeness counts."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: EvalRunStatus
+    main_score: float | None = None
+    case_count: int | None = Field(default=None, ge=0)
+    scored_count: int | None = Field(default=None, ge=0)
+    task_error_count: int | None = Field(default=None, ge=0)
+    scorer_error_count: int | None = Field(default=None, ge=0)
+
+
+class CompleteRunResponse(BaseModel):
+    evaluation_run_id: str
+    # Echoes the persisted run status.
+    status: EvalRunStatus

--- a/backend/rest/schemas/eval.py
+++ b/backend/rest/schemas/eval.py
@@ -101,10 +101,14 @@ class RegisterRunResponse(BaseModel):
     evaluation_run_id: str
     run_number: int
     dataset_version_id: str
-    # UI-relative path "/projects/<projectId>/evaluations/<runId>"; the SDK joins it to
-    # its own host_url to print a clickable run link. The gateway proxies the upstream
-    # body verbatim, so this is documentation/parity only — no logic here builds it.
+    # UI-relative path "/projects/<projectId>/evaluations/<runId>". Kept for back-compat;
+    # prefer run_url for the printed link.
     run_path: str
+    # Absolute clickable run URL — run_path resolved against the control plane's public
+    # app origin. Correct regardless of how the API/UI origins are split, so the SDK
+    # should print this verbatim rather than joining run_path to its own host_url. The
+    # gateway proxies the upstream body verbatim, so this is documentation/parity only.
+    run_url: str
 
 
 # --- (b) Upsert one test-case result with scores ----------------------------

--- a/backend/rest/schemas/eval.py
+++ b/backend/rest/schemas/eval.py
@@ -101,6 +101,10 @@ class RegisterRunResponse(BaseModel):
     evaluation_run_id: str
     run_number: int
     dataset_version_id: str
+    # UI-relative path "/projects/<projectId>/evaluations/<runId>"; the SDK joins it to
+    # its own host_url to print a clickable run link. The gateway proxies the upstream
+    # body verbatim, so this is documentation/parity only — no logic here builds it.
+    run_path: str
 
 
 # --- (b) Upsert one test-case result with scores ----------------------------

--- a/frontend/packages/core/src/__tests__/eval-contract-parity.drift.test.ts
+++ b/frontend/packages/core/src/__tests__/eval-contract-parity.drift.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Cross-layer drift guard (Zod side).
+ *
+ * The public eval reporting contract lives in two places: the Zod schemas here
+ * (the Prisma-owned Next.js control plane validates with them) and the Pydantic
+ * models in the FastAPI gateway (`backend/rest/schemas/eval.py`). Both must agree
+ * on exactly which SDK payloads are valid, or the gateway would accept requests
+ * the control plane rejects (or vice-versa).
+ *
+ * This test and `tests/rest/test_eval_contract_parity.py` load the SAME fixture
+ * file and assert the SAME accept/reject verdicts. If someone edits one schema
+ * without the other, one side goes red.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  RegisterRunRequestSchema,
+  UpsertResultRequestSchema,
+  CompleteRunRequestSchema,
+} from "../eval-contract.ts";
+import fixtures from "./eval-contract-parity-fixtures.json" with { type: "json" };
+
+const SCHEMAS = {
+  register: RegisterRunRequestSchema,
+  upsert_result: UpsertResultRequestSchema,
+  complete: CompleteRunRequestSchema,
+} as const;
+
+type Group = keyof typeof SCHEMAS;
+type Case = { name: string; payload: unknown };
+
+describe("eval reporting contract parity (Zod)", () => {
+  for (const group of Object.keys(SCHEMAS) as Group[]) {
+    const schema = SCHEMAS[group];
+    const bucket = (fixtures as unknown as Record<string, { valid: Case[]; invalid: Case[] }>)[
+      group
+    ];
+
+    it(`accepts every representative valid ${group} payload`, () => {
+      for (const c of bucket.valid) {
+        const result = schema.safeParse(c.payload);
+        expect(result.success, `${group}/${c.name} should be ACCEPTED`).toBe(true);
+      }
+    });
+
+    it(`rejects every representative invalid ${group} payload`, () => {
+      for (const c of bucket.invalid) {
+        const result = schema.safeParse(c.payload);
+        expect(result.success, `${group}/${c.name} should be REJECTED`).toBe(false);
+      }
+    });
+  }
+});

--- a/frontend/packages/core/src/__tests__/eval-contract.test.ts
+++ b/frontend/packages/core/src/__tests__/eval-contract.test.ts
@@ -1,0 +1,175 @@
+// Unit test: the offline-evaluation contract's presence, payload-cap and
+// forward-compatibility rules — the properties the SDK and both validation
+// layers depend on, which are easy to regress with a one-token schema edit.
+import { describe, it, expect } from "vitest";
+import {
+  EVAL_METADATA_MAX,
+  EVAL_PAYLOAD_TEXT_MAX,
+  EVAL_SCORER_LIST_MAX,
+  PublishDatasetVersionRequestSchema,
+  RegisterRunRequestSchema,
+  SCORER_MESSAGES_MAX,
+  SCORER_MESSAGE_CONTENT_MAX,
+  SCORER_SOURCE_MAX,
+  ScorerRefSchema,
+  UpsertResultRequestSchema,
+} from "../eval-contract.ts";
+
+const result = (over: Record<string, unknown> = {}) => ({
+  test_case_id: "tc1",
+  input: "in",
+  status: "passed",
+  ...over,
+});
+
+const publish = (change: Record<string, unknown>) => ({
+  base_version_id: null,
+  changes: [change],
+});
+
+describe("UpsertResultRequestSchema.scores", () => {
+  it("leaves an omitted scores key undefined so a handler can tell it from []", () => {
+    const parsed = UpsertResultRequestSchema.parse(result({ trace_id: "t1" }));
+    expect(parsed.scores).toBeUndefined();
+    expect("scores" in parsed).toBe(false);
+  });
+
+  it("keeps an explicit empty array distinguishable from an omitted one", () => {
+    expect(UpsertResultRequestSchema.parse(result({ scores: [] })).scores).toEqual([]);
+  });
+
+  it("rejects more scores than the per-result cap", () => {
+    const score = { scorer_name: "s", scorer_version: "1" };
+    const under = Array.from({ length: EVAL_SCORER_LIST_MAX }, () => score);
+    expect(UpsertResultRequestSchema.safeParse(result({ scores: under })).success).toBe(true);
+    expect(UpsertResultRequestSchema.safeParse(result({ scores: [...under, score] })).success).toBe(
+      false,
+    );
+  });
+});
+
+describe("UpsertResultRequestSchema payload caps", () => {
+  it.each(["input", "expected_output", "candidate_output", "baseline_output"])(
+    "caps %s at EVAL_PAYLOAD_TEXT_MAX",
+    (field) => {
+      const at = "a".repeat(EVAL_PAYLOAD_TEXT_MAX);
+      expect(UpsertResultRequestSchema.safeParse(result({ [field]: at })).success).toBe(true);
+      expect(UpsertResultRequestSchema.safeParse(result({ [field]: at + "a" })).success).toBe(
+        false,
+      );
+    },
+  );
+});
+
+describe("RegisterRunRequestSchema caps", () => {
+  const run = (over: Record<string, unknown> = {}) => ({
+    evaluation_name: "e",
+    dataset_id: "d",
+    candidate_version: "v1",
+    ...over,
+  });
+
+  it("rejects more scorers than the per-run cap", () => {
+    const scorer = { name: "s", version: "1" };
+    const under = Array.from({ length: EVAL_SCORER_LIST_MAX }, () => scorer);
+    expect(RegisterRunRequestSchema.safeParse(run({ scorers: under })).success).toBe(true);
+    expect(RegisterRunRequestSchema.safeParse(run({ scorers: [...under, scorer] })).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects metadata that serializes past EVAL_METADATA_MAX", () => {
+    const big = { blob: "b".repeat(EVAL_METADATA_MAX) };
+    expect(RegisterRunRequestSchema.safeParse(run({ metadata: big })).success).toBe(false);
+    expect(RegisterRunRequestSchema.safeParse(run({ metadata: { blob: "b" } })).success).toBe(true);
+  });
+});
+
+describe("ScorerRefSchema forward compatibility", () => {
+  const ref = (over: Record<string, unknown> = {}) => ({ name: "s", version: "1", ...over });
+
+  it.each(["scorer_type", "output_type", "language"])(
+    "degrades an unrecognised %s to null instead of failing the whole run",
+    (field) => {
+      const parsed = ScorerRefSchema.parse(ref({ [field]: "from-a-newer-sdk" }));
+      expect(parsed[field as "language"]).toBeNull();
+    },
+  );
+
+  it("still accepts the known values", () => {
+    const parsed = ScorerRefSchema.parse(
+      ref({ scorer_type: "llm_judge", output_type: "score", language: "python" }),
+    );
+    expect(parsed.scorer_type).toBe("llm_judge");
+    expect(parsed.output_type).toBe("score");
+    expect(parsed.language).toBe("python");
+  });
+
+  it("keeps rejecting the vocabularies that drive persistence", () => {
+    expect(ScorerRefSchema.safeParse(ref({ value_type: "vector" })).success).toBe(false);
+    expect(ScorerRefSchema.safeParse(ref({ direction: "sideways" })).success).toBe(false);
+    expect(UpsertResultRequestSchema.safeParse(result({ status: "skipped" })).success).toBe(false);
+    expect(UpsertResultRequestSchema.safeParse(result({ change: "sideways" })).success).toBe(false);
+  });
+
+  it("caps source, message content and message count", () => {
+    expect(
+      ScorerRefSchema.safeParse(ref({ source: "s".repeat(SCORER_SOURCE_MAX + 1) })).success,
+    ).toBe(false);
+    const msg = { role: "user", content: "c" };
+    expect(
+      ScorerRefSchema.safeParse(
+        ref({ messages: [{ role: "user", content: "c".repeat(SCORER_MESSAGE_CONTENT_MAX + 1) }] }),
+      ).success,
+    ).toBe(false);
+    expect(
+      ScorerRefSchema.safeParse(
+        ref({ messages: Array.from({ length: SCORER_MESSAGES_MAX + 1 }, () => msg) }),
+      ).success,
+    ).toBe(false);
+  });
+});
+
+describe("dataset upsert change", () => {
+  it("rejects an upsert with no input rather than creating an empty test case", () => {
+    const parsed = PublishDatasetVersionRequestSchema.safeParse(
+      publish({ op: "upsert", test_case_id: "new-case" }),
+    );
+    expect(parsed.success).toBe(false);
+    expect(JSON.stringify(parsed.error?.issues)).toContain("input is required");
+  });
+
+  it("accepts any JSON value as input, including null and false", () => {
+    for (const input of ["text", 0, false, null, { a: 1 }, [1, 2]]) {
+      expect(
+        PublishDatasetVersionRequestSchema.safeParse(
+          publish({ op: "upsert", test_case_id: "c", input }),
+        ).success,
+      ).toBe(true);
+    }
+  });
+
+  it("leaves expected optional and caps both by serialized size", () => {
+    expect(
+      PublishDatasetVersionRequestSchema.safeParse(
+        publish({ op: "upsert", test_case_id: "c", input: "i" }),
+      ).success,
+    ).toBe(true);
+    expect(
+      PublishDatasetVersionRequestSchema.safeParse(
+        publish({ op: "upsert", test_case_id: "c", input: "i".repeat(EVAL_PAYLOAD_TEXT_MAX) }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("does not require input on archive/delete changes", () => {
+    expect(
+      PublishDatasetVersionRequestSchema.safeParse(publish({ op: "archive", test_case_id: "c" }))
+        .success,
+    ).toBe(true);
+    expect(
+      PublishDatasetVersionRequestSchema.safeParse(publish({ op: "delete", test_case_id: "c" }))
+        .success,
+    ).toBe(true);
+  });
+});

--- a/frontend/packages/core/src/__tests__/eval-scorer-definition.test.ts
+++ b/frontend/packages/core/src/__tests__/eval-scorer-definition.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Guards the scorer-DEFINITION plumbing.
+ *
+ * The SDK reports each scorer's definition (type, prompt/source, config) on the
+ * run's `scorers` manifest, and the control-plane register-run handler persists
+ * that manifest verbatim (`route.ts` stores `req.scorers`). `ScorerRefSchema` is a
+ * plain (non-strict) z.object, so any definition field it does NOT declare is
+ * silently stripped and never reaches the read-only Scorer detail. This asserts
+ * the definition survives the parse (the bug: a code scorer showed "—" because
+ * `scorer_type`/`language`/`source` were dropped here).
+ */
+import { describe, it, expect } from "vitest";
+import { RegisterRunRequestSchema } from "../eval-contract.ts";
+
+const base = { evaluation_name: "e", dataset_id: "ds", candidate_version: "v1" };
+
+describe("scorer definition survives run registration parse", () => {
+  it("retains a code scorer's type + language + source", () => {
+    const parsed = RegisterRunRequestSchema.parse({
+      ...base,
+      scorers: [
+        {
+          name: "no_conclusion_judge",
+          version: "unversioned",
+          scorer_type: "code",
+          language: "python",
+          source: "def no_conclusion_judge(ctx):\n    return 1.0",
+        },
+      ],
+    });
+    expect(parsed.scorers[0]).toMatchObject({
+      scorer_type: "code",
+      language: "python",
+      source: expect.stringContaining("def no_conclusion_judge"),
+    });
+  });
+
+  it("retains an llm_judge's model + messages + shared config", () => {
+    const parsed = RegisterRunRequestSchema.parse({
+      ...base,
+      scorers: [
+        {
+          name: "concise",
+          version: "1",
+          scorer_type: "llm_judge",
+          output_type: "score",
+          description: "Judges conciseness",
+          metadata: { team: "quality" },
+          model: "claude-sonnet-5",
+          messages: [{ role: "system", content: "Rate the answer 0..1" }],
+        },
+      ],
+    });
+    const s = parsed.scorers[0];
+    expect(s).toMatchObject({
+      scorer_type: "llm_judge",
+      output_type: "score",
+      description: "Judges conciseness",
+      model: "claude-sonnet-5",
+      messages: [{ role: "system", content: "Rate the answer 0..1" }],
+    });
+    expect(s.metadata).toEqual({ team: "quality" });
+  });
+
+  it("still accepts a legacy {name, version} scorer and strips unknown keys", () => {
+    const parsed = RegisterRunRequestSchema.parse({
+      ...base,
+      scorers: [{ name: "s", version: "1", bogus_field: 123 }],
+    });
+    expect(parsed.scorers[0]).toEqual({ name: "s", version: "1" });
+  });
+});

--- a/frontend/packages/core/src/__tests__/index.test.ts
+++ b/frontend/packages/core/src/__tests__/index.test.ts
@@ -16,4 +16,16 @@ describe("@traceroot/core entrypoint", () => {
     expect(typeof core.calculateCost).toBe("function");
     expect(core.Role).toBeDefined();
   });
+
+  it("re-exports the offline-evaluation contract", async () => {
+    // The public eval routes, the OpenAPI mirror and the UI all reach these
+    // through `@traceroot/core`; a missing barrel line breaks every consumer.
+    const core = await import("../index.ts");
+    expect(core.PublishDatasetVersionRequestSchema).toBeDefined();
+    expect(core.RegisterRunRequestSchema).toBeDefined();
+    expect(core.UpsertResultRequestSchema).toBeDefined();
+    expect(core.CreateTestCaseRequestSchema).toBeDefined();
+    expect(core.UpdateDatasetRequestSchema).toBeDefined();
+    expect(core.DATASET_VERSION_MAX_CHANGES).toBe(1000);
+  });
 });

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -125,12 +125,18 @@ export interface RegisterRunResponse {
   dataset_version_id: string;
   /**
    * UI-relative path to the run, `/projects/<projectId>/evaluations/<runId>`. The
-   * backend owns the route shape; the SDK joins it to its own `host_url` to print a
-   * clickable run link. Not an absolute URL (the control plane can't reliably know
-   * its public origin) and not the bare projectId (that would hard-code the route in
-   * the SDK).
+   * backend owns the route shape. Kept for back-compat; prefer `run_url` for the
+   * printed link — joining `run_path` to the SDK's `host_url` only resolves when the
+   * API and UI share an origin (breaks in split-origin dev, where host_url is the API).
    */
   run_path: string;
+  /**
+   * Absolute, clickable run URL — `run_path` resolved against the control plane's
+   * configured public app origin (`NEXT_PUBLIC_APP_URL`). Correct regardless of how
+   * the API and UI origins are split, so the SDK should print this verbatim rather
+   * than reconstructing the link from `host_url`.
+   */
+  run_url: string;
 }
 
 /**

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -10,6 +10,50 @@
 import { z } from "zod";
 
 // ---------------------------------------------------------------------------
+// Payload caps
+//
+// Every field of the API-key ingest surface is bounded here: route handlers have
+// no body-size limit of their own, so an unbounded field is buffered in full and
+// then persisted verbatim. Small fields are capped inline at their declaration
+// (ids 64/128, `description`/`string_value` 2000, `explanation`/`error` 5000,
+// `task_error` 10000); the large payload fields share the caps below.
+// ---------------------------------------------------------------------------
+
+/** Max characters of a stored text payload (`input`, `*_output`, dataset case values). */
+export const EVAL_PAYLOAD_TEXT_MAX = 1_000_000;
+/** Max characters of a free-form `metadata` object once serialized to JSON. */
+export const EVAL_METADATA_MAX = 64_000;
+/** Max scorers declared on one run, and max scores sent with one result. */
+export const EVAL_SCORER_LIST_MAX = 200;
+/** Max prompt messages, and max characters of each, on an llm_judge descriptor. */
+export const SCORER_MESSAGES_MAX = 50;
+export const SCORER_MESSAGE_CONTENT_MAX = 20_000;
+/** Max characters of a code scorer's `source` snippet. */
+export const SCORER_SOURCE_MAX = 50_000;
+
+/** Whether a value serializes to at most `max` characters (`false` if unserializable). */
+function withinJsonSize(value: unknown, max: number): boolean {
+  try {
+    return (JSON.stringify(value) ?? "").length <= max;
+  } catch {
+    return false;
+  }
+}
+
+/** Any JSON value, bounded by its serialized size. */
+const boundedJson = (max: number) =>
+  z.unknown().refine((v) => withinJsonSize(v, max), {
+    message: `value must serialize to at most ${max} characters`,
+  });
+
+/** Free-form JSON object, bounded by its serialized size. */
+const MetadataSchema = z
+  .record(z.string(), z.unknown())
+  .refine((v) => withinJsonSize(v, EVAL_METADATA_MAX), {
+    message: `metadata must serialize to at most ${EVAL_METADATA_MAX} characters`,
+  });
+
+// ---------------------------------------------------------------------------
 // Status vocabularies (string enums, validated here, documented in the schema)
 // ---------------------------------------------------------------------------
 
@@ -68,7 +112,7 @@ export const ScorerLanguageSchema = z.enum(SCORER_LANGUAGES);
 /** One prompt message of an LLM-judge scorer's definition. */
 export const ScorerMessageSchema = z.object({
   role: z.string().min(1).max(50),
-  content: z.string(),
+  content: z.string().max(SCORER_MESSAGE_CONTENT_MAX),
 });
 
 /**
@@ -82,6 +126,15 @@ export const ScorerMessageSchema = z.object({
  * This is a plain (non-strict) object: unknown keys are stripped, so a field must
  * be declared here to survive into the persisted per-run manifest that the scorer
  * registry reads back (see `lib/eval/scorer-registry.ts`).
+ *
+ * The three display-only vocabularies (`scorer_type`, `output_type`, `language`)
+ * degrade to null on an unrecognised value instead of rejecting, mirroring how
+ * undeclared keys are dropped: an SDK newer than the control plane must not fail
+ * run registration — and lose the run's every result and score — over a field
+ * that only decides how the Scorer detail renders. The known values stay listed
+ * in SCORER_TYPES / SCORER_OUTPUT_TYPES / SCORER_LANGUAGES above. This tolerance
+ * deliberately stops here: the vocabularies that drive persistence and
+ * aggregation (run/result status, `change`, value type, direction) still reject.
  */
 export const ScorerRefSchema = z.object({
   name: z.string().min(1).max(200),
@@ -89,17 +142,17 @@ export const ScorerRefSchema = z.object({
   value_type: ScorerValueTypeSchema.nullable().optional(),
   direction: ScorerDirectionSchema.nullable().optional(),
   threshold: z.number().nullable().optional(),
-  // SDK-reported definition (all optional; absent → "—" in the detail).
-  scorer_type: ScorerTypeSchema.nullable().optional(),
-  output_type: ScorerOutputTypeSchema.nullable().optional(),
+  // SDK-reported definition (all optional; absent or unrecognised → "—" in the detail).
+  scorer_type: ScorerTypeSchema.nullable().optional().catch(null),
+  output_type: ScorerOutputTypeSchema.nullable().optional().catch(null),
   description: z.string().max(2000).nullable().optional(),
-  metadata: z.unknown().nullable().optional(),
+  metadata: boundedJson(EVAL_METADATA_MAX).nullable().optional(),
   // llm_judge
   model: z.string().max(200).nullable().optional(),
-  messages: z.array(ScorerMessageSchema).nullable().optional(),
+  messages: z.array(ScorerMessageSchema).max(SCORER_MESSAGES_MAX).nullable().optional(),
   // code
-  language: ScorerLanguageSchema.nullable().optional(),
-  source: z.string().nullable().optional(),
+  language: ScorerLanguageSchema.nullable().optional().catch(null),
+  source: z.string().max(SCORER_SOURCE_MAX).nullable().optional(),
 });
 export type ScorerRef = z.infer<typeof ScorerRefSchema>;
 
@@ -136,7 +189,7 @@ export const RegisterRunRequestSchema = z
     candidate_version: z.string().min(1).max(200),
     main_score_name: z.string().min(1).max(200).nullable().optional(),
     environment: z.string().min(1).max(64).default("evaluation"),
-    scorers: z.array(ScorerRefSchema).default([]),
+    scorers: z.array(ScorerRefSchema).max(EVAL_SCORER_LIST_MAX).default([]),
     /** SDK-supplied idempotency key. */
     client_run_id: z.string().min(1).max(128).nullable().optional(),
     baseline_run_id: z.string().min(1).max(64).nullable().optional(),
@@ -147,7 +200,7 @@ export const RegisterRunRequestSchema = z
      * never rejects a run. Presented as informational secondary detail, never as
      * an evaluation error, and never a source of secrets.
      */
-    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    metadata: MetadataSchema.nullable().optional(),
   })
   .strict();
 export type RegisterRunRequest = z.infer<typeof RegisterRunRequestSchema>;
@@ -176,23 +229,31 @@ export interface RegisterRunResponse {
 /**
  * Upsert one test-case result. Idempotent on (`run_id`, `test_case_id`).
  * `trace_id` may be null now and set on a later call (out-of-order arrival).
- * Sending `scores` replaces the result's scores.
+ *
+ * `scores` is genuinely optional and carries three distinct meanings, because the
+ * out-of-order flow this schema invites (POST the result with its scores, then
+ * re-POST later just to attach the OTel `trace_id`) must not destroy them:
+ *   - absent    → leave the result's existing scores untouched
+ *   - `[]`      → clear the result's scores
+ *   - non-empty → replace the result's scores with these
+ * Handlers must branch on `undefined` vs `[]`; do not re-add a `.default([])`
+ * here, which would collapse the first two cases into a silent delete.
  */
 export const UpsertResultRequestSchema = z
   .object({
     test_case_id: z.string().min(1).max(64),
     trace_id: z.string().min(1).max(64).nullable().optional(),
-    input: z.string(),
-    expected_output: z.string().nullable().optional(),
-    candidate_output: z.string().nullable().optional(),
-    baseline_output: z.string().nullable().optional(),
+    input: z.string().max(EVAL_PAYLOAD_TEXT_MAX),
+    expected_output: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
+    candidate_output: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
+    baseline_output: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
     status: EvalResultStatusSchema,
     main_score: z.number().nullable().optional(),
     change: ResultChangeSchema.nullable().optional(),
     task_error: z.string().max(10000).nullable().optional(),
     duration_ms: z.number().int().nonnegative().nullable().optional(),
     cost: z.number().nonnegative().nullable().optional(),
-    scores: z.array(ScoreInputSchema).default([]),
+    scores: z.array(ScoreInputSchema).max(EVAL_SCORER_LIST_MAX).optional(),
   })
   .strict();
 export type UpsertResultRequest = z.infer<typeof UpsertResultRequestSchema>;
@@ -236,10 +297,10 @@ export const UpdateDatasetRequestSchema = z
 /** Save a trace/span as a new test case (publishes a new dataset version). */
 export const CreateTestCaseRequestSchema = z
   .object({
-    input: z.string(),
-    expected: z.string().nullable().optional(),
-    recorded_output: z.string().nullable().optional(),
-    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    input: z.string().max(EVAL_PAYLOAD_TEXT_MAX),
+    expected: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
+    recorded_output: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
+    metadata: MetadataSchema.nullable().optional(),
     review: ReviewStatusSchema.default("needs_review"),
     capture_reason: CaptureReasonSchema.default("manual"),
     source_trace_id: z.string().max(64).nullable().optional(),
@@ -253,9 +314,9 @@ export type CreateTestCaseRequest = z.infer<typeof CreateTestCaseRequestSchema>;
 /** Edit a test case → publishes a new dataset version (old snapshots untouched). */
 export const UpdateTestCaseRequestSchema = z
   .object({
-    input: z.string().optional(),
-    expected: z.string().nullable().optional(),
-    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    input: z.string().max(EVAL_PAYLOAD_TEXT_MAX).optional(),
+    expected: z.string().max(EVAL_PAYLOAD_TEXT_MAX).nullable().optional(),
+    metadata: MetadataSchema.nullable().optional(),
     review: ReviewStatusSchema.optional(),
   })
   .strict();
@@ -288,7 +349,7 @@ export const PublicUpsertDatasetRequestSchema = z
     dataset_id: z.string().min(1).max(64),
     name: z.string().min(1).max(200),
     description: z.string().max(2000).nullable().optional(),
-    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    metadata: MetadataSchema.nullable().optional(),
   })
   .strict();
 export type PublicUpsertDatasetRequest = z.infer<typeof PublicUpsertDatasetRequestSchema>;
@@ -298,7 +359,7 @@ export const PublicUpdateDatasetRequestSchema = z
   .object({
     name: z.string().min(1).max(200).optional(),
     description: z.string().max(2000).nullable().optional(),
-    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+    metadata: MetadataSchema.nullable().optional(),
   })
   .strict();
 export type PublicUpdateDatasetRequest = z.infer<typeof PublicUpdateDatasetRequestSchema>;
@@ -306,9 +367,19 @@ export type PublicUpdateDatasetRequest = z.infer<typeof PublicUpdateDatasetReque
 const UpsertCaseChangeSchema = z.object({
   op: z.literal("upsert"),
   test_case_id: z.string().min(1).max(64),
-  input: z.unknown(),
-  expected: z.unknown().optional(),
-  metadata: z.record(z.string(), z.unknown()).nullable().optional(),
+  /**
+   * Required — `upsert` is a full-case replace/add, and `TestCase.input` is
+   * NOT NULL, so a missing key here would create a permanent case with an empty
+   * input rather than 400. Both modifiers are load-bearing: `z.unknown()` on its
+   * own accepts an absent key (which is also why `expected` below needs no
+   * `.optional()` to be optional), the `.refine` rejects it with a readable
+   * message, and `.nonoptional()` makes it required in the inferred type too.
+   */
+  input: boundedJson(EVAL_PAYLOAD_TEXT_MAX)
+    .refine((v) => v !== undefined, { message: "input is required" })
+    .nonoptional(),
+  expected: boundedJson(EVAL_PAYLOAD_TEXT_MAX).optional(),
+  metadata: MetadataSchema.nullable().optional(),
   source_trace_id: z.string().max(64).nullable().optional(),
   source_span_id: z.string().max(64).nullable().optional(),
 });

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -123,6 +123,14 @@ export interface RegisterRunResponse {
   evaluation_run_id: string;
   run_number: number;
   dataset_version_id: string;
+  /**
+   * UI-relative path to the run, `/projects/<projectId>/evaluations/<runId>`. The
+   * backend owns the route shape; the SDK joins it to its own `host_url` to print a
+   * clickable run link. Not an absolute URL (the control plane can't reliably know
+   * its public origin) and not the bare projectId (that would hard-code the route in
+   * the SDK).
+   */
+  run_path: string;
 }
 
 /**

--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -54,11 +54,34 @@ export const SCORER_DIRECTIONS = ["higher_is_better", "lower_is_better", "none"]
 export const ScorerDirectionSchema = z.enum(SCORER_DIRECTIONS);
 export type ScorerDirection = (typeof SCORER_DIRECTIONS)[number];
 
+/** How a scorer is implemented — drives the read-only Scorer-detail layout. */
+export const SCORER_TYPES = ["llm_judge", "code"] as const;
+export const ScorerTypeSchema = z.enum(SCORER_TYPES);
+export type ScorerType = (typeof SCORER_TYPES)[number];
+
+export const SCORER_OUTPUT_TYPES = ["score", "classification"] as const;
+export const ScorerOutputTypeSchema = z.enum(SCORER_OUTPUT_TYPES);
+
+export const SCORER_LANGUAGES = ["python", "typescript"] as const;
+export const ScorerLanguageSchema = z.enum(SCORER_LANGUAGES);
+
+/** One prompt message of an LLM-judge scorer's definition. */
+export const ScorerMessageSchema = z.object({
+  role: z.string().min(1).max(50),
+  content: z.string(),
+});
+
 /**
  * A scorer's descriptor. `name` + `version` are the identity used for cell
  * comparison; the richer metadata is optional and back-compatible — an old SDK
  * sending only `{name, version}` stays valid, and the backend defaults direction
  * (numeric/boolean → higher-is-better, categorical → none) when it's absent.
+ *
+ * The DEFINITION fields (`scorer_type`, prompt/source, config) let the read-only
+ * Scorer detail render an LLM judge's model + messages or a code scorer's snippet.
+ * This is a plain (non-strict) object: unknown keys are stripped, so a field must
+ * be declared here to survive into the persisted per-run manifest that the scorer
+ * registry reads back (see `lib/eval/scorer-registry.ts`).
  */
 export const ScorerRefSchema = z.object({
   name: z.string().min(1).max(200),
@@ -66,6 +89,17 @@ export const ScorerRefSchema = z.object({
   value_type: ScorerValueTypeSchema.nullable().optional(),
   direction: ScorerDirectionSchema.nullable().optional(),
   threshold: z.number().nullable().optional(),
+  // SDK-reported definition (all optional; absent → "—" in the detail).
+  scorer_type: ScorerTypeSchema.nullable().optional(),
+  output_type: ScorerOutputTypeSchema.nullable().optional(),
+  description: z.string().max(2000).nullable().optional(),
+  metadata: z.unknown().nullable().optional(),
+  // llm_judge
+  model: z.string().max(200).nullable().optional(),
+  messages: z.array(ScorerMessageSchema).nullable().optional(),
+  // code
+  language: ScorerLanguageSchema.nullable().optional(),
+  source: z.string().nullable().optional(),
 });
 export type ScorerRef = z.infer<typeof ScorerRefSchema>;
 

--- a/frontend/packages/core/src/index.ts
+++ b/frontend/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export type {
 // Constants & Zod schemas
 export * from "./constants.ts";
 export * from "./schemas.ts";
+export * from "./eval-contract.ts";
 
 // LLM Providers
 export * from "./llm-providers.ts";

--- a/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
@@ -1,0 +1,280 @@
+/**
+ * Local SDK contract exerciser (Phase 8).
+ *
+ * Drives the real public reporting Route Handlers end to end against an in-memory
+ * fake prisma — the smallest thing that simulates what the SDK will eventually
+ * do: fetch a pinned snapshot, register a run, report successful and failed
+ * results (task error vs scorer error vs not-scored), link a trace, and complete
+ * the run. No database, no network. Proves the reporting contract + idempotency +
+ * out-of-order trace arrival hold.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+  NextRequest: class {},
+}));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  const { fakePrisma } = await import("@/lib/eval/__tests__/fake-prisma");
+  return { ...actual, prisma: fakePrisma };
+});
+
+import { fakePrisma } from "@/lib/eval/__tests__/fake-prisma";
+import { hashApiKey } from "@/lib/api-keys";
+import { POST as registerRun } from "./evaluation-runs/route";
+import { POST as upsertResult } from "./evaluation-runs/[runId]/results/route";
+import { POST as completeRun } from "./evaluation-runs/[runId]/complete/route";
+
+const API_KEY = "tr-test-key";
+const PROJECT_ID = "proj_1";
+
+function req(body: unknown) {
+  return {
+    headers: new Headers({ authorization: `Bearer ${API_KEY}` }),
+    json: async () => body,
+  } as unknown as Request;
+}
+const params = (runId: string) => ({ params: Promise.resolve({ runId }) });
+
+async function readJson(res: { json: () => Promise<unknown> }) {
+  return res.json() as Promise<Record<string, unknown>>;
+}
+
+beforeEach(() => {
+  fakePrisma.reset();
+  // An API key resolving to PROJECT_ID (the SDK's Bearer credential).
+  fakePrisma.accessKey.rows.push({
+    secretHash: hashApiKey(API_KEY),
+    projectId: PROJECT_ID,
+    expireTime: null,
+    project: { deleteTime: null },
+  });
+  // A dataset pinned to version dv1 with two test cases.
+  fakePrisma.dataset.rows.push({
+    id: "ds1",
+    projectId: PROJECT_ID,
+    currentVersionId: "dv1",
+  });
+  fakePrisma.datasetVersion.rows.push({ id: "dv1", datasetId: "ds1", projectId: PROJECT_ID });
+  fakePrisma.testCase.rows.push(
+    { id: "tcrow1", testCaseId: "case-1", datasetVersionId: "dv1", projectId: PROJECT_ID },
+    { id: "tcrow2", testCaseId: "case-2", datasetVersionId: "dv1", projectId: PROJECT_ID },
+  );
+});
+
+describe("SDK reporting: authentication", () => {
+  it("rejects a missing/invalid API key", async () => {
+    const noKey = { headers: new Headers(), json: async () => ({}) } as unknown as Request;
+    const res = await registerRun(noKey);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("SDK reporting: full run lifecycle", () => {
+  it("registers, reports every result state, links a trace, and completes", async () => {
+    // 1. Register — evaluation lineage is created, server assigns run_number 1.
+    const reg = await registerRun(
+      req({
+        evaluation_name: "Billing routing",
+        dataset_id: "ds1",
+        candidate_version: "git:abc123",
+        main_score_name: "Routing accuracy",
+        scorers: [
+          { name: "routing-accuracy", version: "v3" },
+          { name: "helpfulness", version: "v2" },
+        ],
+        client_run_id: "client-1",
+      }),
+    );
+    expect(reg.status).toBe(201);
+    const regBody = await readJson(reg);
+    const runId = regBody.evaluation_run_id as string;
+    expect(regBody.run_number).toBe(1);
+    expect(regBody.dataset_version_id).toBe("dv1");
+    // UI-relative run path the SDK joins to host_url for a clickable run link.
+    expect(regBody.run_path).toBe(`/projects/${PROJECT_ID}/evaluations/${runId}`);
+    expect(fakePrisma.evaluation.rows).toHaveLength(1);
+
+    // Idempotency: same client_run_id returns the same run, no duplicate.
+    const reg2 = await registerRun(
+      req({
+        evaluation_name: "Billing routing",
+        dataset_id: "ds1",
+        candidate_version: "git:abc123",
+        client_run_id: "client-1",
+      }),
+    );
+    expect((await readJson(reg2)).evaluation_run_id).toBe(runId);
+    expect(fakePrisma.evaluationRun.rows).toHaveLength(1);
+
+    // 2a. A clean passing result, linked to a trace, with scores.
+    await upsertResult(
+      req({
+        test_case_id: "case-1",
+        trace_id: "trace-aaa",
+        input: "double charge refund?",
+        candidate_output: "billing",
+        expected_output: "billing",
+        status: "passed",
+        main_score: 1,
+        change: "improved",
+        scores: [
+          { scorer_name: "routing-accuracy", scorer_version: "v3", numeric_value: 1 },
+          { scorer_name: "helpfulness", scorer_version: "v2", numeric_value: 0.9 },
+        ],
+      }),
+      params(runId),
+    );
+
+    // 2b. A task/application error — no output, no scores.
+    await upsertResult(
+      req({
+        test_case_id: "case-2",
+        input: "invoice never arrived",
+        candidate_output: null,
+        status: "errored",
+        task_error: "ToolTimeout: lookup_invoice timed out",
+        scores: [],
+      }),
+      params(runId),
+    );
+
+    // 2c. A scorer error on an otherwise-passing result (kept, not a zero).
+    await upsertResult(
+      req({
+        test_case_id: "case-3",
+        trace_id: "trace-ccc",
+        input: "explain the tax line",
+        candidate_output: "billing",
+        status: "passed",
+        main_score: 1,
+        scores: [
+          { scorer_name: "routing-accuracy", scorer_version: "v3", numeric_value: 1 },
+          {
+            scorer_name: "helpfulness",
+            scorer_version: "v2",
+            numeric_value: null,
+            error: "Judge returned malformed JSON",
+          },
+        ],
+      }),
+      params(runId),
+    );
+
+    // 2d. A not-scored result — every scorer failed, no main score.
+    await upsertResult(
+      req({
+        test_case_id: "case-4",
+        input: "cancel and refund",
+        candidate_output: "billing",
+        status: "not_scored",
+        main_score: null,
+        scores: [
+          {
+            scorer_name: "routing-accuracy",
+            scorer_version: "v3",
+            numeric_value: null,
+            error: "KeyError",
+          },
+          {
+            scorer_name: "helpfulness",
+            scorer_version: "v2",
+            numeric_value: null,
+            error: "timeout",
+          },
+        ],
+      }),
+      params(runId),
+    );
+
+    expect(fakePrisma.evaluationResult.rows).toHaveLength(4);
+
+    // Task error and scorer error are stored on different columns.
+    const errored = fakePrisma.evaluationResult.rows.find((r) => r.testCaseId === "case-2")!;
+    expect(errored.status).toBe("errored");
+    expect(errored.candidateOutput).toBeNull();
+    expect(errored.taskError).toContain("ToolTimeout");
+    expect(fakePrisma.score.rows.filter((s) => s.resultId === errored.id)).toHaveLength(0);
+
+    const scorerErrRow = fakePrisma.evaluationResult.rows.find((r) => r.testCaseId === "case-3")!;
+    expect(scorerErrRow.status).toBe("passed");
+    expect(scorerErrRow.mainScore).toBe(1);
+    const scorerErrScores = fakePrisma.score.rows.filter((s) => s.resultId === scorerErrRow.id);
+    expect(scorerErrScores.find((s) => s.scorerName === "helpfulness")!.error).toContain("JSON");
+
+    const notScored = fakePrisma.evaluationResult.rows.find((r) => r.testCaseId === "case-4")!;
+    expect(notScored.status).toBe("not_scored");
+    expect(notScored.mainScore).toBeNull();
+    expect(
+      fakePrisma.score.rows.filter((s) => s.resultId === notScored.id).every((s) => s.error),
+    ).toBe(true);
+
+    // 3. Idempotent re-report of case-1 replaces its scores, no duplicate row.
+    await upsertResult(
+      req({
+        test_case_id: "case-1",
+        trace_id: "trace-aaa",
+        input: "double charge refund?",
+        candidate_output: "billing",
+        status: "passed",
+        main_score: 1,
+        scores: [{ scorer_name: "routing-accuracy", scorer_version: "v3", numeric_value: 1 }],
+      }),
+      params(runId),
+    );
+    expect(fakePrisma.evaluationResult.rows.filter((r) => r.testCaseId === "case-1")).toHaveLength(
+      1,
+    );
+    const case1 = fakePrisma.evaluationResult.rows.find((r) => r.testCaseId === "case-1")!;
+    expect(fakePrisma.score.rows.filter((s) => s.resultId === case1.id)).toHaveLength(1);
+
+    // 4. Out-of-order trace: a result reported without a trace, then linked later.
+    await upsertResult(
+      req({ test_case_id: "case-5", input: "where is my order", status: "passed", scores: [] }),
+      params(runId),
+    );
+    let case5 = fakePrisma.evaluationResult.rows.find((r) => r.testCaseId === "case-5")!;
+    expect(case5.traceId).toBeNull();
+    await upsertResult(
+      req({
+        test_case_id: "case-5",
+        trace_id: "trace-eee",
+        input: "where is my order",
+        status: "passed",
+        scores: [],
+      }),
+      params(runId),
+    );
+    case5 = fakePrisma.evaluationResult.rows.find((r) => r.testCaseId === "case-5")!;
+    expect(case5.traceId).toBe("trace-eee");
+    expect(fakePrisma.evaluationResult.rows.filter((r) => r.testCaseId === "case-5")).toHaveLength(
+      1,
+    );
+
+    // 5. Complete the run with final completeness counts.
+    const done = await completeRun(
+      req({
+        status: "completed_with_errors",
+        main_score: 93.8,
+        case_count: 24,
+        scored_count: 22,
+        task_error_count: 1,
+        scorer_error_count: 1,
+      }),
+      params(runId),
+    );
+    expect(done.status).toBe(200);
+    const run = fakePrisma.evaluationRun.rows.find((r) => r.id === runId)!;
+    expect(run.status).toBe("completed_with_errors");
+    expect(run.scoredCount).toBe(22);
+    expect(run.caseCount).toBe(24);
+    expect(run.completedAt).toBeInstanceOf(Date);
+  });
+});

--- a/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
@@ -98,8 +98,13 @@ describe("SDK reporting: full run lifecycle", () => {
     const runId = regBody.evaluation_run_id as string;
     expect(regBody.run_number).toBe(1);
     expect(regBody.dataset_version_id).toBe("dv1");
-    // UI-relative run path the SDK joins to host_url for a clickable run link.
+    // UI-relative run path (back-compat).
     expect(regBody.run_path).toBe(`/projects/${PROJECT_ID}/evaluations/${runId}`);
+    // Absolute clickable URL the SDK prints — run_path resolved against the app origin.
+    const appBase = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    expect(regBody.run_url).toBe(
+      new URL(`/projects/${PROJECT_ID}/evaluations/${runId}`, appBase).toString(),
+    );
     expect(fakePrisma.evaluation.rows).toHaveLength(1);
 
     // Idempotency: same client_run_id returns the same run, no duplicate.

--- a/frontend/ui/src/app/api/public/evaluation-runs/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/route.ts
@@ -70,9 +70,15 @@ export async function POST(request: Request) {
         }
       }
 
+      // An evaluation is identified by (project, name) — runs of the same-named
+      // evaluation are additive (run #N) and comparable, even when the dataset id
+      // churns (e.g. the SDK creates a fresh Dataset each run). The per-run dataset /
+      // version is recorded on the run, and comparison flags a dataset mismatch. Oldest
+      // same-named evaluation wins so grouping is stable.
       const evaluation =
         (await tx.evaluation.findFirst({
-          where: { projectId, datasetId: req.dataset_id, name: req.evaluation_name },
+          where: { projectId, name: req.evaluation_name },
+          orderBy: { createTime: "asc" },
           select: { id: true },
         })) ??
         (await tx.evaluation.create({
@@ -126,9 +132,12 @@ export async function POST(request: Request) {
           baselineRunId: req.baseline_run_id ?? null,
           mainScoreName: req.main_score_name ?? null,
           caseCount,
-          // Rich scorer metadata (value_type/direction/threshold) rides along in this
-          // JSON column when the SDK sends it; legacy {name, version} stays valid.
-          scorers: req.scorers,
+          // The full scorer manifest — identity ({name, version}), config
+          // (value_type/direction/threshold) and the read-only DEFINITION
+          // (scorer_type, prompt/source) — rides along in this JSON column when the
+          // SDK sends it; a legacy {name, version} scorer stays valid. Cast because
+          // the scorer metadata field is typed `unknown` (arbitrary JSON).
+          scorers: req.scorers as unknown as Prisma.InputJsonValue,
           metadata: (req.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
           clientRunId: req.client_run_id ?? null,
         },

--- a/frontend/ui/src/app/api/public/evaluation-runs/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/route.ts
@@ -7,6 +7,17 @@ import {
 } from "@traceroot/core";
 import { requireApiKeyProject } from "@/lib/eval/auth";
 
+// The control plane's public app origin, used to make the run link absolute so it
+// resolves regardless of how the API and UI origins are split (the SDK's host_url is
+// the API origin, which need not serve the UI). Mirrors the auth/slack conventions.
+const APP_BASE_URL = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+
+/** The run's UI-relative path + the absolute clickable URL for the SDK to print. */
+function runLink(projectId: string, runId: string): { run_path: string; run_url: string } {
+  const run_path = `/projects/${projectId}/evaluations/${runId}`;
+  return { run_path, run_url: new URL(run_path, APP_BASE_URL).toString() };
+}
+
 // POST /api/public/evaluation-runs — SDK registers/starts a run (API-key auth).
 // Idempotent on client_run_id within an evaluation. The evaluation lineage is
 // resolved (create-if-absent) from evaluation_name + dataset_id; the server
@@ -87,7 +98,7 @@ export async function POST(request: Request) {
               evaluation_run_id: existing.id,
               run_number: existing.runNumber,
               dataset_version_id: existing.datasetVersionId,
-              run_path: `/projects/${projectId}/evaluations/${existing.id}`,
+              ...runLink(projectId, existing.id),
             } satisfies RegisterRunResponse,
           };
         }
@@ -130,7 +141,7 @@ export async function POST(request: Request) {
           evaluation_run_id: run.id,
           run_number: run.runNumber,
           dataset_version_id: run.datasetVersionId,
-          run_path: `/projects/${projectId}/evaluations/${run.id}`,
+          ...runLink(projectId, run.id),
         } satisfies RegisterRunResponse,
       };
     });

--- a/frontend/ui/src/app/api/public/evaluation-runs/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/route.ts
@@ -87,6 +87,7 @@ export async function POST(request: Request) {
               evaluation_run_id: existing.id,
               run_number: existing.runNumber,
               dataset_version_id: existing.datasetVersionId,
+              run_path: `/projects/${projectId}/evaluations/${existing.id}`,
             } satisfies RegisterRunResponse,
           };
         }
@@ -129,6 +130,7 @@ export async function POST(request: Request) {
           evaluation_run_id: run.id,
           run_number: run.runNumber,
           dataset_version_id: run.datasetVersionId,
+          run_path: `/projects/${projectId}/evaluations/${run.id}`,
         } satisfies RegisterRunResponse,
       };
     });

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -1,0 +1,1294 @@
+"use client";
+
+import * as React from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  ChevronDown,
+  ChevronRight,
+  GitCompare,
+  Layers,
+  ListChecks,
+  Ruler,
+  Search,
+  X,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { CopyButton } from "@/components/ui/copy-button";
+import { HighlightedCode } from "@/features/offline-eval/components/syntax";
+import { useToast } from "@/components/ui/toast";
+import { cn } from "@/lib/utils";
+import {
+  EmptyState,
+  Timestamp,
+  useRowSelection,
+  SelectAllHeaderCell,
+  SelectRowCell,
+  BulkActionBar,
+} from "@/features/offline-eval/components";
+import { ProjectBreadcrumb } from "@/features/projects/components";
+import { PassRate } from "../components/pass-rate";
+import { pctFraction, SENTIMENT_CLASS } from "@/features/offline-eval/utils";
+import {
+  useDatasets,
+  useEvaluationRuns,
+  useScorers,
+  useScorer,
+  useDeleteRuns,
+  type ScorerRegistryRow,
+} from "../hooks";
+import { EVAL_RUN_STATUS_LABEL, type EvalRunStatus, type RunRow } from "../types";
+
+// Run-centric: the Evaluations page is one table of immutable runs. Scorers is the
+// SDK-authored catalog. There is no separate "unique evaluations", "all runs", or
+// "compare" tab — lineage is reached by grouping/filtering, and comparison is an
+// action that opens a shareable /evaluations/compare route.
+type Tab = "evaluations" | "scorers";
+
+const TABS: Array<{ id: Tab; label: string; icon: typeof ListChecks }> = [
+  { id: "evaluations", label: "Evaluations", icon: ListChecks },
+  { id: "scorers", label: "Scorers", icon: Ruler },
+];
+
+const STATUS_VARIANT: Record<EvalRunStatus, "success" | "danger" | "warning" | "default"> = {
+  running: "default",
+  completed: "success",
+  completed_with_errors: "warning",
+  failed: "danger",
+  incomplete: "warning",
+};
+
+export function RunStatusBadge({ status }: { status: EvalRunStatus }) {
+  return <Badge variant={STATUS_VARIANT[status]}>{EVAL_RUN_STATUS_LABEL[status]}</Badge>;
+}
+
+const ALL = "__all__";
+
+export function EvaluationsView({ projectId }: { projectId: string }) {
+  const [tab, setTab] = React.useState<Tab>("evaluations");
+
+  return (
+    <div className="flex h-full flex-col text-[12px]">
+      {/* Populates the app's top breadcrumb bar (workspace / project). Without a
+          mounted ProjectBreadcrumb the header goes blank on this route. */}
+      <ProjectBreadcrumb projectId={projectId} current="Evaluations" />
+      {/* Tab bar — same shape as the Traces page's Traces/Users/Sessions bar. */}
+      <div className="flex items-center justify-between border-b border-border bg-background pr-3">
+        <div className="flex">
+          {TABS.map((t) => {
+            const Icon = t.icon;
+            const active = t.id === tab;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                onClick={() => setTab(t.id)}
+                className={cn(
+                  "flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors",
+                  active
+                    ? "border-foreground bg-muted text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {tab === "evaluations" && <RunsTab projectId={projectId} />}
+      {tab === "scorers" && <ScorersTab projectId={projectId} />}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Runs — the flat execution list.
+// ---------------------------------------------------------------------------
+
+const RUNS_COLUMN_COUNT = 9;
+
+/** Human elapsed duration; "—" when unknown (never 0). */
+function formatElapsed(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) return "—";
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m ${rem}s`;
+}
+
+function ScoreValue({ value }: { value: number | null }) {
+  return value === null ? (
+    <span className="text-muted-foreground">—</span>
+  ) : (
+    <>{pctFraction(value)}</>
+  );
+}
+
+/** Total run cost; "—" when no case reported a cost (never a misleading $0). */
+function formatCost(cost: number | null | undefined): React.ReactNode {
+  if (cost === null || cost === undefined) return <span className="text-muted-foreground">—</span>;
+  return `$${cost < 1 ? cost.toFixed(4) : cost.toFixed(2)}`;
+}
+
+/**
+ * One immutable run row. Shared by the flat table and grouped mode (there is no
+ * second run-table implementation). `showEvaluation=false` hides the lineage line
+ * inside an expanded group, where the group header already names it. Clicking the
+ * evaluation name scopes the list to that lineage (?evaluation=<id>).
+ */
+function RunTableRow({
+  run: r,
+  projectId,
+  selected,
+  onToggle,
+  showEvaluation = true,
+  indent = false,
+}: {
+  run: RunRow;
+  projectId: string;
+  selected: boolean;
+  onToggle: () => void;
+  showEvaluation?: boolean;
+  indent?: boolean;
+}) {
+  const router = useRouter();
+  return (
+    <TR
+      interactive
+      selected={selected}
+      onClick={() => router.push(`/projects/${projectId}/evaluations/${r.id}`)}
+    >
+      <SelectRowCell
+        checked={selected}
+        onToggle={onToggle}
+        label={`Select ${r.evaluationName} #${r.runNumber}`}
+      />
+      <Td className={cn(indent && "pl-6")}>
+        {showEvaluation && (
+          <button
+            type="button"
+            className="rounded font-medium hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            title="Scope to this evaluation"
+            onClick={(e) => {
+              e.stopPropagation();
+              router.push(`/projects/${projectId}/evaluations?evaluation=${r.evaluationId}`);
+            }}
+          >
+            {r.evaluationName}
+          </button>
+        )}
+        <div className="text-[11px] text-muted-foreground">
+          Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
+        </div>
+      </Td>
+      <Td className="text-muted-foreground">
+        <div>{r.datasetName}</div>
+        <div className="text-[11px]">{r.datasetVersionLabel}</div>
+      </Td>
+      <Td className="text-right tabular-nums">
+        <ScoreValue value={r.mainScore} />
+      </Td>
+      <Td className="text-right tabular-nums">
+        <PassRate counts={r} />
+      </Td>
+      <Td className="text-right tabular-nums text-muted-foreground">{formatCost(r.cost)}</Td>
+      <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
+        {formatElapsed(r.elapsedMs)}
+      </Td>
+      <Td>
+        <RunStatusBadge status={r.status} />
+      </Td>
+      <Td className="whitespace-nowrap text-right text-muted-foreground">
+        <Timestamp iso={r.startedAt} />
+      </Td>
+    </TR>
+  );
+}
+
+/** Newest run per evaluation lineage (runs arrive newest-first), keeping the latest
+ *  even when it's running/failed — never silently substituting an older one. */
+function latestPerEvaluation(runs: RunRow[]): RunRow[] {
+  const seen = new Set<string>();
+  const out: RunRow[] = [];
+  for (const r of runs) {
+    if (!seen.has(r.evaluationId)) {
+      seen.add(r.evaluationId);
+      out.push(r);
+    }
+  }
+  return out;
+}
+
+interface RunGroup {
+  evaluationId: string;
+  evaluationName: string;
+  datasetName: string | null;
+  runs: RunRow[]; // newest first
+}
+
+/** Group by the STABLE evaluation id (not display-name text). First seen is the latest. */
+function groupRunsByEvaluation(runs: RunRow[]): RunGroup[] {
+  const map = new Map<string, RunGroup>();
+  for (const r of runs) {
+    const g = map.get(r.evaluationId);
+    if (g) g.runs.push(r);
+    else
+      map.set(r.evaluationId, {
+        evaluationId: r.evaluationId,
+        evaluationName: r.evaluationName,
+        datasetName: r.datasetName,
+        runs: [r],
+      });
+  }
+  return [...map.values()];
+}
+
+/** Per-lineage aggregate across a group's runs — pooled where a total is meaningful
+ *  (passed, cost, duration) and averaged for the score. */
+function aggregateGroup(runs: RunRow[]) {
+  let passedCount = 0,
+    failedCount = 0,
+    erroredCount = 0,
+    notScoredCount = 0,
+    durationMs = 0,
+    hasDuration = false,
+    scoreSum = 0,
+    scoreN = 0,
+    cost = 0,
+    hasCost = false;
+  for (const r of runs) {
+    passedCount += r.passedCount ?? 0;
+    failedCount += r.failedCount ?? 0;
+    erroredCount += r.erroredCount ?? 0;
+    notScoredCount += r.notScoredCount ?? 0;
+    if (r.elapsedMs != null) {
+      durationMs += r.elapsedMs;
+      hasDuration = true;
+    }
+    if (r.mainScore != null) {
+      scoreSum += r.mainScore;
+      scoreN += 1;
+    }
+    if (r.cost != null) {
+      cost += r.cost;
+      hasCost = true;
+    }
+  }
+  return {
+    counts: { passedCount, failedCount, erroredCount, notScoredCount },
+    durationMs: hasDuration ? durationMs : null,
+    avgScore: scoreN > 0 ? scoreSum / scoreN : null,
+    cost: hasCost ? cost : null,
+  };
+}
+
+/** Tiny muted caption under an aggregate value, naming how it was rolled up. */
+function AggCaption({ children }: { children: React.ReactNode }) {
+  return <div className="text-[10px] font-normal text-muted-foreground">{children}</div>;
+}
+
+/** Collapsed group summary: the evaluation name + run count, and per-column aggregate
+ *  totals across the lineage aligned under the same columns as the run rows. Expands to
+ *  the (reused) run rows. */
+function GroupHeaderRow({
+  group,
+  isOpen,
+  onToggle,
+  projectId,
+  selected,
+  indeterminate,
+  onToggleSelect,
+}: {
+  group: RunGroup;
+  isOpen: boolean;
+  onToggle: () => void;
+  projectId: string;
+  selected: boolean;
+  indeterminate: boolean;
+  onToggleSelect: () => void;
+}) {
+  const router = useRouter();
+  const latest = group.runs[0];
+  const earlier = group.runs.length - 1;
+  const agg = React.useMemo(() => aggregateGroup(group.runs), [group.runs]);
+  return (
+    <TR className="bg-muted/40 font-medium">
+      {/* Group selection: selects/deselects every run in the lineage at once. */}
+      <td
+        className="w-8 border-r border-border/50 px-3 py-1.5"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Checkbox
+          checked={selected}
+          indeterminate={indeterminate}
+          onCheckedChange={onToggleSelect}
+          aria-label={
+            selected
+              ? `Deselect all runs in ${group.evaluationName}`
+              : `Select all runs in ${group.evaluationName}`
+          }
+        />
+      </td>
+      <Td>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={onToggle}
+            className="rounded p-0.5 text-muted-foreground hover:text-foreground"
+            aria-label={isOpen ? "Collapse" : "Expand"}
+            aria-expanded={isOpen}
+          >
+            {isOpen ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+          </button>
+          <button
+            type="button"
+            className="rounded hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            title="Scope to this evaluation"
+            onClick={() =>
+              router.push(`/projects/${projectId}/evaluations?evaluation=${group.evaluationId}`)
+            }
+          >
+            {group.evaluationName}
+          </button>
+        </div>
+        <div className="pl-6 text-[11px] font-normal text-muted-foreground">
+          {group.runs.length} run{group.runs.length === 1 ? "" : "s"}
+          {earlier > 0 && ` · ${earlier} earlier`}
+        </div>
+      </Td>
+      <Td className="text-muted-foreground">{group.datasetName}</Td>
+      <Td className="text-right tabular-nums">
+        <ScoreValue value={agg.avgScore} />
+        {agg.avgScore !== null && <AggCaption>avg</AggCaption>}
+      </Td>
+      <Td className="text-right font-normal tabular-nums">
+        <PassRate counts={agg.counts} />
+      </Td>
+      <Td className="text-right tabular-nums text-muted-foreground">
+        {formatCost(agg.cost)}
+        {agg.cost !== null && <AggCaption>total</AggCaption>}
+      </Td>
+      <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
+        {formatElapsed(agg.durationMs)}
+        {agg.durationMs !== null && <AggCaption>total</AggCaption>}
+      </Td>
+      <Td>
+        <RunStatusBadge status={latest.status} />
+        <AggCaption>latest</AggCaption>
+      </Td>
+      <Td className="whitespace-nowrap text-right font-normal text-muted-foreground">
+        <Timestamp iso={latest.startedAt} />
+        <AggCaption>latest</AggCaption>
+      </Td>
+    </TR>
+  );
+}
+
+/** Compact lineage header shown when the list is scoped to one evaluation. */
+function LineageHeader({
+  run,
+  runCount,
+  projectId,
+}: {
+  run: RunRow;
+  runCount: number;
+  projectId: string;
+}) {
+  const router = useRouter();
+  return (
+    <div className="flex flex-wrap items-center gap-2 border-b border-border bg-muted/20 px-3 py-2 text-[12px]">
+      <ListChecks className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+      <span className="font-medium">{run.evaluationName}</span>
+      <span className="text-muted-foreground">
+        {run.datasetName ?? "—"} · {runCount} run{runCount === 1 ? "" : "s"} · latest
+      </span>
+      <RunStatusBadge status={run.status} />
+      <button
+        type="button"
+        onClick={() => router.push(`/projects/${projectId}/evaluations`)}
+        className="ml-auto rounded px-1.5 py-0.5 text-[12px] text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        Clear filter
+      </button>
+    </div>
+  );
+}
+
+/** Small pill toggle for the restrained run-table controls. */
+function Toggle({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        "flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-[12px] transition-colors",
+        active
+          ? "border-foreground/30 bg-muted text-foreground"
+          : "border-input text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function RunsTab({ projectId }: { projectId: string }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  // Scoping the list to one evaluation lineage lives in the URL (?evaluation=<id>) so
+  // browser back/forward and sharing work.
+  const scopedEvalId = searchParams.get("evaluation");
+
+  const { toast } = useToast();
+  const [keyword, setKeyword] = React.useState("");
+  const [datasetFilter, setDatasetFilter] = React.useState(ALL);
+  const [statusFilter, setStatusFilter] = React.useState(ALL);
+  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
+    DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
+  );
+  const [customStart, setCustomStart] = React.useState<Date | null>(null);
+  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
+  const [latestOnly, setLatestOnly] = React.useState(false);
+  const [groupBy, setGroupBy] = React.useState(false);
+  const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
+
+  const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
+  const { data, isLoading, error } = useEvaluationRuns(projectId, {
+    evaluation_id: scopedEvalId ?? undefined,
+    search_query: keyword.trim() || undefined,
+    dataset_id: datasetFilter === ALL ? undefined : datasetFilter,
+    status: statusFilter === ALL ? undefined : statusFilter,
+  });
+  const allRuns = React.useMemo(() => data?.data ?? [], [data]);
+  const filtered = !!keyword || datasetFilter !== ALL || statusFilter !== ALL;
+
+  // Latest-only is a client-side convenience over the loaded page (newest-first);
+  // grouping is client-side on the stable evaluation id. When scoped to one lineage,
+  // grouping is meaningless (a single group) so it's suppressed.
+  const runs = React.useMemo(
+    () => (latestOnly ? latestPerEvaluation(allRuns) : allRuns),
+    [allRuns, latestOnly],
+  );
+  const grouped = groupBy && !scopedEvalId;
+  const groups = React.useMemo(() => (grouped ? groupRunsByEvaluation(runs) : []), [grouped, runs]);
+
+  const runIds = React.useMemo(() => runs.map((r) => r.id), [runs]);
+  const sel = useRowSelection(runIds);
+  const deleteRuns = useDeleteRuns(projectId);
+  const deleteSelected = () => {
+    const ids = [...sel.selected];
+    if (ids.length === 0) return;
+    if (
+      !window.confirm(
+        `Delete ${ids.length} run${ids.length === 1 ? "" : "s"}? This can't be undone.`,
+      )
+    )
+      return;
+    deleteRuns.mutate(ids, {
+      onSuccess: () => {
+        sel.clear();
+        toast({
+          title: `Deleted ${ids.length} run${ids.length === 1 ? "" : "s"}`,
+          tone: "success",
+        });
+      },
+      onError: () => toast({ title: "Could not delete runs", tone: "warning" }),
+    });
+  };
+
+  // Comparison is an action: select exactly two runs to compare. Newer → candidate,
+  // older → baseline (by start time); the compare page makes roles explicit + swappable.
+  const comparePair = React.useMemo(() => {
+    const chosen = runs.filter((r) => sel.has(r.id));
+    if (chosen.length !== 2) return null;
+    const [newer, older] = [...chosen].sort(
+      (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+    );
+    return { candidate: newer.id, baseline: older.id };
+  }, [runs, sel]);
+  const openCompare = () => {
+    if (!comparePair) return;
+    router.push(
+      `/projects/${projectId}/evaluations/compare?baseline=${comparePair.baseline}&candidate=${comparePair.candidate}`,
+    );
+  };
+
+  const toggleGroup = (id: string) =>
+    setExpanded((cur) => {
+      const next = new Set(cur);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+
+  return (
+    <>
+      <SearchFilterBar
+        searchValue={keyword}
+        onSearchChange={setKeyword}
+        searchPlaceholder="Search runs..."
+        dateFilter={dateFilter}
+        customStartDate={customStart}
+        customEndDate={customEnd}
+        onDateFilterChange={setDateFilter}
+        onCustomRangeChange={(s, e) => {
+          setCustomStart(s);
+          setCustomEnd(e);
+        }}
+      >
+        <Select value={datasetFilter} onValueChange={setDatasetFilter}>
+          <SelectTrigger className="h-7 w-[160px] text-[12px]">
+            <SelectValue placeholder="Dataset" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL} className="text-[12px]">
+              All datasets
+            </SelectItem>
+            {(datasetsData?.data ?? []).map((d) => (
+              <SelectItem key={d.id} value={d.id} className="text-[12px]">
+                {d.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={statusFilter} onValueChange={setStatusFilter}>
+          <SelectTrigger className="h-7 w-[170px] text-[12px]">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL} className="text-[12px]">
+              All statuses
+            </SelectItem>
+            {(Object.keys(EVAL_RUN_STATUS_LABEL) as EvalRunStatus[]).map((s) => (
+              <SelectItem key={s} value={s} className="text-[12px]">
+                {EVAL_RUN_STATUS_LABEL[s]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Toggle active={latestOnly} onClick={() => setLatestOnly((v) => !v)}>
+          Latest only
+        </Toggle>
+        {!scopedEvalId && (
+          <Toggle active={groupBy} onClick={() => setGroupBy((v) => !v)}>
+            <Layers className="h-3.5 w-3.5" aria-hidden />
+            Group by evaluation
+          </Toggle>
+        )}
+
+        <span className="flex-1" aria-hidden />
+      </SearchFilterBar>
+
+      {scopedEvalId && allRuns[0] && (
+        <LineageHeader run={allRuns[0]} runCount={allRuns.length} projectId={projectId} />
+      )}
+
+      <BulkActionBar
+        count={sel.count}
+        onDelete={deleteSelected}
+        onClear={sel.clear}
+        extra={
+          comparePair && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-6 gap-1 px-1.5 text-[12px]"
+              onClick={openCompare}
+            >
+              <GitCompare className="h-3.5 w-3.5" aria-hidden />
+              Compare
+            </Button>
+          )
+        }
+      />
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <Table>
+          <THead>
+            <TRHead>
+              <SelectAllHeaderCell
+                checked={sel.allSelected}
+                indeterminate={sel.someSelected}
+                onToggle={sel.toggleAll}
+              />
+              <Th>Evaluation / Run</Th>
+              <Th>Dataset</Th>
+              <Th className="w-[110px] text-right">Main score</Th>
+              <Th className="w-[100px] text-right">Passed</Th>
+              <Th className="w-[100px] text-right">Cost</Th>
+              <Th className="w-[90px] text-right">Duration</Th>
+              <Th className="w-[150px]">Status</Th>
+              <Th className="w-[130px] text-right">Timestamp</Th>
+            </TRHead>
+          </THead>
+          <TBody>
+            {isLoading ? (
+              <Cell colSpan={RUNS_COLUMN_COUNT}>
+                <EmptyState>Loading runs...</EmptyState>
+              </Cell>
+            ) : error ? (
+              <Cell colSpan={RUNS_COLUMN_COUNT}>
+                <EmptyState>Error loading runs</EmptyState>
+              </Cell>
+            ) : runs.length === 0 ? (
+              <Cell colSpan={RUNS_COLUMN_COUNT}>
+                <EmptyState>
+                  {filtered || scopedEvalId
+                    ? "No runs match these filters."
+                    : "No evaluation runs yet. Report a run from your SDK and it appears here."}
+                </EmptyState>
+              </Cell>
+            ) : grouped ? (
+              groups.map((g) => {
+                const groupIds = g.runs.map((r) => r.id);
+                const groupAll = groupIds.every((id) => sel.has(id));
+                const groupSome = !groupAll && groupIds.some((id) => sel.has(id));
+                return (
+                  <React.Fragment key={g.evaluationId}>
+                    <GroupHeaderRow
+                      group={g}
+                      isOpen={expanded.has(g.evaluationId)}
+                      onToggle={() => toggleGroup(g.evaluationId)}
+                      projectId={projectId}
+                      selected={groupAll}
+                      indeterminate={groupSome}
+                      onToggleSelect={() => sel.setMany(groupIds, !groupAll)}
+                    />
+                    {expanded.has(g.evaluationId) &&
+                      g.runs.map((r) => (
+                        <RunTableRow
+                          key={r.id}
+                          run={r}
+                          projectId={projectId}
+                          selected={sel.has(r.id)}
+                          onToggle={() => sel.toggle(r.id)}
+                          showEvaluation={false}
+                          indent
+                        />
+                      ))}
+                  </React.Fragment>
+                );
+              })
+            ) : (
+              runs.map((r) => (
+                <RunTableRow
+                  key={r.id}
+                  run={r}
+                  projectId={projectId}
+                  selected={sel.has(r.id)}
+                  onToggle={() => sel.toggle(r.id)}
+                />
+              ))
+            )}
+          </TBody>
+        </Table>
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Scorers — read-only registry, aggregated from reported runs. Master-detail,
+// echoing the prototype: a table on the left, a detail aside on the right.
+//
+// A scorer's definition — what it measures, its type, scope, and score format —
+// lives in the customer's SDK code and is never reported to the server, so the
+// server-backed registry carries only the aggregates it can see (name, version,
+// score count, error rate). The detail aside surfaces those and names the SDK as
+// the source of truth for the rest, rather than fabricating descriptive text.
+// ---------------------------------------------------------------------------
+
+// +1 for the leading selection checkbox column.
+const SCORERS_COLUMN_COUNT = 5;
+
+const VALUE_TYPE_LABEL: Record<ScorerRegistryRow["valueType"], string> = {
+  numeric: "Numeric",
+  boolean: "Boolean",
+  categorical: "Categorical",
+  mixed: "Mixed",
+  unknown: "Unknown",
+};
+
+const DIRECTION_LABEL: Record<NonNullable<ScorerRegistryRow["direction"]>, string> = {
+  higher_is_better: "Higher is better",
+  lower_is_better: "Lower is better",
+  none: "No direction",
+};
+
+function ScorersTab({ projectId }: { projectId: string }) {
+  const { data, isLoading, error } = useScorers(projectId);
+  // Memoized so the derived id list (and therefore row selection) is stable
+  // across renders rather than churning on a fresh array identity.
+  const allScorers = React.useMemo(() => data?.data ?? [], [data]);
+  const [keyword, setKeyword] = React.useState("");
+  const scorers = React.useMemo(() => {
+    const q = keyword.trim().toLowerCase();
+    if (!q) return allScorers;
+    return allScorers.filter(
+      (s) => s.name.toLowerCase().includes(q) || s.version.toLowerCase().includes(q),
+    );
+  }, [allScorers, keyword]);
+
+  // A clicked scorer opens the detail panel (the right slide-in, no backdrop) rather
+  // than a persistent split-pane.
+  const [openKey, setOpenKey] = React.useState<string | null>(null);
+  const active = allScorers.find((s) => `${s.name}@${s.version}` === openKey) ?? null;
+
+  // Checkbox selection, independent of which scorer the panel is showing. The registry
+  // is derived from reported runs, so there is nothing to delete — the bar offers
+  // selection + Clear only.
+  const scorerKeys = React.useMemo(() => scorers.map((s) => `${s.name}@${s.version}`), [scorers]);
+  const sel = useRowSelection(scorerKeys);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="border-b border-border bg-background px-3 py-1.5">
+        <div className="relative min-w-[12rem] max-w-md flex-1">
+          <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Search scorers..."
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+            className="h-8 pl-8 text-[12px]"
+          />
+        </div>
+      </div>
+      <BulkActionBar count={sel.count} onClear={sel.clear} />
+      <div className="min-h-0 flex-1 overflow-auto">
+        <Table>
+          <THead>
+            <TRHead>
+              <SelectAllHeaderCell
+                checked={sel.allSelected}
+                indeterminate={sel.someSelected}
+                onToggle={sel.toggleAll}
+              />
+              <Th>Scorer</Th>
+              <Th className="w-[110px]">Output</Th>
+              <Th className="w-[120px] text-right">Scores</Th>
+              <Th className="w-[120px] text-right">Error rate</Th>
+            </TRHead>
+          </THead>
+          <TBody>
+            {isLoading ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>Loading scorers...</EmptyState>
+              </Cell>
+            ) : error ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>Error loading scorers</EmptyState>
+              </Cell>
+            ) : allScorers.length === 0 ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>
+                  No scorers yet. Scorers are defined in your SDK code and appear here once a run
+                  reports them.
+                </EmptyState>
+              </Cell>
+            ) : scorers.length === 0 ? (
+              <Cell colSpan={SCORERS_COLUMN_COUNT}>
+                <EmptyState>No scorers match “{keyword}”.</EmptyState>
+              </Cell>
+            ) : (
+              scorers.map((s) => {
+                const key = `${s.name}@${s.version}`;
+                return (
+                  <TR
+                    key={key}
+                    interactive
+                    selected={key === openKey}
+                    onClick={() => setOpenKey(key)}
+                  >
+                    <SelectRowCell
+                      checked={sel.has(key)}
+                      onToggle={() => sel.toggle(key)}
+                      label={`Select ${s.name} ${s.version}`}
+                    />
+                    <Td>
+                      <span className="flex items-baseline gap-1.5">
+                        <span className="font-medium">{s.name}</span>
+                        <span className="text-[11px] text-muted-foreground">
+                          {fmtScorerVersion(s.version)}
+                        </span>
+                      </span>
+                    </Td>
+                    <Td>
+                      <Badge variant="outline">{VALUE_TYPE_LABEL[s.valueType]}</Badge>
+                    </Td>
+                    <Td className="text-right tabular-nums text-muted-foreground">
+                      {s.scoreCount}
+                    </Td>
+                    <Td className="text-right tabular-nums">
+                      {s.errorRate === 0 ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        <span className={SENTIMENT_CLASS.bad}>
+                          {(s.errorRate * 100).toFixed(1)}%
+                        </span>
+                      )}
+                    </Td>
+                  </TR>
+                );
+              })
+            )}
+          </TBody>
+        </Table>
+      </div>
+
+      {active && (
+        <ScorerDetailPanel
+          key={`${active.name}@${active.version}`}
+          projectId={projectId}
+          scorer={active}
+          onClose={() => setOpenKey(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Display a scorer version as "v1" — prefix a bare numeric version with "v"; leave a
+ *  sentinel like "unversioned" or an already-prefixed "v3" untouched. */
+function fmtScorerVersion(v: string): string {
+  return /^\d/.test(v) ? `v${v}` : v;
+}
+
+const OUTPUT_TYPE_LABEL: Record<"score" | "classification", string> = {
+  score: "Score",
+  classification: "Classification",
+};
+const LANGUAGE_LABEL: Record<"python" | "typescript", string> = {
+  python: "Python",
+  typescript: "TypeScript",
+};
+
+/** The scorer's type — declared by the SDK, or derived from which definition fields it
+ *  reported (code source ⇒ code; model/messages ⇒ judge). Never guessed from the name. */
+function scorerKind(s: ScorerRegistryRow): "llm_judge" | "code" | null {
+  if (s.scorerType) return s.scorerType;
+  if (s.sourceCode) return "code";
+  if (s.model || s.messages) return "llm_judge";
+  return null;
+}
+
+/** The precise type shown at the top of the definition section and in the header:
+ *  "LLM judge" for a judge, the language ("Python"/"TypeScript") for a code scorer. */
+function definitionTypeLabel(
+  s: ScorerRegistryRow,
+  kind: "llm_judge" | "code" | null,
+): string | null {
+  if (kind === "llm_judge") return "LLM judge";
+  if (kind === "code") return s.language ? LANGUAGE_LABEL[s.language] : "Code";
+  return null;
+}
+
+/** Output type (Score / Classification): the SDK's declared value wins; otherwise it's
+ *  inferred from the declared/observed value type, and flagged as inferred. */
+function outputTypeOf(s: ScorerRegistryRow): { text: string; inferred: boolean } | null {
+  if (s.outputType) return { text: OUTPUT_TYPE_LABEL[s.outputType], inferred: false };
+  const vt =
+    s.declaredValueType ??
+    (s.valueType !== "unknown" && s.valueType !== "mixed" ? s.valueType : null);
+  if (vt === "categorical") return { text: "Classification", inferred: true };
+  if (vt === "numeric" || vt === "boolean") return { text: "Score", inferred: true };
+  return null;
+}
+
+/** For a field the SDK does not (yet) register — shown as a plain em dash. */
+function NotProvided() {
+  return <span className="text-muted-foreground">—</span>;
+}
+
+/** Bordered card with a muted header strip — mirrors the detector detail panel. */
+function ScorerCard({
+  title,
+  action,
+  children,
+}: {
+  title: string;
+  action?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="border border-border">
+      <div className="flex items-center justify-between gap-2 border-b border-border bg-muted/50 px-3 py-1.5">
+        <span className="text-[12px] font-medium text-muted-foreground">{title}</span>
+        {action}
+      </div>
+      <div className="p-3">{children}</div>
+    </div>
+  );
+}
+
+/** A labelled fact row inside a card. */
+function ScorerFact({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-6 py-0.5">
+      <dt className="shrink-0 text-[11px] text-muted-foreground">{label}</dt>
+      <dd className="min-w-0 text-right text-[12px]">{children}</dd>
+    </div>
+  );
+}
+
+/**
+ * Read-only scorer detail — a bigger, detector-style subpage (mirrors DetectorPanel's
+ * 70%-width right slide-in with bordered cards). It does NOT dim/blur the page behind it
+ * and closes on Escape or ✕. A scorer is defined in the customer's SDK; TraceRoot shows
+ * ONLY what the SDK reported (see offline-eval/sdk-ask/scorer-definition-reporting.md) —
+ * anything unreported reads "Not provided by SDK", never invented from the name.
+ */
+export function ScorerDetailPanel({
+  projectId,
+  scorer,
+  onClose,
+}: {
+  projectId: string;
+  scorer: ScorerRegistryRow;
+  onClose: () => void;
+}) {
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [onClose]);
+
+  const kind = scorerKind(scorer);
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Scorer detail"
+      className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 flex w-[70%] max-w-[980px] flex-col border-l border-border bg-background shadow-xl"
+    >
+      {/* Header — detector-panel style */}
+      <div className="flex h-10 shrink-0 items-center justify-between gap-2 border-b border-border bg-muted/30 px-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <Ruler className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="text-[13px] font-medium">Scorer</span>
+          <span className="truncate text-[13px] text-muted-foreground">{scorer.name}</span>
+          <span className="shrink-0 text-[11px] text-muted-foreground">
+            {fmtScorerVersion(scorer.version)}
+          </span>
+          {definitionTypeLabel(scorer, kind) && (
+            <Badge variant="outline">{definitionTypeLabel(scorer, kind)}</Badge>
+          )}
+          <CopyButton
+            value={`${scorer.name}@${scorer.version}`}
+            className="h-5 w-5 text-muted-foreground hover:text-foreground"
+            iconClassName="h-3 w-3"
+            title="Copy scorer id"
+          />
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded-sm text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto text-[12px]">
+        <ScorerDetail projectId={projectId} scorer={scorer} kind={kind} />
+      </div>
+    </div>
+  );
+}
+
+function ScorerDetail({
+  projectId,
+  scorer,
+  kind,
+}: {
+  projectId: string;
+  scorer: ScorerRegistryRow;
+  kind: "llm_judge" | "code" | null;
+}) {
+  const maxCount = scorer.distribution?.reduce((m, d) => Math.max(m, d.count), 0) ?? 0;
+  const family = useScorer(projectId, scorer.name);
+  const versions = family.data?.versions ?? [];
+  const ot = outputTypeOf(scorer);
+  const metadataText =
+    scorer.metadata != null &&
+    (typeof scorer.metadata !== "object" || Object.keys(scorer.metadata).length > 0)
+      ? JSON.stringify(scorer.metadata, null, 2)
+      : null;
+
+  const typeLabel = definitionTypeLabel(scorer, kind);
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      {/* Definition — leads with the exact type: LLM judge, Python, or TypeScript. */}
+      <div className="flex items-baseline gap-2">
+        <h3 className="text-[13px] font-semibold">Definition</h3>
+        <span className="text-[13px] font-medium text-muted-foreground">{typeLabel ?? "—"}</span>
+      </div>
+      {/* Type-specific body */}
+      {kind === "code" ? (
+        <ScorerCard
+          title="Source"
+          action={
+            scorer.sourceCode ? (
+              <CopyButton
+                value={scorer.sourceCode}
+                className="h-5 w-5 text-muted-foreground hover:text-foreground"
+                iconClassName="h-3 w-3"
+                title="Copy code"
+              />
+            ) : undefined
+          }
+        >
+          {scorer.sourceCode ? (
+            <HighlightedCode
+              code={scorer.sourceCode}
+              className="max-h-[45vh] overflow-auto whitespace-pre font-mono text-[11px] leading-relaxed"
+            />
+          ) : (
+            <NotProvided />
+          )}
+        </ScorerCard>
+      ) : kind === "llm_judge" ? (
+        // One "Prompt" card: the model sits in the header; messages are role-labelled
+        // rows separated by dividers (no card-in-card nesting).
+        <ScorerCard
+          title="Prompt"
+          action={
+            scorer.model ? (
+              <span className="font-mono text-[11px] text-muted-foreground">{scorer.model}</span>
+            ) : (
+              <span className="text-[11px] text-muted-foreground">— no model</span>
+            )
+          }
+        >
+          {scorer.messages && scorer.messages.length > 0 ? (
+            <div className="divide-y divide-border">
+              {scorer.messages.map((m, i) => (
+                <div key={i} className="py-2 first:pt-0 last:pb-0">
+                  <div className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {m.role}
+                  </div>
+                  <pre className="max-h-[30vh] overflow-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed">
+                    {m.content}
+                  </pre>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <NotProvided />
+          )}
+        </ScorerCard>
+      ) : (
+        <ScorerCard title="Definition">
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            The SDK hasn&apos;t reported this scorer&apos;s definition — an LLM judge&apos;s model
+            &amp; messages, or a code scorer&apos;s snippet.
+          </p>
+        </ScorerCard>
+      )}
+
+      {/* Shared configuration */}
+      <ScorerCard title="Configuration">
+        <dl>
+          <ScorerFact label="Output type">
+            {ot ? (
+              <>
+                {ot.text}
+                {ot.inferred && (
+                  <span className="ml-1 text-[11px] text-muted-foreground">(inferred)</span>
+                )}
+              </>
+            ) : (
+              <NotProvided />
+            )}
+          </ScorerFact>
+          <ScorerFact label="Pass threshold">
+            {scorer.threshold !== null ? (
+              <span className="tabular-nums">{scorer.threshold}</span>
+            ) : (
+              <NotProvided />
+            )}
+          </ScorerFact>
+          <ScorerFact label="Direction">
+            {scorer.direction ? DIRECTION_LABEL[scorer.direction] : <NotProvided />}
+          </ScorerFact>
+          <ScorerFact label="Description">
+            {scorer.description ? scorer.description : <NotProvided />}
+          </ScorerFact>
+        </dl>
+      </ScorerCard>
+
+      {/* Metadata */}
+      <ScorerCard title="Metadata">
+        {metadataText ? (
+          <HighlightedCode
+            code={metadataText}
+            className="max-h-[30vh] overflow-auto whitespace-pre font-mono text-[11px] leading-relaxed"
+          />
+        ) : (
+          <NotProvided />
+        )}
+      </ScorerCard>
+
+      {/* Observed usage — honest stats derived from reported scores. */}
+      <ScorerCard title="Observed usage">
+        <dl>
+          <ScorerFact label="Evaluations">
+            <span className="tabular-nums">{scorer.evaluationCount}</span>
+          </ScorerFact>
+          <ScorerFact label="Runs">
+            <span className="tabular-nums">{scorer.runCount}</span>
+          </ScorerFact>
+          <ScorerFact label="Scored results">
+            <span className="tabular-nums">{scorer.scoreCount.toLocaleString("en-US")}</span>
+          </ScorerFact>
+          {scorer.numeric && (
+            <>
+              <ScorerFact label="Mean">
+                <span className="tabular-nums">{scorer.numeric.mean.toFixed(3)}</span>
+              </ScorerFact>
+              <ScorerFact label="Range">
+                <span className="tabular-nums">
+                  {scorer.numeric.min.toFixed(2)} – {scorer.numeric.max.toFixed(2)}
+                </span>
+              </ScorerFact>
+            </>
+          )}
+          {scorer.passRate !== null && (
+            <ScorerFact label="Pass rate">
+              <span className="tabular-nums">{(scorer.passRate * 100).toFixed(1)}%</span>
+            </ScorerFact>
+          )}
+          <ScorerFact label="Error rate">
+            {scorer.errorCount === 0 ? (
+              <span className="tabular-nums text-muted-foreground">0%</span>
+            ) : (
+              <span className={cn("tabular-nums", SENTIMENT_CLASS.bad)}>
+                {(scorer.errorRate * 100).toFixed(1)}% ({scorer.errorCount} of {scorer.scoreCount})
+              </span>
+            )}
+          </ScorerFact>
+          <ScorerFact label="Last used">
+            {scorer.lastUsed ? (
+              <Timestamp iso={scorer.lastUsed} className="inline" />
+            ) : (
+              <span className="text-muted-foreground">—</span>
+            )}
+          </ScorerFact>
+        </dl>
+
+        {scorer.distribution && scorer.distribution.length > 0 && (
+          <div className="mt-3">
+            <div className="mb-1 text-[11px] text-muted-foreground">Score distribution</div>
+            <ul className="flex flex-col gap-1.5">
+              {scorer.distribution.map((d) => (
+                <li key={d.label} className="flex items-center gap-2 text-[11px]">
+                  <span className="w-24 shrink-0 truncate" title={d.label}>
+                    {d.label}
+                  </span>
+                  <span className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+                    <span
+                      className="block h-full rounded-full bg-foreground/70"
+                      style={{ width: `${maxCount > 0 ? (d.count / maxCount) * 100 : 0}%` }}
+                    />
+                  </span>
+                  <span className="w-10 shrink-0 text-right tabular-nums text-muted-foreground">
+                    {d.count}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {scorer.recentErrors.length > 0 && (
+          <div className="mt-3">
+            <div className="mb-1 text-[11px] text-muted-foreground">Recent scorer errors</div>
+            <ul className="flex flex-col gap-1.5">
+              {scorer.recentErrors.map((e, i) => (
+                <li
+                  key={i}
+                  className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 font-mono text-[11px] leading-relaxed text-amber-700 dark:text-amber-300"
+                >
+                  {e.message}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {versions.length > 1 && (
+          <div className="mt-3">
+            <div className="mb-1 text-[11px] text-muted-foreground">Version history</div>
+            <ul className="flex flex-col gap-0.5">
+              {versions.map((v) => (
+                <li
+                  key={v.version}
+                  className={cn(
+                    "flex items-center justify-between gap-2 rounded px-1.5 py-0.5 text-[11px]",
+                    v.version === scorer.version && "bg-muted/60",
+                  )}
+                >
+                  <span className="flex items-center gap-1.5">
+                    <span className="font-medium">{fmtScorerVersion(v.version)}</span>
+                    {v.version === scorer.version && (
+                      <span className="text-[10px] text-muted-foreground">viewing</span>
+                    )}
+                  </span>
+                  <span className="tabular-nums text-muted-foreground">
+                    {v.scoreCount} scored{v.lastUsed ? " · " : ""}
+                    {v.lastUsed && <Timestamp iso={v.lastUsed} className="inline" />}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </ScorerCard>
+    </div>
+  );
+}
+
+function Cell({ colSpan, children }: { colSpan: number; children: React.ReactNode }) {
+  return (
+    <tr>
+      <td colSpan={colSpan}>{children}</td>
+    </tr>
+  );
+}

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -23,7 +23,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { SearchFilterBar } from "@/components/search-filter-bar";
-import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { DATE_FILTER_OPTIONS, toTimestampBounds, type DateFilterOption } from "@/lib/date-filter";
 import { Table, TBody, Td, Th, THead, TR, TRHead } from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
 import { CopyButton } from "@/components/ui/copy-button";
@@ -483,11 +483,20 @@ function RunsTab({ projectId }: { projectId: string }) {
   const [expanded, setExpanded] = React.useState<Set<string>>(new Set());
 
   const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
+  // Resolve the selected range to actual bounds and send them to the query — the date
+  // control was previously read for display only, so it never narrowed the runs list.
+  const { startAfter, endBefore } = toTimestampBounds(
+    dateFilter.id,
+    customStart ?? undefined,
+    customEnd ?? undefined,
+  );
   const { data, isLoading, error } = useEvaluationRuns(projectId, {
     evaluation_id: scopedEvalId ?? undefined,
     search_query: keyword.trim() || undefined,
     dataset_id: datasetFilter === ALL ? undefined : datasetFilter,
     status: statusFilter === ALL ? undefined : statusFilter,
+    started_after: startAfter,
+    started_before: endBefore,
   });
   const allRuns = React.useMemo(() => data?.data ?? [], [data]);
   const filtered = !!keyword || datasetFilter !== ALL || statusFilter !== ALL;

--- a/tests/rest/test_eval_schemas.py
+++ b/tests/rest/test_eval_schemas.py
@@ -1,0 +1,127 @@
+"""The offline-evaluation Pydantic mirror keeps parity with the Zod contract.
+
+Covers the properties that the SDK and both validation layers depend on and that
+a one-token schema edit silently regresses: `scores` presence, the payload caps,
+and forward-compatible degradation of the display-only scorer vocabularies. The
+Zod side asserts the same properties in
+``frontend/packages/core/src/__tests__/eval-contract.test.ts``.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from backend.rest.schemas.eval import (
+    EVAL_METADATA_MAX,
+    EVAL_PAYLOAD_TEXT_MAX,
+    EVAL_SCORER_LIST_MAX,
+    SCORER_MESSAGE_CONTENT_MAX,
+    SCORER_MESSAGES_MAX,
+    SCORER_SOURCE_MAX,
+    RegisterRunRequest,
+    ScorerRef,
+    UpsertResultRequest,
+)
+
+
+def _result(**over):
+    return {"test_case_id": "tc1", "input": "in", "status": "passed", **over}
+
+
+def _run(**over):
+    return {
+        "evaluation_name": "e",
+        "dataset_id": "d",
+        "candidate_version": "v1",
+        **over,
+    }
+
+
+class TestUpsertResultScores:
+    def test_omitted_scores_stays_none(self):
+        """Absent must stay distinguishable from `[]` so a re-upsert that only
+        attaches a trace_id does not wipe the result's scores."""
+        parsed = UpsertResultRequest(**_result(trace_id="t1"))
+        assert parsed.scores is None
+        assert "scores" not in parsed.model_dump(exclude_unset=True)
+
+    def test_explicit_empty_list_is_preserved(self):
+        assert UpsertResultRequest(**_result(scores=[])).scores == []
+
+    def test_rejects_more_scores_than_the_cap(self):
+        score = {"scorer_name": "s", "scorer_version": "1"}
+        under = [score] * EVAL_SCORER_LIST_MAX
+        assert len(UpsertResultRequest(**_result(scores=under)).scores) == EVAL_SCORER_LIST_MAX
+        with pytest.raises(ValidationError):
+            UpsertResultRequest(**_result(scores=[*under, score]))
+
+
+@pytest.mark.parametrize(
+    "field", ["input", "expected_output", "candidate_output", "baseline_output"]
+)
+def test_text_payload_fields_are_capped(field):
+    at_cap = "a" * EVAL_PAYLOAD_TEXT_MAX
+    UpsertResultRequest(**_result(**{field: at_cap}))
+    with pytest.raises(ValidationError):
+        UpsertResultRequest(**_result(**{field: at_cap + "a"}))
+
+
+class TestRegisterRunCaps:
+    def test_rejects_more_scorers_than_the_cap(self):
+        scorer = {"name": "s", "version": "1"}
+        under = [scorer] * EVAL_SCORER_LIST_MAX
+        assert len(RegisterRunRequest(**_run(scorers=under)).scorers) == EVAL_SCORER_LIST_MAX
+        with pytest.raises(ValidationError):
+            RegisterRunRequest(**_run(scorers=[*under, scorer]))
+
+    def test_rejects_oversized_metadata(self):
+        RegisterRunRequest(**_run(metadata={"blob": "b"}))
+        with pytest.raises(ValidationError):
+            RegisterRunRequest(**_run(metadata={"blob": "b" * EVAL_METADATA_MAX}))
+
+
+class TestScorerRefForwardCompatibility:
+    @pytest.mark.parametrize("field", ["scorer_type", "output_type", "language"])
+    def test_unknown_display_only_value_degrades_to_none(self, field):
+        """A newer SDK's variant must not 400 the run registration, which would
+        lose every result and score the SDK goes on to report."""
+        ref = ScorerRef(name="s", version="1", **{field: "from-a-newer-sdk"})
+        assert getattr(ref, field) is None
+
+    def test_known_values_still_round_trip(self):
+        ref = ScorerRef(
+            name="s",
+            version="1",
+            scorer_type="llm_judge",
+            output_type="score",
+            language="python",
+        )
+        assert (ref.scorer_type, ref.output_type, ref.language) == ("llm_judge", "score", "python")
+
+    @pytest.mark.parametrize(
+        ("model", "payload"),
+        [
+            (ScorerRef, {"name": "s", "version": "1", "value_type": "vector"}),
+            (ScorerRef, {"name": "s", "version": "1", "direction": "sideways"}),
+            (UpsertResultRequest, _result(status="skipped")),
+            (UpsertResultRequest, _result(change="sideways")),
+        ],
+    )
+    def test_persistence_vocabularies_still_reject(self, model, payload):
+        with pytest.raises(ValidationError):
+            model(**payload)
+
+    def test_source_messages_and_content_are_capped(self):
+        with pytest.raises(ValidationError):
+            ScorerRef(name="s", version="1", source="s" * (SCORER_SOURCE_MAX + 1))
+        with pytest.raises(ValidationError):
+            ScorerRef(
+                name="s",
+                version="1",
+                messages=[{"role": "user", "content": "c" * (SCORER_MESSAGE_CONTENT_MAX + 1)}],
+            )
+        with pytest.raises(ValidationError):
+            ScorerRef(
+                name="s",
+                version="1",
+                messages=[{"role": "user", "content": "c"}] * (SCORER_MESSAGES_MAX + 1),
+            )


### PR DESCRIPTION
## Summary

Fixes: #1643

Defines the single source of truth for the SDK-facing reporting shapes in `frontend/packages/core/src/eval-contract.ts`, imported by every public route handler. It covers the whole reporting lifecycle — run registration, per-result upsert, run completion, and dataset authoring/sync — plus the scorer manifest, including each scorer's read-only definition. Getting the shapes and strictness right here is what later lets the gateway and the control plane validate identically.

## How it works

The contract fixes ownership and strictness so both validation layers agree:

```
top-level requests  →  .strict()  →  unknown keys REJECTED
ScorerRefSchema     →  plain object →  unknown keys DROPPED (a field must be
                                       declared to survive into the manifest)
```

A field only reaches the persisted per-run manifest if it is declared on `ScorerRefSchema`, so the read-time scorer registry can rely on the manifest being clean.

## What's included

### Contract
- `frontend/packages/core/src/eval-contract.ts` — the Zod schemas and their inferred TypeScript types:
  - `RegisterRunRequestSchema` — `evaluation_name`, `dataset_id`, `dataset_version_id?`, `candidate_version`, `main_score_name?`, `environment` (defaults to `"evaluation"`), `scorers[]`, `client_run_id?`, `baseline_run_id?`, `case_count?`, and free-form `metadata?`; `.strict()`.
  - `ScorerRefSchema` — identity (`name`, `version`), config (`value_type?`, `direction?`, `threshold?`), and the definition (`scorer_type?`, `output_type?`, `description?`, `metadata?`; LLM judge `model?`/`messages[]?`; code `language?`/`source?`), with `ScorerMessageSchema` for a judge prompt message. A non-strict object so declared definition fields ride into the manifest while unknown keys are dropped.
  - `ScoreInputSchema` — a scorer's per-result outcome: numeric/boolean/categorical value, `passed?`, `explanation?`, and `error?`; `.strict()`.
  - `UpsertResultRequestSchema` — per-case `test_case_id`, nullable `trace_id`, `input`, `expected_output?`, `candidate_output?`, `baseline_output?`, `status`, `main_score?`, `change?`, `task_error?`, `duration_ms?`, `cost?`, and `scores[]`; `.strict()`.
  - `CompleteRunRequestSchema` — terminal `status` plus completeness counts; `.strict()`.
  - The dataset authoring/sync schemas — `PublicUpsertDatasetRequestSchema`, `PublicUpdateDatasetRequestSchema`, the discriminated `DatasetChangeSchema` (upsert/archive/delete), and `PublishDatasetVersionRequestSchema` with the `DATASET_VERSION_MAX_CHANGES` cap.
  - The status vocabularies (`EVAL_RUN_STATUSES`, `EVAL_RESULT_STATUSES`, scorer value-type/direction/type enums) as shared `z.enum`s with exported types.
- `frontend/packages/core/src/index.ts` — re-exports the contract so every schema and inferred type is available from `@traceroot/core`.

### Tests
- `frontend/packages/core/src/__tests__/eval-scorer-definition.test.ts` — a bare `{ name, version }` scorer still validates; a full LLM-judge / code definition round-trips through parse without being stripped; a field undeclared on `ScorerRefSchema` is dropped.
- `frontend/packages/core/src/__tests__/eval-contract.test.ts` — covers `eval-contract`.
- `frontend/packages/core/src/__tests__/index.test.ts` — covers `index`.
- `tests/rest/test_eval_schemas.py` — The offline-evaluation Pydantic mirror keeps parity with the Zod contract.
- `frontend/packages/core/src/__tests__/eval-contract-parity.drift.test.ts` — covers `eval-contract-parity.drift`.
- `frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts` — covers `eval-reporting.exerciser`.

### Backend
- `backend/rest/schemas/eval.py` — Typed request/response models for the public offline-evaluation reporting API.
- `backend/rest/openapi/public.json` — part of this change.
- `backend/rest/routers/public/eval.py` — Public offline-evaluation API gateway. Datasets, dataset versions, and evaluation runs live in the Postgres control plane, which is owned by the Next.js app (Prisma).
- `frontend/ui/src/app/api/public/evaluation-runs/route.ts` — provides `POST`.

### UI
- `frontend/ui/src/features/evaluations/views/evaluations-view.tsx` — provides `RunStatusBadge`, `EvaluationsView`, `ScorerDetailPanel`.

## Test plan

- [ ] Import every schema and its inferred type from `@traceroot/core` and confirm they resolve.
- [ ] Parse a legacy `{ name, version }`-only scorer and confirm it validates.
- [ ] Parse a scorer carrying `scorer_type` + prompt/source + config and confirm the definition survives verbatim.
- [ ] Parse a scorer with an undeclared extra key and confirm the key is dropped from the result.
- [ ] Send an unknown top-level key on a register/upsert/complete request and confirm it is rejected.
