### PR TITLE
feat(public-api): dataset authoring and sync endpoints

### DIFF
--- a/frontend/packages/core/src/eval-contract.ts
+++ b/frontend/packages/core/src/eval-contract.ts
@@ -343,6 +343,22 @@ export type CreateHumanScoreRequest = z.infer<typeof CreateHumanScoreRequestSche
 /** Max test-case changes accepted in one A4 publish; over this → 413 so the SDK chunks. */
 export const DATASET_VERSION_MAX_CHANGES = 1000;
 
+/**
+ * Size ceilings for a publish. A count cap alone is not a limit: 1000 changes each
+ * carrying an unbounded `input` is still unbounded, and the body is fully buffered
+ * and parsed before any per-item check can run. So the request is refused on the
+ * wire at DATASET_VERSION_MAX_BYTES, and each value is bounded individually here.
+ */
+export const DATASET_VERSION_MAX_BYTES = 8 * 1024 * 1024;
+export const DATASET_CASE_MAX_BYTES = 256 * 1024;
+
+/** UTF-8 size of a value's JSON form — what the request weighs and the column stores. */
+export function serializedByteLength(value: unknown): number {
+  const json = JSON.stringify(value ?? null);
+  if (json === undefined) return 0;
+  return new TextEncoder().encode(json).length;
+}
+
 /** A2 — upsert a dataset by its client-generated id (idempotent, no version). */
 export const PublicUpsertDatasetRequestSchema = z
   .object({

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -25,10 +25,11 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   });
   if (!dataset) return errorResponse("Dataset not found", 404);
 
+  // Newest first for the UI table (latest-added test case at the top).
   const testCases = dataset.currentVersionId
     ? await prisma.testCase.findMany({
         where: { datasetVersionId: dataset.currentVersionId },
-        orderBy: { createTime: "asc" },
+        orderBy: { createTime: "desc" },
       })
     : [];
   const currentVersion = dataset.versions.find((v) => v.id === dataset.currentVersionId) ?? null;

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest } from "next/server";
+import { prisma, Role, UpdateDatasetRequestSchema } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
+
+// GET — dataset detail: current version, its test cases, and the version list.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, datasetId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const dataset = await prisma.dataset.findFirst({
+    where: { id: datasetId, projectId },
+    include: {
+      versions: { orderBy: { versionNumber: "desc" } },
+    },
+  });
+  if (!dataset) return errorResponse("Dataset not found", 404);
+
+  const testCases = dataset.currentVersionId
+    ? await prisma.testCase.findMany({
+        where: { datasetVersionId: dataset.currentVersionId },
+        orderBy: { createTime: "asc" },
+      })
+    : [];
+  const currentVersion = dataset.versions.find((v) => v.id === dataset.currentVersionId) ?? null;
+
+  return successResponse({ dataset, currentVersion, testCases, versions: dataset.versions });
+}
+
+// PATCH — update editable dataset metadata (not its snapshots).
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, datasetId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON", 400);
+  }
+  const parsed = UpdateDatasetRequestSchema.safeParse(body);
+  if (!parsed.success) return errorResponse(parsed.error.issues[0].message, 400);
+
+  const existing = await prisma.dataset.findFirst({
+    where: { id: datasetId, projectId },
+    select: { id: true },
+  });
+  if (!existing) return errorResponse("Dataset not found", 404);
+
+  const dataset = await prisma.dataset.update({
+    where: { id: datasetId },
+    data: {
+      ...(parsed.data.name !== undefined ? { name: parsed.data.name } : {}),
+      ...(parsed.data.description !== undefined ? { description: parsed.data.description } : {}),
+    },
+  });
+  return successResponse({ dataset });
+}
+
+// DELETE — remove the dataset (cascades versions/test cases).
+export async function DELETE(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, datasetId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  const existing = await prisma.dataset.findFirst({
+    where: { id: datasetId, projectId },
+    select: { id: true },
+  });
+  if (!existing) return errorResponse("Dataset not found", 404);
+
+  await prisma.dataset.delete({ where: { id: datasetId } });
+  return successResponse({ deleted: true });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -7,6 +7,7 @@ import {
   successResponse,
 } from "@/lib/auth-helpers";
 import { displayJsonValue } from "@/lib/eval/json-value";
+import { isPrismaKnownError } from "@/lib/eval/prisma-errors";
 
 type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
 
@@ -35,11 +36,13 @@ export async function GET(req: NextRequest, { params }: RouteParams) {
     dataset.versions.find((v) => v.id === dataset.currentVersionId) ??
     null;
 
-  // Newest first for the UI table (latest-added test case at the top).
+  // Newest first for the UI table (latest-added test case at the top). Every case
+  // a publish writes shares one create_time, so testCaseId breaks the tie and the
+  // table does not reshuffle between two loads of the same version.
   const testCases = selectedVersion
     ? await prisma.testCase.findMany({
         where: { datasetVersionId: selectedVersion.id },
-        orderBy: { createTime: "desc" },
+        orderBy: [{ createTime: "desc" }, { testCaseId: "desc" }],
       })
     : [];
   const currentVersion = dataset.versions.find((v) => v.id === dataset.currentVersionId) ?? null;
@@ -95,7 +98,13 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
   return successResponse({ dataset });
 }
 
-// DELETE — remove the dataset (cascades versions/test cases).
+// DELETE — remove the dataset and cascade its versions/test cases.
+//
+// Refused once anything has been evaluated: a run pins a dataset_version_id, and
+// that snapshot must stay byte-stable and pullable for as long as the run exists.
+// The database enforces it (evaluation_runs → dataset_versions is NoAction, so the
+// cascade cannot take a pinned version with it); this pre-check exists so the
+// answer is a deliberate 409 rather than a foreign-key error surfacing as a 500.
 export async function DELETE(_req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
@@ -109,6 +118,20 @@ export async function DELETE(_req: NextRequest, { params }: RouteParams) {
   });
   if (!existing) return errorResponse("Dataset not found", 404);
 
-  await prisma.dataset.delete({ where: { id: datasetId } });
+  const runCount = await prisma.evaluationRun.count({ where: { datasetId, projectId } });
+  if (runCount > 0) {
+    return errorResponse("Cannot delete a dataset that has evaluation runs", 409);
+  }
+
+  try {
+    await prisma.dataset.delete({ where: { id: datasetId } });
+  } catch (err) {
+    // A run registered between the count and the delete: the FK still holds the
+    // line, and the caller gets the same 409 instead of an unexplained 500.
+    if (isPrismaKnownError(err, "P2003") || isPrismaKnownError(err, "P2014")) {
+      return errorResponse("Cannot delete a dataset that has evaluation runs", 409);
+    }
+    throw err;
+  }
   return successResponse({ deleted: true });
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -10,8 +10,10 @@ import { displayJsonValue } from "@/lib/eval/json-value";
 
 type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
 
-// GET — dataset detail: current version, its test cases, and the version list.
-export async function GET(_req: NextRequest, { params }: RouteParams) {
+// GET — dataset detail: a chosen version (default current), its test cases, and
+// the version list. `?version_id=` views an older immutable snapshot; an unknown
+// or omitted id falls back to the current version.
+export async function GET(req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
   const { projectId, datasetId } = await params;
@@ -26,10 +28,17 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   });
   if (!dataset) return errorResponse("Dataset not found", 404);
 
+  // The requested version, if it belongs to this dataset; else the current one.
+  const requestedVersionId = req.nextUrl.searchParams.get("version_id");
+  const selectedVersion =
+    (requestedVersionId ? dataset.versions.find((v) => v.id === requestedVersionId) : undefined) ??
+    dataset.versions.find((v) => v.id === dataset.currentVersionId) ??
+    null;
+
   // Newest first for the UI table (latest-added test case at the top).
-  const testCases = dataset.currentVersionId
+  const testCases = selectedVersion
     ? await prisma.testCase.findMany({
-        where: { datasetVersionId: dataset.currentVersionId },
+        where: { datasetVersionId: selectedVersion.id },
         orderBy: { createTime: "desc" },
       })
     : [];
@@ -46,6 +55,8 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
   return successResponse({
     dataset,
     currentVersion,
+    selectedVersion,
+    isCurrentVersion: selectedVersion?.id === dataset.currentVersionId,
     testCases: presentedCases,
     versions: dataset.versions,
   });

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts
@@ -6,6 +6,7 @@ import {
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
+import { displayJsonValue } from "@/lib/eval/json-value";
 
 type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
 
@@ -34,7 +35,20 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
     : [];
   const currentVersion = dataset.versions.find((v) => v.id === dataset.currentVersionId) ?? null;
 
-  return successResponse({ dataset, currentVersion, testCases, versions: dataset.versions });
+  // Present input/expected as human-readable text for the UI: a genuine string as-is,
+  // structured values (from an SDK push) as pretty JSON — never a bare quoted string.
+  const presentedCases = testCases.map((t) => ({
+    ...t,
+    input: displayJsonValue(t.input),
+    expected: t.expected === null ? null : displayJsonValue(t.expected),
+  }));
+
+  return successResponse({
+    dataset,
+    currentVersion,
+    testCases: presentedCases,
+    versions: dataset.versions,
+  });
 }
 
 // PATCH — update editable dataset metadata (not its snapshots).

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/route.ts
@@ -6,7 +6,8 @@ import {
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
-import { publishDatasetVersion, DatasetNotFound } from "@/lib/eval/versions";
+import { publishDatasetVersion, DatasetNotFound, VersionConflict } from "@/lib/eval/versions";
+import { encodeEditedText } from "@/lib/eval/json-value";
 
 type RouteParams = {
   params: Promise<{ projectId: string; datasetId: string; testCaseId: string }>;
@@ -62,8 +63,21 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
           const demote = touchesContent && seed.review === "ready" && patch.review === undefined;
           return {
             ...seed,
-            ...(patch.input !== undefined ? { input: patch.input } : {}),
-            ...(patch.expected !== undefined ? { expected: patch.expected } : {}),
+            // The UI edits values as text, but the column holds one encoding
+            // (JSON-encoded) shared with the SDK publish/pull paths. Re-encode
+            // against the value being replaced so an edit cannot silently change
+            // a case's type inside the snapshot a run scores against.
+            ...(patch.input !== undefined
+              ? { input: encodeEditedText(seed.input, patch.input) }
+              : {}),
+            ...(patch.expected !== undefined
+              ? {
+                  expected:
+                    patch.expected === null
+                      ? null
+                      : encodeEditedText(seed.expected, patch.expected),
+                }
+              : {}),
             ...(patch.metadata !== undefined
               ? { metadata: patch.metadata as Record<string, unknown> | null }
               : {}),
@@ -76,6 +90,9 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     return successResponse(result, 201);
   } catch (err) {
     if (err instanceof DatasetNotFound) return errorResponse("Dataset not found", 404);
+    if (err instanceof VersionConflict) {
+      return errorResponse("The dataset changed while saving; please retry", 409);
+    }
     throw err;
   }
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest } from "next/server";
+import { prisma, Role, UpdateTestCaseRequestSchema } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+import { publishDatasetVersion, DatasetNotFound } from "@/lib/eval/versions";
+
+type RouteParams = {
+  params: Promise<{ projectId: string; datasetId: string; testCaseId: string }>;
+};
+
+// PATCH — edit a test case. This publishes a NEW dataset version (the historical
+// snapshot a run pinned is never rewritten). Editing content returns a "ready"
+// case to "needs_review" unless the caller sets review explicitly.
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, datasetId, testCaseId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON", 400);
+  }
+  const parsed = UpdateTestCaseRequestSchema.safeParse(body);
+  if (!parsed.success) return errorResponse(parsed.error.issues[0].message, 400);
+  const patch = parsed.data;
+
+  const touchesContent =
+    patch.input !== undefined || patch.expected !== undefined || patch.metadata !== undefined;
+
+  // Guard before publishing so a missing case never creates a no-op version.
+  const dataset = await prisma.dataset.findFirst({
+    where: { id: datasetId, projectId },
+    select: { currentVersionId: true },
+  });
+  if (!dataset) return errorResponse("Dataset not found", 404);
+  const exists = dataset.currentVersionId
+    ? await prisma.testCase.findFirst({
+        where: { datasetVersionId: dataset.currentVersionId, testCaseId },
+        select: { id: true },
+      })
+    : null;
+  if (!exists) return errorResponse("Test case not found in the current version", 404);
+
+  try {
+    const result = await publishDatasetVersion({
+      datasetId,
+      projectId,
+      createdBy: authResult.user.email ?? null,
+      note: `Edited test case ${testCaseId}`,
+      transform: (current) => ({
+        focusTestCaseId: testCaseId,
+        cases: current.map((seed) => {
+          if (seed.testCaseId !== testCaseId) return seed;
+          const demote = touchesContent && seed.review === "ready" && patch.review === undefined;
+          return {
+            ...seed,
+            ...(patch.input !== undefined ? { input: patch.input } : {}),
+            ...(patch.expected !== undefined ? { expected: patch.expected } : {}),
+            ...(patch.metadata !== undefined
+              ? { metadata: patch.metadata as Record<string, unknown> | null }
+              : {}),
+            ...(patch.review !== undefined ? { review: patch.review } : {}),
+            ...(demote ? { review: "needs_review" } : {}),
+          };
+        }),
+      }),
+    });
+    return successResponse(result, 201);
+  } catch (err) {
+    if (err instanceof DatasetNotFound) return errorResponse("Dataset not found", 404);
+    throw err;
+  }
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+
+type RouteParams = {
+  params: Promise<{ projectId: string; datasetId: string; testCaseId: string }>;
+};
+
+// GET — every evaluation run that measured this test case (by stable testCaseId),
+// newest first, with the result this case got in each. Powers the CasePanel "Runs"
+// tab. testCaseId is globally unique, so the dataset in the path is for grouping
+// and access scoping only.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, testCaseId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const results = await prisma.evaluationResult.findMany({
+    where: { projectId, testCaseId },
+    orderBy: { createTime: "desc" },
+    select: {
+      id: true,
+      mainScore: true,
+      status: true,
+      change: true,
+      createTime: true,
+      run: {
+        select: {
+          id: true,
+          runNumber: true,
+          candidateVersion: true,
+          startedAt: true,
+          evaluation: { select: { name: true } },
+        },
+      },
+    },
+  });
+
+  const data = results.map((r) => ({
+    resultId: r.id,
+    runId: r.run.id,
+    runNumber: r.run.runNumber,
+    candidateVersion: r.run.candidateVersion,
+    evaluationName: r.run.evaluation.name,
+    ranAt: r.run.startedAt.toISOString(),
+    score: r.mainScore,
+    status: r.status,
+    change: r.change,
+  }));
+
+  return successResponse({ data });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.ts
@@ -13,12 +13,15 @@ type RouteParams = {
 export async function GET(_req: NextRequest, { params }: RouteParams) {
   const authResult = await requireAuth();
   if (authResult.error) return authResult.error;
-  const { projectId, testCaseId } = await params;
+  const { projectId, datasetId, testCaseId } = await params;
   const accessResult = await requireProjectAccess(authResult.user.id, projectId);
   if (accessResult.error) return accessResult.error;
 
+  // A stable testCaseId can recur across datasets in the same project (it's only
+  // unique within a dataset lineage), so scope through the run's dataset — otherwise
+  // this tab would surface runs from a different dataset that reused the id.
   const results = await prisma.evaluationResult.findMany({
-    where: { projectId, testCaseId },
+    where: { projectId, testCaseId, run: { datasetId } },
     orderBy: { createTime: "desc" },
     select: {
       id: true,

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest } from "next/server";
+import { prisma, Role, CreateTestCaseRequestSchema } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+import { publishDatasetVersion, newTestCaseId, DatasetNotFound } from "@/lib/eval/versions";
+
+type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
+
+// POST — save a trace/span (or a manual case) as a test case. Publishes a NEW
+// dataset version so any run that pinned an earlier snapshot is untouched. If the
+// same source span already exists in the current version, returns that case
+// instead of silently duplicating it.
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, datasetId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON", 400);
+  }
+  const parsed = CreateTestCaseRequestSchema.safeParse(body);
+  if (!parsed.success) return errorResponse(parsed.error.issues[0].message, 400);
+  const c = parsed.data;
+
+  const dataset = await prisma.dataset.findFirst({
+    where: { id: datasetId, projectId },
+    select: { id: true, currentVersionId: true },
+  });
+  if (!dataset) return errorResponse("Dataset not found", 404);
+
+  // Explicit duplicate handling: same source span already in the current version.
+  if (dataset.currentVersionId && c.source_trace_id && c.source_span_id) {
+    const dup = await prisma.testCase.findFirst({
+      where: {
+        datasetVersionId: dataset.currentVersionId,
+        sourceTraceId: c.source_trace_id,
+        sourceSpanId: c.source_span_id,
+      },
+      select: { testCaseId: true },
+    });
+    if (dup) {
+      return successResponse({
+        duplicate: true,
+        testCaseId: dup.testCaseId,
+        versionId: dataset.currentVersionId,
+      });
+    }
+  }
+
+  const testCaseId = newTestCaseId();
+  try {
+    const result = await publishDatasetVersion({
+      datasetId,
+      projectId,
+      createdBy: authResult.user.email ?? null,
+      note: "Added a test case from a trace",
+      transform: (current) => ({
+        focusTestCaseId: testCaseId,
+        cases: [
+          ...current,
+          {
+            testCaseId,
+            input: c.input,
+            expected: c.expected ?? null,
+            recordedOutput: c.recorded_output ?? null,
+            metadata: (c.metadata ?? null) as Record<string, unknown> | null,
+            review: c.review,
+            captureReason: c.capture_reason,
+            sourceTraceId: c.source_trace_id ?? null,
+            sourceSpanId: c.source_span_id ?? null,
+            sourceSpanName: c.source_span_name ?? null,
+            sourceSpanKind: c.source_span_kind ?? null,
+            addedBy: authResult.user.email ?? null,
+          },
+        ],
+      }),
+    });
+    return successResponse({ duplicate: false, ...result }, 201);
+  } catch (err) {
+    if (err instanceof DatasetNotFound) return errorResponse("Dataset not found", 404);
+    throw err;
+  }
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts
@@ -6,7 +6,13 @@ import {
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
-import { publishDatasetVersion, newTestCaseId, DatasetNotFound } from "@/lib/eval/versions";
+import {
+  publishDatasetVersion,
+  newTestCaseId,
+  DatasetNotFound,
+  VersionConflict,
+} from "@/lib/eval/versions";
+import { encodeJsonValue } from "@/lib/eval/json-value";
 
 type RouteParams = { params: Promise<{ projectId: string; datasetId: string }> };
 
@@ -69,8 +75,14 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
           ...current,
           {
             testCaseId,
-            input: c.input,
-            expected: c.expected ?? null,
+            // Stored JSON-ENCODED, the one on-disk encoding for these columns
+            // (the public publish path and the pull path agree on it). Written
+            // raw, a case authored here as the text "123" would come back from
+            // the public API as the number 123 — a type change inside a snapshot
+            // a run scores against.
+            input: encodeJsonValue(c.input),
+            expected:
+              c.expected === null || c.expected === undefined ? null : encodeJsonValue(c.expected),
             recordedOutput: c.recorded_output ?? null,
             metadata: (c.metadata ?? null) as Record<string, unknown> | null,
             review: c.review,
@@ -87,6 +99,11 @@ export async function POST(req: NextRequest, { params }: RouteParams) {
     return successResponse({ duplicate: false, ...result }, 201);
   } catch (err) {
     if (err instanceof DatasetNotFound) return errorResponse("Dataset not found", 404);
+    // Another publish kept winning the pointer swap; ask the caller to retry
+    // rather than surfacing the conflict as a 500.
+    if (err instanceof VersionConflict) {
+      return errorResponse("The dataset changed while saving; please retry", 409);
+    }
     throw err;
   }
 }

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/versions/[versionId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/versions/[versionId]/route.ts
@@ -6,6 +6,7 @@ import {
   errorResponse,
   successResponse,
 } from "@/lib/auth-helpers";
+import { TEST_CASE_ORDER } from "@/lib/eval/versions";
 
 type RouteParams = {
   params: Promise<{ projectId: string; datasetId: string; versionId: string }>;
@@ -21,7 +22,9 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
 
   const version = await prisma.datasetVersion.findFirst({
     where: { id: versionId, datasetId, projectId },
-    include: { testCases: { orderBy: { createTime: "asc" } } },
+    // Same total order as the public pull: a version's cases read identically
+    // everywhere, including when every row shares one create_time.
+    include: { testCases: { orderBy: TEST_CASE_ORDER } },
   });
   if (!version) return errorResponse("Dataset version not found", 404);
 

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/versions/[versionId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/versions/[versionId]/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+
+type RouteParams = {
+  params: Promise<{ projectId: string; datasetId: string; versionId: string }>;
+};
+
+// GET — a specific immutable dataset version and the test cases it snapshotted.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, datasetId, versionId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const version = await prisma.datasetVersion.findFirst({
+    where: { id: versionId, datasetId, projectId },
+    include: { testCases: { orderBy: { createTime: "asc" } } },
+  });
+  if (!version) return errorResponse("Dataset version not found", 404);
+
+  return successResponse({ version, testCases: version.testCases });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
@@ -98,6 +98,25 @@ describe("saving a test case publishes a new immutable version", () => {
     expect(v2Cases.map((c) => c.testCaseId)).toContain("case-1");
   });
 
+  it("preserves each copied case's original created date (does not restamp on add)", async () => {
+    const original = new Date("2026-01-01T00:00:00.000Z");
+    // Give the pre-existing case a known creation time.
+    fakePrisma.testCase.rows.find((c) => c.testCaseId === "case-1")!.createTime = original;
+
+    await saveTestCase(req({ input: "new ticket" }), p());
+
+    const dataset = fakePrisma.dataset.rows.find((d) => d.id === "ds1")!;
+    const v2Cases = fakePrisma.testCase.rows.filter(
+      (c) => c.datasetVersionId === dataset.currentVersionId,
+    );
+    const copied = v2Cases.find((c) => c.testCaseId === "case-1")!;
+    const added = v2Cases.find((c) => c.testCaseId !== "case-1")!;
+    // The unchanged case keeps its original "Created" date...
+    expect(copied.createTime).toEqual(original);
+    // ...while the newly added case is stamped fresh, not restamped to match.
+    expect(added.createTime).not.toEqual(original);
+  });
+
   it("returns the existing case instead of duplicating the same source span", async () => {
     fakePrisma.testCase.rows.push({
       id: "row2",

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
@@ -29,8 +29,10 @@ vi.mock("@traceroot/core", async (importOriginal) => {
 });
 
 import { fakePrisma } from "@/lib/eval/__tests__/fake-prisma";
+import { decodeJsonValue, encodeJsonValue } from "@/lib/eval/json-value";
 import { POST as saveTestCase } from "./[datasetId]/test-cases/route";
 import { PATCH as editTestCase } from "./[datasetId]/test-cases/[testCaseId]/route";
+import { GET as getDataset, DELETE as deleteDataset } from "./[datasetId]/route";
 
 const PROJECT_ID = "proj_1";
 
@@ -161,7 +163,125 @@ describe("editing a test case publishes a new version and leaves the old snapsho
     const v2Case = fakePrisma.testCase.rows.find(
       (c) => c.datasetVersionId === dataset.currentVersionId && c.testCaseId === "case-1",
     )!;
-    expect(v2Case.expected).toBe("account-management");
+    expect(decodeJsonValue(v2Case.expected as string)).toBe("account-management");
     expect(v2Case.review).toBe("needs_review"); // content edit demotes ready
+  });
+});
+
+describe("the stored encoding survives a UI round trip", () => {
+  it("keeps a genuine string that looks like a number a string", async () => {
+    // As an SDK publish would have written it: JSON-encoded, so "123" is a string.
+    fakePrisma.testCase.rows.push({
+      id: "row-str",
+      testCaseId: "case-str",
+      datasetVersionId: "dv1",
+      datasetId: "ds1",
+      projectId: PROJECT_ID,
+      input: encodeJsonValue("123"),
+      review: "ready",
+      captureReason: "manual",
+    });
+
+    // The UI shows it as `123` and saves that text back unchanged.
+    await editTestCase(req({ input: "123" }), p({ testCaseId: "case-str" }));
+
+    const dataset = fakePrisma.dataset.rows.find((d) => d.id === "ds1")!;
+    const edited = fakePrisma.testCase.rows.find(
+      (c) => c.datasetVersionId === dataset.currentVersionId && c.testCaseId === "case-str",
+    )!;
+    expect(decodeJsonValue(edited.input as string)).toBe("123");
+    expect(typeof decodeJsonValue(edited.input as string)).toBe("string");
+  });
+
+  it("keeps a structured value structured", async () => {
+    fakePrisma.testCase.rows.push({
+      id: "row-obj",
+      testCaseId: "case-obj",
+      datasetVersionId: "dv1",
+      datasetId: "ds1",
+      projectId: PROJECT_ID,
+      input: encodeJsonValue({ question: "why?" }),
+      review: "ready",
+      captureReason: "manual",
+    });
+
+    // The UI shows structured values as pretty JSON and saves the edited JSON.
+    await editTestCase(req({ input: '{\n  "question": "how?"\n}' }), p({ testCaseId: "case-obj" }));
+
+    const dataset = fakePrisma.dataset.rows.find((d) => d.id === "ds1")!;
+    const edited = fakePrisma.testCase.rows.find(
+      (c) => c.datasetVersionId === dataset.currentVersionId && c.testCaseId === "case-obj",
+    )!;
+    expect(decodeJsonValue(edited.input as string)).toEqual({ question: "how?" });
+  });
+
+  it("stores a case added in the UI JSON-encoded, not raw", async () => {
+    await saveTestCase(req({ input: "true" }), p());
+
+    const dataset = fakePrisma.dataset.rows.find((d) => d.id === "ds1")!;
+    const added = fakePrisma.testCase.rows.find(
+      (c) => c.datasetVersionId === dataset.currentVersionId && c.testCaseId !== "case-1",
+    )!;
+    expect(added.input).toBe('"true"');
+    expect(decodeJsonValue(added.input as string)).toBe("true"); // not the boolean
+  });
+});
+
+describe("reading a version's cases is deterministically ordered", () => {
+  it("breaks create_time ties on test_case_id instead of returning insertion order", async () => {
+    // Every case a publish writes shares one create_time (CURRENT_TIMESTAMP is the
+    // transaction start time), so the tie is the normal case, not an edge case.
+    const tie = new Date("2026-02-02T00:00:00.000Z");
+    fakePrisma.testCase.rows.length = 0;
+    for (const id of ["case-c", "case-a", "case-b"]) {
+      fakePrisma.testCase.rows.push({
+        id: `row-${id}`,
+        testCaseId: id,
+        datasetVersionId: "dv1",
+        datasetId: "ds1",
+        projectId: PROJECT_ID,
+        input: encodeJsonValue(id),
+        createTime: tie,
+        review: "ready",
+        captureReason: "manual",
+      });
+    }
+
+    const res = await getDataset(
+      { nextUrl: { searchParams: new URLSearchParams() } } as unknown as Parameters<
+        typeof getDataset
+      >[0],
+      p(),
+    );
+    const body = (await res.json()) as { testCases: { testCaseId: string }[] };
+    // The UI table is newest-first, so ties resolve on test_case_id descending.
+    expect(body.testCases.map((c) => c.testCaseId)).toEqual(["case-c", "case-b", "case-a"]);
+  });
+});
+
+describe("deleting a dataset", () => {
+  const del = () => deleteDataset({} as unknown as Parameters<typeof deleteDataset>[0], p());
+
+  it("removes a dataset that has never been evaluated", async () => {
+    const res = await del();
+    expect(res.status).toBe(200);
+    expect(fakePrisma.dataset.rows).toHaveLength(0);
+    expect(fakePrisma.datasetVersion.rows).toHaveLength(0);
+    expect(fakePrisma.testCase.rows).toHaveLength(0);
+  });
+
+  it("refuses with 409 once a run pinned one of its versions, instead of a 500", async () => {
+    fakePrisma.evaluationRun.rows.push({
+      id: "run1",
+      projectId: PROJECT_ID,
+      datasetId: "ds1",
+      datasetVersionId: "dv1",
+    });
+
+    const res = await del();
+    expect(res.status).toBe(409);
+    // The pinned snapshot is still there for the run that scored against it.
+    expect(fakePrisma.datasetVersion.rows).toHaveLength(1);
+    expect(fakePrisma.testCase.rows).toHaveLength(1);
   });
 });

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
@@ -1,5 +1,5 @@
 /**
- * Dataset-version immutability (Phase 8).
+ * Dataset-version immutability.
  *
  * Saving and editing test cases must publish NEW dataset versions, never rewrite
  * a historical snapshot a run may have pinned. Drives the real test-case Route

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Dataset-version immutability (Phase 8).
+ *
+ * Saving and editing test cases must publish NEW dataset versions, never rewrite
+ * a historical snapshot a run may have pinned. Drives the real test-case Route
+ * Handlers against the in-memory fake prisma.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+const auth = vi.hoisted(() => ({
+  requireAuth: vi.fn(),
+  requireProjectAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+vi.mock("@traceroot/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@traceroot/core")>();
+  const { fakePrisma } = await import("@/lib/eval/__tests__/fake-prisma");
+  return { ...actual, prisma: fakePrisma };
+});
+
+import { fakePrisma } from "@/lib/eval/__tests__/fake-prisma";
+import { POST as saveTestCase } from "./[datasetId]/test-cases/route";
+import { PATCH as editTestCase } from "./[datasetId]/test-cases/[testCaseId]/route";
+
+const PROJECT_ID = "proj_1";
+
+function req(body: unknown) {
+  return { json: async () => body } as unknown as Parameters<typeof saveTestCase>[0];
+}
+
+beforeEach(() => {
+  fakePrisma.reset();
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1", email: "e@x.com" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: PROJECT_ID } });
+  // A dataset with an initial version v1 holding one case.
+  fakePrisma.dataset.rows.push({ id: "ds1", projectId: PROJECT_ID, currentVersionId: "dv1" });
+  fakePrisma.datasetVersion.rows.push({
+    id: "dv1",
+    datasetId: "ds1",
+    projectId: PROJECT_ID,
+    versionNumber: 1,
+    label: "v1",
+  });
+  fakePrisma.testCase.rows.push({
+    id: "row1",
+    testCaseId: "case-1",
+    datasetVersionId: "dv1",
+    datasetId: "ds1",
+    projectId: PROJECT_ID,
+    input: "original input",
+    expected: "billing",
+    review: "ready",
+    captureReason: "manual",
+  });
+});
+
+const p = (extra: Record<string, string> = {}) => ({
+  params: Promise.resolve({ projectId: PROJECT_ID, datasetId: "ds1", ...extra }),
+});
+
+describe("saving a test case publishes a new immutable version", () => {
+  it("adds v2 with both cases and leaves v1 untouched", async () => {
+    const res = await saveTestCase(
+      req({
+        input: "new ticket",
+        expected: "billing",
+        source_trace_id: "tr_x",
+        source_span_id: "sp_x",
+      }),
+      p(),
+    );
+    expect(res.status).toBe(201);
+
+    // A new version exists; the current pointer moved to it.
+    expect(fakePrisma.datasetVersion.rows).toHaveLength(2);
+    const v2 = fakePrisma.datasetVersion.rows.find((v) => v.versionNumber === 2)!;
+    const dataset = fakePrisma.dataset.rows.find((d) => d.id === "ds1")!;
+    expect(dataset.currentVersionId).toBe(v2.id);
+
+    // v1's rows are unchanged (still exactly the original case).
+    const v1Cases = fakePrisma.testCase.rows.filter((c) => c.datasetVersionId === "dv1");
+    expect(v1Cases).toHaveLength(1);
+    expect(v1Cases[0].input).toBe("original input");
+
+    // v2 snapshots the original case (same stable testCaseId) plus the new one.
+    const v2Cases = fakePrisma.testCase.rows.filter((c) => c.datasetVersionId === v2.id);
+    expect(v2Cases).toHaveLength(2);
+    expect(v2Cases.map((c) => c.testCaseId)).toContain("case-1");
+  });
+
+  it("returns the existing case instead of duplicating the same source span", async () => {
+    fakePrisma.testCase.rows.push({
+      id: "row2",
+      testCaseId: "case-dup",
+      datasetVersionId: "dv1",
+      datasetId: "ds1",
+      projectId: PROJECT_ID,
+      input: "x",
+      sourceTraceId: "tr_dup",
+      sourceSpanId: "sp_dup",
+      review: "needs_review",
+      captureReason: "manual",
+    });
+    const res = await saveTestCase(
+      req({ input: "again", source_trace_id: "tr_dup", source_span_id: "sp_dup" }),
+      p(),
+    );
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.duplicate).toBe(true);
+    expect(body.testCaseId).toBe("case-dup");
+    // No new version was published.
+    expect(fakePrisma.datasetVersion.rows).toHaveLength(1);
+  });
+});
+
+describe("editing a test case publishes a new version and leaves the old snapshot intact", () => {
+  it("edits content in v2 and demotes a ready case to needs_review", async () => {
+    const res = await editTestCase(
+      req({ expected: "account-management" }),
+      p({ testCaseId: "case-1" }),
+    );
+    expect(res.status).toBe(201);
+
+    // v1's copy of case-1 is unchanged; the new version holds the edit.
+    const v1Case = fakePrisma.testCase.rows.find(
+      (c) => c.datasetVersionId === "dv1" && c.testCaseId === "case-1",
+    )!;
+    expect(v1Case.expected).toBe("billing");
+    expect(v1Case.review).toBe("ready");
+
+    const dataset = fakePrisma.dataset.rows.find((d) => d.id === "ds1")!;
+    const v2Case = fakePrisma.testCase.rows.find(
+      (c) => c.datasetVersionId === dataset.currentVersionId && c.testCaseId === "case-1",
+    )!;
+    expect(v2Case.expected).toBe("account-management");
+    expect(v2Case.review).toBe("needs_review"); // content edit demotes ready
+  });
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts
@@ -64,8 +64,8 @@ beforeEach(() => {
   });
 });
 
-const p = (extra: Record<string, string> = {}) => ({
-  params: Promise.resolve({ projectId: PROJECT_ID, datasetId: "ds1", ...extra }),
+const p = (extra: { testCaseId?: string } = {}) => ({
+  params: Promise.resolve({ projectId: PROJECT_ID, datasetId: "ds1", testCaseId: "", ...extra }),
 });
 
 describe("saving a test case publishes a new immutable version", () => {

--- a/frontend/ui/src/app/api/projects/[projectId]/datasets/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/datasets/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest } from "next/server";
+import { prisma, Role, CreateDatasetRequestSchema } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+// GET /api/projects/[projectId]/datasets — list datasets with case/version counts.
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const { searchParams } = req.nextUrl;
+  const rawLimit = parseInt(searchParams.get("limit") ?? "50", 10);
+  const rawPage = parseInt(searchParams.get("page") ?? "0", 10);
+  const limit = isNaN(rawLimit) ? 50 : Math.min(Math.max(rawLimit, 1), 200);
+  const page = isNaN(rawPage) ? 0 : Math.max(rawPage, 0);
+  const searchQuery = searchParams.get("search_query")?.trim() || null;
+
+  const where = searchQuery
+    ? {
+        projectId,
+        OR: [
+          { name: { contains: searchQuery, mode: "insensitive" as const } },
+          { description: { contains: searchQuery, mode: "insensitive" as const } },
+        ],
+      }
+    : { projectId };
+
+  const [datasets, total] = await prisma.$transaction([
+    prisma.dataset.findMany({
+      where,
+      orderBy: { updateTime: "desc" },
+      skip: page * limit,
+      take: limit,
+      include: { _count: { select: { versions: true } } },
+    }),
+    prisma.dataset.count({ where }),
+  ]);
+
+  // Test-case count comes from each dataset's current version (a version with no
+  // rows counts as 0). One groupBy instead of N per-dataset counts.
+  const currentVersionIds = datasets
+    .map((d) => d.currentVersionId)
+    .filter((id): id is string => Boolean(id));
+  const caseCounts =
+    currentVersionIds.length > 0
+      ? await prisma.testCase.groupBy({
+          by: ["datasetVersionId"],
+          where: { datasetVersionId: { in: currentVersionIds } },
+          _count: { _all: true },
+        })
+      : [];
+  const caseCountByVersion = new Map(caseCounts.map((c) => [c.datasetVersionId, c._count._all]));
+
+  const data = datasets.map((d) => ({
+    ...d,
+    caseCount: d.currentVersionId ? (caseCountByVersion.get(d.currentVersionId) ?? 0) : 0,
+    versionCount: d._count.versions,
+  }));
+
+  return successResponse({ data, meta: { page, limit, total } });
+}
+
+// POST /api/projects/[projectId]/datasets — create an (empty) dataset.
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON", 400);
+  }
+  const parsed = CreateDatasetRequestSchema.safeParse(body);
+  if (!parsed.success) return errorResponse(parsed.error.issues[0].message, 400);
+
+  const dataset = await prisma.dataset.create({
+    data: {
+      projectId,
+      name: parsed.data.name,
+      description: parsed.data.description ?? null,
+    },
+  });
+  return successResponse({ dataset }, 201);
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from "next/server";
+import { prisma, Role, CreateHumanScoreRequestSchema } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string; resultId: string }> };
+
+// POST — human-score one evaluation result. Deliberately separate from editing
+// the dataset's expected output (that is a dataset write, not a scoring action).
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, resultId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId, Role.MEMBER);
+  if (accessResult.error) return accessResult.error;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse("Invalid JSON", 400);
+  }
+  const parsed = CreateHumanScoreRequestSchema.safeParse(body);
+  if (!parsed.success) return errorResponse(parsed.error.issues[0].message, 400);
+
+  const result = await prisma.evaluationResult.findFirst({
+    where: { id: resultId, projectId },
+    select: { id: true },
+  });
+  if (!result) return errorResponse("Evaluation result not found", 404);
+
+  const humanScore = await prisma.humanScore.create({
+    data: {
+      resultId,
+      projectId,
+      verdict: parsed.data.verdict,
+      quality: parsed.data.quality ?? null,
+      comment: parsed.data.comment ?? null,
+      reviewer: parsed.data.reviewer,
+    },
+  });
+  return successResponse({ humanScore }, 201);
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+// GET — evaluation lineages (stable purposes) with their latest run + run count.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const evaluations = await prisma.evaluation.findMany({
+    where: { projectId },
+    orderBy: { updateTime: "desc" },
+    include: {
+      _count: { select: { runs: true } },
+      runs: {
+        orderBy: { startedAt: "desc" },
+        take: 1,
+        select: {
+          id: true,
+          runNumber: true,
+          candidateVersion: true,
+          status: true,
+          mainScore: true,
+          startedAt: true,
+          datasetVersionId: true,
+        },
+      },
+    },
+  });
+
+  const datasetIds = [...new Set(evaluations.map((e) => e.datasetId))];
+  const datasets =
+    datasetIds.length > 0
+      ? await prisma.dataset.findMany({
+          where: { id: { in: datasetIds }, projectId },
+          select: { id: true, name: true },
+        })
+      : [];
+  const datasetName = new Map(datasets.map((d) => [d.id, d.name]));
+
+  const data = evaluations.map((e) => ({
+    ...e,
+    datasetName: datasetName.get(e.datasetId) ?? null,
+    runCount: e._count.runs,
+    latestRun: e.runs[0] ?? null,
+  }));
+
+  return successResponse({ data });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Run-detail shaping: a baseline delta is only computed when the baseline run
+ * measured the identical population (same evaluation + same dataset snapshot);
+ * otherwise the UI must get `changeFromBaseline: null` and `baselineComparable:
+ * false` so it warns instead of subtracting incompatible numbers.
+ */
+import { it, expect, vi, beforeEach } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  evaluationRun: { findFirst: vi.fn() },
+  dataset: { findFirst: vi.fn() },
+}));
+const auth = vi.hoisted(() => ({ requireAuth: vi.fn(), requireProjectAccess: vi.fn() }));
+
+vi.mock("@traceroot/core", () => ({ prisma: prismaMock }));
+vi.mock("@/lib/auth-helpers", () => ({
+  requireAuth: auth.requireAuth,
+  requireProjectAccess: auth.requireProjectAccess,
+  errorResponse: (message: string, status: number) => ({
+    status,
+    json: async () => ({ error: message }),
+  }),
+  successResponse: (data: unknown, status = 200) => ({ status, json: async () => data }),
+}));
+
+import { GET } from "./route";
+
+const params = { params: Promise.resolve({ projectId: "p1", runId: "run-1" }) };
+
+function baseRun(baselineRun: unknown) {
+  return {
+    id: "run-1",
+    projectId: "p1",
+    evaluationId: "eval-1",
+    datasetId: "ds1",
+    datasetVersionId: "dv2",
+    mainScore: 90,
+    taskErrorCount: 0,
+    scorerErrorCount: 0,
+    evaluation: { name: "Billing routing" },
+    datasetVersion: { label: "v2" },
+    baselineRun,
+    results: [],
+  };
+}
+
+beforeEach(() => {
+  auth.requireAuth.mockResolvedValue({ user: { id: "u1" } });
+  auth.requireProjectAccess.mockResolvedValue({ project: { id: "p1" } });
+  prismaMock.dataset.findFirst.mockResolvedValue({ id: "ds1", name: "Billing routing" });
+});
+
+it("computes a delta when the baseline shares the same evaluation and snapshot", async () => {
+  prismaMock.evaluationRun.findFirst.mockResolvedValue(
+    baseRun({
+      id: "run-0",
+      mainScore: 70,
+      evaluationId: "eval-1",
+      datasetVersionId: "dv2",
+      datasetVersion: { label: "v2" },
+    }),
+  );
+  const body = (await (await GET({} as never, params)).json()) as Record<string, never>;
+  const run = body.run as unknown as { changeFromBaseline: number; baselineComparable: boolean };
+  expect(run.baselineComparable).toBe(true);
+  expect(run.changeFromBaseline).toBe(20);
+});
+
+it("refuses a delta when the baseline used a different dataset snapshot", async () => {
+  prismaMock.evaluationRun.findFirst.mockResolvedValue(
+    baseRun({
+      id: "run-0",
+      mainScore: 70,
+      evaluationId: "eval-1",
+      datasetVersionId: "dv1", // different snapshot
+      datasetVersion: { label: "v1" },
+    }),
+  );
+  const body = (await (await GET({} as never, params)).json()) as Record<string, never>;
+  const run = body.run as unknown as {
+    changeFromBaseline: number | null;
+    baselineComparable: boolean;
+  };
+  expect(run.baselineComparable).toBe(false);
+  expect(run.changeFromBaseline).toBeNull();
+});
+
+it("404s an unknown run", async () => {
+  prismaMock.evaluationRun.findFirst.mockResolvedValue(null);
+  const res = await GET({} as never, params);
+  expect(res.status).toBe(404);
+});

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import {
+  requireAuth,
+  requireProjectAccess,
+  errorResponse,
+  successResponse,
+} from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string; runId: string }> };
+
+// GET — a single evaluation run with its results, scores, and human scores.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, runId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const run = await prisma.evaluationRun.findFirst({
+    where: { id: runId, projectId },
+    include: {
+      evaluation: { select: { name: true } },
+      datasetVersion: { select: { label: true } },
+      baselineRun: {
+        select: {
+          id: true,
+          runNumber: true,
+          candidateVersion: true,
+          mainScore: true,
+          evaluationId: true,
+          datasetVersionId: true,
+          datasetVersion: { select: { label: true } },
+        },
+      },
+      results: {
+        orderBy: { createTime: "asc" },
+        include: {
+          scores: { orderBy: { createTime: "asc" } },
+          humanScores: { orderBy: { createTime: "desc" } },
+        },
+      },
+    },
+  });
+  if (!run) return errorResponse("Evaluation run not found", 404);
+
+  const dataset = await prisma.dataset.findFirst({
+    where: { id: run.datasetId, projectId },
+    select: { id: true, name: true },
+  });
+
+  // Baseline delta only when the two runs measured the identical population.
+  const baseline = run.baselineRun;
+  const comparable =
+    !!baseline &&
+    baseline.evaluationId === run.evaluationId &&
+    baseline.datasetVersionId === run.datasetVersionId;
+  const changeFromBaseline =
+    comparable && run.mainScore !== null && baseline!.mainScore !== null
+      ? run.mainScore - baseline!.mainScore
+      : null;
+
+  const { results, ...runFields } = run;
+  return successResponse({
+    run: {
+      ...runFields,
+      evaluationName: run.evaluation.name,
+      datasetName: dataset?.name ?? null,
+      datasetVersionLabel: run.datasetVersion.label,
+      changeFromBaseline,
+      baselineComparable: comparable,
+      errorCount: run.taskErrorCount + run.scorerErrorCount,
+    },
+    results,
+  });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string }> };
+
+/** Delta vs baseline only when the two runs measured the identical population. */
+function changeFromBaseline(
+  run: { mainScore: number | null; evaluationId: string; datasetVersionId: string },
+  baseline: { mainScore: number | null; evaluationId: string; datasetVersionId: string } | null,
+): number | null {
+  if (!baseline || run.mainScore === null || baseline.mainScore === null) return null;
+  if (
+    baseline.evaluationId !== run.evaluationId ||
+    baseline.datasetVersionId !== run.datasetVersionId
+  ) {
+    return null; // incompatible snapshot — no delta
+  }
+  return run.mainScore - baseline.mainScore;
+}
+
+// GET — evaluation runs (executions) for the project. Filters: evaluation_id,
+// dataset_id, status, search_query.
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const { searchParams } = req.nextUrl;
+  const rawLimit = parseInt(searchParams.get("limit") ?? "50", 10);
+  const rawPage = parseInt(searchParams.get("page") ?? "0", 10);
+  const limit = isNaN(rawLimit) ? 50 : Math.min(Math.max(rawLimit, 1), 200);
+  const page = isNaN(rawPage) ? 0 : Math.max(rawPage, 0);
+  const evaluationId = searchParams.get("evaluation_id")?.trim() || null;
+  const datasetId = searchParams.get("dataset_id")?.trim() || null;
+  const status = searchParams.get("status")?.trim() || null;
+  const searchQuery = searchParams.get("search_query")?.trim() || null;
+
+  const where = {
+    projectId,
+    ...(evaluationId ? { evaluationId } : {}),
+    ...(datasetId ? { datasetId } : {}),
+    ...(status ? { status } : {}),
+    ...(searchQuery
+      ? {
+          OR: [
+            { candidateVersion: { contains: searchQuery, mode: "insensitive" as const } },
+            { evaluation: { name: { contains: searchQuery, mode: "insensitive" as const } } },
+          ],
+        }
+      : {}),
+  };
+
+  const [runs, total] = await prisma.$transaction([
+    prisma.evaluationRun.findMany({
+      where,
+      orderBy: { startedAt: "desc" },
+      skip: page * limit,
+      take: limit,
+      include: {
+        evaluation: { select: { name: true } },
+        datasetVersion: { select: { label: true } },
+        baselineRun: {
+          select: { mainScore: true, evaluationId: true, datasetVersionId: true },
+        },
+      },
+    }),
+    prisma.evaluationRun.count({ where }),
+  ]);
+
+  const datasetIds = [...new Set(runs.map((r) => r.datasetId))];
+  const datasets =
+    datasetIds.length > 0
+      ? await prisma.dataset.findMany({
+          where: { id: { in: datasetIds }, projectId },
+          select: { id: true, name: true },
+        })
+      : [];
+  const datasetName = new Map(datasets.map((d) => [d.id, d.name]));
+
+  const data = runs.map((r) => ({
+    ...r,
+    evaluationName: r.evaluation.name,
+    datasetName: datasetName.get(r.datasetId) ?? null,
+    datasetVersionLabel: r.datasetVersion.label,
+    changeFromBaseline: changeFromBaseline(r, r.baselineRun),
+    errorCount: r.taskErrorCount + r.scorerErrorCount,
+  }));
+
+  return successResponse({ data, meta: { page, limit, total } });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/evaluation-results/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/evaluation-results/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string; traceId: string }> };
+
+// GET — evaluation results produced by this trace (trace → evaluation linkage).
+// Mirrors the detector-findings-by-trace pattern; surfaced as an Evaluation tab/
+// badge in the trace panel. Read from Postgres, so it works without ClickHouse.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, traceId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const results = await prisma.evaluationResult.findMany({
+    where: { projectId, traceId },
+    orderBy: { createTime: "desc" },
+    include: {
+      scores: { orderBy: { createTime: "asc" } },
+      run: {
+        select: {
+          id: true,
+          runNumber: true,
+          candidateVersion: true,
+          datasetId: true,
+          datasetVersionId: true,
+          evaluation: { select: { id: true, name: true } },
+          datasetVersion: { select: { label: true } },
+        },
+      },
+    },
+  });
+
+  return successResponse({ data: results });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/test-cases/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/test-cases/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest } from "next/server";
+import { prisma } from "@traceroot/core";
+import { requireAuth, requireProjectAccess, successResponse } from "@/lib/auth-helpers";
+
+type RouteParams = { params: Promise<{ projectId: string; traceId: string }> };
+
+// GET — dataset test cases captured from this trace (span → dataset linkage).
+// Powers the "In <dataset>" chip on a span in the trace panel: it marks spans
+// that have already been saved as a test case. Only the dataset's CURRENT
+// version is reported, so an edited case shows its dataset once, not once per
+// historical snapshot. Read from Postgres, so it works without ClickHouse.
+export async function GET(_req: NextRequest, { params }: RouteParams) {
+  const authResult = await requireAuth();
+  if (authResult.error) return authResult.error;
+  const { projectId, traceId } = await params;
+  const accessResult = await requireProjectAccess(authResult.user.id, projectId);
+  if (accessResult.error) return accessResult.error;
+
+  const cases = await prisma.testCase.findMany({
+    where: { projectId, sourceTraceId: traceId },
+    select: {
+      testCaseId: true,
+      datasetId: true,
+      datasetVersionId: true,
+      sourceSpanId: true,
+      review: true,
+      version: {
+        select: { dataset: { select: { name: true, currentVersionId: true } } },
+      },
+    },
+  });
+
+  const data = cases
+    // Keep only cases that live in their dataset's current version.
+    .filter((c) => c.datasetVersionId === c.version.dataset.currentVersionId)
+    .map((c) => ({
+      testCaseId: c.testCaseId,
+      datasetId: c.datasetId,
+      datasetName: c.version.dataset.name,
+      sourceSpanId: c.sourceSpanId,
+      review: c.review,
+    }));
+
+  return successResponse({ data });
+}

--- a/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/test-cases/route.ts
+++ b/frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/test-cases/route.ts
@@ -25,7 +25,11 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       sourceSpanId: true,
       review: true,
       version: {
-        select: { dataset: { select: { name: true, currentVersionId: true } } },
+        select: {
+          label: true,
+          _count: { select: { testCases: true } },
+          dataset: { select: { name: true, currentVersionId: true, updateTime: true } },
+        },
       },
     },
   });
@@ -39,6 +43,9 @@ export async function GET(_req: NextRequest, { params }: RouteParams) {
       datasetName: c.version.dataset.name,
       sourceSpanId: c.sourceSpanId,
       review: c.review,
+      datasetVersionLabel: c.version.label,
+      datasetUpdatedAt: c.version.dataset.updateTime.toISOString(),
+      caseCount: c.version._count.testCases,
     }));
 
   return successResponse({ data });

--- a/frontend/ui/src/app/api/public/dataset-versions/[versionId]/route.ts
+++ b/frontend/ui/src/app/api/public/dataset-versions/[versionId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@traceroot/core";
 import { requireApiKeyProject } from "@/lib/eval/auth";
+import { decodeJsonValue } from "@/lib/eval/json-value";
 
 type RouteParams = { params: Promise<{ versionId: string }> };
 
@@ -23,10 +24,12 @@ export async function GET(request: Request, { params }: RouteParams) {
     dataset_id: version.datasetId,
     version_number: version.versionNumber,
     label: version.label,
+    // input/expected are returned as NATIVE JSON values (decoded from the stored
+    // JSON-encoded text). Legacy plain-text rows fall back to the raw string.
     items: version.testCases.map((t) => ({
       test_case_id: t.testCaseId,
-      input: t.input,
-      expected: t.expected,
+      input: decodeJsonValue(t.input),
+      expected: t.expected === null ? null : decodeJsonValue(t.expected),
       metadata: t.metadata,
       source_trace_id: t.sourceTraceId,
       source_span_id: t.sourceSpanId,

--- a/frontend/ui/src/app/api/public/dataset-versions/[versionId]/route.ts
+++ b/frontend/ui/src/app/api/public/dataset-versions/[versionId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { prisma } from "@traceroot/core";
 import { requireApiKeyProject } from "@/lib/eval/auth";
 import { decodeJsonValue } from "@/lib/eval/json-value";
+import { TEST_CASE_ORDER } from "@/lib/eval/versions";
 
 type RouteParams = { params: Promise<{ versionId: string }> };
 
@@ -15,13 +16,21 @@ export async function GET(request: Request, { params }: RouteParams) {
 
   const version = await prisma.datasetVersion.findFirst({
     where: { id: versionId, projectId },
-    include: { testCases: { orderBy: { createTime: "asc" } } },
+    include: {
+      dataset: { select: { clientDatasetId: true } },
+      // Pulling the same version twice must yield the same order. create_time
+      // alone does not: Postgres' CURRENT_TIMESTAMP default is the transaction
+      // start time, so every case a publish writes shares one value, and among
+      // ties the row order is whatever the plan happens to produce. testCaseId
+      // is unique within a version, so it makes the order total.
+      testCases: { orderBy: TEST_CASE_ORDER },
+    },
   });
   if (!version) return NextResponse.json({ error: "Dataset version not found" }, { status: 404 });
 
   return NextResponse.json({
     dataset_version_id: version.id,
-    dataset_id: version.datasetId,
+    dataset_id: version.dataset.clientDatasetId ?? version.datasetId,
     version_number: version.versionNumber,
     label: version.label,
     // input/expected are returned as NATIVE JSON values (decoded from the stored

--- a/frontend/ui/src/app/api/public/dataset-versions/[versionId]/route.ts
+++ b/frontend/ui/src/app/api/public/dataset-versions/[versionId]/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@traceroot/core";
+import { requireApiKeyProject } from "@/lib/eval/auth";
+
+type RouteParams = { params: Promise<{ versionId: string }> };
+
+// GET /api/public/dataset-versions/[versionId] — SDK fetches the immutable
+// snapshot it will run against: the version plus its test-case items.
+export async function GET(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { versionId } = await params;
+
+  const version = await prisma.datasetVersion.findFirst({
+    where: { id: versionId, projectId },
+    include: { testCases: { orderBy: { createTime: "asc" } } },
+  });
+  if (!version) return NextResponse.json({ error: "Dataset version not found" }, { status: 404 });
+
+  return NextResponse.json({
+    dataset_version_id: version.id,
+    dataset_id: version.datasetId,
+    version_number: version.versionNumber,
+    label: version.label,
+    items: version.testCases.map((t) => ({
+      test_case_id: t.testCaseId,
+      input: t.input,
+      expected: t.expected,
+      metadata: t.metadata,
+      source_trace_id: t.sourceTraceId,
+      source_span_id: t.sourceSpanId,
+    })),
+  });
+}

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { prisma, Prisma, PublicUpdateDatasetRequestSchema } from "@traceroot/core";
+import { prisma } from "@traceroot/core";
 import { requireApiKeyProject } from "@/lib/eval/auth";
 
 type RouteParams = { params: Promise<{ datasetId: string }> };
@@ -23,51 +23,5 @@ export async function GET(request: Request, { params }: RouteParams) {
     name: dataset.name,
     description: dataset.description,
     current_dataset_version_id: dataset.currentVersionId,
-  });
-}
-
-// PATCH /api/public/datasets/[datasetId] — dataset metadata only (A3). Never
-// mutates a published version; publish test-case changes via .../versions.
-export async function PATCH(request: Request, { params }: RouteParams) {
-  const auth = await requireApiKeyProject(request);
-  if (auth.error) return auth.error;
-  const { projectId } = auth;
-  const { datasetId } = await params;
-
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
-  }
-  const parsed = PublicUpdateDatasetRequestSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
-  }
-  const c = parsed.data;
-
-  const existing = await prisma.dataset.findFirst({
-    where: { id: datasetId, projectId },
-    select: { id: true },
-  });
-  if (!existing) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
-
-  const updated = await prisma.dataset.update({
-    where: { id: datasetId },
-    data: {
-      ...(c.name !== undefined ? { name: c.name } : {}),
-      ...(c.description !== undefined ? { description: c.description } : {}),
-      // JsonB: an explicit null clears the column; an object replaces it.
-      ...(c.metadata !== undefined
-        ? { metadata: c.metadata === null ? Prisma.DbNull : (c.metadata as Prisma.InputJsonValue) }
-        : {}),
-    },
-    select: { id: true, name: true, description: true, currentVersionId: true },
-  });
-  return NextResponse.json({
-    dataset_id: updated.id,
-    name: updated.name,
-    description: updated.description,
-    current_dataset_version_id: updated.currentVersionId,
   });
 }

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/route.ts
@@ -1,27 +1,70 @@
 import { NextResponse } from "next/server";
-import { prisma } from "@traceroot/core";
+import { prisma, Prisma, PublicUpdateDatasetRequestSchema } from "@traceroot/core";
 import { requireApiKeyProject } from "@/lib/eval/auth";
+import { resolvePublicDataset } from "@/lib/eval/versions";
 
 type RouteParams = { params: Promise<{ datasetId: string }> };
 
 // GET /api/public/datasets/[datasetId] — SDK fetches a dataset by stable id and
 // learns its current published version to pin (API-key auth, snake_case body).
+// `datasetId` is the SDK's own project-scoped id, so another tenant using the same
+// id reaches its own dataset and never this one.
 export async function GET(request: Request, { params }: RouteParams) {
   const auth = await requireApiKeyProject(request);
   if (auth.error) return auth.error;
   const { projectId } = auth;
   const { datasetId } = await params;
 
-  const dataset = await prisma.dataset.findFirst({
-    where: { id: datasetId, projectId },
-    select: { id: true, name: true, description: true, currentVersionId: true },
-  });
+  const dataset = await resolvePublicDataset(prisma, projectId, datasetId);
   if (!dataset) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
 
   return NextResponse.json({
-    dataset_id: dataset.id,
+    dataset_id: datasetId,
     name: dataset.name,
     description: dataset.description,
     current_dataset_version_id: dataset.currentVersionId,
+  });
+}
+
+// PATCH /api/public/datasets/[datasetId] — dataset metadata only (A3). Never
+// mutates a published version; publish test-case changes via .../versions.
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { datasetId } = await params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = PublicUpdateDatasetRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const c = parsed.data;
+
+  const existing = await resolvePublicDataset(prisma, projectId, datasetId);
+  if (!existing) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
+
+  const updated = await prisma.dataset.update({
+    where: { id: existing.id },
+    data: {
+      ...(c.name !== undefined ? { name: c.name } : {}),
+      ...(c.description !== undefined ? { description: c.description } : {}),
+      // JsonB: an explicit null clears the column; an object replaces it.
+      ...(c.metadata !== undefined
+        ? { metadata: c.metadata === null ? Prisma.DbNull : (c.metadata as Prisma.InputJsonValue) }
+        : {}),
+    },
+    select: { id: true, name: true, description: true, currentVersionId: true },
+  });
+  return NextResponse.json({
+    dataset_id: datasetId,
+    name: updated.name,
+    description: updated.description,
+    current_dataset_version_id: updated.currentVersionId,
   });
 }

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
@@ -11,16 +11,12 @@ import {
   VersionConflict,
   type TestCaseSeed,
 } from "@/lib/eval/versions";
+import { encodeJsonValue } from "@/lib/eval/json-value";
 
 type RouteParams = { params: Promise<{ datasetId: string }> };
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
-
-/** input/expected arrive as any JSON; store as text (non-strings are stringified). */
-function toText(value: unknown): string {
-  return typeof value === "string" ? value : JSON.stringify(value);
-}
 
 // POST /api/public/datasets/[datasetId]/versions — publish ONE immutable version
 // from a batch of test-case changes (A4). One call → one version, atomically.
@@ -72,8 +68,11 @@ export async function POST(request: Request, { params }: RouteParams) {
           const prev = byId.get(ch.test_case_id);
           byId.set(ch.test_case_id, {
             testCaseId: ch.test_case_id,
-            input: ch.input !== undefined ? toText(ch.input) : (prev?.input ?? ""),
-            expected: ch.expected === undefined ? (prev?.expected ?? null) : toText(ch.expected),
+            // Store input/expected JSON-ENCODED so native types (incl. genuine
+            // JSON-looking strings) round-trip on read. See lib/eval/json-value.
+            input: ch.input !== undefined ? encodeJsonValue(ch.input) : (prev?.input ?? ""),
+            expected:
+              ch.expected === undefined ? (prev?.expected ?? null) : encodeJsonValue(ch.expected),
             recordedOutput: prev?.recordedOutput ?? null,
             metadata: ch.metadata !== undefined ? ch.metadata : (prev?.metadata ?? null),
             review: prev?.review ?? "needs_review",

--- a/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts
@@ -3,15 +3,20 @@ import {
   prisma,
   PublishDatasetVersionRequestSchema,
   DATASET_VERSION_MAX_CHANGES,
+  DATASET_VERSION_MAX_BYTES,
+  serializedByteLength,
 } from "@traceroot/core";
 import { requireApiKeyProject } from "@/lib/eval/auth";
 import {
   publishDatasetVersion,
+  resolvePublicDataset,
   DatasetNotFound,
   VersionConflict,
   type TestCaseSeed,
 } from "@/lib/eval/versions";
 import { encodeJsonValue } from "@/lib/eval/json-value";
+import { readLimitedJson } from "@/lib/eval/body";
+import { isPrismaKnownError, prismaErrorTarget } from "@/lib/eval/prisma-errors";
 
 type RouteParams = { params: Promise<{ datasetId: string }> };
 
@@ -28,13 +33,19 @@ export async function POST(request: Request, { params }: RouteParams) {
   const { projectId } = auth;
   const { datasetId } = await params;
 
-  let body: unknown;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  // Bound the body on the wire, BEFORE it is buffered and parsed: a count cap
+  // cannot stop 1000 changes each carrying a multi-megabyte `input`, and by the
+  // time a parsed payload could be measured it is already resident in memory.
+  const body = await readLimitedJson(request, DATASET_VERSION_MAX_BYTES);
+  if (!body.ok) {
+    return NextResponse.json(
+      body.status === 413
+        ? { error: body.error, limit_bytes: DATASET_VERSION_MAX_BYTES }
+        : { error: body.error },
+      { status: body.status },
+    );
   }
-  const parsed = PublishDatasetVersionRequestSchema.safeParse(body);
+  const parsed = PublishDatasetVersionRequestSchema.safeParse(body.value);
   if (!parsed.success) {
     return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
   }
@@ -47,9 +58,28 @@ export async function POST(request: Request, { params }: RouteParams) {
     );
   }
 
+  // Per-value caps live in the contract; this bounds their SUM, which is what the
+  // transaction actually writes.
+  const totalBytes = c.changes.reduce(
+    (sum, ch) =>
+      ch.op !== "upsert"
+        ? sum
+        : sum +
+          serializedByteLength(ch.input) +
+          serializedByteLength(ch.expected) +
+          serializedByteLength(ch.metadata),
+    0,
+  );
+  if (totalBytes > DATASET_VERSION_MAX_BYTES) {
+    return NextResponse.json(
+      { error: "Publish payload too large", limit_bytes: DATASET_VERSION_MAX_BYTES },
+      { status: 413 },
+    );
+  }
+
   try {
     const result = await publishDatasetVersion({
-      datasetId,
+      clientDatasetId: datasetId,
       projectId,
       label: c.label,
       baseVersionId: c.base_version_id,
@@ -115,6 +145,41 @@ export async function POST(request: Request, { params }: RouteParams) {
         { status: 409 },
       );
     }
+    // Backstop for a constraint violation that outlived the retries in
+    // publishDatasetVersion. An SDK that retries on 409 and treats a repeated
+    // 200 as success must never see an opaque 500 here — least of all for an
+    // idempotency key, where a 500 leaves it unable to tell if the publish landed.
+    if (isPrismaKnownError(err, "P2002")) {
+      const dataset = await resolvePublicDataset(prisma, projectId, datasetId);
+      const target = prismaErrorTarget(err);
+      if (dataset && c.idempotency_key && target.includes("idempotency")) {
+        const landed = await prisma.datasetVersion.findFirst({
+          where: { datasetId: dataset.id, idempotencyKey: c.idempotency_key },
+          select: { id: true, versionNumber: true },
+        });
+        if (landed) {
+          return NextResponse.json(
+            {
+              dataset_id: datasetId,
+              dataset_version_id: landed.id,
+              version_number: landed.versionNumber,
+              case_count: await prisma.testCase.count({
+                where: { datasetVersionId: landed.id },
+              }),
+            },
+            { status: 200 },
+          );
+        }
+      }
+      return NextResponse.json(
+        {
+          error: "conflict",
+          base_version_id: c.base_version_id,
+          current_version_id: dataset?.currentVersionId ?? null,
+        },
+        { status: 409 },
+      );
+    }
     throw err;
   }
 }
@@ -127,10 +192,7 @@ export async function GET(request: Request, { params }: RouteParams) {
   const { projectId } = auth;
   const { datasetId } = await params;
 
-  const dataset = await prisma.dataset.findFirst({
-    where: { id: datasetId, projectId },
-    select: { id: true, currentVersionId: true },
-  });
+  const dataset = await resolvePublicDataset(prisma, projectId, datasetId);
   if (!dataset) return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
 
   const url = new URL(request.url);
@@ -142,7 +204,7 @@ export async function GET(request: Request, { params }: RouteParams) {
   const cursor = url.searchParams.get("cursor");
 
   const rows = await prisma.datasetVersion.findMany({
-    where: { datasetId, projectId },
+    where: { datasetId: dataset.id, projectId },
     orderBy: { versionNumber: "desc" },
     take: limit + 1,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),

--- a/frontend/ui/src/app/api/public/datasets/route.ts
+++ b/frontend/ui/src/app/api/public/datasets/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma, type Prisma, PublicUpsertDatasetRequestSchema } from "@traceroot/core";
 import { requireApiKeyProject } from "@/lib/eval/auth";
+import { isPrismaKnownError } from "@/lib/eval/prisma-errors";
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
@@ -31,14 +32,23 @@ export async function GET(request: Request) {
     orderBy: { id: "desc" },
     take: limit + 1,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
-    select: { id: true, name: true, description: true, currentVersionId: true, updateTime: true },
+    select: {
+      id: true,
+      clientDatasetId: true,
+      name: true,
+      description: true,
+      currentVersionId: true,
+      updateTime: true,
+    },
   });
 
   const hasMore = rows.length > limit;
   const page = hasMore ? rows.slice(0, limit) : rows;
   return NextResponse.json({
     datasets: page.map((d) => ({
-      dataset_id: d.id,
+      // The id the SDK addresses this dataset by: its own, or the row id for a
+      // dataset created in the UI. next_cursor stays an opaque row id.
+      dataset_id: d.clientDatasetId ?? d.id,
       name: d.name,
       description: d.description,
       current_dataset_version_id: d.currentVersionId,
@@ -51,7 +61,13 @@ export async function GET(request: Request) {
 // POST /api/public/datasets — upsert a dataset by its client-generated id (A2).
 // Idempotent within the project: re-sending the same dataset_id returns the
 // existing dataset (200) without creating a duplicate; a version is never created
-// here (see .../versions). An id owned by another project is 404 (not disclosed).
+// here (see .../versions).
+//
+// The client id is stored in `clientDatasetId`, unique per project — NOT as the
+// primary key. As a global PK one tenant could POST a handful of plausible names
+// ("prod-eval", "golden-set") and permanently block every other tenant from
+// creating them. Scoped to the project, two tenants can each own "prod-eval" and
+// neither can observe the other's.
 export async function POST(request: Request) {
   const auth = await requireApiKeyProject(request);
   if (auth.error) return auth.error;
@@ -69,17 +85,17 @@ export async function POST(request: Request) {
   }
   const c = parsed.data;
 
+  const key = { projectId, clientDatasetId: c.dataset_id };
+  const select = { id: true, name: true, description: true, currentVersionId: true };
+
   const existing = await prisma.dataset.findUnique({
-    where: { id: c.dataset_id },
-    select: { id: true, projectId: true, name: true, description: true, currentVersionId: true },
+    where: { projectId_clientDatasetId: key },
+    select,
   });
   if (existing) {
-    if (existing.projectId !== projectId) {
-      return NextResponse.json({ error: "Dataset not found" }, { status: 404 });
-    }
     return NextResponse.json(
       {
-        dataset_id: existing.id,
+        dataset_id: c.dataset_id,
         name: existing.name,
         description: existing.description,
         current_dataset_version_id: existing.currentVersionId,
@@ -88,23 +104,42 @@ export async function POST(request: Request) {
     );
   }
 
-  const created = await prisma.dataset.create({
-    data: {
-      id: c.dataset_id,
-      projectId,
-      name: c.name,
-      description: c.description ?? null,
-      metadata: (c.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
-    },
-    select: { id: true, name: true, description: true, currentVersionId: true },
-  });
-  return NextResponse.json(
-    {
-      dataset_id: created.id,
-      name: created.name,
-      description: created.description,
-      current_dataset_version_id: created.currentVersionId,
-    },
-    { status: 201 },
-  );
+  try {
+    const created = await prisma.dataset.create({
+      data: {
+        ...key,
+        name: c.name,
+        description: c.description ?? null,
+        metadata: (c.metadata ?? undefined) as Prisma.InputJsonValue | undefined,
+      },
+      select,
+    });
+    return NextResponse.json(
+      {
+        dataset_id: c.dataset_id,
+        name: created.name,
+        description: created.description,
+        current_dataset_version_id: created.currentVersionId,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    // Two first-time upserts of the same id raced: uq_dataset_project_client_id
+    // rejected the loser. Re-read and answer as the idempotent 200 this promises.
+    if (!isPrismaKnownError(err, "P2002")) throw err;
+    const raced = await prisma.dataset.findUnique({
+      where: { projectId_clientDatasetId: key },
+      select,
+    });
+    if (!raced) throw err;
+    return NextResponse.json(
+      {
+        dataset_id: c.dataset_id,
+        name: raced.name,
+        description: raced.description,
+        current_dataset_version_id: raced.currentVersionId,
+      },
+      { status: 200 },
+    );
+  }
 }

--- a/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts
@@ -143,7 +143,8 @@ describe("A4: publish an immutable version from changes", () => {
     const v2 = body2.dataset_version_id as string;
     const v2Cases = fakePrisma.testCase.rows.filter((c) => c.datasetVersionId === v2);
     expect(v2Cases.map((c) => c.testCaseId).sort()).toEqual(["tc_1", "tc_3"]);
-    expect(v2Cases.find((c) => c.testCaseId === "tc_1")!.expected).toBe("refunds");
+    // Stored JSON-encoded (a genuine string is quoted); decodes back to "refunds".
+    expect(v2Cases.find((c) => c.testCaseId === "tc_1")!.expected).toBe('"refunds"');
     // The first version still holds its original two cases (immutable).
     expect(fakePrisma.testCase.rows.filter((c) => c.datasetVersionId === versionId)).toHaveLength(
       2,
@@ -192,6 +193,33 @@ describe("A4: publish an immutable version from changes", () => {
     const res = await publishVersion(req({ base_version_id: null, changes }), dsParams("ds1"));
     expect(res.status).toBe(413);
     expect((await readJson(res)).limit).toBe(1000);
+  });
+
+  it("stores input/expected JSON-encoded so native types round-trip (real SDK payloads)", async () => {
+    // The SDK sends native JSON values; the backend must not lose type info. A genuine
+    // JSON-looking string must be stored quoted so it is distinguishable from the value.
+    await publishVersion(
+      req({
+        base_version_id: null,
+        changes: [
+          { op: "upsert", test_case_id: "tc_obj", input: { a: 1, b: [2, 3] } },
+          { op: "upsert", test_case_id: "tc_num", input: 42 },
+          { op: "upsert", test_case_id: "tc_bool", input: true },
+          { op: "upsert", test_case_id: "tc_str", input: "hello" },
+          { op: "upsert", test_case_id: "tc_jsonstr", input: "123", expected: "true" },
+        ],
+      }),
+      dsParams("ds1"),
+    );
+    const stored = (id: string) =>
+      fakePrisma.testCase.rows.filter((c) => c.testCaseId === id).at(-1);
+    expect(stored("tc_obj")!.input).toBe('{"a":1,"b":[2,3]}');
+    expect(stored("tc_num")!.input).toBe("42");
+    expect(stored("tc_bool")!.input).toBe("true");
+    // Genuine strings are quoted, so "123"/"hello" never read back as a number/JSON.
+    expect(stored("tc_str")!.input).toBe('"hello"');
+    expect(stored("tc_jsonstr")!.input).toBe('"123"');
+    expect(stored("tc_jsonstr")!.expected).toBe('"true"');
   });
 });
 

--- a/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
@@ -1,5 +1,5 @@
 /**
- * Local SDK contract exerciser (Phase 8).
+ * Local SDK contract exerciser.
  *
  * Drives the real public reporting Route Handlers end to end against an in-memory
  * fake prisma — the smallest thing that simulates what the SDK will eventually
@@ -98,6 +98,13 @@ describe("SDK reporting: full run lifecycle", () => {
     const runId = regBody.evaluation_run_id as string;
     expect(regBody.run_number).toBe(1);
     expect(regBody.dataset_version_id).toBe("dv1");
+    // UI-relative run path (back-compat).
+    expect(regBody.run_path).toBe(`/projects/${PROJECT_ID}/evaluations/${runId}`);
+    // Absolute clickable URL the SDK prints — run_path resolved against the app origin.
+    const appBase = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+    expect(regBody.run_url).toBe(
+      new URL(`/projects/${PROJECT_ID}/evaluations/${runId}`, appBase).toString(),
+    );
     expect(fakePrisma.evaluation.rows).toHaveLength(1);
 
     // Idempotency: same client_run_id returns the same run, no duplicate.

--- a/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
+++ b/frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts
@@ -98,13 +98,6 @@ describe("SDK reporting: full run lifecycle", () => {
     const runId = regBody.evaluation_run_id as string;
     expect(regBody.run_number).toBe(1);
     expect(regBody.dataset_version_id).toBe("dv1");
-    // UI-relative run path (back-compat).
-    expect(regBody.run_path).toBe(`/projects/${PROJECT_ID}/evaluations/${runId}`);
-    // Absolute clickable URL the SDK prints — run_path resolved against the app origin.
-    const appBase = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-    expect(regBody.run_url).toBe(
-      new URL(`/projects/${PROJECT_ID}/evaluations/${runId}`, appBase).toString(),
-    );
     expect(fakePrisma.evaluation.rows).toHaveLength(1);
 
     // Idempotency: same client_run_id returns the same run, no duplicate.

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/complete/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/complete/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { prisma, CompleteRunRequestSchema } from "@traceroot/core";
+import { requireApiKeyProject } from "@/lib/eval/auth";
+
+type RouteParams = { params: Promise<{ runId: string }> };
+
+// POST /api/public/evaluation-runs/[runId]/complete — SDK marks a run
+// completed/completed_with_errors/failed/incomplete with final counts.
+export async function POST(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { runId } = await params;
+
+  const run = await prisma.evaluationRun.findFirst({
+    where: { id: runId, projectId },
+    select: { id: true },
+  });
+  if (!run) return NextResponse.json({ error: "Evaluation run not found" }, { status: 404 });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = CompleteRunRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const c = parsed.data;
+
+  const terminal = c.status !== "running";
+  const updated = await prisma.evaluationRun.update({
+    where: { id: runId },
+    data: {
+      status: c.status,
+      ...(c.main_score !== undefined ? { mainScore: c.main_score } : {}),
+      ...(c.case_count !== undefined && c.case_count !== null ? { caseCount: c.case_count } : {}),
+      ...(c.scored_count !== undefined && c.scored_count !== null
+        ? { scoredCount: c.scored_count }
+        : {}),
+      ...(c.task_error_count !== undefined && c.task_error_count !== null
+        ? { taskErrorCount: c.task_error_count }
+        : {}),
+      ...(c.scorer_error_count !== undefined && c.scorer_error_count !== null
+        ? { scorerErrorCount: c.scorer_error_count }
+        : {}),
+      ...(terminal ? { completedAt: new Date() } : {}),
+    },
+    select: { id: true, status: true },
+  });
+
+  return NextResponse.json({ evaluation_run_id: updated.id, status: updated.status });
+}

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/route.ts
@@ -44,7 +44,10 @@ export async function POST(request: Request, { params }: RouteParams) {
     cost: r.cost ?? null,
     traceId: r.trace_id ?? null,
   };
-  const scoreRows = r.scores.map((s) => ({
+  // `scores` is optional with no default: undefined = leave the result's stored scores
+  // alone (a follow-up that only attaches a trace_id must not wipe them); [] = clear;
+  // a list = replace. Build defensively so an omitted `scores` never `.map`s undefined.
+  const scoreRows = (r.scores ?? []).map((s) => ({
     projectId,
     scorerName: s.scorer_name,
     scorerVersion: s.scorer_version,
@@ -63,11 +66,15 @@ export async function POST(request: Request, { params }: RouteParams) {
     });
     if (existing) {
       await tx.evaluationResult.update({ where: { id: existing.id }, data: resultFields });
-      await tx.score.deleteMany({ where: { resultId: existing.id } });
-      if (scoreRows.length > 0) {
-        await tx.score.createMany({
-          data: scoreRows.map((s) => ({ ...s, resultId: existing.id })),
-        });
+      // Only rewrite scores when the caller actually sent the field — omitting it
+      // leaves the previously-reported scores intact (out-of-order trace linking).
+      if (r.scores !== undefined) {
+        await tx.score.deleteMany({ where: { resultId: existing.id } });
+        if (scoreRows.length > 0) {
+          await tx.score.createMany({
+            data: scoreRows.map((s) => ({ ...s, resultId: existing.id })),
+          });
+        }
       }
       return existing.id;
     }

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/route.ts
@@ -60,38 +60,32 @@ export async function POST(request: Request, { params }: RouteParams) {
   }));
 
   const resultId = await prisma.$transaction(async (tx) => {
-    const existing = await tx.evaluationResult.findFirst({
-      where: { runId, testCaseId: r.test_case_id },
-      select: { id: true },
-    });
-    if (existing) {
-      await tx.evaluationResult.update({ where: { id: existing.id }, data: resultFields });
-      // Only rewrite scores when the caller actually sent the field — omitting it
-      // leaves the previously-reported scores intact (out-of-order trace linking).
-      if (r.scores !== undefined) {
-        await tx.score.deleteMany({ where: { resultId: existing.id } });
-        if (scoreRows.length > 0) {
-          await tx.score.createMany({
-            data: scoreRows.map((s) => ({ ...s, resultId: existing.id })),
-          });
-        }
-      }
-      return existing.id;
-    }
-    const created = await tx.evaluationResult.create({
-      data: {
+    // Atomic upsert on (runId, testCaseId) — a find-then-create let two concurrent
+    // first reports for the same case both pass the existence check and then one 500
+    // on the unique key. INSERT ... ON CONFLICT DO UPDATE serialises them.
+    const result = await tx.evaluationResult.upsert({
+      where: { runId_testCaseId: { runId, testCaseId: r.test_case_id } },
+      create: {
         runId,
         evaluationId: run.evaluationId,
         projectId,
         testCaseId: r.test_case_id,
         ...resultFields,
       },
+      update: resultFields,
       select: { id: true },
     });
-    if (scoreRows.length > 0) {
-      await tx.score.createMany({ data: scoreRows.map((s) => ({ ...s, resultId: created.id })) });
+    // Only rewrite scores when the caller actually sent the field — omitting it leaves
+    // the previously-reported scores intact (out-of-order trace linking).
+    if (r.scores !== undefined) {
+      await tx.score.deleteMany({ where: { resultId: result.id } });
+      if (scoreRows.length > 0) {
+        await tx.score.createMany({
+          data: scoreRows.map((s) => ({ ...s, resultId: result.id })),
+        });
+      }
     }
-    return created.id;
+    return result.id;
   });
 
   return NextResponse.json({ evaluation_result_id: resultId } satisfies UpsertResultResponse, {

--- a/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/route.ts
+++ b/frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { prisma, UpsertResultRequestSchema, type UpsertResultResponse } from "@traceroot/core";
+import { requireApiKeyProject } from "@/lib/eval/auth";
+
+type RouteParams = { params: Promise<{ runId: string }> };
+
+// POST /api/public/evaluation-runs/[runId]/results — SDK upserts one test-case
+// result. Idempotent on (run_id, test_case_id); re-sending replaces the result's
+// scores. trace_id may be null now and set on a later call (out-of-order OK).
+export async function POST(request: Request, { params }: RouteParams) {
+  const auth = await requireApiKeyProject(request);
+  if (auth.error) return auth.error;
+  const { projectId } = auth;
+  const { runId } = await params;
+
+  const run = await prisma.evaluationRun.findFirst({
+    where: { id: runId, projectId },
+    select: { id: true, evaluationId: true },
+  });
+  if (!run) return NextResponse.json({ error: "Evaluation run not found" }, { status: 404 });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const parsed = UpsertResultRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.issues[0].message }, { status: 400 });
+  }
+  const r = parsed.data;
+
+  const resultFields = {
+    input: r.input,
+    expectedOutput: r.expected_output ?? null,
+    candidateOutput: r.candidate_output ?? null,
+    baselineOutput: r.baseline_output ?? null,
+    status: r.status,
+    mainScore: r.main_score ?? null,
+    change: r.change ?? null,
+    taskError: r.task_error ?? null,
+    durationMs: r.duration_ms ?? null,
+    cost: r.cost ?? null,
+    traceId: r.trace_id ?? null,
+  };
+  const scoreRows = r.scores.map((s) => ({
+    projectId,
+    scorerName: s.scorer_name,
+    scorerVersion: s.scorer_version,
+    numericValue: s.numeric_value ?? null,
+    boolValue: s.bool_value ?? null,
+    stringValue: s.string_value ?? null,
+    passed: s.passed ?? null,
+    explanation: s.explanation ?? null,
+    error: s.error ?? null,
+  }));
+
+  const resultId = await prisma.$transaction(async (tx) => {
+    const existing = await tx.evaluationResult.findFirst({
+      where: { runId, testCaseId: r.test_case_id },
+      select: { id: true },
+    });
+    if (existing) {
+      await tx.evaluationResult.update({ where: { id: existing.id }, data: resultFields });
+      await tx.score.deleteMany({ where: { resultId: existing.id } });
+      if (scoreRows.length > 0) {
+        await tx.score.createMany({
+          data: scoreRows.map((s) => ({ ...s, resultId: existing.id })),
+        });
+      }
+      return existing.id;
+    }
+    const created = await tx.evaluationResult.create({
+      data: {
+        runId,
+        evaluationId: run.evaluationId,
+        projectId,
+        testCaseId: r.test_case_id,
+        ...resultFields,
+      },
+      select: { id: true },
+    });
+    if (scoreRows.length > 0) {
+      await tx.score.createMany({ data: scoreRows.map((s) => ({ ...s, resultId: created.id })) });
+    }
+    return created.id;
+  });
+
+  return NextResponse.json({ evaluation_result_id: resultId } satisfies UpsertResultResponse, {
+    status: 200,
+  });
+}

--- a/frontend/ui/src/app/projects/[projectId]/datasets/layout.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/datasets/layout.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ToastProvider } from "@/components/ui/toast";
+
+/**
+ * The real Datasets pages reuse the offline-eval design components (drawers,
+ * panels, case editors) which surface feedback through the toast system. Mount
+ * the provider for this route subtree, scoped so the global provider stack
+ * stays untouched.
+ */
+export default function DatasetsLayout({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/frontend/ui/src/app/projects/[projectId]/evaluations/layout.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/evaluations/layout.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ToastProvider } from "@/components/ui/toast";
+
+/**
+ * The real Evaluations pages reuse the offline-eval design components, which use
+ * the toast system. Mount the provider for this route subtree, scoped so the
+ * global stack is untouched.
+ */
+export default function EvaluationsLayout({ children }: { children: React.ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}

--- a/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
+++ b/frontend/ui/src/app/projects/[projectId]/traces/page.tsx
@@ -29,6 +29,13 @@ import { useListPageState } from "@/lib/hooks/use-list-page-state";
 import { useLocalStorage } from "@/lib/hooks/use-local-storage";
 import { TraceViewerPanel, GettingStarted } from "@/features/traces/components";
 import { LoadingState } from "@/components/ui/loading-state";
+import type { TraceSelection } from "@/features/traces";
+import { Button } from "@/components/ui/button";
+import {
+  SaveTestCaseDrawer,
+  TraceEvaluationChip,
+  SpanDatasetChip,
+} from "@/features/evaluations/components/trace-integration";
 import { formatContentPreview } from "@/features/traces/utils";
 import { useSession as useAuthSession } from "@/lib/auth-client";
 
@@ -70,6 +77,9 @@ export default function TracesPage() {
   } = useListPageState({ retentionDays: retention.retentionDays });
 
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(traceIdFromUrl);
+  // Save-as-test-case (offline eval): which span the drawer targets (undefined = root).
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [saveSpanId, setSaveSpanId] = useState<string | undefined>(undefined);
   // Persisted per-project so a live view survives reloads, navigation, and re-login.
   // Default false: a project the user never toggled behaves exactly as before.
   const [autoRefresh, setAutoRefresh] = useLocalStorage(
@@ -410,6 +420,33 @@ export default function TracesPage() {
           customStartDate={state.customStartDate}
           customEndDate={state.customEndDate}
           initialFullscreen={startFullscreen}
+          // Offline eval: save any span (or the trace root) as a dataset test case.
+          spanHeaderAction={(selection: TraceSelection) => (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 shrink-0 text-[12px]"
+              onClick={() => {
+                setSaveSpanId(selection.type === "span" ? selection.span.span_id : undefined);
+                setSaveOpen(true);
+              }}
+            >
+              Save as test case
+            </Button>
+          )}
+          // Offline eval: a trace-level chip when this trace came from a run, and
+          // a per-span "Dataset:" chip marking a span already saved as a test case.
+          spanExtraTags={(selection: TraceSelection) =>
+            selection.type === "trace" ? (
+              <TraceEvaluationChip projectId={projectId} traceId={selectedTraceId} />
+            ) : (
+              <SpanDatasetChip
+                projectId={projectId}
+                traceId={selectedTraceId}
+                spanId={selection.span.span_id}
+              />
+            )
+          }
           // Customer surface, so state the scope explicitly rather than inheriting it:
           // the reader already defaults to customer traffic, so this is defense in depth,
           // and it also pins the trace-detail cache key this panel shares with the live
@@ -418,6 +455,14 @@ export default function TracesPage() {
           source="user"
         />
       )}
+
+      <SaveTestCaseDrawer
+        projectId={projectId}
+        traceId={selectedTraceId}
+        spanId={saveSpanId}
+        open={saveOpen}
+        onOpenChange={setSaveOpen}
+      />
 
       <PricingDialog
         open={retention.showPricing}

--- a/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
+++ b/frontend/ui/src/features/evaluations/components/dataset-panels.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import * as React from "react";
+import { Check, Copy, Database, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/toast";
+import {
+  DatasetFormFields,
+  emptyDatasetForm,
+  type DatasetFormState,
+} from "@/features/offline-eval/components";
+import { useCreateDataset, useUpdateDataset } from "../hooks";
+
+/**
+ * Server-wired New-dataset and Edit-dataset panels, sharing DatasetFormFields
+ * and persisting through the real hooks with real toasts. The schema/metadata
+ * form cards are illustrative for now (the server persists name + description);
+ * kept visible by design.
+ */
+
+/** "New dataset" — non-modal right slide-in, same shape as Save as test case. */
+export function NewDatasetPanel({
+  projectId,
+  open,
+  onOpenChange,
+}: {
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { toast } = useToast();
+  const create = useCreateDataset(projectId);
+  const [state, setState] = React.useState<DatasetFormState>(emptyDatasetForm());
+
+  React.useEffect(() => {
+    if (open) setState(emptyDatasetForm());
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onOpenChange(false);
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  const canCreate = state.name.trim() !== "";
+  const handleCreate = () => {
+    if (!canCreate) return;
+    create.mutate(
+      { name: state.name.trim(), description: state.description.trim() || null },
+      {
+        onSuccess: () => {
+          toast({ title: "Dataset created", tone: "success" });
+          onOpenChange(false);
+        },
+        onError: (e) =>
+          toast({ title: "Could not create dataset", description: String(e), tone: "warning" }),
+      },
+    );
+  };
+
+  return (
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-[13px] font-semibold">New dataset</h2>
+        <button
+          type="button"
+          onClick={() => onOpenChange(false)}
+          aria-label="Close"
+          className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <DatasetFormFields state={state} onChange={setState} />
+      </div>
+
+      <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-4 py-3">
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-[12px]"
+          onClick={() => onOpenChange(false)}
+        >
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          className="h-7 text-[12px]"
+          onClick={handleCreate}
+          disabled={!canCreate || create.isPending}
+        >
+          {create.isPending ? "Creating…" : "Create dataset"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** "Edit dataset" — right slide-in, modelled on the detector edit panel. */
+export function DatasetEditPanel({
+  projectId,
+  dataset,
+  onClose,
+}: {
+  projectId: string;
+  dataset: { id: string; name: string; description: string | null };
+  onClose: () => void;
+}) {
+  const { toast } = useToast();
+  const update = useUpdateDataset(projectId, dataset.id);
+  const [copied, setCopied] = React.useState(false);
+  const [state, setState] = React.useState<DatasetFormState>(() =>
+    emptyDatasetForm({ name: dataset.name, description: dataset.description ?? "" }),
+  );
+
+  React.useEffect(() => {
+    setState(emptyDatasetForm({ name: dataset.name, description: dataset.description ?? "" }));
+  }, [dataset]);
+
+  const copyId = () => {
+    navigator.clipboard?.writeText(dataset.id);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  const handleSave = () => {
+    update.mutate(
+      { name: state.name.trim(), description: state.description.trim() || null },
+      {
+        onSuccess: () => {
+          toast({ title: "Dataset saved", tone: "success" });
+          onClose();
+        },
+        onError: (e) =>
+          toast({ title: "Could not save dataset", description: String(e), tone: "warning" }),
+      },
+    );
+  };
+
+  return (
+    <div className="animate-slide-in-right fixed bottom-0 right-0 top-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex h-10 flex-shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <span className="text-[13px] font-medium">Dataset</span>
+          <span className="truncate text-[13px] text-muted-foreground">{dataset.name}</span>
+          <button
+            type="button"
+            onClick={copyId}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground/60 transition-colors hover:bg-muted hover:text-muted-foreground"
+            title="Copy dataset ID"
+          >
+            {dataset.id}
+            {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
+          </button>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClose}
+          className="h-7 w-7 p-0"
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4">
+        <DatasetFormFields state={state} onChange={setState} />
+      </div>
+
+      <div className="flex flex-shrink-0 justify-end gap-2 border-t border-border px-4 py-3">
+        <Button variant="outline" size="sm" onClick={onClose} className="h-7 text-[12px]">
+          Cancel
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleSave}
+          className="h-7 text-[12px]"
+          disabled={update.isPending}
+        >
+          {update.isPending ? "Saving…" : "Save"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
+++ b/frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx
@@ -1,0 +1,241 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { FormCard } from "@/features/offline-eval/components";
+import { HighlightedCode } from "@/features/offline-eval/components/syntax";
+import { useDatasets } from "../hooks";
+import type { DatasetRow } from "../types";
+
+/**
+ * "Run evaluation" — a copyable SDK starter snippet (not a form), wired to real
+ * datasets: the snippet references the
+ * selected dataset's real id and current version id. Evaluations run in the
+ * customer's app/CI and report back; this panel configures nothing.
+ */
+
+type Lang = "python" | "typescript";
+
+function snippet(lang: Lang, dataset: DatasetRow | undefined): string {
+  const name = dataset?.name ?? "My dataset";
+  const datasetId = dataset?.id ?? "ds_...";
+  const versionId = dataset?.currentVersionId ?? "dsv_...";
+
+  if (lang === "python") {
+    return `import traceroot
+from traceroot import evaluate, pull_dataset
+
+# 1. Your application. Point this at your own entry point.
+from my_app.support import handle_ticket
+
+# 2. Your scorers. A scorer takes a ScorerContext and returns a Score.
+from evals.scorers import routing_accuracy
+
+# Initialize with your TraceRoot API key so the run is reported and traced.
+traceroot.initialize()
+
+# 3. Pull the dataset this run measures (its current published version).
+#    dataset_id:         ${datasetId}
+#    dataset_version_id: ${versionId}
+dataset = pull_dataset("${datasetId}")
+
+# 4. The task receives EvalCase.input and returns your application's output.
+def run_candidate(ticket):
+    return handle_ticket(ticket)
+
+result = evaluate(
+    name="${name}",
+    data=dataset,
+    task=run_candidate,
+    scorers=[routing_accuracy],
+    candidate_version="git:REPLACE_ME",  # what changed in this run (e.g. a git sha)
+)
+
+print(result.to_dict())`;
+  }
+
+  return `import * as traceroot from "traceroot";
+import { Dataset, evaluate } from "traceroot";
+
+// 1. Your application. Point this at your own entry point.
+import { handleTicket } from "./src/support";
+
+// 2. Your scorers. A scorer takes a ScorerContext and returns a Score.
+import { routingAccuracy } from "./evals/scorers";
+
+traceroot.initialize();
+
+// 3. The dataset this run measures.
+//    datasetId:        ${datasetId}
+//    datasetVersionId: ${versionId}
+const dataset = new Dataset("${name}");
+
+// 4. The task receives EvalCase.input and returns your application's output.
+async function runCandidate(ticket) {
+  return handleTicket(ticket);
+}
+
+const result = await evaluate({
+  name: "${name}",
+  data: dataset,
+  task: runCandidate,
+  scorers: [routingAccuracy],
+});
+
+console.log(result.toJSON());`;
+}
+
+export function RunEvaluationDrawer({
+  projectId,
+  open,
+  onOpenChange,
+  datasetId,
+}: {
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Prefills and hides the picker when opened from a dataset. */
+  datasetId?: string;
+}) {
+  const { data } = useDatasets(projectId, { limit: 200 });
+  const datasets = data?.data ?? [];
+  const [lang, setLang] = React.useState<Lang>("python");
+  const [chosen, setChosen] = React.useState(datasetId ?? "");
+
+  React.useEffect(() => {
+    if (open) setChosen(datasetId ?? datasets[0]?.id ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, datasetId]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onOpenChange(false);
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  const dataset = datasets.find((d) => d.id === chosen);
+  const code = snippet(lang, dataset);
+
+  return (
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex shrink-0 items-start justify-between gap-2 border-b border-border px-4 py-3">
+        <div>
+          <h2 className="text-[13px] font-semibold">Copy starter code</h2>
+          <p className="mt-1 text-[12px] leading-relaxed text-muted-foreground">
+            The evaluation runs in your application or CI environment. Its results are reported back
+            to TraceRoot and appear on this page.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => onOpenChange(false)}
+          aria-label="Close"
+          className="mt-0.5 rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto px-4 pb-6 pt-3 text-[12px]">
+        <FormCard label="Dataset">
+          {datasetId ? (
+            <p className="text-[13px] font-medium">{dataset?.name ?? chosen}</p>
+          ) : (
+            <Select value={chosen} onValueChange={setChosen}>
+              <SelectTrigger className="h-7 text-[13px]">
+                <SelectValue placeholder={datasets.length ? "Select dataset" : "No datasets yet"} />
+              </SelectTrigger>
+              <SelectContent>
+                {datasets.map((item) => (
+                  <SelectItem key={item.id} value={item.id} className="text-[12px]">
+                    {item.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        </FormCard>
+
+        <div className="overflow-hidden rounded border border-border">
+          <div className="flex items-center justify-between border-b border-border bg-muted/50 px-1.5 py-1">
+            <div className="flex items-center gap-0.5">
+              {(["python", "typescript"] as Lang[]).map((l) => (
+                <button
+                  key={l}
+                  type="button"
+                  onClick={() => setLang(l)}
+                  className={cn(
+                    "rounded px-1.5 py-0.5 text-xs font-medium transition-colors",
+                    lang === l
+                      ? "bg-background text-foreground shadow-sm"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {l === "python" ? "Python" : "TypeScript"}
+                </button>
+              ))}
+            </div>
+            <CopyButton
+              value={code}
+              className="h-6 w-6 text-muted-foreground hover:text-foreground"
+              title="Copy"
+            />
+          </div>
+          {/* Self-contained scroll box: the code scrolls WITHIN a bounded height
+              (independent of the drawer body's scroll), and pb-6 keeps the last line
+              clear of the horizontal scrollbar at the pre's bottom edge. */}
+          <HighlightedCode
+            code={code}
+            className="max-h-[55vh] overflow-auto whitespace-pre px-3 pb-6 pt-2.5 font-mono text-[11px] leading-relaxed"
+          />
+        </div>
+
+        <div className="border border-border">
+          <div className="border-b border-border bg-muted/50 px-3 py-1.5">
+            <span className="text-[12px] font-medium text-muted-foreground">
+              Change these for your application
+            </span>
+          </div>
+          <ul className="flex list-disc flex-col gap-1 py-2 pl-7 pr-3 text-[11px] leading-relaxed text-muted-foreground">
+            <li>Import the function that runs your application.</li>
+            <li>Map the test-case input into that function.</li>
+            <li>Import or define the scorers you want to use.</li>
+          </ul>
+          <p className="border-t border-border px-3 py-2 text-[11px] leading-relaxed text-muted-foreground">
+            The dataset id and snapshot id are already filled in.
+          </p>
+        </div>
+
+        <p className="text-[11px] leading-relaxed text-muted-foreground">
+          The task function and the scorers stay in your code. TraceRoot records the run, its
+          results, and the traces they produced.
+        </p>
+      </div>
+
+      <div className="flex shrink-0 items-center justify-between gap-2 border-t border-border px-4 py-3">
+        <span className="text-[11px] text-muted-foreground">Nothing runs from this panel.</span>
+        <Button size="sm" className="h-7 text-[12px]" onClick={() => onOpenChange(false)}>
+          Done
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -14,6 +14,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
 import { getTrace } from "@/lib/api/traces";
 import { SpanKindIcon, useSpanIO } from "@/features/traces";
@@ -21,7 +23,9 @@ import {
   FormCard,
   EditableValueBlock,
   LineNumberedTextarea,
+  Timestamp,
 } from "@/features/offline-eval/components";
+import { datasetInitCode, datasetInitCodeTs } from "@/features/offline-eval/utils";
 import {
   CAPTURE_REASON_LABEL,
   SPAN_KIND_LABEL,
@@ -540,11 +544,45 @@ export function TraceEvaluationChip({
   );
 }
 
+/** Small SDK-snippet card with a Python / TypeScript toggle (one shown at a time). */
+function DatasetSdkSnippet({ datasetName }: { datasetName: string }) {
+  const [lang, setLang] = React.useState<"python" | "typescript">("python");
+  const code = lang === "python" ? datasetInitCode(datasetName) : datasetInitCodeTs(datasetName);
+  return (
+    <div className="overflow-hidden rounded border border-border">
+      <div className="flex items-center justify-between border-b border-border bg-muted/50 px-1.5 py-1">
+        <div className="flex items-center gap-0.5">
+          {(["python", "typescript"] as const).map((l) => (
+            <button
+              key={l}
+              type="button"
+              onClick={() => setLang(l)}
+              className={cn(
+                "rounded px-1.5 py-0.5 text-xs font-medium transition-colors",
+                lang === l
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {l === "python" ? "Python" : "TypeScript"}
+            </button>
+          ))}
+        </div>
+        <CopyButton value={code} className="h-6 w-6" iconClassName="h-3.5 w-3.5" title="Copy" />
+      </div>
+      <pre className="max-h-48 overflow-auto whitespace-pre px-2.5 py-2 font-mono text-xs leading-relaxed">
+        {code}
+      </pre>
+    </div>
+  );
+}
+
 /**
  * "Dataset:" chip shown on a span that already backs a test case — the trace-
  * viewer marker for a span that's been saved to a dataset. Renders one chip per
- * dataset the span belongs to (current version only), each linking to it, or
- * nothing when the span isn't a saved case.
+ * dataset the span belongs to (current version only), each linking to it, with a
+ * hover card carrying the dataset's version, last-updated, case count, and a
+ * copyable SDK snippet. Nothing renders when the span isn't a saved case.
  */
 export function SpanDatasetChip({
   projectId,
@@ -559,19 +597,42 @@ export function SpanDatasetChip({
   const matches = (data?.data ?? []).filter((c) => c.sourceSpanId === spanId);
   if (matches.length === 0) return null;
   return (
-    <>
+    <TooltipProvider delayDuration={150}>
       {matches.map((c) => (
-        <Link
-          key={`${c.datasetId}:${c.testCaseId}`}
-          href={`/projects/${projectId}/datasets/${c.datasetId}`}
-          className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors hover:bg-muted"
-          title={`In dataset ${c.datasetName}`}
-        >
-          <Database className="h-3 w-3 text-muted-foreground" aria-hidden />
-          <span className="text-muted-foreground">Dataset:</span>
-          <span className="font-medium">{c.datasetName}</span>
-        </Link>
+        <Tooltip key={`${c.datasetId}:${c.testCaseId}`}>
+          <TooltipTrigger asChild>
+            <Link
+              href={`/projects/${projectId}/datasets/${c.datasetId}`}
+              className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors hover:bg-muted"
+              title={`In dataset ${c.datasetName}`}
+            >
+              <Database className="h-3 w-3 text-muted-foreground" aria-hidden />
+              <span className="text-muted-foreground">Dataset:</span>
+              <span className="font-medium">{c.datasetName}</span>
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent
+            align="start"
+            className="w-[540px] max-w-[92vw] border bg-popover px-3 pb-2 pt-3 text-xs text-popover-foreground shadow-md"
+          >
+            <div className="mb-2">
+              <div className="font-semibold">{c.datasetName}</div>
+              <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-0.5 text-muted-foreground">
+                <span>
+                  Version <span className="font-mono">{c.datasetVersionLabel}</span>
+                </span>
+                <span className="inline-flex items-center gap-1">
+                  Updated <Timestamp iso={c.datasetUpdatedAt} />
+                </span>
+                <span>
+                  {c.caseCount} {c.caseCount === 1 ? "case" : "cases"}
+                </span>
+              </div>
+            </div>
+            <DatasetSdkSnippet datasetName={c.datasetName} />
+          </TooltipContent>
+        </Tooltip>
       ))}
-    </>
+    </TooltipProvider>
   );
 }

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -1,0 +1,577 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { ArrowDown, ArrowUp, ArrowUpRight, Database, Info, Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { getTrace } from "@/lib/api/traces";
+import { SpanKindIcon, useSpanIO } from "@/features/traces";
+import {
+  FormCard,
+  EditableValueBlock,
+  LineNumberedTextarea,
+} from "@/features/offline-eval/components";
+import {
+  CAPTURE_REASON_LABEL,
+  SPAN_KIND_LABEL,
+  type CaptureReason,
+} from "@/features/offline-eval/types";
+import type { Span } from "@/types/api";
+import {
+  useDatasets,
+  useCreateDataset,
+  useTraceEvaluationResults,
+  useTraceTestCases,
+} from "../hooks";
+
+/** Sentinel dataset-select value for "create a new dataset". */
+const NEW_DATASET = "__new__";
+
+/** How the optional expected outcome is set for a captured case. */
+type ExpectedMode = "none" | "recorded" | "corrected";
+
+/** Root = the span with no parent (the application / evaluation-item root). */
+function rootSpan(spans: Span[]): Span | undefined {
+  return spans.find((s) => !s.parent_span_id) ?? spans[0];
+}
+
+/** Pretty-print JSON so metadata shows expanded and indented; leave other text. */
+function prettyJson(raw: string | null | undefined): string {
+  if (!raw) return "";
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
+/** One short line explaining what a case sourced from this span actually tests. */
+function boundaryHint(displayKind: string, spanName: string): string {
+  const name = spanName.toLowerCase();
+  if (displayKind === "trace" || displayKind === "AGENT")
+    return "This tests the application from this input.";
+  if (displayKind === "LLM") return "This tests this model or prompt step.";
+  if (displayKind === "TOOL")
+    return "This tests the tool using these arguments. To test whether the agent selected the correct tool, choose its parent agent or LLM span.";
+  if (/retriev|search|recall|policy|vector|embed/.test(name))
+    return "This tests retrieval from this query.";
+  return "This tests this step from its input.";
+}
+
+/**
+ * "Save as test case" — a faithful port of the approved mock drawer, wired to the
+ * server. Opened from the existing trace viewer's span header. Self-contained: it
+ * fetches the trace, walks its spans (up/down), lets you pick or create a
+ * dataset, and persists via the server (which publishes a new dataset version).
+ * The span's input becomes the proposed test input; its output is shown read-only
+ * ("Recorded output") and is never treated as the expected answer.
+ */
+export function SaveTestCaseDrawer({
+  projectId,
+  traceId,
+  spanId,
+  open,
+  onOpenChange,
+}: {
+  projectId: string;
+  traceId: string | null;
+  /** Initial span; undefined = the trace root / application scope. */
+  spanId?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const qc = useQueryClient();
+  const { data: datasetsData } = useDatasets(projectId, { limit: 200 });
+  const datasets = datasetsData?.data ?? [];
+
+  const { data: trace } = useQuery({
+    queryKey: ["trace", projectId, traceId],
+    queryFn: () => getTrace(projectId, traceId as string, ""),
+    enabled: open && !!traceId,
+  });
+
+  const [datasetId, setDatasetId] = React.useState("");
+  const [newDatasetName, setNewDatasetName] = React.useState("");
+  const [selectedSpanId, setSelectedSpanId] = React.useState<string | undefined>(spanId);
+  const [input, setInput] = React.useState("");
+  const [metadata, setMetadata] = React.useState("");
+  const [attachSource, setAttachSource] = React.useState(true);
+  const [expectedMode, setExpectedMode] = React.useState<ExpectedMode>("none");
+  const [correctedExpected, setCorrectedExpected] = React.useState("");
+  const [duplicate, setDuplicate] = React.useState<{ datasetId: string } | null>(null);
+  const [feedback, setFeedback] = React.useState<{
+    tone: "error" | "success";
+    text: string;
+  } | null>(null);
+
+  // Reset the dataset choice and toggles only when the panel opens, so the
+  // selected dataset persists while walking between spans with up/down.
+  React.useEffect(() => {
+    if (open) {
+      setDatasetId("");
+      setNewDatasetName("");
+      setSelectedSpanId(spanId);
+      setAttachSource(true);
+      setExpectedMode("none");
+      setCorrectedExpected("");
+      setDuplicate(null);
+      setFeedback(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const spans = React.useMemo(() => trace?.spans ?? [], [trace]);
+  const root = trace ? rootSpan(spans) : undefined;
+  const span = React.useMemo(() => {
+    if (!trace) return undefined;
+    return selectedSpanId ? spans.find((s) => s.span_id === selectedSpanId) : root;
+  }, [trace, selectedSpanId, spans, root]);
+  const isRoot = !!span && !span.parent_span_id;
+
+  // The trace-detail response OMITS span input/output/metadata — they are fetched
+  // per span on demand (getSpanIO), so read them from that hook, not the span.
+  const { data: spanIO } = useSpanIO(projectId, traceId ?? "", span?.span_id ?? null);
+
+  // Input / recorded output / metadata follow the fetched span I/O (incl. nav).
+  React.useEffect(() => {
+    if (open && spanIO) {
+      setInput(spanIO.input ?? "");
+      setMetadata(prettyJson(spanIO.metadata));
+    }
+  }, [open, spanIO]);
+
+  // Reset the duplicate note whenever the selected span changes.
+  React.useEffect(() => {
+    if (open) setDuplicate(null);
+  }, [open, span?.span_id]);
+
+  // Non-modal: Escape closes this panel without touching the trace behind it.
+  React.useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onOpenChange(false);
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, onOpenChange]);
+
+  const createDataset = useCreateDataset(projectId);
+  const save = useMutation({
+    mutationFn: async (vars: { datasetId: string; body: Record<string, unknown> }) => {
+      const res = await fetch(`/api/projects/${projectId}/datasets/${vars.datasetId}/test-cases`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(vars.body),
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => null);
+        throw new Error(detail?.error ?? `Save failed: ${res.status}`);
+      }
+      return res.json() as Promise<{ duplicate: boolean; testCaseId?: string; versionId?: string }>;
+    },
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+  });
+
+  if (!open || !traceId) return null;
+
+  const creatingNew = datasetId === NEW_DATASET;
+  const dataset = datasets.find((item) => item.id === datasetId);
+  const displayKind = isRoot ? "trace" : (span?.span_kind ?? "SPAN");
+  const recordedOutput = spanIO?.output ?? "";
+  const currentIndex = span ? spans.findIndex((s) => s.span_id === span.span_id) : -1;
+  const canNavigateUp = currentIndex > 0;
+  const canNavigateDown = currentIndex >= 0 && currentIndex < spans.length - 1;
+
+  const inferredReason: CaptureReason =
+    span?.status === "ERROR" ? (displayKind === "TOOL" ? "failed_tool" : "error") : "manual";
+
+  const canSave =
+    !!span && (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") && !save.isPending;
+
+  const navigate = (dir: "up" | "down") => {
+    if (currentIndex < 0) return;
+    const next = dir === "up" ? currentIndex - 1 : currentIndex + 1;
+    if (next >= 0 && next < spans.length) setSelectedSpanId(spans[next].span_id);
+  };
+
+  const handleSave = async () => {
+    if (!span || !canSave) return;
+    setFeedback(null);
+    try {
+      let dsId = datasetId;
+      if (creatingNew) {
+        const created = await createDataset.mutateAsync({ name: newDatasetName.trim() });
+        dsId = created.dataset.id;
+        setDatasetId(dsId);
+      }
+      let metadataObj: Record<string, unknown> | null = null;
+      try {
+        const parsed = metadata.trim() ? JSON.parse(metadata) : null;
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) metadataObj = parsed;
+      } catch {
+        /* non-JSON metadata → not persisted */
+      }
+      const expected =
+        expectedMode === "recorded"
+          ? recordedOutput || null
+          : expectedMode === "corrected"
+            ? correctedExpected.trim() || null
+            : null;
+      const res = await save.mutateAsync({
+        datasetId: dsId,
+        body: {
+          input,
+          expected,
+          recorded_output: recordedOutput || null,
+          metadata: metadataObj,
+          review: "needs_review",
+          capture_reason: inferredReason,
+          source_trace_id: attachSource ? traceId : null,
+          source_span_id: attachSource ? span.span_id : null,
+          source_span_name: attachSource ? span.name : null,
+          source_span_kind: attachSource ? displayKind : null,
+        },
+      });
+      if (res.duplicate) {
+        setDuplicate({ datasetId: dsId });
+        return;
+      }
+      setFeedback({ tone: "success", text: "Saved — published as a new dataset version." });
+      setTimeout(() => onOpenChange(false), 700);
+    } catch {
+      setFeedback({ tone: "error", text: "Could not save test case." });
+    }
+  };
+
+  return (
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[560px] max-w-[96vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
+        <h2 className="text-[13px] font-semibold">Save as test case</h2>
+        <button
+          type="button"
+          onClick={() => onOpenChange(false)}
+          aria-label="Close"
+          className="rounded-sm text-muted-foreground opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-1 focus:ring-ring"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-auto px-4 py-3">
+        <FormCard label="Dataset">
+          <Select value={datasetId} onValueChange={setDatasetId}>
+            <SelectTrigger className="h-7 text-[13px]">
+              <SelectValue placeholder="Select dataset" />
+            </SelectTrigger>
+            <SelectContent>
+              {datasets.map((item) => (
+                <SelectItem key={item.id} value={item.id} className="text-[12px]">
+                  {item.name}
+                </SelectItem>
+              ))}
+              <SelectItem
+                value={NEW_DATASET}
+                icon={<Plus className="h-4 w-4" />}
+                className="mt-1 border-t border-border text-[12px]"
+              >
+                New dataset
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          {creatingNew && (
+            <Input
+              value={newDatasetName}
+              onChange={(event) => setNewDatasetName(event.target.value)}
+              placeholder="New dataset name"
+              autoFocus
+              className="mt-2 h-7 text-[13px]"
+            />
+          )}
+          {duplicate && (
+            <p className="mt-1.5 text-[11px] text-muted-foreground">
+              This span is already a test case in this dataset. Open it instead of adding another
+              row.
+            </p>
+          )}
+        </FormCard>
+
+        <FormCard label="Selected span">
+          <div className="flex items-center gap-2">
+            <SpanKindIcon kind={displayKind} inTree />
+            <span className="text-[13px] font-medium">{span?.name ?? "Loading trace…"}</span>
+            <span className="text-[11px] text-muted-foreground">
+              {SPAN_KIND_LABEL[displayKind as keyof typeof SPAN_KIND_LABEL] ?? displayKind}
+            </span>
+            <span className="ml-auto flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => navigate("up")}
+                disabled={!canNavigateUp}
+                aria-label="Previous span"
+                className="rounded border border-border p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+              >
+                <ArrowUp className="h-3.5 w-3.5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => navigate("down")}
+                disabled={!canNavigateDown}
+                aria-label="Next span"
+                className="rounded border border-border p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+              >
+                <ArrowDown className="h-3.5 w-3.5" />
+              </button>
+            </span>
+          </div>
+          <p className="mt-2 flex items-start gap-1.5 text-[11px] text-muted-foreground">
+            <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+            {boundaryHint(displayKind, span?.name ?? "")}
+          </p>
+          <p className="mt-1.5 text-[11px] text-muted-foreground">
+            Capture reason:{" "}
+            <span className="font-medium text-foreground">
+              {CAPTURE_REASON_LABEL[inferredReason]}
+            </span>
+          </p>
+        </FormCard>
+
+        <EditableValueBlock
+          label="Input"
+          text={input}
+          onChange={setInput}
+          copyable
+          autoDetectKind
+          boxed
+          minRows={2}
+        />
+
+        <div>
+          <EditableValueBlock
+            label="Recorded output"
+            text={recordedOutput}
+            onChange={() => {}}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={2}
+            readOnly
+          />
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            What happened in production. Kept separate from the expected outcome.
+          </p>
+        </div>
+
+        <FormCard label="Expected outcome">
+          <div className="flex flex-col gap-1" role="radiogroup" aria-label="Expected outcome">
+            {(
+              [
+                ["none", "Not required"],
+                ["recorded", "Use recorded output"],
+                ["corrected", "Enter a corrected outcome"],
+              ] as Array<[ExpectedMode, string]>
+            ).map(([value, label]) => (
+              <label
+                key={value}
+                className={cn(
+                  "flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-[12px]",
+                  expectedMode === value ? "text-foreground" : "text-muted-foreground",
+                )}
+              >
+                <input
+                  type="radio"
+                  name="expected-outcome"
+                  value={value}
+                  checked={expectedMode === value}
+                  onChange={() => setExpectedMode(value)}
+                  className="h-3.5 w-3.5 accent-foreground"
+                />
+                {label}
+              </label>
+            ))}
+          </div>
+
+          {expectedMode === "recorded" && (
+            <p className="mt-2 flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
+              <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+              This will become the outcome future runs are evaluated against.
+            </p>
+          )}
+          {expectedMode === "corrected" && (
+            <div className="mt-2">
+              <LineNumberedTextarea
+                value={correctedExpected}
+                onChange={setCorrectedExpected}
+                minRows={2}
+                placeholder="Corrected expected outcome"
+                aria-label="Corrected expected outcome"
+              />
+            </div>
+          )}
+        </FormCard>
+
+        <EditableValueBlock
+          label="Metadata"
+          text={metadata}
+          onChange={setMetadata}
+          copyable
+          autoDetectKind
+          boxed
+          minRows={2}
+        />
+
+        <div className="border border-border">
+          <div className="flex items-center justify-between border-b border-border bg-muted/50 px-3 py-1.5">
+            <span className="text-[12px] font-medium text-muted-foreground">Source</span>
+            <Switch checked={attachSource} onCheckedChange={setAttachSource} />
+          </div>
+          {attachSource ? (
+            <div className="p-3">
+              <dl className="flex flex-col gap-1 text-[11px]">
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground">Source trace</dt>
+                  <dd className="font-mono text-muted-foreground">{traceId}</dd>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <dt className="text-muted-foreground">Source span</dt>
+                  <dd className="font-mono text-muted-foreground">{span?.span_id ?? "—"}</dd>
+                </div>
+              </dl>
+            </div>
+          ) : (
+            <div className="p-3">
+              <p className="text-[11px] text-muted-foreground">
+                Added as a manual case — no source trace or span is linked.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <p className="text-[11px] text-muted-foreground">
+          This case will start as <span className="font-medium text-foreground">Needs review</span>.
+          Review it from the dataset row.
+        </p>
+      </div>
+
+      <div className="flex shrink-0 items-center justify-end gap-2 border-t border-border px-4 py-3">
+        {feedback && (
+          <span
+            className={cn(
+              "mr-auto text-[11px]",
+              feedback.tone === "error"
+                ? "text-destructive"
+                : "text-emerald-600 dark:text-emerald-400",
+            )}
+          >
+            {feedback.text}
+          </span>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-7 text-[12px]"
+          onClick={() => onOpenChange(false)}
+        >
+          Cancel
+        </Button>
+        {duplicate ? (
+          <Link
+            href={`/projects/${projectId}/datasets/${duplicate.datasetId}`}
+            className="inline-flex h-7 items-center gap-1.5 rounded-md bg-primary px-3 text-[12px] font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            <ArrowUpRight className="h-3.5 w-3.5" aria-hidden />
+            Open existing test case
+          </Link>
+        ) : (
+          <Button size="sm" className="h-7 text-[12px]" onClick={handleSave} disabled={!canSave}>
+            {creatingNew
+              ? "Create dataset & save"
+              : datasetId
+                ? `Save to ${dataset?.name ?? "dataset"}`
+                : "Save"}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * "Evaluation" chip for a trace that produced evaluation results — the trace →
+ * evaluation-run link, surfaced in the trace viewer (detector-findings pattern).
+ */
+export function TraceEvaluationChip({
+  projectId,
+  traceId,
+}: {
+  projectId: string;
+  traceId: string;
+}) {
+  const { data } = useTraceEvaluationResults(projectId, traceId);
+  const results = data?.data ?? [];
+  if (results.length === 0) return null;
+  const run = results[0].run;
+  return (
+    <Link
+      href={`/projects/${projectId}/evaluations/${run.id}`}
+      className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs transition-colors hover:bg-muted"
+      title="This trace was produced by an evaluation run"
+    >
+      <Database className="h-3 w-3 text-muted-foreground" aria-hidden />
+      <span className="text-muted-foreground">Evaluation:</span>
+      <span className="font-medium">{run.evaluation.name}</span>
+      <span className="text-muted-foreground">
+        Run #{run.runNumber} · {run.candidateVersion}
+      </span>
+    </Link>
+  );
+}
+
+/**
+ * "Dataset:" chip shown on a span that already backs a test case — the trace-
+ * viewer marker for a span that's been saved to a dataset. Renders one chip per
+ * dataset the span belongs to (current version only), each linking to it, or
+ * nothing when the span isn't a saved case.
+ */
+export function SpanDatasetChip({
+  projectId,
+  traceId,
+  spanId,
+}: {
+  projectId: string;
+  traceId: string;
+  spanId: string;
+}) {
+  const { data } = useTraceTestCases(projectId, traceId);
+  const matches = (data?.data ?? []).filter((c) => c.sourceSpanId === spanId);
+  if (matches.length === 0) return null;
+  return (
+    <>
+      {matches.map((c) => (
+        <Link
+          key={`${c.datasetId}:${c.testCaseId}`}
+          href={`/projects/${projectId}/datasets/${c.datasetId}`}
+          className="inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors hover:bg-muted"
+          title={`In dataset ${c.datasetName}`}
+        >
+          <Database className="h-3 w-3 text-muted-foreground" aria-hidden />
+          <span className="text-muted-foreground">Dataset:</span>
+          <span className="font-medium">{c.datasetName}</span>
+        </Link>
+      ))}
+    </>
+  );
+}

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -152,17 +152,28 @@ export function SaveTestCaseDrawer({
   // The trace-detail response OMITS span input/output/metadata — they are fetched
   // per span on demand (getSpanIO), so read them from that hook, not the span.
   const { data: spanIO } = useSpanIO(projectId, traceId ?? "", span?.span_id ?? null);
+  // True only once the fetched I/O actually belongs to the selected span. Switching
+  // spans leaves `spanIO` on the PREVIOUS span's values until the new fetch lands, so
+  // this gates both seeding and Save — otherwise a click made immediately after
+  // navigating would publish the new span's id with the previous span's input/output.
+  const spanIOReady = !!spanIO && !!span && spanIO.span_id === span.span_id;
 
   // Input / output / metadata follow the fetched span I/O (incl. nav). Output reseeds
-  // from the recorded output on each span (nav resets any in-progress edit).
+  // from the recorded output on each span (nav resets any in-progress edit). Cleared
+  // while the current span's I/O hasn't arrived rather than left on the previous span.
   React.useEffect(() => {
-    if (open && spanIO) {
+    if (!open) return;
+    if (spanIOReady && spanIO) {
       setInput(spanIO.input ?? "");
       setMetadata(prettyJson(spanIO.metadata));
       setOutput(spanIO.output ?? "");
       setOutputEdited(false);
+    } else {
+      setInput("");
+      setMetadata("");
+      setOutput("");
     }
-  }, [open, spanIO]);
+  }, [open, spanIOReady, spanIO]);
 
   // Reset the duplicate note whenever the selected span changes.
   React.useEffect(() => {
@@ -217,7 +228,9 @@ export function SaveTestCaseDrawer({
     span?.status === "ERROR" ? (displayKind === "TOOL" ? "failed_tool" : "error") : "manual";
 
   const canSave =
-    !!span && (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") && !save.isPending;
+    spanIOReady &&
+    (creatingNew ? newDatasetName.trim() !== "" : datasetId !== "") &&
+    !save.isPending;
 
   const navigate = (dir: "up" | "down") => {
     if (currentIndex < 0) return;

--- a/frontend/ui/src/features/evaluations/components/trace-integration.tsx
+++ b/frontend/ui/src/features/evaluations/components/trace-integration.tsx
@@ -19,13 +19,9 @@ import { CopyButton } from "@/components/ui/copy-button";
 import { cn } from "@/lib/utils";
 import { getTrace } from "@/lib/api/traces";
 import { SpanKindIcon, useSpanIO } from "@/features/traces";
-import {
-  FormCard,
-  EditableValueBlock,
-  LineNumberedTextarea,
-  Timestamp,
-} from "@/features/offline-eval/components";
-import { datasetInitCode, datasetInitCodeTs } from "@/features/offline-eval/utils";
+import { FormCard, EditableValueBlock, Timestamp } from "@/features/offline-eval/components";
+import { tokenizeCode } from "@/features/offline-eval/components/syntax";
+import { useProject } from "@/features/projects/hooks";
 import {
   CAPTURE_REASON_LABEL,
   SPAN_KIND_LABEL,
@@ -42,15 +38,16 @@ import {
 /** Sentinel dataset-select value for "create a new dataset". */
 const NEW_DATASET = "__new__";
 
-/** How the optional expected outcome is set for a captured case. */
-type ExpectedMode = "none" | "recorded" | "corrected";
-
 /** Root = the span with no parent (the application / evaluation-item root). */
 function rootSpan(spans: Span[]): Span | undefined {
   return spans.find((s) => !s.parent_span_id) ?? spans[0];
 }
 
-/** Pretty-print JSON so metadata shows expanded and indented; leave other text. */
+/**
+ * Normalise a captured JSON blob (2-space indent); leave non-JSON text alone.
+ * The field's own `seedJson` preference decides the final shape it opens in —
+ * this just guarantees the seed is valid, canonical JSON when it is JSON.
+ */
 function prettyJson(raw: string | null | undefined): string {
   if (!raw) return "";
   try {
@@ -74,12 +71,12 @@ function boundaryHint(displayKind: string, spanName: string): string {
 }
 
 /**
- * "Save as test case" — a faithful port of the approved mock drawer, wired to the
+ * "Save as test case" — the capture drawer, wired to the
  * server. Opened from the existing trace viewer's span header. Self-contained: it
  * fetches the trace, walks its spans (up/down), lets you pick or create a
  * dataset, and persists via the server (which publishes a new dataset version).
- * The span's input becomes the proposed test input; its output is shown read-only
- * ("Recorded output") and is never treated as the expected answer.
+ * The span's input becomes the proposed test input; the single editable Output field
+ * seeds from the recorded output and, when edited, becomes the expected outcome.
  */
 export function SaveTestCaseDrawer({
   projectId,
@@ -111,8 +108,12 @@ export function SaveTestCaseDrawer({
   const [input, setInput] = React.useState("");
   const [metadata, setMetadata] = React.useState("");
   const [attachSource, setAttachSource] = React.useState(true);
-  const [expectedMode, setExpectedMode] = React.useState<ExpectedMode>("none");
-  const [correctedExpected, setCorrectedExpected] = React.useState("");
+  // The single editable Output field. It seeds from the recorded output; editing it
+  // makes the edit the EXPECTED outcome future runs are graded against, while the
+  // untouched recorded output is still stored separately. Left as-is, expected ==
+  // recorded — but all three fields (input, expected, recorded_output) are persisted.
+  const [output, setOutput] = React.useState("");
+  const [outputEdited, setOutputEdited] = React.useState(false);
   const [duplicate, setDuplicate] = React.useState<{ datasetId: string } | null>(null);
   const [feedback, setFeedback] = React.useState<{
     tone: "error" | "success";
@@ -125,15 +126,20 @@ export function SaveTestCaseDrawer({
     if (open) {
       setDatasetId("");
       setNewDatasetName("");
-      setSelectedSpanId(spanId);
       setAttachSource(true);
-      setExpectedMode("none");
-      setCorrectedExpected("");
+      setOutputEdited(false);
       setDuplicate(null);
       setFeedback(null);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
+
+  // Follow the tree: when the parent retargets the span — a click on a different
+  // span in the span tree while this drawer is open — select it here too. The
+  // drawer's own up/down nav sets internal state without changing this prop, so
+  // it keeps working; only a genuine tree selection re-syncs.
+  React.useEffect(() => {
+    setSelectedSpanId(spanId);
+  }, [spanId]);
 
   const spans = React.useMemo(() => trace?.spans ?? [], [trace]);
   const root = trace ? rootSpan(spans) : undefined;
@@ -147,11 +153,14 @@ export function SaveTestCaseDrawer({
   // per span on demand (getSpanIO), so read them from that hook, not the span.
   const { data: spanIO } = useSpanIO(projectId, traceId ?? "", span?.span_id ?? null);
 
-  // Input / recorded output / metadata follow the fetched span I/O (incl. nav).
+  // Input / output / metadata follow the fetched span I/O (incl. nav). Output reseeds
+  // from the recorded output on each span (nav resets any in-progress edit).
   React.useEffect(() => {
     if (open && spanIO) {
       setInput(spanIO.input ?? "");
       setMetadata(prettyJson(spanIO.metadata));
+      setOutput(spanIO.output ?? "");
+      setOutputEdited(false);
     }
   }, [open, spanIO]);
 
@@ -187,7 +196,11 @@ export function SaveTestCaseDrawer({
       }
       return res.json() as Promise<{ duplicate: boolean; testCaseId?: string; versionId?: string }>;
     },
-    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["datasets"] });
+      // Refresh the span→dataset chips so the just-saved span is marked at once.
+      void qc.invalidateQueries({ queryKey: ["evaluations", "trace-test-cases"] });
+    },
   });
 
   if (!open || !traceId) return null;
@@ -229,17 +242,13 @@ export function SaveTestCaseDrawer({
       } catch {
         /* non-JSON metadata → not persisted */
       }
-      const expected =
-        expectedMode === "recorded"
-          ? recordedOutput || null
-          : expectedMode === "corrected"
-            ? correctedExpected.trim() || null
-            : null;
+      // The Output field IS the expected outcome (edited or not); the recorded output
+      // is always stored separately. Unedited → expected == recorded output.
       const res = await save.mutateAsync({
         datasetId: dsId,
         body: {
           input,
-          expected,
+          expected: output.trim() || null,
           recorded_output: recordedOutput || null,
           metadata: metadataObj,
           review: "needs_review",
@@ -358,83 +367,60 @@ export function SaveTestCaseDrawer({
           text={input}
           onChange={setInput}
           copyable
-          autoDetectKind
+          // Read + hand-edited most, and usually the most nested → expand it.
+          seedJson="expanded"
           boxed
           minRows={2}
+          collapsible
+          collapseResetKey={span?.span_id}
         />
 
         <div>
           <EditableValueBlock
-            label="Recorded output"
-            text={recordedOutput}
-            onChange={() => {}}
+            label="Output"
+            text={output}
+            onChange={(v) => {
+              setOutput(v);
+              setOutputEdited(true);
+            }}
             copyable
-            autoDetectKind
+            // Read and possibly hand-corrected — expand it like Input.
+            seedJson="expanded"
             boxed
             minRows={2}
-            readOnly
+            collapsible
+            collapseResetKey={span?.span_id}
           />
-          <p className="mt-1 text-[11px] text-muted-foreground">
-            What happened in production. Kept separate from the expected outcome.
+          <p className="mt-1 flex items-start gap-1.5 text-[11px] text-muted-foreground">
+            <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
+            {outputEdited ? (
+              <span>
+                Edited — your version becomes the{" "}
+                <span className="font-medium text-foreground">expected outcome</span>; the original
+                recorded output is still stored.
+              </span>
+            ) : (
+              <span>
+                The recorded production output. Leave it to grade against it, or edit to set a
+                corrected <span className="font-medium text-foreground">expected outcome</span> —
+                the recorded output is kept either way.
+              </span>
+            )}
           </p>
         </div>
-
-        <FormCard label="Expected outcome">
-          <div className="flex flex-col gap-1" role="radiogroup" aria-label="Expected outcome">
-            {(
-              [
-                ["none", "Not required"],
-                ["recorded", "Use recorded output"],
-                ["corrected", "Enter a corrected outcome"],
-              ] as Array<[ExpectedMode, string]>
-            ).map(([value, label]) => (
-              <label
-                key={value}
-                className={cn(
-                  "flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-[12px]",
-                  expectedMode === value ? "text-foreground" : "text-muted-foreground",
-                )}
-              >
-                <input
-                  type="radio"
-                  name="expected-outcome"
-                  value={value}
-                  checked={expectedMode === value}
-                  onChange={() => setExpectedMode(value)}
-                  className="h-3.5 w-3.5 accent-foreground"
-                />
-                {label}
-              </label>
-            ))}
-          </div>
-
-          {expectedMode === "recorded" && (
-            <p className="mt-2 flex items-start gap-1.5 rounded border border-amber-500/40 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-700 dark:text-amber-300">
-              <Info className="mt-0.5 h-3 w-3 shrink-0" aria-hidden />
-              This will become the outcome future runs are evaluated against.
-            </p>
-          )}
-          {expectedMode === "corrected" && (
-            <div className="mt-2">
-              <LineNumberedTextarea
-                value={correctedExpected}
-                onChange={setCorrectedExpected}
-                minRows={2}
-                placeholder="Corrected expected outcome"
-                aria-label="Corrected expected outcome"
-              />
-            </div>
-          )}
-        </FormCard>
 
         <EditableValueBlock
           label="Metadata"
           text={metadata}
           onChange={setMetadata}
           copyable
-          autoDetectKind
+          // Incidental context, usually one or two short keys → keep it inline
+          // (seedFormat expands it anyway once it stops fitting on one line).
+          seedJson="compact"
           boxed
           minRows={2}
+          collapsible
+          collapseResetKey={span?.span_id}
         />
 
         <div className="border border-border">
@@ -544,15 +530,42 @@ export function TraceEvaluationChip({
   );
 }
 
-/** Small SDK-snippet card with a Python / TypeScript toggle (one shown at a time). */
-function DatasetSdkSnippet({ datasetName }: { datasetName: string }) {
-  const [lang, setLang] = React.useState<"python" | "typescript">("python");
-  const code = lang === "python" ? datasetInitCode(datasetName) : datasetInitCodeTs(datasetName);
+type Lang = "python" | "typescript";
+
+/** e.g. "Billing routing" → "billing-routing". */
+function slugify(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, "-");
+}
+
+/**
+ * A 4-line initDataset snippet for one language — identical in shape to the
+ * DatasetInfoChip. Indents differ on purpose: 4 spaces for
+ * Python (PEP 8), 2 for TypeScript (Prettier).
+ */
+function sdkSnippet(lang: Lang, projectName: string, datasetSlug: string, version: string): string {
+  if (lang === "python") {
+    return `traceroot.init_dataset("${projectName}", {\n    "dataset": "${datasetSlug}",\n    "version": "${version}",\n})`;
+  }
+  return `traceroot.initDataset("${projectName}", {\n  dataset: "${datasetSlug}",\n  version: "${version}",\n});`;
+}
+
+/** SDK init snippet with a Python / TypeScript toggle — one shown at a time. */
+function DatasetSdkSnippet({
+  projectName,
+  datasetName,
+  version,
+}: {
+  projectName: string;
+  datasetName: string;
+  version: string;
+}) {
+  const [lang, setLang] = React.useState<Lang>("python");
+  const code = sdkSnippet(lang, projectName, slugify(datasetName), version);
   return (
     <div className="overflow-hidden rounded border border-border">
       <div className="flex items-center justify-between border-b border-border bg-muted/50 px-1.5 py-1">
         <div className="flex items-center gap-0.5">
-          {(["python", "typescript"] as const).map((l) => (
+          {(["python", "typescript"] as Lang[]).map((l) => (
             <button
               key={l}
               type="button"
@@ -570,8 +583,14 @@ function DatasetSdkSnippet({ datasetName }: { datasetName: string }) {
         </div>
         <CopyButton value={code} className="h-6 w-6" iconClassName="h-3.5 w-3.5" title="Copy" />
       </div>
-      <pre className="max-h-48 overflow-auto whitespace-pre px-2.5 py-2 font-mono text-xs leading-relaxed">
-        {code}
+      {/* pb-6 so the horizontal scrollbar at the pre's bottom doesn't overlap the
+          last line (it scrolls in both axes with a small max height). */}
+      <pre className="max-h-48 overflow-auto whitespace-pre px-2.5 pb-6 pt-2 font-mono text-xs leading-relaxed">
+        {tokenizeCode(code).map((t, i) => (
+          <span key={i} className={t.cls || undefined}>
+            {t.text}
+          </span>
+        ))}
       </pre>
     </div>
   );
@@ -594,6 +613,8 @@ export function SpanDatasetChip({
   spanId: string;
 }) {
   const { data } = useTraceTestCases(projectId, traceId);
+  const { data: project } = useProject(projectId);
+  const projectName = project?.name ?? "your-project";
   const matches = (data?.data ?? []).filter((c) => c.sourceSpanId === spanId);
   if (matches.length === 0) return null;
   return (
@@ -629,7 +650,11 @@ export function SpanDatasetChip({
                 </span>
               </div>
             </div>
-            <DatasetSdkSnippet datasetName={c.datasetName} />
+            <DatasetSdkSnippet
+              projectName={projectName}
+              datasetName={c.datasetName}
+              version={c.datasetVersionLabel}
+            />
           </TooltipContent>
         </Tooltip>
       ))}

--- a/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx
@@ -1,0 +1,372 @@
+// @vitest-environment jsdom
+/**
+ * View-mount ("e2e") smoke for the real, server-backed Datasets + Evaluations
+ * pages. The routes sit behind auth and can't be driven over HTTP
+ * without a session, and the repo has no browser driver — so mounting the views
+ * against a stubbed fetch (server-shaped payloads) is how the browser path is
+ * checked, exactly like offline-eval.smoke.test.tsx.
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, cleanup, screen, fireEvent, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@/components/ui/toast";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1", datasetId: "ds1", runId: "run1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/evaluations",
+}));
+// ProjectBreadcrumb pulls layout/workspace context we don't mount here.
+vi.mock("@/features/projects/components", () => ({ ProjectBreadcrumb: () => null }));
+
+import { DatasetsView } from "./views/datasets-view";
+import { EvaluationsView } from "./views/evaluations-view";
+import { RunDetailView } from "./views/run-detail-view";
+
+const RUN = {
+  id: "run1",
+  evaluationId: "eval1",
+  datasetId: "ds1",
+  datasetVersionId: "dv1",
+  runNumber: 27,
+  candidateVersion: "git:4a91c02",
+  environment: "ci",
+  status: "completed_with_errors",
+  baselineRunId: "run0",
+  mainScore: 0.938,
+  mainScoreName: "Routing accuracy",
+  caseCount: 24,
+  scoredCount: 22,
+  taskErrorCount: 1,
+  scorerErrorCount: 1,
+  scorers: [{ name: "routing-accuracy", version: "v3" }],
+  model: null,
+  startedAt: "2026-07-17T10:24:00Z",
+  completedAt: "2026-07-17T10:30:00Z",
+  evaluationName: "Billing routing",
+  datasetName: "Billing routing",
+  datasetVersionLabel: "v12",
+  changeFromBaseline: 0.224,
+  errorCount: 2,
+  baselineComparable: true,
+  elapsedMs: 360000,
+  comparison: {
+    available: true,
+    trustworthy: true,
+    reasons: [],
+    baseline: { runId: "run0", runNumber: 26, candidateVersion: "git:0000000" },
+    mainScore: { candidate: 0.938, baseline: 0.714, delta: 0.224 },
+    caseCounts: {
+      improved: 1,
+      regressed: 0,
+      unchanged: 21,
+      changed: 0,
+      unpaired: 0,
+      not_comparable: 0,
+    },
+    scoreCellCounts: {
+      improved: 1,
+      regressed: 0,
+      unchanged: 21,
+      changed: 0,
+      unpaired: 0,
+      not_comparable: 0,
+    },
+    scorers: [
+      {
+        name: "routing-accuracy",
+        version: "v3",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateMean: 0.938,
+        baselineMean: 0.714,
+        delta: 0.224,
+        pairedCount: 22,
+      },
+    ],
+    duration: { candidateMeanMs: 1500, baselineMeanMs: 1400, deltaMs: 100, pairedCount: 22 },
+  },
+};
+
+const RESULT = {
+  id: "res1",
+  runId: "run1",
+  evaluationId: "eval1",
+  testCaseId: "case-1",
+  traceId: "tr_1",
+  input: "I was charged twice for my July invoice",
+  expectedOutput: "billing",
+  candidateOutput: "billing",
+  baselineOutput: "account-management",
+  status: "passed",
+  mainScore: 1,
+  change: "improved",
+  taskError: null,
+  durationMs: 2400,
+  cost: 0.012,
+  createTime: "2026-07-17T10:24:00Z",
+  scores: [
+    {
+      id: "s1",
+      scorerName: "routing-accuracy",
+      scorerVersion: "v3",
+      numericValue: 1,
+      boolValue: null,
+      stringValue: null,
+      passed: null,
+      explanation: "Reached billing",
+      error: null,
+    },
+  ],
+  humanScores: [],
+  comparison: {
+    caseChange: "improved",
+    pairing: "paired",
+    mainScore: { candidate: 1, baseline: 0, delta: 1 },
+    scorerCells: [
+      {
+        scorerName: "routing-accuracy",
+        scorerVersion: "v3",
+        valueType: "numeric",
+        direction: "higher_is_better",
+        candidateValue: 1,
+        baselineValue: 0,
+        delta: 1,
+        classification: "improved",
+      },
+    ],
+    regressedCellCount: 0,
+    comparableCellCount: 1,
+  },
+};
+
+// An older run of the SAME evaluation lineage, distinct candidate, so grouping and
+// latest-only are meaningful in the run-centric table.
+const RUN_OLDER = {
+  ...RUN,
+  id: "run0",
+  runNumber: 26,
+  candidateVersion: "git:0000000",
+  startedAt: "2026-07-16T10:24:00Z",
+  completedAt: "2026-07-16T10:30:00Z",
+  changeFromBaseline: null,
+  baselineRunId: null,
+};
+
+function payloadFor(url: string): unknown {
+  if (url.includes("/evaluations/runs/run1")) return { run: RUN, results: [RESULT] };
+  if (url.includes("/evaluations/runs"))
+    return { data: [RUN, RUN_OLDER], meta: { page: 0, limit: 50, total: 2 } };
+  if (url.includes("/evaluations/scorers"))
+    return {
+      data: [
+        {
+          name: "routing-accuracy",
+          version: "v3",
+          scoreCount: 22,
+          errorCount: 0,
+          errorRate: 0,
+          valueType: "numeric",
+          declaredValueType: "numeric",
+          direction: "higher_is_better",
+          threshold: null,
+          numeric: { mean: 0.9, min: 0.5, max: 1, count: 22 },
+          passRate: null,
+          distribution: null,
+          runCount: 2,
+          evaluationCount: 1,
+          lastUsed: "2026-07-17T10:24:00Z",
+          recentErrors: [],
+          source: "SDK",
+        },
+      ],
+    };
+  if (url.includes("/evaluations")) {
+    return {
+      data: [
+        {
+          id: "eval1",
+          name: "Billing routing",
+          datasetId: "ds1",
+          mainScoreName: "Routing accuracy",
+          datasetName: "Billing routing",
+          runCount: 1,
+          latestRun: {
+            id: "run1",
+            runNumber: 27,
+            candidateVersion: "git:4a91c02",
+            status: "completed_with_errors",
+            mainScore: 0.938,
+            startedAt: "2026-07-17T10:24:00Z",
+            datasetVersionId: "dv1",
+          },
+        },
+      ],
+    };
+  }
+  if (url.match(/\/datasets\/ds1$/)) {
+    return {
+      dataset: {
+        id: "ds1",
+        projectId: "p1",
+        name: "Billing routing",
+        description: null,
+        currentVersionId: "dv1",
+        createTime: "2026-07-16T00:00:00Z",
+        updateTime: "2026-07-17T00:00:00Z",
+        caseCount: 2,
+        versionCount: 1,
+      },
+      currentVersion: {
+        id: "dv1",
+        datasetId: "ds1",
+        projectId: "p1",
+        versionNumber: 1,
+        label: "v1",
+        note: null,
+        createdBy: null,
+        createTime: "2026-07-16T00:00:00Z",
+      },
+      testCases: [],
+      versions: [
+        {
+          id: "dv1",
+          datasetId: "ds1",
+          projectId: "p1",
+          versionNumber: 1,
+          label: "v1",
+          note: null,
+          createdBy: null,
+          createTime: "2026-07-16T00:00:00Z",
+        },
+      ],
+    };
+  }
+  if (url.includes("/datasets")) {
+    return {
+      data: [
+        {
+          id: "ds1",
+          projectId: "p1",
+          name: "Billing routing",
+          description: "Routing tickets",
+          currentVersionId: "dv1",
+          createTime: "2026-07-16T00:00:00Z",
+          updateTime: "2026-07-17T00:00:00Z",
+          caseCount: 8,
+          versionCount: 3,
+        },
+      ],
+      meta: { page: 0, limit: 50, total: 1 },
+    };
+  }
+  return {};
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn(async (url: RequestInfo | URL) => ({
+    ok: true,
+    status: 200,
+    json: async () => payloadFor(String(url)),
+  })) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function mount(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // The real /datasets and /evaluations route subtrees mount a ToastProvider;
+  // the views use toasts, so the harness mirrors that wrapping.
+  return render(
+    <QueryClientProvider client={qc}>
+      <ToastProvider>{node}</ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("real Datasets + Evaluations views render server data", () => {
+  it("Datasets list shows a server dataset", async () => {
+    mount(<DatasetsView projectId="p1" />);
+    expect(await screen.findByText("Billing routing")).toBeDefined();
+  });
+
+  it("Evaluations Runs tab shows a run with its candidate version", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    expect((await screen.findAllByText("git:4a91c02")).length).toBeGreaterThan(0);
+  });
+
+  it("Evaluations shows an empty state that points at the SDK (no Run evaluation CTA)", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: [], meta: { page: 0, limit: 50, total: 0 } }),
+    })) as unknown as typeof fetch;
+    mount(<EvaluationsView projectId="p1" />);
+    expect(await screen.findByText(/No evaluation runs yet/)).toBeDefined();
+    expect(screen.queryByRole("button", { name: /Run evaluation/ })).toBeNull();
+  });
+
+  it("run-centric table shows immutable-run identity (Run # + candidate) for both runs", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    expect(await screen.findByText(/Run #27 ·/)).toBeDefined();
+    expect(await screen.findByText(/Run #26 ·/)).toBeDefined();
+  });
+
+  it("Latest only keeps just the newest run of each lineage", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    // Both runs visible first.
+    expect(await screen.findByText("git:0000000")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { name: /Latest only/ }));
+    // The older run (#26) drops out; the newest (#27) stays.
+    expect(screen.queryByText("git:0000000")).toBeNull();
+    expect(screen.getByText("git:4a91c02")).toBeDefined();
+  });
+
+  it("Group by evaluation collapses runs under a lineage header", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    await screen.findByText(/Run #27 ·/);
+    fireEvent.click(screen.getByRole("button", { name: /Group by evaluation/ }));
+    // Group header shows per-column aggregate totals across the lineage (not the latest
+    // run's values): run count, the averaged main score, and total captions.
+    expect(await screen.findByText(/2 runs/)).toBeDefined();
+    expect(screen.getByText(/93\.8%/)).toBeDefined(); // avg main score across the lineage
+    expect(screen.getAllByText("total").length).toBeGreaterThan(0);
+  });
+
+  it("selecting exactly two runs offers a Compare action", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    await screen.findByText(/Run #27 ·/);
+    // Only the per-row checkboxes (labels like "Select … #27"), not the select-all header.
+    const boxes = screen
+      .getAllByRole("checkbox")
+      .filter((b) => /^Select .*#\d/.test(b.getAttribute("aria-label") ?? ""));
+    expect(boxes.length).toBe(2);
+    fireEvent.click(boxes[0]);
+    fireEvent.click(boxes[1]);
+    expect(await screen.findByRole("button", { name: /Compare/ })).toBeDefined();
+  });
+
+  it("Scorers tab shows an SDK-defined scorer and its detail is honest about gaps", async () => {
+    mount(<EvaluationsView projectId="p1" />);
+    fireEvent.click(await screen.findByRole("button", { name: /Scorers/ }));
+    // Clicking a scorer row opens the detail panel; then assert on it.
+    fireEvent.click(await screen.findByText("routing-accuracy"));
+    const detail = await screen.findByLabelText("Scorer detail");
+    // This fixture reports no definition (no type/model/source), so the detector-style
+    // detail is honest about the gap but still shows the observed usage + config cards.
+    expect(within(detail).getByText(/hasn't reported this scorer/i)).toBeDefined();
+    expect(within(detail).getByText("Configuration")).toBeDefined();
+    expect(within(detail).getByText("Observed usage")).toBeDefined();
+    // Scorers are SDK-authored — no create/edit control.
+    expect(screen.queryByRole("button", { name: /Create scorer/ })).toBeNull();
+  });
+
+  it("Run detail renders the run header and the result row (results-forward)", async () => {
+    mount(<RunDetailView projectId="p1" runId="run1" />);
+    // The run's identity (evaluation name + candidate version) in the header.
+    expect((await screen.findAllByText("Billing routing")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("git:4a91c02")).length).toBeGreaterThan(0);
+    // The result row is present (the hero results table shows the case input).
+    expect((await screen.findAllByText(/charged twice/)).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -1,0 +1,308 @@
+/**
+ * React Query hooks for the server-backed evaluation feature. Mirrors the
+ * detectors hooks: queryKey arrays, fetch() against the committed Route Handlers,
+ * throw on !res.ok, enabled on projectId, mutations invalidate the caches.
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  DatasetRow,
+  DatasetDetailResponse,
+  EvaluationRow,
+  RunRow,
+  RunDetailResponse,
+  EvalResultStatus,
+  ScoreRow,
+} from "./types";
+
+interface Meta {
+  page: number;
+  limit: number;
+  total: number;
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Request failed: ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+async function sendJson<T>(url: string, method: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    throw new Error(detail?.error ?? `Request failed: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+// ---------------------------------------------------------------------------
+// Datasets
+// ---------------------------------------------------------------------------
+
+export function useDatasets(
+  projectId: string,
+  query: { search_query?: string; page?: number; limit?: number } = {},
+) {
+  const params = new URLSearchParams();
+  if (query.search_query) params.set("search_query", query.search_query);
+  if (query.page !== undefined) params.set("page", String(query.page));
+  if (query.limit !== undefined) params.set("limit", String(query.limit));
+  const qs = params.toString();
+  return useQuery({
+    queryKey: ["datasets", "list", projectId, query.search_query ?? null, query.page ?? 0],
+    queryFn: () =>
+      getJson<{ data: DatasetRow[]; meta: Meta }>(
+        `/api/projects/${projectId}/datasets${qs ? `?${qs}` : ""}`,
+      ),
+    enabled: !!projectId,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useDataset(projectId: string, datasetId: string) {
+  return useQuery({
+    queryKey: ["datasets", "detail", projectId, datasetId],
+    queryFn: () =>
+      getJson<DatasetDetailResponse>(`/api/projects/${projectId}/datasets/${datasetId}`),
+    enabled: !!projectId && !!datasetId,
+  });
+}
+
+export function useCreateDataset(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { name: string; description?: string | null }) =>
+      sendJson<{ dataset: DatasetRow }>(`/api/projects/${projectId}/datasets`, "POST", input),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+  });
+}
+
+export function useUpdateDataset(projectId: string, datasetId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: { name?: string; description?: string | null }) =>
+      sendJson<{ dataset: DatasetRow }>(
+        `/api/projects/${projectId}/datasets/${datasetId}`,
+        "PATCH",
+        input,
+      ),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+  });
+}
+
+export function useDeleteDataset(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (datasetId: string) =>
+      sendJson<{ deleted: boolean }>(
+        `/api/projects/${projectId}/datasets/${datasetId}`,
+        "DELETE",
+        undefined,
+      ),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+  });
+}
+
+export interface SaveTestCaseInput {
+  input: string;
+  expected?: string | null;
+  recorded_output?: string | null;
+  metadata?: Record<string, unknown> | null;
+  review?: "needs_review" | "ready";
+  capture_reason?: string;
+  source_trace_id?: string | null;
+  source_span_id?: string | null;
+  source_span_name?: string | null;
+  source_span_kind?: string | null;
+}
+
+export function useSaveTestCase(projectId: string, datasetId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: SaveTestCaseInput) =>
+      sendJson<{ duplicate: boolean; testCaseId?: string; versionId?: string }>(
+        `/api/projects/${projectId}/datasets/${datasetId}/test-cases`,
+        "POST",
+        input,
+      ),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ["datasets"] });
+      // Refresh the trace's span→dataset chips so a just-saved span is marked.
+      void qc.invalidateQueries({ queryKey: ["evaluations", "trace-test-cases"] });
+    },
+  });
+}
+
+export function useUpdateTestCase(projectId: string, datasetId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: {
+      testCaseId: string;
+      patch: {
+        input?: string;
+        expected?: string | null;
+        metadata?: Record<string, unknown> | null;
+        review?: "needs_review" | "ready";
+      };
+    }) =>
+      sendJson<{ versionId: string; versionNumber: number; focusTestCaseId: string }>(
+        `/api/projects/${projectId}/datasets/${datasetId}/test-cases/${args.testCaseId}`,
+        "PATCH",
+        args.patch,
+      ),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["datasets"] }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Evaluations
+// ---------------------------------------------------------------------------
+
+export function useEvaluations(projectId: string) {
+  return useQuery({
+    queryKey: ["evaluations", "lineages", projectId],
+    queryFn: () => getJson<{ data: EvaluationRow[] }>(`/api/projects/${projectId}/evaluations`),
+    enabled: !!projectId,
+  });
+}
+
+export function useEvaluationRuns(
+  projectId: string,
+  query: {
+    evaluation_id?: string;
+    dataset_id?: string;
+    status?: string;
+    search_query?: string;
+    page?: number;
+    limit?: number;
+  } = {},
+) {
+  const params = new URLSearchParams();
+  if (query.evaluation_id) params.set("evaluation_id", query.evaluation_id);
+  if (query.dataset_id) params.set("dataset_id", query.dataset_id);
+  if (query.status) params.set("status", query.status);
+  if (query.search_query) params.set("search_query", query.search_query);
+  if (query.page !== undefined) params.set("page", String(query.page));
+  const qs = params.toString();
+  return useQuery({
+    queryKey: [
+      "evaluations",
+      "runs",
+      projectId,
+      query.evaluation_id ?? null,
+      query.dataset_id ?? null,
+      query.status ?? null,
+      query.search_query ?? null,
+      query.page ?? 0,
+    ],
+    queryFn: () =>
+      getJson<{ data: RunRow[]; meta: Meta }>(
+        `/api/projects/${projectId}/evaluations/runs${qs ? `?${qs}` : ""}`,
+      ),
+    enabled: !!projectId,
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useEvaluationRun(projectId: string, runId: string) {
+  return useQuery({
+    queryKey: ["evaluations", "run", projectId, runId],
+    queryFn: () =>
+      getJson<RunDetailResponse>(`/api/projects/${projectId}/evaluations/runs/${runId}`),
+    enabled: !!projectId && !!runId,
+  });
+}
+
+export function useCreateHumanScore(projectId: string, resultId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      verdict: "pass" | "fail" | "unsure";
+      quality?: number | null;
+      comment?: string | null;
+      reviewer: string;
+    }) =>
+      sendJson(
+        `/api/projects/${projectId}/evaluations/results/${resultId}/human-score`,
+        "POST",
+        input,
+      ),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: ["evaluations", "run"] }),
+  });
+}
+
+export interface TraceEvaluationResultRow {
+  id: string;
+  runId: string;
+  testCaseId: string;
+  traceId: string | null;
+  status: EvalResultStatus;
+  mainScore: number | null;
+  scores: ScoreRow[];
+  run: {
+    id: string;
+    runNumber: number;
+    candidateVersion: string;
+    datasetId: string;
+    datasetVersionId: string;
+    evaluation: { id: string; name: string };
+    datasetVersion: { label: string };
+  };
+}
+
+/** Evaluation results a trace produced — the trace -> evaluation-run link. */
+export function useTraceEvaluationResults(projectId: string, traceId: string) {
+  return useQuery({
+    queryKey: ["evaluations", "trace-results", projectId, traceId],
+    queryFn: () =>
+      getJson<{ data: TraceEvaluationResultRow[] }>(
+        `/api/projects/${projectId}/traces/${traceId}/evaluation-results`,
+      ),
+    enabled: !!projectId && !!traceId,
+  });
+}
+
+export interface TraceTestCaseRow {
+  testCaseId: string;
+  datasetId: string;
+  datasetName: string;
+  sourceSpanId: string | null;
+  review: string;
+}
+
+/**
+ * Dataset test cases captured from a given trace, keyed by source span. Powers
+ * the "In <dataset>" chip that marks a span already saved as a test case.
+ */
+export function useTraceTestCases(projectId: string, traceId: string) {
+  return useQuery({
+    queryKey: ["evaluations", "trace-test-cases", projectId, traceId],
+    queryFn: () =>
+      getJson<{ data: TraceTestCaseRow[] }>(
+        `/api/projects/${projectId}/traces/${traceId}/test-cases`,
+      ),
+    enabled: !!projectId && !!traceId,
+  });
+}
+
+export interface ScorerRegistryRow {
+  name: string;
+  version: string;
+  scoreCount: number;
+  errorCount: number;
+  errorRate: number;
+}
+
+/** Read-only scorer registry, aggregated from reported runs. */
+export function useScorers(projectId: string) {
+  return useQuery({
+    queryKey: ["evaluations", "scorers", projectId],
+    queryFn: () =>
+      getJson<{ data: ScorerRegistryRow[] }>(`/api/projects/${projectId}/evaluations/scorers`),
+    enabled: !!projectId,
+  });
+}

--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -158,6 +158,30 @@ export function useUpdateTestCase(projectId: string, datasetId: string) {
   });
 }
 
+export interface TestCaseRunRow {
+  resultId: string;
+  runId: string;
+  runNumber: number;
+  candidateVersion: string;
+  evaluationName: string;
+  ranAt: string;
+  score: number | null;
+  status: string;
+  change: "improved" | "regressed" | "unchanged" | null;
+}
+
+/** Every evaluation run that measured a given test case (newest first). */
+export function useTestCaseRuns(projectId: string, datasetId: string, testCaseId: string | null) {
+  return useQuery({
+    queryKey: ["datasets", projectId, datasetId, "test-case-runs", testCaseId],
+    queryFn: () =>
+      getJson<{ data: TestCaseRunRow[] }>(
+        `/api/projects/${projectId}/datasets/${datasetId}/test-cases/${testCaseId}/runs`,
+      ),
+    enabled: !!projectId && !!datasetId && !!testCaseId,
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Evaluations
 // ---------------------------------------------------------------------------

--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -63,12 +63,14 @@ export function useDatasets(
   });
 }
 
-export function useDataset(projectId: string, datasetId: string) {
+export function useDataset(projectId: string, datasetId: string, versionId?: string | null) {
+  const qs = versionId ? `?version_id=${encodeURIComponent(versionId)}` : "";
   return useQuery({
-    queryKey: ["datasets", "detail", projectId, datasetId],
+    queryKey: ["datasets", "detail", projectId, datasetId, versionId ?? null],
     queryFn: () =>
-      getJson<DatasetDetailResponse>(`/api/projects/${projectId}/datasets/${datasetId}`),
+      getJson<DatasetDetailResponse>(`/api/projects/${projectId}/datasets/${datasetId}${qs}`),
     enabled: !!projectId && !!datasetId,
+    placeholderData: (prev) => prev,
   });
 }
 
@@ -211,6 +213,7 @@ export function useEvaluationRuns(
   if (query.status) params.set("status", query.status);
   if (query.search_query) params.set("search_query", query.search_query);
   if (query.page !== undefined) params.set("page", String(query.page));
+  if (query.limit !== undefined) params.set("limit", String(query.limit));
   const qs = params.toString();
   return useQuery({
     queryKey: [
@@ -222,6 +225,7 @@ export function useEvaluationRuns(
       query.status ?? null,
       query.search_query ?? null,
       query.page ?? 0,
+      query.limit ?? null,
     ],
     queryFn: () =>
       getJson<{ data: RunRow[]; meta: Meta }>(
@@ -313,6 +317,9 @@ export function useTraceTestCases(projectId: string, traceId: string) {
         `/api/projects/${projectId}/traces/${traceId}/test-cases`,
       ),
     enabled: !!projectId && !!traceId,
+    // Warmed when the trace opens (see the traces page) and reused as spans are
+    // selected, so the "Dataset:" chip appears without a per-span round trip.
+    staleTime: 60_000,
   });
 }
 

--- a/frontend/ui/src/features/evaluations/hooks.ts
+++ b/frontend/ui/src/features/evaluations/hooks.ts
@@ -272,6 +272,9 @@ export interface TraceTestCaseRow {
   datasetName: string;
   sourceSpanId: string | null;
   review: string;
+  datasetVersionLabel: string;
+  datasetUpdatedAt: string;
+  caseCount: number;
 }
 
 /**

--- a/frontend/ui/src/features/evaluations/save-test-case-drawer.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/save-test-case-drawer.smoke.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+/**
+ * The real Save-as-test-case drawer exposes the full capture flow:
+ * dataset picker (with a "New dataset" option), selected span + capture reason,
+ * read-only Recorded output, the three-way Expected outcome, Metadata, and the
+ * Source toggle. This mounts it against a stubbed trace + datasets and asserts
+ * those details are present (the earlier version was missing most of them).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/lib/api/traces", () => ({
+  getTrace: vi.fn(async () => ({
+    trace_id: "t1",
+    spans: [
+      {
+        span_id: "root",
+        parent_span_id: null,
+        name: "support-ticket-triage",
+        span_kind: "AGENT",
+        input: "I was charged twice",
+        output: "billing",
+        status: "OK",
+        metadata: null,
+      },
+    ],
+  })),
+}));
+
+import { SaveTestCaseDrawer } from "./components/trace-integration";
+
+beforeEach(() => {
+  global.fetch = vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      data: [{ id: "ds1", name: "Billing routing", caseCount: 2, versionCount: 1 }],
+      meta: { page: 0, limit: 200, total: 1 },
+    }),
+  })) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function mount(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{node}</QueryClientProvider>);
+}
+
+describe("Save as test case drawer", () => {
+  it("renders every drawer detail", async () => {
+    mount(<SaveTestCaseDrawer projectId="p1" traceId="t1" open onOpenChange={() => {}} />);
+    // Header + the selected span derived from the fetched trace.
+    expect(screen.getByText("Save as test case")).toBeDefined();
+    expect(await screen.findByText("support-ticket-triage")).toBeDefined();
+    // The details the earlier stripped version was missing. The single editable Output
+    // field replaced the read-only Recorded output + three-way Expected outcome.
+    expect(screen.getByText("Output")).toBeDefined();
+    expect(
+      screen.getByText(/becomes the outcome future runs are evaluated against|expected outcome/i),
+    ).toBeDefined();
+    expect(screen.getByText("Source")).toBeDefined();
+    expect(screen.getByText(/Capture reason/)).toBeDefined();
+    // (The inline "New dataset" option lives inside the closed Select portal,
+    // which Radix only mounts on open — not assertable in jsdom while closed.)
+  });
+});

--- a/frontend/ui/src/features/evaluations/trace-integration.smoke.test.tsx
+++ b/frontend/ui/src/features/evaluations/trace-integration.smoke.test.tsx
@@ -1,0 +1,467 @@
+// @vitest-environment jsdom
+/**
+ * The parts of the trace ↔ evaluation integration the existing Save-as-test-case
+ * smokes don't reach: the capture drawer's full save round trip (pick or create a
+ * dataset, walk spans, detach the source, duplicate + failure handling) and the
+ * two read-only trace-viewer chips — "Evaluation:" for a trace an evaluation run
+ * produced, and "Dataset:" for a span already saved as a test case.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll } from "vitest";
+import { render, cleanup, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ projectId: "p1" }),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/projects/p1/traces",
+}));
+
+// A two-span trace so the up/down span walk has somewhere to go. The child is a
+// failed TOOL span, which is what makes the capture reason "failed_tool".
+vi.mock("@/lib/api/traces", () => ({
+  getTrace: vi.fn(async () => ({
+    trace_id: "t1",
+    spans: [
+      {
+        span_id: "root",
+        parent_span_id: null,
+        name: "support-ticket-triage",
+        span_kind: "AGENT",
+        status: "OK",
+        metadata: null,
+      },
+      {
+        span_id: "child",
+        parent_span_id: "root",
+        name: "lookup_invoice",
+        span_kind: "TOOL",
+        status: "ERROR",
+        metadata: null,
+      },
+    ],
+  })),
+}));
+
+// Captured span I/O. Metadata is absent here; a span whose metadata is not a JSON
+// object now blocks the save outright rather than being silently dropped, which is
+// covered on its own below.
+const spanIO = vi.hoisted(() => ({
+  data: {
+    input: "I was charged twice for my July invoice",
+    output: "billing",
+    metadata: null as string | null,
+  },
+}));
+vi.mock("@/features/traces", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/traces")>();
+  // The drawer only treats I/O as ready once it belongs to the selected span, so
+  // the stub has to echo back the span it was asked for — a fixed payload would
+  // read as "still loading" forever and never enable Save. Results are cached per
+  // span so each render returns the same object, as a real query would; a fresh
+  // one each time re-fires the seeding effect and loops.
+  const cache = new Map<string, { data: unknown }>();
+  return {
+    ...actual,
+    useSpanIO: (_projectId: string, traceId: string, spanId: string | null) => {
+      if (!spanId) return { data: undefined };
+      // Key on the payload too, so a test that varies the fixture is not served a
+      // stale entry from an earlier one.
+      const key = `${spanId}|${JSON.stringify(spanIO.data)}`;
+      if (!cache.has(key)) {
+        cache.set(key, { data: { ...spanIO.data, span_id: spanId, trace_id: traceId } });
+      }
+      return cache.get(key)!;
+    },
+  };
+});
+// Radix Select renders through a portal and is flaky in jsdom; mock it to a
+// native <select>, matching save-test-case-drawer.smoke.test.tsx, so the dataset
+// picker can be driven directly.
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value: string;
+    onValueChange: (v: string) => void;
+    children: React.ReactNode;
+  }) => (
+    <select aria-label="Dataset" value={value} onChange={(e) => onValueChange(e.target.value)}>
+      <option value="" />
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+vi.mock("@/features/projects/hooks", () => ({
+  useProject: () => ({ data: { id: "p1", name: "support-bot" } }),
+}));
+
+import {
+  SaveTestCaseDrawer,
+  TraceEvaluationChip,
+  SpanDatasetChip,
+} from "./components/trace-integration";
+
+const DATASETS = [{ id: "ds1", name: "Billing routing", caseCount: 2, versionCount: 1 }];
+
+let requests: Array<{ url: string; method: string; body: Record<string, unknown> }> = [];
+/** Toggled per-test to drive the duplicate / failure branches of the save. */
+let saveResponse: { duplicate: boolean } = { duplicate: false };
+let saveFails = false;
+
+/** Evaluation results a trace produced; empty means the chip renders nothing. */
+let evaluationResults: unknown[] = [];
+/** Dataset test cases captured from the trace, keyed by source span. */
+let traceTestCases: unknown[] = [];
+
+beforeAll(() => {
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
+  window.HTMLElement.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  window.HTMLElement.prototype.releasePointerCapture = vi.fn();
+});
+
+beforeEach(() => {
+  requests = [];
+  saveResponse = { duplicate: false };
+  saveFails = false;
+  evaluationResults = [];
+  traceTestCases = [];
+  global.fetch = vi.fn(async (url: RequestInfo | URL, init?: RequestInit) => {
+    const s = String(url);
+    const method = init?.method ?? "GET";
+    requests.push({
+      url: s,
+      method,
+      body: init?.body ? JSON.parse(String(init.body)) : {},
+    });
+    if (s.endsWith("/test-cases") && method === "POST") {
+      if (saveFails) return { ok: false, status: 500, json: async () => ({ error: "nope" }) };
+      return { ok: true, status: 200, json: async () => saveResponse };
+    }
+    if (s.includes("/evaluation-results")) {
+      return { ok: true, status: 200, json: async () => ({ data: evaluationResults }) };
+    }
+    if (s.endsWith("/test-cases") || s.includes("/traces/")) {
+      return { ok: true, status: 200, json: async () => ({ data: traceTestCases }) };
+    }
+    if (s.includes("/datasets") && method === "POST") {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ dataset: { id: "ds_new", name: "Refund routing" } }),
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ data: DATASETS, meta: { page: 0, limit: 200, total: 1 } }),
+    };
+  }) as unknown as typeof fetch;
+});
+afterEach(() => cleanup());
+
+function mount(node: React.ReactNode) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={qc}>{node}</QueryClientProvider>);
+}
+
+function mountDrawer(onOpenChange = vi.fn()) {
+  mount(<SaveTestCaseDrawer projectId="p1" traceId="t1" open onOpenChange={onOpenChange} />);
+  return onOpenChange;
+}
+
+/** Picks a dataset by name from the drawer's dataset select. */
+async function pickDataset(name: string) {
+  const select = screen.getByLabelText("Dataset") as HTMLSelectElement;
+  const option = Array.from(select.options).find((o) => o.textContent === name);
+  if (!option) throw new Error(`no dataset option named ${name}`);
+  fireEvent.change(select, { target: { value: option.value } });
+}
+
+function savePayload() {
+  return requests.find((r) => r.method === "POST" && r.url.endsWith("/test-cases"))?.body;
+}
+
+describe("SaveTestCaseDrawer — save round trip", () => {
+  it("renders nothing without a trace id", () => {
+    mount(<SaveTestCaseDrawer projectId="p1" traceId={null} open onOpenChange={vi.fn()} />);
+    expect(screen.queryByText("Save as test case")).toBeNull();
+  });
+
+  it("cannot save until a dataset is picked, then posts the captured case", async () => {
+    const onOpenChange = mountDrawer();
+    await screen.findByText("support-ticket-triage");
+
+    // No dataset yet: the button is generic and disabled.
+    const before = screen.getByRole("button", { name: "Save" });
+    expect(before.hasAttribute("disabled")).toBe(true);
+
+    await pickDataset("Billing routing");
+    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+
+    await waitFor(() => expect(savePayload()).toBeDefined());
+    expect(savePayload()).toMatchObject({
+      input: "I was charged twice for my July invoice",
+      // Untouched, the Output field is still the expected outcome.
+      expected: "billing",
+      recorded_output: "billing",
+      metadata: null,
+      review: "needs_review",
+      capture_reason: "manual",
+      source_trace_id: "t1",
+      source_span_id: "root",
+      source_span_name: "support-ticket-triage",
+      source_span_kind: "trace",
+    });
+
+    expect(await screen.findByText(/Saved — published as a new dataset version/)).toBeDefined();
+    // The drawer closes itself shortly after a successful save.
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false), { timeout: 2000 });
+  });
+
+  it("an edited Output is what future runs are graded against", async () => {
+    mountDrawer();
+    await screen.findByText("support-ticket-triage");
+    fireEvent.change(screen.getByLabelText("Output"), { target: { value: "refunds" } });
+    await pickDataset("Billing routing");
+    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+    await waitFor(() => expect(savePayload()).toBeDefined());
+    expect(savePayload()).toMatchObject({ expected: "refunds", recorded_output: "billing" });
+  });
+
+  it("walking to a failed tool span changes the span, kind, and capture reason", async () => {
+    mountDrawer();
+    await screen.findByText("support-ticket-triage");
+    expect(screen.getByLabelText("Previous span").hasAttribute("disabled")).toBe(true);
+
+    fireEvent.click(screen.getByLabelText("Next span"));
+    expect(await screen.findByText("lookup_invoice")).toBeDefined();
+    expect(screen.getByLabelText("Next span").hasAttribute("disabled")).toBe(true);
+
+    await pickDataset("Billing routing");
+    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+    await waitFor(() => expect(savePayload()).toBeDefined());
+    expect(savePayload()).toMatchObject({
+      capture_reason: "failed_tool",
+      source_span_id: "child",
+      source_span_kind: "TOOL",
+    });
+
+    // And back up to the root.
+    fireEvent.click(screen.getByLabelText("Previous span"));
+    expect(await screen.findByText("support-ticket-triage")).toBeDefined();
+  });
+
+  it("turning Source off saves the case with no trace or span linked", async () => {
+    mountDrawer();
+    await screen.findByText("support-ticket-triage");
+    // The source block lists the trace and span it would attach.
+    expect(screen.getByText("Source trace")).toBeDefined();
+
+    fireEvent.click(screen.getByRole("switch"));
+    expect(await screen.findByText(/Added as a manual case/)).toBeDefined();
+
+    await pickDataset("Billing routing");
+    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+    await waitFor(() => expect(savePayload()).toBeDefined());
+    expect(savePayload()).toMatchObject({
+      source_trace_id: null,
+      source_span_id: null,
+      source_span_name: null,
+      source_span_kind: null,
+    });
+  });
+
+  it("creating a dataset inline creates it first, then saves into it", async () => {
+    mountDrawer();
+    await screen.findByText("support-ticket-triage");
+
+    await pickDataset("New dataset");
+    fireEvent.change(await screen.findByPlaceholderText("New dataset name"), {
+      target: { value: "  Refund routing  " },
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Create dataset & save" }));
+    await waitFor(() => expect(savePayload()).toBeDefined());
+
+    const create = requests.find((r) => r.method === "POST" && r.url.endsWith("/datasets"));
+    expect(create?.body).toEqual({ name: "Refund routing" });
+    // The case lands in the dataset that was just created.
+    expect(
+      requests.find((r) => r.method === "POST" && r.url.endsWith("/test-cases"))?.url,
+    ).toContain("/datasets/ds_new/test-cases");
+  });
+
+  it("a duplicate span offers the existing case instead of adding another row", async () => {
+    saveResponse = { duplicate: true };
+    mountDrawer();
+    await screen.findByText("support-ticket-triage");
+    await pickDataset("Billing routing");
+    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+
+    expect(await screen.findByText(/already a test case in this dataset/)).toBeDefined();
+    const link = screen.getByText("Open existing test case").closest("a") as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/projects/p1/datasets/ds1");
+    // No success note — nothing was written.
+    expect(screen.queryByText(/Saved — published/)).toBeNull();
+  });
+
+  it("surfaces a failed save without closing", async () => {
+    saveFails = true;
+    const onOpenChange = mountDrawer();
+    await screen.findByText("support-ticket-triage");
+    await pickDataset("Billing routing");
+    fireEvent.click(await screen.findByRole("button", { name: "Save to Billing routing" }));
+
+    expect(await screen.findByText("Could not save test case.")).toBeDefined();
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("refuses to save a span whose metadata isn't a JSON object", async () => {
+    spanIO.data.metadata = "not json at all";
+    try {
+      mountDrawer();
+      await screen.findByText("support-ticket-triage");
+      await pickDataset("Billing routing");
+      expect(
+        screen.getByRole("button", { name: "Save to Billing routing" }).hasAttribute("disabled"),
+      ).toBe(true);
+      expect(
+        screen.getByText(/Metadata isn't valid JSON|Metadata must be a JSON object/),
+      ).toBeDefined();
+    } finally {
+      spanIO.data.metadata = null;
+    }
+  });
+
+  it("closes from the X, from Cancel, and from Escape", async () => {
+    const onOpenChange = mountDrawer();
+    await screen.findByText("support-ticket-triage");
+
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    onOpenChange.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    // Escape is handled on the drawer's own root in the bubble phase, so that a
+    // nested Radix layer (the dataset select, a format popover) keeps its own
+    // Escape. The event therefore has to originate inside the drawer, not window.
+    onOpenChange.mockClear();
+    fireEvent.keyDown(screen.getByLabelText("Close"), { key: "Escape" });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    onOpenChange.mockClear();
+    fireEvent.keyDown(screen.getByLabelText("Close"), { key: "Enter" });
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("TraceEvaluationChip", () => {
+  it("renders nothing for a trace no evaluation produced", async () => {
+    mount(<TraceEvaluationChip projectId="p1" traceId="t1" />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.queryByText("Evaluation:")).toBeNull();
+  });
+
+  it("links to the run that produced the trace", async () => {
+    evaluationResults = [
+      {
+        id: "res1",
+        runId: "run1",
+        testCaseId: "tc_1",
+        traceId: "t1",
+        status: "passed",
+        mainScore: 1,
+        scores: [],
+        run: {
+          id: "run1",
+          runNumber: 27,
+          candidateVersion: "git:4a91c02",
+          datasetId: "ds1",
+          datasetVersionId: "dv1",
+          evaluation: { id: "eval1", name: "Billing routing nightly" },
+          datasetVersion: { label: "v2" },
+        },
+      },
+    ];
+    mount(<TraceEvaluationChip projectId="p1" traceId="t1" />);
+    expect(await screen.findByText("Billing routing nightly")).toBeDefined();
+    expect(screen.getByText(/Run #27 · git:4a91c02/)).toBeDefined();
+    const link = screen.getByText("Evaluation:").closest("a") as HTMLAnchorElement;
+    expect(link.getAttribute("href")).toBe("/projects/p1/evaluations/run1");
+  });
+});
+
+describe("SpanDatasetChip", () => {
+  const CASE = {
+    testCaseId: "tc_1",
+    datasetId: "ds1",
+    datasetName: "Billing routing",
+    sourceSpanId: "root",
+    review: "ready",
+    datasetVersionLabel: "v12",
+    datasetUpdatedAt: "2026-07-17T10:24:00Z",
+    caseCount: 8,
+  };
+
+  it("renders nothing for a span that isn't a saved case", async () => {
+    traceTestCases = [{ ...CASE, sourceSpanId: "other" }];
+    mount(<SpanDatasetChip projectId="p1" traceId="t1" spanId="root" />);
+    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    expect(screen.queryByText("Dataset:")).toBeNull();
+  });
+
+  it("marks the span with a chip per dataset it belongs to", async () => {
+    traceTestCases = [
+      CASE,
+      { ...CASE, testCaseId: "tc_2", datasetId: "ds2", datasetName: "Refund routing" },
+    ];
+    mount(<SpanDatasetChip projectId="p1" traceId="t1" spanId="root" />);
+    expect((await screen.findAllByText("Dataset:")).length).toBe(2);
+    // The chip is the popover trigger, not the link: the card it opens holds
+    // interactive controls, which may not live inside a tooltip. The dataset link
+    // sits inside that card.
+    const trigger = await screen.findByTitle("In dataset Billing routing");
+    expect(trigger.tagName).toBe("BUTTON");
+    fireEvent.click(trigger);
+    const open = await screen.findByRole("link", { name: /Open/ });
+    expect(open.getAttribute("href")).toBe("/projects/p1/datasets/ds1");
+  });
+
+  it("the card carries the version, case count, and a copyable SDK snippet", async () => {
+    traceTestCases = [CASE];
+    mount(<SpanDatasetChip projectId="p1" traceId="t1" spanId="root" />);
+    fireEvent.click(await screen.findByTitle("In dataset Billing routing"));
+
+    await screen.findAllByRole("button", { name: "Python" });
+    const card = screen
+      .getAllByRole("button", { name: "Python" })[0]
+      .closest("[data-radix-popper-content-wrapper], [role='dialog']") as HTMLElement;
+    expect(card.textContent).toContain("v12");
+    expect(card.textContent).toContain("8 cases");
+    // The snippet slugifies the dataset name and uses the real project name.
+    expect(card.textContent).toContain('traceroot.init_dataset("support-bot"');
+    expect(card.textContent).toContain('"dataset": "billing-routing"');
+
+    fireEvent.click(screen.getAllByRole("button", { name: "TypeScript" })[0]);
+    await waitFor(() => expect(card.textContent).toContain("traceroot.initDataset"));
+    expect(card.textContent).toContain('dataset: "billing-routing"');
+  });
+
+  it("a single-case dataset is described in the singular", async () => {
+    traceTestCases = [{ ...CASE, caseCount: 1 }];
+    mount(<SpanDatasetChip projectId="p1" traceId="t1" spanId="root" />);
+    fireEvent.click(await screen.findByTitle("In dataset Billing routing"));
+    expect((await screen.findAllByText("1 case")).length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/ui/src/features/evaluations/types.ts
+++ b/frontend/ui/src/features/evaluations/types.ts
@@ -1,0 +1,200 @@
+/**
+ * Client-side shapes for the server-backed evaluation feature. Timestamps arrive
+ * as ISO strings over JSON, so these mirror the Prisma rows with string dates.
+ */
+import type { RunComparison, ResultComparison } from "@/lib/eval/comparison";
+
+export type { RunComparison, ResultComparison, Classification } from "@/lib/eval/comparison";
+
+/** The per-result comparison block the run-detail route embeds on each result. */
+export type ResultRowComparison = Pick<
+  ResultComparison,
+  | "caseChange"
+  | "pairing"
+  | "mainScore"
+  | "baselineDurationMs"
+  | "durationDeltaMs"
+  | "scorerCells"
+  | "regressedCellCount"
+  | "comparableCellCount"
+>;
+
+export type ReviewStatus = "needs_review" | "ready";
+export type EvalResultStatus = "passed" | "failed" | "errored" | "not_scored";
+export type EvalRunStatus =
+  | "running"
+  | "completed"
+  | "completed_with_errors"
+  | "failed"
+  | "incomplete";
+
+export const EVAL_RUN_STATUS_LABEL: Record<EvalRunStatus, string> = {
+  running: "Running",
+  completed: "Completed",
+  completed_with_errors: "Completed with errors",
+  failed: "Failed",
+  incomplete: "Incomplete",
+};
+
+export interface DatasetRow {
+  id: string;
+  projectId: string;
+  name: string;
+  description: string | null;
+  currentVersionId: string | null;
+  createTime: string;
+  updateTime: string;
+  caseCount: number;
+  versionCount: number;
+}
+
+export interface DatasetVersionRow {
+  id: string;
+  datasetId: string;
+  projectId: string;
+  versionNumber: number;
+  label: string;
+  note: string | null;
+  createdBy: string | null;
+  createTime: string;
+}
+
+export interface TestCaseRow {
+  id: string;
+  testCaseId: string;
+  datasetVersionId: string;
+  datasetId: string;
+  projectId: string;
+  input: string;
+  expected: string | null;
+  recordedOutput: string | null;
+  metadata: unknown;
+  review: ReviewStatus;
+  captureReason: string;
+  sourceTraceId: string | null;
+  sourceSpanId: string | null;
+  sourceSpanName: string | null;
+  sourceSpanKind: string | null;
+  addedBy: string | null;
+  createTime: string;
+}
+
+export interface DatasetDetailResponse {
+  dataset: DatasetRow;
+  currentVersion: DatasetVersionRow | null;
+  /** The version whose cases are returned (the requested one, or current). */
+  selectedVersion: DatasetVersionRow | null;
+  /** True when `selectedVersion` is the dataset's current version. */
+  isCurrentVersion: boolean;
+  testCases: TestCaseRow[];
+  versions: DatasetVersionRow[];
+}
+
+export interface ScoreRow {
+  id: string;
+  scorerName: string;
+  scorerVersion: string;
+  numericValue: number | null;
+  boolValue: boolean | null;
+  stringValue: string | null;
+  passed: boolean | null;
+  explanation: string | null;
+  error: string | null;
+}
+
+export interface HumanScoreRow {
+  id: string;
+  verdict: string;
+  quality: number | null;
+  comment: string | null;
+  reviewer: string;
+  createTime: string;
+}
+
+export interface ResultRow {
+  id: string;
+  runId: string;
+  evaluationId: string;
+  testCaseId: string;
+  traceId: string | null;
+  input: string;
+  expectedOutput: string | null;
+  candidateOutput: string | null;
+  baselineOutput: string | null;
+  status: EvalResultStatus;
+  mainScore: number | null;
+  change: "improved" | "regressed" | "unchanged" | null;
+  taskError: string | null;
+  durationMs: number | null;
+  cost: number | null;
+  createTime: string;
+  scores: ScoreRow[];
+  humanScores: HumanScoreRow[];
+  /** Backend-derived candidate-vs-baseline comparison for this result. */
+  comparison: ResultRowComparison | null;
+}
+
+export interface RunRow {
+  id: string;
+  evaluationId: string;
+  datasetId: string;
+  datasetVersionId: string;
+  runNumber: number;
+  candidateVersion: string;
+  environment: string;
+  status: EvalRunStatus;
+  baselineRunId: string | null;
+  mainScore: number | null;
+  mainScoreName: string | null;
+  caseCount: number;
+  scoredCount: number;
+  taskErrorCount: number;
+  scorerErrorCount: number;
+  scorers: Array<{ name: string; version: string }> | null;
+  model: string | null;
+  /** Structured run provenance (model, prompt, config, git). Free-form; may be null. */
+  metadata: Record<string, unknown> | null;
+  startedAt: string;
+  completedAt: string | null;
+  evaluationName: string;
+  datasetName: string | null;
+  datasetVersionLabel: string;
+  changeFromBaseline: number | null;
+  errorCount: number;
+  /** Derived (list route): regressed test-case count when trustworthy, else null. */
+  regressedCaseCount?: number | null;
+  /** Derived: whether the candidate-vs-baseline comparison is trustworthy. */
+  baselineComparable?: boolean;
+  /** Run wall-clock (completedAt − startedAt), null while running. */
+  elapsedMs?: number | null;
+}
+
+export interface RunDetail extends RunRow {
+  baselineComparable: boolean;
+  elapsedMs: number | null;
+  /** The backend-derived run-level comparison (single source of truth). */
+  comparison: RunComparison;
+}
+
+export interface RunDetailResponse {
+  run: RunDetail;
+  results: ResultRow[];
+}
+
+export interface EvaluationRow {
+  id: string;
+  name: string;
+  datasetId: string;
+  mainScoreName: string;
+  datasetName: string | null;
+  runCount: number;
+  latestRun: {
+    id: string;
+    runNumber: number;
+    candidateVersion: string;
+    status: EvalRunStatus;
+    mainScore: number | null;
+    startedAt: string;
+    datasetVersionId: string;
+  } | null;
+}

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -24,6 +24,13 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -49,11 +56,12 @@ import {
   TestCaseReviewDrawer,
   type TestCaseReviewTarget,
 } from "@/features/offline-eval/components";
+import { tokenizeCode } from "@/features/offline-eval/components/syntax";
 import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
 import {
   caseDisplayId,
   changeSentiment,
-  datasetInitCode,
+  datasetPullCode,
   pct,
   scoreDisplay,
   SENTIMENT_CLASS,
@@ -61,6 +69,7 @@ import {
 } from "@/features/offline-eval/utils";
 import {
   useDataset,
+  useDatasets,
   useSaveTestCase,
   useUpdateTestCase,
   useEvaluationRuns,
@@ -123,7 +132,10 @@ export function DatasetDetailView({
   const { toast } = useToast();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data, isLoading, error } = useDataset(projectId, datasetId);
+  // null = the current version. Selecting an older version loads its snapshot
+  // (read-only — editing always branches from the current version).
+  const [selectedVersionId, setSelectedVersionId] = React.useState<string | null>(null);
+  const { data, isLoading, error } = useDataset(projectId, datasetId, selectedVersionId);
   const save = useSaveTestCase(projectId, datasetId);
   const update = useUpdateTestCase(projectId, datasetId);
 
@@ -156,6 +168,9 @@ export function DatasetDetailView({
   const [codeOpen, setCodeOpen] = React.useState(false);
 
   const dataset = data?.dataset ?? null;
+  const versions = React.useMemo(() => data?.versions ?? [], [data]);
+  const selectedVersion = data?.selectedVersion ?? null;
+  const isCurrentVersion = data?.isCurrentVersion ?? true;
   const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
 
   const cases = React.useMemo(() => {
@@ -168,6 +183,10 @@ export function DatasetDetailView({
 
   const caseIds = React.useMemo(() => cases.map((c) => c.id), [cases]);
   const sel = useRowSelection(caseIds);
+
+  // All datasets in the project, for the breadcrumb's dataset switcher.
+  const { data: allDatasetsData } = useDatasets(projectId, { limit: 200 });
+  const allDatasets = React.useMemo(() => allDatasetsData?.data ?? [], [allDatasetsData]);
 
   const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
   const runs = React.useMemo(() => evaluations.data?.data ?? [], [evaluations.data]);
@@ -288,10 +307,34 @@ export function DatasetDetailView({
 
   return (
     <>
-      <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+      <ProjectBreadcrumb
+        projectId={projectId}
+        trail={[
+          {
+            // Just the dataset segment (no separate "Datasets" crumb) — a dropdown
+            // of all datasets, like the project segment. Its menu header still links
+            // to the Datasets list, so that page stays one click away.
+            label: dataset.name,
+            menuHeader: { label: "Datasets", href: `/projects/${projectId}/datasets` },
+            options: allDatasets.map((d) => ({
+              id: d.id,
+              label: d.name,
+              href: `/projects/${projectId}/datasets/${d.id}`,
+              isCurrent: d.id === dataset.id,
+            })),
+          },
+        ]}
+      />
       <div className="flex h-full flex-col text-[13px]">
         <EvalPageHeader
-          title={dataset.name}
+          title={
+            <span className="flex flex-wrap items-center gap-2">
+              <span>{dataset.name}</span>
+              <span className="font-mono text-xs font-normal text-muted-foreground">
+                {dataset.id}
+              </span>
+            </span>
+          }
           action={
             <Button size="sm" className="h-7 gap-1.5 text-[12px]" onClick={() => setRunOpen(true)}>
               <Play className="h-3.5 w-3.5" aria-hidden />
@@ -299,6 +342,43 @@ export function DatasetDetailView({
             </Button>
           }
         />
+
+        {/* Version bar — pick a snapshot to view (previous versions are read-only),
+            with its immutable version id + copy. */}
+        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-4 py-1.5 text-[12px]">
+          <span className="text-muted-foreground">Version</span>
+          <Select value={selectedVersion?.id ?? ""} onValueChange={(v) => setSelectedVersionId(v)}>
+            <SelectTrigger className="h-7 w-[240px] text-[12px]">
+              <SelectValue placeholder="Current version" />
+            </SelectTrigger>
+            <SelectContent>
+              {versions.map((v) => (
+                <SelectItem key={v.id} value={v.id} className="text-[12px]">
+                  v{v.versionNumber}
+                  {v.id === dataset.currentVersionId ? " (current)" : ""}
+                  {v.label ? ` · ${v.label}` : ""}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {selectedVersion && (
+            <>
+              <span className="font-mono text-[11px] text-muted-foreground">
+                {selectedVersion.id}
+              </span>
+              <CopyButton
+                value={selectedVersion.id}
+                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                title="Copy version ID"
+              />
+            </>
+          )}
+          {!isCurrentVersion && (
+            <span className="ml-auto rounded border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-700 dark:text-amber-300">
+              Viewing an older version — read only
+            </span>
+          )}
+        </div>
 
         <Tabs defaultValue="cases" className="flex min-h-0 flex-1 flex-col">
           <TabsList className="shrink-0 px-4 pt-2" aria-label="Dataset views">
@@ -330,6 +410,9 @@ export function DatasetDetailView({
                 size="sm"
                 className="h-7 gap-1.5 text-[12px]"
                 onClick={() => setImportOpen(true)}
+                // Editing branches from the current version, so it's disabled while
+                // viewing an older snapshot.
+                disabled={!isCurrentVersion}
               >
                 <Upload className="h-3.5 w-3.5" aria-hidden />
                 Import
@@ -339,7 +422,7 @@ export function DatasetDetailView({
                 size="sm"
                 className="h-7 gap-1.5 text-[12px]"
                 onClick={addEmptyRow}
-                disabled={save.isPending}
+                disabled={save.isPending || !isCurrentVersion}
               >
                 <Plus className="h-3.5 w-3.5" aria-hidden />
                 Row
@@ -421,7 +504,7 @@ export function DatasetDetailView({
                   onClick={() => setCodeOpen(true)}
                 >
                   <FileCode className="h-3.5 w-3.5" aria-hidden />
-                  Init code
+                  Pull code
                 </Button>
               </span>
             </SearchFilterBar>
@@ -542,6 +625,7 @@ export function DatasetDetailView({
           testCase={openCase}
           projectId={projectId}
           datasetId={datasetId}
+          readOnly={!isCurrentVersion}
           onClose={() => setOpenCaseId(null)}
           onReview={() => setReviewCaseId(openCase.id)}
           onNavigate={(dir) => {
@@ -580,19 +664,25 @@ export function DatasetDetailView({
       <Dialog open={codeOpen} onOpenChange={setCodeOpen}>
         <DialogContent className="max-w-[560px]">
           <DialogHeader>
-            <DialogTitle className="text-[13px] font-medium">
-              Create this dataset in code
-            </DialogTitle>
+            <DialogTitle className="text-[13px] font-medium">Pull this dataset in code</DialogTitle>
           </DialogHeader>
-          <pre className="overflow-x-auto rounded border border-border bg-muted/20 px-3 py-2.5 font-mono text-[11px] leading-relaxed">
-            {datasetInitCode(dataset.name)}
-          </pre>
+          {/* Padding on the wrapper, scroll on the inner <pre>: a horizontal
+              scrollbar can't eat the bottom padding (see run-evaluation-drawer). */}
+          <div className="rounded border border-border bg-muted/20 px-3 pb-5 pt-2.5">
+            <pre className="overflow-x-auto whitespace-pre font-mono text-[11px] leading-relaxed">
+              {tokenizeCode(datasetPullCode(dataset.id)).map((t, i) => (
+                <span key={i} className={t.cls || undefined}>
+                  {t.text}
+                </span>
+              ))}
+            </pre>
+          </div>
           <div className="flex justify-end">
             <Button
               size="sm"
               className="h-7 text-[12px]"
               onClick={() => {
-                navigator.clipboard?.writeText(datasetInitCode(dataset.name));
+                navigator.clipboard?.writeText(datasetPullCode(dataset.id));
                 toast({ title: "Copied", tone: "success" });
                 setCodeOpen(false);
               }}
@@ -632,6 +722,7 @@ function CasePanel({
   testCase,
   projectId,
   datasetId,
+  readOnly = false,
   onClose,
   onReview,
   onNavigate,
@@ -641,6 +732,9 @@ function CasePanel({
   testCase: TestCaseRow;
   projectId: string;
   datasetId: string;
+  /** Viewing an older snapshot: fields and Save are disabled (editing branches
+   * from the current version, not this one). */
+  readOnly?: boolean;
   onClose: () => void;
   onReview: () => void;
   onNavigate: (direction: "up" | "down") => void;
@@ -672,9 +766,10 @@ function CasePanel({
   }, [testCase.id, testCase.input, testCase.expected, initialMetadata]);
 
   const dirty =
-    inputText !== testCase.input ||
-    expectedText !== (testCase.expected ?? "") ||
-    metadataText !== initialMetadata;
+    !readOnly &&
+    (inputText !== testCase.input ||
+      expectedText !== (testCase.expected ?? "") ||
+      metadataText !== initialMetadata);
 
   // Metadata only persists when it parses to an object; a half-typed edit keeps
   // the prior value rather than blowing it away.
@@ -858,6 +953,7 @@ function CasePanel({
       {view === "details" ? (
         <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 text-[12px]">
           <EditableValueBlock
+            key={`input-${testCase.id}`}
             label="Input"
             text={inputText}
             onChange={setInputText}
@@ -865,8 +961,10 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            readOnly={readOnly}
           />
           <EditableValueBlock
+            key={`expected-${testCase.id}`}
             label="Expected"
             text={expectedText}
             onChange={setExpectedText}
@@ -874,10 +972,12 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            readOnly={readOnly}
           />
           {/* Recorded production output — read-only, kept separate from Expected. */}
           {testCase.recordedOutput !== null && (
             <EditableValueBlock
+              key={`recorded-${testCase.id}`}
               label="What happened in production"
               text={testCase.recordedOutput}
               onChange={() => {}}
@@ -889,14 +989,16 @@ function CasePanel({
             />
           )}
           <EditableValueBlock
+            key={`metadata-${testCase.id}`}
             label="Metadata"
             text={metadataText}
-            defaultKind="json"
+            defaultKind="pretty"
             onChange={setMetadataText}
             copyable
             autoDetectKind
             boxed
             minRows={2}
+            readOnly={readOnly}
           />
           <p className="text-[11px] leading-snug text-muted-foreground">
             Saving publishes a new dataset version — it changes what future runs are compared

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -220,23 +220,26 @@ export function DatasetDetailView({
     );
   };
 
-  const duplicateSelected = () => {
+  const duplicateSelected = async () => {
     const chosen = cases.filter((c) => sel.has(c.id));
     if (chosen.length === 0) return;
-    Promise.all(
-      chosen.map((c) =>
-        save.mutateAsync({
+    try {
+      // Sequential, NOT Promise.all: each duplicate publishes a new version off the
+      // PREVIOUS one. Firing them concurrently makes every publish copy the same
+      // pre-duplication snapshot, so all but one duplicate is dropped from the live
+      // dataset (and, with the publish CAS, the losers now conflict outright).
+      for (const c of chosen) {
+        await save.mutateAsync({
           input: c.input,
           expected: c.expected,
           metadata: asRecord(c.metadata),
           capture_reason: "manual",
-        }),
-      ),
-    )
-      .then(() => toast({ title: `Duplicated ${chosen.length}`, tone: "success" }))
-      .catch((e) =>
-        toast({ title: "Could not duplicate", description: String(e), tone: "warning" }),
-      );
+        });
+      }
+      toast({ title: `Duplicated ${chosen.length}`, tone: "success" });
+    } catch (e) {
+      toast({ title: "Could not duplicate", description: String(e), tone: "warning" });
+    }
     sel.clear();
   };
 

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -406,6 +406,9 @@ export function DatasetDetailView({
                     variant="ghost"
                     size="sm"
                     className="h-7 gap-1 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                    // Duplicate publishes into the current version — disabled while
+                    // viewing a read-only older snapshot.
+                    disabled={!isCurrentVersion}
                     onClick={duplicateSelected}
                   >
                     <Copy className="h-3.5 w-3.5" aria-hidden />
@@ -1020,9 +1023,13 @@ function CasePanel({
             Save changes
           </Button>
         )}
-        <Button size="sm" className="h-8 flex-1 text-[12px]" onClick={onReview}>
-          Review
-        </Button>
+        {/* Review publishes a new version, so it's only offered on the editable
+            current snapshot — not while viewing a read-only older version. */}
+        {!readOnly && (
+          <Button size="sm" className="h-8 flex-1 text-[12px]" onClick={onReview}>
+            Review
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -195,22 +195,18 @@ export function DatasetDetailView({
     };
   }, [reviewCase, dataset]);
 
-  const submitReview = (result: { review: ReviewStatus; correctedExpected?: string }) => {
+  const submitReview = async (result: { review: ReviewStatus; correctedExpected?: string }) => {
     if (!reviewCase) return;
-    update.mutate(
-      {
-        testCaseId: reviewCase.testCaseId,
-        patch: {
-          review: result.review,
-          ...(result.correctedExpected ? { expected: result.correctedExpected } : {}),
-        },
+    // Return the promise so the drawer only reports success / closes once the publish
+    // actually lands, and stays open (input intact) on failure. The drawer owns the
+    // success toast + close; a rejection there keeps the reviewer's work.
+    await update.mutateAsync({
+      testCaseId: reviewCase.testCaseId,
+      patch: {
+        review: result.review,
+        ...(result.correctedExpected ? { expected: result.correctedExpected } : {}),
       },
-      {
-        onSuccess: () =>
-          toast({ title: "Review saved — new dataset version published", tone: "success" }),
-      },
-    );
-    setReviewCaseId(null);
+    });
   };
 
   const addEmptyRow = () => {

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -9,12 +9,10 @@ import {
   ChevronRight,
   Copy,
   Database,
-  Download,
   Expand,
   FileCode,
   FileText,
   History,
-  Play,
   Plus,
   Shrink,
   SquareArrowOutUpRight,
@@ -47,7 +45,6 @@ import {
   EvalPageHeader,
   ReviewBadge,
   EditableValueBlock,
-  EvalResultBadge,
   SelectAllHeaderCell,
   SelectRowCell,
   Timestamp,
@@ -56,38 +53,28 @@ import {
   TestCaseReviewDrawer,
   type TestCaseReviewTarget,
 } from "@/features/offline-eval/components";
-import { tokenizeCode } from "@/features/offline-eval/components/syntax";
 import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
+import { RunStatusBadge, ScoreValue, formatCost, formatElapsed } from "./evaluations-view";
+import { PassRate } from "../components/pass-rate";
 import {
   caseDisplayId,
-  changeSentiment,
   datasetPullCode,
-  pct,
-  scoreDisplay,
-  SENTIMENT_CLASS,
+  datasetPullCodeTs,
   truncate,
 } from "@/features/offline-eval/utils";
 import {
   useDataset,
-  useDatasets,
   useSaveTestCase,
   useUpdateTestCase,
   useEvaluationRuns,
   useTestCaseRuns,
 } from "../hooks";
 import type { TestCaseRow } from "../types";
-import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
+import { PullCodeDrawer, type PullOption } from "../components/pull-code-drawer";
 
 /** "Last 14 days" default, matching the traces/datasets lists. */
 const DEFAULT_DATE_FILTER =
   DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
-
-/** Map a per-case change direction to a signed delta for the sentiment colour. */
-const CHANGE_DELTA: Record<"improved" | "regressed" | "unchanged", number> = {
-  improved: 1,
-  regressed: -1,
-  unchanged: 0,
-};
 
 /** A dash for the list; empty reads as a placeholder, not a blank cell. */
 function orDash(value: string | null): React.ReactNode {
@@ -112,7 +99,7 @@ function metadataPreview(metadata: unknown): React.ReactNode {
 }
 
 /**
- * Dataset detail — a faithful port of the prototype's dataset detail, wired to
+ * Dataset detail — the dataset detail surface, wired to
  * the server.
  *
  * Columns are Created · Input · Expected · Metadata (empty reads as "-"). New
@@ -163,7 +150,6 @@ export function DatasetDetailView({
   const [historyDate, setHistoryDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
   const [historyStart, setHistoryStart] = React.useState<Date | null>(null);
   const [historyEnd, setHistoryEnd] = React.useState<Date | null>(null);
-  const [runOpen, setRunOpen] = React.useState(false);
   const [importOpen, setImportOpen] = React.useState(false);
   const [codeOpen, setCodeOpen] = React.useState(false);
 
@@ -183,10 +169,6 @@ export function DatasetDetailView({
 
   const caseIds = React.useMemo(() => cases.map((c) => c.id), [cases]);
   const sel = useRowSelection(caseIds);
-
-  // All datasets in the project, for the breadcrumb's dataset switcher.
-  const { data: allDatasetsData } = useDatasets(projectId, { limit: 200 });
-  const allDatasets = React.useMemo(() => allDatasetsData?.data ?? [], [allDatasetsData]);
 
   const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
   const runs = React.useMemo(() => evaluations.data?.data ?? [], [evaluations.data]);
@@ -276,7 +258,7 @@ export function DatasetDetailView({
   if (isLoading) {
     return (
       <>
-        <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+        <ProjectBreadcrumb projectId={projectId} />
         <div className="flex h-64 items-center justify-center text-[13px] text-muted-foreground">
           Loading dataset...
         </div>
@@ -286,9 +268,12 @@ export function DatasetDetailView({
   if (error || !dataset || !data) {
     return (
       <>
-        <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+        <ProjectBreadcrumb projectId={projectId} />
         <div className="flex h-full flex-col text-[13px]">
-          <EvalPageHeader title="Dataset not found" />
+          <EvalPageHeader
+            parent={{ label: "Datasets", href: `/projects/${projectId}/datasets` }}
+            title="Dataset not found"
+          />
           <EvalBody>
             <EmptyState>
               No dataset with the id {datasetId}.{" "}
@@ -307,26 +292,10 @@ export function DatasetDetailView({
 
   return (
     <>
-      <ProjectBreadcrumb
-        projectId={projectId}
-        trail={[
-          {
-            // Just the dataset segment (no separate "Datasets" crumb) — a dropdown
-            // of all datasets, like the project segment. Its menu header still links
-            // to the Datasets list, so that page stays one click away.
-            label: dataset.name,
-            menuHeader: { label: "Datasets", href: `/projects/${projectId}/datasets` },
-            options: allDatasets.map((d) => ({
-              id: d.id,
-              label: d.name,
-              href: `/projects/${projectId}/datasets/${d.id}`,
-              isCurrent: d.id === dataset.id,
-            })),
-          },
-        ]}
-      />
+      <ProjectBreadcrumb projectId={projectId} />
       <div className="flex h-full flex-col text-[13px]">
         <EvalPageHeader
+          parent={{ label: "Datasets", href: `/projects/${projectId}/datasets` }}
           title={
             <span className="flex flex-wrap items-center gap-2">
               <span>{dataset.name}</span>
@@ -334,12 +303,6 @@ export function DatasetDetailView({
                 {dataset.id}
               </span>
             </span>
-          }
-          action={
-            <Button size="sm" className="h-7 gap-1.5 text-[12px]" onClick={() => setRunOpen(true)}>
-              <Play className="h-3.5 w-3.5" aria-hidden />
-              Run evaluation
-            </Button>
           }
         />
 
@@ -480,27 +443,6 @@ export function DatasetDetailView({
                   variant="ghost"
                   size="sm"
                   className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                  onClick={() => toast({ title: "Export — coming soon", tone: "success" })}
-                >
-                  <Download className="h-3.5 w-3.5" aria-hidden />
-                  Download
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
-                  onClick={() => {
-                    navigator.clipboard?.writeText(dataset.id);
-                    toast({ title: "Dataset ID copied", tone: "success" });
-                  }}
-                >
-                  <Copy className="h-3.5 w-3.5" aria-hidden />
-                  Copy ID
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
                   onClick={() => setCodeOpen(true)}
                 >
                   <FileCode className="h-3.5 w-3.5" aria-hidden />
@@ -548,9 +490,13 @@ export function DatasetDetailView({
                         <Td className="whitespace-nowrap text-muted-foreground">
                           <Timestamp iso={tc.createTime} />
                         </Td>
-                        <Td>{orDash(truncate(tc.input, 60) || null)}</Td>
-                        <Td>{orDash(tc.expected)}</Td>
-                        <Td>{metadataPreview(tc.metadata)}</Td>
+                        <Td className="max-w-[320px] truncate" title={tc.input || undefined}>
+                          {orDash(tc.input || null)}
+                        </Td>
+                        <Td className="max-w-[320px] truncate" title={tc.expected ?? undefined}>
+                          {orDash(tc.expected)}
+                        </Td>
+                        <Td className="max-w-[240px] truncate">{metadataPreview(tc.metadata)}</Td>
                       </TR>
                     ))}
                   </TBody>
@@ -584,10 +530,14 @@ export function DatasetDetailView({
                 <Table>
                   <THead>
                     <TRHead>
-                      <Th className="w-[170px]">Ran at</Th>
-                      <Th>Evaluation</Th>
-                      <Th>Main score</Th>
-                      <Th className="text-right">Score</Th>
+                      <Th>Evaluation / Run</Th>
+                      <Th>Dataset</Th>
+                      <Th className="w-[110px] text-right">Main score</Th>
+                      <Th className="w-[100px] text-right">Passed</Th>
+                      <Th className="w-[100px] text-right">Cost</Th>
+                      <Th className="w-[90px] text-right">Duration</Th>
+                      <Th className="w-[150px]">Status</Th>
+                      <Th className="w-[130px] text-right">Timestamp</Th>
                     </TRHead>
                   </THead>
                   <TBody>
@@ -597,17 +547,34 @@ export function DatasetDetailView({
                         interactive
                         onClick={() => router.push(`/projects/${projectId}/evaluations/${run.id}`)}
                       >
-                        <Td className="whitespace-nowrap text-muted-foreground">
-                          <Timestamp iso={run.startedAt} />
+                        <Td>
+                          <div className="font-medium">{run.evaluationName}</div>
+                          <div className="text-[11px] text-muted-foreground">
+                            Run #{run.runNumber} ·{" "}
+                            <span className="font-mono">{run.candidateVersion}</span>
+                          </div>
                         </Td>
-                        <Td className="font-medium">{run.evaluationName}</Td>
-                        <Td className="text-muted-foreground">{run.mainScoreName ?? "—"}</Td>
+                        <Td className="text-muted-foreground">
+                          <div>{run.datasetName}</div>
+                          <div className="text-[11px]">{run.datasetVersionLabel}</div>
+                        </Td>
                         <Td className="text-right tabular-nums">
-                          {run.mainScore === null ? (
-                            <span className="text-muted-foreground">—</span>
-                          ) : (
-                            pct(run.mainScore)
-                          )}
+                          <ScoreValue value={run.mainScore} />
+                        </Td>
+                        <Td className="text-right tabular-nums">
+                          <PassRate counts={run} />
+                        </Td>
+                        <Td className="text-right tabular-nums text-muted-foreground">
+                          {formatCost(run.cost)}
+                        </Td>
+                        <Td className="whitespace-nowrap text-right tabular-nums text-muted-foreground">
+                          {formatElapsed(run.elapsedMs)}
+                        </Td>
+                        <Td>
+                          <RunStatusBadge status={run.status} />
+                        </Td>
+                        <Td className="whitespace-nowrap text-right text-muted-foreground">
+                          <Timestamp iso={run.startedAt} />
                         </Td>
                       </TR>
                     ))}
@@ -625,6 +592,7 @@ export function DatasetDetailView({
           testCase={openCase}
           projectId={projectId}
           datasetId={datasetId}
+          datasetName={dataset.name}
           readOnly={!isCurrentVersion}
           onClose={() => setOpenCaseId(null)}
           onReview={() => setReviewCaseId(openCase.id)}
@@ -660,45 +628,28 @@ export function DatasetDetailView({
         </DialogContent>
       </Dialog>
 
-      {/* Init code — the SDK snippet, in a dialog with a copy button. */}
-      <Dialog open={codeOpen} onOpenChange={setCodeOpen}>
-        <DialogContent className="max-w-[560px]">
-          <DialogHeader>
-            <DialogTitle className="text-[13px] font-medium">Pull this dataset in code</DialogTitle>
-          </DialogHeader>
-          {/* Padding on the wrapper, scroll on the inner <pre>: a horizontal
-              scrollbar can't eat the bottom padding (see run-evaluation-drawer). */}
-          <div className="rounded border border-border bg-muted/20 px-3 pb-5 pt-2.5">
-            <pre className="overflow-x-auto whitespace-pre font-mono text-[11px] leading-relaxed">
-              {tokenizeCode(datasetPullCode(dataset.id)).map((t, i) => (
-                <span key={i} className={t.cls || undefined}>
-                  {t.text}
-                </span>
-              ))}
-            </pre>
-          </div>
-          <div className="flex justify-end">
-            <Button
-              size="sm"
-              className="h-7 text-[12px]"
-              onClick={() => {
-                navigator.clipboard?.writeText(datasetPullCode(dataset.id));
-                toast({ title: "Copied", tone: "success" });
-                setCodeOpen(false);
-              }}
-            >
-              Copy
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      {/* Launched from a dataset, so the snippet is prefilled with it. */}
-      <RunEvaluationDrawer
-        projectId={projectId}
-        open={runOpen}
-        onOpenChange={setRunOpen}
-        datasetId={datasetId}
+      {/* Pull code — the shared drawer: one snippet that fetches the dataset. */}
+      <PullCodeDrawer
+        title="Pull this dataset in code"
+        subtitle={
+          <>
+            Fetch <span className="font-medium text-foreground">{dataset.name}</span> to run an
+            evaluation against. Only the dataset is pullable — an evaluation or run id isn&apos;t.
+          </>
+        }
+        options={
+          [
+            {
+              id: "latest",
+              label: "Pull dataset",
+              note: "Fetches the dataset's current published version when the run starts.",
+              py: datasetPullCode(dataset.id),
+              ts: datasetPullCodeTs(dataset.id),
+            },
+          ] satisfies PullOption[]
+        }
+        open={codeOpen}
+        onOpenChange={setCodeOpen}
       />
 
       <TestCaseReviewDrawer
@@ -722,6 +673,7 @@ function CasePanel({
   testCase,
   projectId,
   datasetId,
+  datasetName,
   readOnly = false,
   onClose,
   onReview,
@@ -732,6 +684,7 @@ function CasePanel({
   testCase: TestCaseRow;
   projectId: string;
   datasetId: string;
+  datasetName: string;
   /** Viewing an older snapshot: fields and Save are disabled (editing branches
    * from the current version, not this one). */
   readOnly?: boolean;
@@ -742,6 +695,7 @@ function CasePanel({
   canNavigateDown: boolean;
 }) {
   const { toast } = useToast();
+  const router = useRouter();
   const { sidebarCollapsed } = useLayout();
   const update = useUpdateTestCase(projectId, datasetId);
   const caseRuns = useTestCaseRuns(projectId, datasetId, testCase.testCaseId);
@@ -961,6 +915,7 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            collapsible
             readOnly={readOnly}
           />
           <EditableValueBlock
@@ -972,6 +927,7 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            collapsible
             readOnly={readOnly}
           />
           {/* Recorded production output — read-only, kept separate from Expected. */}
@@ -985,6 +941,7 @@ function CasePanel({
               autoDetectKind
               boxed
               minRows={2}
+              collapsible
               readOnly
             />
           )}
@@ -998,6 +955,7 @@ function CasePanel({
             autoDetectKind
             boxed
             minRows={2}
+            collapsible
             readOnly={readOnly}
           />
           <p className="text-[11px] leading-snug text-muted-foreground">
@@ -1016,48 +974,31 @@ function CasePanel({
             <Table>
               <THead>
                 <TRHead>
-                  <Th className="w-[150px]">Ran at</Th>
-                  <Th>Candidate version</Th>
-                  <Th className="w-[90px] text-right">Score</Th>
-                  <Th className="w-[100px]">Change</Th>
-                  <Th className="w-[110px]">Status</Th>
+                  <Th>Evaluation / Run</Th>
+                  <Th>Dataset</Th>
+                  <Th className="w-[110px] text-right">Main score</Th>
+                  <Th className="w-[130px] text-right">Timestamp</Th>
                 </TRHead>
               </THead>
               <TBody>
                 {runs.map((r) => (
-                  <TR key={r.resultId}>
-                    <Td className="whitespace-nowrap text-muted-foreground">
-                      <Timestamp iso={r.ranAt} />
-                    </Td>
+                  <TR
+                    key={r.resultId}
+                    interactive
+                    onClick={() => router.push(`/projects/${projectId}/evaluations/${r.runId}`)}
+                  >
                     <Td>
-                      <Link
-                        href={`/projects/${projectId}/evaluations/${r.runId}`}
-                        className="rounded font-mono text-[11px] hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                      >
-                        {r.candidateVersion}
-                      </Link>
-                      <span className="ml-1.5 text-[11px] text-muted-foreground">
-                        {r.evaluationName}
-                      </span>
+                      <div className="font-medium">{r.evaluationName}</div>
+                      <div className="text-[11px] text-muted-foreground">
+                        Run #{r.runNumber} · <span className="font-mono">{r.candidateVersion}</span>
+                      </div>
                     </Td>
+                    <Td className="text-muted-foreground">{datasetName}</Td>
                     <Td className="text-right tabular-nums">
-                      {r.score === null ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : (
-                        scoreDisplay(r.score)
-                      )}
+                      <ScoreValue value={r.score} />
                     </Td>
-                    <Td>
-                      {r.change === null ? (
-                        <span className="text-muted-foreground">—</span>
-                      ) : (
-                        <span className={SENTIMENT_CLASS[changeSentiment(CHANGE_DELTA[r.change])]}>
-                          {r.change}
-                        </span>
-                      )}
-                    </Td>
-                    <Td>
-                      <EvalResultBadge status={r.status as never} />
+                    <Td className="whitespace-nowrap text-right text-muted-foreground">
+                      <Timestamp iso={r.ranAt} />
                     </Td>
                   </TR>
                 ))}

--- a/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx
@@ -1,0 +1,987 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronRight,
+  Copy,
+  Database,
+  Download,
+  Expand,
+  FileCode,
+  FileText,
+  History,
+  Play,
+  Plus,
+  Shrink,
+  SquareArrowOutUpRight,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useToast } from "@/components/ui/toast";
+import { useLayout } from "@/components/layout/app-layout";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { ProjectBreadcrumb } from "@/features/projects/components";
+import { SpanKindIcon } from "@/features/traces";
+import { cn } from "@/lib/utils";
+import {
+  EmptyState,
+  EvalBody,
+  EvalPageHeader,
+  ReviewBadge,
+  EditableValueBlock,
+  EvalResultBadge,
+  SelectAllHeaderCell,
+  SelectRowCell,
+  Timestamp,
+  UploadControl,
+  useRowSelection,
+  TestCaseReviewDrawer,
+  type TestCaseReviewTarget,
+} from "@/features/offline-eval/components";
+import { CAPTURE_REASON_LABEL, type ReviewStatus } from "@/features/offline-eval/types";
+import {
+  caseDisplayId,
+  changeSentiment,
+  datasetInitCode,
+  pct,
+  scoreDisplay,
+  SENTIMENT_CLASS,
+  truncate,
+} from "@/features/offline-eval/utils";
+import {
+  useDataset,
+  useSaveTestCase,
+  useUpdateTestCase,
+  useEvaluationRuns,
+  useTestCaseRuns,
+} from "../hooks";
+import type { TestCaseRow } from "../types";
+import { RunEvaluationDrawer } from "../components/run-evaluation-drawer";
+
+/** "Last 14 days" default, matching the traces/datasets lists. */
+const DEFAULT_DATE_FILTER =
+  DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
+
+/** Map a per-case change direction to a signed delta for the sentiment colour. */
+const CHANGE_DELTA: Record<"improved" | "regressed" | "unchanged", number> = {
+  improved: 1,
+  regressed: -1,
+  unchanged: 0,
+};
+
+/** A dash for the list; empty reads as a placeholder, not a blank cell. */
+function orDash(value: string | null): React.ReactNode {
+  return value && value.trim() !== "" ? value : <span className="text-muted-foreground">-</span>;
+}
+
+/** Metadata is stored as unknown JSON; coerce to a flat record for display/edit. */
+function asRecord(metadata: unknown): Record<string, unknown> {
+  return metadata && typeof metadata === "object" && !Array.isArray(metadata)
+    ? (metadata as Record<string, unknown>)
+    : {};
+}
+
+function metadataPreview(metadata: unknown): React.ReactNode {
+  const entries = Object.entries(asRecord(metadata));
+  if (entries.length === 0) return <span className="text-muted-foreground">-</span>;
+  return (
+    <span className="font-mono text-[11px] text-muted-foreground">
+      {truncate(entries.map(([k, v]) => `${k}: ${String(v)}`).join(", "), 48)}
+    </span>
+  );
+}
+
+/**
+ * Dataset detail — a faithful port of the prototype's dataset detail, wired to
+ * the server.
+ *
+ * Columns are Created · Input · Expected · Metadata (empty reads as "-"). New
+ * row adds an empty test case; Import is a centered dialog. Selecting rows
+ * offers Duplicate, Add to dataset, and Delete, with an X to cancel. Focusing a
+ * row slides in a panel from the right (the way a trace opens) showing the
+ * input, expected, and metadata as editable value blocks. Editing publishes a
+ * new immutable dataset version — an earlier run's snapshot is never rewritten.
+ */
+export function DatasetDetailView({
+  projectId,
+  datasetId,
+}: {
+  projectId: string;
+  datasetId: string;
+}) {
+  const { toast } = useToast();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { data, isLoading, error } = useDataset(projectId, datasetId);
+  const save = useSaveTestCase(projectId, datasetId);
+  const update = useUpdateTestCase(projectId, datasetId);
+
+  const [openCaseId, setOpenCaseId] = React.useState<string | null>(null);
+
+  // Deep link: /datasets/[id]?case=<testCaseId> opens that case's panel once (e.g.
+  // "View source test case" from an evaluation result). Matched on the stable
+  // testCaseId, not the per-version row id.
+  const handledCaseParam = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    const caseParam = searchParams.get("case");
+    if (!caseParam || !data || handledCaseParam.current === caseParam) return;
+    const match = data.testCases.find((c) => c.testCaseId === caseParam);
+    if (match) {
+      setOpenCaseId(match.id);
+      handledCaseParam.current = caseParam;
+    }
+  }, [searchParams, data]);
+  const [reviewCaseId, setReviewCaseId] = React.useState<string | null>(null);
+  const [keyword, setKeyword] = React.useState("");
+  const [caseDate, setCaseDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
+  const [caseStart, setCaseStart] = React.useState<Date | null>(null);
+  const [caseEnd, setCaseEnd] = React.useState<Date | null>(null);
+  const [historyKeyword, setHistoryKeyword] = React.useState("");
+  const [historyDate, setHistoryDate] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
+  const [historyStart, setHistoryStart] = React.useState<Date | null>(null);
+  const [historyEnd, setHistoryEnd] = React.useState<Date | null>(null);
+  const [runOpen, setRunOpen] = React.useState(false);
+  const [importOpen, setImportOpen] = React.useState(false);
+  const [codeOpen, setCodeOpen] = React.useState(false);
+
+  const dataset = data?.dataset ?? null;
+  const allCases = React.useMemo(() => data?.testCases ?? [], [data]);
+
+  const cases = React.useMemo(() => {
+    const q = keyword.trim().toLowerCase();
+    if (!q) return allCases;
+    return allCases.filter(
+      (c) => c.input.toLowerCase().includes(q) || (c.expected ?? "").toLowerCase().includes(q),
+    );
+  }, [allCases, keyword]);
+
+  const caseIds = React.useMemo(() => cases.map((c) => c.id), [cases]);
+  const sel = useRowSelection(caseIds);
+
+  const evaluations = useEvaluationRuns(projectId, { dataset_id: datasetId });
+  const runs = React.useMemo(() => evaluations.data?.data ?? [], [evaluations.data]);
+  const visibleRuns = React.useMemo(() => {
+    const q = historyKeyword.trim().toLowerCase();
+    if (!q) return runs;
+    return runs.filter(
+      (r) =>
+        r.evaluationName.toLowerCase().includes(q) ||
+        (r.mainScoreName ?? "").toLowerCase().includes(q),
+    );
+  }, [runs, historyKeyword]);
+
+  const openCase = openCaseId ? (cases.find((c) => c.id === openCaseId) ?? null) : null;
+  const reviewCase = reviewCaseId ? (cases.find((c) => c.id === reviewCaseId) ?? null) : null;
+
+  const reviewTarget = React.useMemo<TestCaseReviewTarget | null>(() => {
+    if (!reviewCase || !dataset) return null;
+    return {
+      contextLabel: `${caseDisplayId(reviewCase.testCaseId)} · ${dataset.name}`,
+      input: reviewCase.input,
+      expected: reviewCase.expected,
+      currentReview: reviewCase.review,
+    };
+  }, [reviewCase, dataset]);
+
+  const submitReview = (result: { review: ReviewStatus; correctedExpected?: string }) => {
+    if (!reviewCase) return;
+    update.mutate(
+      {
+        testCaseId: reviewCase.testCaseId,
+        patch: {
+          review: result.review,
+          ...(result.correctedExpected ? { expected: result.correctedExpected } : {}),
+        },
+      },
+      {
+        onSuccess: () =>
+          toast({ title: "Review saved — new dataset version published", tone: "success" }),
+      },
+    );
+    setReviewCaseId(null);
+  };
+
+  const addEmptyRow = () => {
+    save.mutate(
+      { input: "", review: "needs_review", capture_reason: "manual" },
+      { onSuccess: () => toast({ title: "Empty row added", tone: "success" }) },
+    );
+  };
+
+  const duplicateSelected = () => {
+    const chosen = cases.filter((c) => sel.has(c.id));
+    if (chosen.length === 0) return;
+    Promise.all(
+      chosen.map((c) =>
+        save.mutateAsync({
+          input: c.input,
+          expected: c.expected,
+          metadata: asRecord(c.metadata),
+          capture_reason: "manual",
+        }),
+      ),
+    )
+      .then(() => toast({ title: `Duplicated ${chosen.length}`, tone: "success" }))
+      .catch((e) =>
+        toast({ title: "Could not duplicate", description: String(e), tone: "warning" }),
+      );
+    sel.clear();
+  };
+
+  const addSelectedToDataset = () => {
+    if (sel.count === 0) return;
+    // Cross-dataset copy needs a target picker that isn't wired yet.
+    toast({ title: "Add to another dataset — coming soon", tone: "success" });
+    sel.clear();
+  };
+
+  const deleteSelected = () => {
+    if (sel.count === 0) return;
+    // Removing a case republishes the version without it — not wired yet, so the
+    // action stays honest rather than pretending rows were removed.
+    toast({ title: "Deleting cases — coming soon", tone: "success" });
+    sel.clear();
+  };
+
+  if (isLoading) {
+    return (
+      <>
+        <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+        <div className="flex h-64 items-center justify-center text-[13px] text-muted-foreground">
+          Loading dataset...
+        </div>
+      </>
+    );
+  }
+  if (error || !dataset || !data) {
+    return (
+      <>
+        <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+        <div className="flex h-full flex-col text-[13px]">
+          <EvalPageHeader title="Dataset not found" />
+          <EvalBody>
+            <EmptyState>
+              No dataset with the id {datasetId}.{" "}
+              <Link
+                href={`/projects/${projectId}/datasets`}
+                className="underline underline-offset-2"
+              >
+                Back to datasets
+              </Link>
+            </EmptyState>
+          </EvalBody>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+      <div className="flex h-full flex-col text-[13px]">
+        <EvalPageHeader
+          title={dataset.name}
+          action={
+            <Button size="sm" className="h-7 gap-1.5 text-[12px]" onClick={() => setRunOpen(true)}>
+              <Play className="h-3.5 w-3.5" aria-hidden />
+              Run evaluation
+            </Button>
+          }
+        />
+
+        <Tabs defaultValue="cases" className="flex min-h-0 flex-1 flex-col">
+          <TabsList className="shrink-0 px-4 pt-2" aria-label="Dataset views">
+            <TabsTrigger value="cases" count={cases.length}>
+              Test cases
+            </TabsTrigger>
+            <TabsTrigger value="history" count={runs.length}>
+              Evaluation history
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="cases" className="flex min-h-0 flex-1 flex-col">
+            {/* Toolbar — the standard SearchFilterBar (search + actions + date). */}
+            <SearchFilterBar
+              searchValue={keyword}
+              onSearchChange={setKeyword}
+              searchPlaceholder="Search cases..."
+              dateFilter={caseDate}
+              customStartDate={caseStart}
+              customEndDate={caseEnd}
+              onDateFilterChange={setCaseDate}
+              onCustomRangeChange={(s, e) => {
+                setCaseStart(s);
+                setCaseEnd(e);
+              }}
+            >
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 text-[12px]"
+                onClick={() => setImportOpen(true)}
+              >
+                <Upload className="h-3.5 w-3.5" aria-hidden />
+                Import
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 text-[12px]"
+                onClick={addEmptyRow}
+                disabled={save.isPending}
+              >
+                <Plus className="h-3.5 w-3.5" aria-hidden />
+                Row
+              </Button>
+
+              {/* Selection actions appear beside the editing actions when rows are selected. */}
+              {sel.count > 0 && (
+                <span className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={sel.clear}
+                    aria-label="Cancel selection"
+                    className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  >
+                    <X className="h-3.5 w-3.5" aria-hidden />
+                  </button>
+                  <span className="text-[12px] font-medium tabular-nums">{sel.count} selected</span>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                    onClick={duplicateSelected}
+                  >
+                    <Copy className="h-3.5 w-3.5" aria-hidden />
+                    Duplicate
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                    onClick={addSelectedToDataset}
+                  >
+                    <Plus className="h-3.5 w-3.5" aria-hidden />
+                    Add to dataset
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 gap-1 px-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    onClick={deleteSelected}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                    Delete
+                  </Button>
+                  <span className="h-4 w-px bg-border" aria-hidden />
+                </span>
+              )}
+
+              {/* Spacer keeps the dataset-level actions flush against the date filter. */}
+              <span className="flex-1" aria-hidden />
+
+              {/* Dataset-level actions (no dropdown). */}
+              <span className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                  onClick={() => toast({ title: "Export — coming soon", tone: "success" })}
+                >
+                  <Download className="h-3.5 w-3.5" aria-hidden />
+                  Download
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                  onClick={() => {
+                    navigator.clipboard?.writeText(dataset.id);
+                    toast({ title: "Dataset ID copied", tone: "success" });
+                  }}
+                >
+                  <Copy className="h-3.5 w-3.5" aria-hidden />
+                  Copy ID
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 gap-1.5 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+                  onClick={() => setCodeOpen(true)}
+                >
+                  <FileCode className="h-3.5 w-3.5" aria-hidden />
+                  Init code
+                </Button>
+              </span>
+            </SearchFilterBar>
+
+            {/* Table + focused-case slide-in panel */}
+            <div className="min-h-0 flex-1 overflow-auto">
+              {cases.length === 0 ? (
+                <EmptyState>
+                  {keyword
+                    ? "No cases match your search."
+                    : "No test cases yet — use Row to add one, or open a trace, select the root or a span, and save it as a test case."}
+                </EmptyState>
+              ) : (
+                <Table>
+                  <THead>
+                    <TRHead>
+                      <SelectAllHeaderCell
+                        checked={sel.allSelected}
+                        indeterminate={sel.someSelected}
+                        onToggle={sel.toggleAll}
+                      />
+                      <Th className="w-[150px]">Created</Th>
+                      <Th>Input</Th>
+                      <Th>Expected</Th>
+                      <Th>Metadata</Th>
+                    </TRHead>
+                  </THead>
+                  <TBody>
+                    {cases.map((tc) => (
+                      <TR
+                        key={tc.id}
+                        interactive
+                        selected={tc.id === openCaseId}
+                        onClick={() => setOpenCaseId(tc.id)}
+                      >
+                        <SelectRowCell
+                          checked={sel.has(tc.id)}
+                          onToggle={() => sel.toggle(tc.id)}
+                          label={`Select ${tc.testCaseId}`}
+                        />
+                        <Td className="whitespace-nowrap text-muted-foreground">
+                          <Timestamp iso={tc.createTime} />
+                        </Td>
+                        <Td>{orDash(truncate(tc.input, 60) || null)}</Td>
+                        <Td>{orDash(tc.expected)}</Td>
+                        <Td>{metadataPreview(tc.metadata)}</Td>
+                      </TR>
+                    ))}
+                  </TBody>
+                </Table>
+              )}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="history" className="flex min-h-0 flex-1 flex-col">
+            <SearchFilterBar
+              searchValue={historyKeyword}
+              onSearchChange={setHistoryKeyword}
+              searchPlaceholder="Search evaluations..."
+              dateFilter={historyDate}
+              customStartDate={historyStart}
+              customEndDate={historyEnd}
+              onDateFilterChange={setHistoryDate}
+              onCustomRangeChange={(s, e) => {
+                setHistoryStart(s);
+                setHistoryEnd(e);
+              }}
+            />
+            <EvalBody>
+              {visibleRuns.length === 0 ? (
+                <EmptyState>
+                  {historyKeyword
+                    ? "No evaluations match your search."
+                    : `Nothing has been run against ${dataset.name} yet.`}
+                </EmptyState>
+              ) : (
+                <Table>
+                  <THead>
+                    <TRHead>
+                      <Th className="w-[170px]">Ran at</Th>
+                      <Th>Evaluation</Th>
+                      <Th>Main score</Th>
+                      <Th className="text-right">Score</Th>
+                    </TRHead>
+                  </THead>
+                  <TBody>
+                    {visibleRuns.map((run) => (
+                      <TR
+                        key={run.id}
+                        interactive
+                        onClick={() => router.push(`/projects/${projectId}/evaluations/${run.id}`)}
+                      >
+                        <Td className="whitespace-nowrap text-muted-foreground">
+                          <Timestamp iso={run.startedAt} />
+                        </Td>
+                        <Td className="font-medium">{run.evaluationName}</Td>
+                        <Td className="text-muted-foreground">{run.mainScoreName ?? "—"}</Td>
+                        <Td className="text-right tabular-nums">
+                          {run.mainScore === null ? (
+                            <span className="text-muted-foreground">—</span>
+                          ) : (
+                            pct(run.mainScore)
+                          )}
+                        </Td>
+                      </TR>
+                    ))}
+                  </TBody>
+                </Table>
+              )}
+            </EvalBody>
+          </TabsContent>
+        </Tabs>
+      </div>
+
+      {/* Focused case — slides in from the right like a trace. */}
+      {openCase && (
+        <CasePanel
+          testCase={openCase}
+          projectId={projectId}
+          datasetId={datasetId}
+          onClose={() => setOpenCaseId(null)}
+          onReview={() => setReviewCaseId(openCase.id)}
+          onNavigate={(dir) => {
+            const idx = cases.findIndex((c) => c.id === openCase.id);
+            const next = dir === "up" ? idx - 1 : idx + 1;
+            if (next >= 0 && next < cases.length) setOpenCaseId(cases[next].id);
+          }}
+          canNavigateUp={cases.findIndex((c) => c.id === openCase.id) > 0}
+          canNavigateDown={cases.findIndex((c) => c.id === openCase.id) < cases.length - 1}
+        />
+      )}
+
+      {/* Import — centered island. */}
+      <Dialog open={importOpen} onOpenChange={setImportOpen}>
+        <DialogContent className="max-w-[520px]">
+          <DialogHeader>
+            <DialogTitle className="text-[13px] font-medium">Import test cases</DialogTitle>
+          </DialogHeader>
+          <UploadControl
+            onFile={(fileName) =>
+              toast({
+                title: "File selected — import coming soon",
+                description: `${fileName} would be imported.`,
+                tone: "success",
+              })
+            }
+          />
+          <p className="text-[11px] text-muted-foreground">
+            CSV or JSON. Bulk import isn&apos;t wired yet — add cases with Row, or save a span from
+            a trace.
+          </p>
+        </DialogContent>
+      </Dialog>
+
+      {/* Init code — the SDK snippet, in a dialog with a copy button. */}
+      <Dialog open={codeOpen} onOpenChange={setCodeOpen}>
+        <DialogContent className="max-w-[560px]">
+          <DialogHeader>
+            <DialogTitle className="text-[13px] font-medium">
+              Create this dataset in code
+            </DialogTitle>
+          </DialogHeader>
+          <pre className="overflow-x-auto rounded border border-border bg-muted/20 px-3 py-2.5 font-mono text-[11px] leading-relaxed">
+            {datasetInitCode(dataset.name)}
+          </pre>
+          <div className="flex justify-end">
+            <Button
+              size="sm"
+              className="h-7 text-[12px]"
+              onClick={() => {
+                navigator.clipboard?.writeText(datasetInitCode(dataset.name));
+                toast({ title: "Copied", tone: "success" });
+                setCodeOpen(false);
+              }}
+            >
+              Copy
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Launched from a dataset, so the snippet is prefilled with it. */}
+      <RunEvaluationDrawer
+        projectId={projectId}
+        open={runOpen}
+        onOpenChange={setRunOpen}
+        datasetId={datasetId}
+      />
+
+      <TestCaseReviewDrawer
+        target={reviewTarget}
+        open={reviewCaseId !== null}
+        onOpenChange={(open) => !open && setReviewCaseId(null)}
+        onSubmit={submitReview}
+      />
+    </>
+  );
+}
+
+/**
+ * Slide-in case panel, matching the trace/span detail panel: a header with an
+ * icon, the row id, a copy button and the up/down/fullscreen/open-in-new-tab/
+ * close controls; then the created date; then Source / Captured chips (in place
+ * of a span kind). Input, expected, and metadata render as editable value
+ * blocks; saving any edit publishes a new immutable dataset version.
+ */
+function CasePanel({
+  testCase,
+  projectId,
+  datasetId,
+  onClose,
+  onReview,
+  onNavigate,
+  canNavigateUp,
+  canNavigateDown,
+}: {
+  testCase: TestCaseRow;
+  projectId: string;
+  datasetId: string;
+  onClose: () => void;
+  onReview: () => void;
+  onNavigate: (direction: "up" | "down") => void;
+  canNavigateUp: boolean;
+  canNavigateDown: boolean;
+}) {
+  const { toast } = useToast();
+  const { sidebarCollapsed } = useLayout();
+  const update = useUpdateTestCase(projectId, datasetId);
+  const caseRuns = useTestCaseRuns(projectId, datasetId, testCase.testCaseId);
+  const runs = caseRuns.data?.data ?? [];
+  const [fullscreen, setFullscreen] = React.useState(false);
+  const [view, setView] = React.useState<"details" | "runs">("details");
+
+  // Editable buffers, seeded from the case and re-seeded when it changes.
+  // Input/expected are plain strings; metadata is edited as JSON and parsed back.
+  const initialMetadata = React.useMemo(() => {
+    const record = asRecord(testCase.metadata);
+    return Object.keys(record).length ? JSON.stringify(record, null, 2) : "";
+  }, [testCase.metadata]);
+  const [inputText, setInputText] = React.useState(testCase.input);
+  const [expectedText, setExpectedText] = React.useState(testCase.expected ?? "");
+  const [metadataText, setMetadataText] = React.useState(initialMetadata);
+
+  React.useEffect(() => {
+    setInputText(testCase.input);
+    setExpectedText(testCase.expected ?? "");
+    setMetadataText(initialMetadata);
+  }, [testCase.id, testCase.input, testCase.expected, initialMetadata]);
+
+  const dirty =
+    inputText !== testCase.input ||
+    expectedText !== (testCase.expected ?? "") ||
+    metadataText !== initialMetadata;
+
+  // Metadata only persists when it parses to an object; a half-typed edit keeps
+  // the prior value rather than blowing it away.
+  const parseMetadata = (): Record<string, unknown> | null | undefined => {
+    if (metadataText.trim() === "") return null;
+    try {
+      const parsed = JSON.parse(metadataText);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {
+      /* invalid JSON mid-edit */
+    }
+    return undefined; // leave stored metadata untouched
+  };
+
+  const saveEdits = () => {
+    const patch: {
+      input?: string;
+      expected?: string | null;
+      metadata?: Record<string, unknown> | null;
+    } = {};
+    if (inputText !== testCase.input) patch.input = inputText;
+    if (expectedText !== (testCase.expected ?? "")) {
+      patch.expected = expectedText.trim() === "" ? null : expectedText;
+    }
+    if (metadataText !== initialMetadata) {
+      const parsed = parseMetadata();
+      if (parsed !== undefined) patch.metadata = parsed;
+    }
+    if (Object.keys(patch).length === 0) return;
+    update.mutate(
+      { testCaseId: testCase.testCaseId, patch },
+      {
+        onSuccess: () => toast({ title: "Saved — new dataset version published", tone: "success" }),
+      },
+    );
+  };
+
+  return (
+    <div
+      className={cn(
+        "animate-slide-in-right fixed bottom-0 right-0 z-50 flex flex-col border-l border-border bg-background shadow-xl transition-[width,top] duration-200",
+        fullscreen
+          ? sidebarCollapsed
+            ? "top-14 w-[calc(100%-3.5rem)]"
+            : "top-14 w-[calc(100%-12rem)]"
+          : "top-0 w-[45%] min-w-[520px] max-w-[94vw]",
+      )}
+    >
+      {/* Header — same shape as the trace/span detail panel. */}
+      <div className="shrink-0 border-b border-border bg-muted/30 px-4 py-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <Database className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="text-sm font-medium">Row</span>
+            <span className="truncate font-mono text-xs text-muted-foreground">
+              {caseDisplayId(testCase.testCaseId)}
+            </span>
+            <CopyButton
+              value={testCase.testCaseId}
+              className="h-6 w-6 text-muted-foreground hover:text-foreground"
+              title="Copy ID"
+            />
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onNavigate("up")}
+              disabled={!canNavigateUp}
+              className="h-7 w-7 p-0"
+              title="Previous row"
+            >
+              <ArrowUp className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => onNavigate("down")}
+              disabled={!canNavigateDown}
+              className="h-7 w-7 p-0"
+              title="Next row"
+            >
+              <ArrowDown className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setFullscreen((v) => !v)}
+              className="h-7 w-7 p-0"
+              title={fullscreen ? "Restore default size" : "Expand to full screen"}
+            >
+              {fullscreen ? <Shrink className="h-4 w-4" /> : <Expand className="h-4 w-4" />}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => window.open(`/projects/${projectId}/datasets/${datasetId}`, "_blank")}
+              className="h-7 w-7 p-0"
+              title="Open in new tab"
+            >
+              <SquareArrowOutUpRight className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 w-7 p-0"
+              onClick={onClose}
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+
+        <Timestamp iso={testCase.createTime} className="mt-1 block text-xs text-muted-foreground" />
+
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <ReviewBadge status={testCase.review} />
+          {testCase.sourceTraceId ? (
+            <Link
+              href={`/projects/${projectId}/traces?traceId=${testCase.sourceTraceId}&fullscreen=1`}
+              className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 py-1 pl-2.5 pr-1.5 text-xs transition-colors hover:bg-muted"
+            >
+              <span className="text-muted-foreground">Source:</span>
+              <SpanKindIcon kind={(testCase.sourceSpanKind ?? "SPAN") as never} />
+              <span className="font-medium">{testCase.sourceSpanName ?? "trace"}</span>
+              <ChevronRight className="h-3 w-3 text-muted-foreground" />
+            </Link>
+          ) : (
+            <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
+              <span className="text-muted-foreground">Source:</span>
+              <span className="font-medium">Added manually</span>
+            </span>
+          )}
+          {/* Why this case was captured — read-only context. */}
+          <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
+            <span className="text-muted-foreground">Captured:</span>
+            <span className="font-medium">
+              {CAPTURE_REASON_LABEL[testCase.captureReason as keyof typeof CAPTURE_REASON_LABEL] ??
+                testCase.captureReason}
+            </span>
+          </span>
+        </div>
+      </div>
+
+      {/* View toggle — Details / Runs, where a trace shows Tree / Timeline. */}
+      <div className="flex h-10 shrink-0 items-center border-b border-border px-2">
+        <button
+          type="button"
+          onClick={() => setView("details")}
+          className={cn(
+            "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+            view === "details"
+              ? "bg-muted text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <FileText className="h-3.5 w-3.5" /> Details
+        </button>
+        <button
+          type="button"
+          onClick={() => setView("runs")}
+          className={cn(
+            "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+            view === "runs"
+              ? "bg-muted text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          <History className="h-3.5 w-3.5" /> Runs
+          {runs.length > 0 && (
+            <span className="rounded bg-muted px-1 text-[10px] tabular-nums text-muted-foreground">
+              {runs.length}
+            </span>
+          )}
+        </button>
+      </div>
+
+      {view === "details" ? (
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 text-[12px]">
+          <EditableValueBlock
+            label="Input"
+            text={inputText}
+            onChange={setInputText}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={2}
+          />
+          <EditableValueBlock
+            label="Expected"
+            text={expectedText}
+            onChange={setExpectedText}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={2}
+          />
+          {/* Recorded production output — read-only, kept separate from Expected. */}
+          {testCase.recordedOutput !== null && (
+            <EditableValueBlock
+              label="What happened in production"
+              text={testCase.recordedOutput}
+              onChange={() => {}}
+              copyable
+              autoDetectKind
+              boxed
+              minRows={2}
+              readOnly
+            />
+          )}
+          <EditableValueBlock
+            label="Metadata"
+            text={metadataText}
+            defaultKind="json"
+            onChange={setMetadataText}
+            copyable
+            autoDetectKind
+            boxed
+            minRows={2}
+          />
+          <p className="text-[11px] leading-snug text-muted-foreground">
+            Saving publishes a new dataset version — it changes what future runs are compared
+            against and never rewrites a snapshot an earlier run used.
+          </p>
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 overflow-auto p-4">
+          {runs.length === 0 ? (
+            <EmptyState>
+              No evaluation run has measured this test case yet. Runs appear here once your
+              application or CI reports them.
+            </EmptyState>
+          ) : (
+            <Table>
+              <THead>
+                <TRHead>
+                  <Th className="w-[150px]">Ran at</Th>
+                  <Th>Candidate version</Th>
+                  <Th className="w-[90px] text-right">Score</Th>
+                  <Th className="w-[100px]">Change</Th>
+                  <Th className="w-[110px]">Status</Th>
+                </TRHead>
+              </THead>
+              <TBody>
+                {runs.map((r) => (
+                  <TR key={r.resultId}>
+                    <Td className="whitespace-nowrap text-muted-foreground">
+                      <Timestamp iso={r.ranAt} />
+                    </Td>
+                    <Td>
+                      <Link
+                        href={`/projects/${projectId}/evaluations/${r.runId}`}
+                        className="rounded font-mono text-[11px] hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      >
+                        {r.candidateVersion}
+                      </Link>
+                      <span className="ml-1.5 text-[11px] text-muted-foreground">
+                        {r.evaluationName}
+                      </span>
+                    </Td>
+                    <Td className="text-right tabular-nums">
+                      {r.score === null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        scoreDisplay(r.score)
+                      )}
+                    </Td>
+                    <Td>
+                      {r.change === null ? (
+                        <span className="text-muted-foreground">—</span>
+                      ) : (
+                        <span className={SENTIMENT_CLASS[changeSentiment(CHANGE_DELTA[r.change])]}>
+                          {r.change}
+                        </span>
+                      )}
+                    </Td>
+                    <Td>
+                      <EvalResultBadge status={r.status as never} />
+                    </Td>
+                  </TR>
+                ))}
+              </TBody>
+            </Table>
+          )}
+        </div>
+      )}
+
+      {/* Save (when edited) + Review — primary actions, at the bottom. */}
+      <div className="flex shrink-0 items-center gap-2 border-t border-border p-3">
+        {dirty && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 flex-1 text-[12px]"
+            disabled={update.isPending}
+            onClick={saveEdits}
+          >
+            Save changes
+          </Button>
+        )}
+        <Button size="sm" className="h-8 flex-1 text-[12px]" onClick={onReview}>
+          Review
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/evaluations/views/datasets-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/datasets-view.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Trash2, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { useToast } from "@/components/ui/toast";
+import { ProjectBreadcrumb } from "@/features/projects/components";
+import {
+  DatasetActionsMenu,
+  SelectAllHeaderCell,
+  SelectRowCell,
+  Timestamp,
+  useRowSelection,
+} from "@/features/offline-eval/components";
+import { useDatasets, useDeleteDataset, useEvaluations } from "../hooks";
+import type { DatasetRow } from "../types";
+import { NewDatasetPanel, DatasetEditPanel } from "../components/dataset-panels";
+
+const DEFAULT_DATE_FILTER =
+  DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0];
+
+const TH =
+  "h-7 whitespace-nowrap border-r border-border/50 px-3 text-left text-[12px] font-medium text-muted-foreground";
+const TD = "border-r border-border/50 px-3 py-1.5 text-[12px]";
+
+/**
+ * Dataset list — the dataset library, wired to the server: tracing-style
+ * search + date filter, row
+ * selection with "N selected · Delete" beside the search, a three-dot
+ * Edit/Delete menu, and right-side New/Edit panels.
+ */
+export function DatasetsView({ projectId }: { projectId: string }) {
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [keyword, setKeyword] = React.useState("");
+  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(DEFAULT_DATE_FILTER);
+  const [customStart, setCustomStart] = React.useState<Date | null>(null);
+  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
+  const [newOpen, setNewOpen] = React.useState(false);
+  const [editing, setEditing] = React.useState<DatasetRow | null>(null);
+
+  const { data, isLoading, error } = useDatasets(projectId, {
+    search_query: keyword.trim() || undefined,
+  });
+  const datasets = React.useMemo(() => data?.data ?? [], [data]);
+  const del = useDeleteDataset(projectId);
+
+  // Evaluations-per-dataset comes from the lineage list (one row per evaluation
+  // purpose, each carrying its datasetId); the dataset row itself has no count.
+  const { data: evaluationsData } = useEvaluations(projectId);
+  const evalCountByDataset = React.useMemo(() => {
+    const map = new Map<string, number>();
+    for (const e of evaluationsData?.data ?? []) {
+      map.set(e.datasetId, (map.get(e.datasetId) ?? 0) + 1);
+    }
+    return map;
+  }, [evaluationsData]);
+
+  const ids = React.useMemo(() => datasets.map((d) => d.id), [datasets]);
+  const sel = useRowSelection(ids);
+
+  const deleteOne = (dataset: DatasetRow) => {
+    del.mutate(dataset.id, {
+      onSuccess: () => toast({ title: `Deleted ${dataset.name}`, tone: "success" }),
+      onError: (e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }),
+    });
+  };
+
+  const deleteSelected = () => {
+    const chosen = [...sel.selected];
+    if (chosen.length === 0) return;
+    Promise.all(chosen.map((id) => del.mutateAsync(id)))
+      .then(() => toast({ title: `${chosen.length} deleted`, tone: "success" }))
+      .catch((e) => toast({ title: "Could not delete", description: String(e), tone: "warning" }));
+    sel.clear();
+  };
+
+  return (
+    <div className="flex h-full flex-col text-[13px]">
+      {/* Populates the app's top breadcrumb bar (workspace / project). Without a
+          mounted ProjectBreadcrumb the header goes blank on this route. */}
+      <ProjectBreadcrumb projectId={projectId} current="Datasets" />
+      <div className="flex items-center justify-between border-b border-border px-4 py-2">
+        <h1 className="text-[13px] font-medium">Datasets</h1>
+        <Button size="sm" className="h-7 text-[12px]" onClick={() => setNewOpen(true)}>
+          New Dataset
+        </Button>
+      </div>
+
+      <SearchFilterBar
+        searchValue={keyword}
+        onSearchChange={setKeyword}
+        searchPlaceholder="Search datasets..."
+        dateFilter={dateFilter}
+        customStartDate={customStart}
+        customEndDate={customEnd}
+        onDateFilterChange={setDateFilter}
+        onCustomRangeChange={(s, e) => {
+          setCustomStart(s);
+          setCustomEnd(e);
+        }}
+      >
+        {sel.count > 0 && (
+          <span className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={sel.clear}
+              aria-label="Cancel selection"
+              className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <X className="h-3.5 w-3.5" aria-hidden />
+            </button>
+            <span className="text-[12px] font-medium tabular-nums">{sel.count} selected</span>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1 px-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
+              onClick={deleteSelected}
+            >
+              <Trash2 className="h-3.5 w-3.5" aria-hidden />
+              Delete
+            </Button>
+          </span>
+        )}
+        <span className="flex-1" aria-hidden />
+      </SearchFilterBar>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <table className="w-full">
+          <thead className="sticky top-0 bg-background">
+            <tr className="border-b border-border bg-muted/50">
+              <SelectAllHeaderCell
+                checked={sel.allSelected}
+                indeterminate={sel.someSelected}
+                onToggle={sel.toggleAll}
+              />
+              <th className={`${TH} w-[170px]`}>Last updated</th>
+              <th className={`${TH} w-[240px]`}>Dataset ID</th>
+              <th className={TH}>Name</th>
+              <th className={`${TH} w-[110px] text-right`}>Test cases</th>
+              <th className={`${TH} w-[110px] text-right`}>Evaluations</th>
+              <th className="w-[56px] px-2 py-1.5 text-right text-[12px] font-medium text-muted-foreground">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <RowMessage>Loading datasets...</RowMessage>
+            ) : error ? (
+              <RowMessage tone="destructive">Error loading datasets</RowMessage>
+            ) : datasets.length === 0 ? (
+              <RowMessage>
+                {keyword
+                  ? "No datasets match your search."
+                  : "No datasets yet — save a trace or span as a test case to start one."}
+              </RowMessage>
+            ) : (
+              datasets.map((dataset) => (
+                <tr
+                  key={dataset.id}
+                  onClick={() => router.push(`/projects/${projectId}/datasets/${dataset.id}`)}
+                  className="cursor-pointer border-b border-border/50 transition-colors last:border-0 hover:bg-muted/50"
+                >
+                  <SelectRowCell
+                    checked={sel.has(dataset.id)}
+                    onToggle={() => sel.toggle(dataset.id)}
+                    label={`Select ${dataset.name}`}
+                  />
+                  <td className={`${TD} whitespace-nowrap text-muted-foreground`}>
+                    <Timestamp iso={dataset.updateTime} />
+                  </td>
+                  <td
+                    className={`${TD} max-w-[240px] truncate font-mono text-[11px] text-muted-foreground`}
+                    title={dataset.id}
+                  >
+                    {dataset.id}
+                  </td>
+                  <td className={`${TD} font-medium`}>{dataset.name}</td>
+                  <td className={`${TD} text-right tabular-nums`}>{dataset.caseCount}</td>
+                  <td className={`${TD} text-right tabular-nums text-muted-foreground`}>
+                    {evalCountByDataset.get(dataset.id) || "—"}
+                  </td>
+                  <td className="px-2 text-right">
+                    <DatasetActionsMenu
+                      onEdit={() => setEditing(dataset)}
+                      onDelete={() => deleteOne(dataset)}
+                    />
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <NewDatasetPanel projectId={projectId} open={newOpen} onOpenChange={setNewOpen} />
+      {editing && (
+        <DatasetEditPanel
+          projectId={projectId}
+          dataset={editing}
+          onClose={() => setEditing(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+function RowMessage({ children, tone }: { children: React.ReactNode; tone?: "destructive" }) {
+  return (
+    <tr>
+      <td
+        colSpan={7}
+        className={`px-3 py-10 text-center text-[12px] ${
+          tone ? "text-destructive" : "text-muted-foreground"
+        }`}
+      >
+        {children}
+      </td>
+    </tr>
+  );
+}

--- a/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/evaluations-view.tsx
@@ -123,7 +123,7 @@ export function EvaluationsView({ projectId }: { projectId: string }) {
 const RUNS_COLUMN_COUNT = 9;
 
 /** Human elapsed duration; "—" when unknown (never 0). */
-function formatElapsed(ms: number | null | undefined): string {
+export function formatElapsed(ms: number | null | undefined): string {
   if (ms === null || ms === undefined) return "—";
   if (ms < 1000) return `${ms}ms`;
   const s = ms / 1000;
@@ -133,7 +133,7 @@ function formatElapsed(ms: number | null | undefined): string {
   return `${m}m ${rem}s`;
 }
 
-function ScoreValue({ value }: { value: number | null }) {
+export function ScoreValue({ value }: { value: number | null }) {
   return value === null ? (
     <span className="text-muted-foreground">—</span>
   ) : (
@@ -142,7 +142,7 @@ function ScoreValue({ value }: { value: number | null }) {
 }
 
 /** Total run cost; "—" when no case reported a cost (never a misleading $0). */
-function formatCost(cost: number | null | undefined): React.ReactNode {
+export function formatCost(cost: number | null | undefined): React.ReactNode {
   if (cost === null || cost === undefined) return <span className="text-muted-foreground">—</span>;
   return `$${cost < 1 ? cost.toFixed(4) : cost.toFixed(2)}`;
 }
@@ -721,7 +721,7 @@ function RunsTab({ projectId }: { projectId: string }) {
 
 // ---------------------------------------------------------------------------
 // Scorers — read-only registry, aggregated from reported runs. Master-detail,
-// echoing the prototype: a table on the left, a detail aside on the right.
+// a table on the left, a detail aside on the right.
 //
 // A scorer's definition — what it measures, its type, scope, and score format —
 // lives in the customer's SDK code and is never reported to the server, so the

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -572,12 +572,16 @@ export function RunDetailView({ projectId, runId }: { projectId: string; runId: 
         open={reviewOpen}
         onOpenChange={setReviewOpen}
         onSave={(review) =>
-          humanScore.mutate({
-            verdict: review.verdict,
-            quality: review.quality ?? null,
-            comment: review.comment ?? null,
-            reviewer: review.reviewer,
-          })
+          // Return the promise so the panel awaits persistence — a failed human-score
+          // request is no longer shown as saved.
+          humanScore
+            .mutateAsync({
+              verdict: review.verdict,
+              quality: review.quality ?? null,
+              comment: review.comment ?? null,
+              reviewer: review.reviewer,
+            })
+            .then(() => {})
         }
       />
 

--- a/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
+++ b/frontend/ui/src/features/evaluations/views/run-detail-view.tsx
@@ -1,0 +1,1185 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import {
+  ArrowDown,
+  ArrowUp,
+  Check,
+  ChevronDown,
+  Database,
+  GitCompare,
+  Loader2,
+  Search,
+  X,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
+import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { SearchFilterBar } from "@/components/search-filter-bar";
+import { DATE_FILTER_OPTIONS, type DateFilterOption } from "@/lib/date-filter";
+import { Table, TBody, THead, TR, TRHead, Td, Th } from "@/components/ui/table";
+import { ProjectBreadcrumb } from "@/features/projects/components";
+import {
+  EvalPageHeader,
+  EvalResultBadge,
+  ReviewPanel,
+  useSeedTraceIO,
+  type ReviewTarget,
+} from "@/features/offline-eval/components";
+import { TraceViewerPanel } from "@/features/traces/components";
+import { useTrace } from "@/features/traces/hooks";
+import type { Span, TraceDetail } from "@/types/api";
+import type { SpanKind, SpanStatus } from "@traceroot/core";
+import { cn } from "@/lib/utils";
+import {
+  changeSentiment,
+  pctFraction,
+  SENTIMENT_CLASS,
+  signedPoints,
+} from "@/features/offline-eval/utils";
+import { useEvaluationRun, useEvaluationRuns, useCreateHumanScore, useCompareRuns } from "../hooks";
+import { PullCodeDrawer } from "../components/pull-code-drawer";
+import { PassRate } from "../components/pass-rate";
+import { SaveTestCaseDrawer } from "../components/trace-integration";
+import { reproduceRunCode, reproduceRunCodeTs } from "@/features/offline-eval/utils";
+import { matchSpans } from "@/lib/eval/span-match";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type {
+  ResultRow,
+  RunDetail,
+  ScoreRow,
+  Classification,
+  CompareResultRow,
+  CompareRunsResponse,
+  ResultRowComparison,
+} from "../types";
+
+/** Case/run duration; "Unknown" when unmeasured (never 0s). */
+function fmtDurationMs(ms: number | null | undefined): string {
+  if (ms === null || ms === undefined) return "Unknown";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/** Signed candidate−baseline delta beside a duration/cost cell (lower is better:
+ *  an increase is red, a decrease green). Rendered only when comparing. */
+function CellDelta({
+  delta,
+  format,
+}: {
+  delta: number | null;
+  format: (n: number) => string;
+}): React.ReactNode {
+  if (delta === null || delta === 0) return null;
+  return (
+    <span className={`ml-1 ${SENTIMENT_CLASS[changeSentiment(-delta)]}`}>
+      {delta > 0 ? "+" : "−"}
+      {format(Math.abs(delta))}
+    </span>
+  );
+}
+
+/**
+ * Whether two authored values are the SAME value. A pure reformat (re-indenting
+ * JSON, whether from the seed format or the format switcher) is not an edit —
+ * without this, opening a case would offer to publish a new dataset version that
+ * changes nothing but whitespace.
+ */
+export function sameAuthoredValue(a: string, b: string): boolean {
+  if (a.trim() === b.trim()) return true;
+  try {
+    return JSON.stringify(JSON.parse(a)) === JSON.stringify(JSON.parse(b));
+  } catch {
+    return false; // one side isn't JSON — trust the text comparison above
+  }
+}
+
+function scoreValue(s: ScoreRow): string {
+  if (s.error) return "error";
+  if (s.numericValue !== null) return String(s.numericValue);
+  if (s.boolValue !== null) return s.boolValue ? "pass" : "fail";
+  if (s.stringValue !== null) return s.stringValue;
+  if (s.passed !== null) return s.passed ? "pass" : "fail";
+  return "—";
+}
+
+/** Base span with the fields the trace viewer expects; `partial` overrides. */
+function evalSpan(
+  partial: Partial<Span> & Pick<Span, "span_id" | "trace_id" | "name" | "span_kind">,
+): Span {
+  return {
+    parent_span_id: null,
+    span_start_time: "1970-01-01T00:00:00.000Z",
+    span_end_time: "1970-01-01T00:00:00.000Z",
+    status: "OK" as SpanStatus,
+    status_message: null,
+    model_name: null,
+    cost: null,
+    input_tokens: null,
+    output_tokens: null,
+    total_tokens: null,
+    input: null,
+    output: null,
+    metadata: null,
+    git_source_file: null,
+    git_source_line: null,
+    git_source_function: null,
+    ...partial,
+  };
+}
+
+/**
+ * The eval-shaped trace for one result, so the run detail opens into the real
+ * trace viewer (span tree + span detail) — the shape the SDK reports:
+ *
+ *   evaluation item (root)
+ *     ├─ task span      ← the candidate application's run
+ *     ├─ scorer span    ← siblings of the task, one per scorer that ran
+ *     └─ scorer span
+ *
+ * Built from the actual result + scores only (no fabricated sub-spans). This is a
+ * clearly-LABELED fallback, used only when a result emitted no real trace; a result
+ * with a real ingested trace opens that real trace directly instead.
+ */
+function buildEvalTrace(result: ResultRow, run: RunDetail): TraceDetail {
+  const id = result.traceId || `eval-${result.id}`;
+  const failed = Boolean(result.taskError);
+  const rootStatus = (failed ? "ERROR" : "OK") as SpanStatus;
+
+  // Ordered fake timestamps so the reconstructed tree is deterministic and reads in
+  // the real order: task first, then scorers (which run after it). Without distinct
+  // starts, the stable sibling sort would tie and fall back to span_id.
+  const base = new Date(result.createTime).getTime();
+  const t0 = Number.isFinite(base) ? base : 0;
+  const iso = (ms: number) => new Date(ms).toISOString();
+
+  const spans: Span[] = [
+    evalSpan({
+      span_id: `${id}-root`,
+      trace_id: id,
+      name: `${run.evaluationName} · ${result.testCaseId}`,
+      span_kind: "AGENT" as SpanKind,
+      span_start_time: iso(t0),
+      span_end_time: iso(t0 + result.scores.length + 2),
+      input: result.input,
+      output: result.candidateOutput,
+      status: rootStatus,
+      status_message: result.taskError ?? null,
+      metadata: JSON.stringify({
+        evaluation: run.evaluationName,
+        candidate_version: run.candidateVersion,
+        dataset: run.datasetName,
+        test_case: result.testCaseId,
+      }),
+    }),
+    evalSpan({
+      span_id: `${id}-task`,
+      trace_id: id,
+      parent_span_id: `${id}-root`,
+      name: "task",
+      span_kind: "SPAN" as SpanKind,
+      span_start_time: iso(t0),
+      span_end_time: iso(t0 + 1),
+      input: result.input,
+      output: result.candidateOutput,
+      cost: result.cost,
+      status: rootStatus,
+      status_message: result.taskError ?? null,
+      metadata: JSON.stringify({ step: "task" }),
+    }),
+  ];
+
+  // Scorer spans — siblings of the task, one per scorer that ran, starting after it.
+  result.scores.forEach((s, i) => {
+    spans.push(
+      evalSpan({
+        span_id: `${id}-scorer-${s.id}`,
+        trace_id: id,
+        parent_span_id: `${id}-root`,
+        name: s.scorerName,
+        span_kind: "SPAN" as SpanKind,
+        span_start_time: iso(t0 + i + 2),
+        span_end_time: iso(t0 + i + 2),
+        input: `output: ${result.candidateOutput ?? "—"}\nexpected: ${result.expectedOutput ?? "—"}`,
+        output: s.error ?? scoreValue(s),
+        status: (s.error ? "ERROR" : "OK") as SpanStatus,
+        status_message: s.error ?? null,
+        metadata: JSON.stringify({ scorer: s.scorerName, version: s.scorerVersion }),
+      }),
+    );
+  });
+
+  return {
+    trace_id: id,
+    project_id: run.evaluationId,
+    name: `${run.evaluationName} · ${result.testCaseId}`,
+    trace_start_time: result.createTime,
+    user_id: null,
+    session_id: null,
+    git_ref: null,
+    git_repo: null,
+    environment: "evaluation",
+    release: null,
+    input: result.input,
+    output: result.candidateOutput,
+    metadata: JSON.stringify({ evaluation: run.evaluationName, test_case: result.testCaseId }),
+    spans,
+  };
+}
+
+type ResultFilterId =
+  | "all"
+  | "regressions"
+  | "improvements"
+  | "failed"
+  | "errors"
+  | "unpaired"
+  | "not_scored";
+
+const RESULT_FILTERS: Array<{ id: ResultFilterId; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "regressions", label: "Regressions" },
+  { id: "improvements", label: "Improvements" },
+  { id: "failed", label: "Did not pass" },
+  { id: "errors", label: "Errors" },
+  { id: "unpaired", label: "Unpaired" },
+  { id: "not_scored", label: "Not scored" },
+];
+
+// Filters key on the DERIVED case verdict (comparison.caseChange), never the stored
+// change column. "Unpaired" folds in not_comparable (paired but un-trustable) cases.
+const RESULT_FILTER_FN: Record<ResultFilterId, (r: ResultRow) => boolean> = {
+  all: () => true,
+  regressions: (r) => r.comparison?.caseChange === "regressed",
+  improvements: (r) => r.comparison?.caseChange === "improved",
+  failed: (r) => r.status === "failed",
+  errors: (r) => r.status === "errored" || r.scores.some((s) => s.error),
+  unpaired: (r) =>
+    r.comparison?.caseChange === "unpaired" || r.comparison?.caseChange === "not_comparable",
+  not_scored: (r) => r.status === "not_scored",
+};
+
+/**
+ * Evaluation run detail — the run detail surface, wired to
+ * the server. Ordered to answer, in sequence: did the candidate improve, what
+ * regressed, what broke, and can the aggregate be trusted? Verdict strip first
+ * (its Regressions/Errors counts filter the results table in place), then the
+ * results hero, then folded Regressions / Errors / Run details.
+ *
+ * Opening a result opens the REAL trace viewer (span tree + span detail) on an
+ * eval-shaped trace built from the result, with the evaluation context, scores,
+ * and human review as the span-actions panel.
+ */
+export function RunDetailView({ projectId, runId }: { projectId: string; runId: string }) {
+  const { data, isLoading, error } = useEvaluationRun(projectId, runId);
+  const [openResultId, setOpenResultId] = React.useState<string | null>(null);
+  const [resultFilter, setResultFilter] = React.useState<ResultFilterId>("all");
+  const [reviewOpen, setReviewOpen] = React.useState(false);
+  // "Save as test case" drawer (only for real ingested traces): which span it targets.
+  const [saveTestCaseOpen, setSaveTestCaseOpen] = React.useState(false);
+  const [saveTestCaseSpanId, setSaveTestCaseSpanId] = React.useState<string | undefined>(undefined);
+  // "Compare with" — another run of the SAME evaluation, chosen inline. The current run
+  // is the candidate; the picked run is the baseline. Comparison is computed on demand
+  // by the backend engine (the SDK no longer declares baselines).
+  const [compareId, setCompareId] = React.useState<string | null>(null);
+
+  const results = React.useMemo(() => data?.results ?? [], [data]);
+  const run = data?.run;
+
+  // This evaluation's other runs — the compare-baseline picker below and the
+  // header RunSwitcher share this query key, so it's one fetch, not two.
+  const siblingRuns = useEvaluationRuns(projectId, {
+    evaluation_id: run?.evaluationId,
+    limit: 100,
+  });
+
+  // Other runs of this evaluation, to pick a comparison baseline from (never an
+  // arbitrary run from another evaluation). Newest first, current run excluded.
+  const compareOptions = React.useMemo(
+    () =>
+      run
+        ? (siblingRuns.data?.data ?? [])
+            .filter((s) => s.id !== run.id)
+            .sort((a, b) => b.runNumber - a.runNumber)
+            .map((s) => ({
+              id: s.id,
+              label: `#${s.runNumber} · ${s.candidateVersion}`,
+              score: s.mainScore,
+            }))
+        : [],
+    [siblingRuns.data, run],
+  );
+
+  // On-demand comparison of this run (candidate) vs the picked run (baseline), from the
+  // same backend engine + route the compare page uses — no second implementation.
+  const compare = useCompareRuns(projectId, runId, compareId);
+  const comparing = !!compareId && !!compare.data;
+  const compareByCase = React.useMemo(() => {
+    const m = new Map<string, CompareResultRow>();
+    for (const c of compare.data?.results ?? []) m.set(c.testCaseId, c);
+    return m;
+  }, [compare.data]);
+
+  const openResult = openResultId ? (results.find((r) => r.id === openResultId) ?? null) : null;
+  const openCompareRow = openResult ? (compareByCase.get(openResult.testCaseId) ?? null) : null;
+
+  // Prefer the result's REAL ingested trace. Probe it — this shares TraceViewerPanel's
+  // ["trace", projectId, traceId] cache key, so opening the real panel does not refetch.
+  // A result trace id means telemetry was emitted: show the real trace when it's
+  // available, and a pending state (retry) while it is still ingesting. When no trace
+  // id was emitted (fully-local run), fall back to a clearly-labeled reconstructed trace.
+  const realTraceId = openResult?.traceId ?? null;
+  const realTrace = useTrace(projectId, realTraceId ?? "", !!realTraceId);
+  // Only treat a reported trace as "pending" when its fetch genuinely fails (not yet
+  // ingested → 404). While it's merely loading, keep the trace panel mounted and let it
+  // show its own loading — so navigating between results updates in place instead of
+  // flickering through the pending panel and re-animating the slide-in.
+  const tracePending = !!realTraceId && realTrace.isError;
+  const useRealTrace = !!realTraceId && !realTrace.isError;
+
+  // Reconstructed eval-shaped trace — the labeled fallback, only for results that
+  // emitted no real trace. Seed span I/O just for those so the detail panel has it.
+  const fallbackTrace = React.useMemo(
+    () => (run && openResult && !realTraceId ? buildEvalTrace(openResult, run) : undefined),
+    [run, openResult, realTraceId],
+  );
+  const fallbackTraces = React.useMemo(
+    () => (run ? results.filter((r) => !r.traceId).map((r) => buildEvalTrace(r, run)) : []),
+    [results, run],
+  );
+  useSeedTraceIO(projectId, fallbackTraces);
+
+  const humanScore = useCreateHumanScore(projectId, openResult?.id ?? "");
+
+  const panelTraceId = useRealTrace ? realTraceId : fallbackTrace?.trace_id;
+  const panelOverride = useRealTrace ? undefined : fallbackTrace;
+
+  const openTraceSpans = useRealTrace ? realTrace.data?.spans : panelOverride?.spans;
+
+  // The baseline case's trace (from the picked compare run), fetched so the trace
+  // viewer's Diff toggle can diff each span (I/O, metadata, latency/token/cost) against
+  // its baseline counterpart. Span ids differ across runs, so we match structurally
+  // (kind + name + sibling index) once the baseline trace is loaded.
+  const baselineTraceId = comparing ? (openCompareRow?.baselineTraceId ?? null) : null;
+  const baselineTrace = useTrace(projectId, baselineTraceId ?? "", !!baselineTraceId);
+  const baselineSpanMatch = React.useMemo(() => {
+    const baseSpans = baselineTrace.data?.spans;
+    if (!openTraceSpans?.length || !baseSpans?.length) return null;
+    return matchSpans(openTraceSpans, baseSpans);
+  }, [openTraceSpans, baselineTrace.data]);
+
+  const closeResult = () => setOpenResultId(null);
+
+  // The trace panel's up/down chevrons step between this run's results (in the same
+  // order + filter as the table), so you can walk case-by-case without closing it.
+  const visibleResults = React.useMemo(
+    () => results.filter(RESULT_FILTER_FN[resultFilter]),
+    [results, resultFilter],
+  );
+  const openIndex = openResult ? visibleResults.findIndex((r) => r.id === openResult.id) : -1;
+  const navigateResult = (dir: "up" | "down") => {
+    if (openIndex === -1) return;
+    const next = dir === "up" ? openIndex - 1 : openIndex + 1;
+    if (next >= 0 && next < visibleResults.length) setOpenResultId(visibleResults[next].id);
+  };
+
+  return (
+    <>
+      <ProjectBreadcrumb projectId={projectId} />
+      <div className="flex flex-1 flex-col overflow-hidden text-[12px]">
+        {isLoading ? (
+          <div className="flex h-64 items-center justify-center">
+            <p className="text-[13px] text-muted-foreground">Loading run...</p>
+          </div>
+        ) : error || !data ? (
+          <div className="flex h-64 flex-col items-center justify-center gap-2">
+            <p className="text-[13px] text-destructive">Evaluation run not found</p>
+            <Link
+              href={`/projects/${projectId}/evaluations`}
+              className="text-[12px] text-muted-foreground underline"
+            >
+              Back to evaluations
+            </Link>
+          </div>
+        ) : (
+          <RunBody
+            projectId={projectId}
+            run={data.run}
+            results={results}
+            filter={resultFilter}
+            onFilterChange={setResultFilter}
+            onOpenResult={setOpenResultId}
+            openResultId={openResultId}
+            compareId={compareId}
+            onCompareChange={setCompareId}
+            compareOptions={compareOptions}
+            compareData={compare.data ?? null}
+            compareLoading={!!compareId && compare.isLoading}
+            compareByCase={comparing ? compareByCase : null}
+          />
+        )}
+      </div>
+
+      {/* Telemetry for this result is still ingesting — pending state with retry. */}
+      {openResult && run && tracePending && (
+        <PendingTracePanel
+          traceId={realTraceId as string}
+          isFetching={realTrace.isFetching}
+          onRetry={() => realTrace.refetch()}
+          onClose={closeResult}
+        />
+      )}
+
+      {/* The result opens directly in the REAL trace viewer (span tree + span detail)
+          when its trace is available; otherwise a clearly-labeled reconstructed trace.
+          The evaluation context, scores, and human review are the span-actions panel. */}
+      {openResult && run && !tracePending && panelTraceId && (
+        <TraceViewerPanel
+          // No key on panelTraceId: navigating results updates the panel in place
+          // (TraceViewerPanel resets its selection on traceId change), matching the
+          // trace-list navigation — a fresh key would replay the slide-in animation.
+          projectId={projectId}
+          traceId={panelTraceId}
+          traceOverride={panelOverride}
+          newTabPath={`/projects/${projectId}/evaluations/${runId}`}
+          onClose={closeResult}
+          onNavigate={navigateResult}
+          canNavigateUp={openIndex > 0}
+          canNavigateDown={openIndex >= 0 && openIndex < visibleResults.length - 1}
+          // The test case is the identity that matters across runs (a trace id is
+          // per-execution, and synthetic when nothing was ingested), so the header
+          // leads with it instead of the trace id.
+          headerIdentity={{ label: "Test case", value: openResult.testCaseId }}
+          // The case's outcome, in the header's findings-alert slot.
+          headerStatus={<EvalResultBadge status={openResult.status} />}
+          // With a compare run picked, open straight into diff mode against its matching
+          // case (the user chose to compare — don't make them toggle it on per trace).
+          defaultDiffOn={comparing}
+          // While the "Save as test case" drawer is open, clicking a different span
+          // retargets it to that span.
+          onSelectionChange={(selection) => {
+            if (saveTestCaseOpen) {
+              setSaveTestCaseSpanId(selection.type === "span" ? selection.span.span_id : undefined);
+            }
+          }}
+          // The case actions live in the span panel's header-section bar, directly
+          // above the I/O — human review, the source test case, and (for a real
+          // ingested trace) saving the selected span as a new test case. Everything
+          // else that used to sit above the I/O has moved to the run detail table
+          // and the trace header.
+          spanActions={(selection) => (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 text-[12px]"
+                onClick={() => setReviewOpen(true)}
+              >
+                Review output
+              </Button>
+              <Link
+                href={`/projects/${projectId}/datasets/${run.datasetId}?case=${openResult.testCaseId}`}
+                className="inline-flex h-7 items-center gap-1.5 rounded-md border border-input bg-background px-2.5 text-[12px] font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                <Database className="h-3.5 w-3.5" aria-hidden />
+                View source test case
+              </Link>
+              {useRealTrace && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-7 text-[12px]"
+                  onClick={() => {
+                    setSaveTestCaseSpanId(
+                      selection.type === "span" ? selection.span.span_id : undefined,
+                    );
+                    setSaveTestCaseOpen(true);
+                  }}
+                >
+                  Save as test case
+                </Button>
+              )}
+            </>
+          )}
+          spanExtraTags={() => (
+            <>
+              {!useRealTrace && (
+                <span className="inline-flex items-center gap-1.5 rounded-md border border-amber-400/60 bg-amber-100/60 px-2.5 py-1 text-xs text-amber-800 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-300">
+                  Reconstructed — no telemetry was emitted for this result
+                </span>
+              )}
+              <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
+                <span className="text-muted-foreground">Evaluation:</span>
+                <span className="font-medium">{run.evaluationName}</span>
+                <span className="text-muted-foreground">
+                  Run #{run.runNumber} · {run.candidateVersion}
+                </span>
+              </span>
+              <span className="inline-flex items-center gap-1.5 rounded-md border bg-muted/40 px-2.5 py-1 text-xs">
+                <span className="text-muted-foreground">Snapshot:</span>
+                <span className="font-medium">
+                  {run.datasetName} · {run.datasetVersionLabel}
+                </span>
+              </span>
+            </>
+          )}
+          /* Baseline run's trace + a per-span matcher. Powers the viewer's Diff
+             toggle: latency/token/cost deltas + I/O line diffs vs the baseline, at
+             both the trace level and per span. Present (so the toggle appears) only
+             once the baseline trace has loaded. */
+          diffBaseline={
+            baselineTrace.data
+              ? {
+                  trace: baselineTrace.data,
+                  matchSpan: (selection) =>
+                    selection.type === "span"
+                      ? (baselineSpanMatch?.get(selection.span.span_id) ?? null)
+                      : null,
+                }
+              : undefined
+          }
+        />
+      )}
+
+      {/* Human review of one output — scores it, never touches the dataset. */}
+      <ReviewPanel
+        target={
+          openResult
+            ? ({
+                contextLabel: `${openResult.testCaseId} · ${run?.evaluationName} ${run?.candidateVersion}`,
+                input: openResult.input,
+                output: openResult.candidateOutput ?? "No output — the task errored.",
+                expected: openResult.expectedOutput,
+                autoScores: openResult.scores.map((s) => ({
+                  name: `${s.scorerName} ${s.scorerVersion}`,
+                  display: s.error ? "Scorer error" : scoreValue(s),
+                  explanation: s.error ?? s.explanation ?? undefined,
+                })),
+                existing: undefined,
+              } satisfies ReviewTarget)
+            : null
+        }
+        open={reviewOpen}
+        onOpenChange={setReviewOpen}
+        onSave={(review) =>
+          humanScore.mutate({
+            verdict: review.verdict,
+            quality: review.quality ?? null,
+            comment: review.comment ?? null,
+            reviewer: review.reviewer,
+          })
+        }
+      />
+
+      {/* Save a span (or the trace root) of the open result's real trace as a test case. */}
+      <SaveTestCaseDrawer
+        projectId={projectId}
+        traceId={useRealTrace ? realTraceId : null}
+        spanId={saveTestCaseSpanId}
+        open={saveTestCaseOpen}
+        onOpenChange={setSaveTestCaseOpen}
+      />
+    </>
+  );
+}
+
+/** Slide-in panel shown while a result's real trace is still ingesting. */
+function PendingTracePanel({
+  traceId,
+  isFetching,
+  onRetry,
+  onClose,
+}: {
+  traceId: string;
+  isFetching: boolean;
+  onRetry: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="animate-slide-in-right fixed inset-y-0 right-0 z-50 flex w-[45%] min-w-[520px] max-w-[94vw] flex-col border-l border-border bg-background shadow-xl">
+      <div className="flex shrink-0 items-center justify-between border-b border-border bg-muted/30 px-4 py-3">
+        <span className="text-sm font-medium">Evaluation trace</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center text-[12px]">
+        <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" aria-hidden />
+        <p className="text-[13px] font-medium">Trace is still being ingested</p>
+        <p className="max-w-[360px] leading-relaxed text-muted-foreground">
+          This result reported a trace (<span className="font-mono">{traceId.slice(0, 12)}…</span>),
+          but its telemetry hasn&apos;t finished ingesting yet. It will appear here once it lands.
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1.5 text-[12px]"
+          disabled={isFetching}
+          onClick={onRetry}
+        >
+          <Loader2 className={cn("h-3.5 w-3.5", isFetching && "animate-spin")} aria-hidden />
+          Retry
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function RunBody({
+  projectId,
+  run,
+  results,
+  filter,
+  onFilterChange,
+  onOpenResult,
+  openResultId,
+  compareId,
+  onCompareChange,
+  compareOptions,
+  compareData,
+  compareLoading,
+  compareByCase,
+}: {
+  projectId: string;
+  run: RunDetail;
+  results: ResultRow[];
+  filter: ResultFilterId;
+  onFilterChange: (filter: ResultFilterId) => void;
+  onOpenResult: (id: string) => void;
+  openResultId: string | null;
+  compareId: string | null;
+  onCompareChange: (id: string | null) => void;
+  compareOptions: Array<{ id: string; label: string; score: number | null }>;
+  compareData: CompareRunsResponse | null;
+  compareLoading: boolean;
+  compareByCase: Map<string, CompareResultRow> | null;
+}) {
+  const router = useRouter();
+  const [reproduceOpen, setReproduceOpen] = React.useState(false);
+  const comparing = !!compareByCase;
+  const cmp = compareData?.comparison ?? null;
+
+  return (
+    <>
+      <EvalPageHeader
+        parent={{ label: "Evaluations", href: `/projects/${projectId}/evaluations` }}
+        title={
+          <span className="flex flex-wrap items-center gap-2">
+            <span>{run.evaluationName}</span>
+            {/* The run being viewed is immutable; the candidate is what changed.
+                The run number opens a switcher to this evaluation's other runs. */}
+            <RunSwitcher
+              projectId={projectId}
+              run={run}
+              onPick={(id) => router.push(`/projects/${projectId}/evaluations/${id}`)}
+            />
+            <Badge variant="foreground" className="font-mono text-[11px]">
+              {run.candidateVersion}
+            </Badge>
+            <span className="font-mono text-xs font-normal text-muted-foreground">{run.id}</span>
+            <CopyButton
+              value={run.id}
+              className="h-6 w-6 text-muted-foreground hover:text-foreground"
+              title="Copy run ID"
+            />
+          </span>
+        }
+        action={
+          <div className="flex items-center gap-2">
+            {/* Comparison is an inline action: this run is the candidate; pick another
+                run of the same evaluation as the baseline. The diff appears in place. */}
+            <Select
+              value={compareId ?? ""}
+              onValueChange={(v) => onCompareChange(v === NO_COMPARE ? null : v)}
+            >
+              <SelectTrigger
+                className="h-7 w-fit max-w-[240px] gap-1.5 text-[12px]"
+                aria-label="Compare with"
+              >
+                <GitCompare className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                <SelectValue placeholder="Compare with…" />
+              </SelectTrigger>
+              <SelectContent>
+                {/* Clear option — only meaningful once a run is picked. */}
+                {compareId && (
+                  <SelectItem value={NO_COMPARE} className="text-[12px] text-muted-foreground">
+                    None (stop comparing)
+                  </SelectItem>
+                )}
+                {compareOptions.length === 0 ? (
+                  <div className="px-2 py-1.5 text-[11px] text-muted-foreground">
+                    No other runs in this evaluation
+                  </div>
+                ) : (
+                  compareOptions.map((o) => (
+                    <SelectItem key={o.id} value={o.id} className="text-[12px]">
+                      {o.label}
+                      {o.score !== null && (
+                        <span className="ml-1.5 tabular-nums text-muted-foreground">
+                          {pctFraction(o.score)}
+                        </span>
+                      )}
+                    </SelectItem>
+                  ))
+                )}
+              </SelectContent>
+            </Select>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1.5 text-[12px]"
+              onClick={() => setReproduceOpen(true)}
+            >
+              <Database className="h-3.5 w-3.5" aria-hidden />
+              Reproduce locally
+            </Button>
+          </div>
+        }
+      />
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <div className="flex flex-col gap-3 p-4">
+          {compareLoading && (
+            <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
+              Computing comparison…
+            </div>
+          )}
+
+          {comparing && cmp && (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-[11px]">
+              <span className="flex items-center gap-1.5">
+                <GitCompare className="h-3.5 w-3.5 text-muted-foreground" aria-hidden />
+                <span className="font-medium">
+                  Comparing vs #{compareData?.baseline.runNumber} ·{" "}
+                  <span className="font-mono">{compareData?.baseline.candidateVersion}</span>
+                </span>
+              </span>
+              <span className="text-muted-foreground">baseline → candidate (this run)</span>
+              <span className="h-3 w-px bg-border" aria-hidden />
+              <span className={cmp.caseCounts.regressed > 0 ? SENTIMENT_CLASS.bad : ""}>
+                {cmp.caseCounts.regressed} regressed
+              </span>
+              <span className={cmp.caseCounts.improved > 0 ? SENTIMENT_CLASS.good : ""}>
+                {cmp.caseCounts.improved} improved
+              </span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="ml-auto h-6 px-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+                onClick={() => onCompareChange(null)}
+              >
+                Clear
+              </Button>
+            </div>
+          )}
+
+          <ResultsSection
+            run={run}
+            results={results}
+            comparing={comparing}
+            compareByCase={compareByCase}
+            filter={filter}
+            onFilterChange={onFilterChange}
+            onOpen={onOpenResult}
+            openResultId={openResultId}
+          />
+        </div>
+      </div>
+
+      {/* Reproduce this run locally = pull the EXACT dataset version it scored (not
+          the run/evaluation id, which pulls nothing). Shared pull-code drawer. */}
+      <PullCodeDrawer
+        title="Reproduce this run locally"
+        subtitle={
+          <>
+            Re-run a new candidate against the exact cases{" "}
+            <span className="font-medium text-foreground">
+              {run.evaluationName} #{run.runNumber}
+            </span>{" "}
+            scored — the same dataset snapshot, so the results line up against this run.
+          </>
+        }
+        options={[
+          {
+            id: "reproduce",
+            label: "Reproduce this run",
+            note: (
+              <>
+                Pins{" "}
+                <span className="font-medium text-foreground">
+                  {run.datasetName ?? "this dataset"}
+                </span>{" "}
+                at version <span className="font-mono">{run.datasetVersionLabel}</span> (snapshot{" "}
+                <span className="font-mono">{run.datasetVersionId}</span>), and passes this run
+                (candidate <span className="font-mono">{run.candidateVersion}</span>) as the
+                baseline to compare the new run against.
+              </>
+            ),
+            py: reproduceRunCode(run.datasetVersionId, run.evaluationName, run.id),
+            ts: reproduceRunCodeTs(run.datasetVersionId, run.evaluationName, run.id),
+          },
+        ]}
+        open={reproduceOpen}
+        onOpenChange={setReproduceOpen}
+      />
+    </>
+  );
+}
+
+/** Jump to another run of the same evaluation, newest first. */
+function RunSwitcher({
+  projectId,
+  run,
+  onPick,
+}: {
+  projectId: string;
+  run: RunDetail;
+  onPick: (runId: string) => void;
+}) {
+  const [open, setOpen] = React.useState(false);
+  const { data } = useEvaluationRuns(projectId, { evaluation_id: run.evaluationId, limit: 100 });
+  const runs = React.useMemo(
+    () => [...(data?.data ?? [])].sort((a, b) => b.runNumber - a.runNumber),
+    [data],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 rounded border border-border px-1.5 py-0.5 text-sm font-normal text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          Run #{run.runNumber}
+          <ChevronDown className="h-3 w-3" aria-hidden />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="max-h-[360px] w-72 overflow-y-auto p-1">
+        <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+          Run history
+        </div>
+        {runs.map((sibling) => (
+          <button
+            key={sibling.id}
+            type="button"
+            onClick={() => {
+              onPick(sibling.id);
+              setOpen(false);
+            }}
+            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] transition-colors hover:bg-muted/50"
+          >
+            <Check
+              className={cn(
+                "h-3.5 w-3.5 shrink-0",
+                sibling.id === run.id ? "opacity-100" : "opacity-0",
+              )}
+              aria-hidden
+            />
+            <span className="font-medium">Run #{sibling.runNumber}</span>
+            <span className="font-mono text-[11px] text-muted-foreground">
+              {sibling.candidateVersion}
+            </span>
+            <span className="ml-auto tabular-nums text-muted-foreground">
+              {sibling.mainScore === null ? "—" : pctFraction(sibling.mainScore)}
+            </span>
+          </button>
+        ))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+const RESULT_COLUMN_COUNT = 8;
+
+/** Sentinel for the "Compare with" select's no-selection option (Radix needs a value). */
+const NO_COMPARE = "__none__";
+
+function ResultsSection({
+  run,
+  results,
+  comparing,
+  compareByCase,
+  filter,
+  onFilterChange,
+  onOpen,
+  openResultId,
+}: {
+  run: RunDetail;
+  results: ResultRow[];
+  comparing: boolean;
+  compareByCase: Map<string, CompareResultRow> | null;
+  filter: ResultFilterId;
+  onFilterChange: (filter: ResultFilterId) => void;
+  onOpen: (id: string) => void;
+  openResultId: string | null;
+}) {
+  const [keyword, setKeyword] = React.useState("");
+  const [sortWorst, setSortWorst] = React.useState(false);
+  const [dateFilter, setDateFilter] = React.useState<DateFilterOption>(
+    DATE_FILTER_OPTIONS.find((o) => o.id === "14d") ?? DATE_FILTER_OPTIONS[0],
+  );
+  const [customStart, setCustomStart] = React.useState<Date | null>(null);
+  const [customEnd, setCustomEnd] = React.useState<Date | null>(null);
+
+  // Per-result comparison vs the picked run (null when not comparing).
+  const cmpFor = React.useCallback(
+    (r: ResultRow) => (comparing ? (compareByCase?.get(r.testCaseId) ?? null) : null),
+    [comparing, compareByCase],
+  );
+
+  const visible = React.useMemo(() => {
+    const q = keyword.trim().toLowerCase();
+    const filtered = results.filter((r) => {
+      if (!RESULT_FILTER_FN[filter](r)) return false;
+      if (!q) return true;
+      return (
+        r.input.toLowerCase().includes(q) ||
+        (r.candidateOutput ?? "").toLowerCase().includes(q) ||
+        (r.expectedOutput ?? "").toLowerCase().includes(q)
+      );
+    });
+    if (!sortWorst) return filtered;
+    // Worst main-score regression first (most-negative delta vs the picked run); unknown last.
+    return [...filtered].sort((a, b) => {
+      const da = cmpFor(a)?.comparison?.mainScore.delta;
+      const db = cmpFor(b)?.comparison?.mainScore.delta;
+      if (da == null && db == null) return 0;
+      if (da == null) return 1;
+      if (db == null) return -1;
+      return da - db;
+    });
+  }, [results, keyword, filter, sortWorst, cmpFor]);
+
+  return (
+    <div className="rounded-md border border-border">
+      <SearchFilterBar
+        searchInput={
+          <div className="relative min-w-[10rem] max-w-md flex-1">
+            <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              placeholder="Search results..."
+              className="h-7 pl-8 text-[12px]"
+            />
+          </div>
+        }
+        dateFilter={dateFilter}
+        customStartDate={customStart}
+        customEndDate={customEnd}
+        onDateFilterChange={setDateFilter}
+        onCustomRangeChange={(s, e) => {
+          setCustomStart(s);
+          setCustomEnd(e);
+        }}
+      >
+        <div className="flex items-center gap-1">
+          {RESULT_FILTERS.map((option) => (
+            <Button
+              key={option.id}
+              variant={filter === option.id ? "default" : "outline"}
+              size="sm"
+              className="h-7 px-2 text-[12px]"
+              onClick={() => onFilterChange(option.id)}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+        <span className="flex-1" aria-hidden />
+        <PassRate counts={run} withLabel />
+        <span className="flex-1" aria-hidden />
+        <Button
+          variant={sortWorst ? "default" : "outline"}
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-[12px]"
+          onClick={() => setSortWorst((s) => !s)}
+          title="Sort by the worst main-score regression first"
+        >
+          <ArrowDown className="h-3.5 w-3.5" aria-hidden />
+          Worst regression
+        </Button>
+      </SearchFilterBar>
+
+      <Table>
+        <THead>
+          <TRHead>
+            <Th>Input</Th>
+            <Th>Output</Th>
+            <Th>Expected</Th>
+            <Th className="w-[170px]">Main score</Th>
+            {/* Change is only meaningful against a picked run; hidden otherwise. */}
+            {comparing && <Th className="w-[110px] text-right">vs baseline</Th>}
+            <Th className="w-[90px] text-right">Duration</Th>
+            <Th className="w-[90px] text-right">Cost</Th>
+            <Th className="w-[110px]">Status</Th>
+          </TRHead>
+        </THead>
+        <TBody>
+          {visible.length === 0 ? (
+            <tr>
+              <td colSpan={comparing ? RESULT_COLUMN_COUNT : RESULT_COLUMN_COUNT - 1}>
+                <p className="px-4 py-12 text-center text-[12px] text-muted-foreground">
+                  {results.length === 0
+                    ? "No per-case results reported for this run yet."
+                    : "No results match this filter."}
+                </p>
+              </td>
+            </tr>
+          ) : (
+            visible.map((result) => {
+              const row = cmpFor(result);
+              const rowCmp = row?.comparison ?? null;
+              return (
+                <TR
+                  key={result.id}
+                  interactive
+                  selected={result.id === openResultId}
+                  onClick={() => onOpen(result.id)}
+                >
+                  <Td className="max-w-[260px] truncate" title={result.input}>
+                    {result.input}
+                  </Td>
+                  <Td className="max-w-[260px]">
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <span className="truncate" title={result.candidateOutput ?? undefined}>
+                        {result.candidateOutput ?? (
+                          <span className="text-muted-foreground">No output</span>
+                        )}
+                      </span>
+                      {row?.outputChanged === true && (
+                        <span
+                          className="shrink-0 rounded bg-muted px-1 text-[10px] text-muted-foreground"
+                          title="Output differs from the baseline run"
+                        >
+                          ≠ baseline
+                        </span>
+                      )}
+                    </div>
+                  </Td>
+                  <Td
+                    className="max-w-[220px] truncate text-muted-foreground"
+                    title={result.expectedOutput ?? undefined}
+                  >
+                    {result.expectedOutput ?? "—"}
+                  </Td>
+                  <Td>
+                    <MainScoreCell result={result} comparison={rowCmp} />
+                  </Td>
+                  {comparing && (
+                    <Td className="text-right">
+                      <ChangeCell change={rowCmp?.caseChange ?? null} />
+                    </Td>
+                  )}
+                  <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
+                    {fmtDurationMs(result.durationMs)}
+                    {comparing && (
+                      <CellDelta delta={rowCmp?.durationDeltaMs ?? null} format={fmtDurationMs} />
+                    )}
+                  </Td>
+                  <Td className="whitespace-nowrap text-right text-[11px] tabular-nums text-muted-foreground">
+                    {result.cost === null ? "—" : `$${result.cost.toFixed(4)}`}
+                    {comparing && result.cost !== null && row?.baselineCost != null && (
+                      <CellDelta
+                        delta={result.cost - row.baselineCost}
+                        format={(n) => `$${n.toFixed(4)}`}
+                      />
+                    )}
+                  </Td>
+                  <Td>
+                    <EvalResultBadge status={result.status} />
+                  </Td>
+                </TR>
+              );
+            })
+          )}
+        </TBody>
+      </Table>
+    </div>
+  );
+}
+
+/**
+ * Per-result candidate main score, and — when comparing against a picked run — its
+ * baseline counterpart + delta (the backend engine derives the per-case baseline value,
+ * so we show a real magnitude). Missing values render "—", never a fabricated 0.
+ */
+function MainScoreCell({
+  result,
+  comparison,
+}: {
+  result: ResultRow;
+  comparison: ResultRowComparison | null;
+}) {
+  const cand = comparison?.mainScore.candidate ?? result.mainScore;
+  if (cand === null || cand === undefined) return <span className="text-muted-foreground">—</span>;
+  const base = comparison?.mainScore.baseline ?? null;
+  const delta = comparison?.mainScore.delta ?? null;
+  return (
+    <div className="flex flex-col gap-0.5 text-[12px] tabular-nums">
+      <span>
+        {pctFraction(cand)}
+        {base !== null && <span className="text-muted-foreground"> vs {pctFraction(base)}</span>}
+      </span>
+      {delta !== null && (
+        <span className={SENTIMENT_CLASS[changeSentiment(delta)]}>{signedPoints(delta)} pp</span>
+      )}
+    </div>
+  );
+}
+
+/** Per-result case verdict (derived from the main scorer). */
+function ChangeCell({ change }: { change: Classification | null }) {
+  if (change === "improved") {
+    return (
+      <span
+        className={cn("inline-flex items-center justify-end gap-0.5", SENTIMENT_CLASS.good)}
+        title="Improved"
+      >
+        <ArrowUp className="h-3.5 w-3.5" aria-hidden />
+        Improved
+      </span>
+    );
+  }
+  if (change === "regressed") {
+    return (
+      <span
+        className={cn("inline-flex items-center justify-end gap-0.5", SENTIMENT_CLASS.bad)}
+        title="Regressed"
+      >
+        <ArrowDown className="h-3.5 w-3.5" aria-hidden />
+        Regressed
+      </span>
+    );
+  }
+  if (change === "changed") {
+    return <span title="Changed (categorical)">Changed</span>;
+  }
+  if (change === "unchanged") {
+    return <span className="text-muted-foreground">Unchanged</span>;
+  }
+  if (change === "unpaired" || change === "not_comparable") {
+    return (
+      <span className="text-muted-foreground" title="Not compared against a baseline value">
+        {change === "unpaired" ? "Unpaired" : "Not comparable"}
+      </span>
+    );
+  }
+  return <span className="text-muted-foreground">—</span>;
+}

--- a/frontend/ui/src/features/offline-eval/components/index.ts
+++ b/frontend/ui/src/features/offline-eval/components/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Offline Evaluation feature components.
+ */
+
+export { StatusBadge, ReviewBadge, EvalResultBadge } from "./badges";
+export { Timestamp } from "./timestamp";
+export { DatasetInfoChip } from "./dataset-info-chip";
+export {
+  EvalPageHeader,
+  EvalBody,
+  DetailsSection,
+  DetailRow,
+  QuietAction,
+  EmptyState,
+} from "./page-chrome";
+export { TraceInspector } from "./trace-inspector";
+export { CreateDrawer, FormCard, AdvancedSection } from "./form-kit";
+export { SaveTestCaseDrawer } from "./save-test-case-drawer";
+export { RunEvaluationDrawer } from "./run-evaluation-drawer";
+export { ReviewPanel, type ReviewTarget } from "./review-panel";
+export { TestCaseReviewDrawer, type TestCaseReviewTarget } from "./test-case-review-drawer";
+export { useRowSelection, SelectAllHeaderCell, SelectRowCell, BulkActionBar } from "./selection";
+export { ScoreChart, DistributionBar, type ChartSeries } from "./score-chart";
+export { UploadControl } from "./upload-control";
+export { useSeedTraceIO } from "./seed-trace-io";
+export { DatasetFormFields, emptyDatasetForm, type DatasetFormState } from "./dataset-form";
+export { DatasetActionsMenu } from "./dataset-actions-menu";
+export { NewDatasetDialog } from "./new-dataset-dialog";
+export { DatasetEditPanel } from "./dataset-edit-panel";
+export {
+  LineNumberedTextarea,
+  ValueBlock,
+  EditableValueBlock,
+  formatValue,
+  seedFormat,
+  type SeedJsonPreference,
+  type ValueKind,
+} from "./code";

--- a/frontend/ui/src/features/offline-eval/components/page-chrome.tsx
+++ b/frontend/ui/src/features/offline-eval/components/page-chrome.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Page chrome.
+ *
+ * One heading, one plain sentence explaining the object, and at most one
+ * primary action. The sentence is the point: every page names a concept
+ * (Trace, Dataset, Evaluation run, Scorer) that a new reader has not met yet.
+ */
+export function EvalPageHeader({
+  title,
+  parent,
+  purpose,
+  backHref,
+  backLabel,
+  action,
+}: {
+  title: React.ReactNode;
+  /** Parent section for a nested page: renders as a `Parent › title` breadcrumb
+   *  bar (the parent is a link back to the list), matching the detectors detail. */
+  parent?: { label: string; href: string };
+  /** One plain sentence. Not marketing copy — a definition. */
+  purpose?: React.ReactNode;
+  backHref?: string;
+  backLabel?: string;
+  /** At most one primary action per page. */
+  action?: React.ReactNode;
+}) {
+  return (
+    <div className="shrink-0 border-b border-border px-4 py-3">
+      {backHref && !parent && (
+        <Link
+          href={backHref}
+          className="mb-1.5 inline-flex items-center gap-1 rounded text-[12px] text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" aria-hidden />
+          {backLabel ?? "Back"}
+        </Link>
+      )}
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            {parent && (
+              <>
+                <Link
+                  href={parent.href}
+                  className="shrink-0 rounded text-[13px] text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  {parent.label}
+                </Link>
+                <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden />
+              </>
+            )}
+            <h1 className="min-w-0 text-[13px] font-medium">{title}</h1>
+          </div>
+          {purpose && (
+            <p className="mt-0.5 max-w-[70ch] text-[12px] leading-relaxed text-muted-foreground">
+              {purpose}
+            </p>
+          )}
+        </div>
+        {action && <div className="shrink-0">{action}</div>}
+      </div>
+    </div>
+  );
+}
+
+/** Body wrapper: consistent padding and scroll behaviour for every page. */
+export function EvalBody({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <div className={cn("min-h-0 flex-1 overflow-auto", className)}>{children}</div>;
+}
+
+/**
+ * The single, consistent place advanced information hides.
+ * Native <details> so it is keyboard-accessible for free.
+ */
+export function DetailsSection({
+  label = "Details",
+  children,
+  className,
+}: {
+  label?: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <details className={cn("group", className)}>
+      <summary className="inline-flex cursor-pointer list-none items-center rounded text-[12px] text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring">
+        {label}
+      </summary>
+      <div className="mt-2">{children}</div>
+    </details>
+  );
+}
+
+/** Label/value row used inside Details areas. */
+export function DetailRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="flex justify-between gap-4 py-1">
+      <dt className="text-[12px] text-muted-foreground">{label}</dt>
+      <dd className="text-[12px] tabular-nums">{value}</dd>
+    </div>
+  );
+}
+
+/** Quiet secondary action — used for "View SDK example" style links. */
+export function QuietAction({
+  children,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded text-[12px] text-muted-foreground underline-offset-2 transition-colors hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    >
+      {children}
+    </button>
+  );
+}
+
+export function EmptyState({ children }: { children: React.ReactNode }) {
+  return <div className="px-4 py-12 text-center text-[12px] text-muted-foreground">{children}</div>;
+}

--- a/frontend/ui/src/features/offline-eval/components/review-panel.tsx
+++ b/frontend/ui/src/features/offline-eval/components/review-panel.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { useToast } from "@/components/ui/toast";
+import { cn } from "@/lib/utils";
+import { HUMAN_VERDICT_LABEL, type HumanReview, type HumanVerdict } from "../types";
+
+/**
+ * Human review — the essential human-scoring step, and the one thing a person
+ * creates in the UI. The same panel opens from a production span and from an
+ * evaluation result, so reviewing feels like one activity.
+ *
+ * It scores one observed output and nothing else. Changing what future runs are
+ * compared against is a separate, confirmed action ("Update expected outcome"),
+ * so human-scoring can never silently mutate the source dataset.
+ */
+
+export interface ReviewTarget {
+  /** Where the review was opened from. */
+  contextLabel: string;
+  input: string;
+  output: string;
+  expected: string | null;
+  /** Existing automatic scores, shown alongside the human decision. */
+  autoScores: Array<{ name: string; display: string; explanation?: string }>;
+  existing?: HumanReview;
+  /** Optional trace/span evidence rendered by the caller. */
+  evidence?: React.ReactNode;
+}
+
+export function ReviewPanel({
+  target,
+  open,
+  onOpenChange,
+  onSave,
+  savedDescription,
+  footerNote = "Recorded on this run.",
+}: {
+  target: ReviewTarget | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (review: HumanReview) => void;
+  /** Toast description shown after saving; omit for none. */
+  savedDescription?: string;
+  /** Small note in the footer (e.g. "Saved in this page only."). */
+  footerNote?: string;
+}) {
+  const { toast } = useToast();
+
+  const [verdict, setVerdict] = React.useState<HumanVerdict>("pass");
+  const [quality, setQuality] = React.useState<number | undefined>(undefined);
+  const [comment, setComment] = React.useState("");
+  const [showEvidence, setShowEvidence] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!open || !target) return;
+    const existing = target.existing;
+    setVerdict(existing?.verdict ?? "pass");
+    setQuality(existing?.quality);
+    setComment(existing?.comment ?? "");
+    setShowEvidence(false);
+  }, [open, target]);
+
+  if (!target) return null;
+
+  const handleSave = () => {
+    onSave({
+      verdict,
+      quality,
+      comment: comment.trim() || undefined,
+      reviewer: "You",
+      at: new Date().toISOString(),
+    });
+    toast({
+      title: "Review saved",
+      ...(savedDescription ? { description: savedDescription } : {}),
+      tone: "success",
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent width="w-[560px]">
+        <DrawerHeader className="pr-10">
+          <DrawerTitle>Review</DrawerTitle>
+          <p className="mt-1 text-[12px] text-muted-foreground">{target.contextLabel}</p>
+        </DrawerHeader>
+
+        <DrawerBody className="flex flex-col gap-4 text-[12px]">
+          <Block label="What was asked">
+            <p className="leading-relaxed">{target.input}</p>
+          </Block>
+          <Block label="What the app produced">
+            <p className="leading-relaxed">{target.output}</p>
+          </Block>
+          <Block label="Expected output">
+            {target.expected ? (
+              <p className="leading-relaxed">{target.expected}</p>
+            ) : (
+              <p className="text-muted-foreground">
+                Not required — a scorer judges the output directly.
+              </p>
+            )}
+          </Block>
+
+          {target.autoScores.length > 0 && (
+            <Block label="Automatic scores">
+              <ul className="flex flex-col gap-1.5">
+                {target.autoScores.map((score) => (
+                  <li key={score.name}>
+                    <span className="text-foreground">{score.name}: </span>
+                    <span className="text-muted-foreground">{score.display}</span>
+                    {score.explanation && (
+                      <p className="mt-0.5 leading-relaxed text-muted-foreground">
+                        {score.explanation}
+                      </p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </Block>
+          )}
+
+          {target.evidence && (
+            <div>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-0 text-[12px] text-muted-foreground hover:bg-transparent hover:text-foreground"
+                onClick={() => setShowEvidence((current) => !current)}
+                aria-expanded={showEvidence}
+              >
+                {showEvidence ? "Hide the trace" : "Show the trace"}
+              </Button>
+              {showEvidence && <div className="mt-2">{target.evidence}</div>}
+            </div>
+          )}
+
+          <div className="h-px bg-border" />
+
+          <div>
+            <p className="mb-1.5 font-medium">Was this right?</p>
+            <div className="flex gap-1.5" role="radiogroup" aria-label="Decision">
+              {(Object.keys(HUMAN_VERDICT_LABEL) as HumanVerdict[]).map((option) => (
+                <Button
+                  key={option}
+                  type="button"
+                  role="radio"
+                  aria-checked={verdict === option}
+                  variant={verdict === option ? "default" : "outline"}
+                  size="sm"
+                  className="h-7 text-[12px]"
+                  onClick={() => setVerdict(option)}
+                >
+                  {HUMAN_VERDICT_LABEL[option]}
+                </Button>
+              ))}
+            </div>
+            <p className="mt-1.5 text-[11px] text-muted-foreground">
+              This judges what happened this time. It does not change what future runs are compared
+              against.
+            </p>
+          </div>
+
+          <div>
+            <p className="mb-1.5 font-medium">
+              Quality <span className="font-normal text-muted-foreground">optional</span>
+            </p>
+            <div className="flex gap-1.5" role="radiogroup" aria-label="Quality score">
+              {[1, 2, 3, 4, 5].map((value) => (
+                <Button
+                  key={value}
+                  type="button"
+                  role="radio"
+                  aria-checked={quality === value}
+                  variant={quality === value ? "default" : "outline"}
+                  size="sm"
+                  className="h-7 w-7 p-0 text-[12px] tabular-nums"
+                  onClick={() => setQuality(quality === value ? undefined : value)}
+                >
+                  {value}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor="review-comment" className="mb-1.5 block font-medium">
+              Comment <span className="font-normal text-muted-foreground">optional</span>
+            </label>
+            <Input
+              id="review-comment"
+              value={comment}
+              onChange={(event) => setComment(event.target.value)}
+              placeholder="Why did you decide this?"
+              className="h-7 text-[12px]"
+            />
+          </div>
+        </DrawerBody>
+
+        <DrawerFooter>
+          <span className="text-[11px] text-muted-foreground">{footerNote}</span>
+          <span className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 text-[12px]"
+              onClick={() => onOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button size="sm" className="h-7 text-[12px]" onClick={handleSave}>
+              Save review
+            </Button>
+          </span>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+function Block({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="mb-1 text-[11px] text-muted-foreground">{label}</p>
+      <div className={cn("rounded border border-border bg-muted/20 px-2.5 py-2")}>{children}</div>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/review-panel.tsx
+++ b/frontend/ui/src/features/offline-eval/components/review-panel.tsx
@@ -49,7 +49,7 @@ export function ReviewPanel({
   target: ReviewTarget | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSave: (review: HumanReview) => void;
+  onSave: (review: HumanReview) => void | Promise<void>;
   /** Toast description shown after saving; omit for none. */
   savedDescription?: string;
   /** Small note in the footer (e.g. "Saved in this page only."). */
@@ -73,14 +73,25 @@ export function ReviewPanel({
 
   if (!target) return null;
 
-  const handleSave = () => {
-    onSave({
-      verdict,
-      quality,
-      comment: comment.trim() || undefined,
-      reviewer: "You",
-      at: new Date().toISOString(),
-    });
+  const handleSave = async () => {
+    try {
+      // Await the persist so a failed request is never presented as saved. onSave may
+      // be sync (returns void) or return a promise that rejects on failure.
+      await onSave({
+        verdict,
+        quality,
+        comment: comment.trim() || undefined,
+        reviewer: "You",
+        at: new Date().toISOString(),
+      });
+    } catch {
+      toast({
+        title: "Could not save review",
+        description: "It wasn't persisted — please try again.",
+        tone: "warning",
+      });
+      return; // keep the drawer open with the reviewer's input intact
+    }
     toast({
       title: "Review saved",
       ...(savedDescription ? { description: savedDescription } : {}),

--- a/frontend/ui/src/features/offline-eval/components/seed-trace-io.tsx
+++ b/frontend/ui/src/features/offline-eval/components/seed-trace-io.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { spanIOQueryKey } from "@/features/traces";
+import type { TraceDetail } from "../types";
+
+/**
+ * Seeds the span-IO react-query cache from hardcoded traces, so the real
+ * `SpanInfoPanel` (which reads span input/output/metadata from that cache, not
+ * from the span object) shows the fixture values. The reading hook is auth-gated
+ * and disabled here, but a disabled query still returns seeded data.
+ *
+ * Call once with all traces the page might open.
+ */
+export function useSeedTraceIO(projectId: string, details: TraceDetail[]) {
+  const queryClient = useQueryClient();
+  React.useEffect(() => {
+    for (const trace of details) {
+      for (const span of trace.spans) {
+        queryClient.setQueryData(spanIOQueryKey(projectId, trace.trace_id, span.span_id), {
+          span_id: span.span_id,
+          trace_id: trace.trace_id,
+          input: span.input ?? null,
+          output: span.output ?? null,
+          metadata: span.metadata ?? null,
+        });
+      }
+    }
+    // details is a stable module-level fixture; seed once per project.
+  }, [queryClient, projectId, details]);
+}

--- a/frontend/ui/src/features/offline-eval/components/selection.tsx
+++ b/frontend/ui/src/features/offline-eval/components/selection.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import * as React from "react";
+import { Trash2 } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/**
+ * Row selection, the way the reference tables do it: a checkbox
+ * column with a select/deselect-all header, and a bar that appears once anything
+ * is selected — "N selected", with Delete and any extra actions.
+ */
+export function useRowSelection<T extends string>(allIds: T[]) {
+  const [selected, setSelected] = React.useState<Set<T>>(new Set());
+
+  // Drop ids that no longer exist (e.g. after a local delete).
+  React.useEffect(() => {
+    setSelected((current) => {
+      const next = new Set([...current].filter((id) => allIds.includes(id)));
+      return next.size === current.size ? current : next;
+    });
+  }, [allIds]);
+
+  const toggle = React.useCallback((id: T) => {
+    setSelected((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  /** Add or remove a batch of ids at once (e.g. select every run under a group). */
+  const setMany = React.useCallback((ids: T[], on: boolean) => {
+    setSelected((current) => {
+      const next = new Set(current);
+      for (const id of ids) {
+        if (on) next.add(id);
+        else next.delete(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const clear = React.useCallback(() => setSelected(new Set()), []);
+
+  const allSelected = allIds.length > 0 && allIds.every((id) => selected.has(id));
+  const someSelected = selected.size > 0 && !allSelected;
+
+  const toggleAll = React.useCallback(() => {
+    setSelected((current) => (current.size === allIds.length ? new Set() : new Set(allIds)));
+  }, [allIds]);
+
+  return {
+    selected,
+    count: selected.size,
+    has: (id: T) => selected.has(id),
+    toggle,
+    toggleAll,
+    setMany,
+    clear,
+    allSelected,
+    someSelected,
+  };
+}
+
+/** Header checkbox cell — select / deselect all. */
+export function SelectAllHeaderCell({
+  checked,
+  indeterminate,
+  onToggle,
+}: {
+  checked: boolean;
+  indeterminate: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <th className="w-8 border-r border-border/50 px-3 py-1.5 text-left">
+      <Checkbox
+        checked={checked}
+        indeterminate={indeterminate}
+        onCheckedChange={onToggle}
+        aria-label={checked ? "Deselect all" : "Select all"}
+      />
+    </th>
+  );
+}
+
+/** Per-row checkbox cell. Stops propagation so it doesn't open the row. */
+export function SelectRowCell({
+  checked,
+  onToggle,
+  label,
+}: {
+  checked: boolean;
+  onToggle: () => void;
+  label: string;
+}) {
+  return (
+    <td className="w-8 border-r border-border/50 px-3 py-1.5" onClick={(e) => e.stopPropagation()}>
+      <Checkbox checked={checked} onCheckedChange={onToggle} aria-label={label} />
+    </td>
+  );
+}
+
+/**
+ * The bar shown while rows are selected: "N selected", Delete, plus any extra
+ * actions. Sits above the table, matching the reference bulk-action pattern.
+ */
+export function BulkActionBar({
+  count,
+  onDelete,
+  onClear,
+  extra,
+  className,
+}: {
+  count: number;
+  /** Omit on lists with no delete API (e.g. the derived scorer registry). */
+  onDelete?: () => void;
+  onClear: () => void;
+  extra?: React.ReactNode;
+  className?: string;
+}) {
+  if (count === 0) return null;
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 border-b border-border bg-muted/40 px-3 py-1.5",
+        className,
+      )}
+    >
+      <span className="text-[12px] font-medium tabular-nums">{count} selected</span>
+      {(onDelete || extra) && <span className="h-4 w-px bg-border" aria-hidden />}
+      {onDelete && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 px-1.5 text-[12px] text-destructive hover:bg-destructive/10 hover:text-destructive"
+          onClick={onDelete}
+        >
+          <Trash2 className="h-3.5 w-3.5" aria-hidden />
+          Delete
+        </Button>
+      )}
+      {extra}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="ml-auto h-6 px-1.5 text-[12px] text-muted-foreground hover:text-foreground"
+        onClick={onClear}
+      >
+        Clear
+      </Button>
+    </div>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/test-case-review-drawer.tsx
+++ b/frontend/ui/src/features/offline-eval/components/test-case-review-drawer.tsx
@@ -47,7 +47,7 @@ export function TestCaseReviewDrawer({
   target: TestCaseReviewTarget | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (result: { review: ReviewStatus; correctedExpected?: string }) => void;
+  onSubmit: (result: { review: ReviewStatus; correctedExpected?: string }) => void | Promise<void>;
 }) {
   const { toast } = useToast();
   const [checked, setChecked] = React.useState<boolean[]>(() => CHECKS.map(() => false));
@@ -63,8 +63,21 @@ export function TestCaseReviewDrawer({
 
   const expectedChanged = corrected.trim() !== "" && corrected.trim() !== (target.expected ?? "");
 
-  const submit = (review: ReviewStatus) => {
-    onSubmit({ review, correctedExpected: expectedChanged ? corrected.trim() : undefined });
+  const submit = async (review: ReviewStatus) => {
+    try {
+      // Await the persist so a failed request is never shown as saved.
+      await onSubmit({
+        review,
+        correctedExpected: expectedChanged ? corrected.trim() : undefined,
+      });
+    } catch {
+      toast({
+        title: "Could not save review",
+        description: "It wasn't persisted — please try again.",
+        tone: "warning",
+      });
+      return; // keep the drawer open
+    }
     toast({
       title: review === "ready" ? "Marked Ready" : "Sent back for work",
       description: expectedChanged

--- a/frontend/ui/src/features/offline-eval/components/test-case-review-drawer.tsx
+++ b/frontend/ui/src/features/offline-eval/components/test-case-review-drawer.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { useToast } from "@/components/ui/toast";
+import type { ReviewStatus } from "../types";
+
+/**
+ * Review test case — verifies that a dataset row is a good, reusable test case,
+ * which is a different question from scoring one output. It deliberately does
+ * NOT ask Pass / Fail / Quality (those belong to production annotation or
+ * evaluation-result scoring). The reviewer confirms the case is rerunnable and
+ * appropriate, may correct the expected outcome, and marks it Ready or Needs
+ * work. Ready is advisory — it never blocks the case from an evaluation here.
+ */
+
+export interface TestCaseReviewTarget {
+  contextLabel: string;
+  input: string;
+  expected: string | null;
+  currentReview: ReviewStatus;
+}
+
+const CHECKS = [
+  "The input is sufficient and rerunnable.",
+  "The case belongs in this dataset.",
+  "The expected outcome is correct, or intentionally not required.",
+  "Sensitive or irrelevant production data has been removed.",
+  "The source span provides the intended test boundary.",
+];
+
+export function TestCaseReviewDrawer({
+  target,
+  open,
+  onOpenChange,
+  onSubmit,
+}: {
+  target: TestCaseReviewTarget | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSubmit: (result: { review: ReviewStatus; correctedExpected?: string }) => void;
+}) {
+  const { toast } = useToast();
+  const [checked, setChecked] = React.useState<boolean[]>(() => CHECKS.map(() => false));
+  const [corrected, setCorrected] = React.useState("");
+
+  React.useEffect(() => {
+    if (!open || !target) return;
+    setChecked(CHECKS.map(() => false));
+    setCorrected("");
+  }, [open, target]);
+
+  if (!target) return null;
+
+  const expectedChanged = corrected.trim() !== "" && corrected.trim() !== (target.expected ?? "");
+
+  const submit = (review: ReviewStatus) => {
+    onSubmit({ review, correctedExpected: expectedChanged ? corrected.trim() : undefined });
+    toast({
+      title: review === "ready" ? "Marked Ready" : "Sent back for work",
+      description: expectedChanged
+        ? "Saved with a corrected expected outcome."
+        : "Saved in this page only.",
+      tone: "success",
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent width="w-[560px]">
+        <DrawerHeader className="pr-10">
+          <DrawerTitle>Review test case</DrawerTitle>
+          <p className="mt-1 text-[12px] text-muted-foreground">{target.contextLabel}</p>
+        </DrawerHeader>
+
+        <DrawerBody className="flex flex-col gap-4 text-[12px]">
+          <p className="leading-relaxed text-muted-foreground">
+            Confirm this is a good, reusable test case — not whether one run passed. Output scoring
+            (Pass / Fail / quality) happens elsewhere.
+          </p>
+
+          <div>
+            <p className="mb-1 text-[11px] text-muted-foreground">Input</p>
+            <div className="rounded border border-border bg-muted/20 px-2.5 py-2 leading-relaxed">
+              {target.input || <span className="text-muted-foreground">—</span>}
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-1 text-[11px] text-muted-foreground">Expected outcome</p>
+            <div className="rounded border border-border bg-muted/20 px-2.5 py-2 leading-relaxed">
+              {target.expected ? (
+                target.expected
+              ) : (
+                <span className="text-muted-foreground">
+                  Not required — a scorer judges the output directly.
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="h-px bg-border" />
+
+          <div>
+            <p className="mb-2 font-medium">Verify</p>
+            <ul className="flex flex-col gap-2">
+              {CHECKS.map((label, i) => (
+                <li key={label}>
+                  <label className="flex cursor-pointer items-start gap-2 leading-relaxed">
+                    <input
+                      type="checkbox"
+                      checked={checked[i]}
+                      onChange={(e) =>
+                        setChecked((prev) => prev.map((v, j) => (j === i ? e.target.checked : v)))
+                      }
+                      className="mt-0.5 h-3.5 w-3.5 shrink-0 accent-foreground"
+                    />
+                    <span>{label}</span>
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <label htmlFor="tc-corrected-expected" className="mb-1.5 block font-medium">
+              Correct the expected outcome{" "}
+              <span className="font-normal text-muted-foreground">optional</span>
+            </label>
+            <Input
+              id="tc-corrected-expected"
+              value={corrected}
+              onChange={(event) => setCorrected(event.target.value)}
+              placeholder={target.expected ?? "e.g. billing"}
+              className="h-7 text-[12px]"
+            />
+            <p className="mt-1.5 text-[11px] text-muted-foreground">
+              Changing this changes what future runs are evaluated against.
+            </p>
+          </div>
+        </DrawerBody>
+
+        <DrawerFooter>
+          <span className="text-[11px] text-muted-foreground">
+            Ready is advisory — saved here only.
+          </span>
+          <span className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 text-[12px]"
+              onClick={() => submit("needs_review")}
+            >
+              Needs work
+            </Button>
+            <Button size="sm" className="h-7 text-[12px]" onClick={() => submit("ready")}>
+              Mark ready
+            </Button>
+          </span>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/components/upload-control.tsx
+++ b/frontend/ui/src/features/offline-eval/components/upload-control.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import * as React from "react";
+import { Upload, FileText } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * CSV / JSON upload control for creating a dataset or importing rows.
+ *
+ * It accepts a file and reports the name, but nothing is parsed or stored.
+ * `onFile` lets the caller show a confirmation.
+ */
+export function UploadControl({
+  onFile,
+  className,
+}: {
+  onFile?: (fileName: string) => void;
+  className?: string;
+}) {
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const [fileName, setFileName] = React.useState<string | null>(null);
+  const [dragging, setDragging] = React.useState(false);
+
+  const accept = (file: File | undefined) => {
+    if (!file) return;
+    setFileName(file.name);
+    onFile?.(file.name);
+  };
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={() => inputRef.current?.click()}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragging(true);
+        }}
+        onDragLeave={() => setDragging(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragging(false);
+          accept(e.dataTransfer.files?.[0]);
+        }}
+        className={cn(
+          "flex w-full flex-col items-center justify-center gap-1.5 rounded border border-dashed px-4 py-6 text-center transition-colors",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          dragging ? "border-foreground bg-muted/50" : "border-border hover:bg-muted/30",
+        )}
+      >
+        {fileName ? (
+          <>
+            <FileText className="h-5 w-5 text-muted-foreground" aria-hidden />
+            <span className="text-[12px] font-medium">{fileName}</span>
+            <span className="text-[11px] text-muted-foreground">
+              Click to choose a different file
+            </span>
+          </>
+        ) : (
+          <>
+            <Upload className="h-5 w-5 text-muted-foreground" aria-hidden />
+            <span className="text-[12px]">Drop a CSV or JSON file, or click to browse</span>
+            <span className="text-[11px] text-muted-foreground">
+              Columns map to input, expected, and metadata
+            </span>
+          </>
+        )}
+      </button>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".csv,.json,application/json,text/csv"
+        className="hidden"
+        onChange={(e) => accept(e.target.files?.[0])}
+        aria-label="Upload CSV or JSON"
+      />
+    </div>
+  );
+}

--- a/frontend/ui/src/features/offline-eval/types.ts
+++ b/frontend/ui/src/features/offline-eval/types.ts
@@ -1,0 +1,388 @@
+/**
+ * Offline Evaluation — domain types.
+ *
+ * v1 loop: an existing trace → select a span → save it as a test case →
+ * dataset → run an evaluation → compare → inspect the resulting trace → review.
+ * Plus a small Scorers section.
+ *
+ * This version deliberately reuses the *real* trace types (`Span`,
+ * `TraceDetail`) rather than a parallel shape, so the trace-inspection UI is the
+ * genuine TraceRoot component fed with hardcoded data — not a lookalike.
+ */
+
+import type { Span, TraceDetail } from "@/types/api";
+import type { SpanKind } from "@traceroot/core";
+
+export type { Span, TraceDetail };
+export type { SpanKind };
+
+// ---------------------------------------------------------------------------
+// Status vocabulary — plain, and no "Golden"
+// ---------------------------------------------------------------------------
+
+/** How a single result turned out. */
+export type ResultStatus = "passed" | "failed" | "needs_review";
+
+/**
+ * How much the team trusts a test case. Advisory only — Ready never blocks a
+ * case from evaluations here; it communicates trust. New cases start needs_review.
+ */
+export type ReviewStatus = "needs_review" | "ready";
+
+/** Why a span was captured into a dataset — read-only context for the reviewer. */
+export type CaptureReason = "manual" | "error" | "failed_tool" | "negative_feedback";
+
+export const CAPTURE_REASON_LABEL: Record<CaptureReason, string> = {
+  manual: "Captured manually",
+  error: "Span ended with an error",
+  failed_tool: "Failed tool call",
+  negative_feedback: "Negative user feedback",
+};
+
+export const RESULT_STATUS_LABEL: Record<ResultStatus, string> = {
+  passed: "Passed",
+  failed: "Failed",
+  needs_review: "Needs review",
+};
+
+export const REVIEW_STATUS_LABEL: Record<ReviewStatus, string> = {
+  needs_review: "Needs review",
+  ready: "Ready",
+};
+
+export const REVIEW_STATUS_HELP: Record<ReviewStatus, string> = {
+  needs_review: "Nobody has verified this case is reusable yet.",
+  ready: "A reviewer verified this case; later runs may optionally use Ready cases only.",
+};
+
+/**
+ * Human-readable label for a span kind. The real kinds are LLM / AGENT / TOOL /
+ * SPAN; "retrieval" and "root" are conveyed by the span's name, not a new kind.
+ */
+export const SPAN_KIND_LABEL: Record<SpanKind, string> = {
+  LLM: "LLM call",
+  AGENT: "Agent step",
+  TOOL: "Tool call",
+  SPAN: "Step",
+  EVALUATION: "Evaluation",
+  TASK: "Task",
+  SCORER: "Scorer",
+};
+
+// ---------------------------------------------------------------------------
+// Human review — the one thing people create in the UI
+// ---------------------------------------------------------------------------
+
+export type HumanVerdict = "pass" | "fail" | "unsure";
+
+export const HUMAN_VERDICT_LABEL: Record<HumanVerdict, string> = {
+  pass: "Pass",
+  fail: "Fail",
+  unsure: "Unsure",
+};
+
+/**
+ * One person's judgment of one observed result.
+ *
+ * `correctedExpected` is kept separate from the verdict on purpose: judging what
+ * happened once and changing what future runs are compared against are two
+ * different decisions.
+ */
+export interface HumanReview {
+  verdict: HumanVerdict;
+  quality?: number;
+  correctedExpected?: string;
+  comment?: string;
+  reviewer: string;
+  at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Traces (real TraceDetail, plus the display fields a list needs)
+// ---------------------------------------------------------------------------
+
+/**
+ * A trace: the genuine `TraceDetail` (rendered by the real
+ * SpanTreeView / SpanInfoPanel) plus the summary fields a list shows.
+ */
+export interface ProtoTrace {
+  detail: TraceDetail;
+  /** Short plain summary of the top-level input, for the list. */
+  inputSummary: string;
+  /** Short plain summary of the outcome, for the list. */
+  resultSummary: string;
+  status: ResultStatus;
+  mainScore: number | null;
+  mainScoreName: string;
+  humanReview?: HumanReview;
+}
+
+export type TraceFilter = "all" | "passed" | "failed" | "needs_review" | "has_error";
+
+export const TRACE_FILTERS: Array<{ id: TraceFilter; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "passed", label: "Passed" },
+  { id: "failed", label: "Failed" },
+  { id: "needs_review", label: "Needs review" },
+  { id: "has_error", label: "Has error" },
+];
+
+// ---------------------------------------------------------------------------
+// Datasets & test cases
+// ---------------------------------------------------------------------------
+
+export interface Dataset {
+  id: string;
+  name: string;
+  description: string;
+  caseCount: number;
+  reviewedCount: number;
+  /** Names of evaluations that have run against this dataset. */
+  evaluationNames: string[];
+  updatedAt: string;
+  /** Optional free-form tags, shown only in a collapsed section. */
+  tags: string[];
+}
+
+/**
+ * Where a test case came from. Always a span inside a parent trace — the whole
+ * trace is retained as context, but the case *is* the selected span.
+ */
+export interface CaseSource {
+  traceId: string;
+  spanId: string;
+  spanName: string;
+  spanKind: SpanKind;
+}
+
+export interface TestCase {
+  id: string;
+  /** The selected span's input becomes the proposed test input. */
+  input: string;
+  /**
+   * Optional. Null means a scorer judges the produced output directly rather
+   * than comparing it to one exact answer.
+   */
+  expected: string | null;
+  /** What the span actually produced in production. Read-only, never = expected. */
+  recordedOutput: string | null;
+  /** Why this span was captured — read-only context for the reviewer. */
+  captureReason: CaptureReason;
+  source: CaseSource;
+  review: ReviewStatus;
+  latestScore: number | null;
+  latestStatus: ResultStatus | null;
+  metadata: Record<string, string>;
+  addedAt: string;
+  addedBy: string;
+  humanReview?: HumanReview;
+}
+
+export interface DatasetVersion {
+  version: string;
+  createdAt: string;
+  author: string;
+  note: string;
+  caseCount: number;
+}
+
+export interface DatasetActivity {
+  at: string;
+  actor: string;
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Evaluations (the run — the term chosen for this product)
+// ---------------------------------------------------------------------------
+
+export type EvaluationStatus =
+  | "running"
+  | "completed"
+  | "completed_with_errors"
+  | "failed"
+  | "incomplete";
+
+export const EVALUATION_STATUS_LABEL: Record<EvaluationStatus, string> = {
+  running: "Running",
+  completed: "Completed",
+  completed_with_errors: "Completed with errors",
+  failed: "Failed",
+  incomplete: "Incomplete",
+};
+
+/**
+ * How one result turned out. Distinct from a dataset case's status: "Not scored"
+ * is not a zero, and "Errored" says the run broke rather than judged badly.
+ */
+export type EvalResultStatus = "passed" | "failed" | "errored" | "not_scored";
+
+export const EVAL_RESULT_STATUS_LABEL: Record<EvalResultStatus, string> = {
+  passed: "Passed",
+  // "Did not pass" (scored below the scorer's bar), not "Failed" — a low score
+  // reads as a broken run otherwise. A crash is "Errored", kept distinct.
+  failed: "Did not pass",
+  errored: "Errored",
+  not_scored: "Not scored",
+};
+
+/** Per-run totals reported by the SDK, shown low on the run detail page. */
+export interface EvaluationMetrics {
+  /** Wall-clock duration of the run. */
+  durationMs: number;
+  /** Summed duration of every span in the run. */
+  totalDurationMs: number;
+  /** Summed duration of the LLM spans only. */
+  llmDurationMs: number;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  spanErrors: number;
+  /** Estimated dollar cost of the run. */
+  cost: number;
+}
+
+/**
+ * One evaluation run: a candidate version measured against a dataset snapshot.
+ *
+ * `name` is the stable purpose ("Billing routing") and stays constant across
+ * runs; `candidateVersion` is what changed ("prompt-v19", a git sha). They are
+ * deliberately separate — the name is how runs are matched to a baseline.
+ */
+export interface Evaluation {
+  /**
+   * Immutable identity of ONE execution. This is what a run URL points at; a run
+   * is never edited, so there is no evaluation-version field.
+   */
+  runId: string;
+  /** Stable identity of the evaluation purpose, constant across its runs. */
+  evaluationId: string;
+  /** Monotonic run counter within one evaluation, for display as "Run #27". */
+  runNumber: number;
+  /** Stable suite name. Never the candidate version. */
+  name: string;
+  /** What was being tested this time: "prompt-v19" or a commit. */
+  candidateVersion: string;
+  /** Stable dataset identity. */
+  datasetId: string;
+  datasetName: string;
+  /** Immutable dataset snapshot this run measured against. */
+  datasetVersionId: string;
+  /** Human-readable label for that snapshot, e.g. "v12". */
+  datasetVersion: string;
+  /** Where the run executed — the SDK reports this. */
+  environment: string;
+  status: EvaluationStatus;
+  mainScore: number | null;
+  mainScoreName: string;
+  /** Percentage-point change vs the baseline. Null when there is no baseline. */
+  changeFromBaseline: number | null;
+  baselineId: string | null;
+  baselineName: string | null;
+  regressionCount: number;
+  ranAt: string;
+  /** Test cases in the dataset snapshot — the denominator. */
+  caseCount: number;
+  /** How many of them actually produced a score. Never silently equals caseCount. */
+  scoredCount: number;
+  /** The candidate application failed for this many cases. */
+  taskErrorCount: number;
+  /** The candidate produced output, but a scorer failed to judge it. */
+  scorerErrorCount: number;
+  scorerIds: string[];
+  /** Per-run totals (duration, tokens, cost) — shown low on the detail page. */
+  metrics: EvaluationMetrics;
+  details: {
+    task: string;
+    model: string;
+    trials: number;
+  };
+}
+
+export type ResultChange = "improved" | "regressed" | "unchanged";
+
+/** One scorer's verdict on one result. `score` is null when the scorer failed. */
+export interface ScorerOutcome {
+  scorerId: string;
+  score: number | null;
+  /** Short plain reason from the scorer. */
+  explanation?: string;
+  /** Set when this scorer failed to judge an output the candidate did produce. */
+  error?: string;
+}
+
+export interface EvaluationResult {
+  /** Identity of this one test-case result within this one run. */
+  resultId: string;
+  /** Stable identity of the source dataset test case. Baselines match on this. */
+  datasetItemId: string;
+  input: string;
+  expected: string | null;
+  /** Null when the candidate application errored before producing anything. */
+  currentOutput: string | null;
+  /** Null when this run has no baseline. */
+  baselineOutput: string | null;
+  /** Main score. Null when not scored (errored, or no scorer produced a value). */
+  score: number | null;
+  baselineScore: number | null;
+  status: EvalResultStatus;
+  /** Null when there is no baseline to compare against. */
+  change: ResultChange | null;
+  /** Every scorer that ran, including the ones that failed. */
+  scores: ScorerOutcome[];
+  /** Set when the candidate application itself failed for this case. */
+  taskError?: string;
+  durationMs: number;
+  cost: number;
+  /** The trace this result produced — opens the real trace detail. */
+  traceId: string;
+  humanReview?: HumanReview;
+}
+
+export type ResultFilter = "all" | "regressions" | "failed" | "needs_review";
+
+export const RESULT_FILTERS: Array<{ id: ResultFilter; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "regressions", label: "Regressions" },
+  { id: "failed", label: "Failed" },
+  { id: "needs_review", label: "Needs review" },
+];
+
+// ---------------------------------------------------------------------------
+// Scorers
+// ---------------------------------------------------------------------------
+
+/** Friendly types. */
+export type ScorerType = "rule" | "ai_judge" | "human_review";
+
+export const SCORER_TYPE_LABEL: Record<ScorerType, string> = {
+  rule: "Rule / code",
+  ai_judge: "LLM judge",
+  human_review: "Human review",
+};
+
+export const SCORER_TYPE_HELP: Record<ScorerType, string> = {
+  rule: "Plain code. Same input, same answer, every time.",
+  ai_judge: "A model reads the output and grades it against a rubric.",
+  human_review: "A person decides. Used when nothing automatic is good enough.",
+};
+
+export interface Scorer {
+  id: string;
+  name: string;
+  /** One plain sentence: what it measures. */
+  measures: string;
+  type: ScorerType;
+  /** e.g. "Pass / fail", "0–1", "1–5". */
+  scoreFormat: string;
+  /** How the number should be read. */
+  interpretation: string;
+  version: string;
+  higherIsBetter: boolean;
+  /** What the scorer judges: the whole run's output, or one span. */
+  scope: "Evaluation item" | "Span";
+  /** Share of results where this scorer failed to produce a score, 0–1. */
+  errorRate: number;
+  /** Names of evaluations using this scorer. */
+  usedByEvaluationNames: string[];
+}

--- a/frontend/ui/src/features/offline-eval/utils.ts
+++ b/frontend/ui/src/features/offline-eval/utils.ts
@@ -1,0 +1,274 @@
+/**
+ * Offline Evaluation — helpers and route builders.
+ */
+
+import { formatDate } from "@/lib/utils";
+import type { ResultStatus, ReviewStatus } from "./types";
+
+/** v1 navigation: Traces, Datasets, Evaluations, Scorers. */
+export function evalRoutes(projectId: string) {
+  const base = `/projects/${projectId}/offline-eval`;
+  return {
+    base,
+    traces: `${base}/traces`,
+    trace: (traceId: string) => `${base}/traces?trace=${traceId}`,
+    datasets: `${base}/datasets`,
+    dataset: (datasetId: string) => `${base}/datasets/${datasetId}`,
+    datasetCase: (datasetId: string, caseId: string) =>
+      `${base}/datasets/${datasetId}?case=${caseId}`,
+    evaluations: `${base}/evaluations`,
+    evaluation: (evaluationId: string) => `${base}/evaluations/${evaluationId}`,
+    scorers: `${base}/scorers`,
+  };
+}
+
+/** Badge variants for the status labels. Muted on purpose. */
+export const RESULT_STATUS_VARIANT: Record<ResultStatus, "success" | "danger" | "warning"> = {
+  passed: "success",
+  failed: "danger",
+  needs_review: "warning",
+};
+
+export const REVIEW_STATUS_VARIANT: Record<ReviewStatus, "success" | "warning"> = {
+  ready: "success",
+  needs_review: "warning",
+};
+
+/** e.g. 93.8 → "93.8%" (value already in 0–100 percentage points). */
+export function pct(value: number, digits = 1): string {
+  return `${value.toFixed(digits)}%`;
+}
+
+/**
+ * A 0–1 rate as a percentage, e.g. 0.857 → "85.7%". Server-backed evaluation main
+ * scores are 0–1 fractions (not 0–100 values), so they use this.
+ */
+export function pctFraction(value: number, digits = 1): string {
+  return pct(value * 100, digits);
+}
+
+/** e.g. 22.4 → "+22.4", -9.5 → "−9.5" (true minus sign). */
+export function signed(value: number, digits = 1): string {
+  const sign = value > 0 ? "+" : value < 0 ? "−" : "";
+  return `${sign}${Math.abs(value).toFixed(digits)}`;
+}
+
+/** A 0–1 delta as signed percentage points, e.g. -0.143 → "−14.3". */
+export function signedPoints(value: number, digits = 1): string {
+  return signed(value * 100, digits);
+}
+
+/**
+ * Reads a change the way a person would, not by arithmetic sign. Everything in
+ * v1 is higher-is-better, but the direction stays explicit.
+ */
+export function changeSentiment(change: number, higherIsBetter = true): "good" | "bad" | "neutral" {
+  if (change === 0) return "neutral";
+  const isUp = change > 0;
+  return (higherIsBetter ? isUp : !isUp) ? "good" : "bad";
+}
+
+export const SENTIMENT_CLASS: Record<"good" | "bad" | "neutral", string> = {
+  good: "text-emerald-600 dark:text-emerald-400",
+  bad: "text-red-600 dark:text-red-400",
+  neutral: "text-muted-foreground",
+};
+
+/** 0/1 scores read as Pass/Fail; fractional scores read as a percentage. */
+export function scoreDisplay(value: number | null): string {
+  if (value === null) return "—";
+  if (value === 0 || value === 1) return value === 1 ? "Pass" : "Fail";
+  return `${Math.round(value * 100)}%`;
+}
+
+/**
+ * Absolute timestamp, matching the rest of the app.
+ *
+ * Delegates to `formatDate` from lib/utils so dataset/evaluation timestamps read
+ * exactly like the traces and detectors tables ("2026-07-16 15:41:12"). That
+ * helper is hand-built (no `toLocaleString`), so it stays hydration-safe for the
+ * fixtures that render during SSR.
+ */
+export function formatStamp(iso: string): string {
+  return formatDate(iso);
+}
+
+/**
+ * A stable, trace-id-looking display id for a dataset row, derived from its
+ * internal case id (which stays "case-001" for lookups/routes/refs).
+ */
+export function caseDisplayId(id: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < id.length; i++) {
+    h ^= id.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  const a = (h >>> 0).toString(16).padStart(8, "0");
+  const b = (Math.imul(h ^ 0x9e3779b9, 16777619) >>> 0).toString(16).padStart(8, "0");
+  return `tc_${a}${b}`.slice(0, 15);
+}
+
+export function truncate(text: string, max = 80): string {
+  return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}
+
+/** The Python SDK snippet copied by "Copy init code" on a dataset. */
+export function datasetInitCode(datasetName: string): string {
+  return `import traceroot
+from traceroot import Dataset
+
+# Initialize with your API key, then author the dataset in code and
+# publish it as one immutable server version.
+traceroot.initialize()
+
+ds = Dataset("${datasetName}")
+ds.add(input="…", expected="…")
+
+ds.push()`;
+}
+
+// ---------------------------------------------------------------------------
+// Pull snippets. You only pull DATA: a dataset (its CURRENT version) or an exact
+// immutable version. An evaluation series and a run id are identifiers, not
+// runnable — so there is no "pull run" here. Reproducing a run = pulling that
+// run's pinned dataset version. Each helper has a Python and a TypeScript form.
+// ---------------------------------------------------------------------------
+
+/** Python — pull the dataset's CURRENT published version (independent of any run). */
+export function datasetPullCode(datasetId: string): string {
+  return `import traceroot
+from traceroot import pull_dataset
+
+# Initialize with your API key so the pull is authenticated.
+traceroot.initialize()
+
+# Pull this dataset's CURRENT published version (moves as the dataset is edited).
+dataset = pull_dataset("${datasetId}")
+
+for case in dataset:
+    print(case.id, case.input, case.expected)`;
+}
+
+/** TypeScript — pull the dataset's current published version. */
+export function datasetPullCodeTs(datasetId: string): string {
+  return `import * as traceroot from "traceroot";
+import { pullDataset } from "traceroot";
+
+// Initialize with your API key so the pull is authenticated.
+traceroot.initialize();
+
+// Pull this dataset's CURRENT published version (moves as the dataset is edited).
+const dataset = await pullDataset("${datasetId}");
+
+for (const testCase of dataset) {
+  console.log(testCase.id, testCase.input, testCase.expected);
+}`;
+}
+
+/** Python — pull one EXACT immutable dataset version by its version id. */
+export function datasetPullVersionCode(versionId: string): string {
+  return `import traceroot
+from traceroot import pull_dataset_version
+
+traceroot.initialize()
+
+# Pull this EXACT version (an immutable snapshot — never changes).
+dataset = pull_dataset_version("${versionId}")
+
+for case in dataset:
+    print(case.id, case.input, case.expected)`;
+}
+
+/** TypeScript — pull one exact immutable dataset version by its version id. */
+export function datasetPullVersionCodeTs(versionId: string): string {
+  return `import * as traceroot from "traceroot";
+import { pullDatasetVersion } from "traceroot";
+
+traceroot.initialize();
+
+// Pull this EXACT version (an immutable snapshot — never changes).
+const dataset = await pullDatasetVersion("${versionId}");
+
+for (const testCase of dataset) {
+  console.log(testCase.id, testCase.input, testCase.expected);
+}`;
+}
+
+/**
+ * Python — reproduce ONE run locally: pull the exact dataset version that run
+ * scored (so a new candidate is measured on the same cases), then the commented
+ * evaluate(... baseline=...) stub to run your candidate and compare against it.
+ */
+export function reproduceRunCode(versionId: string, evaluationName: string, runId: string): string {
+  return `import traceroot
+from traceroot import evaluate, pull_dataset_version
+
+traceroot.initialize()
+
+# The EXACT cases this run scored — pin them so a new candidate is comparable.
+dataset = pull_dataset_version("${versionId}")
+
+# Point task at your candidate; report baseline=this run to get the comparison.
+# result = evaluate(
+#     name=${JSON.stringify(evaluationName)},
+#     data=dataset,
+#     task=your_task,
+#     scorers=[...],
+#     candidate_version="git:REPLACE_ME",
+#     baseline=${JSON.stringify(runId)},  # compare against this run
+# )`;
+}
+
+/** TypeScript — reproduce one run locally (version pull + commented evaluate stub). */
+export function reproduceRunCodeTs(
+  versionId: string,
+  evaluationName: string,
+  runId: string,
+): string {
+  return `import * as traceroot from "traceroot";
+import { evaluate, pullDatasetVersion } from "traceroot";
+
+traceroot.initialize();
+
+// The EXACT cases this run scored — pin them so a new candidate is comparable.
+const dataset = await pullDatasetVersion("${versionId}");
+
+// Point task at your candidate; report baseline=this run to get the comparison.
+// const result = await evaluate({
+//   name: ${JSON.stringify(evaluationName)},
+//   data: dataset,
+//   task: yourTask,
+//   scorers: [...],
+//   candidateVersion: "git:REPLACE_ME",
+//   baseline: ${JSON.stringify(runId)}, // compare against this run
+// });`;
+}
+
+/** The TypeScript SDK snippet for a dataset. */
+export function datasetInitCodeTs(datasetName: string): string {
+  return `import { dataset } from "traceroot";
+
+const ds = dataset("${datasetName}");
+
+ds.add({
+  input: "…",
+  expected: "…",
+});
+
+await ds.publish();`;
+}
+
+/** Parses a span's JSON metadata string into a flat record for display. */
+export function parseMetadata(raw: string | null | undefined): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object") {
+      return Object.fromEntries(Object.entries(parsed).map(([k, v]) => [k, String(v)]));
+    }
+  } catch {
+    // Non-JSON metadata is shown as a single value.
+    return { value: raw };
+  }
+  return {};
+}

--- a/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
+++ b/frontend/ui/src/features/traces/components/TraceViewerPanel.tsx
@@ -11,14 +11,19 @@ import {
   Expand,
   Shrink,
   SquareArrowOutUpRight,
+  GitCompare,
 } from "lucide-react";
+import type { ReactNode } from "react";
 import { cn, buildUrlWithFilters, parseAsUTC } from "@/lib/utils";
 import { DOMAIN_ICONS } from "@/components/icons/domain-icons";
 import { Button } from "@/components/ui/button";
+import { CopyButton } from "@/components/ui/copy-button";
 import { LoadingState } from "@/components/ui/loading-state";
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from "@/components/ui/resizable";
 import { getTrace } from "@/lib/api";
+import type { Span, TraceDetail } from "@/types/api";
 import { ApiError } from "@/lib/api/errors";
+import type { TraceDetail } from "@/types/api";
 import type { TraceSelection } from "../types";
 import { SpanTreeView, type SpanTreeViewHandle } from "./SpanTreeView";
 import { SpanInfoPanel } from "./SpanInfoPanel";
@@ -55,6 +60,67 @@ interface TraceViewerPanelProps {
    */
   newTabPath?: string;
   /**
+   * When provided, this trace is used directly instead of fetching it, and the
+   * live SSE stream + detector-findings lookups are disabled. Lets the
+   * offline-eval surface render the genuine viewer from provided data.
+   * Unset in production.
+   */
+  traceOverride?: TraceDetail;
+  /**
+   * Optional action bar for the span detail panel, computed per selection —
+   * e.g. offline-eval's "Save as test case" / "Review". Return null to hide it
+   * (e.g. at trace level). Unset in production.
+   */
+  spanActions?: (selection: TraceSelection) => ReactNode;
+  /**
+   * Optional action for the span panel's header title row, computed per
+   * selection — e.g. offline-eval's "Save as test case". Unset in production.
+   */
+  spanHeaderAction?: (selection: TraceSelection) => ReactNode;
+  /**
+   * Optional extra chips for the span panel's badge row, computed per selection
+   * — e.g. offline-eval's "Dataset:" chip. Unset in production.
+   */
+  spanExtraTags?: (selection: TraceSelection) => ReactNode;
+  /**
+   * Notified whenever the selected span (or the trace root) changes, so an open
+   * side panel can follow the tree — e.g. offline-eval's "Save as test case"
+   * drawer tracking the clicked span. Unset in production.
+   */
+  onSelectionChange?: (selection: TraceSelection) => void;
+  /**
+   * Diff mode (offline-eval only): the baseline run's trace plus a matcher that
+   * resolves the baseline counterpart of a span selection (matched structurally,
+   * since span ids differ across runs). When provided, a "Diff" toggle appears in
+   * the sub-header; turning it on renders latency/token/cost tags with ± deltas and
+   * Input/Output/Metadata as git-style line diffs vs the baseline — for the whole
+   * trace (root row) as well as each span. Unset in production.
+   */
+  diffBaseline?: {
+    trace: TraceDetail;
+    matchSpan: (selection: TraceSelection) => Span | null;
+  };
+  /**
+   * Replaces the main header's "Trace" label + trace id (offline-eval), so an
+   * evaluation trace leads with its test case (e.g. label "Test case", value the
+   * test-case id). Unset in production, where the header shows "Trace" + traceId.
+   */
+  headerIdentity?: { label: string; value: string };
+  /**
+   * A badge rendered in the main header, immediately left of the navigation
+   * buttons — the same spot the findings "Alert" tag uses. offline-eval puts the
+   * test case's outcome (Passed / Did not pass / Errored) here. Unset in production.
+   */
+  headerStatus?: ReactNode;
+  /**
+   * Open the panel with diff mode already on (offline-eval compare-with). Only has an
+   * effect once `diffBaseline` is supplied — the toggle stays user-controllable after.
+   */
+  defaultDiffOn?: boolean;
+  traceIdentity?: { kindLabel: string; title: string; copyValue: string };
+  /** Badge shown where a span's ERROR badge sits, at trace level. Unset in production. */
+  traceStatusBadge?: ReactNode;
+  diffBaseline?: (selection: TraceSelection) => Span | null;
    * Scope the trace fetch: "detector" opens a detector self-trace (excluded
    * from normal reads), "user" excludes self-traces. Omit for no scoping.
    */
@@ -116,10 +182,37 @@ export function TraceViewerPanel({
   autoOpenRca,
   initialFullscreen,
   newTabPath,
+  traceOverride,
+  spanActions,
+  spanHeaderAction,
+  spanExtraTags,
+  onSelectionChange,
+  diffBaseline,
+  headerIdentity,
+  headerStatus,
+  defaultDiffOn,
+  traceIdentity,
+  traceStatusBadge,
   source,
   runTimestamp,
 }: TraceViewerPanelProps) {
   const [selection, setSelection] = useState<TraceSelection>({ type: "trace" });
+  // Diff mode is opt-in per panel (offline-eval only); the toggle only appears
+  // when a baseline matcher is supplied. Persists across ↑/↓ navigation like
+  // fullscreen, since the panel instance stays mounted.
+  const [diffMode, setDiffMode] = useState(defaultDiffOn ?? false);
+  // When a compare run is picked (offline-eval), auto-open diff mode so opening a case
+  // trace lands in the diff directly. The user can still toggle it off afterward.
+  useEffect(() => {
+    if (defaultDiffOn) setDiffMode(true);
+  }, [defaultDiffOn]);
+  // Emit selection changes to the parent (kept in a ref so an inline callback
+  // doesn't retrigger the effect — it fires only when `selection` actually changes).
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  onSelectionChangeRef.current = onSelectionChange;
+  useEffect(() => {
+    onSelectionChangeRef.current?.(selection);
+  }, [selection]);
   const [viewMode, setViewMode] = useState<"tree" | "timeline" | "detectors">("tree");
   // Fullscreen widens the slide-in overlay from ~70% to the full viewport.
   // Seeded from initialFullscreen so a trace opened in a new tab lands expanded.
@@ -162,7 +255,9 @@ export function TraceViewerPanel({
   // analysis, so it only renders when an RCA record exists — a finding from an
   // RCA-disabled detector has no analysis to open (gate on the record, not the
   // sessionId, so the button doesn't flicker while the RCA is still pending).
-  const { data: traceFindingsData } = useTraceFindings(projectId, traceId);
+  // With an override we render hardcoded data and touch no network: disable the
+  // findings lookup (empty id), the trace fetch, and the live SSE stream.
+  const { data: traceFindingsData } = useTraceFindings(projectId, traceOverride ? "" : traceId);
   const traceFinding = traceFindingsData?.findings?.[0];
   const { data: rcaData } = useRca(projectId, traceFinding?.finding_id ?? "");
   const hasRca = !!traceFinding && !!rcaData?.rca;
@@ -179,16 +274,19 @@ export function TraceViewerPanel({
   }, [autoOpenRca, rcaSessionId, traceId, setAiContext, setAiInitialSessionId, setAiPanelOpen]);
 
   const {
-    data: trace,
-    isLoading,
+    data: fetchedTrace,
+    isLoading: isFetching,
     error,
   } = useQuery({
     queryKey: traceQueryKey(projectId, traceId, source),
     queryFn: () => getTrace(projectId, traceId, "", undefined, source),
+    enabled: !traceOverride,
   });
+  const trace = traceOverride ?? fetchedTrace;
+  const isLoading = traceOverride ? false : isFetching;
 
   // source must match the query key above, or SSE span merging silently no-ops.
-  useTraceStream(projectId, traceId, true, source);
+  useTraceStream(projectId, traceId, !traceOverride, source);
 
   // Reset when navigating to a different trace
   useEffect(() => {
@@ -279,12 +377,28 @@ export function TraceViewerPanel({
       <div className="flex h-full flex-col bg-background">
         {/* ── MAIN HEADER ── */}
         <div className="flex h-12 items-center justify-between border-b border-border bg-muted/30 px-4">
-          <div className="flex min-w-0 items-center gap-2">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <Workflow className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="shrink-0 text-sm font-medium">{headerIdentity?.label ?? "Trace"}</span>
+            <span className="truncate font-mono text-xs text-muted-foreground">
+              {headerIdentity?.value ?? traceId}
+            </span>
+            {/* Copy affordance for the header id. Only offered when an identity is
+                supplied (offline-eval's test case); the standard trace header is
+                unchanged. */}
+            {headerIdentity && (
+              <CopyButton
+                value={headerIdentity.value}
+                className="h-6 w-6 shrink-0 text-muted-foreground hover:text-foreground"
+                title={`Copy ${headerIdentity.label.toLowerCase()} id`}
+              />
+            )}
             <DOMAIN_ICONS.trace className="h-4 w-4 text-muted-foreground" />
             <span className="text-sm font-medium">Trace</span>
             <span className="truncate font-mono text-xs text-muted-foreground">{traceId}</span>
           </div>
           <div className="flex items-center gap-1">
+            {headerStatus}
             {hasRca && (
               <button
                 type="button"
@@ -416,6 +530,23 @@ export function TraceViewerPanel({
               <DOMAIN_ICONS.detector className="h-3.5 w-3.5" /> Detectors
             </button>
           </div>
+          {/* Diff toggle — only when a baseline is available (offline-eval). */}
+          {diffBaseline && viewMode === "tree" && (
+            <div className="ml-auto pr-3">
+              <button
+                onClick={() => setDiffMode((v) => !v)}
+                className={cn(
+                  "flex items-center gap-2 rounded-md px-3 py-1 text-xs font-medium transition-all",
+                  diffMode
+                    ? "bg-muted text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                title="Diff each span's input, output, metadata and metrics against the baseline run"
+              >
+                <GitCompare className="h-3.5 w-3.5" /> Diff
+              </button>
+            </div>
+          )}
         </div>
 
         {/* ── CONTENT AREA ── */}
@@ -521,6 +652,12 @@ export function TraceViewerPanel({
                       dateFilter={dateFilter}
                       customStartDate={customStartDate}
                       customEndDate={customEndDate}
+                      spanActions={spanActions?.(selection)}
+                      headerAction={spanHeaderAction?.(selection)}
+                      extraTags={spanExtraTags?.(selection)}
+                      diffMode={!!diffBaseline && diffMode}
+                      baselineSpan={diffBaseline?.matchSpan(selection) ?? null}
+                      baselineTrace={diffBaseline?.trace ?? null}
                     />
                   ) : (
                     <SpanTimelineView

--- a/frontend/ui/src/lib/eval/__tests__/fake-prisma.ts
+++ b/frontend/ui/src/lib/eval/__tests__/fake-prisma.ts
@@ -1,117 +1,475 @@
+import { Prisma } from "@prisma/client";
+
 /**
  * A tiny in-memory stand-in for the subset of the Prisma client the offline-eval
  * reporting + read routes use. Enough to drive the real Route Handlers end to end
  * in a Vitest integration test (the local "SDK contract exerciser") without a
  * database, matching the repo convention of never touching a real DB in tests.
  *
- * Supports top-level-equality `where`, single-key `orderBy`, `create`,
- * `createMany`, `update`, `deleteMany`, `count`, `findFirst/findUnique/findMany`,
- * and an interactive `$transaction` (same store, no rollback). `select`/`include`
- * are ignored (the row is returned whole) — the reporting routes only read scalar
- * fields off what they create, so that is sufficient.
+ * Supports top-level-equality `where` (incl. compound-unique-key objects, e.g.
+ * `{ runId_testCaseId: { runId, testCaseId } }`), single-key `orderBy`, `create`,
+ * `createMany`, `update`, `updateMany` (a real compare-and-swap: it re-checks
+ * `where` per matched row), `upsert`, `delete` (cascading through declared
+ * `hasMany` relations, e.g. deleting a `dataset` takes its `datasetVersion`s and
+ * their `testCase`s with it — the fake's analogue of the schema's `onDelete:
+ * Cascade`), `deleteMany` (not cascading), `count`,
+ * `findFirst/findUnique/findMany` (with `take`/`skip`/`cursor`), and an
+ * interactive `$transaction` that snapshots every model on entry and restores it
+ * if `fn` rejects, so a route that writes some rows and then throws leaves no
+ * partial mutation behind. `select` is ignored (the row is returned whole).
+ * `include` resolves declared one-to-many relations (see `wireRelations`) so the
+ * public dataset-version READ route — which reads `version.testCases` — can be
+ * driven end to end; unknown include keys are ignored.
+ *
+ * Every `@@unique`/`@unique` this surface declares (see each Model's
+ * `uniqueKeys` below) is enforced: `create`/`update`/`upsert` throw a real
+ * `Prisma.PrismaClientKnownRequestError` (code `P2002`) on collision, matching
+ * what the routes already catch. A null/undefined key field never collides —
+ * Postgres unique constraints treat NULL as distinct from any other NULL (e.g. a
+ * dataset version published without an `idempotency_key`). A compound key's
+ * client-accessor name is its fields joined by "_" (Prisma's convention for
+ * `@@unique([a, b])`), which doubles as how `where` resolves it back to its
+ * constituent fields.
+ *
+ * `$transaction(fn)` hands `fn` a per-call view (`TxModel`) wrapping each model,
+ * closing over an undo log private to that one call. A mutation records exactly
+ * what it changed (the inserted id, or the prior value of an updated/deleted
+ * row); on rejection those entries are undone in reverse, restoring only what
+ * THIS transaction touched. That is deliberately not a whole-store
+ * snapshot/restore: two `$transaction` calls driven concurrently with
+ * `Promise.all` genuinely interleave (every fake method is async), and a
+ * global snapshot taken at one call's start would, when that call rolls back,
+ * erase whatever the OTHER call committed in between. Per-row undo can't do
+ * that — it only ever reverses rows it can name.
  */
 
 type Row = Record<string, unknown>;
 
-function matches(row: Row, where: Row | undefined): boolean {
-  if (!where) return true;
-  return Object.entries(where).every(([k, v]) => {
-    if (v && typeof v === "object" && "in" in (v as Row)) {
-      return (v as { in: unknown[] }).in.includes(row[k]);
-    }
-    return row[k] === v;
-  });
+/**
+ * A declared relation resolvable via `include`. `hasMany`: `model` rows whose
+ * `fk` equals this row's `id` (e.g. a version's `testCases`). `belongsTo`: the
+ * single `model` row whose `id` equals this row's own `fk` field (e.g. a
+ * version's owning `dataset`).
+ */
+type Relation = { kind: "hasMany" | "belongsTo"; model: Model; fk: string };
+
+/**
+ * One declared `@@unique`/`@unique`. `fields` joined by "_" is both the client's
+ * compound-key `where` accessor (e.g. `runId_testCaseId`) and how the constraint
+ * is checked on write; `name` is the constraint Postgres reports on a P2002.
+ */
+type UniqueKey = { fields: string[]; name: string };
+
+/** One reversible mutation, enough to undo it without touching anything else. */
+type UndoEntry =
+  | { kind: "insert"; model: Model; id: unknown }
+  | { kind: "mutate"; model: Model; id: unknown; prev: Row }
+  | { kind: "delete"; model: Model; rows: Row[] };
+
+function throwUniqueViolation(name: string): never {
+  throw new Prisma.PrismaClientKnownRequestError(
+    `Unique constraint failed on the constraint: \`${name}\``,
+    { code: "P2002", clientVersion: "5.22.0", meta: { target: name } },
+  );
 }
 
 class Model {
   rows: Row[] = [];
+  /** Declared relations resolvable via `include`, keyed by the include field name. */
+  relations: Record<string, Relation> = {};
   private seq = 0;
-  constructor(private name: string) {}
+  constructor(
+    private name: string,
+    private uniqueKeys: UniqueKey[] = [],
+    private hasUpdatedAt = false,
+  ) {}
 
   private id() {
     this.seq += 1;
     return `${this.name}_${this.seq}`;
   }
 
-  private order(rows: Row[], orderBy?: Row): Row[] {
-    if (!orderBy) return rows;
-    const [key, dir] = Object.entries(orderBy)[0] as [string, "asc" | "desc"];
-    return [...rows].sort((a, b) => {
-      const av = a[key] as number | string;
-      const bv = b[key] as number | string;
-      const cmp = av < bv ? -1 : av > bv ? 1 : 0;
-      return dir === "desc" ? -cmp : cmp;
+  private matches(row: Row, where: Row | undefined): boolean {
+    if (!where) return true;
+    return Object.entries(where).every(([k, v]) => {
+      // A compound-unique-key `where`, e.g. { runId_testCaseId: { runId, testCaseId } }:
+      // decompose it back into its constituent fields rather than looking for a
+      // literal "runId_testCaseId" column.
+      const uk = this.uniqueKeys.find((u) => u.fields.join("_") === k);
+      if (uk && v && typeof v === "object") {
+        return uk.fields.every((f) => row[f] === (v as Row)[f]);
+      }
+      if (v && typeof v === "object" && "in" in (v as Row)) {
+        return (v as { in: unknown[] }).in.includes(row[k]);
+      }
+      return row[k] === v;
     });
   }
 
-  async findFirst(args: { where?: Row; orderBy?: Row } = {}) {
-    return (
-      this.order(
-        this.rows.filter((r) => matches(r, args.where)),
-        args.orderBy,
-      )[0] ?? null
+  /** Throw P2002 if `row` collides with an existing row (other than `excludeId`,
+   * for an update-in-place) on any declared unique key. */
+  private checkUnique(row: Row, excludeId?: unknown) {
+    for (const uk of this.uniqueKeys) {
+      if (uk.fields.some((f) => row[f] === null || row[f] === undefined)) continue;
+      const dup = this.rows.find(
+        (r) => r.id !== excludeId && uk.fields.every((f) => r[f] === row[f]),
+      );
+      if (dup) throwUniqueViolation(uk.name);
+    }
+  }
+
+  // `orderBy` is either one `{ field: dir }` or, for a tie-break, an array of
+  // them applied in order (e.g. `[{ createTime: "desc" }, { testCaseId: "desc" }]`).
+  private order(rows: Row[], orderBy?: Row | Row[]): Row[] {
+    if (!orderBy) return rows;
+    const specs = (Array.isArray(orderBy) ? orderBy : [orderBy]).map(
+      (spec) => Object.entries(spec)[0] as [string, "asc" | "desc"],
     );
+    return [...rows].sort((a, b) => {
+      for (const [key, dir] of specs) {
+        const av = a[key] as number | string;
+        const bv = b[key] as number | string;
+        const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+        if (cmp !== 0) return dir === "desc" ? -cmp : cmp;
+      }
+      return 0;
+    });
   }
-  async findUnique(args: { where?: Row } = {}) {
-    return this.rows.find((r) => matches(r, args.where)) ?? null;
+
+  /**
+   * Attach each requested `include` relation to a shallow copy of `row` (leaving
+   * the stored row untouched). `hasMany` resolves to the target model's rows
+   * whose foreign key equals this row's id (honoring an optional nested
+   * `orderBy`); `belongsTo` resolves to the single target row this row's own
+   * foreign key points at (or `null` if it doesn't point anywhere / the target
+   * is gone).
+   */
+  private withInclude(row: Row | null, include?: Row): Row | null {
+    if (!row || !include) return row;
+    const out = { ...row };
+    for (const [key, spec] of Object.entries(include)) {
+      if (!spec) continue;
+      const rel = this.relations[key];
+      if (!rel) continue;
+      if (rel.kind === "belongsTo") {
+        out[key] = rel.model.rows.find((r) => r.id === row[rel.fk]) ?? null;
+        continue;
+      }
+      const nested = typeof spec === "object" ? (spec as { orderBy?: Row | Row[] }) : {};
+      out[key] = rel.model.order(
+        rel.model.rows.filter((r) => r[rel.fk] === row.id),
+        nested.orderBy,
+      );
+    }
+    return out;
   }
-  async findMany(args: { where?: Row; orderBy?: Row } = {}) {
-    return this.order(
-      this.rows.filter((r) => matches(r, args.where)),
+
+  async findFirst(args: { where?: Row; orderBy?: Row | Row[]; include?: Row } = {}) {
+    const row =
+      this.order(
+        this.rows.filter((r) => this.matches(r, args.where)),
+        args.orderBy,
+      )[0] ?? null;
+    return this.withInclude(row, args.include);
+  }
+  async findUnique(args: { where?: Row; include?: Row } = {}) {
+    const row = this.rows.find((r) => this.matches(r, args.where)) ?? null;
+    return this.withInclude(row, args.include);
+  }
+  async findMany(
+    args: {
+      where?: Row;
+      orderBy?: Row | Row[];
+      include?: Row;
+      take?: number;
+      skip?: number;
+      cursor?: Row;
+    } = {},
+  ) {
+    let rows = this.order(
+      this.rows.filter((r) => this.matches(r, args.where)),
       args.orderBy,
     );
+    // Cursor pagination: find the cursor row in the (already filtered + ordered)
+    // page, then start from it — `skip: 1` (the routes always pair the two) moves
+    // past it so the next page starts right after.
+    if (args.cursor) {
+      const idx = rows.findIndex((r) => this.matches(r, args.cursor));
+      rows = idx >= 0 ? rows.slice(idx) : [];
+    }
+    if (args.skip) rows = rows.slice(args.skip);
+    if (args.take !== undefined) rows = rows.slice(0, args.take);
+    return rows.map((r) => this.withInclude(r, args.include));
   }
   async count(args: { where?: Row } = {}) {
-    return this.rows.filter((r) => matches(r, args.where)).length;
+    return this.rows.filter((r) => this.matches(r, args.where)).length;
   }
-  async create(args: { data: Row }) {
-    const row: Row = { id: args.data.id ?? this.id(), createTime: new Date(), ...args.data };
+  // Every mutator takes an optional undo `log`: outside a transaction it is
+  // omitted and the write is simply permanent; `TxModel` passes its call's own
+  // log so a later rollback can find exactly what to undo.
+  async create(args: { data: Row }, log?: UndoEntry[]) {
+    const row: Row = {
+      id: args.data.id ?? this.id(),
+      createTime: new Date(),
+      ...(this.hasUpdatedAt ? { updateTime: new Date() } : {}),
+      ...args.data,
+    };
+    this.checkUnique(row);
     this.rows.push(row);
+    log?.push({ kind: "insert", model: this, id: row.id });
     return row;
   }
-  async createMany(args: { data: Row[] }) {
-    for (const d of args.data) await this.create({ data: d });
+  async createMany(args: { data: Row[] }, log?: UndoEntry[]) {
+    for (const d of args.data) await this.create({ data: d }, log);
     return { count: args.data.length };
   }
-  async update(args: { where: Row; data: Row }) {
-    const row = this.rows.find((r) => matches(r, args.where));
+  async update(args: { where: Row; data: Row }, log?: UndoEntry[]) {
+    const row = this.rows.find((r) => this.matches(r, args.where));
     if (!row) throw new Error(`${this.name}.update: not found`);
-    Object.assign(row, args.data);
+    const next = { ...row, ...args.data, ...(this.hasUpdatedAt ? { updateTime: new Date() } : {}) };
+    this.checkUnique(next, row.id);
+    const prev = { ...row };
+    Object.assign(row, args.data, this.hasUpdatedAt ? { updateTime: new Date() } : {});
+    log?.push({ kind: "mutate", model: this, id: row.id, prev });
     return row;
   }
-  async deleteMany(args: { where?: Row } = {}) {
-    const before = this.rows.length;
-    this.rows = this.rows.filter((r) => !matches(r, args.where));
-    return { count: before - this.rows.length };
+  async upsert(args: { where: Row; create: Row; update: Row }, log?: UndoEntry[]) {
+    const row = this.rows.find((r) => this.matches(r, args.where));
+    if (row) return this.update({ where: { id: row.id }, data: args.update }, log);
+    return this.create({ data: args.create }, log);
+  }
+  async updateMany(args: { where?: Row; data: Row }, log?: UndoEntry[]) {
+    const matched = this.rows.filter((r) => this.matches(r, args.where));
+    for (const row of matched) {
+      const next = {
+        ...row,
+        ...args.data,
+        ...(this.hasUpdatedAt ? { updateTime: new Date() } : {}),
+      };
+      this.checkUnique(next, row.id);
+      const prev = { ...row };
+      Object.assign(row, args.data, this.hasUpdatedAt ? { updateTime: new Date() } : {});
+      log?.push({ kind: "mutate", model: this, id: row.id, prev });
+    }
+    return { count: matched.length };
+  }
+  async deleteMany(args: { where?: Row } = {}, log?: UndoEntry[]) {
+    const removed = this.rows.filter((r) => this.matches(r, args.where));
+    if (removed.length === 0) return { count: 0 };
+    this.rows = this.rows.filter((r) => !this.matches(r, args.where));
+    log?.push({ kind: "delete", model: this, rows: removed });
+    return { count: removed.length };
+  }
+  /**
+   * Singular delete: exactly one row (Prisma throws P2025 if none matches),
+   * cascading through every declared `hasMany` relation first — deepest child
+   * rows go before their parent — the fake's analogue of the schema's
+   * `onDelete: Cascade` (e.g. deleting a `dataset` takes its `datasetVersion`s
+   * and, transitively, their `testCase`s with it). `belongsTo` relations are
+   * never followed: deleting a version must not take its owning dataset with it.
+   */
+  async delete(args: { where: Row }, log?: UndoEntry[]) {
+    const row = this.rows.find((r) => this.matches(r, args.where));
+    if (!row) throw new Error(`${this.name}.delete: not found`);
+    this.cascadeRemove(row, log);
+    return row;
+  }
+  private cascadeRemove(row: Row, log?: UndoEntry[]) {
+    for (const rel of Object.values(this.relations)) {
+      if (rel.kind !== "hasMany") continue;
+      for (const child of rel.model.rows.filter((r) => r[rel.fk] === row.id)) {
+        rel.model.cascadeRemove(child, log);
+      }
+    }
+    this.rows = this.rows.filter((r) => r !== row);
+    log?.push({ kind: "delete", model: this, rows: [row] });
+  }
+}
+
+/**
+ * The `tx` a `$transaction` callback receives: same models, same rows, but every
+ * mutation is appended to this one call's own `log` instead of a shared/global
+ * one — see the file-level doc for why that matters under concurrent calls.
+ */
+class TxModel {
+  constructor(
+    private base: Model,
+    private log: UndoEntry[],
+  ) {}
+  findFirst(args?: Parameters<Model["findFirst"]>[0]) {
+    return this.base.findFirst(args);
+  }
+  findUnique(args?: Parameters<Model["findUnique"]>[0]) {
+    return this.base.findUnique(args);
+  }
+  findMany(args?: Parameters<Model["findMany"]>[0]) {
+    return this.base.findMany(args);
+  }
+  count(args?: Parameters<Model["count"]>[0]) {
+    return this.base.count(args);
+  }
+  create(args: Parameters<Model["create"]>[0]) {
+    return this.base.create(args, this.log);
+  }
+  createMany(args: Parameters<Model["createMany"]>[0]) {
+    return this.base.createMany(args, this.log);
+  }
+  update(args: Parameters<Model["update"]>[0]) {
+    return this.base.update(args, this.log);
+  }
+  upsert(args: Parameters<Model["upsert"]>[0]) {
+    return this.base.upsert(args, this.log);
+  }
+  updateMany(args: Parameters<Model["updateMany"]>[0]) {
+    return this.base.updateMany(args, this.log);
+  }
+  deleteMany(args?: Parameters<Model["deleteMany"]>[0]) {
+    return this.base.deleteMany(args, this.log);
+  }
+  delete(args: Parameters<Model["delete"]>[0]) {
+    return this.base.delete(args, this.log);
   }
 }
 
 export class FakePrisma {
   accessKey = new Model("accessKey");
-  dataset = new Model("dataset");
-  datasetVersion = new Model("datasetVersion");
+  dataset = new Model(
+    "dataset",
+    [{ fields: ["projectId", "clientDatasetId"], name: "uq_dataset_project_client_id" }],
+    true,
+  );
+  datasetVersion = new Model("datasetVersion", [
+    { fields: ["datasetId", "versionNumber"], name: "uq_dataset_version_number" },
+    { fields: ["datasetId", "idempotencyKey"], name: "uq_dataset_version_idempotency" },
+  ]);
   testCase = new Model("testCase");
-  evaluation = new Model("evaluation");
-  evaluationRun = new Model("evaluationRun");
-  evaluationResult = new Model("evaluationResult");
-  score = new Model("score");
+  evaluation = new Model(
+    "evaluation",
+    [{ fields: ["projectId", "name"], name: "uq_evaluation_project_name" }],
+    true,
+  );
+  evaluationRun = new Model(
+    "evaluationRun",
+    [
+      { fields: ["evaluationId", "clientRunId"], name: "uq_run_client_run_id" },
+      { fields: ["evaluationId", "runNumber"], name: "uq_run_evaluation_run_number" },
+    ],
+    true,
+  );
+  evaluationResult = new Model(
+    "evaluationResult",
+    [{ fields: ["runId", "testCaseId"], name: "uq_result_run_test_case" }],
+    true,
+  );
+  score = new Model("score", [
+    { fields: ["resultId", "scorerName", "scorerVersion"], name: "uq_score_result_scorer" },
+  ]);
   humanScore = new Model("humanScore");
 
-  // Interactive transaction: same store, no isolation/rollback (fine for tests).
+  constructor() {
+    this.wireRelations();
+  }
+
+  // Interactive transaction: `fn` gets a `tx` whose mutations are logged to this
+  // one call's private undo log (see `TxModel`) and undone, in reverse, if `fn`
+  // rejects — precise per-row rollback rather than a whole-store snapshot, which
+  // a concurrently interleaved `$transaction` call could otherwise stomp on.
   async $transaction<T>(fn: (tx: this) => Promise<T>): Promise<T> {
-    return fn(this);
+    const log: UndoEntry[] = [];
+    const tx = this.txView(log);
+    try {
+      return await fn(tx);
+    } catch (e) {
+      for (let i = log.length - 1; i >= 0; i--) {
+        const entry = log[i];
+        if (entry.kind === "insert") {
+          entry.model.rows = entry.model.rows.filter((r) => r.id !== entry.id);
+        } else if (entry.kind === "mutate") {
+          const row = entry.model.rows.find((r) => r.id === entry.id);
+          if (row) Object.assign(row, entry.prev);
+        } else {
+          entry.model.rows.push(...entry.rows);
+        }
+      }
+      throw e;
+    }
+  }
+
+  private modelEntries(): Array<[string, Model]> {
+    return Object.entries(this).filter((e): e is [string, Model] => e[1] instanceof Model);
+  }
+
+  /** A `this`-shaped view whose models are `TxModel`s sharing one undo log. */
+  private txView(log: UndoEntry[]): this {
+    const view: Record<string, unknown> = { $transaction: this.$transaction.bind(this) };
+    for (const [key, model] of this.modelEntries()) view[key] = new TxModel(model, log);
+    return view as this;
+  }
+
+  /**
+   * Declare the relations the routes resolve via `include`, and — via `hasMany`
+   * — the cascade graph `delete` follows. Matches schema.prisma's `onDelete:
+   * Cascade` edges: dataset → version → test case, and evaluation → run →
+   * result → score/human score. Deliberately NOT wired: run → dataset version
+   * is `onDelete: NoAction` in the schema (a pinned version must survive a
+   * dataset delete's cascade so a run can still be read), so there is no
+   * `hasMany` from datasetVersion to evaluationRun here.
+   */
+  private wireRelations() {
+    this.datasetVersion.relations = {
+      testCases: { kind: "hasMany", model: this.testCase, fk: "datasetVersionId" },
+      dataset: { kind: "belongsTo", model: this.dataset, fk: "datasetId" },
+    };
+    this.dataset.relations = {
+      versions: { kind: "hasMany", model: this.datasetVersion, fk: "datasetId" },
+    };
+    this.evaluation.relations = {
+      runs: { kind: "hasMany", model: this.evaluationRun, fk: "evaluationId" },
+    };
+    this.evaluationRun.relations = {
+      results: { kind: "hasMany", model: this.evaluationResult, fk: "runId" },
+    };
+    this.evaluationResult.relations = {
+      scores: { kind: "hasMany", model: this.score, fk: "resultId" },
+      humanScores: { kind: "hasMany", model: this.humanScore, fk: "resultId" },
+    };
   }
 
   reset() {
     this.accessKey = new Model("accessKey");
-    this.dataset = new Model("dataset");
-    this.datasetVersion = new Model("datasetVersion");
+    this.dataset = new Model(
+      "dataset",
+      [{ fields: ["projectId", "clientDatasetId"], name: "uq_dataset_project_client_id" }],
+      true,
+    );
+    this.datasetVersion = new Model("datasetVersion", [
+      { fields: ["datasetId", "versionNumber"], name: "uq_dataset_version_number" },
+      { fields: ["datasetId", "idempotencyKey"], name: "uq_dataset_version_idempotency" },
+    ]);
     this.testCase = new Model("testCase");
-    this.evaluation = new Model("evaluation");
-    this.evaluationRun = new Model("evaluationRun");
-    this.evaluationResult = new Model("evaluationResult");
-    this.score = new Model("score");
+    this.evaluation = new Model(
+      "evaluation",
+      [{ fields: ["projectId", "name"], name: "uq_evaluation_project_name" }],
+      true,
+    );
+    this.evaluationRun = new Model(
+      "evaluationRun",
+      [
+        { fields: ["evaluationId", "clientRunId"], name: "uq_run_client_run_id" },
+        { fields: ["evaluationId", "runNumber"], name: "uq_run_evaluation_run_number" },
+      ],
+      true,
+    );
+    this.evaluationResult = new Model(
+      "evaluationResult",
+      [{ fields: ["runId", "testCaseId"], name: "uq_result_run_test_case" }],
+      true,
+    );
+    this.score = new Model("score", [
+      { fields: ["resultId", "scorerName", "scorerVersion"], name: "uq_score_result_scorer" },
+    ]);
     this.humanScore = new Model("humanScore");
+    this.wireRelations();
   }
 }
 

--- a/frontend/ui/src/lib/eval/__tests__/fake-prisma.ts
+++ b/frontend/ui/src/lib/eval/__tests__/fake-prisma.ts
@@ -1,0 +1,119 @@
+/**
+ * A tiny in-memory stand-in for the subset of the Prisma client the offline-eval
+ * reporting + read routes use. Enough to drive the real Route Handlers end to end
+ * in a Vitest integration test (the local "SDK contract exerciser") without a
+ * database, matching the repo convention of never touching a real DB in tests.
+ *
+ * Supports top-level-equality `where`, single-key `orderBy`, `create`,
+ * `createMany`, `update`, `deleteMany`, `count`, `findFirst/findUnique/findMany`,
+ * and an interactive `$transaction` (same store, no rollback). `select`/`include`
+ * are ignored (the row is returned whole) — the reporting routes only read scalar
+ * fields off what they create, so that is sufficient.
+ */
+
+type Row = Record<string, unknown>;
+
+function matches(row: Row, where: Row | undefined): boolean {
+  if (!where) return true;
+  return Object.entries(where).every(([k, v]) => {
+    if (v && typeof v === "object" && "in" in (v as Row)) {
+      return (v as { in: unknown[] }).in.includes(row[k]);
+    }
+    return row[k] === v;
+  });
+}
+
+class Model {
+  rows: Row[] = [];
+  private seq = 0;
+  constructor(private name: string) {}
+
+  private id() {
+    this.seq += 1;
+    return `${this.name}_${this.seq}`;
+  }
+
+  private order(rows: Row[], orderBy?: Row): Row[] {
+    if (!orderBy) return rows;
+    const [key, dir] = Object.entries(orderBy)[0] as [string, "asc" | "desc"];
+    return [...rows].sort((a, b) => {
+      const av = a[key] as number | string;
+      const bv = b[key] as number | string;
+      const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+      return dir === "desc" ? -cmp : cmp;
+    });
+  }
+
+  async findFirst(args: { where?: Row; orderBy?: Row } = {}) {
+    return (
+      this.order(
+        this.rows.filter((r) => matches(r, args.where)),
+        args.orderBy,
+      )[0] ?? null
+    );
+  }
+  async findUnique(args: { where?: Row } = {}) {
+    return this.rows.find((r) => matches(r, args.where)) ?? null;
+  }
+  async findMany(args: { where?: Row; orderBy?: Row } = {}) {
+    return this.order(
+      this.rows.filter((r) => matches(r, args.where)),
+      args.orderBy,
+    );
+  }
+  async count(args: { where?: Row } = {}) {
+    return this.rows.filter((r) => matches(r, args.where)).length;
+  }
+  async create(args: { data: Row }) {
+    const row: Row = { id: args.data.id ?? this.id(), createTime: new Date(), ...args.data };
+    this.rows.push(row);
+    return row;
+  }
+  async createMany(args: { data: Row[] }) {
+    for (const d of args.data) await this.create({ data: d });
+    return { count: args.data.length };
+  }
+  async update(args: { where: Row; data: Row }) {
+    const row = this.rows.find((r) => matches(r, args.where));
+    if (!row) throw new Error(`${this.name}.update: not found`);
+    Object.assign(row, args.data);
+    return row;
+  }
+  async deleteMany(args: { where?: Row } = {}) {
+    const before = this.rows.length;
+    this.rows = this.rows.filter((r) => !matches(r, args.where));
+    return { count: before - this.rows.length };
+  }
+}
+
+export class FakePrisma {
+  accessKey = new Model("accessKey");
+  dataset = new Model("dataset");
+  datasetVersion = new Model("datasetVersion");
+  testCase = new Model("testCase");
+  evaluation = new Model("evaluation");
+  evaluationRun = new Model("evaluationRun");
+  evaluationResult = new Model("evaluationResult");
+  score = new Model("score");
+  humanScore = new Model("humanScore");
+
+  // Interactive transaction: same store, no isolation/rollback (fine for tests).
+  async $transaction<T>(fn: (tx: this) => Promise<T>): Promise<T> {
+    return fn(this);
+  }
+
+  reset() {
+    this.accessKey = new Model("accessKey");
+    this.dataset = new Model("dataset");
+    this.datasetVersion = new Model("datasetVersion");
+    this.testCase = new Model("testCase");
+    this.evaluation = new Model("evaluation");
+    this.evaluationRun = new Model("evaluationRun");
+    this.evaluationResult = new Model("evaluationResult");
+    this.score = new Model("score");
+    this.humanScore = new Model("humanScore");
+  }
+}
+
+/** Shared instance so the `@traceroot/core` mock and the test see one store. */
+export const fakePrisma = new FakePrisma();

--- a/frontend/ui/src/lib/eval/auth.ts
+++ b/frontend/ui/src/lib/eval/auth.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@traceroot/core";
+import { hashApiKey } from "@/lib/api-keys";
+
+/**
+ * Resolve the project for an API-key-authenticated request (the SDK reporting
+ * surface). Mirrors the trace-ingestion trust model: `Authorization: Bearer
+ * tr-…`, hashed and looked up against `AccessKey.secretHash`. Kept in the Next.js
+ * app so the reporting path is locally testable without the Python hop.
+ */
+export async function requireApiKeyProject(
+  request: Request,
+): Promise<{ projectId: string; error?: never } | { projectId?: never; error: NextResponse }> {
+  const authz = request.headers.get("authorization") ?? "";
+  const match = authz.match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    return { error: NextResponse.json({ error: "Missing bearer API key" }, { status: 401 }) };
+  }
+  const secretHash = hashApiKey(match[1].trim());
+  const accessKey = await prisma.accessKey.findUnique({
+    where: { secretHash },
+    select: {
+      projectId: true,
+      expireTime: true,
+      project: { select: { deleteTime: true } },
+    },
+  });
+  if (!accessKey || accessKey.project?.deleteTime) {
+    return { error: NextResponse.json({ error: "Invalid API key" }, { status: 401 }) };
+  }
+  if (accessKey.expireTime && accessKey.expireTime.getTime() < Date.now()) {
+    return { error: NextResponse.json({ error: "API key expired" }, { status: 401 }) };
+  }
+  // Best-effort last-use stamp; never blocks the request.
+  void prisma.accessKey
+    .update({ where: { secretHash }, data: { lastUseTime: new Date() } })
+    .catch(() => {});
+  return { projectId: accessKey.projectId };
+}

--- a/frontend/ui/src/lib/eval/body.ts
+++ b/frontend/ui/src/lib/eval/body.ts
@@ -1,0 +1,70 @@
+/**
+ * Size-bounded JSON body reading for the public evaluation routes.
+ *
+ * `request.json()` buffers and parses the whole body with no ceiling — the 4 MB
+ * `bodyParser.sizeLimit` default is a Pages Router feature and does not apply to
+ * Route Handlers. A publish carrying unbounded `input` strings would therefore be
+ * materialized in full before any per-item check could reject it, so the limit has
+ * to be enforced on the wire: refuse an oversized `Content-Length` outright, and
+ * stop reading the stream the moment it exceeds the ceiling.
+ */
+
+export type LimitedJsonResult =
+  | { ok: true; value: unknown }
+  | { ok: false; status: 400 | 413; error: string };
+
+const tooLarge = (maxBytes: number): LimitedJsonResult => ({
+  ok: false,
+  status: 413,
+  error: `Request body exceeds ${maxBytes} bytes`,
+});
+
+/** Read and parse a JSON body, refusing anything over `maxBytes`. */
+export async function readLimitedJson(
+  request: Request,
+  maxBytes: number,
+): Promise<LimitedJsonResult> {
+  const declared = Number(request.headers?.get?.("content-length") ?? Number.NaN);
+  if (Number.isFinite(declared) && declared > maxBytes) return tooLarge(maxBytes);
+
+  const stream = request.body;
+  if (!stream) {
+    // No readable stream (an already-buffered body): fall back to the parsed form.
+    try {
+      return { ok: true, value: await request.json() };
+    } catch {
+      return { ok: false, status: 400, error: "Invalid JSON" };
+    }
+  }
+
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel();
+        return tooLarge(maxBytes);
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return { ok: false, status: 400, error: "Could not read the request body" };
+  }
+
+  const joined = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    joined.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  try {
+    return { ok: true, value: JSON.parse(new TextDecoder().decode(joined)) };
+  } catch {
+    return { ok: false, status: 400, error: "Invalid JSON" };
+  }
+}

--- a/frontend/ui/src/lib/eval/json-value.test.ts
+++ b/frontend/ui/src/lib/eval/json-value.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { encodeJsonValue, decodeJsonValue, displayJsonValue } from "./json-value";
+
+// The canonical public representation: encode-on-write, decode-on-read must round-trip
+// every JSON value type — the crux of the dataset value contract with the SDK.
+describe("dataset value round-trip", () => {
+  const cases: Array<[string, unknown]> = [
+    ["object", { a: 1, nested: { b: [1, 2] } }],
+    ["array", [1, "two", true, null]],
+    ["number", 42],
+    ["float", 3.14],
+    ["boolean true", true],
+    ["boolean false", false],
+    ["null", null],
+    ["plain string", "hello world"],
+    ["empty string", ""],
+    // The lossy cases the naive text contract got wrong — genuine strings that look
+    // like JSON must survive as strings, not be coerced to number/bool/array/null.
+    ["numeric-looking string", "123"],
+    ["boolean-looking string", "true"],
+    ["array-looking string", "[1, 2]"],
+    ["object-looking string", '{"a":1}'],
+    ["null-looking string", "null"],
+  ];
+
+  it.each(cases)("round-trips a %s", (_label, value) => {
+    expect(decodeJsonValue(encodeJsonValue(value))).toEqual(value);
+  });
+
+  it("preserves the type of a JSON-looking string (not coerced)", () => {
+    expect(typeof decodeJsonValue(encodeJsonValue("123"))).toBe("string");
+    expect(typeof decodeJsonValue(encodeJsonValue(123))).toBe("number");
+    expect(decodeJsonValue(encodeJsonValue("true"))).toBe("true");
+    expect(decodeJsonValue(encodeJsonValue(true))).toBe(true);
+  });
+
+  it("falls back to the raw string for legacy plain-text (non-JSON) rows", () => {
+    // A value stored before JSON-encoding, e.g. plain text, is returned unchanged.
+    expect(decodeJsonValue("just some plain text")).toBe("just some plain text");
+    expect(decodeJsonValue(null)).toBeNull();
+  });
+});
+
+describe("displayJsonValue (session/UI text form)", () => {
+  it("shows a genuine string as-is, never quoted", () => {
+    expect(displayJsonValue(encodeJsonValue("hello"))).toBe("hello");
+    expect(displayJsonValue(encodeJsonValue("123"))).toBe("123");
+  });
+
+  it("shows structured values as pretty JSON", () => {
+    expect(displayJsonValue(encodeJsonValue({ a: 1 }))).toBe('{\n  "a": 1\n}');
+  });
+
+  it("shows an empty string for null/absent", () => {
+    expect(displayJsonValue(null)).toBe("");
+    expect(displayJsonValue(encodeJsonValue(null))).toBe("");
+  });
+
+  it("passes legacy plain text through", () => {
+    expect(displayJsonValue("plain legacy input")).toBe("plain legacy input");
+  });
+});

--- a/frontend/ui/src/lib/eval/json-value.test.ts
+++ b/frontend/ui/src/lib/eval/json-value.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { encodeJsonValue, decodeJsonValue, displayJsonValue } from "./json-value";
+import { encodeJsonValue, decodeJsonValue, displayJsonValue, encodeEditedText } from "./json-value";
 
 // The canonical public representation: encode-on-write, decode-on-read must round-trip
 // every JSON value type — the crux of the dataset value contract with the SDK.
@@ -58,5 +58,44 @@ describe("displayJsonValue (session/UI text form)", () => {
 
   it("passes legacy plain text through", () => {
     expect(displayJsonValue("plain legacy input")).toBe("plain legacy input");
+  });
+});
+
+// The UI edits values as the text displayJsonValue produced, so re-encoding has to
+// put back a value of the same kind — otherwise a UI save changes a case's type
+// inside an immutable snapshot a run scores against.
+describe("encodeEditedText (UI edit → stored encoding)", () => {
+  const roundTrip = (value: unknown, edited?: string) => {
+    const stored = encodeJsonValue(value);
+    return decodeJsonValue(encodeEditedText(stored, edited ?? displayJsonValue(stored)));
+  };
+
+  it("keeps a genuine JSON-looking string a string", () => {
+    expect(roundTrip("123")).toBe("123");
+    expect(roundTrip("true")).toBe("true");
+    expect(roundTrip("null")).toBe("null");
+    expect(roundTrip('{"a":1}')).toBe('{"a":1}');
+  });
+
+  it("keeps structured and scalar values in their own kind", () => {
+    expect(roundTrip({ a: 1 })).toEqual({ a: 1 });
+    expect(roundTrip([1, 2])).toEqual([1, 2]);
+    expect(roundTrip(42)).toBe(42);
+    expect(roundTrip(true)).toBe(true);
+  });
+
+  it("carries an edit through", () => {
+    expect(roundTrip("hello", "goodbye")).toBe("goodbye");
+    expect(roundTrip({ a: 1 }, '{"a": 2}')).toEqual({ a: 2 });
+    expect(roundTrip(42, "43")).toBe(43);
+  });
+
+  it("falls back to a string when a structured value is edited into free text", () => {
+    expect(roundTrip({ a: 1 }, "not json any more")).toBe("not json any more");
+  });
+
+  it("treats a legacy plain-text row as a string", () => {
+    expect(decodeJsonValue(encodeEditedText("legacy text", "123"))).toBe("123");
+    expect(decodeJsonValue(encodeEditedText(null, "123"))).toBe("123");
   });
 });

--- a/frontend/ui/src/lib/eval/json-value.ts
+++ b/frontend/ui/src/lib/eval/json-value.ts
@@ -1,0 +1,45 @@
+/**
+ * Canonical representation for dataset test-case `input` / `expected` values.
+ *
+ * The public dataset API transports these as NATIVE JSON values — objects, arrays,
+ * numbers, booleans, null, and genuine strings (including strings that happen to
+ * look like JSON, e.g. `"123"` or `"true"`). The database column stays text for now,
+ * so a value is stored JSON-ENCODED: encoding a genuine string quotes it (`"123"`),
+ * which is what makes it distinguishable on read from the number `123`.
+ *
+ * See docs/offline-eval-trace-classification-plan.md (Contract 2). Coordinated with
+ * the SDK: `pull_dataset` should treat the returned values as already-native and stop
+ * re-decoding strings, otherwise a genuine JSON-looking string would be double-decoded.
+ */
+
+/** Encode a native JSON value for text storage so its type round-trips on read. */
+export function encodeJsonValue(value: unknown): string {
+  // JSON.stringify(undefined) is `undefined`; callers guard undefined separately,
+  // but treat it as null defensively so we never store the literal string.
+  return JSON.stringify(value ?? null);
+}
+
+/**
+ * Decode a stored value back to its native JSON form. A legacy row written as plain
+ * (non-JSON-encoded) text — or any value that isn't valid JSON — is returned as the
+ * raw string, so pre-existing datasets keep working.
+ */
+export function decodeJsonValue(text: string | null | undefined): unknown {
+  if (text === null || text === undefined) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * A human-readable string for a decoded value, for the session/UI surface (which
+ * edits values as text): a genuine string shows as-is; structured values show as
+ * pretty JSON. Never shows a bare string quoted.
+ */
+export function displayJsonValue(text: string | null | undefined): string {
+  const decoded = decodeJsonValue(text);
+  if (decoded === null || decoded === undefined) return "";
+  return typeof decoded === "string" ? decoded : JSON.stringify(decoded, null, 2);
+}

--- a/frontend/ui/src/lib/eval/json-value.ts
+++ b/frontend/ui/src/lib/eval/json-value.ts
@@ -34,6 +34,32 @@ export function decodeJsonValue(text: string | null | undefined): unknown {
 }
 
 /**
+ * Encode text submitted by the UI editor, preserving the kind of the value it edits.
+ *
+ * The UI edits values as text through `displayJsonValue`, which is lossy: a genuine
+ * string renders as-is and a structured value renders as pretty JSON, so the text
+ * alone cannot say which it was. Both write paths must nonetheless produce the one
+ * on-disk encoding (JSON-encoded), or a value silently changes type inside an
+ * immutable snapshot a run scores against. The previous stored value is the missing
+ * bit of type information:
+ *
+ * - the value was a string (or the row is legacy plain text) → the edit is a string,
+ *   so the genuine string "123" survives an edit instead of becoming the number 123;
+ * - the value was structured/scalar → the UI showed JSON, so parse the text back and
+ *   keep its kind, falling back to a string if the user typed something that is not
+ *   JSON any more.
+ */
+export function encodeEditedText(previous: string | null | undefined, text: string): string {
+  if (previous === null || previous === undefined) return encodeJsonValue(text);
+  if (typeof decodeJsonValue(previous) === "string") return encodeJsonValue(text);
+  try {
+    return encodeJsonValue(JSON.parse(text));
+  } catch {
+    return encodeJsonValue(text);
+  }
+}
+
+/**
  * A human-readable string for a decoded value, for the session/UI surface (which
  * edits values as text): a genuine string shows as-is; structured values show as
  * pretty JSON. Never shows a bare string quoted.

--- a/frontend/ui/src/lib/eval/prisma-errors.ts
+++ b/frontend/ui/src/lib/eval/prisma-errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Prisma error probes.
+ *
+ * Deliberately duck-typed rather than `instanceof PrismaClientKnownRequestError`:
+ * route tests swap `prisma` for an in-memory fake, and an `instanceof` check against
+ * the generated client would then quietly stop matching, turning a handled conflict
+ * back into the unhandled 500 these guards exist to prevent.
+ */
+
+/** True when `err` is a Prisma known-request error carrying `code` (e.g. "P2002"). */
+export function isPrismaKnownError(err: unknown, code: string): boolean {
+  return typeof err === "object" && err !== null && (err as { code?: unknown }).code === code;
+}
+
+/**
+ * The constraint/field(s) a P2002 (or P2003) names, as a lowercase string. Postgres
+ * reports the index name for a named `@@unique(map: ...)`, so callers can tell a
+ * version-number collision from an idempotency-key collision.
+ */
+export function prismaErrorTarget(err: unknown): string {
+  const target = (err as { meta?: { target?: unknown } } | null)?.meta?.target;
+  if (Array.isArray(target)) return target.map(String).join(",").toLowerCase();
+  if (typeof target === "string") return target.toLowerCase();
+  return "";
+}

--- a/frontend/ui/src/lib/eval/scorer-contract.test.ts
+++ b/frontend/ui/src/lib/eval/scorer-contract.test.ts
@@ -1,5 +1,5 @@
 /**
- * Phase 4 reporting contract: rich scorer metadata + run metadata are accepted, and
+ * Reporting contract: rich scorer metadata + run metadata are accepted, and
  * old SDK clients ({name, version} scorers, no metadata) remain valid.
  */
 import { describe, it, expect } from "vitest";


### PR DESCRIPTION
## Summary

Fixes: #1646

Adds the public dataset authoring and pull endpoints so the SDK can push and pull dataset contents and versions, letting a run execute against a known snapshot. A create or edit publishes a new immutable version rather than mutating the current one, and version immutability is enforced server-side so a snapshot a run pinned is never rewritten under it. Pull paths return a version's test cases in a stable order so the same snapshot reads identically each time.

## How it works

```
upsert dataset (A2)   →  create-or-return by client dataset_id (no version)
patch metadata (A3)   →  name/description only, never touches a version
publish version (A4)  →  fold changes over current cases → NEW immutable
                         version → advance Dataset.currentVersionId
pull current / by id  →  ordered test-case set for the pinned snapshot
```

Publishing is optimistic-concurrency-checked on `base_version_id` (409 on mismatch) and idempotent on `idempotency_key` (a retried publish returns the same version), so authoring is safe under retries and concurrent editors.

## What's included

### Backend
- `frontend/ui/src/app/api/public/datasets/route.ts` — `GET` list datasets (cursor-paginated, newest-first) and `POST` upsert a dataset by its client-generated id (A1/A2), idempotent within the project and never creating a version.
- `frontend/ui/src/app/api/public/datasets/[datasetId]/route.ts` — `GET` a dataset by stable id (returning the current version to pin) and `PATCH` dataset metadata only (A3), which never mutates a published version.
- `frontend/ui/src/app/api/public/datasets/[datasetId]/versions/route.ts` — `POST` publish one immutable version from a batch of test-case changes (A4), enforcing the `DATASET_VERSION_MAX_CHANGES` cap as a 413, the `base_version_id` concurrency check as a 409, and `idempotency_key` replay; and `GET` list versions (A5), newest-first and cursor-paginated with `is_current` and per-version case counts.
- `frontend/ui/src/app/api/public/dataset-versions/[versionId]/route.ts` — `GET` an immutable snapshot: the version plus its ordered test-case items, the exact set the SDK runs against.
- `frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/route.ts` — provides `GET`, `PATCH`, `DELETE`.
- `frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/route.ts` — provides `PATCH`.
- `frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/[testCaseId]/runs/route.ts` — provides `GET`.
- `frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/test-cases/route.ts` — provides `POST`.
- `frontend/ui/src/app/api/projects/[projectId]/datasets/[datasetId]/versions/[versionId]/route.ts` — provides `GET`.
- `frontend/ui/src/app/api/projects/[projectId]/datasets/route.ts` — provides `GET`, `POST`.
- `frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/test-cases/route.ts` — provides `GET`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/results/[resultId]/human-score/route.ts` — provides `POST`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/route.ts` — provides `GET`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.ts` — provides `GET`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/route.ts` — provides `GET`.
- `frontend/ui/src/app/api/projects/[projectId]/traces/[traceId]/evaluation-results/route.ts` — provides `GET`.
- `frontend/ui/src/app/api/public/evaluation-runs/[runId]/complete/route.ts` — provides `POST`.
- `frontend/ui/src/app/api/public/evaluation-runs/[runId]/results/route.ts` — provides `POST`.

### Library
- `frontend/ui/src/lib/eval/json-value.ts` — encodes `input`/`expected` as JSON-encoded text on write and decodes on read, so native (non-string) values and genuine JSON-looking strings round-trip byte-stably across a pull.

### Tests
- `frontend/ui/src/app/api/public/eval-dataset-sync.exerciser.test.ts` — drives the authoring and pull paths through the real handlers: upsert, publish, pull-current, pull-by-version, and stable ordering.
- `frontend/ui/src/app/api/projects/[projectId]/datasets/datasets-versioning.test.ts` — version immutability: an edit branches a new version while prior versions stay unchanged and still pullable.
- `frontend/ui/src/lib/eval/json-value.test.ts` — covers `json-value`.
- `frontend/ui/src/app/api/projects/[projectId]/evaluations/runs/[runId]/route.test.ts` — covers `route`.
- `frontend/ui/src/app/api/public/eval-reporting.exerciser.test.ts` — covers `eval-reporting.exerciser`.
- `frontend/ui/src/features/evaluations/evaluations.smoke.test.tsx` — covers `evaluations.smoke`.
- `frontend/ui/src/features/evaluations/save-test-case-drawer.smoke.test.tsx` — covers `save-test-case-drawer.smoke`.
- `frontend/ui/src/features/evaluations/trace-integration.smoke.test.tsx` — covers `trace-integration.smoke`.
- `frontend/ui/src/lib/eval/scorer-contract.test.ts` — covers `scorer-contract`.

### Frontend
- `frontend/packages/core/src/eval-contract.ts` — Offline-evaluation contract — the shared, typed shapes for both the user-session CRUD routes and the API-key SDK reporting routes.
- `frontend/ui/src/app/projects/[projectId]/datasets/layout.tsx` — part of this change.
- `frontend/ui/src/app/projects/[projectId]/evaluations/layout.tsx` — part of this change.
- `frontend/ui/src/app/projects/[projectId]/traces/page.tsx` — part of this change.
- `frontend/ui/src/features/evaluations/components/dataset-panels.tsx` — provides `NewDatasetPanel`, `DatasetEditPanel`.
- `frontend/ui/src/features/evaluations/components/run-evaluation-drawer.tsx` — provides `RunEvaluationDrawer`.
- `frontend/ui/src/features/evaluations/components/trace-integration.tsx` — provides `SaveTestCaseDrawer`, `TraceEvaluationChip`, `SpanDatasetChip`.
- `frontend/ui/src/features/evaluations/hooks.ts` — React Query hooks for the server-backed evaluation feature.
- `frontend/ui/src/features/evaluations/types.ts` — Client-side shapes for the server-backed evaluation feature. Timestamps arrive as ISO strings over JSON, so these mirror the Prisma rows with string dates.
- `frontend/ui/src/features/evaluations/views/dataset-detail-view.tsx` — provides `DatasetDetailView`.
- `frontend/ui/src/features/evaluations/views/datasets-view.tsx` — provides `DatasetsView`.
- `frontend/ui/src/features/evaluations/views/evaluations-view.tsx` — provides `RunStatusBadge`, `EvaluationsView`, `formatElapsed`, `ScoreValue`.
- `frontend/ui/src/features/evaluations/views/run-detail-view.tsx` — provides `sameAuthoredValue`, `RunDetailView`.
- `frontend/ui/src/features/offline-eval/components/index.ts` — Offline Evaluation feature components.
- `frontend/ui/src/features/offline-eval/components/page-chrome.tsx` — provides `EvalPageHeader`, `EvalBody`, `DetailsSection`, `DetailRow`.
- `frontend/ui/src/features/offline-eval/components/review-panel.tsx` — provides `ReviewTarget`, `ReviewPanel`.
- `frontend/ui/src/features/offline-eval/components/seed-trace-io.tsx` — provides `useSeedTraceIO`.
- `frontend/ui/src/features/offline-eval/components/selection.tsx` — provides `useRowSelection`, `SelectAllHeaderCell`, `SelectRowCell`, `BulkActionBar`.
- `frontend/ui/src/features/offline-eval/components/test-case-review-drawer.tsx` — provides `TestCaseReviewTarget`, `TestCaseReviewDrawer`.
- `frontend/ui/src/features/offline-eval/components/upload-control.tsx` — provides `UploadControl`.
- `frontend/ui/src/features/offline-eval/types.ts` — Offline Evaluation — domain types. v1 loop: an existing trace → select a span → save it as a test case → dataset → run an evaluation → compare → inspect the resulting trace → …
- `frontend/ui/src/features/offline-eval/utils.ts` — Offline Evaluation — helpers and route builders.
- `frontend/ui/src/features/traces/components/TraceViewerPanel.tsx` — provides `TraceViewerPanel`.

### Hooks / data
- `frontend/ui/src/lib/eval/__tests__/fake-prisma.ts` — provides `FakePrisma`, `fakePrisma`.
- `frontend/ui/src/lib/eval/auth.ts` — provides `requireApiKeyProject`.
- `frontend/ui/src/lib/eval/body.ts` — Size-bounded JSON body reading for the public evaluation routes.
- `frontend/ui/src/lib/eval/prisma-errors.ts` — Prisma error probes. Deliberately duck-typed rather than `instanceof PrismaClientKnownRequestError`: route tests swap `prisma` for an in-memory fake, and an `instanceof` check …

## Test plan

- [ ] Pull a dataset and confirm it returns the exact cases of the requested (or current) version.
- [ ] Pull the same version twice and confirm an identical, identically-ordered set of cases.
- [ ] Edit a dataset and confirm a new version is created while prior versions are unchanged and still pullable.
- [ ] Pin a version on a run, then later pull it and confirm the precise snapshot reproduces.
- [ ] Publish a new version and confirm `currentVersionId` advances while any prior run's pinned version is untouched.
- [ ] Republish with the same `idempotency_key` and confirm the same version is returned; publish with a stale `base_version_id` and confirm a 409.
- [ ] Attempt cross-project authoring and confirm it is rejected.
